### PR TITLE
[push browser destinations] Adapt to remote plugins API changes

### DIFF
--- a/packages/cli/src/lib/control-plane-client.ts
+++ b/packages/cli/src/lib/control-plane-client.ts
@@ -141,10 +141,13 @@ export async function getRemotePluginByDestinationIds(metadataIds: string[]): Pr
 export async function updateRemotePlugin(plugin: RemotePlugin): Promise<RemotePlugin> {
   const { data, error } = await controlPlaneService.updateRemotePlugin(NOOP_CONTEXT, {
     metadataId: plugin.metadataId,
+    libraryName: plugin.libraryName,
     name: plugin.name,
     input: {
       url: plugin.url,
-      libraryName: plugin.libraryName
+      libraryName: plugin.libraryName,
+      // @ts-expect-error TODO: (@juliofarah) remove `libraryName` from the input as it is no longer editable; remove `name` from the top level params as it is no longer a primary key;
+      name: plugin.name
     }
   })
 


### PR DESCRIPTION
Following up on the database changes applied to remote plugins, this PR adapts the `push-browser-destinations` command to the upcoming control plane API changes.

As control plane doesn't fail when clients pass unnecessary fields to its apis, it'll be faster to adapt the push command to the upcoming changes first than make a phased rollout on control plane.

## Testing
No regression added to the push-browser-destination command
![image](https://user-images.githubusercontent.com/484013/135539617-182ec0a4-a6ee-4c0d-a8fc-33186ecd3764.png)
