### PR TITLE
add internal handling of batches of events

### DIFF
--- a/packages/core/src/__tests__/batching.test.ts
+++ b/packages/core/src/__tests__/batching.test.ts
@@ -1,0 +1,190 @@
+import { Destination, DestinationDefinition } from '../destination-kit'
+import type { JSONObject } from '../json-object'
+import type { SegmentEvent } from '../segment-event'
+import { createTestEvent } from '../create-test-event'
+
+const basicBatch: DestinationDefinition<JSONObject> = {
+  name: 'Batching Destination',
+  mode: 'cloud',
+  actions: {
+    testAction: {
+      title: 'Test Action',
+      description: 'Test Action',
+      fields: {
+        user_id: {
+          type: 'string',
+          label: 'User ID',
+          description: 'User ID',
+          required: true,
+          default: {
+            '@path': '$.userId'
+          }
+        }
+      },
+      perform: (_request) => {
+        return 'success'
+      },
+      performBatch: (_request) => {
+        return 'batch success'
+      }
+    }
+  }
+}
+
+const events: SegmentEvent[] = [
+  createTestEvent({
+    anonymousId: 'anon_123',
+    userId: 'user_123',
+    timestamp: '2021-07-12T23:02:40.563Z',
+    event: 'Test Event'
+  }),
+  createTestEvent({
+    anonymousId: 'anon_456',
+    userId: 'user_456',
+    timestamp: '2021-07-12T23:02:41.563Z',
+    event: 'Test Event'
+  })
+]
+
+const basicBatchSettings = {
+  subscription: {
+    subscribe: 'type = "track"',
+    partnerAction: 'testAction',
+    mapping: {
+      user_id: {
+        '@path': '$.userId'
+      }
+    }
+  }
+}
+
+describe('Batching', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('basic happy path', async () => {
+    const destination = new Destination(basicBatch)
+    const res = await destination.onBatch(events, basicBatchSettings)
+    expect(res).toEqual(expect.arrayContaining([{ output: 'successfully processed batch of events' }]))
+  })
+
+  test('transforms all the payloads based on the subscription mapping', async () => {
+    const destination = new Destination(basicBatch)
+    const spy = jest.spyOn(basicBatch.actions.testAction, 'performBatch')
+
+    await destination.onBatch(events, basicBatchSettings)
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        payload: expect.arrayContaining([{ user_id: 'user_123' }, { user_id: 'user_456' }])
+      })
+    )
+  })
+
+  test('validates all the payloads, ignores invalid payloads', async () => {
+    const destination = new Destination(basicBatch)
+    const spy = jest.spyOn(basicBatch.actions.testAction, 'performBatch')
+
+    const invalidEvent = createTestEvent({
+      event: 'Test Event',
+      type: 'track',
+      userId: undefined
+    })
+
+    await destination.onBatch([...events, invalidEvent], basicBatchSettings)
+    expect(spy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        // excludes the invalid event!
+        payload: expect.arrayContaining([{ user_id: 'user_123' }, { user_id: 'user_456' }])
+      })
+    )
+  })
+
+  test('invokes the individual perform function when there is only 1 event', async () => {
+    const destination = new Destination(basicBatch)
+    const batchSpy = jest.spyOn(basicBatch.actions.testAction, 'performBatch')
+    const spy = jest.spyOn(basicBatch.actions.testAction, 'perform')
+
+    // send a single event
+    await destination.onBatch([events[0]], basicBatchSettings)
+
+    expect(batchSpy).not.toHaveBeenCalled()
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        payload: { user_id: 'user_123' }
+      })
+    )
+  })
+
+  test('invokes the individual perform function when there is only 1 subscribed event', async () => {
+    const destination = new Destination(basicBatch)
+    const batchSpy = jest.spyOn(basicBatch.actions.testAction, 'performBatch')
+    const spy = jest.spyOn(basicBatch.actions.testAction, 'perform')
+
+    const unsubscribedEvent = createTestEvent({
+      event: 'Test Event',
+      type: 'identify',
+      userId: 'nope'
+    })
+
+    await destination.onBatch([unsubscribedEvent, events[0]], basicBatchSettings)
+    expect(batchSpy).not.toHaveBeenCalled()
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        payload: expect.not.arrayContaining([{ user_id: 'nope' }])
+      })
+    )
+  })
+
+  test('ensures that only subscribed events get passed on', async () => {
+    const destination = new Destination(basicBatch)
+    const spy = jest.spyOn(basicBatch.actions.testAction, 'performBatch')
+
+    const unsubscribedEvent = createTestEvent({
+      event: 'Test Event',
+      type: 'identify',
+      userId: 'nope'
+    })
+
+    await destination.onBatch([unsubscribedEvent, ...events], basicBatchSettings)
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        payload: expect.not.arrayContaining([{ user_id: 'nope' }])
+      })
+    )
+  })
+
+  test('doesnt invoke anything if there are no subscribed, valid events', async () => {
+    const destination = new Destination(basicBatch)
+    const batchSpy = jest.spyOn(basicBatch.actions.testAction, 'performBatch')
+    const spy = jest.spyOn(basicBatch.actions.testAction, 'performBatch')
+
+    const unsubscribedEvent = createTestEvent({
+      event: 'Test Event',
+      type: 'identify',
+      userId: 'nope'
+    })
+
+    const invalidEvent = createTestEvent({
+      event: 'Test Event',
+      type: 'track',
+      userId: undefined
+    })
+
+    const promise = destination.onBatch([unsubscribedEvent, invalidEvent], basicBatchSettings)
+    await expect(promise).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"The root value is missing the required field 'user_id'."`
+    )
+    expect(batchSpy).not.toHaveBeenCalled()
+    expect(spy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/__tests__/schema-validation.test.ts
+++ b/packages/core/src/__tests__/schema-validation.test.ts
@@ -36,7 +36,7 @@ describe('validateSchema', () => {
       nope: 'not a property'
     }
 
-    validateSchema(payload, schema, `testSchema`)
+    validateSchema(payload, schema, { schemaKey: `testSchema` })
 
     expect(payload).not.toHaveProperty('nope')
     expect(payload).toMatchInlineSnapshot(`Object {}`)
@@ -51,7 +51,7 @@ describe('validateSchema', () => {
       d: 'd'
     }
 
-    validateSchema(payload, schema, `testSchema`)
+    validateSchema(payload, schema, { schemaKey: `testSchema` })
     expect(payload).toHaveProperty('b')
     expect(payload.b).toHaveProperty('anything')
     expect(payload).toMatchInlineSnapshot(`
@@ -64,6 +64,22 @@ describe('validateSchema', () => {
     `)
   })
 
+  it('should not throw when throwIfInvalid = false', () => {
+    const requiredSchema = fieldsToJsonSchema({
+      a: {
+        label: 'a',
+        type: 'string',
+        required: true
+      }
+    })
+
+    const payload = {}
+
+    const isValid = validateSchema(payload, requiredSchema, { schemaKey: `testInvalid`, throwIfInvalid: false })
+    expect(isValid).toBe(false)
+    expect(payload).toMatchInlineSnapshot(`Object {}`)
+  })
+
   // For now we always remove unknown keys, until builders have a way to specify the behavior
   it.todo('should not remove nested keys for valid properties')
 
@@ -74,7 +90,7 @@ describe('validateSchema', () => {
       f: '123'
     }
 
-    validateSchema(payload, schema, `testSchema`)
+    validateSchema(payload, schema, { schemaKey: `testSchema` })
     expect(payload).toMatchInlineSnapshot(`
       Object {
         "a": "1234",

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -334,7 +334,7 @@ export class Destination<Settings = JSONObject> {
         return results
       }
 
-      const isSubscribed = validate(parsedSubscription, event)
+      const isSubscribed = validate(parsedSubscription, data)
       if (!isSubscribed) {
         results = [{ output: 'not subscribed' }]
         return results

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -14,7 +14,7 @@ export interface ExecuteInput<Settings, Payload> {
   readonly mapping?: JSONObject
   /** The global destination settings */
   readonly settings: Settings
-  /** The transformed input data, based on `mapping` + `event` */
+  /** The transformed input data, based on `mapping` + `event` (or `events` if batched) */
   payload: Payload
   /** The page used in dynamic field requests */
   page?: string
@@ -149,4 +149,4 @@ export type Directive = IfDirective | TemplateDirective | PathDirective
  * A function to configure a request client instance with options
  * that will be applied to every request made by that instance
  */
-export type RequestExtension<Settings, Payload = unknown> = (data: ExecuteInput<Settings, Payload>) => RequestOptions
+export type RequestExtension<Settings, Payload = undefined> = (data: ExecuteInput<Settings, Payload>) => RequestOptions

--- a/packages/core/src/mapping-kit/__tests__/index.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.test.ts
@@ -48,9 +48,11 @@ describe('validations', () => {
 describe('payload validations', () => {
   test('invalid type', () => {
     expect(() => {
+      // @ts-expect-error
       transform({ a: 1 }, 123)
     }).toThrowError()
     expect(() => {
+      // @ts-expect-error
       transform({ a: 1 }, [])
     }).toThrowError()
   })

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -1,0 +1,30 @@
+interface RetryOptions {
+  retries?: number
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onFailedAttempt?: (error: any, attemptCount: number) => PromiseLike<void> | void
+}
+
+export async function retry<T>(
+  input: (attemptCount: number) => PromiseLike<T> | T,
+  options?: RetryOptions
+): Promise<T> {
+  const retries = options?.retries ?? 2
+
+  for (let attemptCount = 1; attemptCount <= retries; attemptCount++) {
+    try {
+      return await input(attemptCount)
+    } catch (error) {
+      if (options?.onFailedAttempt) {
+        await options.onFailedAttempt(error, attemptCount)
+      }
+
+      // Let the final error bubble
+      if (!error || attemptCount >= retries) {
+        throw error
+      }
+    }
+  }
+
+  // Note: this is unreachable, but TS can't figure that out
+  throw new Error('Exhausted all retries.')
+}

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -4,11 +4,13 @@ interface RetryOptions {
   onFailedAttempt?: (error: any, attemptCount: number) => PromiseLike<void> | void
 }
 
+const DEFAULT_RETRY_ATTEMPTS = 2
+
 export async function retry<T>(
   input: (attemptCount: number) => PromiseLike<T> | T,
   options?: RetryOptions
 ): Promise<T> {
-  const retries = options?.retries ?? 2
+  const retries = options?.retries ?? DEFAULT_RETRY_ATTEMPTS
 
   for (let attemptCount = 1; attemptCount <= retries; attemptCount++) {
     try {

--- a/packages/core/src/schema-validation.ts
+++ b/packages/core/src/schema-validation.ts
@@ -34,11 +34,17 @@ ajv.addFormat('date-like', (data: string) => {
   return date.isValid()
 })
 
+interface ValidationOptions {
+  schemaKey?: string
+  throwIfInvalid?: boolean
+}
+
 /**
  * Validates an object against a json schema
  * and caches the schema for subsequent validations when a key is provided
  */
-export function validateSchema(obj: unknown, schema: object, schemaKey?: string) {
+export function validateSchema(obj: unknown, schema: object, options?: ValidationOptions) {
+  const { schemaKey, throwIfInvalid = true } = options ?? {}
   let validate: Ajv.ValidateFunction
 
   if (schemaKey) {
@@ -48,8 +54,12 @@ export function validateSchema(obj: unknown, schema: object, schemaKey?: string)
     validate = ajv.compile(schema)
   }
 
-  if (!validate(obj)) {
+  const isValid = validate(obj) as boolean
+
+  if (throwIfInvalid && !isValid) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     throw new AggregateAjvError(validate.errors)
   }
+
+  return isValid
 }

--- a/packages/destination-actions/src/destinations/webhook/send/index.ts
+++ b/packages/destination-actions/src/destinations/webhook/send/index.ts
@@ -41,6 +41,15 @@ const action: ActionDefinition<Settings, Payload> = {
       method: payload.method as RequestMethod,
       json: payload.data
     })
+  },
+  performBatch: (request, { payload }) => {
+    // Expect these to be the same across the payloads
+    const { url, method } = payload[0]
+
+    return request(url, {
+      method: method as RequestMethod,
+      json: payload.map(({ data }) => data)
+    })
   }
 }
 


### PR DESCRIPTION
This PR spikes on our ability to support _batching_ in Actions.

The basic premise:
- Centrifuge produces a batch of events (based on a batching key that's a hash of settings + auth + subscription) and sends it to our `integrations` cluster
- `integrations` will see the `batch` method and invoke it (will hook this up in a later PR)
- the `batch` method will proxy events + subscriptions by calling the destination's `.onBatch` method instead of the `.onEvent` method
- `.onBatch` will assume that the settings, auth data, and subscription(s) are the same for the entire batch of events
- each subscription will be parsed and evaluated only once for the entire batch
- each event will get transformed by the `subscription.mapping` and validated (this is optimized with a cached validator)
- the entire batch of transformed payloads will be passed to a `performBatch` method if defined on the action. Otherwise it will throw a 501