### PR TITLE
add nested resolution for @literal directives

### DIFF
--- a/packages/core/src/mapping-kit/__tests__/index.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.test.ts
@@ -68,6 +68,35 @@ describe('no-op', () => {
   })
 })
 
+describe('@literal', () => {
+  test('simple', () => {
+    const output = transform({ simple: { '@literal': false } })
+    expect(output).toStrictEqual({ simple: false })
+  })
+
+  test('nested directives', () => {
+    const output = transform(
+      {
+        nested: {
+          '@literal': {
+            a: {
+              '@path': '$.a'
+            },
+            b: {
+              '@path': '$.b'
+            }
+          }
+        }
+      },
+      {
+        a: 'some value'
+      }
+    )
+
+    expect(output).toStrictEqual({ nested: { a: 'some value' } })
+  })
+})
+
 describe('@if', () => {
   const payload = { a: 1, b: true, c: false, d: null }
 

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -77,8 +77,8 @@ registerStringDirective('@template', (template: string, payload) => {
 })
 
 // Literal should be used in place of 'empty' template strings as they will not resolve correctly
-registerDirective('@literal', (value) => {
-  return value
+registerDirective('@literal', (value, payload) => {
+  return resolve(value, payload)
 })
 
 /**


### PR DESCRIPTION
I noticed that `@literal` directives containing an object with nested directives wasn't getting fully resolved. This fixes that behavior and adds some tests.