### PR TITLE
[braze web] Change API Key desc and fix trackPurchase number parsing

### DIFF
--- a/packages/browser-destinations/src/destinations/braze/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/braze/generated-types.ts
@@ -6,7 +6,7 @@ export interface Settings {
    */
   sdkVersion: string
   /**
-   * Use the API Key to identify your application to Braze during [SDK setup](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/initial_sdk_setup/).
+   * Found in the Braze Dashboard under Settings → Manage Settings → Apps → Web
    */
   api_key: string
   /**

--- a/packages/browser-destinations/src/destinations/braze/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/index.ts
@@ -62,8 +62,7 @@ export const destination: BrowserDestinationDefinition<Settings, typeof appboy> 
       required: true
     },
     api_key: {
-      description:
-        'Use the API Key to identify your application to Braze during [SDK setup](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/initial_sdk_setup/).',
+      description: 'Found in the Braze Dashboard under Settings → Manage Settings → Apps → Web',
       label: 'API Key',
       type: 'password',
       required: true

--- a/packages/browser-destinations/src/destinations/braze/trackPurchase/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/trackPurchase/index.ts
@@ -61,7 +61,7 @@ const action: BrowserActionDefinition<Settings, typeof appboy, Payload> = {
     if (purchaseProperties?.products && Array.isArray(purchaseProperties?.products)) {
       purchaseProperties?.products?.forEach((product) => {
         const result = client.logPurchase(
-          product.product_id,
+          (product.product_id as string | number).toString(),
           product.price,
           product.currency ?? 'USD',
           product.quantity ?? 1,


### PR DESCRIPTION
This PR:
- Changes the API Key description for braze web;
- Fixes the `trackPurchase` action that was failing when a `productId` was passed as a number instead of a string