### PR TITLE
[Bugfix] Fixes 'could not read Username' error in Publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,8 +44,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          persist-credentials: false
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
@@ -84,10 +82,14 @@ jobs:
       - name: Set author
         run: |
           git config user.email "`git log --format='%ae' HEAD^!`"
+          git config user.email
           git config user.name "`git log --format='%an' HEAD^!`"
+          git config user.name
+
+      - name: Set NPM Token
+        run: |
+          npm set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_TOKEN }}
+          npm whoami 
 
       - name: Publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: lerna publish ${{ needs.get-version.outputs.version }} --yes
+        run: lerna publish ${{ needs.get-version.outputs.version }} --no-verify-access --yes


### PR DESCRIPTION
An [issue](https://github.com/segmentio/action-destinations/runs/3655379660?check_suite_focus=true) was discovered while running the `publish` workflow in order to publish the action-destinations packages using CI. Lerna returned the following error: 
```
lerna ERR! fatal: could not read Username for 'https://github.com': No such device or address
```

This was caused by the `actions/checkout@v2` step not persisting credentials throughout the workflow. I've removed that section and added a `Set NPM Token` step to authorize the workflow with NPM before publishing. This should allow us to now automatically publish packages as specified in [the original PR](https://github.com/segmentio/action-destinations/pull/152).

Note: Automatic publishing is still opt-in, as you must either set a label on your PR or run the workflow manually from the actions tab. If no label is set on a PR before it is merged, the 'automatic' publishing workflow will not run.

