### PR TITLE
Add `replyToEqualsFrom` setting to Personas Sendgrid

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
@@ -26,6 +26,10 @@ export interface Payload {
    */
   fromName: string
   /**
+   * Whether "reply to" settings are the same as "from"
+   */
+  replyToEqualsFrom?: boolean
+  /**
    * The Email used by user to Reply To
    */
   replyToEmail: string

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -104,6 +104,11 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: true
     },
+    replyToEqualsFrom: {
+      label: 'Reply To Equals From',
+      description: 'Whether "reply to" settings are the same as "from"',
+      type: 'boolean'
+    },
     replyToEmail: {
       label: 'Reply To Email',
       description: 'The Email used by user to Reply To',


### PR DESCRIPTION
Related to https://segment.atlassian.net/browse/GROW-313. Adds a setting that is used to determine if "reply to" values are the same as "from". Note that this is only used for UI access, it doesn't affect email delivery.

@vikramkumar19 If this looks ok to you, could you please deploy it?