### PR TITLE
[braze web] Fix traits being passed as custom_attributes on

### DIFF
--- a/packages/browser-destinations/src/destinations/braze/updateUserProfile/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/updateUserProfile/index.ts
@@ -174,6 +174,7 @@ const action: BrowserActionDefinition<Settings, typeof appboy, Payload> = {
       }
     }
 
+    // Adding `firstName` and `lastName` here as these fields are mapped using cammel_case.
     const reservedFields = [...Object.keys(action.fields ?? {}), 'firstName', 'lastName']
     if (payload.custom_attributes !== undefined) {
       Object.entries(payload.custom_attributes).forEach(([key, value]) => {

--- a/packages/browser-destinations/src/destinations/braze/updateUserProfile/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/updateUserProfile/index.ts
@@ -174,9 +174,9 @@ const action: BrowserActionDefinition<Settings, typeof appboy, Payload> = {
       }
     }
 
+    const reservedFields = [...Object.keys(action.fields ?? {}), 'firstName', 'lastName']
     if (payload.custom_attributes !== undefined) {
       Object.entries(payload.custom_attributes).forEach(([key, value]) => {
-        const reservedFields = Object.keys(action.fields ?? {})
         if (!reservedFields.includes(key)) {
           user.setCustomUserAttribute(key, value as string | number | boolean | Date | string[] | null)
         }

--- a/packages/browser-destinations/src/destinations/braze/updateUserProfile/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/updateUserProfile/index.ts
@@ -175,7 +175,7 @@ const action: BrowserActionDefinition<Settings, typeof appboy, Payload> = {
     }
 
     // Adding `firstName` and `lastName` here as these fields are mapped using cammel_case.
-    const reservedFields = [...Object.keys(action.fields ?? {}), 'firstName', 'lastName']
+    const reservedFields = [...Object.keys(action.fields), 'firstName', 'lastName']
     if (payload.custom_attributes !== undefined) {
       Object.entries(payload.custom_attributes).forEach(([key, value]) => {
         if (!reservedFields.includes(key)) {


### PR DESCRIPTION
This PR fixes traits (such as `firstName` and `lastName`) being passed as `custom_attributes` to braze