### PR TITLE
Support tsconfig-paths in serve fork

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -76,14 +76,15 @@ export default class Serve extends Command {
     })
 
     const start = () => {
+      console.log(process.cwd())
       child = fork(require.resolve('../lib/server.ts'), {
-        cwd: process.cwd(),
         env: {
           ...process.env,
           DESTINATION: destinationName,
-          DIRECTORY: flags.directory
+          DIRECTORY: flags.directory,
+          TS_NODE_PROJECT: require.resolve('../../tsconfig.json')
         },
-        execArgv: ['-r', 'ts-node/register/transpile-only', ...argv]
+        execArgv: ['-r', 'ts-node/register/transpile-only', '-r', 'tsconfig-paths/register', ...argv]
       })
 
       child.once('exit', (code?: number) => {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -76,8 +76,8 @@ export default class Serve extends Command {
     })
 
     const start = () => {
-      console.log(process.cwd())
       child = fork(require.resolve('../lib/server.ts'), {
+        cwd: process.cwd(),
         env: {
           ...process.env,
           DESTINATION: destinationName,


### PR DESCRIPTION
This pull request adds `tsconfig-paths` support to the forked server process created by the `./bin/run serve` command.

The CLI process handles paths within `packages/cli/bin/run` but this isn't passed down to the forked process. Because of this, new builders must run `yarn build` before being able to use the serve command. If they don't, the command fails with this error:
```
Watching required files for changes .. 
Error: Cannot find module '/Users/builder/action-destinations/node_modules/@segment/actions-core/dist/cjs/index.js'
    at createEsmNotFoundErr (internal/modules/cjs/loader.js:907:15)
    at finalizeEsmResolution (internal/modules/cjs/loader.js:900:15)
    at resolveExports (internal/modules/cjs/loader.js:432:14)
    at Function.Module._findPath (internal/modules/cjs/loader.js:472:31)
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:867:27)
    at Function.Module._load (internal/modules/cjs/loader.js:725:27)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/Users/builder/action-destinations/packages/cli/src/lib/server.ts:7:1)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
```