### PR TITLE
fix browser ready fn

### DIFF
--- a/packages/browser-destinations/src/runtime/plugin.ts
+++ b/packages/browser-destinations/src/runtime/plugin.ts
@@ -62,7 +62,7 @@ export function generatePlugins<S, C>(
       name: `${def.name} ${key}`,
       type: action.lifecycleHook ?? 'destination',
       version: '0.1.0',
-      ready: Promise.resolve,
+      ready: () => Promise.resolve(),
 
       isLoaded: () => hasInitialized,
       load,


### PR DESCRIPTION
Promise.resolve requires the correct binding context to be called.