### PR TITLE
Add `toEmail` mapping to Twilio for sending test SMS

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   userId: string
   /**
+   * Number to send SMS to when testing
+   */
+  toNumber?: string
+  /**
    * Which number to send SMS from
    */
   fromNumber: string

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
@@ -74,6 +74,11 @@ const action: ActionDefinition<Settings, Payload> = {
       required: true,
       default: { '@path': '$.userId' }
     },
+    toNumber: {
+      label: 'To Number',
+      description: 'Number to send SMS to when testing',
+      type: 'string'
+    },
     fromNumber: {
       label: 'From Number',
       description: 'Which number to send SMS from',
@@ -100,7 +105,9 @@ const action: ActionDefinition<Settings, Payload> = {
       traits
     }
 
-    if (!profile.phone) {
+    const phone = payload.toNumber || profile.phone
+
+    if (!phone) {
       return
     }
 
@@ -116,7 +123,7 @@ const action: ActionDefinition<Settings, Payload> = {
       body: new URLSearchParams({
         Body: Mustache.render(payload.body, { profile }),
         From: payload.fromNumber,
-        To: profile.phone
+        To: phone
       })
     })
   }


### PR DESCRIPTION
This is necessary to send test SMS to a custom phone number specified in the UI by the customer