### PR TITLE
Touch up fullstory actions

### DIFF
--- a/packages/browser-destinations/src/destinations/fullstory/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/generated-types.ts
@@ -21,4 +21,8 @@ export interface Settings {
    * Sends pages to FullStory as tracking events.
    */
   trackPagesWithEvents?: boolean
+  /**
+   * Enables FullStory debug mode.
+   */
+  debug?: boolean
 }

--- a/packages/browser-destinations/src/destinations/fullstory/identifyUser/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/identifyUser/index.ts
@@ -9,7 +9,7 @@ const action: BrowserActionDefinition<Settings, typeof FullStory, Payload> = {
   title: 'Identify User',
   description: 'Sets user identity variables',
   platform: 'web',
-  defaultSubscription: "type = 'identify'",
+  defaultSubscription: 'type = "identify"',
   fields: {
     userId: {
       type: 'string',

--- a/packages/browser-destinations/src/destinations/fullstory/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/index.ts
@@ -6,11 +6,32 @@ import { initScript } from './init-script'
 import trackEvent from './trackEvent'
 import identifyUser from './identifyUser'
 import viewedPage from './viewedPage'
+import { defaultValues } from '@segment/actions-core'
 
 export const destination: BrowserDestinationDefinition<Settings, typeof FullStory> = {
   name: 'Fullstory',
   slug: 'actions-fullstory',
   mode: 'device',
+  presets: [
+    {
+      name: 'Track Event',
+      subscribe: 'type = "track"',
+      partnerAction: 'trackEvent',
+      mapping: defaultValues(trackEvent.fields)
+    },
+    {
+      name: 'Identify User',
+      subscribe: 'type = "identify"',
+      partnerAction: 'identifyUser',
+      mapping: defaultValues(identifyUser.fields)
+    },
+    {
+      name: 'Viewed Page',
+      subscribe: 'type = "page"',
+      partnerAction: 'viewedPage',
+      mapping: defaultValues(viewedPage.fields)
+    }
+  ],
   settings: {
     orgId: {
       description: 'The organization ID for FullStory.',
@@ -45,6 +66,13 @@ export const destination: BrowserDestinationDefinition<Settings, typeof FullStor
       type: 'boolean',
       required: false,
       default: true
+    },
+    debug: {
+      description: 'Enables FullStory debug mode.',
+      label: 'debug',
+      type: 'boolean',
+      required: false,
+      default: false
     }
   },
   actions: {
@@ -53,7 +81,7 @@ export const destination: BrowserDestinationDefinition<Settings, typeof FullStor
     viewedPage
   },
   initialize: async ({ settings }, dependencies) => {
-    initScript({ debug: false, org: settings.orgId })
+    initScript({ debug: settings.debug, org: settings.orgId })
     await dependencies.loadScript('https://edge.fullstory.com/s/fs.js')
     await dependencies.resolveWhen(() => Object.prototype.hasOwnProperty.call(window, 'FS'), 100)
     return FullStory

--- a/packages/browser-destinations/src/destinations/fullstory/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/index.ts
@@ -41,35 +41,35 @@ export const destination: BrowserDestinationDefinition<Settings, typeof FullStor
     },
     trackAllPages: {
       description: 'Sends all page calls as tracking events to FullStory.',
-      label: 'trackAllPages',
+      label: 'Track All Pages',
       type: 'boolean',
       required: false,
       default: false
     },
     trackNamedPages: {
       description: 'Sends pages with names to FullStory as tracking events.',
-      label: 'trackNamedPages',
+      label: 'Track Named Pages',
       type: 'boolean',
       required: false,
       default: false
     },
     trackCategorizedPages: {
       description: 'Sends pages that specify a category to Fullstory as tracking events.',
-      label: 'trackCategorizedPages',
+      label: 'Track Categorized Pages',
       type: 'boolean',
       required: false,
       default: false
     },
     trackPagesWithEvents: {
       description: 'Sends pages to FullStory as tracking events.',
-      label: 'trackPagesWithEvents',
+      label: 'Track Pages With Events',
       type: 'boolean',
       required: false,
       default: true
     },
     debug: {
       description: 'Enables FullStory debug mode.',
-      label: 'debug',
+      label: 'Debug mode',
       type: 'boolean',
       required: false,
       default: false

--- a/packages/browser-destinations/src/destinations/fullstory/viewedPage/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/viewedPage/index.ts
@@ -7,7 +7,7 @@ import * as FullStory from '@fullstory/browser'
 const action: BrowserActionDefinition<Settings, typeof FullStory, Payload> = {
   title: 'Viewed Page',
   description: 'Page events',
-  defaultSubscription: "type = 'page'",
+  defaultSubscription: 'type = "page"',
   platform: 'web',
   fields: {
     name: {

--- a/packages/browser-destinations/src/destinations/fullstory/viewedPage/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/viewedPage/index.ts
@@ -49,7 +49,7 @@ const action: BrowserActionDefinition<Settings, typeof FullStory, Payload> = {
     if (name && event.settings.trackNamedPages) {
       // named pages
       if (event.settings.trackPagesWithEvents) {
-        client.event(name, event.payload.properties || {})
+        client.event(`Viewed ${name} Page`, event.payload.properties || {})
       }
 
       // @ts-ignore setVars in beta
@@ -57,7 +57,7 @@ const action: BrowserActionDefinition<Settings, typeof FullStory, Payload> = {
     } else if (event.payload.category && event.settings.trackCategorizedPages) {
       // categorized pages
       if (event.settings.trackPagesWithEvents) {
-        client.event(event.payload.category, event.payload.properties || {})
+        client.event(`Viewed ${event.payload.category} Page`, event.payload.properties || {})
       }
 
       // @ts-ignore setVars in beta
@@ -65,7 +65,7 @@ const action: BrowserActionDefinition<Settings, typeof FullStory, Payload> = {
     } else if (event.settings.trackAllPages) {
       // all pages
       if (event.settings.trackPagesWithEvents) {
-        client.event(event.payload.name || '', event.payload.properties || {})
+        client.event('Loaded a Page', event.payload.properties || {})
       }
 
       // @ts-ignore setVars in beta


### PR DESCRIPTION
- Changes quotations to fix default subscriptions
- Adds debug option
- Adds quick setup capability
- Updates labels to be cleaner/match legacy FullStory destination
- Changes page action to match output that legacy FullStory destination gets from `facade`