### PR TITLE
Remove `ab_segment_group` logic from logUser action

### DIFF
--- a/packages/browser-destinations/src/destinations/braze/__tests__/logUser.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/logUser.test.ts
@@ -26,8 +26,7 @@ describe('logUser', () => {
         language: { '@path': '$.traits.language' },
         last_name: { '@path': '$.traits.last_name' },
         phone: { '@path': '$.traits.phone' },
-        push_subscribe: { '@path': '$.traits.push_subscribe' },
-        group_id: { '@path': '$.groupId' }
+        push_subscribe: { '@path': '$.traits.push_subscribe' }
       }
     }
   ]
@@ -162,24 +161,6 @@ describe('logUser', () => {
     expect(userMock.setLastKnownLocation).toHaveBeenCalledWith(-23.54, -46.65)
     expect(userMock.setPhoneNumber).toHaveBeenCalledWith('555 5555')
     expect(userMock.setPushNotificationSubscriptionType).toHaveBeenCalledWith(true)
-  })
-
-  test('set custom attribute based on group_id property', async () => {
-    const [logPurchase] = await brazeDestination({
-      api_key: 'b_123',
-      endpoint: 'endpoint',
-      subscriptions
-    })
-
-    await logPurchase.load(Context.system(), {} as Analytics)
-    await logPurchase.identify?.(
-      new Context({
-        type: 'identify',
-        groupId: '123'
-      })
-    )
-
-    expect(userMock.setCustomUserAttribute).toHaveBeenCalledWith('ab_segment_group_123', true)
   })
 
   test('can set gender', async () => {

--- a/packages/browser-destinations/src/destinations/braze/logUser/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/braze/logUser/generated-types.ts
@@ -67,8 +67,4 @@ export interface Payload {
    * The user's push subscription preference: “opted_in” (explicitly registered to receive push messages), “unsubscribed” (explicitly opted out of push messages), and “subscribed” (neither opted in nor out).
    */
   push_subscribe?: string
-  /**
-   * The ID used to identify the group
-   */
-  group_id?: string
 }

--- a/packages/browser-destinations/src/destinations/braze/logUser/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/logUser/index.ts
@@ -146,14 +146,6 @@ const action: BrowserActionDefinition<Settings, typeof appboy, Payload> = {
       label: 'Push Subscribe',
       description: `The user's push subscription preference: “opted_in” (explicitly registered to receive push messages), “unsubscribed” (explicitly opted out of push messages), and “subscribed” (neither opted in nor out).`,
       type: 'string'
-    },
-    group_id: {
-      label: 'Group ID',
-      description: 'The ID used to identify the group',
-      type: 'string',
-      default: {
-        '@path': '$.groupId'
-      }
     }
   },
 
@@ -190,11 +182,6 @@ const action: BrowserActionDefinition<Settings, typeof appboy, Payload> = {
           user.setCustomUserAttribute(key, value as string | number | boolean | Date | string[] | null)
         }
       })
-    }
-
-    if (payload.group_id !== undefined) {
-      const groupIdKey = `ab_segment_group_${payload.group_id}`
-      user.setCustomUserAttribute(groupIdKey, true)
     }
 
     payload.email_subscribe !== undefined &&

--- a/packages/cli/src/commands/push-browser-destinations.ts
+++ b/packages/cli/src/commands/push-browser-destinations.ts
@@ -25,7 +25,7 @@ export default class PushBrowserDestinations extends Command {
     env: flags.string({
       char: 'e',
       default: 'stage',
-      env: 'NODE_ENV' // or whatever
+      env: 'NODE_ENV'
     })
   }
 


### PR DESCRIPTION
This PR removes all `ab_segment_group` usage and references (and `group_id` given it's no longer used) from the `logUser` action as per Braze's team feedback.