### PR TITLE
Change alpha to canary release

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "subscriptions": "yarn workspace @segment/destination-subscriptions",
     "test": "lerna run test --stream",
     "typecheck": "lerna run typecheck --stream",
-    "alpha": "lerna publish prerelease --pre-dist-tag next --allow-branch '**' --no-git-tag-version"
+    "alpha": "lerna publish prerelease --pre-dist-tag next --canary --allow-branch '**' --no-git-tag-version"
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",


### PR DESCRIPTION
This should prevent folks that are pushing multiple alphas across separate branches from stepping on each other.

Its not clear to me if the `--pre-dist-tag next` should stay or not from the lerna docs