### PR TITLE
allow more flexible gender formats for braze cloud

### DIFF
--- a/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
+++ b/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
@@ -34,7 +34,6 @@ function toBrazeGender(gender: string | null | undefined): string | null | undef
     M: ['man', 'male', 'm'],
     F: ['woman', 'female', 'w', 'f'],
     O: ['other', 'o'],
-    U: ['u', 'unknown'],
     N: ['not applicable', 'n'],
     P: ['prefer not to say', 'p']
   }


### PR DESCRIPTION
This adds similar support to Braze Cloud mode for flexible gender input formats. We match those with a corresponding Braze gender.