### PR TITLE
dont mutate destination name during register

### DIFF
--- a/packages/cli/src/commands/register.ts
+++ b/packages/cli/src/commands/register.ts
@@ -77,7 +77,7 @@ export default class Register extends Command {
       this.spinner.succeed()
     }
 
-    const name = destination.name.includes('Actions') ? destination.name : `${destination.name} (Actions)`
+    const name = destination.name
     const slug = generateSlug(destination.slug ?? name)
 
     if (destination.slug && destination.slug !== slug) {


### PR DESCRIPTION
We should use the prescribed name as-is. Builders can be in charge of how the destination is named without us mucking around with it.