### PR TITLE
prefer auth.fields order

### DIFF
--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -395,6 +395,9 @@ export function getOptions(
       }
     }
 
+    // Remove the previous entry if it exists so we can respect the order of keys as defined in the repo
+    delete options[fieldKey]
+
     options[fieldKey] = {
       default: schema.default ?? '',
       description: schema.description,

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -341,7 +341,7 @@ function definitionToJson(definition: DestinationDefinition) {
 }
 
 function getBasicOptions(metadata: DestinationMetadata, options: DestinationMetadataOptions): string[] {
-  return uniq([...metadata.basicOptions, ...Object.keys(options)])
+  return uniq([...Object.keys(options), ...metadata.basicOptions])
 }
 
 // Note: exporting for testing purposes only


### PR DESCRIPTION
Currently we always use the order of existing `basicOptions` and then append new `authentication.fields` after, but that means you can't reorder `authentication.fields` later. Let's invert this and prefer `authentication.fields` order first, then append any other existing keys at the end.