### PR TITLE
cli: validate command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Lint
         run: yarn lint
 
+      - name: Validate
+        run: yarn validate
+
       - name: Test
         run: yarn test
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "bootstrap": "lerna bootstrap",
     "build": "./bin/run generate:types && lerna run build --stream --ignore @segment/actions-cli",
     "types": "./bin/run generate:types",
+    "validate": "./bin/run validate",
     "lint": "eslint '**/*.ts' --cache",
     "subscriptions": "yarn workspace @segment/destination-subscriptions",
     "test": "lerna run test --stream",

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -1,14 +1,9 @@
 import { Command, flags } from '@oclif/command'
 import type { DestinationDefinition as CloudDestinationDefinition, MinimalInputField } from '@segment/actions-core'
 import { fieldsToJsonSchema } from '@segment/actions-core'
-import { manifest as cloudManifest, ManifestEntry as CloudManifest } from '@segment/action-destinations'
-import {
-  manifest as browserManifest,
-  ManifestEntry as BrowserManifest,
-  BrowserDestinationDefinition
-} from '@segment/browser-destinations'
+import { BrowserDestinationDefinition } from '@segment/browser-destinations'
 import chalk from 'chalk'
-import { pick, omit, sortBy, mergeWith } from 'lodash'
+import { pick, omit, sortBy } from 'lodash'
 import { diffString } from 'json-diff'
 import ora from 'ora'
 import type {
@@ -31,37 +26,10 @@ import {
   createDestinationMetadataActions,
   setSubscriptionPresets
 } from '../lib/control-plane-client'
-import { DestinationDefinition, hasOauthAuthentication } from '../lib/destinations'
+import { DestinationDefinition, manifest, hasOauthAuthentication } from '../lib/destinations'
 import type { JSONSchema4 } from 'json-schema'
 
 type BaseActionInput = Omit<DestinationMetadataActionCreateInput, 'metadataId'>
-
-// Right now it's possible for browser destinations and cloud destinations to have the same
-// metadataId. This is because we currently rely on a separate directory for all web actions.
-// So here we need to intelligently merge them until we explore colocating all actions with a single
-// definition file.
-const manifest: Record<string, CloudManifest | BrowserManifest> = mergeWith(
-  {},
-  cloudManifest,
-  browserManifest,
-  (objValue, srcValue) => {
-    if (Object.keys(objValue?.definition?.actions ?? {}).length === 0) {
-      return
-    }
-
-    for (const [actionKey, action] of Object.entries(srcValue.definition?.actions ?? {})) {
-      if (actionKey in objValue.definition.actions) {
-        throw new Error(
-          `Could not merge browser + cloud actions because there is already an action with the same key "${actionKey}"`
-        )
-      }
-
-      objValue.definition.actions[actionKey] = action
-    }
-
-    return objValue
-  }
-)
 
 export default class Push extends Command {
   private spinner: ora.Ora = ora()

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -1,0 +1,75 @@
+import { Command, flags } from '@oclif/command'
+import ora from 'ora'
+import { manifest, DestinationDefinition } from '../lib/destinations'
+
+export default class Validate extends Command {
+  private spinner: ora.Ora = ora()
+  private isInvalid = false
+
+  static description = `Validate an integration by statically analyzing the integration’s definition files.`
+
+  static examples = [`$ ./bin/run validate`]
+
+  static flags = {
+    help: flags.help({ char: 'h' })
+  }
+
+  static args = []
+
+  async run() {
+    // TODO validate the definition against the schema
+    const destinations = Object.values(manifest)
+
+    for (const destination of destinations) {
+      this.spinner.start(`Validating presets for ${destination.definition.name}`)
+      const errors = this.validatePresets(destination.definition)
+      if (errors.length) {
+        this.spinner.fail(
+          `Validating presets for ${destination.definition.name}: \n  ${errors.map((e) => e.message).join('\n  ')}`
+        )
+      } else {
+        this.spinner.succeed()
+      }
+    }
+
+    if (this.isInvalid) {
+      this.error(new Error('One or more validation errors were found.'))
+    }
+  }
+
+  validatePresets(destination: DestinationDefinition) {
+    if (!destination.presets) return []
+
+    const errors = []
+
+    for (const preset of destination.presets) {
+      if (!Object.keys(destination.actions).includes(preset.partnerAction)) {
+        this.isInvalid = true
+        errors.push(new Error(`The preset "${preset.name}" references an action key that does not exist.`))
+      }
+
+      const presetFields = Object.keys(preset.mapping ?? {})
+      const actionFields = Object.keys(destination.actions[preset.partnerAction].fields ?? {})
+
+      for (const field of presetFields) {
+        if (!actionFields.includes(field)) {
+          this.isInvalid = true
+          errors.push(
+            new Error(
+              `The preset "${preset.name}" references a field "${field}" that the "${preset.partnerAction}" action does not define.`
+            )
+          )
+        }
+      }
+    }
+
+    return errors
+  }
+
+  async catch(error: unknown) {
+    if (this.spinner?.isSpinning) {
+      this.spinner.fail()
+    }
+    throw error
+  }
+}


### PR DESCRIPTION
This adds the beginnings of a `validate` command. We can do other local validations here to prevent common mistakes or ensure the definition is valid before a change gets merged (and later `push`ed into Segment which may encounter an error).

Here's the current output:
```sh
➜  action-destinations git:(main) ✗ ./bin/run validate
✔ Validating presets for 1plusX
✔ Validating presets for Actions Amplitude
✔ Validating presets for Braze Cloud Mode
✔ Validating presets for Customer.io
✔ Validating presets for Google Analytics 4
✔ Validating presets for Actions Google Enhanced Conversions
✖ Validating presets for Mixpanel (Actions):
  The preset "Page Calls" references a field "event_type" that the "trackEvent" action does not define.
  The preset "Screen Calls" references a field "event_type" that the "trackEvent" action does not define.
✔ Validating presets for Actions Personas Messaging Sendgrid
✔ Validating presets for Personas Messaging Twilio (Actions)
✔ Validating presets for Pipedrive
✔ Validating presets for Slack
✔ Validating presets for Twilio
✔ Validating presets for Webhook
✔ Validating presets for Braze Web Mode
✔ Validating presets for Fullstory (Actions)
    Error: One or more validation errors were found.
```

If we want to get nicer diffing/error output we could consider using a testing framework and run it programmatically via `validate`.