### PR TITLE
make github cancel jobs that take too long

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,4 +103,4 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --severity-threshold=high --fail-on=upgradable --all-projects --policy-path=/.snyk
+          args: --severity-threshold=high --fail-on=upgradable --all-projects --policy-path=.snyk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ jobs:
   test-and-build:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 10
+
     strategy:
       matrix:
         node-version: [14.x]
@@ -58,6 +60,8 @@ jobs:
 
   snyk:
     runs-on: ubuntu-latest
+
+    timeout-minutes: 5
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,4 +103,4 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --severity-threshold=high --fail-on=upgradable --all-projects
+          args: --severity-threshold=high --fail-on=upgradable --all-projects --policy-path=/.snyk

--- a/.github/workflows/ext.yml
+++ b/.github/workflows/ext.yml
@@ -6,6 +6,8 @@ jobs:
   install-and-test:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 10
+
     strategy:
       matrix:
         node-version: [14.x]

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,13 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.14.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-ANSIREGEX-1583908:
+    - '*':
+        reason: no commonjs patch
+        expires: 2021-10-13T21:57:12.496Z
+  SNYK-JS-LODASHTEMPLATE-1088054:
+    - '*':
+        reason: no commonjs patch
+        expires: 2021-10-13T21:57:12.496Z
+patch: {}


### PR DESCRIPTION
Prevent this insanity:

<img width="155" alt="Screen Shot 2021-09-13 at 4 31 37 PM" src="https://user-images.githubusercontent.com/710752/133159613-d99399df-cc3b-47e2-b195-cd0fcad96840.png">
