### PR TITLE
Clean up mapping in Twilio

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
@@ -78,15 +78,13 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'From Number',
       description: 'Which number to send SMS from',
       type: 'string',
-      required: true,
-      default: { '@path': '$.properties.fromNumber' }
+      required: true
     },
     body: {
       label: 'Message',
       description: 'Message to send',
       type: 'text',
-      required: true,
-      default: { '@path': '$.properties.body' }
+      required: true
     }
   },
   perform: async (request, { settings, payload }) => {


### PR DESCRIPTION
Removes default mapping that's not going to be ever used, so that people working on this code aren't confused.