### PR TITLE
scaffold example for criteo

### DIFF
--- a/packages/destination-actions/src/destinations/criteo/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/criteo/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-criteo destination: exampleAction action - all fields 1`] = `
+Object {
+  "greeting": ")7zwy1TWgrhp*",
+}
+`;
+
+exports[`Testing snapshot for actions-criteo destination: exampleAction action - required fields 1`] = `
+Object {
+  "greeting": ")7zwy1TWgrhp*",
+}
+`;

--- a/packages/destination-actions/src/destinations/criteo/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/criteo/__tests__/index.test.ts
@@ -1,6 +1,5 @@
 import nock from 'nock'
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { createTestIntegration } from '@segment/actions-core'
 import Definition from '../index'
 
 const testDestination = createTestIntegration(Definition)

--- a/packages/destination-actions/src/destinations/criteo/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/criteo/__tests__/index.test.ts
@@ -1,0 +1,21 @@
+import nock from 'nock'
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Criteo', () => {
+  describe('testAuthentication', () => {
+    it.skip('should validate authentication inputs', async () => {
+      nock('https://your.destination.endpoint').get('*').reply(200, {})
+
+      // This should match your authentication.fields
+      const authData = {
+        api_key: 'super_secret_123'
+      }
+
+      await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/criteo/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/criteo/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-criteo'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/criteo/exampleAction/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/criteo/exampleAction/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Criteo's exampleAction destination action: all fields 1`] = `
+Object {
+  "greeting": "2vMFL6kn(3qug",
+}
+`;
+
+exports[`Testing snapshot for Criteo's exampleAction destination action: required fields 1`] = `
+Object {
+  "greeting": "2vMFL6kn(3qug",
+}
+`;

--- a/packages/destination-actions/src/destinations/criteo/exampleAction/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/criteo/exampleAction/__tests__/index.test.ts
@@ -1,0 +1,10 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Criteo.exampleAction', () => {
+  // TODO: Test your action
+})

--- a/packages/destination-actions/src/destinations/criteo/exampleAction/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/criteo/exampleAction/__tests__/index.test.ts
@@ -1,10 +1,62 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 
 const testDestination = createTestIntegration(Destination)
