### PR TITLE
Allow ChildProcess to be undefined

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -69,7 +69,7 @@ export default class Serve extends Command {
 
     const folderPath = path.join(process.cwd(), flags.directory, destinationName)
 
-    let child: ChildProcess | null = null
+    let child: ChildProcess | null | undefined = null
 
     const watcher = chokidar.watch(folderPath, {
       cwd: process.cwd()


### PR DESCRIPTION
When running the `./bin/push-browser-destinations`, `child` receives an undefined value, causing a TS compilation error as the variable `child` is only typed as `ChildProcess | null`, breaking the push command.

This PR changes the type of `ChildProcess` to allow it to received `undefined` values.