### PR TITLE
GRAMA-5 [personas-messaging-sendgrid] Allows journey metadata to be added to a send

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -196,9 +196,11 @@ for (const environment of ['stage', 'production']) {
               email: 'test@test.com'
             }
           ]),
-          journeyId: 'journeyId',
-          journeyStateId: 'journeyStateId',
-          audienceId: 'audienceId',
+          customArgs: {
+            journey_id: 'journeyId',
+            journey_state_id: 'journeyStateId',
+            audience_id: 'audienceId',
+          },
           previewText: '',
           subject: 'Test email with metadata',
           body: 'Welcome to segment',

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -14,45 +14,59 @@ for (const environment of ['stage', 'production']) {
     sourceId: 'sourceId'
   }
 
+  const userData = {
+    userId: 'jane',
+    firstName: 'First Name',
+    lastName: 'Browning',
+    phone: '+11235554657',
+    email: 'test@example.com'
+  }
+
   const endpoint = `https://profiles.segment.${environment === 'production' ? 'com' : 'build'}`
+
+  beforeEach(() => {
+    nock(`${endpoint}/v1/spaces/spaceId/collections/users/profiles/user_id:${userData.userId}`)
+      .get('/traits?limit=200')
+      .reply(200, {
+        traits: {
+          firstName: userData.firstName,
+          lastName: userData.lastName
+        }
+      })
+
+    nock(`${endpoint}/v1/spaces/spaceId/collections/users/profiles/user_id:${userData.userId}`)
+      .get('/external_ids?limit=25')
+      .reply(200, {
+        data: [
+          {
+            type: 'user_id',
+            id: userData.userId
+          },
+          {
+            type: 'phone',
+            id: userData.phone
+          },
+          {
+            type: 'email',
+            id: userData.email
+          }
+        ]
+      })
+  })
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
 
   describe(`${environment} - send Email`, () => {
     it('should send Email', async () => {
-      nock(`${endpoint}/v1/spaces/spaceId/collections/users/profiles/user_id:jane`)
-        .get('/traits?limit=200')
-        .reply(200, {
-          traits: {
-            firstName: 'First Name',
-            lastName: 'Browning'
-          }
-        })
-
-      nock(`${endpoint}/v1/spaces/spaceId/collections/users/profiles/user_id:jane`)
-        .get('/external_ids?limit=25')
-        .reply(200, {
-          data: [
-            {
-              type: 'user_id',
-              id: 'jane'
-            },
-            {
-              type: 'phone',
-              id: '+1234567891'
-            },
-            {
-              type: 'email',
-              id: 'test@example.com'
-            }
-          ]
-        })
-
       const expectedSendGridRequest = {
         personalizations: [
           {
             to: [
               {
-                email: 'test@example.com',
-                name: 'First Name Browning'
+                email: userData.email,
+                name: `${userData.firstName} ${userData.lastName}`
               }
             ],
             bcc: [
@@ -63,7 +77,7 @@ for (const environment of ['stage', 'production']) {
             custom_args: {
               source_id: 'sourceId',
               space_id: 'spaceId',
-              user_id: 'jane'
+              user_id: userData.userId
             }
           }
         ],
@@ -75,11 +89,11 @@ for (const environment of ['stage', 'production']) {
           email: 'replyto@example.com',
           name: 'Test user'
         },
-        subject: 'Hello Browning First Name.',
+        subject: `Hello ${userData.lastName} ${userData.firstName}.`,
         content: [
           {
             type: 'text/html',
-            value: 'Hi First Name, Welcome to segment'
+            value: `Hi ${userData.firstName}, Welcome to segment`
           }
         ]
       }
@@ -92,7 +106,7 @@ for (const environment of ['stage', 'production']) {
         event: createTestEvent({
           timestamp,
           event: 'Audience Entered',
-          userId: 'jane'
+          userId: userData.userId
         }),
         settings,
         mapping: {
@@ -115,6 +129,89 @@ for (const environment of ['stage', 'production']) {
       })
 
       expect(responses.length).toEqual(3)
+      expect(sendGridRequest.isDone()).toEqual(true)
+    })
+
+    it('should send email with journey metadata', async () => {
+      const expectedSendGridRequest = {
+        personalizations: [
+          {
+            to: [
+              {
+                email: userData.email,
+                name: `${userData.firstName} ${userData.lastName}`
+              }
+            ],
+            bcc: [
+              {
+                email: 'test@test.com'
+              }
+            ],
+            custom_args: {
+              source_id: 'sourceId',
+              space_id: 'spaceId',
+              user_id: userData.userId,
+              journey_id: 'journeyId',
+              journey_state_id: 'journeyStateId',
+              audience_id: 'audienceId'
+            }
+          }
+        ],
+        from: {
+          email: 'from@example.com',
+          name: 'From Name'
+        },
+        reply_to: {
+          email: 'replyto@example.com',
+          name: 'Test user'
+        },
+        subject: 'Test email with metadata',
+        content: [
+          {
+            type: 'text/html',
+            value: 'Welcome to segment'
+          }
+        ]
+      }
+
+      const sendGridRequest = nock('https://api.sendgrid.com')
+        .post('/v3/mail/send', expectedSendGridRequest)
+        .reply(200, {})
+
+      const responses = await sendgrid.testAction('sendEmail', {
+        event: createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          userId: userData.userId
+        }),
+        settings,
+        mapping: {
+          userId: { '@path': '$.userId' },
+          fromEmail: 'from@example.com',
+          fromName: 'From Name',
+          replyToEmail: 'replyto@example.com',
+          replyToName: 'Test user',
+          bcc: JSON.stringify([
+            {
+              email: 'test@test.com'
+            }
+          ]),
+          journeyId: 'journeyId',
+          journeyStateId: 'journeyStateId',
+          audienceId: 'audienceId',
+          previewText: '',
+          subject: 'Test email with metadata',
+          body: 'Welcome to segment',
+          bodyType: 'html',
+          bodyHtml: 'Welcome to segment'
+        }
+      })
+
+      expect(responses.map((r) => r.url)).toStrictEqual([
+        `${endpoint}/v1/spaces/spaceId/collections/users/profiles/user_id:jane/traits?limit=200`,
+        `${endpoint}/v1/spaces/spaceId/collections/users/profiles/user_id:jane/external_ids?limit=25`,
+        `https://api.sendgrid.com/v3/mail/send`
+      ])
       expect(sendGridRequest.isDone()).toEqual(true)
     })
   })

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
@@ -50,15 +50,9 @@ export interface Payload {
    */
   bodyHtml: string
   /**
-   * Journey id used for analytics
+   * Additional custom args that we be passed back opaquely on webhook events
    */
-  journeyId?: string
-  /**
-   * Journey state id used for analytics
-   */
-  journeyStateId?: string
-  /**
-   * Audience id used for analytics
-   */
-  audienceId?: string
+  customArgs?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
@@ -49,4 +49,16 @@ export interface Payload {
    * The HTML content of the body
    */
   bodyHtml: string
+  /**
+   * Journey id used for analytics
+   */
+  journeyId?: string
+  /**
+   * Journey state id used for analytics
+   */
+  journeyStateId?: string
+  /**
+   * Audience id used for analytics
+   */
+  audienceId?: string
 }

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -139,6 +139,24 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'The HTML content of the body',
       type: 'string',
       required: true
+    },
+    journeyId: {
+      label: 'Journey Id',
+      description: 'Journey id used for analytics',
+      type: 'string',
+      required: false
+    },
+    journeyStateId: {
+      label: 'Journey State Id',
+      description: 'Journey state id used for analytics',
+      type: 'string',
+      required: false
+    },
+    audienceId: {
+      label: 'Audience Id',
+      description: 'Audience id used for analytics',
+      type: 'string',
+      required: false
     }
   },
   perform: async (request, { settings, payload }) => {
@@ -187,7 +205,10 @@ const action: ActionDefinition<Settings, Payload> = {
             custom_args: {
               source_id: settings.sourceId,
               space_id: settings.spaceId,
-              user_id: payload.userId
+              user_id: payload.userId,
+              journey_id: payload.journeyId,
+              journey_state_id: payload.journeyStateId,
+              audience_id: payload.audienceId
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -140,24 +140,12 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: true
     },
-    journeyId: {
-      label: 'Journey Id',
-      description: 'Journey id used for analytics',
-      type: 'string',
+    customArgs: {
+      label: 'Custom Args',
+      description: 'Additional custom args that we be passed back opaquely on webhook events',
+      type: 'object',
       required: false
     },
-    journeyStateId: {
-      label: 'Journey State Id',
-      description: 'Journey state id used for analytics',
-      type: 'string',
-      required: false
-    },
-    audienceId: {
-      label: 'Audience Id',
-      description: 'Audience id used for analytics',
-      type: 'string',
-      required: false
-    }
   },
   perform: async (request, { settings, payload }) => {
     const [traits, externalIds] = await Promise.all([
@@ -203,12 +191,10 @@ const action: ActionDefinition<Settings, Payload> = {
             ],
             bcc: bcc.length > 0 ? bcc : undefined,
             custom_args: {
+              ...payload.customArgs,
               source_id: settings.sourceId,
               space_id: settings.spaceId,
               user_id: payload.userId,
-              journey_id: payload.journeyId,
-              journey_state_id: payload.journeyStateId,
-              audience_id: payload.audienceId
             }
           }
         ],


### PR DESCRIPTION
We're going to want to track analytical data on sends from journeys, so we'll need to ensure that certain journey metadata is included in the webhook callback.