### PR TITLE
Remove --no-git-tag-version from alpha script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "subscriptions": "yarn workspace @segment/destination-subscriptions",
     "test": "lerna run test --stream",
     "typecheck": "lerna run typecheck --stream",
-    "alpha": "lerna publish prerelease --pre-dist-tag next --allow-branch '*'"
+    "alpha": "lerna publish prerelease --pre-dist-tag next --allow-branch '*' --no-git-tag-version"
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",


### PR DESCRIPTION
_Tags, we don't need no stinkin' tags_

This pull request adds a `--no-git-tag-version` flag to the `yarn alpha` script in order to avoid pushing git tags during releases. Documentation will be updated to with the `--no-git-tag-version` once this pull request is merged.

From [Lerna docs](https://github.com/lerna/lerna/tree/main/commands/publish#options):
> lerna publish supports all of the options provided by lerna version in addition to the following:
