### PR TITLE
Subproperty schemas

### DIFF
--- a/packages/cli/src/commands/generate/types.ts
+++ b/packages/cli/src/commands/generate/types.ts
@@ -137,7 +137,7 @@ async function generateTypes(fields: Record<string, InputField> = {}, name: stri
 }
 
 function prepareSchema(fields: Record<string, InputField>): JSONSchema4 {
-  let schema = fieldsToJsonSchema(fields)
+  let schema = fieldsToJsonSchema(fields, { tsType: true })
   // Remove titles so it produces cleaner output
   schema = removeTitles(schema)
   return schema

--- a/packages/core/src/destination-kit/fields-to-jsonschema.ts
+++ b/packages/core/src/destination-kit/fields-to-jsonschema.ts
@@ -16,67 +16,63 @@ function toJsonSchemaType(type: FieldTypeName): JSONSchema4TypeName | JSONSchema
 
 export type MinimalInputField = Optional<InputField, 'description'> | Optional<GlobalSetting, 'description'>
 
+export type MinimalFields = Record<string, MinimalInputField>
+
 interface SchemaOptions {
   tsType?: boolean
 }
-
-export function fieldToSchema(field: MinimalInputField, options?: SchemaOptions): JSONSchema4 {
-  const schemaType = toJsonSchemaType(field.type)
-
-  let schema: JSONSchema4 = {
-    title: field.label,
-    description: field.description,
-    type: schemaType,
-    format: field.format,
-    default: field.default as JSONSchema4Type
-  }
-
-  if (field.type === 'datetime') {
-    schema.format = 'date-like'
-
-    if (options?.tsType) {
-      // Override generated types
-      schema.tsType = 'string | number'
-    }
-  } else if (field.type === 'password') {
-    schema.format = 'password'
-  } else if (field.type === 'text') {
-    schema.format = 'text'
-  }
-
-  if ('allowNull' in field && field.allowNull) {
-    schema.type = ([] as JSONSchema4TypeName[]).concat(schemaType, 'null')
-
-    if (typeof schema.tsType === 'string' && !schema.tsType.includes('null')) {
-      schema.tsType += ' | null'
-    }
-  }
-
-  const isMulti = 'multiple' in field && field.multiple
-  if (isMulti) {
-    schema.items = { type: schemaType }
-    schema.type = 'array'
-  }
-
-  if (schemaType === 'object' && field.properties) {
-    if (isMulti) {
-      schema.items = fieldsToJsonSchema(field.properties)
-    } else {
-      schema = { ...schema, ...fieldsToJsonSchema(field.properties) }
-    }
-  }
-
-  return schema
-}
-
-type MinimalFields = Record<string, MinimalInputField>
 
 export function fieldsToJsonSchema(fields: MinimalFields = {}, options?: SchemaOptions): JSONSchema4 {
   const required: string[] = []
   const properties: Record<string, JSONSchema4> = {}
 
   for (const [key, field] of Object.entries(fields)) {
-    properties[key] = fieldToSchema(field, options)
+    const schemaType = toJsonSchemaType(field.type)
+
+    let schema: JSONSchema4 = {
+      title: field.label,
+      description: field.description,
+      type: schemaType,
+      format: field.format,
+      default: field.default as JSONSchema4Type
+    }
+
+    if (field.type === 'datetime') {
+      schema.format = 'date-like'
+
+      if (options?.tsType) {
+        // Override generated types
+        schema.tsType = 'string | number'
+      }
+    } else if (field.type === 'password') {
+      schema.format = 'password'
+    } else if (field.type === 'text') {
+      schema.format = 'text'
+    }
+
+    if ('allowNull' in field && field.allowNull) {
+      schema.type = ([] as JSONSchema4TypeName[]).concat(schemaType, 'null')
+
+      if (typeof schema.tsType === 'string' && !schema.tsType.includes('null')) {
+        schema.tsType += ' | null'
+      }
+    }
+
+    const isMulti = 'multiple' in field && field.multiple
+    if (isMulti) {
+      schema.items = { type: schemaType }
+      schema.type = 'array'
+    }
+
+    if (schemaType === 'object' && field.properties) {
+      if (isMulti) {
+        schema.items = fieldsToJsonSchema(field.properties)
+      } else {
+        schema = { ...schema, ...fieldsToJsonSchema(field.properties) }
+      }
+    }
+
+    properties[key] = schema
 
     // Grab all the field keys with `required: true`
     if (field.required) {

--- a/packages/core/src/destination-kit/fields-to-jsonschema.ts
+++ b/packages/core/src/destination-kit/fields-to-jsonschema.ts
@@ -16,61 +16,67 @@ function toJsonSchemaType(type: FieldTypeName): JSONSchema4TypeName | JSONSchema
 
 export type MinimalInputField = Optional<InputField, 'description'> | Optional<GlobalSetting, 'description'>
 
-export function fieldsToJsonSchema(fields: Record<string, MinimalInputField> = {}): JSONSchema4 {
+interface SchemaOptions {
+  tsType?: boolean
+}
+
+export function fieldToSchema(field: MinimalInputField, options?: SchemaOptions): JSONSchema4 {
+  const schemaType = toJsonSchemaType(field.type)
+
+  let schema: JSONSchema4 = {
+    title: field.label,
+    description: field.description,
+    type: schemaType,
+    format: field.format,
+    default: field.default as JSONSchema4Type
+  }
+
+  if (field.type === 'datetime') {
+    schema.format = 'date-like'
+
+    if (options?.tsType) {
+      // Override generated types
+      schema.tsType = 'string | number'
+    }
+  } else if (field.type === 'password') {
+    schema.format = 'password'
+  } else if (field.type === 'text') {
+    schema.format = 'text'
+  }
+
+  if ('allowNull' in field && field.allowNull) {
+    schema.type = ([] as JSONSchema4TypeName[]).concat(schemaType, 'null')
+
+    if (typeof schema.tsType === 'string' && !schema.tsType.includes('null')) {
+      schema.tsType += ' | null'
+    }
+  }
+
+  const isMulti = 'multiple' in field && field.multiple
+  if (isMulti) {
+    schema.items = { type: schemaType }
+    schema.type = 'array'
+  }
+
+  if (schemaType === 'object' && field.properties) {
+    if (isMulti) {
+      schema.items = fieldsToJsonSchema(field.properties)
+    } else {
+      schema = { ...schema, ...fieldsToJsonSchema(field.properties) }
+    }
+  }
+
+  return schema
+}
+
+type MinimalFields = Record<string, MinimalInputField>
+
+export function fieldsToJsonSchema(fields: MinimalFields = {}, options?: SchemaOptions): JSONSchema4 {
   const required: string[] = []
   const properties: Record<string, JSONSchema4> = {}
 
   for (const [key, field] of Object.entries(fields)) {
-    const schemaType = toJsonSchemaType(field.type)
-
-    let schema: JSONSchema4 = {
-      title: field.label,
-      description: field.description,
-      type: schemaType,
-      format: field.format,
-      default: field.default as JSONSchema4Type
-    }
-
-    if (field.type === 'datetime') {
-      schema.format = 'date-like'
-      // Override generated types
-      schema.tsType = 'string | number'
-    } else if (field.type === 'password') {
-      schema.format = 'password'
-    } else if (field.type === 'text') {
-      schema.format = 'text'
-    }
-
-    if ('dynamic' in field && field.dynamic) {
-      schema.autocomplete = true
-      schema.dynamic = true
-    }
-
-    if ('allowNull' in field && field.allowNull) {
-      schema.type = ([] as JSONSchema4TypeName[]).concat(schemaType, 'null')
-
-      if (typeof schema.tsType === 'string' && !schema.tsType.includes('null')) {
-        schema.tsType += ' | null'
-      }
-    }
-
-    const isMulti = 'multiple' in field && field.multiple
-    if (isMulti) {
-      schema.items = { type: schemaType }
-      schema.type = 'array'
-    }
-
-    // Note: this is used for the json schema validation and type-generation,
-    // but is not stored in the db. It only lives in the code.
-    if (schemaType === 'object' && field.properties) {
-      if (isMulti) {
-        schema.items = fieldsToJsonSchema(field.properties)
-      } else {
-        schema = { ...schema, ...fieldsToJsonSchema(field.properties) }
-      }
-    }
-
-    properties[key] = schema
+    properties[key] = fieldToSchema(field, options)
 
     // Grab all the field keys with `required: true`
     if (field.required) {


### PR DESCRIPTION
This PR removes `tsType` when not needed and removes the `autocomplete` and `dynamic` properties which previously were used by the app to display data differently. They've become unnecessary since we have those configurations in our data model.