### PR TITLE
[Amplitude] Dual-write sessionId for a future migration

### DIFF
--- a/packages/browser-destinations/src/destinations/amplitude-plugins/sessionId/__tests__/sessionId.test.ts
+++ b/packages/browser-destinations/src/destinations/amplitude-plugins/sessionId/__tests__/sessionId.test.ts
@@ -84,8 +84,11 @@ describe('ajs-integration', () => {
     })
 
     const updatedCtx = await sessionIdPlugin.track?.(ctx)
+
     // @ts-expect-error Need to fix ajs-next types to allow for complex objects in `integrations`
     expect(updatedCtx?.event.integrations?.Amplitude?.session_id).not.toBeUndefined()
+    // @ts-expect-error Need to fix ajs-next types to allow for complex objects in `integrations`
+    expect(updatedCtx?.event.integrations['Actions Amplitude']?.session_id).not.toBeUndefined()
   })
 
   test('runs as an enrichment middleware', async () => {

--- a/packages/browser-destinations/src/destinations/amplitude-plugins/sessionId/index.ts
+++ b/packages/browser-destinations/src/destinations/amplitude-plugins/sessionId/index.ts
@@ -56,7 +56,14 @@ const action: BrowserActionDefinition<Settings, {}, Payload> = {
     }
 
     ls.setItem('analytics_session_id.last_access', newSession.toString())
+
+    /**
+     * We're changing the session id plugin to stop writing on the `integrations.Amplitude`
+     * field and start writing `integrations['Actions Amplitude']` instead. In the meantime, we're
+     * writing to both. Once we finish the migration, we'll stop writing to the first.
+     */
     context.updateEvent('integrations.Amplitude.session_id', id)
+    context.updateEvent('integrations.Actions Amplitude.session_id', id)
 
     return
   }


### PR DESCRIPTION
Initially, we should be writing and reading `session_id` from `integrations['Actions Amplitude']` instead of `integrations.Amplitude`. This PR dual-writes the `session_id` value into both properties from the `integrations` object so we can start the migration.

![Screen Shot 2021-09-21 at 3 14 25 PM](https://user-images.githubusercontent.com/484013/134255502-d2261c7b-a191-4b41-937b-570fa4f21fa8.png)
![Screen Shot 2021-09-21 at 3 17 36 PM](https://user-images.githubusercontent.com/484013/134255503-4494bba1-f688-43f9-97bf-e0648eabe550.png)
![Screen Shot 2021-09-21 at 3 18 14 PM](https://user-images.githubusercontent.com/484013/134255505-5a1997d8-31a9-4f32-ad5e-cdf99ad8fc26.png)


