### PR TITLE
[Amplitude Browser] Remove duo-writing for session_id plugin

### DIFF
--- a/packages/browser-destinations/src/destinations/amplitude-plugins/sessionId/__tests__/sessionId.test.ts
+++ b/packages/browser-destinations/src/destinations/amplitude-plugins/sessionId/__tests__/sessionId.test.ts
@@ -86,8 +86,6 @@ describe('ajs-integration', () => {
     const updatedCtx = await sessionIdPlugin.track?.(ctx)
 
     // @ts-expect-error Need to fix ajs-next types to allow for complex objects in `integrations`
-    expect(updatedCtx?.event.integrations?.Amplitude?.session_id).not.toBeUndefined()
-    // @ts-expect-error Need to fix ajs-next types to allow for complex objects in `integrations`
     expect(updatedCtx?.event.integrations['Actions Amplitude']?.session_id).not.toBeUndefined()
   })
 
@@ -137,7 +135,7 @@ describe('sessoinId', () => {
 
       const updatedCtx = await sessionIdPlugin.track?.(ctx)
       // @ts-expect-error Need to fix ajs-next types to allow for complex objects in `integrations`
-      expect(updatedCtx?.event.integrations?.Amplitude?.session_id).toBeWithinOneSecondOf(id())
+      expect(updatedCtx?.event.integrations['Actions Amplitude']?.session_id).toBeWithinOneSecondOf(id())
     })
 
     test('persists the session id', async () => {
@@ -173,7 +171,7 @@ describe('sessoinId', () => {
 
       const updatedCtx = await sessionIdPlugin.track?.(ctx)
       // @ts-expect-error Need to fix ajs-next types to allow for complex objects in `integrations`
-      expect(updatedCtx?.event.integrations?.Amplitude?.session_id).toBeWithinOneSecondOf(then)
+      expect(updatedCtx?.event.integrations['Actions Amplitude']?.session_id).toBeWithinOneSecondOf(then)
     })
 
     test('keeps track of when the session was last accessed', async () => {
@@ -193,7 +191,7 @@ describe('sessoinId', () => {
 
       const updatedCtx = await sessionIdPlugin.track?.(ctx)
       // @ts-expect-error Need to fix ajs-next types to allow for complex objects in `integrations`
-      expect(updatedCtx?.event.integrations?.Amplitude?.session_id).toBeWithinOneSecondOf(then)
+      expect(updatedCtx?.event.integrations['Actions Amplitude']?.session_id).toBeWithinOneSecondOf(then)
 
       expect(window.localStorage.getItem('analytics_session_id.last_access')).toBeWithinOneSecondOf(now)
     })
@@ -218,7 +216,7 @@ describe('sessoinId', () => {
 
       const updatedCtx = await sessionIdPlugin.track?.(ctx)
       // @ts-expect-error Need to fix ajs-next types to allow for complex objects in `integrations`
-      expect(updatedCtx?.event.integrations?.Amplitude?.session_id).toBeWithinOneSecondOf(now)
+      expect(updatedCtx?.event.integrations['Actions Amplitude']?.session_id).toBeWithinOneSecondOf(now)
 
       expect(window.localStorage.getItem('analytics_session_id')).toBeWithinOneSecondOf(now.toString())
       expect(window.localStorage.getItem('analytics_session_id.last_access')).toBeWithinOneSecondOf(now.toString())

--- a/packages/browser-destinations/src/destinations/amplitude-plugins/sessionId/index.ts
+++ b/packages/browser-destinations/src/destinations/amplitude-plugins/sessionId/index.ts
@@ -57,12 +57,6 @@ const action: BrowserActionDefinition<Settings, {}, Payload> = {
 
     ls.setItem('analytics_session_id.last_access', newSession.toString())
 
-    /**
-     * We're changing the session id plugin to stop writing on the `integrations.Amplitude`
-     * field and start writing `integrations['Actions Amplitude']` instead. In the meantime, we're
-     * writing to both. Once we finish the migration, we'll stop writing to the first.
-     */
-    context.updateEvent('integrations.Amplitude.session_id', id)
     context.updateEvent('integrations.Actions Amplitude.session_id', id)
 
     return


### PR DESCRIPTION
As we migrate the session_id plugin to write into `integrations.Actions Amplitude.session_id` instead of `integrations.Amplitude.session_id`, we need to stop writing into both keys (https://github.com/segmentio/action-destinations/pull/185).

Now that the default mapping for Actions Amplitude Cloud mode has been changed and all customers have been migrated to the new pattern, this PR is the last step to complete the migration. 

![image](https://user-images.githubusercontent.com/484013/134961814-e502713a-3126-4dee-86dc-8b1f263f4d08.png)
![image](https://user-images.githubusercontent.com/484013/134961880-00ab2723-2f34-4613-af9f-f07eee8a8399.png)
