### PR TITLE
Fix yarn alpha's allowed branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "subscriptions": "yarn workspace @segment/destination-subscriptions",
     "test": "lerna run test --stream",
     "typecheck": "lerna run typecheck --stream",
-    "alpha": "lerna publish prerelease --pre-dist-tag next --allow-branch $(git rev-parse --abbrev-ref HEAD) --no-git-tag-version"
+    "alpha": "lerna publish prerelease --pre-dist-tag next --allow-branch '**' --no-git-tag-version"
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "subscriptions": "yarn workspace @segment/destination-subscriptions",
     "test": "lerna run test --stream",
     "typecheck": "lerna run typecheck --stream",
-    "alpha": "lerna publish prerelease --pre-dist-tag next --allow-branch '*' --no-git-tag-version"
+    "alpha": "lerna publish prerelease --pre-dist-tag next --allow-branch $(git rev-parse --abbrev-ref HEAD) --no-git-tag-version"
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",


### PR DESCRIPTION
Lerna uses [minimatch](https://github.com/isaacs/minimatch) when matching branches set in the `--allowed-branches` flag. The library uses `**` as a wildcard as opposed to `*`. This pull request fixes that.

## Testing

```
action-destinations on  gps/alpha
yarn run v1.19.1
$ lerna publish prerelease --pre-dist-tag next --allow-branch '*' --no-git-tag-version
lerna notice cli v4.0.0
lerna info versioning independent
lerna WARN Yarn's registry proxy is broken, replacing with public npm registry
lerna WARN If you don't have an npm token, you should exit and run `npm login`
lerna ERR! ENOTALLOWED Branch 'gps/alpha' is restricted from versioning due to allowBranch config.
lerna ERR! ENOTALLOWED Please consider the reasons for this restriction before overriding the option.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

action-destinations on  gps/alpha 
yarn run v1.19.1
$ lerna publish prerelease --pre-dist-tag next --allow-branch '**' --no-git-tag-version
lerna notice cli v4.0.0
lerna info versioning independent
lerna WARN Yarn's registry proxy is broken, replacing with public npm registry
lerna WARN If you don't have an npm token, you should exit and run `npm login`
lerna info Looking for changed packages since @segment/action-destinations@3.5.1
lerna success No changed packages to publish
```