### PR TITLE
make testAuthentication optional

### DIFF
--- a/packages/cli/templates/destinations/basic-auth/index.ts
+++ b/packages/cli/templates/destinations/basic-auth/index.ts
@@ -22,8 +22,10 @@ const destination: DestinationDefinition<Settings> = {
         required: true
       }
     },
-    testAuthentication: (_request) => {
-      // Return a request that tests/validates the user's credentials here
+    testAuthentication: (request) => {
+      // Return a request that tests/validates the user's credentials.
+      // If you do not have a way to validate the authentication fields safely,
+      // you can remove the `testAuthentication` function, though discouraged.
     }
   },
 

--- a/packages/cli/templates/destinations/custom-auth/index.ts
+++ b/packages/cli/templates/destinations/custom-auth/index.ts
@@ -9,8 +9,10 @@ const destination: DestinationDefinition<Settings> = {
   authentication: {
     scheme: 'custom',
     fields: {},
-    testAuthentication: (_request) => {
-      // Return a request that tests/validates the user's authentication fields here
+    testAuthentication: (request) => {
+      // Return a request that tests/validates the user's credentials.
+      // If you do not have a way to validate the authentication fields safely,
+      // you can remove the `testAuthentication` function, though discouraged.
     }
   },
 

--- a/packages/cli/templates/destinations/oauth2-auth/index.ts
+++ b/packages/cli/templates/destinations/oauth2-auth/index.ts
@@ -9,8 +9,10 @@ const destination: DestinationDefinition<Settings> = {
   authentication: {
     scheme: 'oauth2',
     fields: {},
-    testAuthentication: (_request) => {
-      // Return a request that tests/validates the user's credentials here
+    testAuthentication: (request) => {
+      // Return a request that tests/validates the user's credentials.
+      // If you do not have a way to validate the authentication fields safely,
+      // you can remove the `testAuthentication` function, though discouraged.
     },
     refreshAccessToken: async (request, { auth }) => {
       // Return a request that refreshes the access_token if the API supports it

--- a/packages/core/src/__tests__/destination-kit.test.ts
+++ b/packages/core/src/__tests__/destination-kit.test.ts
@@ -14,9 +14,6 @@ const destinationCustomAuth: DestinationDefinition<JSONObject> = {
         type: 'string',
         required: true
       }
-    },
-    testAuthentication: (_request) => {
-      return true
     }
   },
   actions: {
@@ -44,9 +41,6 @@ const destinationOAuth2: DestinationDefinition<JSONObject> = {
         type: 'string',
         required: true
       }
-    },
-    testAuthentication: (_request) => {
-      return true
     },
     refreshAccessToken: (_request) => {
       return new Promise((resolve, _reject) => {

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -110,8 +110,8 @@ interface Authentication<Settings> {
   scheme: 'basic' | 'custom' | 'oauth2'
   /** The fields related to authentication */
   fields: Record<string, GlobalSetting>
-  /** A function that validates the user's authentication inputs */
-  testAuthentication: (request: RequestClient, input: AuthSettings<Settings>) => Promise<unknown> | unknown
+  /** A function that validates the user's authentication inputs. It is highly encouraged to define this whenever possible. */
+  testAuthentication?: (request: RequestClient, input: AuthSettings<Settings>) => Promise<unknown> | unknown
 }
 
 /**

--- a/packages/destination-actions/src/destinations/braze/index.ts
+++ b/packages/destination-actions/src/destinations/braze/index.ts
@@ -32,10 +32,6 @@ const destination: DestinationDefinition<Settings> = {
         format: 'uri',
         required: true
       }
-    },
-    testAuthentication: (_request) => {
-      // Return a request that tests/validates the user's authentication fields here
-      // TODO explore docs for side-effect free way to handle this
     }
   },
   extendRequest({ settings }) {

--- a/packages/destination-actions/src/destinations/google-analytics-4/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/index.ts
@@ -40,11 +40,6 @@ const destination: DestinationDefinition<Settings> = {
         type: 'string',
         required: true
       }
-    },
-    testAuthentication: (_request) => {
-      // Return a request that tests/validates the user's authentication fields here
-      // TODO: maybe run a post to the google measurements protocol debug endpoint
-      return true
     }
   },
   extendRequest({ settings }) {


### PR DESCRIPTION
This makes `testAuthentication` optional since there are several destinations already that don't support it.

Requiring it with the hack of `return true` is less than ideal, so instead we'll include it in the templates and encourage it through documentation when possible.