### PR TITLE
[browser] Fix destination-subscription dep version

### DIFF
--- a/packages/browser-destinations/package.json
+++ b/packages/browser-destinations/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@braze/web-sdk": "^3.3.0",
     "@fullstory/browser": "^1.4.9",
-    "@segment/destination-subscriptions": "^3.0.1-alpha.0",
+    "@segment/destination-subscriptions": "^3.1.0",
     "dayjs": "^1.10.3",
     "tslib": "^2.1.0",
     "vm-browserify": "^1.1.2"


### PR DESCRIPTION
This pull request fixes the `destination-subscriptions` dependency version in the `browser-destinations` package.

Correct version: https://github.com/segmentio/action-destinations/blob/main/packages/destination-subscriptions/package.json#L3