### PR TITLE
[BE-102] Automate Package Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,95 @@
+name: Publish
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Semver version to bump'
+        required: true
+        default: 'patch'
+
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.workflow.outputs.version || steps.major.outputs.version ||  steps.minor.outputs.version ||  steps.patch.outputs.version }}
+    steps:
+      - id: patch
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'patch') }}
+        run: echo "::set-output name=version::patch"
+      - id: minor
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'minor') }}
+        run: echo "::set-output name=version::minor"
+      - id: major
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'major') }}
+        run: echo "::set-output name=version::major"
+      - id: workflow
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: echo "::set-output name=version::${{ github.event.inputs.version }}"
+
+  test-build-and-publish:
+    runs-on: ubuntu-latest
+
+    needs: get-version
+    if: ${{ needs.get-version.outputs.version }}
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Build
+        run: NODE_ENV=production yarn build
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Test
+        run: yarn test
+
+      - name: destination-subscriptions size
+        run: |
+          if $(lerna changed | grep -q destination-subscriptions); then
+            yarn subscriptions size
+          fi
+
+      - name: Set author
+        run: |
+          git config user.email "github-actions@github.com"
+          git config user.name "github-actions"
+
+      - name: Publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: lerna version ${{ needs.get-version.outputs.version }} --yes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,8 +89,8 @@ jobs:
 
       - name: Set author
         run: |
-          git config user.email "github-actions@github.com"
-          git config user.name "github-actions"
+          git config user.email "`git log --format='%ae' HEAD^!`"
+          git config user.name "`git log --format='%an' HEAD^!`"
 
       - name: Publish
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,11 +81,6 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: yarn test
 
-      - name: destination-subscriptions size
-        run: |
-          if $(lerna changed | grep -q destination-subscriptions); then
-            yarn subscriptions size
-          fi
 
       - name: Set author
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,9 +72,11 @@ jobs:
         run: NODE_ENV=production yarn build
 
       - name: Lint
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: yarn lint
 
       - name: Test
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: yarn test
 
       - name: destination-subscriptions size

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches: [main]
     types: [closed]
+    paths:
+      - packages/**
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,6 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: yarn test
 
-
       - name: Set author
         run: |
           git config user.email "`git log --format='%ae' HEAD^!`"
@@ -91,4 +90,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: lerna version ${{ needs.get-version.outputs.version }} --yes
+        run: lerna publish ${{ needs.get-version.outputs.version }} --yes


### PR DESCRIPTION
[RFC: Publish action-destinations Package Using CI Pipeline](https://paper.dropbox.com/doc/RFC-Publish-action-destinations-Package-Using-CI-Pipeline--BSEadZPFIYUeAi9sUggLCRTlAg-H0LJ3fjhkyJLVICXjGOTn)
[BE-102](https://segment.atlassian.net/browse/BE-102)

## Background
One pain point of this repository is that it requires developers to publish new packages from their local machines. I recently proposed an RFC (linked above) that outlined a plan to automate this package publishing process. The proposed solution, `auto`, did not work as seamlessly with monorepos as expected, so the solution in this PR is a bit different (and forgoes the changelog requirement altogether). The RFC contains a lot of good discussion and ideas on alternate implementations, which is why I've included it as a reference document. Since there are many different ideas, I intend this solution to be iterated on and modified in the future. My goal of this PR is to see if this is an agreeable first step in the right direction.

## Developer Experience
This PR establishes a `publish` GitHub action that can run **manually via workflow dispatch** or **automatically when a new pull request is merged**. 

[auto-publish-demo](https://github.com/segmentio/auto-publish-demo) is a repository that demonstrates this experience. Feel free experiment and merge PRs on that repository to get a better understanding. Since it is a demo, no `hello-world` or `random-number-generator` packages are published, but the [release tags](https://github.com/segmentio/auto-publish-demo/releases) are updated after the publish action is run. Running the `publish` action on `action-destinations` publishes NPM packages as well as updates release tags.

### Option 1: Manual trigger
1. In this repository, navigate to the 'Actions' tab
2. Under 'Workflows', click 'Publish'
3. In the workflow history box, click 'Run workflow'
4. Ensure the `main` branch is selected and enter the semver version you would like to publish
    - accepts any valid command for [lerna publish](https://github.com/lerna/lerna/tree/main/commands/publish#readme) (e.g., major, minor, patch)

### Option 2: Automated via PR
1. Clone the repository
2. Create a new branch
3. Modify one of the packages in the `./packages` directory
4. Push your changes
5. Create a pull request
6. Specify a label associated with the semver version you would like to publish
    - valid labels include `major`, `minor`, or `patch`
7. Merge the pull request

## Potential Issues
- All PRs that contain a label of `major`, `minor`, or `patch` will be published upon PR merge.
  - maybe only PRs with the label `publish` (or similar) should be published
- No changelog is generated
  - would be a nice addition if we began batching changes together