### PR TITLE
Update Sendgrid and Twilio personas action

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -97,7 +97,8 @@ for (const environment of ['stage', 'production']) {
           replyToName: 'Test user',
           bodyType: 'html',
           profile: {},
-          previewText: ''
+          previewText: '',
+          bcc: '[]'
         }
       })
       expect(responses.length).toEqual(3)

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -18,19 +18,24 @@ for (const environment of ['stage', 'production']) {
             to: [
               {
                 email: 'test@example.com',
-                name: 'First Name'
+                name: 'First Name Browning'
               }
             ],
+            bcc: [],
             custom_args: {
-              user_id: 'jane',
-              source_id: '',
-              space_id: ''
+              source_id: 'sourceId',
+              space_id: 'spaceId',
+              user_id: 'jane'
             }
           }
         ],
         from: {
           email: 'from@example.com',
           name: 'From Name'
+        },
+        reply_to: {
+          email: 'replyto@example.com',
+          name: 'Test user'
         },
         subject: 'Hello Browning First Name.',
         content: [
@@ -54,13 +59,18 @@ for (const environment of ['stage', 'production']) {
           userId: { '@path': '$.userId' },
           body: 'Hi {{firstName}}, Welcome to segment',
           subject: 'Hello {{lastName}} {{firstName}}.',
-          email: 'test@example.com',
-          firstName: 'First Name',
-          from: 'from@example.com',
+          fromEmail: 'from@example.com',
           fromName: 'From Name',
+          spaceId: 'spaceId',
+          sourceId: 'sourceId',
+          bodyHtml: '<p>Some content</p>',
+          replyToEmail: 'replyto@example.com',
+          replyToName: 'Test user',
+          bodyType: 'html',
           profile: {
             firstName: 'First Name',
-            lastName: 'Browning'
+            lastName: 'Browning',
+            email: 'test@example.com'
           }
         }
       })

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -96,7 +96,8 @@ for (const environment of ['stage', 'production']) {
           replyToEmail: 'replyto@example.com',
           replyToName: 'Test user',
           bodyType: 'html',
-          profile: {}
+          profile: {},
+          previewText: ''
         }
       })
       expect(responses.length).toEqual(3)

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -10,12 +10,12 @@ for (const environment of ['stage', 'production']) {
     sendGridApiKey: 'sendGridApiKey',
     profileApiEnvironment: environment,
     profileApiAccessToken: 'c',
-    profileApiSpaceId: 'd'
+    spaceId: 'spaceId'
   }
   const endpoint = `https://profiles.segment.${environment === 'production' ? 'com' : 'build'}`
   describe(`${environment} - send Email`, () => {
     it('should send Email', async () => {
-      nock(`${endpoint}/v1/spaces/d/collections/users/profiles/user_id:jane`)
+      nock(`${endpoint}/v1/spaces/spaceId/collections/users/profiles/user_id:jane`)
         .get('/traits?limit=200')
         .reply(200, {
           traits: {
@@ -24,7 +24,7 @@ for (const environment of ['stage', 'production']) {
           }
         })
 
-      nock(`${endpoint}/v1/spaces/d/collections/users/profiles/user_id:jane`)
+      nock(`${endpoint}/v1/spaces/spaceId/collections/users/profiles/user_id:jane`)
         .get('/external_ids?limit=25')
         .reply(200, {
           data: [
@@ -91,7 +91,6 @@ for (const environment of ['stage', 'production']) {
           subject: 'Hello {{profile.traits.lastName}} {{profile.traits.firstName}}.',
           fromEmail: 'from@example.com',
           fromName: 'From Name',
-          spaceId: 'spaceId',
           sourceId: 'sourceId',
           bodyHtml: '<p>Some content</p>',
           replyToEmail: 'replyto@example.com',

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -10,7 +10,8 @@ for (const environment of ['stage', 'production']) {
     sendGridApiKey: 'sendGridApiKey',
     profileApiEnvironment: environment,
     profileApiAccessToken: 'c',
-    spaceId: 'spaceId'
+    spaceId: 'spaceId',
+    sourceId: 'sourceId'
   }
   const endpoint = `https://profiles.segment.${environment === 'production' ? 'com' : 'build'}`
   describe(`${environment} - send Email`, () => {
@@ -91,7 +92,6 @@ for (const environment of ['stage', 'production']) {
           subject: 'Hello {{profile.traits.lastName}} {{profile.traits.firstName}}.',
           fromEmail: 'from@example.com',
           fromName: 'From Name',
-          sourceId: 'sourceId',
           bodyHtml: '<p>Some content</p>',
           replyToEmail: 'replyto@example.com',
           replyToName: 'Test user',

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/generated-types.ts
@@ -17,4 +17,8 @@ export interface Settings {
    * Space ID
    */
   spaceId: string
+  /**
+   * Source ID
+   */
+  sourceId: string
 }

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/generated-types.ts
@@ -10,11 +10,11 @@ export interface Settings {
    */
   profileApiEnvironment: string
   /**
-   * Profile API Space ID
-   */
-  profileApiSpaceId: string
-  /**
    * Profile API Access Token
    */
   profileApiAccessToken: string
+  /**
+   * Space ID
+   */
+  spaceId: string
 }

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/generated-types.ts
@@ -5,4 +5,16 @@ export interface Settings {
    * The Api Key for your sendGrid account
    */
   sendGridApiKey: string
+  /**
+   * Profile API Environment
+   */
+  profileApiEnvironment: string
+  /**
+   * Profile API Space ID
+   */
+  profileApiSpaceId: string
+  /**
+   * Profile API Access Token
+   */
+  profileApiAccessToken: string
 }

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/index.ts
@@ -32,6 +32,12 @@ const destination: DestinationDefinition<Settings> = {
         description: 'Space ID',
         type: 'string',
         required: true
+      },
+      sourceId: {
+        label: 'Source ID',
+        description: 'Source ID',
+        type: 'string',
+        required: true
       }
     },
 

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/index.ts
@@ -14,8 +14,27 @@ const destination: DestinationDefinition<Settings> = {
         type: 'password',
         description: 'The Api Key for your sendGrid account',
         required: true
+      },
+      profileApiEnvironment: {
+        label: 'Profile API Environment',
+        description: 'Profile API Environment',
+        type: 'string',
+        required: true
+      },
+      profileApiSpaceId: {
+        label: 'Profile API Space ID',
+        description: 'Profile API Space ID',
+        type: 'string',
+        required: true
+      },
+      profileApiAccessToken: {
+        label: 'Profile API Access Token',
+        description: 'Profile API Access Token',
+        type: 'password',
+        required: true
       }
     },
+
     testAuthentication: (request) => {
       // Return a request that tests/validates the user's authentication fields here
       return request('https://api.sendgrid.com/v3/mail_settings')

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/index.ts
@@ -40,9 +40,7 @@ const destination: DestinationDefinition<Settings> = {
         required: true
       }
     },
-
     testAuthentication: (request) => {
-      // Return a request that tests/validates the user's authentication fields here
       return request('https://api.sendgrid.com/v3/mail_settings')
     }
   },

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/index.ts
@@ -21,16 +21,16 @@ const destination: DestinationDefinition<Settings> = {
         type: 'string',
         required: true
       },
-      profileApiSpaceId: {
-        label: 'Profile API Space ID',
-        description: 'Profile API Space ID',
-        type: 'string',
-        required: true
-      },
       profileApiAccessToken: {
         label: 'Profile API Access Token',
         description: 'Profile API Access Token',
         type: 'password',
+        required: true
+      },
+      spaceId: {
+        label: 'Space ID',
+        description: 'Space ID',
+        type: 'string',
         required: true
       }
     },

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
@@ -14,28 +14,6 @@ export interface Payload {
    */
   fromName: string
   /**
-   * The message body
-   */
-  body: string
-  /**
-   * Subject for the email to be sent
-   */
-  subject: string
-  /**
-   * The Profile/Traits Properties
-   */
-  profile?: {
-    [k: string]: unknown
-  }
-  /**
-   * The type of body which is used generally html | design
-   */
-  bodyType: string
-  /**
-   * The HTML content of the body
-   */
-  bodyHtml: string
-  /**
    * The Email used by user to Reply To
    */
   replyToEmail: string
@@ -46,9 +24,25 @@ export interface Payload {
   /**
    * BCC list of emails
    */
-  bcc?: string
+  bcc: string
   /**
    * Preview Text
    */
   previewText: string
+  /**
+   * Subject for the email to be sent
+   */
+  subject: string
+  /**
+   * The message body
+   */
+  body: string
+  /**
+   * The type of body which is used generally html | design
+   */
+  bodyType: string
+  /**
+   * The HTML content of the body
+   */
+  bodyHtml: string
 }

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
@@ -4,7 +4,7 @@ export interface Payload {
   /**
    * User ID in Segment
    */
-  userId?: string
+  userId: string
   /**
    * From Email
    */
@@ -32,7 +32,7 @@ export interface Payload {
   /**
    * The Profile/Traits Properties
    */
-  profile: {
+  profile?: {
     [k: string]: unknown
   }
   /**

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
@@ -22,10 +22,6 @@ export interface Payload {
    */
   subject: string
   /**
-   * Your Profile API Space ID
-   */
-  spaceId: string
-  /**
    * The ID of your Source
    */
   sourceId: string

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
@@ -4,23 +4,15 @@ export interface Payload {
   /**
    * User ID in Segment
    */
-  userId?: string | null
+  userId?: string
   /**
    * From Email
    */
-  from: string
+  fromEmail: string
   /**
    * From Name displayed to end user email
    */
   fromName: string
-  /**
-   * The Email Address to send an email to
-   */
-  email: string
-  /**
-   * The Name of the user to send an email
-   */
-  firstName: string
   /**
    * The message body
    */
@@ -32,15 +24,35 @@ export interface Payload {
   /**
    * Your Profile API Space ID
    */
-  spaceId?: string
+  spaceId: string
   /**
    * The ID of your Source
    */
-  sourceId?: string
+  sourceId: string
   /**
    * The Profile/Traits Properties
    */
   profile: {
     [k: string]: unknown
   }
+  /**
+   * The type of body which is used generally html | design
+   */
+  bodyType: string
+  /**
+   * The HTML content of the body
+   */
+  bodyHtml: string
+  /**
+   * The Email used by user to Reply To
+   */
+  replyToEmail: string
+  /**
+   * The Name used by user to Reply To
+   */
+  replyToName: string
+  /**
+   * BCC list of emails
+   */
+  bcc: string
 }

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
@@ -22,10 +22,6 @@ export interface Payload {
    */
   subject: string
   /**
-   * The ID of your Source
-   */
-  sourceId: string
-  /**
    * The Profile/Traits Properties
    */
   profile?: {

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
@@ -54,5 +54,5 @@ export interface Payload {
   /**
    * BCC list of emails
    */
-  bcc: string
+  bcc?: string
 }

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
@@ -47,4 +47,8 @@ export interface Payload {
    * BCC list of emails
    */
   bcc?: string
+  /**
+   * Preview Text
+   */
+  previewText: string
 }

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -132,6 +132,12 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'BCC',
       description: 'BCC list of emails',
       type: 'string'
+    },
+    previewText: {
+      label: 'Preview Text',
+      description: 'Preview Text',
+      type: 'string',
+      required: true
     }
   },
   perform: async (request, { settings, payload }) => {

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -17,7 +17,7 @@ const fetchProfileTraits = async (
 ): Promise<Record<string, string>> => {
   const endpoint = getProfileApiEndpoint(settings.profileApiEnvironment)
   const response = await request(
-    `${endpoint}/v1/spaces/${settings.profileApiSpaceId}/collections/users/profiles/user_id:${profileId}/traits?limit=200`,
+    `${endpoint}/v1/spaces/${settings.spaceId}/collections/users/profiles/user_id:${profileId}/traits?limit=200`,
     {
       headers: {
         authorization: `Basic ${Buffer.from(settings.profileApiAccessToken + ':').toString('base64')}`,
@@ -37,7 +37,7 @@ const fetchProfileExternalIds = async (
 ): Promise<Record<string, string>> => {
   const endpoint = getProfileApiEndpoint(settings.profileApiEnvironment)
   const response = await request(
-    `${endpoint}/v1/spaces/${settings.profileApiSpaceId}/collections/users/profiles/user_id:${profileId}/external_ids?limit=25`,
+    `${endpoint}/v1/spaces/${settings.spaceId}/collections/users/profiles/user_id:${profileId}/external_ids?limit=25`,
     {
       headers: {
         authorization: `Basic ${Buffer.from(settings.profileApiAccessToken + ':').toString('base64')}`,
@@ -98,13 +98,6 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'Subject for the email to be sent',
       type: 'string',
       required: true
-    },
-    spaceId: {
-      label: 'Space ID',
-      description: 'Your Profile API Space ID',
-      type: 'string',
-      required: true,
-      default: { '@path': '$.context.personas.space_id' }
     },
     sourceId: {
       label: 'Source ID',
@@ -186,7 +179,7 @@ const action: ActionDefinition<Settings, Payload> = {
             bcc: JSON.parse(payload.bcc || '[]'),
             custom_args: {
               source_id: payload.sourceId ? payload.sourceId : '',
-              space_id: payload.spaceId ? payload.spaceId : '',
+              space_id: settings.spaceId,
               user_id: payload.userId
             }
           }

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -131,7 +131,8 @@ const action: ActionDefinition<Settings, Payload> = {
     bcc: {
       label: 'BCC',
       description: 'BCC list of emails',
-      type: 'string'
+      type: 'string',
+      required: true
     },
     previewText: {
       label: 'Preview Text',

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -99,12 +99,6 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: true
     },
-    sourceId: {
-      label: 'Source ID',
-      description: 'The ID of your Source',
-      type: 'string',
-      required: true
-    },
     profile: {
       label: 'Profile Properties',
       description: 'The Profile/Traits Properties',
@@ -178,7 +172,7 @@ const action: ActionDefinition<Settings, Payload> = {
             ],
             bcc: JSON.parse(payload.bcc || '[]'),
             custom_args: {
-              source_id: payload.sourceId ? payload.sourceId : '',
+              source_id: settings.sourceId,
               space_id: settings.spaceId,
               user_id: payload.userId
             }

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -83,8 +83,7 @@ const action: ActionDefinition<Settings, Payload> = {
     bcc: {
       label: 'BCC',
       description: 'BCC list of emails',
-      type: 'string',
-      required: true
+      type: 'string'
     }
   },
   perform: async (request, { payload }) => {

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -87,35 +87,6 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: true
     },
-    body: {
-      label: 'Body',
-      description: 'The message body',
-      type: 'text',
-      required: true
-    },
-    subject: {
-      label: 'Subject',
-      description: 'Subject for the email to be sent',
-      type: 'string',
-      required: true
-    },
-    profile: {
-      label: 'Profile Properties',
-      description: 'The Profile/Traits Properties',
-      type: 'object'
-    },
-    bodyType: {
-      label: 'Body Type',
-      description: 'The type of body which is used generally html | design',
-      type: 'string',
-      required: true
-    },
-    bodyHtml: {
-      label: 'Body Html',
-      description: 'The HTML content of the body',
-      type: 'string',
-      required: true
-    },
     replyToEmail: {
       label: 'Reply To Email',
       description: 'The Email used by user to Reply To',
@@ -139,6 +110,30 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'Preview Text',
       type: 'string',
       required: true
+    },
+    subject: {
+      label: 'Subject',
+      description: 'Subject for the email to be sent',
+      type: 'string',
+      required: true
+    },
+    body: {
+      label: 'Body',
+      description: 'The message body',
+      type: 'text',
+      required: true
+    },
+    bodyType: {
+      label: 'Body Type',
+      description: 'The type of body which is used generally html | design',
+      type: 'string',
+      required: true
+    },
+    bodyHtml: {
+      label: 'Body Html',
+      description: 'The HTML content of the body',
+      type: 'string',
+      required: true
     }
   },
   perform: async (request, { settings, payload }) => {
@@ -151,12 +146,13 @@ const action: ActionDefinition<Settings, Payload> = {
       ...externalIds,
       traits
     }
-    // const profile = payload.profile
 
     if (!profile.email) {
       return
     }
+
     let name
+
     if (traits.first_name && traits.last_name) {
       name = `${traits.first_name} ${traits.last_name}`
     } else if (traits.firstName && traits.lastName) {
@@ -166,6 +162,7 @@ const action: ActionDefinition<Settings, Payload> = {
     } else {
       name = traits.first_name || traits.last_name || traits.firstName || traits.lastName || 'User'
     }
+
     return request('https://api.sendgrid.com/v3/mail/send', {
       method: 'post',
       json: {
@@ -185,7 +182,6 @@ const action: ActionDefinition<Settings, Payload> = {
             }
           }
         ],
-
         from: {
           email: payload.fromEmail,
           name: payload.fromName
@@ -194,11 +190,11 @@ const action: ActionDefinition<Settings, Payload> = {
           email: payload.replyToEmail,
           name: payload.replyToName
         },
-        subject: Mustache.render(payload.subject, { profile: profile }),
+        subject: Mustache.render(payload.subject, { profile }),
         content: [
           {
             type: 'text/html',
-            value: Mustache.render(payload.body, { profile: profile })
+            value: Mustache.render(payload.body, { profile })
           }
         ]
       }

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/__tests__/send-sms.test.ts
@@ -11,7 +11,8 @@ for (const environment of ['stage', 'production']) {
     twilioAuthToken: 'b',
     profileApiEnvironment: environment,
     profileApiAccessToken: 'c',
-    profileApiSpaceId: 'd'
+    spaceId: 'd',
+    sourceId: 'e'
   }
 
   const endpoint = `https://profiles.segment.${environment === 'production' ? 'com' : 'build'}`
@@ -43,7 +44,7 @@ for (const environment of ['stage', 'production']) {
         mapping: {
           userId: { '@path': '$.userId' },
           fromNumber: '+1234567890',
-          body: 'Hello world, {{user_id}}!'
+          body: 'Hello world, {{profile.user_id}}!'
         }
       })
 
@@ -89,7 +90,7 @@ for (const environment of ['stage', 'production']) {
         mapping: {
           userId: { '@path': '$.userId' },
           fromNumber: '+1234567890',
-          body: 'Hello world, {{user_id}}!'
+          body: 'Hello world, {{profile.user_id}}!'
         }
       })
 

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/generated-types.ts
@@ -14,11 +14,15 @@ export interface Settings {
    */
   profileApiEnvironment: string
   /**
-   * Profile API Space ID
-   */
-  profileApiSpaceId: string
-  /**
    * Profile API Access Token
    */
   profileApiAccessToken: string
+  /**
+   * Space ID
+   */
+  spaceId: string
+  /**
+   * Source ID
+   */
+  sourceId: string
 }

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
@@ -26,16 +26,22 @@ const destination: DestinationDefinition<Settings> = {
         type: 'string',
         required: true
       },
-      profileApiSpaceId: {
-        label: 'Profile API Space ID',
-        description: 'Profile API Space ID',
-        type: 'string',
-        required: true
-      },
       profileApiAccessToken: {
         label: 'Profile API Access Token',
         description: 'Profile API Access Token',
         type: 'password',
+        required: true
+      },
+      spaceId: {
+        label: 'Space ID',
+        description: 'Space ID',
+        type: 'string',
+        required: true
+      },
+      sourceId: {
+        label: 'Source ID',
+        description: 'Source ID',
+        type: 'string',
         required: true
       }
     },

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
@@ -16,7 +16,7 @@ const fetchProfileTraits = async (
 ): Promise<Record<string, string>> => {
   const endpoint = getProfileApiEndpoint(settings.profileApiEnvironment)
   const response = await request(
-    `${endpoint}/v1/spaces/${settings.profileApiSpaceId}/collections/users/profiles/user_id:${profileId}/traits?limit=200`,
+    `${endpoint}/v1/spaces/${settings.spaceId}/collections/users/profiles/user_id:${profileId}/traits?limit=200`,
     {
       headers: {
         authorization: `Basic ${Buffer.from(settings.profileApiAccessToken + ':').toString('base64')}`,
@@ -36,7 +36,7 @@ const fetchProfileExternalIds = async (
 ): Promise<Record<string, string>> => {
   const endpoint = getProfileApiEndpoint(settings.profileApiEnvironment)
   const response = await request(
-    `${endpoint}/v1/spaces/${settings.profileApiSpaceId}/collections/users/profiles/user_id:${profileId}/external_ids?limit=25`,
+    `${endpoint}/v1/spaces/${settings.spaceId}/collections/users/profiles/user_id:${profileId}/external_ids?limit=25`,
     {
       headers: {
         authorization: `Basic ${Buffer.from(settings.profileApiAccessToken + ':').toString('base64')}`,
@@ -114,7 +114,7 @@ const action: ActionDefinition<Settings, Payload> = {
         authorization: `Basic ${token}`
       },
       body: new URLSearchParams({
-        Body: Mustache.render(payload.body, profile),
+        Body: Mustache.render(payload.body, { profile }),
         From: payload.fromNumber,
         To: profile.phone
       })


### PR DESCRIPTION
This PR reverts the Profile sync which does not fetch externalId. Adding back profile calls. 
This action is still in private beta and none of the customers are using it hence the changes to any fields will not impact customers. Made subscriptions fields consistent with destination function: [https://app.segment.build/personas-stage/functions/catalog/dfn_60b4d269eeed335e5155bad2/edit/code]
