### PR TITLE
Reduce the final number of chunks in the web runtime

### DIFF
--- a/packages/browser-destinations/webpack.config.js
+++ b/packages/browser-destinations/webpack.config.js
@@ -35,6 +35,12 @@ if (process.env.ANALYZE) {
   )
 }
 
+plugins.push(
+  new webpack.optimize.LimitChunkCountPlugin({
+    maxChunks: 1
+  })
+)
+
 module.exports = {
   entry: entries,
   mode: process.env.NODE_ENV || 'development',
@@ -97,17 +103,7 @@ module.exports = {
           }
         }
       })
-    ],
-    splitChunks: {
-      cacheGroups: {
-        default: false,
-        defaultVendors: false,
-        commons: {
-          chunks: 'all',
-          minChunks: 2
-        }
-      }
-    }
+    ]
   },
   plugins
 }


### PR DESCRIPTION
This will make sure Webpack doesn't try to generate
new chunk names too aggressively, forcing us to have to
deal with multiple versions for libraries or manually having
to import dynamic chunks.

We can achieve the level of bundle splitting we want by using
named chunk imports (as we do with the runtime).