### PR TITLE
Remove actions-core from optional deps

### DIFF
--- a/packages/browser-destinations/package.json
+++ b/packages/browser-destinations/package.json
@@ -41,6 +41,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.13.8",
     "@babel/preset-env": "^7.13.10",
     "@babel/preset-typescript": "^7.13.0",
+    "@segment/actions-core": "^3.8.2",
     "@types/amplitude-js": "^7.0.1",
     "@types/intercom-web": "^2.8.11",
     "@types/jest": "^26.0.23",
@@ -59,9 +60,6 @@
     "webpack-bundle-analyzer": "^4.4.1",
     "webpack-cli": "^4.4.0",
     "webpack-dev-server": "^4.2.0"
-  },
-  "optionalDependencies": {
-    "@segment/actions-core": "^3.8.2"
   },
   "prettier": {
     "semi": false,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,6 +56,7 @@
     "@oclif/config": "^1",
     "@oclif/errors": "^1",
     "@oclif/plugin-help": "^3",
+    "@segment/actions-core": "^3.8.2",
     "@segment/action-destinations": "^3.8.4",
     "chalk": "^4.1.1",
     "chokidar": "^3.5.1",
@@ -79,7 +80,6 @@
     "tslib": "^2"
   },
   "optionalDependencies": {
-    "@segment/actions-core": "^3.8.2",
     "@segment/browser-destinations": "^3.8.4",
     "@segment/control-plane-service-client": "github:segmentio/control-plane-service-js-client.git#master"
   },

--- a/packages/destination-actions/package.json
+++ b/packages/destination-actions/package.json
@@ -38,12 +38,10 @@
   },
   "dependencies": {
     "@amplitude/ua-parser-js": "^0.7.24",
+    "@segment/actions-core": "^3.8.2",
     "dayjs": "^1.10.3",
     "lodash": "^4.17.21",
     "mustache": "^4.2.0"
-  },
-  "optionalDependencies": {
-    "@segment/actions-core": "^3.8.2"
   },
   "jest": {
     "preset": "ts-jest",


### PR DESCRIPTION
Removes `@segment/actions-core` as an _optional_ dependency of other packages. The external workflow doesn't break with this change: https://github.com/segmentio/action-destinations/runs/3592019198