### PR TITLE
Publish a minor package version

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/actions-cli",
   "description": "CLI to interact with Segment integrations",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -56,7 +56,7 @@
     "@oclif/config": "^1",
     "@oclif/errors": "^1",
     "@oclif/plugin-help": "^3",
-    "@segment/action-destinations": "^3.15.0",
+    "@segment/action-destinations": "^3.16.0",
     "@segment/actions-core": "^3.11.1",
     "chalk": "^4.1.1",
     "chokidar": "^3.5.1",

--- a/packages/destination-actions/package.json
+++ b/packages/destination-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/action-destinations",
   "description": "Destination Actions engine and definitions.",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",


### PR DESCRIPTION
This pull request bumps the minor version of two packages, one of which is already published to NPM: https://www.npmjs.com/package/@segment/action-destinations/v/3.16.0. This is a necessary PR while we sort out branch protection compatibility with our publishing process.

 - @segment/actions-cli@3.16.0
 - @segment/action-destinations@3.16.0