### PR TITLE
push-browser-destination touch ups

### DIFF
--- a/packages/browser-destinations/package.json
+++ b/packages/browser-destinations/package.json
@@ -17,7 +17,7 @@
     "build-ts": "yarn tsc -b tsconfig.build.json",
     "build-web": "NODE_ENV=production ASSET_ENV=production yarn webpack -c webpack.config.js",
     "build-web-stage": "NODE_ENV=production ASSET_ENV=stage yarn webpack -c webpack.config.js",
-    "deploy-prod": "yarn build-web && aws-okta exec plat-write -- aws s3 sync ./dist/web/ s3://segment-ajs-next-destinations-production/next-integrations/actions --grants read=id=$npm_config_prod_cdn_oai,id=$npm_config_prod_custom_domain_oai",
+    "deploy-prod": "yarn build-web && aws s3 sync ./dist/web/ s3://segment-ajs-next-destinations-production/next-integrations/actions --grants read=id=$npm_config_prod_cdn_oai,id=$npm_config_prod_custom_domain_oai",
     "deploy-stage": "yarn build-web-stage && aws-okta exec plat-write -- aws s3 sync ./dist/web/ s3://segment-ajs-next-destinations-stage/next-integrations/actions --grants read=id=$npm_config_stage_cdn_oai,id=$npm_config_stage_custom_domain_oai",
     "clean": "tsc -b tsconfig.build.json --clean",
     "postclean": "rm -rf dist",

