### PR TITLE
Add `toEmail` mapping to Sendgrid for sending test emails

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   userId: string
   /**
+   * Email to send to when testing
+   */
+  toEmail?: string
+  /**
    * From Email
    */
   fromEmail: string

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -75,6 +75,11 @@ const action: ActionDefinition<Settings, Payload> = {
       required: true,
       default: { '@path': '$.userId' }
     },
+    toEmail: {
+      label: 'To Email',
+      description: 'Email to send to when testing',
+      type: 'string'
+    },
     fromEmail: {
       label: 'From Email',
       description: 'From Email',
@@ -147,7 +152,9 @@ const action: ActionDefinition<Settings, Payload> = {
       traits
     }
 
-    if (!profile.email) {
+    const toEmail = payload.toEmail || profile.email
+
+    if (!toEmail) {
       return
     }
 
@@ -170,7 +177,7 @@ const action: ActionDefinition<Settings, Payload> = {
           {
             to: [
               {
-                email: profile.email,
+                email: toEmail,
                 name: name
               }
             ],


### PR DESCRIPTION
This is necessary to send an email to custom email address for testing email in the UI.