### PR TITLE
Update personas sendgrid destination name to match in partner portal

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from './generated-types'
 import sendEmail from './sendEmail'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Personas Messaging Sendgrid',
+  name: 'Actions Personas Messaging Sendgrid',
   mode: 'cloud',
   description: 'This is a personas specific action to send an email',
   authentication: {


### PR DESCRIPTION
This PR address the mismatch of name in Actions and Partner portal