### PR TITLE
Braze/plugin

### DIFF
--- a/packages/browser-destinations/src/destinations/braze-cloud-plugins/debouncePlugin.types.ts
+++ b/packages/browser-destinations/src/destinations/braze-cloud-plugins/debouncePlugin.types.ts
@@ -1,0 +1,3 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {}

--- a/packages/browser-destinations/src/destinations/index.ts
+++ b/packages/browser-destinations/src/destinations/index.ts
@@ -28,3 +28,4 @@ function register(id: MetadataId, destinationPath: string) {
 // TODO figure out if it's possible to colocate the Amplitude web action with the rest of its destination definition (in `./packages/destination-actions`)
 register('5f7dd6d21ad74f3842b1fc47', './amplitude-plugins')
 register('60fb01aec459242d3b6f20c1', './braze')
+register('60f9d0d048950c356be2e4da', './braze-cloud-plugins')


### PR DESCRIPTION
This adds the definition file that includes the Braze Cloud web plugin (whew!) to the manifest + its generated types.