### PR TITLE
strip reserved keys from logUser

### DIFF
--- a/packages/browser-destinations/src/destinations/braze/logUser/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/logUser/index.ts
@@ -3,6 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import appboy from '@braze/web-sdk'
 import dayjs from '../../../lib/dayjs'
+import { omit } from '@segment/actions-core'
 
 const known_traits = ['email', 'firstName', 'gender', 'city', 'avatar', 'lastName', 'phone']
 
@@ -198,6 +199,15 @@ const action: BrowserActionDefinition<Settings, typeof appboy, Payload> = {
     payload.phone !== undefined && user.setPhoneNumber(payload.phone)
     payload.push_subscribe !== undefined &&
       user.setPushNotificationSubscriptionType(payload.push_subscribe as appboy.User.NotificationSubscriptionTypes)
+
+    if (payload.custom_attributes !== undefined) {
+      const reservedKeys = Object.keys(action.fields.custom_attributes ?? {})
+      const customAttributes = omit(payload.custom_attributes, reservedKeys)
+
+      for (const [key, val] of Object.entries(customAttributes)) {
+        user.setCustomUserAttribute(key, val as string | number | boolean | Date | string[] | null)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Based on what we do for classic braze Identify, this PR omits reserved keys from `custom_attribuets` for the `logUser` action

see: https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/appboy/lib/index.js#L296-L319