### PR TITLE
[LIBWEB-916] add userId and name to FQL IR

### DIFF
--- a/packages/destination-subscriptions/src/__tests__/fql.test.ts
+++ b/packages/destination-subscriptions/src/__tests__/fql.test.ts
@@ -94,6 +94,33 @@ test('event = "Product Added"', () => {
 	})
 })
 
+test('userId != null', () => {
+	testFql('userId != null', {
+		type: 'group',
+		operator: 'and',
+		children: [
+			{
+				type: 'userId',
+				operator: 'exists'
+			}
+		]
+	})
+})
+
+test('name = "Home"', () => {
+	testFql('name = "Home"', {
+		type: 'group',
+		operator: 'and',
+		children: [
+			{
+				type: 'name',
+				operator: '=',
+				value: 'Home'
+			}
+		]
+	})
+})
+
 test('event = "Product Added" or event = "Order Completed"', () => {
 	testFql('event = "Product Added" or event = "Order Completed"', {
 		type: 'group',

--- a/packages/destination-subscriptions/src/__tests__/generate-fql.test.ts
+++ b/packages/destination-subscriptions/src/__tests__/generate-fql.test.ts
@@ -43,11 +43,17 @@ test('should handle ast with multiple childs (or condition)', () => {
 				type: 'event-type',
 				operator: '=',
 				value: 'identify'
+			},
+			{
+				type: 'userId',
+				operator: 'exists'
 			}
 		]
 	}
 
-	expect(generateFql(ast)).toEqual('type = "track" or type = "identify"')
+	expect(generateFql(ast)).toEqual(
+		'type = "track" or type = "identify" or userId != null'
+	)
 })
 
 test('should handle ast with multiple childs (and condition)', () => {

--- a/packages/destination-subscriptions/src/generate-fql.ts
+++ b/packages/destination-subscriptions/src/generate-fql.ts
@@ -6,6 +6,8 @@ import {
 	EventPropertyCondition,
 	EventTraitCondition,
 	EventContextCondition,
+	EventUserIdCondition,
+	EventNameCondition,
 	Operator,
 	ErrorCondition
 } from './types'
@@ -71,12 +73,16 @@ const stringifyChildNode = (
 		| EventPropertyCondition
 		| EventTraitCondition
 		| EventContextCondition
+		| EventUserIdCondition
+		| EventNameCondition
 ): string => {
 	let result = ''
 
 	switch (node.type) {
+		case 'name':
+		case 'userId':
 		case 'event': {
-			result += fqlExpression('event', node.operator, node.value)
+			result += fqlExpression(node.type, node.operator, node.value)
 			break
 		}
 

--- a/packages/destination-subscriptions/src/parse-fql.ts
+++ b/packages/destination-subscriptions/src/parse-fql.ts
@@ -10,6 +10,8 @@ import {
 const tokenToConditionType: Record<string, ConditionType> = {
 	type: 'event-type',
 	event: 'event',
+	name: 'name',
+	userId: 'userId',
 	properties: 'event-property',
 	traits: 'event-trait'
 }
@@ -62,9 +64,9 @@ const parseFqlFunction = (
 		// Skip ")" token
 		tokens.shift()
 
-		if (nameToken.value === 'event') {
+		if (['event', 'name', 'userId'].includes(nameToken.value)) {
 			nodes.push({
-				type: 'event',
+				type: nameToken.value as 'event' | 'name' | 'userId',
 				operator: negate ? 'not_contains' : 'contains',
 				value: String(getTokenValue(valueToken))
 			})
@@ -122,9 +124,9 @@ const parseFqlFunction = (
 			value = String(getTokenValue(valueToken)).slice(1)
 		}
 
-		if (nameToken.value === 'event') {
+		if (['event', 'name', 'userId'].includes(nameToken.value)) {
 			nodes.push({
-				type: 'event',
+				type: nameToken.value as 'event' | 'name' | 'userId',
 				operator,
 				value
 			})
@@ -173,6 +175,11 @@ const parse = (tokens: Token[]): Condition => {
 					throw new Error('Value token is missing')
 				}
 
+				const isExists =
+					operatorToken.value === '!=' && valueToken.value === 'null'
+				const isNotExists =
+					operatorToken.value === '=' && valueToken.value === 'null'
+
 				if (conditionType === 'event') {
 					nodes.push({
 						type: 'event',
@@ -185,17 +192,38 @@ const parse = (tokens: Token[]): Condition => {
 						operator: operatorToken.value as Operator,
 						value: String(getTokenValue(valueToken))
 					})
+				} else if (conditionType === 'name') {
+					nodes.push({
+						type: 'name',
+						operator: operatorToken.value as Operator,
+						value: String(getTokenValue(valueToken))
+					})
+				} else if (conditionType === 'userId') {
+					if (isExists) {
+						nodes.push({
+							type: 'userId',
+							operator: 'exists'
+						})
+					} else if (isNotExists) {
+						nodes.push({
+							type: 'userId',
+							operator: 'not_exists'
+						})
+					} else {
+						nodes.push({
+							type: 'userId',
+							operator: operatorToken.value as Operator,
+							value: String(getTokenValue(valueToken))
+						})
+					}
 				} else if (conditionType === 'event-property') {
-					if (operatorToken.value === '!=' && valueToken.value === 'null') {
+					if (isExists) {
 						nodes.push({
 							type: 'event-property',
 							name: token.value.replace(/^(properties)\./, ''),
 							operator: 'exists'
 						})
-					} else if (
-						operatorToken.value === '=' &&
-						valueToken.value === 'null'
-					) {
+					} else if (isNotExists) {
 						nodes.push({
 							type: 'event-property',
 							name: token.value.replace(/^(properties)\./, ''),
@@ -210,16 +238,13 @@ const parse = (tokens: Token[]): Condition => {
 						})
 					}
 				} else if (conditionType === 'event-trait') {
-					if (operatorToken.value === '!=' && valueToken.value === 'null') {
+					if (isExists) {
 						nodes.push({
 							type: 'event-trait',
 							name: token.value.replace(/^(traits)\./, ''),
 							operator: 'exists'
 						})
-					} else if (
-						operatorToken.value === '=' &&
-						valueToken.value === 'null'
-					) {
+					} else if (isNotExists) {
 						nodes.push({
 							type: 'event-trait',
 							name: token.value.replace(/^(traits)\./, ''),

--- a/packages/destination-subscriptions/src/types.ts
+++ b/packages/destination-subscriptions/src/types.ts
@@ -16,6 +16,9 @@ export type Condition =
 	| EventPropertyCondition
 	| EventTraitCondition
 	| EventContextCondition
+	| EventUserIdCondition
+	| EventTimeCondition
+	| EventNameCondition
 
 export type GroupConditionOperator = 'and' | 'or'
 
@@ -27,6 +30,18 @@ export interface EventTypeCondition {
 
 export interface EventCondition {
 	type: 'event'
+	operator: Operator
+	value?: string
+}
+
+export interface EventUserIdCondition {
+	type: 'userId'
+	operator: Operator
+	value?: string
+}
+
+export interface EventNameCondition {
+	type: 'name'
 	operator: Operator
 	value?: string
 }
@@ -75,5 +90,7 @@ export type ConditionType =
 	| 'event-property'
 	| 'event-trait'
 	| 'event-context'
+	| 'name'
+	| 'userId'
 
 export type PropertyConditionType = 'event-property' | 'event-context'

--- a/packages/destination-subscriptions/src/types.ts
+++ b/packages/destination-subscriptions/src/types.ts
@@ -17,7 +17,6 @@ export type Condition =
 	| EventTraitCondition
 	| EventContextCondition
 	| EventUserIdCondition
-	| EventTimeCondition
 	| EventNameCondition
 
 export type GroupConditionOperator = 'and' | 'or'


### PR DESCRIPTION
This enhances the destination-subscriptions intermediate representation (the thing we translate between UI <> FQL for displaying and parsing) to include a couple new top-level attributes: `name` and `userId`. This will allow users to construct subscriptions like `'type = "page" and name = "Homepage"'` (page calls with a given page name) or `'type = "track" and userId != null'` (only identified users)