### PR TITLE
Add `fromDomain` setting to Sendgrid

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -111,6 +111,7 @@ for (const environment of ['stage', 'production']) {
         settings,
         mapping: {
           userId: { '@path': '$.userId' },
+          fromDomain: null,
           fromEmail: 'from@example.com',
           fromName: 'From Name',
           replyToEmail: 'replyto@example.com',
@@ -142,6 +143,7 @@ for (const environment of ['stage', 'production']) {
         settings,
         mapping: {
           userId: { '@path': '$.userId' },
+          fromDomain: null,
           fromEmail: 'from@example.com',
           fromName: 'From Name',
           replyToEmail: 'replyto@example.com',
@@ -173,6 +175,7 @@ for (const environment of ['stage', 'production']) {
         settings,
         mapping: {
           userId: { '@path': '$.userId' },
+          fromDomain: null,
           fromEmail: 'from@example.com',
           fromName: 'From Name',
           replyToEmail: 'replyto@example.com',
@@ -248,6 +251,7 @@ for (const environment of ['stage', 'production']) {
         settings,
         mapping: {
           userId: { '@path': '$.userId' },
+          fromDomain: null,
           fromEmail: 'from@example.com',
           fromName: 'From Name',
           replyToEmail: 'replyto@example.com',

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
@@ -16,7 +16,7 @@ export interface Payload {
   /**
    * Verified domain in Sendgrid
    */
-  fromDomain: string
+  fromDomain?: string
   /**
    * From Email
    */

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
@@ -14,6 +14,10 @@ export interface Payload {
    */
   toEmail?: string
   /**
+   * Verified domain in Sendgrid
+   */
+  fromDomain: string
+  /**
    * From Email
    */
   fromEmail: string

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -90,8 +90,7 @@ const action: ActionDefinition<Settings, Payload> = {
     fromDomain: {
       label: 'From Domain',
       description: 'Verified domain in Sendgrid',
-      type: 'string',
-      required: true
+      type: 'string'
     },
     fromEmail: {
       label: 'From Email',

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -87,6 +87,12 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'Email to send to when testing',
       type: 'string'
     },
+    fromDomain: {
+      label: 'From Domain',
+      description: 'Verified domain in Sendgrid',
+      type: 'string',
+      required: true
+    },
     fromEmail: {
       label: 'From Email',
       description: 'From Email',


### PR DESCRIPTION
Needed to store `fromDomain` email setting value for https://segment.atlassian.net/browse/GROW-264.