### PR TITLE
subscribe group events to the logUser action by default

### DIFF
--- a/packages/browser-destinations/src/destinations/braze/logUser/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/logUser/index.ts
@@ -9,7 +9,7 @@ const known_traits = ['email', 'firstName', 'gender', 'city', 'avatar', 'lastNam
 const action: BrowserActionDefinition<Settings, typeof appboy, Payload> = {
   title: 'Log User',
   description: 'Updates a users profile attributes in Braze',
-  defaultSubscription: 'type = "identify"',
+  defaultSubscription: 'type = "identify" or type = "group"',
   platform: 'web',
   fields: {
     external_id: {


### PR DESCRIPTION
As the classic braze web destination invokes `logUser` by default on `group` calls, and the `logUser` action has been changed to include `groupId`, we're making group events subscribe to this action by default