### PR TITLE
GRAMA-7 [personas-messaging-twilio] Allows journey metadata to be added to a send

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/__tests__/send-sms.test.ts
@@ -17,12 +17,19 @@ for (const environment of ['stage', 'production']) {
 
   const endpoint = `https://profiles.segment.${environment === 'production' ? 'com' : 'build'}`
 
+  beforeEach(() => {
+    nock(`${endpoint}/v1/spaces/d/collections/users/profiles/user_id:jane`).get('/traits?limit=200').reply(200, {
+      traits: {}
+    })
+  })
+
+  afterEach(() => {
+    twilio.responses = []
+    nock.cleanAll()
+  })
+
   describe(`${environment} - send SMS`, () => {
     it('should abort when there is no `phone` external ID', async () => {
-      nock(`${endpoint}/v1/spaces/d/collections/users/profiles/user_id:jane`).get('/traits?limit=200').reply(200, {
-        traits: {}
-      })
-
       nock(`${endpoint}/v1/spaces/d/collections/users/profiles/user_id:jane`)
         .get('/external_ids?limit=25')
         .reply(200, {
@@ -51,11 +58,7 @@ for (const environment of ['stage', 'production']) {
       expect(responses.length).toEqual(2)
     })
 
-    it('should send SMS', async () => {
-      nock(`${endpoint}/v1/spaces/d/collections/users/profiles/user_id:jane`).get('/traits?limit=200').reply(200, {
-        traits: {}
-      })
-
+    const testSendSms = async (expectedTwilioRequest: any, actionInputData: any) => {
       nock(`${endpoint}/v1/spaces/d/collections/users/profiles/user_id:jane`)
         .get('/external_ids?limit=25')
         .reply(200, {
@@ -71,16 +74,27 @@ for (const environment of ['stage', 'production']) {
           ]
         })
 
-      const expectedTwilioRequest = new URLSearchParams()
-      expectedTwilioRequest.set('Body', 'Hello world, jane!')
-      expectedTwilioRequest.set('From', '+1234567890')
-      expectedTwilioRequest.set('To', '+1234567891')
-
       const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
         .post('/Messages.json', expectedTwilioRequest.toString())
         .reply(201, {})
 
-      const responses = await twilio.testAction('sendSms', {
+      const responses = await twilio.testAction('sendSms', actionInputData)
+
+      expect(responses.map((response) => response.url)).toStrictEqual([
+        `${endpoint}/v1/spaces/d/collections/users/profiles/user_id:jane/traits?limit=200`,
+        `${endpoint}/v1/spaces/d/collections/users/profiles/user_id:jane/external_ids?limit=25`,
+        'https://api.twilio.com/2010-04-01/Accounts/a/Messages.json'
+      ])
+      expect(twilioRequest.isDone()).toEqual(true)
+    }
+
+    it('should send SMS', async () => {
+      const expectedTwilioRequest = new URLSearchParams({
+        Body: 'Hello world, jane!',
+        From: '+1234567890',
+        To: '+1234567891'
+      })
+      const actionInputData = {
         event: createTestEvent({
           timestamp,
           event: 'Audience Entered',
@@ -92,10 +106,79 @@ for (const environment of ['stage', 'production']) {
           fromNumber: '+1234567890',
           body: 'Hello world, {{profile.user_id}}!'
         }
+      }
+
+      await testSendSms(expectedTwilioRequest, actionInputData)
+    })
+
+    it('should send SMS with custom metadata', async () => {
+      const expectedTwilioRequest = new URLSearchParams({
+        Body: 'Hello world, jane!',
+        From: '+1234567890',
+        To: '+1234567891',
+        StatusCallback: 'http://localhost/?foo=bar'
       })
 
-      expect(responses.length).toEqual(3)
-      expect(twilioRequest.isDone()).toEqual(true)
+      const actionInputData = {
+        event: createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          userId: 'jane'
+        }),
+        settings: {
+          ...settings,
+          webhookUrl: 'http://localhost'
+        },
+        mapping: {
+          userId: { '@path': '$.userId' },
+          fromNumber: '+1234567890',
+          body: 'Hello world, {{profile.user_id}}!',
+          customArgs: {
+            foo: 'bar'
+          }
+        }
+      }
+
+      await testSendSms(expectedTwilioRequest, actionInputData)
+    })
+
+    it('should fail on invalid webhook url', async () => {
+      nock(`${endpoint}/v1/spaces/d/collections/users/profiles/user_id:jane`)
+        .get('/external_ids?limit=25')
+        .reply(200, {
+          data: [
+            {
+              type: 'user_id',
+              id: 'jane'
+            },
+            {
+              type: 'phone',
+              id: '+1234567891'
+            }
+          ]
+        })
+
+      const actionInputData = {
+        event: createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          userId: 'jane'
+        }),
+        settings: {
+          ...settings,
+          webhookUrl: 'foo'
+        },
+        mapping: {
+          userId: { '@path': '$.userId' },
+          fromNumber: '+1234567890',
+          body: 'Hello world, {{profile.user_id}}!',
+          customArgs: {
+            foo: 'bar'
+          }
+        }
+      }
+
+      await expect(twilio.testAction('sendSms', actionInputData)).rejects.toHaveProperty('code', 'ERR_INVALID_URL')
     })
   })
 }

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/generated-types.ts
@@ -25,4 +25,8 @@ export interface Settings {
    * Source ID
    */
   sourceId: string
+  /**
+   * Webhook URL that will receive all events for the sent message
+   */
+  webhookUrl?: string
 }

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
@@ -43,6 +43,13 @@ const destination: DestinationDefinition<Settings> = {
         description: 'Source ID',
         type: 'string',
         required: true
+      },
+      webhookUrl: {
+        label: 'Webhook URL',
+        description: 'Webhook URL that will receive all events for the sent message',
+        type: 'string',
+        format: 'uri',
+        required: false
       }
     },
     testAuthentication: (request) => {

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/generated-types.ts
@@ -17,4 +17,10 @@ export interface Payload {
    * Message to send
    */
   body: string
+  /**
+   * Additional custom arguments that will be opaquely sent back on webhook events
+   */
+  customArgs?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
@@ -90,6 +90,12 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'Message to send',
       type: 'text',
       required: true
+    },
+    customArgs: {
+      label: 'Custom Arguments',
+      description: 'Additional custom arguments that will be opaquely sent back on webhook events',
+      type: 'object',
+      required: false
     }
   },
   perform: async (request, { settings, payload }) => {
@@ -113,16 +119,31 @@ const action: ActionDefinition<Settings, Payload> = {
     // and we no longer need to call the profiles API first
     const token = Buffer.from(`${settings.twilioAccountId}:${settings.twilioAuthToken}`).toString('base64')
 
+    const body = new URLSearchParams({
+      Body: Mustache.render(payload.body, { profile }),
+      From: payload.fromNumber,
+      To: phone
+    })
+
+    const webhookUrl = settings.webhookUrl
+    const customArgs = payload.customArgs
+    if (webhookUrl && customArgs) {
+      // Webhook URL parsing has a potential of failing. I think it's better that
+      // we fail out of any invocation than silently not getting analytics
+      // data if that's what we're expecting.
+      const webhookUrlWithParams = new URL(webhookUrl)
+      for (const key of Object.keys(customArgs)) {
+        webhookUrlWithParams.searchParams.append(key, String(customArgs[key]))
+      }
+      body.append('StatusCallback', webhookUrlWithParams.toString())
+    }
+
     return request(`https://api.twilio.com/2010-04-01/Accounts/${settings.twilioAccountId}/Messages.json`, {
       method: 'POST',
       headers: {
         authorization: `Basic ${token}`
       },
-      body: new URLSearchParams({
-        Body: Mustache.render(payload.body, { profile }),
-        From: payload.fromNumber,
-        To: phone
-      })
+      body
     })
   }
 }


### PR DESCRIPTION
We're going to want to track analytical data on sends from journeys. This will allow us to add that data via custom args. This will require additional backend setup to ensure that the action-destination is configured with the proper source base webhook.

This follows from #149. My plan is probably to wait on feedback so that this can take a similar approach.