### PR TITLE
Update Viewed Page action fields

### DIFF
--- a/packages/browser-destinations/src/destinations/fullstory/viewedPage/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/viewedPage/generated-types.ts
@@ -4,11 +4,7 @@ export interface Payload {
   /**
    * The name of the page that was viewed.
    */
-  name?: string
-  /**
-   * The category of the page that was viewed.
-   */
-  category?: string
+  pageName?: string
   /**
    * The properties of the page that was viewed.
    */

--- a/packages/browser-destinations/src/destinations/fullstory/viewedPage/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/viewedPage/index.ts
@@ -18,22 +18,17 @@ const action: BrowserActionDefinition<Settings, typeof FullStory, Payload> = {
   defaultSubscription: 'type = "page"',
   platform: 'web',
   fields: {
-    name: {
+    pageName: {
       type: 'string',
       required: false,
       description: 'The name of the page that was viewed.',
-      label: 'Name',
+      label: 'Page Name',
       default: {
-        '@path': '$.name'
-      }
-    },
-    category: {
-      type: 'string',
-      required: false,
-      description: 'The category of the page that was viewed.',
-      label: 'Category',
-      default: {
-        '@path': '$.category'
+        '@if': {
+          exists: { '@path': '$.category' },
+          then: { '@path': '$.category' },
+          else: { '@path': '$.name' }
+        }
       }
     },
     properties: {
@@ -47,10 +42,8 @@ const action: BrowserActionDefinition<Settings, typeof FullStory, Payload> = {
     }
   },
   perform: (_, event) => {
-    if (event.payload.category && event.payload.name) {
-      window.FS.setVars('page', { pageName: event.payload.category + event.payload.name, ...event.payload.properties })
-    } else if (event.payload.name) {
-      window.FS.setVars('page', { pageName: event.payload.name, ...event.payload.properties })
+    if (event.payload.pageName) {
+      window.FS.setVars('page', { pageName: event.payload.pageName, ...event.payload.properties })
     } else {
       window.FS.setVars('page', event.payload.properties || {})
     }


### PR DESCRIPTION
This PR updates the files of Viewed Page to take a single "pageName" field after discussing with the FullStory team.

Testing done in stage:
![image](https://user-images.githubusercontent.com/2866515/134967917-1b96ffce-4582-4cc9-8d22-702badc75001.png)
