### PR TITLE
omit reserved keys for trackPurchase action

### DIFF
--- a/packages/core/src/omit.ts
+++ b/packages/core/src/omit.ts
@@ -1,8 +1,8 @@
 /**
  * Lightweight alternative to lodash.omit. Faster, and way less code.
  */
-export function omit<T extends object, K extends string[]>(obj: T, keys: K) {
-  return Object.keys(obj).reduce((newObject, key) => {
+export function omit<T extends object | { [key: string]: unknown }, K extends string[]>(obj: T | undefined, keys: K) {
+  return Object.keys(obj || {}).reduce((newObject, key) => {
     if (keys.indexOf(key) === -1) newObject[key] = (obj as Record<string, unknown>)[key]
     return newObject
   }, {} as Record<string, unknown>) as Omit<T, keyof K>

--- a/packages/destination-actions/src/destinations/braze/trackPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/braze/trackPurchase/index.ts
@@ -1,4 +1,4 @@
-import { IntegrationError } from '@segment/actions-core'
+import { omit, IntegrationError } from '@segment/actions-core'
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -127,13 +127,16 @@ const action: ActionDefinition<Settings, Payload> = {
       return
     }
 
+    const reservedKeys = Object.keys(action.fields.products.properties ?? {})
+    const properties = omit(payload.properties, reservedKeys)
+
     const base = {
       braze_id,
       external_id,
       user_alias,
       app_id: settings.app_id,
       time: toISO8601(payload.time),
-      properties: payload.properties,
+      properties,
       _update_existing_only: payload._update_existing_only
     }
 


### PR DESCRIPTION
This PR removes reserved keys from the `properties` object sent with each "purchase" in the `trackPurchase` action 