### PR TITLE
Fix email content in Sendgrid

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -110,7 +110,7 @@ for (const environment of ['stage', 'production']) {
           subject: 'Hello {{profile.traits.lastName}} {{profile.traits.firstName}}.',
           body: 'Hi {{profile.traits.firstName}}, Welcome to segment',
           bodyType: 'html',
-          bodyHtml: '<p>Some content</p>'
+          bodyHtml: 'Hi {{profile.traits.firstName}}, Welcome to segment'
         }
       })
 

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -203,7 +203,7 @@ const action: ActionDefinition<Settings, Payload> = {
         content: [
           {
             type: 'text/html',
-            value: Mustache.render(payload.body, { profile })
+            value: Mustache.render(payload.bodyHtml, { profile })
           }
         ]
       }


### PR DESCRIPTION
`bodyHtml` is the actual mapping parameter that needs to be sent out, not `body`, which is only used by the UI.