### PR TITLE
Move Snyk to a parallel CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
       - name: Install Dependencies
         run: yarn install --frozen-lockfile --ignore-optional
         env:


### PR DESCRIPTION
This pull request moves Snyk's vuln scan into a parallel job! It is required that we `yarn install` before running the scan. There is no way to share deps between job runners.