### PR TITLE
Remove page presets from fullstory

### DIFF
--- a/packages/browser-destinations/src/destinations/fullstory/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/index.ts
@@ -37,12 +37,6 @@ export const destination: BrowserDestinationDefinition<Settings, typeof FullStor
       subscribe: 'type = "identify"',
       partnerAction: 'identifyUser',
       mapping: defaultValues(identifyUser.fields)
-    },
-    {
-      name: 'Viewed Page',
-      subscribe: 'type = "page"',
-      partnerAction: 'viewedPage',
-      mapping: defaultValues(viewedPage.fields)
     }
   ],
   settings: {

--- a/packages/browser-destinations/src/destinations/fullstory/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/index.ts
@@ -20,19 +20,6 @@ export const destination: BrowserDestinationDefinition<Settings, typeof FullStor
       mapping: defaultValues(trackEvent.fields)
     },
     {
-      name: 'Track Page Events',
-      subscribe: 'type = "page"',
-      partnerAction: 'trackEvent',
-      mapping: {
-        name: {
-          '@path': '$.name' // Page events will use "name" instead of "event"
-        },
-        properties: {
-          '@path': '$.properties'
-        }
-      }
-    },
-    {
       name: 'Identify User',
       subscribe: 'type = "identify"',
       partnerAction: 'identifyUser',


### PR DESCRIPTION
This PR removes the two page call related presets from fullstory actions to match the behaviour of the legacy destinations default settings on quick setup.