### PR TITLE
[cli] Don't push null choices

### DIFF
--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -142,7 +142,7 @@ export default class Push extends Command {
             )
           }
 
-          let choices: null | { label: string; value: string } = null
+          let choices: undefined | { label: string; value: string } = undefined
           if (Array.isArray(field.choices) && field.choices.length > 0) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             choices = field.choices.map((choice: string | { label: string; value: string }) => {


### PR DESCRIPTION
This pull request avoids pushing a null value if there is no choices defined for an action's field. CPS throws an error if choices is defined as anything but an array.

From Matt: 
![image](https://user-images.githubusercontent.com/11635476/134068646-bcca83a2-9a64-486c-a15b-21fdefed29b0.png)
