### PR TITLE
add test and update normalizer to support full dot-delimited sequences

### DIFF
--- a/packages/destination-subscriptions/src/__tests__/fql.test.ts
+++ b/packages/destination-subscriptions/src/__tests__/fql.test.ts
@@ -47,6 +47,21 @@ test('should handle missing values', () => {
 	})
 })
 
+test('should handle nested properties', () => {
+	testFql('properties.foo.bar = "baz"', {
+		type: 'group',
+		operator: 'and',
+		children: [
+			{
+				name: 'foo.bar',
+				type: 'event-property',
+				operator: '=',
+				value: 'baz'
+			}
+		]
+	})
+})
+
 test('type = "track"', () => {
 	testFql('type = "track"', {
 		type: 'group',

--- a/packages/destination-subscriptions/src/parse-fql.ts
+++ b/packages/destination-subscriptions/src/parse-fql.ts
@@ -312,20 +312,22 @@ const normalize = (tokens: Token[]): Token[] => {
 	let index = 0
 
 	while (tokens[index]) {
+		const last = normalizedTokens[normalizedTokens.length - 1]
+		const current = tokens[index]
+		const next = tokens[index + 1]
+
 		if (
-			tokens[index].type === 'ident' &&
-			tokens[index + 1].type === 'dot' &&
-			tokens[index + 2].type === 'ident'
+			last?.type === 'ident' &&
+			current.type === 'dot' &&
+			next?.type === 'ident'
 		) {
+			const previous = normalizedTokens.pop()
 			normalizedTokens.push({
 				type: TokenType.Ident,
-				value:
-					tokens[index].value +
-					tokens[index + 1].value +
-					tokens[index + 2].value
+				value: `${previous?.value}${current.value}${next.value}`
 			})
 
-			index += 3
+			index += 2
 		} else {
 			normalizedTokens.push(tokens[index])
 			index++


### PR DESCRIPTION
Previously the IR would choke on `parseFql` when given a dot-delimited sequence > 1 delimiter.

`properties.foo` would work, but `properties.foo.bar` or beyond would fail.

I added a test case for this and then fixed the normalizer to handle this more elegantly.