### PR TITLE
invert url logic so anon goes to correct url always

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackEvent/index.ts
@@ -90,9 +90,12 @@ const action: ActionDefinition<Settings, Payload> = {
       data: payload.data,
       timestamp
     }
-    let url = `${trackApiEndpoint(settings.accountRegion)}/api/v1/customers/${payload.id}/events`
 
-    if (payload.id === undefined) {
+    let url: string
+
+    if (payload.id) {
+      url = `${trackApiEndpoint(settings.accountRegion)}/api/v1/customers/${payload.id}/events`
+    } else {
       url = `${trackApiEndpoint(settings.accountRegion)}/api/v1/events`
       body.anonymous_id = payload.anonymous_id
     }

--- a/packages/destination-actions/src/destinations/customerio/trackPageView/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackPageView/index.ts
@@ -81,9 +81,12 @@ const action: ActionDefinition<Settings, Payload> = {
       data: payload.data,
       timestamp
     }
-    let url = `${trackApiEndpoint(settings.accountRegion)}/api/v1/customers/${payload.id}/events`
 
-    if (payload.id === undefined) {
+    let url: string
+
+    if (payload.id) {
+      url = `${trackApiEndpoint(settings.accountRegion)}/api/v1/customers/${payload.id}/events`
+    } else {
       url = `${trackApiEndpoint(settings.accountRegion)}/api/v1/events`
       body.anonymous_id = payload.anonymous_id
     }


### PR DESCRIPTION
If `userId` is getting sent as `null` (as it can via ajs) our flexible coercion/validation rules turn `null` into `''` for string fields. Unfortunately that means that the logic here doesn't work 100% of the time because we are checking explicitly that `payload.id === undefined` not `''`.

I've inverted the logic that constructs the anonymous vs identified endpoints (and request `body`) so the logic is a bit more resilient. Now, only when a valid, _non-empty_ `id` exists do we attempt to send to the identified endpoint. All empty values (`null`, `undefined`, `''`) will instead send to the anonymous url.

cc @mike-engel 