### PR TITLE
Remove default data from fieldSchema

### DIFF
--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -285,10 +285,12 @@ export default class Push extends Command {
 }
 
 function getFieldPropertySchema(fieldKey: string, field: MinimalInputField): JSONSchema4 {
-  // Build a temporary object in which they key = field name and value = field properties
+  // Build a temporary object in which key = field name and value = field properties
   // since that's the structure expected by fieldsToJsonSchema
   const tmpFieldObject: Record<string, MinimalInputField> = {}
-  tmpFieldObject[fieldKey] = field
+  // removing default data since it's available under defaultValue
+  const { default: def, ...fieldWODefault } = field
+  tmpFieldObject[fieldKey] = fieldWODefault
   return fieldsToJsonSchema(tmpFieldObject)
 }
 


### PR DESCRIPTION
Removing `default` data from `fieldSchema` since it is already available in `defaultValue`. We want to avoid repeating unnecessary data and make things clear when consuming field data.