### PR TITLE
Update to use @segment/action-destination in cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=12"
   },
   "scripts": {
-    "cloud": "yarn workspace @segment/destination-actions",
+    "cloud": "yarn workspace @segment/action-destinations",
     "cli": "yarn workspace @segment/actions-cli",
     "core": "yarn workspace @segment/actions-core",
     "bootstrap": "lerna bootstrap",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,7 @@
     "@oclif/config": "^1",
     "@oclif/errors": "^1",
     "@oclif/plugin-help": "^3",
-    "@segment/destination-actions": "^3.1.0",
+    "@segment/action-destinations": "^3.1.0",
     "chalk": "^4.1.1",
     "chokidar": "^3.5.1",
     "execa": "^5.1.1",

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -1,6 +1,6 @@
 import { Command, flags } from '@oclif/command'
 import type { DestinationDefinition as CloudDestinationDefinition } from '@segment/actions-core'
-import { manifest as cloudManifest } from '@segment/destination-actions'
+import { manifest as cloudManifest } from '@segment/action-destinations'
 import { manifest as browserManifest, BrowserDestinationDefinition } from '@segment/browser-destinations'
 import chalk from 'chalk'
 import { uniq, pick, omit, sortBy, mergeWith } from 'lodash'

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -21,7 +21,7 @@
     "paths": {
       "@segment/actions-core": ["../core/src"],
       "@segment/actions-core/*": ["../core/src/*"],
-      "@segment/destination-actions": ["../destination-actions/src"],
+      "@segment/action-destinations": ["../destination-actions/src"],
       "@segment/destination-subscriptions": ["../destination-subscriptions/src"]
     }
   },


### PR DESCRIPTION
Updates the CLI module to use `@segment/action-destination` which ensures the build uses the code in the destination-actions module here instead of installing `@segment/destination-actions` from npm while building the repo.