### PR TITLE
Load cps-client at runtime

### DIFF
--- a/packages/cli/src/commands/push-browser-destinations.ts
+++ b/packages/cli/src/commands/push-browser-destinations.ts
@@ -7,6 +7,7 @@ import ora from 'ora'
 import { assetPath } from '../config'
 import type { RemotePlugin } from '../lib/control-plane-service'
 import { prompt } from '../lib/prompt'
+import loadCPS from '../lib/control-plane-service'
 import {
   getDestinationMetadatas,
   getRemotePluginByDestinationIds,
@@ -34,6 +35,18 @@ export default class PushBrowserDestinations extends Command {
   static args = []
 
   async run() {
+    try {
+      await loadCPS()
+    } catch (err) {
+      if (err.code === 'MODULE_NOT_FOUND') {
+        this.warn(
+          'This command is only available to Segmenters. If you are a Segment internal builder please run `yarn install` and ensure the control-plane-service-client is installed.'
+        )
+      } else {
+        this.error(err.message)
+      }
+      this.exit()
+    }
     const { flags } = this.parse(PushBrowserDestinations)
     const { destinationIds } = await prompt<{ destinationIds: string[] }>({
       type: 'multiselect',

--- a/packages/cli/src/commands/push-browser-destinations.ts
+++ b/packages/cli/src/commands/push-browser-destinations.ts
@@ -36,7 +36,7 @@ export default class PushBrowserDestinations extends Command {
 
   async run() {
     try {
-      await loadCPS()
+      loadCPS()
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND') {
         this.warn(

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -81,7 +81,7 @@ export default class Push extends Command {
 
   async run() {
     try {
-      await loadCPS()
+      loadCPS()
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND') {
         this.warn(

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -11,6 +11,7 @@ import chalk from 'chalk'
 import { uniq, pick, omit, sortBy, mergeWith } from 'lodash'
 import { diffString } from 'json-diff'
 import ora from 'ora'
+import loadCPS from '../lib/control-plane-service'
 import type {
   ClientRequestError,
   DestinationMetadata,
@@ -79,6 +80,19 @@ export default class Push extends Command {
   static args = []
 
   async run() {
+    try {
+      await loadCPS()
+    } catch (err) {
+      if (err.code === 'MODULE_NOT_FOUND') {
+        this.warn(
+          'This command is only available to Segmenters. If you are a Segment internal builder please run `yarn install` and ensure the control-plane-service-client is installed.'
+        )
+      } else {
+        this.error(err.message)
+      }
+      this.exit()
+    }
+
     const { flags } = this.parse(Push)
 
     const { metadataIds } = await prompt<{ metadataIds: string[] }>({

--- a/packages/cli/src/commands/register.ts
+++ b/packages/cli/src/commands/register.ts
@@ -33,7 +33,7 @@ export default class Register extends Command {
 
   async run() {
     try {
-      this.controlPlaneService = await loadCPS()
+      this.controlPlaneService = loadCPS()
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND') {
         this.warn(

--- a/packages/cli/src/lib/control-plane-client.ts
+++ b/packages/cli/src/lib/control-plane-client.ts
@@ -1,5 +1,5 @@
-import {
-  controlPlaneService,
+import loadCPS from '../lib/control-plane-service'
+import type {
   DestinationMetadata,
   DestinationMetadataAction,
   DestinationMetadataActionCreateInput,
@@ -12,6 +12,7 @@ import {
 const NOOP_CONTEXT = {}
 
 export async function getDestinationMetadatas(destinationIds: string[]): Promise<DestinationMetadata[]> {
+  const controlPlaneService = await loadCPS()
   const { data, error } = await controlPlaneService.getAllDestinationMetadatas(NOOP_CONTEXT, {
     byIds: destinationIds
   })
@@ -28,6 +29,7 @@ export async function getDestinationMetadatas(destinationIds: string[]): Promise
 }
 
 export async function getDestinationMetadataActions(destinationIds: string[]): Promise<DestinationMetadataAction[]> {
+  const controlPlaneService = await loadCPS()
   const { data, error } = await controlPlaneService.getDestinationMetadataActions(NOOP_CONTEXT, {
     metadataIds: destinationIds
   })
@@ -47,6 +49,7 @@ export async function updateDestinationMetadata(
   destinationId: string,
   input: DestinationMetadataUpdateInput
 ): Promise<DestinationMetadata> {
+  const controlPlaneService = await loadCPS()
   const { data, error } = await controlPlaneService.updateDestinationMetadata(NOOP_CONTEXT, {
     destinationId,
     input
@@ -64,6 +67,7 @@ export async function updateDestinationMetadata(
 }
 
 export async function setSubscriptionPresets(metadataId: string, presets: DestinationSubscriptionPresetInput[]) {
+  const controlPlaneService = await loadCPS()
   const { data, error } = await controlPlaneService.setDestinationSubscriptionPresets(NOOP_CONTEXT, {
     metadataId,
     presets
@@ -86,6 +90,7 @@ export async function createDestinationMetadataActions(
 ): Promise<DestinationMetadataAction[]> {
   if (!input.length) return []
 
+  const controlPlaneService = await loadCPS()
   const { data, error } = await controlPlaneService.createDestinationMetadataActions(NOOP_CONTEXT, {
     input
   })
@@ -107,6 +112,7 @@ export async function updateDestinationMetadataActions(
 ): Promise<DestinationMetadataAction[]> {
   if (!input.length) return []
 
+  const controlPlaneService = await loadCPS()
   const { data, error } = await controlPlaneService.updateDestinationMetadataActions(NOOP_CONTEXT, {
     input
   })
@@ -123,6 +129,7 @@ export async function updateDestinationMetadataActions(
 }
 
 export async function getRemotePluginByDestinationIds(metadataIds: string[]): Promise<RemotePlugin[]> {
+  const controlPlaneService = await loadCPS()
   const { data, error } = await controlPlaneService.getRemotePluginsByDestinationMetadataIds(NOOP_CONTEXT, {
     metadataIds
   })
@@ -139,6 +146,7 @@ export async function getRemotePluginByDestinationIds(metadataIds: string[]): Pr
 }
 
 export async function updateRemotePlugin(plugin: RemotePlugin): Promise<RemotePlugin> {
+  const controlPlaneService = await loadCPS()
   const { data, error } = await controlPlaneService.updateRemotePlugin(NOOP_CONTEXT, {
     metadataId: plugin.metadataId,
     name: plugin.name,
@@ -160,6 +168,7 @@ export async function updateRemotePlugin(plugin: RemotePlugin): Promise<RemotePl
 }
 
 export async function createRemotePlugin(plugin: RemotePlugin): Promise<RemotePlugin> {
+  const controlPlaneService = await loadCPS()
   const { data, error } = await controlPlaneService.createRemotePlugin(NOOP_CONTEXT, {
     input: plugin
   })

--- a/packages/cli/src/lib/control-plane-client.ts
+++ b/packages/cli/src/lib/control-plane-client.ts
@@ -12,7 +12,7 @@ import type {
 const NOOP_CONTEXT = {}
 
 export async function getDestinationMetadatas(destinationIds: string[]): Promise<DestinationMetadata[]> {
-  const controlPlaneService = await loadCPS()
+  const controlPlaneService = loadCPS()
   const { data, error } = await controlPlaneService.getAllDestinationMetadatas(NOOP_CONTEXT, {
     byIds: destinationIds
   })
@@ -29,7 +29,7 @@ export async function getDestinationMetadatas(destinationIds: string[]): Promise
 }
 
 export async function getDestinationMetadataActions(destinationIds: string[]): Promise<DestinationMetadataAction[]> {
-  const controlPlaneService = await loadCPS()
+  const controlPlaneService = loadCPS()
   const { data, error } = await controlPlaneService.getDestinationMetadataActions(NOOP_CONTEXT, {
     metadataIds: destinationIds
   })
@@ -49,7 +49,7 @@ export async function updateDestinationMetadata(
   destinationId: string,
   input: DestinationMetadataUpdateInput
 ): Promise<DestinationMetadata> {
-  const controlPlaneService = await loadCPS()
+  const controlPlaneService = loadCPS()
   const { data, error } = await controlPlaneService.updateDestinationMetadata(NOOP_CONTEXT, {
     destinationId,
     input
@@ -67,7 +67,7 @@ export async function updateDestinationMetadata(
 }
 
 export async function setSubscriptionPresets(metadataId: string, presets: DestinationSubscriptionPresetInput[]) {
-  const controlPlaneService = await loadCPS()
+  const controlPlaneService = loadCPS()
   const { data, error } = await controlPlaneService.setDestinationSubscriptionPresets(NOOP_CONTEXT, {
     metadataId,
     presets
@@ -90,7 +90,7 @@ export async function createDestinationMetadataActions(
 ): Promise<DestinationMetadataAction[]> {
   if (!input.length) return []
 
-  const controlPlaneService = await loadCPS()
+  const controlPlaneService = loadCPS()
   const { data, error } = await controlPlaneService.createDestinationMetadataActions(NOOP_CONTEXT, {
     input
   })
@@ -112,7 +112,7 @@ export async function updateDestinationMetadataActions(
 ): Promise<DestinationMetadataAction[]> {
   if (!input.length) return []
 
-  const controlPlaneService = await loadCPS()
+  const controlPlaneService = loadCPS()
   const { data, error } = await controlPlaneService.updateDestinationMetadataActions(NOOP_CONTEXT, {
     input
   })
@@ -129,7 +129,7 @@ export async function updateDestinationMetadataActions(
 }
 
 export async function getRemotePluginByDestinationIds(metadataIds: string[]): Promise<RemotePlugin[]> {
-  const controlPlaneService = await loadCPS()
+  const controlPlaneService = loadCPS()
   const { data, error } = await controlPlaneService.getRemotePluginsByDestinationMetadataIds(NOOP_CONTEXT, {
     metadataIds
   })
@@ -146,7 +146,7 @@ export async function getRemotePluginByDestinationIds(metadataIds: string[]): Pr
 }
 
 export async function updateRemotePlugin(plugin: RemotePlugin): Promise<RemotePlugin> {
-  const controlPlaneService = await loadCPS()
+  const controlPlaneService = loadCPS()
   const { data, error } = await controlPlaneService.updateRemotePlugin(NOOP_CONTEXT, {
     metadataId: plugin.metadataId,
     name: plugin.name,
@@ -168,7 +168,7 @@ export async function updateRemotePlugin(plugin: RemotePlugin): Promise<RemotePl
 }
 
 export async function createRemotePlugin(plugin: RemotePlugin): Promise<RemotePlugin> {
-  const controlPlaneService = await loadCPS()
+  const controlPlaneService = loadCPS()
   const { data, error } = await controlPlaneService.createRemotePlugin(NOOP_CONTEXT, {
     input: plugin
   })

--- a/packages/cli/src/lib/control-plane-service.ts
+++ b/packages/cli/src/lib/control-plane-service.ts
@@ -1,16 +1,26 @@
 // @ts-ignore it's ok if CPS isn't available
-import ControlPlaneService from '@segment/control-plane-service-client'
+import type { Client } from '@segment/control-plane-service-client'
 // @ts-ignore it's ok if CPS isn't available
-export * from '@segment/control-plane-service-client'
+export type * from '@segment/control-plane-service-client'
 
-export const controlPlaneService = new ControlPlaneService({
-  name: 'control-plane-service',
-  url: 'http://control-plane-service.segment.local',
-  userAgent: 'Segment (actions cli)',
-  timeout: 10000,
-  headers: {
-    // All calls from this script are system-to-system and shouldn't require authz checks
-    // TODO remove this once we support auth tokens
-    'skip-authz': '1'
+let client: Client
+
+export default async function loadCPS(): Client {
+  if (!client) {
+    const module = await import('@segment/control-plane-service-client')
+    const ControlPlaneService = module.default as Client
+    client = new ControlPlaneService({
+      name: 'control-plane-service',
+      url: 'http://control-plane-service.segment.local',
+      userAgent: 'Segment (actions cli)',
+      timeout: 10000,
+      headers: {
+        // All calls from this script are system-to-system and shouldn't require authz checks
+        // TODO remove this once we support auth tokens
+        'skip-authz': '1'
+      }
+    })
   }
-})
+
+  return client
+}

--- a/packages/cli/src/lib/control-plane-service.ts
+++ b/packages/cli/src/lib/control-plane-service.ts
@@ -5,10 +5,13 @@ export type * from '@segment/control-plane-service-client'
 
 let client: Client
 
-export default async function loadCPS(): Client {
+export default function loadCPS(): Client {
   if (!client) {
-    const module = await import('@segment/control-plane-service-client')
-    const ControlPlaneService = module.default as Client
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const module = require('@segment/control-plane-service-client')
+    const ControlPlaneService: Client = module.default as Client
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     client = new ControlPlaneService({
       name: 'control-plane-service',
       url: 'http://control-plane-service.segment.local',


### PR DESCRIPTION
Oclif suffers from a bug where all commands are imported (but not invoked) anytime the CLI is called, regardless of which command it is (see https://github.com/oclif/oclif/issues/606). This issue causes confusing errors to be logged when the builder doesn't have `@segment/control-plane-service-client` installed:

```
(node:19492) [MODULE_NOT_FOUND] Error Plugin: @segment/actions-cli: Cannot find module '@segment/control-plane-service-client'
Require stack:
- /Users/builder/action-destinations/packages/cli/src/lib/control-plane-service.ts
- /Users/builder/action-destinations/packages/cli/src/lib/control-plane-client.ts
- /Users/builder/action-destinations/packages/cli/src/commands/push-browser-destinations.ts
- /Users/builder/action-destinations/node_modules/@oclif/config/lib/plugin.js
- /Users/builder/action-destinations/node_modules/@oclif/config/lib/config.js
- /Users/builder/action-destinations/node_modules/@oclif/config/lib/index.js
- /Users/builder/action-destinations/node_modules/@oclif/command/lib/command.js
- /Users/builder/action-destinations/node_modules/@oclif/command/lib/index.js
- /Users/builder/action-destinations/packages/cli/bin/run
module: @oclif/config@1.17.0
task: toCached
plugin: @segment/actions-cli
root: /Users/builder/action-destinations/packages/cli
See more details with DEBUG=*
(Use `node --trace-warnings ...` to show where the warning was created)
```

This pull request updates the CLI so the `@segment/control-plane-service-client` dependency is loaded when commands are run/invoked so `MODULE_NOT_FOUND` are no longer logged.

When a command is invoked and the CPS client can't be loaded, this warning will be printed:
```
❯ ./bin/run push
 ›   Warning: This command is only available to Segmenters. If you are a Segment internal builder please run `yarn
 ›   install` and ensure the control-plane-service-client is installed.
```