### PR TITLE
[braze web] Call update user in track event if user id is present

### DIFF
--- a/packages/browser-destinations/src/destinations/braze/__tests__/trackEvent.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/trackEvent.test.ts
@@ -107,4 +107,38 @@ describe('trackEvent', () => {
 
     expect(changeUser).toHaveBeenCalledWith('some user')
   })
+  test('changeUser is not called if userId is not present', async () => {
+    const changeUser = jest.spyOn(appboy, 'changeUser')
+
+    const [trackEvent] = await brazeDestination({
+      api_key: 'b_123',
+      endpoint: 'endpoint',
+      subscriptions: [
+        {
+          partnerAction: 'trackEvent',
+          name: 'Log Custom Event',
+          enabled: true,
+          subscribe: 'type = "track"',
+          mapping: {
+            eventName: {
+              '@path': '$.event'
+            },
+            eventProperties: {
+              '@path': '$.properties'
+            }
+          }
+        }
+      ]
+    })
+
+    await trackEvent.load(Context.system(), {} as Analytics)
+    await trackEvent.track?.(
+      new Context({
+        type: 'track',
+        event: 'UFC'
+      })
+    )
+
+    expect(changeUser).not.toHaveBeenCalledWith('some user')
+  })
 })

--- a/packages/browser-destinations/src/destinations/braze/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/trackEvent/index.ts
@@ -30,7 +30,7 @@ const action: BrowserActionDefinition<Settings, typeof appboy, Payload> = {
   },
   perform: (client, event) => {
     if (event.payload.eventProperties?.userId) {
-      client.changeUser(event.payload.eventProperties?.userId as string)
+      client.changeUser(event.payload.eventProperties.userId as string)
     }
     client.logCustomEvent(event.payload.eventName, event.payload.eventProperties)
   }


### PR DESCRIPTION
In order to keep parity with the classic destination, this PR changes the `track event` action to call `updateUser` if the `userId` property is present on the track call payload.

https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/appboy/lib/index.js#L383-L384