+const timestamp = '2021-08-17T15:21:15.449Z'
 
 describe('Criteo.exampleAction', () => {
-  // TODO: Test your action
+  it('should invoke the performBatch function for batches', async () => {
+    nock('https://example.com').post(/.*/).reply(200)
+
+    const events = [
+      createTestEvent({ event: 'Button Clicked', userId: 'u_123', timestamp, properties: { name: 'Tami' } }),
+      createTestEvent({ event: 'Demo Requested', userId: 'u_456', timestamp, properties: { name: 'Matt' } })
+    ]
+
+    const responses = await testDestination.testBatchAction('exampleAction', {
+      events,
+      settings: {
+        api_key: 'super secret'
+      },
+      // This is an example of a customer's configuration, including an
+      // example of mapping-kit's `@template` directive.
+      mapping: {
+        greeting: {
+          '@template': 'Hello {{properties.name}}!'
+        }
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          status: 200
+        })
+      ])
+    )
+    expect(responses[0].options.headers).toMatchInlineSnapshot(`
+      Headers {
+        Symbol(map): Object {
+          "authorization": Array [
+            "Bearer super secret",
+          ],
+          "user-agent": Array [
+            "Segment",
+          ],
+        },
+      }
+    `)
+    expect(responses[0].options.json).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "greeting": "Hello Tami!",
+        },
+        Object {
+          "greeting": "Hello Matt!",
+        },
+      ]
+    `)
+  })
 })

--- a/packages/destination-actions/src/destinations/criteo/exampleAction/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/criteo/exampleAction/__tests__/snapshot.test.ts
@@ -4,8 +4,8 @@ import destination from '../../index'
 import nock from 'nock'
 
 const testDestination = createTestIntegration(destination)
-const actionSlug = '{{actionSlug}}'
-const destinationSlug = '{{destination}}'
+const actionSlug = 'exampleAction'
+const destinationSlug = 'Criteo'
 const seedName = `${destinationSlug}#${actionSlug}`
 
 describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {

--- a/packages/destination-actions/src/destinations/criteo/exampleAction/generated-types.ts
+++ b/packages/destination-actions/src/destinations/criteo/exampleAction/generated-types.ts
@@ -1,0 +1,3 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {}

--- a/packages/destination-actions/src/destinations/criteo/exampleAction/generated-types.ts
+++ b/packages/destination-actions/src/destinations/criteo/exampleAction/generated-types.ts
@@ -1,3 +1,8 @@
 // Generated file. DO NOT MODIFY IT BY HAND.
 
-export interface Payload {}
+export interface Payload {
+  /**
+   * A greeting message
+   */
+  greeting: string
+}

--- a/packages/destination-actions/src/destinations/criteo/exampleAction/index.ts
+++ b/packages/destination-actions/src/destinations/criteo/exampleAction/index.ts
@@ -4,23 +4,29 @@ import type { Payload } from './generated-types'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Example Action',
-  description: '',
-  fields: {},
-  perform: (_request, _data) => {
-    // Make your partner api request here!
-    // return request('https://example.com', {
-    //   method: 'post',
-    //   json: data.payload
-    // })
+  description: 'An example action that supports batch payloads.',
+  fields: {
+    // Feel free to remove/replace this field with relevant ones for Criteo
+    greeting: {
+      label: 'Greeting',
+      description: 'A greeting message',
+      type: 'string',
+      required: true
+    }
+  },
+  perform: (request, data) => {
+    return request('https://example.com', {
+      method: 'post',
+      json: data.payload
+    })
   },
   // `performBatch` defines the behavior for a batch of events
   // `data.payload` is an array of payloads in the `performBatch` function
-  performBatch: (_request, _data) => {
-    //
-    // return request('https://example.com', {
-    //   method: 'post',
-    //   json: data.payload
-    // })
+  performBatch: (request, data) => {
+    return request('https://example.com', {
+      method: 'post',
+      json: data.payload
+    })
   }
 }
 

--- a/packages/destination-actions/src/destinations/criteo/exampleAction/index.ts
+++ b/packages/destination-actions/src/destinations/criteo/exampleAction/index.ts
@@ -1,0 +1,27 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Example Action',
+  description: '',
+  fields: {},
+  perform: (_request, _data) => {
+    // Make your partner api request here!
+    // return request('https://example.com', {
+    //   method: 'post',
+    //   json: data.payload
+    // })
+  },
+  // `performBatch` defines the behavior for a batch of events
+  // `data.payload` is an array of payloads in the `performBatch` function
+  performBatch: (_request, _data) => {
+    //
+    // return request('https://example.com', {
+    //   method: 'post',
+    //   json: data.payload
+    // })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/criteo/generated-types.ts
+++ b/packages/destination-actions/src/destinations/criteo/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your Criteo API key
+   */
+  api_key: string
+}

--- a/packages/destination-actions/src/destinations/criteo/index.ts
+++ b/packages/destination-actions/src/destinations/criteo/index.ts
@@ -1,0 +1,44 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import exampleAction from './exampleAction'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Criteo',
+  slug: 'actions-criteo',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    // Define any authentication-related fields here that customers need to provide
+    // For example, `api_key`, `subdomain`, etc.
+    fields: {
+      // Feel free to remove/replace this example field
+      api_key: {
+        label: 'API Key',
+        description: 'Your Criteo API key',
+        type: 'string',
+        required: true
+      }
+    },
+    testAuthentication: (_request) => {
+      // Return a request that tests/validates the user's credentials.
+      // If you do not have a way to validate the authentication fields safely,
+      // you can remove the `testAuthentication` function, though discouraged.
+    }
+  },
+
+  // You can use `extendRequest` to provide options for the request client instance
+  // provided to all actions
+  extendRequest: ({ settings }) => {
+    return {
+      headers: { Authorization: `Bearer ${settings.api_key}` }
+    }
+  },
+
+  actions: {
+    exampleAction
+  }
+}
+
+export default destination


### PR DESCRIPTION
This adds scaffolding for a Criteo action destination, with an `exampleAction` action that has batching support (via the `performBatch` method).