### PR TITLE
fix build output structure for browser-destinations

### DIFF
--- a/packages/browser-destinations/tsconfig.build.json
+++ b/packages/browser-destinations/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "dist",
+    "rootDir": "src",
     "allowJs": true,
     "importHelpers": true,
     "lib": ["es2020", "dom"],

--- a/packages/destination-subscriptions/package.json
+++ b/packages/destination-subscriptions/package.json
@@ -21,7 +21,7 @@
 	},
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
-	"types": "dist/esm/index.d.ts",
+	"types": "dist/cjs/index.d.ts",
 	"exports": {
 		".": {
 			"require": "./dist/cjs/index.js",

--- a/packages/destination-subscriptions/tsconfig.build.json
+++ b/packages/destination-subscriptions/tsconfig.build.json
@@ -1,10 +1,13 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "composite": true,
-    "rootDir": "src",
-    "outDir": "dist"
-  },
-  "exclude": ["**/__tests__/**/*.ts"],
-  "include": ["src"]
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"target": "es2018",
+		"lib": ["es2018"],
+		"composite": true,
+		"module": "es2020",
+		"rootDir": "src",
+		"outDir": "dist/esm"
+	},
+	"exclude": ["**/__tests__/**/*.ts"],
+	"include": ["src"]
 }

--- a/packages/destination-subscriptions/tsconfig.json
+++ b/packages/destination-subscriptions/tsconfig.json
@@ -1,12 +1,5 @@
 {
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "module": "es2020",
-    "outDir": "dist/esm",
-    "target": "es2018",
-    "lib": ["es2018"],
-    "esModuleInterop": true
-  },
-  "exclude": [],
-  "include": ["src"]
+	"extends": "./tsconfig.build.json",
+	"exclude": [],
+	"include": ["src"]
 }


### PR DESCRIPTION
Turns out the build output was broken from a recent PR when I added `composite: true`. I needed to add the `rootDir: "src"` to get it to produce the previous output structure for browser-destinations. Note that only the CLI commands that use browser-destinations will break – and only when using the compiled output for that package (which isn't the default behavior since we use ts-node)