### PR TITLE
Move docs to root

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -131,6 +131,7 @@ describe('SendGrid', () => {
 ```
 
 ## Snapshot Tests
+
 Snapshot tests help developers understand how their changes affect the request body and the downstream tool. In `action-destinations`, they are automatically generated with both the `init` and `generate:action` CLI commands - the former creating destination-level snapshots and the latter creating action-level snapshots. These tests can be found in the `snapshot.test.ts` file under the `__tests__` folder.
 
 The `snapshot.test.ts` file mocks an HTTP server using `nock`, and generates random test data (w/ `Chance`) based on the destination action's fields and corresponding data type. For each destination action, it creates two snapshot tests - one for all fields and another for just the required fields. To ensure deterministic tests, the `Chance` instance is instantiated with a fixed seed corresponding to the destination action name.


### PR DESCRIPTION
This pull request moves the directory to the root, and tests out the new `pr2jira.yml` workflow.