### PR TITLE
cli: fix `register` to listen to "no"

### DIFF
--- a/packages/cli/src/commands/register.ts
+++ b/packages/cli/src/commands/register.ts
@@ -132,6 +132,7 @@ export default class Register extends Command {
 
     if (!shouldContinue) {
       this.log('Exiting without registering.')
+      this.exit()
     }
 
     await this.createDestinationMetadata(definition)


### PR DESCRIPTION
Previously, `register` would just go ahead and do it anyway:

<img width="493" alt="Screen Shot 2021-09-08 at 12 45 40 PM" src="https://user-images.githubusercontent.com/710752/132558781-ac63fc89-b2eb-47a8-a63f-80999ba643a5.png">
