### PR TITLE
Remove actions-core dep clash

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,6 @@
     "@oclif/config": "^1",
     "@oclif/errors": "^1",
     "@oclif/plugin-help": "^3",
-    "@segment/actions-core": "^3.0.0",
     "@segment/destination-actions": "^3.1.0",
     "chalk": "^4.1.1",
     "chokidar": "^3.5.1",


### PR DESCRIPTION
This pull request removes a dependency clash within the CLI package. The [optional dependency](https://github.com/segmentio/action-destinations/pull/20/files#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L80) is preferred because `@segment/actions-core` will remain restricted within NPM. Builders will be able to relatively resolves thanks to `tsconfig.json`