### PR TITLE
[Amplitude-Cloud] Support `session_id` fetched from `$.integrations.Actions Amplitude.session_id`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,6 +28,17 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Run CLI Serve",
+      "program": "${workspaceFolder}/bin/run",
+      "restart": true,
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "port": 47082,
+      "args": ["serve"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Run CLI",
       "program": "${workspaceFolder}/bin/run",
       "args": [

--- a/packages/core/src/mapping-kit/__tests__/index.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.test.ts
@@ -174,6 +174,20 @@ describe('@path', () => {
     }).toThrowError()
   })
 
+  test('spaced nested value', () => {
+    const output = transform(
+      { neat: { '@path': '$.integrations.Actions Amplitude.session_id' } },
+      {
+        integrations: {
+          'Actions Amplitude': {
+            session_id: 'bar'
+          }
+        }
+      }
+    )
+    expect(output).toStrictEqual({ neat: 'bar' })
+  })
+
   test('invalid nested value type', () => {
     const output = transform({ neat: { '@path': '$.foo.bar.baz' } }, { foo: 'bar' })
     expect(output).toStrictEqual({})

--- a/packages/core/src/mapping-kit/__tests__/index.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.test.ts
@@ -188,6 +188,20 @@ describe('@path', () => {
     expect(output).toStrictEqual({ neat: 'bar' })
   })
 
+  test('invalid bracket-spaced nested value', () => {
+    const output = transform(
+      { neat: { '@path': "$.integrations['Actions Amplitude'].session_id" } },
+      {
+        integrations: {
+          'Actions Amplitude': {
+            session_id: 'bar'
+          }
+        }
+      }
+    )
+    expect(output).toStrictEqual({})
+  })
+
   test('invalid nested value type', () => {
     const output = transform({ neat: { '@path': '$.foo.bar.baz' } }, { foo: 'bar' })
     expect(output).toStrictEqual({})

--- a/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
@@ -256,6 +256,112 @@ describe('Amplitude', () => {
         }
       `)
     })
+
+    describe('session_id', () => {
+      it('should support session_id from `integrations.Amplitude.session_id`', async () => {
+        const event = createTestEvent({
+          timestamp,
+          event: 'Test Event',
+          anonymousId: 'julio',
+          integrations: {
+            // @ts-expect-error integrations should accept complext objects;
+            Amplitude: {
+              session_id: '1234567890'
+            }
+          }
+        })
+
+        nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+        const responses = await testDestination.testAction('logEvent', { event, useDefaultMappings: true })
+
+        expect(responses.length).toBe(1)
+        expect(responses[0].status).toBe(200)
+        expect(responses[0].data).toMatchObject({})
+
+        expect(responses[0].options.json).toMatchInlineSnapshot(`
+          Object {
+            "api_key": undefined,
+            "events": Array [
+              Object {
+                "city": "San Francisco",
+                "country": "United States",
+                "device_id": "julio",
+                "device_model": "iPhone",
+                "device_type": "mobile",
+                "event_properties": Object {},
+                "event_type": "Test Event",
+                "ip": "8.8.8.8",
+                "language": "en-US",
+                "library": "segment",
+                "location_lat": 40.2964197,
+                "location_lng": -76.9411617,
+                "os_name": "Mobile Safari",
+                "os_version": "9",
+                "session_id": -23074351200000,
+                "time": 1629213675449,
+                "use_batch_endpoint": false,
+                "user_id": "user1234",
+                "user_properties": Object {},
+              },
+            ],
+            "options": undefined,
+          }
+        `)
+      })
+
+      it('should support session_id from `integrations.Actions Amplitude.session_id`', async () => {
+        const event = createTestEvent({
+          timestamp,
+          event: 'Test Event',
+          anonymousId: 'julio',
+          integrations: {
+            // @ts-expect-error integrations should accept complext objects;
+            'Actions Amplitude': {
+              session_id: '1234567890'
+            }
+          }
+        })
+
+        nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+        const responses = await testDestination.testAction('logEvent', { event, useDefaultMappings: true })
+
+        expect(responses.length).toBe(1)
+        expect(responses[0].status).toBe(200)
+        expect(responses[0].data).toMatchObject({})
+
+        expect(responses[0].options.json).toMatchInlineSnapshot(`
+          Object {
+            "api_key": undefined,
+            "events": Array [
+              Object {
+                "city": "San Francisco",
+                "country": "United States",
+                "device_id": "julio",
+                "device_model": "iPhone",
+                "device_type": "mobile",
+                "event_properties": Object {},
+                "event_type": "Test Event",
+                "ip": "8.8.8.8",
+                "language": "en-US",
+                "library": "segment",
+                "location_lat": 40.2964197,
+                "location_lng": -76.9411617,
+                "os_name": "Mobile Safari",
+                "os_version": "9",
+                "session_id": -23074351200000,
+                "time": 1629213675449,
+                "use_batch_endpoint": false,
+                "user_id": "user1234",
+                "user_properties": Object {},
+              },
+            ],
+            "options": undefined,
+          }
+        `)
+      })
+    })
   })
 
   it('should not send parsed user agent properties when setting is false', async () => {

--- a/packages/destination-actions/src/destinations/amplitude/event-schema.ts
+++ b/packages/destination-actions/src/destinations/amplitude/event-schema.ts
@@ -43,7 +43,11 @@ export const eventSchema: Record<string, InputField> = {
     description:
       'The start time of the session, necessary if you want to associate events with a particular system. To use automatic Amplitude session tracking in browsers, enable Analytics 2.0 on your connected source.',
     default: {
-      '@path': '$.integrations.Amplitude.session_id'
+      '@if': {
+        exists: { '@path': '$.integrations.Actions Amplitude.session_id' },
+        then: { '@path': '$.integrations.Actions Amplitude.session_id' },
+        else: { '@path': '$.integrations.Amplitude.session_id' }
+      }
     }
   },
   time: {


### PR DESCRIPTION
We are currently migrating the Amplitude's `session_id` field from `$.integrations.Amplitude.session_id` to `$.integrations.Actions Amplitude.session_id`. This PR adds support to Amplitude Cloud to fetch `session_id` from both paths using an `@if` directive.

Once all customers have been migrated to the new pattern, we'll remove the `@if` directive, supporting only `$.integrations.Actions Amplitude.session_id`.

![image](https://user-images.githubusercontent.com/484013/134425186-c9247963-75ea-4ad0-939b-d11742f67013.png)

![image](https://user-images.githubusercontent.com/484013/134425923-a094fc4f-3113-44ba-9918-26b2f751f03c.png)

![image](https://user-images.githubusercontent.com/484013/134426002-ea3627e5-0efd-4398-84a4-19237772d9c3.png)