--- a/packages/cli/src/commands/push-browser-destinations.ts
+++ b/packages/cli/src/commands/push-browser-destinations.ts
@@ -85,14 +85,12 @@ export default class PushBrowserDestinations extends Command {
       const existingPlugin = remotePlugins.find((p) => p.metadataId === metadata.id && p.name === metadata.name)
 
       if (existingPlugin) {
-        this.log(`Updating remote plugin for ${metadata.name}`)
         await updateRemotePlugin(input)
+        this.spinner.succeed(`Updated existing remote plugin for ${metadata.name}`)
       } else {
-        this.log(`Creating remote plugin for ${metadata.name}`)
         await createRemotePlugin(input)
+        this.spinner.succeed(`Created new remote plugin for ${metadata.name}`)
       }
-
-      this.spinner.succeed(`Saved remote plugin for ${metadata.name}`)
     }
 
     try {

--- a/packages/cli/src/commands/push-browser-destinations.ts
+++ b/packages/cli/src/commands/push-browser-destinations.ts
@@ -106,12 +106,7 @@ export default class PushBrowserDestinations extends Command {
 }
 
 async function build(): Promise<string> {
-  execa.commandSync('lerna run build')
-  if (process.env.NODE_ENV === 'stage') {
-    return execa.commandSync('lerna run build-web-stage').stdout
-  }
-
-  return execa.commandSync('lerna run build-web').stdout
+  return execa.commandSync('lerna run build').stdout
 }
 
 async function syncToS3(): Promise<string> {

--- a/packages/cli/src/commands/push-browser-destinations.ts
+++ b/packages/cli/src/commands/push-browser-destinations.ts
@@ -108,7 +108,12 @@ export default class PushBrowserDestinations extends Command {
 }
 
 async function build(): Promise<string> {
-  return execa.commandSync('lerna run build').stdout
+  execa.commandSync('lerna run build').stdout
+  if (process.env.SERVER_ENVIRONMENT === 'production') {
+    return execa.commandSync('lerna run build-web').stdout
+  }
+
+  return execa.commandSync('lerna run build-web-stage').stdout
 }
 
 async function syncToS3(): Promise<string> {

--- a/packages/cli/src/commands/push-browser-destinations.ts
+++ b/packages/cli/src/commands/push-browser-destinations.ts
@@ -85,8 +85,10 @@ export default class PushBrowserDestinations extends Command {
       const existingPlugin = remotePlugins.find((p) => p.metadataId === metadata.id && p.name === metadata.name)
 
       if (existingPlugin) {
+        this.log(`Updating remote plugin for ${metadata.name}`)
         await updateRemotePlugin(input)
       } else {
+        this.log(`Creating remote plugin for ${metadata.name}`)
         await createRemotePlugin(input)
       }
 

--- a/packages/cli/src/commands/push-browser-destinations.ts
+++ b/packages/cli/src/commands/push-browser-destinations.ts
@@ -108,7 +108,7 @@ export default class PushBrowserDestinations extends Command {
 }
 
 async function build(): Promise<string> {
-  execa.commandSync('lerna run build').stdout
+  execa.commandSync('lerna run build')
   if (process.env.SERVER_ENVIRONMENT === 'production') {
     return execa.commandSync('lerna run build-web').stdout
   }

--- a/packages/cli/src/commands/push-browser-destinations.ts
+++ b/packages/cli/src/commands/push-browser-destinations.ts
@@ -110,15 +110,11 @@ async function build(): Promise<string> {
 }
 
 async function syncToS3(): Promise<string> {
-  if (process.env.NODE_ENV === 'production') {
-    const command = `lerna run deploy-prod`
-    return execa.commandSync(command).stdout
-  }
-
   if (process.env.NODE_ENV === 'stage') {
     const command = `lerna run deploy-stage`
     return execa.commandSync(command).stdout
   }
 
-  return 'Nothing to upload.'
+  const command = `lerna run deploy-prod`
+  return execa.commandSync(command).stdout
 }

--- a/packages/cli/src/commands/push-browser-destinations.ts
+++ b/packages/cli/src/commands/push-browser-destinations.ts
@@ -110,11 +110,11 @@ async function build(): Promise<string> {
 }
 
 async function syncToS3(): Promise<string> {
-  if (process.env.NODE_ENV === 'stage') {
-    const command = `lerna run deploy-stage`
+  if (process.env.SERVER_ENVIRONMENT === 'production') {
+    const command = `lerna run deploy-prod`
     return execa.commandSync(command).stdout
   }
 
-  const command = `lerna run deploy-prod`
+  const command = `lerna run deploy-stage`
   return execa.commandSync(command).stdout
 }

--- a/packages/cli/src/commands/push-browser-destinations.ts
+++ b/packages/cli/src/commands/push-browser-destinations.ts
@@ -3,7 +3,7 @@ import execa from 'execa'
 import chalk from 'chalk'
 import { manifest } from '@segment/browser-destinations'
 import ora from 'ora'
-import { ASSET_PATH } from '../config'
+import { assetPath } from '../config'
 import type { RemotePlugin } from '../lib/control-plane-service'
 import { prompt } from '../lib/prompt'
 import {
@@ -41,6 +41,8 @@ export default class PushBrowserDestinations extends Command {
         value: id
       }))
     })
+
+    const path = assetPath(flags.env)
 
     if (!destinationIds.length) {
       this.warn(`You must select at least one destination. Exiting...`)
@@ -82,7 +84,7 @@ export default class PushBrowserDestinations extends Command {
         // This MUST match the way webpack exports the libraryName in the umd bundle
         // TODO make this more automatic for consistency
         libraryName: `${entry.directory}Destination`,
-        url: `${ASSET_PATH}/${entry.directory}.js`
+        url: `${path}/${entry.directory}.js`
       }
 
       // We expect that each definition produces a single Remote Plugin bundle

--- a/packages/cli/src/commands/push-browser-destinations.ts
+++ b/packages/cli/src/commands/push-browser-destinations.ts
@@ -116,10 +116,8 @@ async function build(): Promise<string> {
 
 async function syncToS3(): Promise<string> {
   if (process.env.SERVER_ENVIRONMENT === 'production') {
-    const command = `lerna run deploy-prod`
-    return execa.commandSync(command).stdout
+    return execa.commandSync(`lerna run deploy-prod`).stdout
   }
 
-  const command = `lerna run deploy-stage`
-  return execa.commandSync(command).stdout
+  return execa.commandSync(`lerna run deploy-stage`).stdout
 }

--- a/packages/cli/src/commands/push-browser-destinations.ts
+++ b/packages/cli/src/commands/push-browser-destinations.ts
@@ -24,7 +24,8 @@ export default class PushBrowserDestinations extends Command {
     help: flags.help({ char: 'h' }),
     env: flags.string({
       char: 'e',
-      default: 'stage'
+      default: 'stage',
+      env: 'NODE_ENV' // or whatever
     })
   }
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,5 +1,5 @@
 export const ASSET_PATH =
-  process.env.NODE_ENV === 'production'
+  process.env.NODE_ENV === 'production' || process.env.SERVER_ENVIRONMENT === 'production'
     ? 'https://cdn.segment.com/next-integrations/actions'
     : process.env.NODE_ENV === 'stage'
     ? 'https://cdn.segment.build/next-integrations/actions'

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,6 +1,4 @@
 export const ASSET_PATH =
   process.env.NODE_ENV === 'production' || process.env.SERVER_ENVIRONMENT === 'production'
     ? 'https://cdn.segment.com/next-integrations/actions'
-    : process.env.NODE_ENV === 'stage'
-    ? 'https://cdn.segment.build/next-integrations/actions'
-    : undefined
+    : 'https://cdn.segment.build/next-integrations/actions'

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,4 +1,5 @@
-export const ASSET_PATH =
-  process.env.NODE_ENV === 'production' || process.env.SERVER_ENVIRONMENT === 'production'
+export function assetPath(env: string): string {
+  return env === 'production'
     ? 'https://cdn.segment.com/next-integrations/actions'
     : 'https://cdn.segment.build/next-integrations/actions'
+}


### PR DESCRIPTION
This PR just adds a little bit of logging to the `push-browser-destination` command and tweaks around environment variables.

The command no longer requires environment variables to be passed on. If run on the production workbench, the script will check for `SERVER_ENVIRONMENT`, present on the workbench, otherwise, it'll assume it's a stage build.

![image](https://user-images.githubusercontent.com/484013/129814471-0c2dc4d4-ff50-4725-b59f-4242ba2a27c5.png)
