### PR TITLE
GROW-254 [personas-messaging-twilio] Rename Twilio DA to Creation name

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
@@ -3,7 +3,9 @@ import type { Settings } from './generated-types'
 import sendSms from './sendSms'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Actions Personas Messaging Twilio',
+  //The name below is creation name however in partner portal this is Actions Personas Messaging Twilio
+  //This is due to integrations-consumer fetches the creation name instead of current name
+  name: 'Personas Messaging Twilio (Actions)',
   mode: 'cloud',
   authentication: {
     scheme: 'custom',


### PR DESCRIPTION
This PR renames the Twilio Action name to the Creation name.
integration-consumer fetches the creation name and creates the slug. 
https://github.com/segmentio/integrations-consumer/blob/89a5eb73c0523c68b58e82e0a0563f647e4aedcc/destination.go#L263
Which will be incorrect for any destination after the name change.
The table below is being fetched
ctlstore_destination_metadata  and this table does not have a column for name just creation name :how:. Will let integrations team know this is  bug and need to be rectified for anyone who lands to this issue in future. I will look at renaming the creation name since we were able to rename the slug before. That should solve this issue for us. Will keep you all posted how it goes
mysql> select * from ctlstore_destination_metadata where id='6116a41e2e8fc680d8daf821';
+--------------------------+-------------------------------------+----------+--------------------+------------------+-----------------------------------------------------------------------------+
| id                       | creation_name                       | endpoint | type               | partner_settings | previous_names                                                              |
+--------------------------+-------------------------------------+----------+--------------------+------------------+-----------------------------------------------------------------------------+
| 6116a41e2e8fc680d8daf821 | Personas Messaging Twilio (Actions) |          | action_destination | {}               | ["Personas Messaging Twilio (Actions)","Actions Personas Messaging Twilio"] |
+--------------------------+-------------------------------------+----------+--------------------+------------------+-----------------------------------------------------------------------------+
1 row in set (0.00 sec)

Will reachout to integrations team about this issue.