### PR TITLE
add choices to interface for InputField and enforce as enum

### DIFF
--- a/packages/cli/src/commands/generate/types.ts
+++ b/packages/cli/src/commands/generate/types.ts
@@ -138,22 +138,23 @@ async function generateTypes(fields: Record<string, InputField> = {}, name: stri
 
 function prepareSchema(fields: Record<string, InputField>): JSONSchema4 {
   let schema = fieldsToJsonSchema(fields, { tsType: true })
-  // Remove titles so it produces cleaner output
-  schema = removeTitles(schema)
+  // Remove extra properties so it produces cleaner output
+  schema = removeExtra(schema)
   return schema
 }
 
-function removeTitles(schema: JSONSchema4) {
+function removeExtra(schema: JSONSchema4) {
   const copy = { ...schema }
 
   delete copy.title
+  delete copy.enum
 
   if (copy.type === 'object' && copy.properties) {
     for (const [key, property] of Object.entries(copy.properties)) {
-      copy.properties[key] = removeTitles(property)
+      copy.properties[key] = removeExtra(property)
     }
   } else if (copy.type === 'array' && copy.items) {
-    copy.items = removeTitles(copy.items)
+    copy.items = removeExtra(copy.items)
   }
 
   return copy

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -142,6 +142,18 @@ export default class Push extends Command {
             )
           }
 
+          let choices: null | { label: string; value: string } = null
+          if (Array.isArray(field.choices) && field.choices.length > 0) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            choices = field.choices.map((choice: string | { label: string; value: string }) => {
+              if (typeof choice === 'string') {
+                return { label: choice, value: choice }
+              }
+
+              return choice
+            })
+          }
+
           return {
             fieldKey,
             type: field.type,
@@ -150,8 +162,7 @@ export default class Push extends Command {
             defaultValue: field.default,
             required: field.required ?? false,
             multiple: field.multiple ?? false,
-            // TODO implement
-            choices: null,
+            choices,
             dynamic: field.dynamic ?? false,
             placeholder: field.placeholder ?? '',
             allowNull: field.allowNull ?? false,

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -83,6 +83,18 @@ export interface InputField {
   placeholder?: string
   /** Whether or not the field supports dynamically fetching options */
   dynamic?: boolean
+  /**
+   * A predefined set of options for the setting.
+   * Only relevant for `type: 'string'` or `type: 'number'`.
+   */
+  choices?:
+    | Array<string>
+    | Array<{
+        /** The value of the option */
+        value: string | number
+        /** A human-friendly label for the option */
+        label: string
+      }>
   /** Whether or not the field is required */
   required?: boolean
   /**

--- a/packages/destination-actions/src/destinations/braze/__tests__/braze.test.ts
+++ b/packages/destination-actions/src/destinations/braze/__tests__/braze.test.ts
@@ -7,13 +7,13 @@ const receivedAt = '2021-08-03T17:40:04.055Z'
 const settings = {
   app_id: 'my-app-id',
   api_key: 'my-api-key',
-  endpoint: 'https://example.com'
+  endpoint: 'https://rest.iad-01.braze.com' as const
 }
 
 describe(Braze.name, () => {
   describe('updateUserProfile', () => {
     it('should work with default mappings', async () => {
-      nock('https://example.com').post('/users/track').reply(200, {})
+      nock('https://rest.iad-01.braze.com').post('/users/track').reply(200, {})
 
       const event = createTestEvent({
         type: 'identify',
@@ -81,7 +81,7 @@ describe(Braze.name, () => {
     })
 
     it('should require one of braze_id, user_alias, or external_id', async () => {
-      nock('https://example.com').post('/users/track').reply(200, {})
+      nock('https://rest.iad-01.braze.com').post('/users/track').reply(200, {})
 
       const event = createTestEvent({
         type: 'identify',
@@ -102,7 +102,7 @@ describe(Braze.name, () => {
 
   describe('trackEvent', () => {
     it('should work with default mappings', async () => {
-      nock('https://example.com').post('/users/track').reply(200, {})
+      nock('https://rest.iad-01.braze.com').post('/users/track').reply(200, {})
 
       const event = createTestEvent({
         event: 'Test Event',
@@ -152,7 +152,7 @@ describe(Braze.name, () => {
 
   describe('trackPurchase', () => {
     it('should work with default mappings', async () => {
-      nock('https://example.com').post('/users/track').reply(200, {})
+      nock('https://rest.iad-01.braze.com').post('/users/track').reply(200, {})
 
       const event = createTestEvent({
         event: 'Order Completed',


### PR DESCRIPTION
We have choices exposed for global/auth settings, but forgot to expose it for action fields. This PR fixes that!

We also will need to hook it up in Control Plane:
https://github.com/segmentio/control-plane/blob/250b8c149fcce3a3caf2e9142debd2a3a05a4528/src/resources/destination-metadata/actions/action.ts#L29-L44

And in the UI:
https://github.com/segmentio/app/blob/c00d71b09c716ad98676918d1b7493d7bcf6baf0/client/containers/DestinationActions/components/RichInput/RichInput.tsx#L283-L293