### PR TITLE
Update Enhanced Conversions to handle invalid/expired tokens

### DIFF
--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -99,7 +99,6 @@ loadDestination(targetDirectory)
           spinner.succeed(chalk`${destination.name} action '${actionSlug}' completed`)
           return res.status(200).json(debug)
         } catch (err) {
-          logger.error(`There was an error ${err}`)
           spinner.fail()
           let statusCode = err?.status ?? 500
           let msg = err?.message

--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -99,6 +99,7 @@ loadDestination(targetDirectory)
           spinner.succeed(chalk`${destination.name} action '${actionSlug}' completed`)
           return res.status(200).json(debug)
         } catch (err) {
+          logger.error(`There was an error ${err}`)
           spinner.fail()
           let statusCode = err?.status ?? 500
           let msg = err?.message

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,8 @@ export { time, duration } from './time'
 export { realTypeOf, isObject, isArray, isString } from './real-type-of'
 
 export type { RequestOptions } from './request-client'
+export { HTTPError } from './request-client'
+export { ModifiedResponse } from './types'
 export { default as fetch, Request, Response, Headers } from './fetch'
 
 export type {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
@@ -227,9 +227,8 @@ const action: ActionDefinition<Settings, Payload> = {
       hashed_phone_number: [formatPhone(payload.phone_number)]
     })
 
-    let res
     try {
-      res = await request('https://www.google.com/ads/event/api/v1', {
+      return await request('https://www.google.com/ads/event/api/v1', {
         method: 'post',
         json: {
           pii_data: { ...pii_data, address: [address] },
@@ -250,8 +249,9 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       }
+      // throw original error if unrelated to invalid/expired tokens
+      throw err
     }
-    return res
   }
 }
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
@@ -1,4 +1,5 @@
-import { ActionDefinition, IntegrationError } from '@segment/actions-core'
+import { ActionDefinition, IntegrationError, HTTPError } from '@segment/actions-core'
+import type { ModifiedResponse } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import {
@@ -11,6 +12,16 @@ import {
   formatRegion,
   cleanData
 } from './formatter'
+
+interface GoogleError {
+  status: string
+  error_statuses: [
+    {
+      error_code: string
+      error_message: string
+    }
+  ]
+}
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Post Conversion',
@@ -183,7 +194,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
 
-  perform: (request, { payload }) => {
+  perform: async (request, { payload }) => {
     const conversionData = cleanData({
       oid: payload.transaction_id,
       user_agent: payload.user_agent,
@@ -216,13 +227,31 @@ const action: ActionDefinition<Settings, Payload> = {
       hashed_phone_number: [formatPhone(payload.phone_number)]
     })
 
-    return request('https://www.google.com/ads/event/api/v1', {
-      method: 'post',
-      json: {
-        pii_data: { ...pii_data, address: [address] },
-        ...conversionData
+    let res
+    try {
+      res = await request('https://www.google.com/ads/event/api/v1', {
+        method: 'post',
+        json: {
+          pii_data: { ...pii_data, address: [address] },
+          ...conversionData
+        }
+      })
+    } catch (err) {
+      // Google returns a 400 when using invalid tokens
+      // We'll catch invalid token errors and throw an internal 401 to
+      // trigger the refresh token flow in this transaction
+      if (err instanceof HTTPError) {
+        const statusCode = err.response.status
+        if (statusCode === 400) {
+          const data = (err.response as ModifiedResponse).data as GoogleError
+          const invalidOAuth = data.error_statuses.find((es) => es.error_code === 'INVALID_OAUTH_TOKEN')
+          if (invalidOAuth) {
+            throw new IntegrationError('The OAuth token is missing or invalid.', 'INVALID_OAUTH_TOKEN', 401)
+          }
+        }
       }
-    })
+    }
+    return res
   }
 }
 


### PR DESCRIPTION
Update post conversion action to handle invalid/expired oauth tokens. Since the API returns a 400 http code instead of a 401, we are catching errors, checking if they belong to an invalid/expired oauth token and internally throwing a 401 error so we can trigger the oauth refresh token flow in actions core.