### PR TITLE
CLI: README

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -27,7 +27,6 @@ USAGE
 - [`./bin/run generate:types`](#binrun-generatetypes)
 - [`./bin/run help [COMMAND]`](#binrun-help-command)
 - [`./bin/run init [PATH]`](#binrun-init-path)
-- [`./bin/run register`](#binrun-register)
 - [`./bin/run serve [DESTINATION]`](#binrun-serve-destination)
 
 ## `./bin/run generate:action NAME TYPE`
@@ -122,24 +121,6 @@ EXAMPLES
 ```
 
 _See code: [src/commands/init.ts](https://github.com/segmentio/action-destinations/blob/main/packages/cli/src/commands/init.ts)_
-
-## `./bin/run register`
-
-Creates a new integration on Segment.
-
-```
-USAGE
-  $ ./bin/run register
-
-OPTIONS
-  -h, --help       show CLI help
-  -p, --path=path  Path to the destination to register.
-
-EXAMPLE
-  $ ./bin/run register
-```
-
-_See code: [src/commands/register.ts](https://github.com/segmentio/action-destinations/blob/main/packages/cli/src/commands/register.ts)_
 
 ## `./bin/run serve [DESTINATION]`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -33,6 +33,9 @@ USAGE
 
 Scaffolds a new integration action.
 
+NOTE: `browser` actions are considered experimental and major breaking changes may be
+introduced without warning.
+
 ```
 USAGE
   $ ./bin/run generate:action NAME TYPE

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,5 +1,171 @@
 # CLI
 
+## Usage
+
+<!-- usage -->
+
+```sh-session
+$ ./bin/run COMMAND
+running command...
+
+$ ./bin/run (-v|--version|version)
+@segment/actions-cli/3.8.2 darwin-x64 node-v14.17.1
+
+$ ./bin/run --help [COMMAND]
+USAGE
+  $ ./bin/run COMMAND
+...
+```
+
+<!-- usagestop -->
+
+## Commands
+
+<!-- commands -->
+
+- [`./bin/run generate:action NAME TYPE`](#binrun-generateaction-name-type)
+- [`./bin/run generate:types`](#binrun-generatetypes)
+- [`./bin/run help [COMMAND]`](#binrun-help-command)
+- [`./bin/run init [PATH]`](#binrun-init-path)
+- [`./bin/run register`](#binrun-register)
+- [`./bin/run serve [DESTINATION]`](#binrun-serve-destination)
+
+## `./bin/run generate:action NAME TYPE`
+
+Scaffolds a new integration action.
+
+```
+USAGE
+  $ ./bin/run generate:action NAME TYPE
+
+ARGUMENTS
+  NAME  the action name
+  TYPE  the type of action (browser, server)
+
+OPTIONS
+  -d, --directory=directory  base directory to scaffold the action
+  -f, --force
+  -h, --help                 show CLI help
+  -t, --title=title          the display name of the action
+
+EXAMPLES
+  $ ./bin/run generate:action ACTION <browser|server>
+  $ ./bin/run generate:action postToChannel server --directory=./destinations/slack
+```
+
+_See code: [src/commands/generate/action.ts](https://github.com/segmentio/action-destinations/blob/main/packages/cli/src/commands/generate/action.ts)_
+
+## `./bin/run generate:types`
+
+Generates TypeScript definitions for an integration.
+
+```
+USAGE
+  $ ./bin/run generate:types
+
+OPTIONS
+  -h, --help       show CLI help
+  -p, --path=path  file path for the integration(s). Accepts glob patterns.
+  -w, --watch      Watch for file changes to regenerate types
+
+EXAMPLES
+  $ ./bin/run generate:types
+  $ ./bin/run generate:types --path ./packages/*/src/destinations/*/index.ts
+```
+
+_See code: [src/commands/generate/types.ts](https://github.com/segmentio/action-destinations/blob/main/packages/cli/src/commands/generate/types.ts)_
+
+## `./bin/run help [COMMAND]`
+
+display help for ./bin/run
+
+```
+USAGE
+  $ ./bin/run help [COMMAND]
+
+ARGUMENTS
+  COMMAND  command to show help for
+
+OPTIONS
+  --all  see all commands in CLI
+```
+
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v3.2.3/src/commands/help.ts)_
+
+## `./bin/run init [PATH]`
+
+Scaffolds a new integration with a template. This does not register or deploy the integration.
+
+```
+USAGE
+  $ ./bin/run init [PATH]
+
+ARGUMENTS
+  PATH  path to scaffold the integration
+
+OPTIONS
+  -d, --directory=directory                                    [default:
+                                                               ./packages/destination-actions/src/destinations] target
+                                                               directory to scaffold the integration
+
+  -h, --help                                                   show CLI help
+
+  -n, --name=name                                              name of the integration
+
+  -s, --slug=slug                                              url-friendly slug of the integration
+
+  -t, --template=(basic-auth|custom-auth|oauth2-auth|minimal)  the template to use to scaffold your integration
+
+EXAMPLES
+  $ ./bin/run init my-integration
+  $ ./bin/run init my-integration --directory packages/destination-actions --template basic-auth
+```
+
+_See code: [src/commands/init.ts](https://github.com/segmentio/action-destinations/blob/main/packages/cli/src/commands/init.ts)_
+
+## `./bin/run register`
+
+Creates a new integration on Segment.
+
+```
+USAGE
+  $ ./bin/run register
+
+OPTIONS
+  -h, --help       show CLI help
+  -p, --path=path  Path to the destination to register.
+
+EXAMPLE
+  $ ./bin/run register
+```
+
+_See code: [src/commands/register.ts](https://github.com/segmentio/action-destinations/blob/main/packages/cli/src/commands/register.ts)_
+
+## `./bin/run serve [DESTINATION]`
+
+Starts a local development server to test your integration.
+
+```
+USAGE
+  $ ./bin/run serve [DESTINATION]
+
+ARGUMENTS
+  DESTINATION  destination to serve
+
+OPTIONS
+  -d, --directory=directory  [default: ./packages/destination-actions/src/destinations] destination actions directory
+  -h, --help                 show CLI help
+
+EXAMPLES
+  $ ./bin/run serve
+  $ PORT=3001 ./bin/run serve
+  $ ./bin/run serve slack
+```
+
+_See code: [src/commands/serve.ts](https://github.com/segmentio/action-destinations/blob/main/packages/cli/src/commands/serve.ts)_
+
+<!-- commandsstop -->
+
 ## License
 
 MIT License


### PR DESCRIPTION
Adds a basic CLI readme with the help of [`oclif-dev readme`](https://github.com/oclif/dev-cli#oclif-dev-readme)

preview: https://github.com/segmentio/action-destinations/blob/06c7b683a2530c46ac816921f7d0546b2be29703/packages/cli/README.md