### PR TITLE
Add fullstory production id

### DIFF
--- a/packages/browser-destinations/src/destinations/index.ts
+++ b/packages/browser-destinations/src/destinations/index.ts
@@ -30,3 +30,4 @@ register('5f7dd6d21ad74f3842b1fc47', './amplitude-plugins')
 register('60fb01aec459242d3b6f20c1', './braze')
 register('60f9d0d048950c356be2e4da', './braze-cloud-plugins')
 register('6138f272036e7c6650387fa4', './fullstory')
+register('6141153ee7500f15d3838703', './fullstory') // fullstory-prod

--- a/packages/browser-destinations/src/destinations/index.ts
+++ b/packages/browser-destinations/src/destinations/index.ts
@@ -29,5 +29,4 @@ function register(id: MetadataId, destinationPath: string) {
 register('5f7dd6d21ad74f3842b1fc47', './amplitude-plugins')
 register('60fb01aec459242d3b6f20c1', './braze')
 register('60f9d0d048950c356be2e4da', './braze-cloud-plugins')
-register('6138f272036e7c6650387fa4', './fullstory')
-register('6141153ee7500f15d3838703', './fullstory') // fullstory-prod
+register('6141153ee7500f15d3838703', './fullstory')


### PR DESCRIPTION
I had initially registered separate stage and production versions of fullstory instead of registering prod and then syncing with sprout. This changes it to the proper production ID