### PR TITLE
Upgrade fql package to fql-ts@1.10.1

### DIFF
--- a/packages/destination-subscriptions/package.json
+++ b/packages/destination-subscriptions/package.json
@@ -37,7 +37,7 @@
 		"package.json"
 	],
 	"dependencies": {
-		"@segment/fql": "^1.9.1"
+		"@segment/fql-ts": "^1.10.1"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^0.7.0",

--- a/packages/destination-subscriptions/src/parse-fql.ts
+++ b/packages/destination-subscriptions/src/parse-fql.ts
@@ -1,4 +1,4 @@
-import { lex, Token, types as TokenType } from '@segment/fql'
+import { lex, Token, types as TokenType } from '@segment/fql-ts'
 import {
 	Subscription,
 	Condition,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,10 +2302,10 @@
     new-date "^1.0.3"
     obj-case "0.2.1"
 
-"@segment/fql@^1.9.1":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@segment/fql/-/fql-1.10.0.tgz#4e50d689c77e078887e673acda2b5fad384e461c"
-  integrity sha512-bQU4o+HC+Oo2fjdxBsxNlYw7EasxgufveKWeg2ORR8huIo6M47riV3oVo34bcLfXyEWsmWISvtgzRQOrI2XbHw==
+"@segment/fql-ts@^1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@segment/fql-ts/-/fql-ts-1.10.1.tgz#16f0056db934085b213a9c7a0115ef7f47480436"
+  integrity sha512-y2JVHeQsRADEWRLNXV5uf8BAP5PowYU5IBxsSiJY9WCIDS3/RT98g6fFRURefKn+9Dalmp7X7pcHUX5wW2ljYw==
 
 "@segment/isodate-traverse@^1.1.1":
   version "1.1.1"


### PR DESCRIPTION
This pull request updates `destination-subscriptions` package's `@segment/fql` dependency. `@segment/fql` was renamed `@segment/fql-ts` as part of the open source push.