### PR TITLE
[braze-web] Fix trackPurchase products mapping

### DIFF
--- a/packages/browser-destinations/src/destinations/braze/__tests__/trackPurchase.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/trackPurchase.test.ts
@@ -116,7 +116,7 @@ test('reports products when present', async () => {
         subscribe: 'type = "track"',
         mapping: {
           purchaseProperties: {
-            '@path': '$.properties.purchaseProperties'
+            '@path': '$.properties'
           },
           products: {
             '@path': '$.properties.products'
@@ -131,18 +131,16 @@ test('reports products when present', async () => {
     new Context({
       type: 'track',
       properties: {
-        purchaseProperties: {
-          banana: 'yellow'
-        },
+        banana: 'yellow',
         products: [
           {
-            productId: 'p_123',
+            product_id: 'p_123',
             price: 399,
-            currencyCode: 'BGP',
+            currency: 'BGP',
             quantity: 2
           },
           {
-            productId: 'p_456',
+            product_id: 'p_456',
             price: 0
           }
         ]
@@ -158,6 +156,18 @@ test('reports products when present', async () => {
       2,
       Object {
         "banana": "yellow",
+        "products": Array [
+          Object {
+            "currency": "BGP",
+            "price": 399,
+            "product_id": "p_123",
+            "quantity": 2,
+          },
+          Object {
+            "price": 0,
+            "product_id": "p_456",
+          },
+        ],
       },
     ]
   `)
@@ -171,6 +181,18 @@ test('reports products when present', async () => {
       1,
       Object {
         "banana": "yellow",
+        "products": Array [
+          Object {
+            "currency": "BGP",
+            "price": 399,
+            "product_id": "p_123",
+            "quantity": 2,
+          },
+          Object {
+            "price": 0,
+            "product_id": "p_456",
+          },
+        ],
       },
     ]
   `)

--- a/packages/browser-destinations/src/destinations/braze/trackPurchase/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/braze/trackPurchase/generated-types.ts
@@ -18,7 +18,7 @@ export interface Payload {
     /**
      * A string identifier for the product purchased, e.g. an SKU. Value is limited to 255 characters in length, cannot begin with a $, and can only contain alphanumeric characters and punctuation.
      */
-    productId: string
+    product_id: string
     /**
      * The price paid. Base units depend on the currency. As an example, USD should be reported as Dollars.Cents, whereas JPY should be reported as a whole number of Yen. All provided values will be rounded to two digits with toFixed(2)
      */
@@ -26,7 +26,7 @@ export interface Payload {
     /**
      * Default USD. Currencies should be represented as an ISO 4217 currency code
      */
-    currencyCode?: string
+    currency?: string
     /**
      * Default 1. The quantity of items purchased expressed as a whole number. Must be at least 1 and at most 100.
      */

--- a/packages/browser-destinations/src/destinations/braze/trackPurchase/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/trackPurchase/index.ts
@@ -67,8 +67,8 @@ const action: BrowserActionDefinition<Settings, typeof appboy, Payload> = {
     const reservedKeys = Object.keys(action.fields.products.properties ?? {})
     const purchaseProperties = omit(payload.purchaseProperties, reservedKeys)
 
-    if (payload.purchaseProperties?.products && Array.isArray(payload.purchaseProperties?.products)) {
-      payload.purchaseProperties?.products?.forEach((product) => {
+    if (purchaseProperties?.products && Array.isArray(purchaseProperties?.products)) {
+      purchaseProperties?.products?.forEach((product) => {
         const result = client.logPurchase(
           product.product_id,
           product.price,

--- a/packages/browser-destinations/src/destinations/braze/trackPurchase/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/trackPurchase/index.ts
@@ -27,7 +27,7 @@ const action: BrowserActionDefinition<Settings, typeof appboy, Payload> = {
       label: 'Products',
       description: 'List of products purchased by the user',
       properties: {
-        productId: {
+        product_id: {
           label: 'Product ID',
           type: 'string',
           required: true,
@@ -39,7 +39,7 @@ const action: BrowserActionDefinition<Settings, typeof appboy, Payload> = {
           required: true,
           description: `The price paid. Base units depend on the currency. As an example, USD should be reported as Dollars.Cents, whereas JPY should be reported as a whole number of Yen. All provided values will be rounded to two digits with toFixed(2)`
         },
-        currencyCode: {
+        currency: {
           label: 'Currency Code',
           type: 'string',
           description: `Default USD. Currencies should be represented as an ISO 4217 currency code`
@@ -67,19 +67,21 @@ const action: BrowserActionDefinition<Settings, typeof appboy, Payload> = {
     const reservedKeys = Object.keys(action.fields.products.properties ?? {})
     const purchaseProperties = omit(payload.purchaseProperties, reservedKeys)
 
-    payload.products?.forEach((product) => {
-      const result = client.logPurchase(
-        product.productId,
-        product.price,
-        product.currencyCode ?? 'USD',
-        product.quantity ?? 1,
-        purchaseProperties
-      )
+    if (payload.purchaseProperties?.products && Array.isArray(payload.purchaseProperties?.products)) {
+      payload.purchaseProperties?.products?.forEach((product) => {
+        const result = client.logPurchase(
+          product.product_id,
+          product.price,
+          product.currency ?? 'USD',
+          product.quantity ?? 1,
+          purchaseProperties
+        )
 
-      if (!result) {
-        console.warn('Braze failed to attach purchase to the session for product ', product.productId)
-      }
-    })
+        if (!result) {
+          console.warn('Braze failed to attach purchase to the session for product ', product.productId)
+        }
+      })
+    }
   }
 }
 


### PR DESCRIPTION
the `trackPurchase` action wasn't being invoked because of a few issues:
- the customer passes in product properties in snake_case instead of camelCase;
- the `products` array is located inside the `purchaseProperties` object;