### PR TITLE
[Amplitude] Remove @if directive from session_id reading

### DIFF
--- a/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
@@ -257,29 +257,28 @@ describe('Amplitude', () => {
       `)
     })
 
-    describe('session_id', () => {
-      it('should support session_id from `integrations.Amplitude.session_id`', async () => {
-        const event = createTestEvent({
-          timestamp,
-          event: 'Test Event',
-          anonymousId: 'julio',
-          integrations: {
-            // @ts-expect-error integrations should accept complext objects;
-            Amplitude: {
-              session_id: '1234567890'
-            }
+    it('should support session_id from `integrations.Actions Amplitude.session_id`', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        anonymousId: 'julio',
+        integrations: {
+          // @ts-expect-error integrations should accept complext objects;
+          'Actions Amplitude': {
+            session_id: '1234567890'
           }
-        })
+        }
+      })
 
-        nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
 
-        const responses = await testDestination.testAction('logEvent', { event, useDefaultMappings: true })
+      const responses = await testDestination.testAction('logEvent', { event, useDefaultMappings: true })
 
-        expect(responses.length).toBe(1)
-        expect(responses[0].status).toBe(200)
-        expect(responses[0].data).toMatchObject({})
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
 
-        expect(responses[0].options.json).toMatchInlineSnapshot(`
+      expect(responses[0].options.json).toMatchInlineSnapshot(`
           Object {
             "api_key": undefined,
             "events": Array [
@@ -308,59 +307,6 @@ describe('Amplitude', () => {
             "options": undefined,
           }
         `)
-      })
-
-      it('should support session_id from `integrations.Actions Amplitude.session_id`', async () => {
-        const event = createTestEvent({
-          timestamp,
-          event: 'Test Event',
-          anonymousId: 'julio',
-          integrations: {
-            // @ts-expect-error integrations should accept complext objects;
-            'Actions Amplitude': {
-              session_id: '1234567890'
-            }
-          }
-        })
-
-        nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
-
-        const responses = await testDestination.testAction('logEvent', { event, useDefaultMappings: true })
-
-        expect(responses.length).toBe(1)
-        expect(responses[0].status).toBe(200)
-        expect(responses[0].data).toMatchObject({})
-
-        expect(responses[0].options.json).toMatchInlineSnapshot(`
-          Object {
-            "api_key": undefined,
-            "events": Array [
-              Object {
-                "city": "San Francisco",
-                "country": "United States",
-                "device_id": "julio",
-                "device_model": "iPhone",
-                "device_type": "mobile",
-                "event_properties": Object {},
-                "event_type": "Test Event",
-                "ip": "8.8.8.8",
-                "language": "en-US",
-                "library": "segment",
-                "location_lat": 40.2964197,
-                "location_lng": -76.9411617,
-                "os_name": "Mobile Safari",
-                "os_version": "9",
-                "session_id": -23074351200000,
-                "time": 1629213675449,
-                "use_batch_endpoint": false,
-                "user_id": "user1234",
-                "user_properties": Object {},
-              },
-            ],
-            "options": undefined,
-          }
-        `)
-      })
     })
   })
 

--- a/packages/destination-actions/src/destinations/amplitude/event-schema.ts
+++ b/packages/destination-actions/src/destinations/amplitude/event-schema.ts
@@ -43,11 +43,7 @@ export const eventSchema: Record<string, InputField> = {
     description:
       'The start time of the session, necessary if you want to associate events with a particular system. To use automatic Amplitude session tracking in browsers, enable Analytics 2.0 on your connected source.',
     default: {
-      '@if': {
-        exists: { '@path': '$.integrations.Actions Amplitude.session_id' },
-        then: { '@path': '$.integrations.Actions Amplitude.session_id' },
-        else: { '@path': '$.integrations.Amplitude.session_id' }
-      }
+      '@path': '$.integrations.Actions Amplitude.session_id'
     }
   },
   time: {


### PR DESCRIPTION
As we're ready migrating users from the old session_id format (`integrations.Amplitude.session_id` => `integrations.Actions Amplitude.session_Id`), this PR removes the usage of the `@if` directive used during the migration.