### PR TITLE
Surface HTTPError details when requests fail via serve command

### DIFF
--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -9,6 +9,8 @@ import asyncHandler from './async-handler'
 import getExchanges from './summarize-http'
 import ora from 'ora'
 import chalk from 'chalk'
+import { HTTPError } from '@segment/actions-core/request-client'
+import type { ModifiedResponse } from '@segment/actions-core/types'
 
 const app = express()
 app.use(express.json())
@@ -67,45 +69,57 @@ server.on('error', (err: Error) => {
   logger.error(`Server error: ${err.message}`, err)
 })
 
-loadDestination(targetDirectory).then(def => {
-  app.post(
-    '/:action',
-    asyncHandler(async (req: express.Request, res: express.Response) => {
-      const actionSlug = req.params.action
+loadDestination(targetDirectory)
+  .then((def) => {
+    app.post(
+      '/:action',
+      asyncHandler(async (req: express.Request, res: express.Response) => {
+        const actionSlug = req.params.action
 
-      spinner.start(chalk`Handling ${process.env.DESTINATION}#${actionSlug} action request`)
+        spinner.start(chalk`Handling ${process.env.DESTINATION}#${actionSlug} action request`)
 
-      try {
-        const destination = new Destination(def as CloudDestinationDefinition)
-        const action = destination.actions[actionSlug]
+        try {
+          const destination = new Destination(def as CloudDestinationDefinition)
+          const action = destination.actions[actionSlug]
 
-        if (!action) {
-          const msg = `${destination.name} action '${actionSlug}' is invalid or not found`
-          spinner.fail(chalk`${msg}`)
-          return res.status(400).send(msg)
+          if (!action) {
+            const msg = `${destination.name} action '${actionSlug}' is invalid or not found`
+            spinner.fail(chalk`${msg}`)
+            return res.status(400).send(msg)
+          }
+
+          await action.execute({
+            data: req.body.payload || {},
+            settings: req.body.settings || {},
+            mapping: req.body.payload || {},
+            auth: req.body.auth || {}
+          })
+
+          const debug = await getExchanges(destination.responses)
+          spinner.succeed(chalk`${destination.name} action '${actionSlug}' completed`)
+          return res.status(200).json(debug)
+        } catch (err) {
+          spinner.fail()
+          let statusCode = err?.status ?? 500
+          let msg = err?.message
+
+          if (err instanceof HTTPError) {
+            statusCode = err?.response?.status ?? 500
+            msg = (err.response as ModifiedResponse).data ?? (err.response as ModifiedResponse).content
+          }
+
+          return res.status(statusCode).send(msg)
         }
+      })
+    )
 
-        await action.execute({
-          data: req.body.payload || {},
-          settings: req.body.settings || {},
-          mapping: req.body.payload || {},
-          auth: req.body.auth || {}
-        })
-
-        const debug = await getExchanges(destination.responses)
-        spinner.succeed(chalk`${destination.name} action '${actionSlug}' completed`)
-        return res.status(200).json(debug)
-      } catch (err) {
-        spinner.fail()
-        return res.status(err.status ?? 500).send(err.message)
-      }
+    server.listen(port, () => {
+      logger.info(`Listening at http://localhost:${port} ->
+${Object.keys(def?.actions ?? {})
+  .map((action) => `  POST http://localhost:${port}/${action}`)
+  .join('\n')}`)
     })
-  )
-
-  server.listen(port, () => {
-    logger.info(`Listening at http://localhost:${port} ->
-${Object.keys(def?.actions ?? {}).map(action => `  POST http://localhost:${port}/${action}`).join('\n')}`)
   })
-}).catch(error => {
-  logger.error(`There was an issue booting up the development server:\n\n ${error.message}`)
-})
+  .catch((error) => {
+    logger.error(`There was an issue booting up the development server:\n\n ${error.message}`)
+  })

--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -114,7 +114,7 @@ loadDestination(targetDirectory)
     )
 
     server.listen(port, () => {
-      logger.info(`Listening at http://localhost:${port} ->
+      logger.info(`Listening at http://localhost:${port} -> 
 ${Object.keys(def?.actions ?? {})
   .map((action) => `  POST http://localhost:${port}/${action}`)
   .join('\n')}`)

--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -104,7 +104,7 @@ loadDestination(targetDirectory)
           let msg = err?.message
 
           if (err instanceof HTTPError) {
-            statusCode = err?.response?.status ?? 500
+            statusCode = err?.response?.status ?? statusCode
             msg = (err.response as ModifiedResponse).data ?? (err.response as ModifiedResponse).content
           }
 


### PR DESCRIPTION
Update `serve` command to return `HTTPError` details when a request fails.

Before
```
$ curl --request POST --url http://localhost:3000/postConversion ....
Bad Request
```

Now
```
$ curl --request POST --url http://localhost:3000/postConversion ....
{"status":"INVALID_REQUEST","error_statuses":[{"error_code":"INVALID_OAUTH_TOKEN","error_message":"The OAuth token is missing or invalid."}]}
```