### PR TITLE
[Amplitude] Adjust device type casing with what's expected by amplitude's API

### DIFF
--- a/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
@@ -390,6 +390,7 @@ describe('Amplitude', () => {
           'some-trait-key': 'some-trait-value'
         }
       })
+
       nock('https://api.amplitude.com').post('/identify').reply(200, {})
       const responses = await testDestination.testAction('identifyUser', { event, useDefaultMappings: true })
       expect(responses.length).toBe(1)
@@ -526,6 +527,7 @@ describe('Amplitude', () => {
         }
       `)
     })
+
     it('should not send parsed user agent properties when setting is false', async () => {
       const event = createTestEvent({
         anonymousId: 'some-anonymous-id',
@@ -561,6 +563,68 @@ describe('Amplitude', () => {
             "undefined",
             "identification",
             "{\\"user_id\\":\\"some-user-id\\",\\"device_id\\":\\"foo\\",\\"user_properties\\":{\\"some-trait-key\\":\\"some-trait-value\\"},\\"library\\":\\"segment\\"}",
+            "options",
+            "undefined",
+          ],
+          Symbol(context): null,
+        }
+      `)
+    })
+
+    it('should change casing for device type when value is android', async () => {
+      const event = createTestEvent({
+        context: {
+          device: {
+            id: 'foo',
+            type: 'android'
+          }
+        }
+      })
+
+      const mapping = {
+        userAgentParsing: false
+      }
+
+      nock('https://api.amplitude.com').post('/identify').reply(200, {})
+      const responses = await testDestination.testAction('identifyUser', { event, mapping, useDefaultMappings: true })
+      expect(responses[0].options.body).toMatchInlineSnapshot(`
+        URLSearchParams {
+          Symbol(query): Array [
+            "api_key",
+            "undefined",
+            "identification",
+            "{\\"user_id\\":\\"user1234\\",\\"device_id\\":\\"foo\\",\\"user_properties\\":{},\\"platform\\":\\"android\\",\\"library\\":\\"segment\\"}",
+            "options",
+            "undefined",
+          ],
+          Symbol(context): null,
+        }
+      `)
+    })
+
+    it('should change casing for device type when value is ios', async () => {
+      const event = createTestEvent({
+        context: {
+          device: {
+            id: 'foo',
+            type: 'ios'
+          }
+        }
+      })
+
+      const mapping = {
+        userAgentParsing: false
+      }
+
+      nock('https://api.amplitude.com').post('/identify').reply(200, {})
+      const responses = await testDestination.testAction('identifyUser', { event, mapping, useDefaultMappings: true })
+      expect(responses[0].options.body).toMatchInlineSnapshot(`
+        URLSearchParams {
+          Symbol(query): Array [
+            "api_key",
+            "undefined",
+            "identification",
+            "{\\"user_id\\":\\"user1234\\",\\"device_id\\":\\"foo\\",\\"user_properties\\":{},\\"platform\\":\\"ios\\",\\"library\\":\\"segment\\"}",
             "options",
             "undefined",
           ],

--- a/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
@@ -28,6 +28,56 @@ describe('Amplitude', () => {
       })
     })
 
+    it('should change casing for device type when value is ios', async () => {
+      const event = createTestEvent({
+        event: 'Test Event',
+        context: {
+          device: {
+            id: 'foo',
+            type: 'ios'
+          }
+        }
+      })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const responses = await testDestination.testAction('logEvent', { event, useDefaultMappings: true })
+      expect(responses[0].options.json).toMatchObject({
+        api_key: undefined,
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            device_id: 'foo',
+            platform: 'ios'
+          })
+        ])
+      })
+    })
+
+    it('should change casing for device type when value is android', async () => {
+      const event = createTestEvent({
+        event: 'Test Event',
+        context: {
+          device: {
+            id: 'foo',
+            type: 'android'
+          }
+        }
+      })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const responses = await testDestination.testAction('logEvent', { event, useDefaultMappings: true })
+      expect(responses[0].options.json).toMatchObject({
+        api_key: undefined,
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            device_id: 'foo',
+            platform: 'android'
+          })
+        ])
+      })
+    })
+
     it('should accept null for user_id', async () => {
       const event = createTestEvent({ timestamp, userId: null, event: 'Null User' })
 

--- a/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
@@ -47,7 +47,7 @@ describe('Amplitude', () => {
         events: expect.arrayContaining([
           expect.objectContaining({
             device_id: 'foo',
-            platform: 'ios'
+            platform: 'iOS'
           })
         ])
       })
@@ -72,7 +72,7 @@ describe('Amplitude', () => {
         events: expect.arrayContaining([
           expect.objectContaining({
             device_id: 'foo',
-            platform: 'android'
+            platform: 'Android'
           })
         ])
       })
@@ -643,7 +643,7 @@ describe('Amplitude', () => {
             "api_key",
             "undefined",
             "identification",
-            "{\\"user_id\\":\\"user1234\\",\\"device_id\\":\\"foo\\",\\"user_properties\\":{},\\"platform\\":\\"android\\",\\"library\\":\\"segment\\"}",
+            "{\\"user_id\\":\\"user1234\\",\\"device_id\\":\\"foo\\",\\"user_properties\\":{},\\"platform\\":\\"Android\\",\\"library\\":\\"segment\\"}",
             "options",
             "undefined",
           ],
@@ -674,7 +674,7 @@ describe('Amplitude', () => {
             "api_key",
             "undefined",
             "identification",
-            "{\\"user_id\\":\\"user1234\\",\\"device_id\\":\\"foo\\",\\"user_properties\\":{},\\"platform\\":\\"ios\\",\\"library\\":\\"segment\\"}",
+            "{\\"user_id\\":\\"user1234\\",\\"device_id\\":\\"foo\\",\\"user_properties\\":{},\\"platform\\":\\"iOS\\",\\"library\\":\\"segment\\"}",
             "options",
             "undefined",
           ],

--- a/packages/destination-actions/src/destinations/amplitude/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/identifyUser/index.ts
@@ -243,7 +243,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const properties = rest as AmplitudeEvent
 
     if (properties.platform) {
-      properties.platform = properties.platform.replace('ios', 'iOS').replace('android', 'Android')
+      properties.platform = properties.platform.replace(/ios/i, 'iOS').replace(/android/i, 'Android')
     }
 
     if (Object.keys(utm_properties ?? {}).length || referrer) {

--- a/packages/destination-actions/src/destinations/amplitude/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/identifyUser/index.ts
@@ -242,6 +242,10 @@ const action: ActionDefinition<Settings, Payload> = {
     let options
     const properties = rest as AmplitudeEvent
 
+    if (properties.platform) {
+      properties.platform = properties.platform.replace('ios', 'iOS').replace('android', 'Android')
+    }
+
     if (Object.keys(utm_properties ?? {}).length || referrer) {
       properties.user_properties = mergeUserProperties(
         omit(properties.user_properties ?? {}, ['utm_properties', 'referrer']),

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
@@ -185,6 +185,10 @@ const action: ActionDefinition<Settings, Payload> = {
     const properties = rest as AmplitudeEvent
     let options
 
+    if (properties.platform) {
+      properties.platform = properties.platform.replace('ios', 'iOS').replace('android', 'Android')
+    }
+
     if (time && dayjs.utc(time).isValid()) {
       properties.time = dayjs.utc(time).valueOf()
     }

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
@@ -186,7 +186,7 @@ const action: ActionDefinition<Settings, Payload> = {
     let options
 
     if (properties.platform) {
-      properties.platform = properties.platform.replace('ios', 'iOS').replace('android', 'Android')
+      properties.platform = properties.platform.replace(/ios/i, 'iOS').replace(/android/i, 'Android')
     }
 
     if (time && dayjs.utc(time).isValid()) {


### PR DESCRIPTION
This PR adjusts the casing of `device_type` when it's set as `ios` or `android` to use what's implicitly expected by amplitude's API (`iOS` or `Android`)

![Screen Shot 2021-09-24 at 3 50 40 PM](https://user-images.githubusercontent.com/484013/134747145-2ab07f58-5938-495c-82cf-b76d53d3fe73.png)

![Screen Shot 2021-09-24 at 3 50 23 PM](https://user-images.githubusercontent.com/484013/134747141-25fd41ed-af2b-4dc6-84c9-55a750705b13.png)
