### PR TITLE
switch Braze API Key to password

### DIFF
--- a/packages/destination-actions/src/destinations/braze/index.ts
+++ b/packages/destination-actions/src/destinations/braze/index.ts
@@ -15,7 +15,7 @@ const destination: DestinationDefinition<Settings> = {
       api_key: {
         label: 'API Key',
         description: 'Created under Developer Console in the Braze Dashboard.',
-        type: 'string',
+        type: 'password',
         required: true
       },
       app_id: {


### PR DESCRIPTION
This will present API Key as a password field in the UI instead.