### PR TITLE
[braze-web] Make sure sdk version isnt empty

### DIFF
--- a/packages/browser-destinations/src/destinations/braze/__tests__/initialization.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/initialization.test.ts
@@ -85,16 +85,12 @@ describe('initialization', () => {
   })
 
   test('loads sdk version 3.3 by default', async () => {
-    const withVersion = {
-      ...settings
-    }
-
     const dependencies = {
       loadScript: jest.fn()
     }
 
     // @ts-expect-error
-    await destination.initialize({ settings: withVersion }, dependencies)
+    await destination.initialize({ settings }, dependencies)
 
     expect(dependencies.loadScript).toHaveBeenCalledWith(`https://js.appboycdn.com/web-sdk/3.3/service-worker.js`)
   })

--- a/packages/browser-destinations/src/destinations/braze/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/braze/generated-types.ts
@@ -4,7 +4,7 @@ export interface Settings {
   /**
    * The version of the SDK to use. Defaults to 3.3.
    */
-  sdkVersion?: string
+  sdkVersion: string
   /**
    * Use the API Key to identify your application to Braze during [SDK setup](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/initial_sdk_setup/).
    */

--- a/packages/browser-destinations/src/destinations/braze/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/index.ts
@@ -58,7 +58,7 @@ export const destination: BrowserDestinationDefinition<Settings, typeof appboy> 
           label: '3.3'
         }
       ],
-      required: false
+      required: true
     },
     api_key: {
       description:
@@ -239,9 +239,11 @@ export const destination: BrowserDestinationDefinition<Settings, typeof appboy> 
     }
   },
   initialize: async ({ settings }, dependencies) => {
-    const { endpoint, sdkVersion, api_key, ...expectedConfig } = settings
+    const { endpoint, api_key, ...expectedConfig } = settings
 
-    await dependencies.loadScript(`https://js.appboycdn.com/web-sdk/${settings.sdkVersion ?? '3.3'}/service-worker.js`)
+    const sdkVersion = settings.sdkVersion?.length ? settings.sdkVersion : '3.3'
+
+    await dependencies.loadScript(`https://js.appboycdn.com/web-sdk/${sdkVersion}/service-worker.js`)
 
     const initialized = appboy.initialize(settings.api_key, { baseUrl: endpoint, ...expectedConfig })
     if (!initialized) {


### PR DESCRIPTION
This PR makes sure `sdkVersion`, is:
1. mandatory
2. not empty
3. version 3.3 is applied if no value is provided