### PR TITLE
update test to include proper time value

### DIFF
--- a/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
@@ -3,7 +3,7 @@ import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Amplitude from '../index'
 
 const testDestination = createTestIntegration(Amplitude)
-const timestamp = new Date().toISOString()
+const timestamp = '2021-08-17T15:22:15.449Z'
 
 describe('Amplitude', () => {
   describe('logEvent', () => {
@@ -238,14 +238,14 @@ describe('Amplitude', () => {
           "api_key": undefined,
           "events": Array [
             Object {
-              "device_id": "e2ec5c80-d07d-4528-8aca-ac539f9a6db3",
+              "device_id": "6fd32a7e-3c56-44c2-bd32-62bbec44c53d",
               "device_model": undefined,
               "event_properties": Object {},
               "event_type": "Test Event",
               "library": "segment",
               "os_name": "Mac",
               "os_version": "10.11.6",
-              "time": 1629213252572,
+              "time": 1629213735449,
               "use_batch_endpoint": false,
               "user_id": "user1234",
               "user_properties": Object {},

--- a/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
@@ -218,6 +218,7 @@ describe('Amplitude', () => {
 
     it('should support parsing user_agent when the setting is true', async () => {
       const event = createTestEvent({
+        anonymousId: '6fd32a7e-3c56-44c2-bd32-62bbec44c53d',
         timestamp,
         event: 'Test Event',
         context: {

--- a/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
@@ -233,16 +233,26 @@ describe('Amplitude', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       expect(responses[0].data).toMatchObject({})
-      expect(responses[0].options.json).toMatchObject({
-        api_key: undefined,
-        events: expect.arrayContaining([
-          expect.objectContaining({
-            event_type: 'Test Event',
-            os_name: 'Mac',
-            os_version: '10.11.6'
-          })
-        ])
-      })
+      expect(responses[0].options.json).toMatchInlineSnapshot(`
+        Object {
+          "api_key": undefined,
+          "events": Array [
+            Object {
+              "device_id": "e2ec5c80-d07d-4528-8aca-ac539f9a6db3",
+              "device_model": undefined,
+              "event_properties": Object {},
+              "event_type": "Test Event",
+              "library": "segment",
+              "os_name": "Mac",
+              "os_version": "10.11.6",
+              "time": 1629213252572,
+              "use_batch_endpoint": false,
+              "user_id": "user1234",
+              "user_properties": Object {},
+            },
+          ],
+        }
+      `)
     })
   })
 
@@ -447,7 +457,7 @@ describe('Amplitude', () => {
             "api_key",
             "undefined",
             "identification",
-            "{\\"user_id\\":\\"some-user-id\\",\\"device_id\\":\\"foo\\",\\"user_properties\\":{\\"some-trait-key\\":\\"some-trait-value\\"},\\"os_name\\":\\"Mac\\",\\"os_version\\":\\"10.11.6\\",\\"library\\":\\"segment\\"}",
+            "{\\"os_name\\":\\"Mac\\",\\"os_version\\":\\"10.11.6\\",\\"user_id\\":\\"some-user-id\\",\\"device_id\\":\\"foo\\",\\"user_properties\\":{\\"some-trait-key\\":\\"some-trait-value\\"},\\"library\\":\\"segment\\"}",
           ],
           Symbol(context): null,
         }

--- a/packages/destination-actions/src/destinations/amplitude/__tests__/user-agent.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude/__tests__/user-agent.test.ts
@@ -1,15 +1,13 @@
-import { parseAndMergeUserAgentProperties } from '../user-agent'
+import { parseUserAgentProperties } from '../user-agent'
 
 describe('amplitude - custom user agent parsing', () => {
   it('should parse custom user agent', () => {
-    const event = {
-      //This is borrowed from amplitude tests so we know its parsable:
-      // https://github.com/amplitude/ua-parser-js/blob/master/test/device-test.json#L138
-      userAgent:
-        '"Mozilla/5.0 (Linux; Android 5.0.1; Lenovo TAB 2 A7-30HC Build/LRX21M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Safari/537.36"'
-    }
+    //This is borrowed from amplitude tests so we know its parsable:
+    // https://github.com/amplitude/ua-parser-js/blob/master/test/device-test.json#L138
+    const userAgent =
+      '"Mozilla/5.0 (Linux; Android 5.0.1; Lenovo TAB 2 A7-30HC Build/LRX21M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Safari/537.36"'
 
-    const result = parseAndMergeUserAgentProperties(event)
+    const result = parseUserAgentProperties(userAgent)
 
     expect(result).toEqual({
       os_name: 'Android',
@@ -18,22 +16,8 @@ describe('amplitude - custom user agent parsing', () => {
     })
   })
 
-  it('should not override any already set fields on payload', () => {
-    const event = {
-      //This is borrowed from amplitude tests so we know its parsable:
-      // https://github.com/amplitude/ua-parser-js/blob/master/test/device-test.json#L138
-      userAgent:
-        '"Mozilla/5.0 (Linux; Android 5.0.1; Lenovo TAB 2 A7-30HC Build/LRX21M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Safari/537.36"',
-      os_name: 'Not Android',
-      os_version: '9.9.9'
-    }
-
-    const result = parseAndMergeUserAgentProperties(event)
-
-    expect(result).toEqual({
-      os_name: 'Not Android',
-      os_version: '9.9.9',
-      device_model: 'TAB 2 A7'
-    })
+  it('should return an empty object when there is no user agent', () => {
+    const result = parseUserAgentProperties(undefined)
+    expect(result).toEqual({})
   })
 })

--- a/packages/destination-actions/src/destinations/amplitude/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/identifyUser/index.ts
@@ -1,5 +1,5 @@
 import { URLSearchParams } from 'url'
-import type { ActionDefinition } from '@segment/actions-core'
+import { ActionDefinition, removeUndefined } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { convertUTMProperties } from '../utm'
@@ -239,7 +239,7 @@ const action: ActionDefinition<Settings, Payload> = {
       // Conditionally parse user agent using amplitude's library
       ...(userAgentParsing && parseUserAgentProperties(userAgent)),
       // Make sure any top-level properties take precedence over user-agent properties
-      ...rest,
+      ...removeUndefined(rest),
       user_properties: userProperties,
       library: 'segment'
     })

--- a/packages/destination-actions/src/destinations/amplitude/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/identifyUser/index.ts
@@ -4,7 +4,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { convertUTMProperties } from '../utm'
 import { convertReferrerProperty } from '../referrer'
-import { parseAndMergeUserAgentProperties } from '../user-agent'
+import { parseUserAgentProperties } from '../user-agent'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Identify User',
@@ -236,10 +236,11 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     const identification = JSON.stringify({
+      // Conditionally parse user agent using amplitude's library
+      ...(userAgentParsing && parseUserAgentProperties(userAgent)),
+      // Make sure any top-level properties take precedence over user-agent properties
       ...rest,
       user_properties: userProperties,
-      // Conditionally parse user agent using amplitude's library, we spread payload here to pick up existing os, browser, and device properties
-      ...(userAgentParsing && { ...parseAndMergeUserAgentProperties({ userAgent, ...rest }) }),
       library: 'segment'
     })
     return request('https://api.amplitude.com/identify', {

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
@@ -7,7 +7,7 @@ import type { Payload } from './generated-types'
 import { convertUTMProperties } from '../utm'
 import { convertReferrerProperty } from '../referrer'
 import { mergeUserProperties } from '../merge-user-properties'
-import { parseAndMergeUserAgentProperties } from '../user-agent'
+import { parseUserAgentProperties } from '../user-agent'
 
 export interface AmplitudeEvent extends Omit<Payload, 'products' | 'trackRevenuePerProduct' | 'time' | 'session_id'> {
   library?: string
@@ -183,9 +183,10 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const events: AmplitudeEvent[] = [
       {
+        // Conditionally parse user agent using amplitude's library
+        ...(userAgentParsing && parseUserAgentProperties(userAgent)),
+        // Make sure any top-level properties take precedence over user-agent properties
         ...properties,
-        // Conditionally parse user agent using amplitude's library, we spread payload here to pick up existing os, browser, and device properties
-        ...(userAgentParsing && { ...parseAndMergeUserAgentProperties({ userAgent, ...payload }) }),
         // Conditionally track revenue with main event
         ...(products.length && trackRevenuePerProduct ? {} : getRevenueProperties(payload)),
         library: 'segment'

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
@@ -1,4 +1,4 @@
-import { omit } from '@segment/actions-core'
+import { omit, removeUndefined } from '@segment/actions-core'
 import dayjs from '../../../lib/dayjs'
 import { eventSchema } from '../event-schema'
 import type { ActionDefinition } from '@segment/actions-core'
@@ -186,7 +186,7 @@ const action: ActionDefinition<Settings, Payload> = {
         // Conditionally parse user agent using amplitude's library
         ...(userAgentParsing && parseUserAgentProperties(userAgent)),
         // Make sure any top-level properties take precedence over user-agent properties
-        ...properties,
+        ...removeUndefined(properties),
         // Conditionally track revenue with main event
         ...(products.length && trackRevenuePerProduct ? {} : getRevenueProperties(payload)),
         library: 'segment'

--- a/packages/destination-actions/src/destinations/amplitude/user-agent.ts
+++ b/packages/destination-actions/src/destinations/amplitude/user-agent.ts
@@ -1,9 +1,4 @@
 import UaParser from '@amplitude/ua-parser-js'
-import { omit } from 'lodash'
-
-interface Payload {
-  userAgent?: string
-}
 
 interface ParsedUA {
   os_name?: string
@@ -11,20 +6,21 @@ interface ParsedUA {
   device_model?: string
 }
 
-export function parseAndMergeUserAgentProperties(payload: Payload & ParsedUA): ParsedUA {
-  if (!payload?.userAgent) {
-    return omit(payload, 'userAgent')
+export function parseUserAgentProperties(userAgent?: string): ParsedUA {
+  if (!userAgent) {
+    return {}
   }
+
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-  const parser = new UaParser(payload?.userAgent)
+  const parser = new UaParser(userAgent)
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   const device = parser.getDevice()
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   const os = parser.getOS()
 
   return {
-    os_name: payload.os_name ?? os.name,
-    os_version: payload.os_version ?? os.version,
-    device_model: payload.device_model ?? device.model
+    os_name: os.name,
+    os_version: os.version,
+    device_model: device.model
   }
 }


### PR DESCRIPTION
The user agent parsing code was incorrectly overwriting some fields that have special formatting for Amplitude.

I fixed how the user agent object gets merged and updated the tests to include the time value so we would caught something like this next time!