### PR TITLE
Fix type generation

### DIFF
--- a/packages/browser-destinations/src/destinations/braze/debounce/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/debounce/index.ts
@@ -42,7 +42,6 @@ const action: BrowserActionDefinition<Settings, typeof appboy, Payload> = {
   description:
     'When enabled, it ensures that only events where at least one changed trait value are sent to Braze, and events with duplicate traits are not sent.',
   platform: 'web',
-  hidden: true,
   defaultSubscription: 'type = "identify" or type = "group"',
   fields: {},
   lifecycleHook: 'before',

--- a/packages/core/src/__tests__/schema-validation.test.ts
+++ b/packages/core/src/__tests__/schema-validation.test.ts
@@ -42,6 +42,28 @@ describe('validateSchema', () => {
     expect(payload).toMatchInlineSnapshot(`Object {}`)
   })
 
+  it('should allow any properties when an object type does not specify', () => {
+    const payload = {
+      a: 'a',
+      b: {
+        anything: 'goes'
+      },
+      d: 'd'
+    }
+
+    validateSchema(payload, schema, `testSchema`)
+    expect(payload).toHaveProperty('b')
+    expect(payload.b).toHaveProperty('anything')
+    expect(payload).toMatchInlineSnapshot(`
+      Object {
+        "a": "a",
+        "b": Object {
+          "anything": "goes",
+        },
+      }
+    `)
+  })
+
   // For now we always remove unknown keys, until builders have a way to specify the behavior
   it.todo('should not remove nested keys for valid properties')
 

--- a/packages/core/src/__tests__/schema-validation.test.ts
+++ b/packages/core/src/__tests__/schema-validation.test.ts
@@ -42,36 +42,8 @@ describe('validateSchema', () => {
     expect(payload).toMatchInlineSnapshot(`Object {}`)
   })
 
-  it('should not remove nested keys for valid properties', () => {
-    const payload = {
-      a: 1234,
-      b: {
-        anything: 'goes'
-      },
-      c: {
-        d: 'works!',
-        whatever: 'also works!'
-      },
-      e: 'true',
-      f: '123'
-    }
-
-    validateSchema(payload, schema, `testSchema`)
-    expect(payload).toMatchInlineSnapshot(`
-      Object {
-        "a": "1234",
-        "b": Object {
-          "anything": "goes",
-        },
-        "c": Object {
-          "d": "works!",
-          "whatever": "also works!",
-        },
-        "e": true,
-        "f": 123,
-      }
-    `)
-  })
+  // For now we always remove unknown keys, until builders have a way to specify the behavior
+  it.todo('should not remove nested keys for valid properties')
 
   it('should coerce properties for more flexible but type-safe inputs', () => {
     const payload = {

--- a/packages/core/src/destination-kit/fields-to-jsonschema.ts
+++ b/packages/core/src/destination-kit/fields-to-jsonschema.ts
@@ -16,10 +16,7 @@ function toJsonSchemaType(type: FieldTypeName): JSONSchema4TypeName | JSONSchema
 
 type MinimalInputField = Optional<InputField, 'description'> | Optional<GlobalSetting, 'description'>
 
-export function fieldsToJsonSchema(
-  fields: Record<string, MinimalInputField> = {},
-  overrides?: JSONSchema4
-): JSONSchema4 {
+export function fieldsToJsonSchema(fields: Record<string, MinimalInputField> = {}): JSONSchema4 {
   const required: string[] = []
   const properties: Record<string, JSONSchema4> = {}
 
@@ -66,11 +63,10 @@ export function fieldsToJsonSchema(
     // Note: this is used for the json schema validation and type-generation,
     // but is not stored in the db. It only lives in the code.
     if (schemaType === 'object' && field.properties) {
-      const additionalProperties = true
       if (isMulti) {
-        schema.items = fieldsToJsonSchema(field.properties, { additionalProperties })
+        schema.items = fieldsToJsonSchema(field.properties)
       } else {
-        schema = { ...schema, ...fieldsToJsonSchema(field.properties, { additionalProperties }) }
+        schema = { ...schema, ...fieldsToJsonSchema(field.properties) }
       }
     }
 
@@ -85,7 +81,7 @@ export function fieldsToJsonSchema(
   return {
     $schema: 'http://json-schema.org/schema#',
     type: 'object',
-    additionalProperties: overrides?.additionalProperties ?? false,
+    additionalProperties: false,
     properties,
     required
   }


### PR DESCRIPTION
This PR fixes a small type regression I introduced yesterday. We want type-safety even for object fields, but my changes to allow additional properties yields types like `[key: string]: unknown` on those object fields. So for now we must remove additional properties for all object fields until we give builders more control.

I added a test to verify the behavior, and a `todo` test for if/when we add different behavior based on builder definitions.