### PR TITLE
fix serve command to accept Node args/flags

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,6 +61,12 @@ module.exports = {
       }
     },
     {
+      files: ['packages/cli/**/*.ts'],
+      rules: {
+        '@typescript-eslint/no-var-requires': 'off'
+      }
+    },
+    {
       files: ['**/benchmarks/**/*.js'],
       env: {
         node: true

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
       "name": "Attach to running server",
       "restart": true,
       "address": "localhost",
-      "port": 47082,
+      "port": 9229,
       "skipFiles": ["<node_internals>/**"]
     },
     {

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -26,7 +26,7 @@ import {
   createDestinationMetadataActions,
   setSubscriptionPresets
 } from '../lib/control-plane-client'
-import { DestinationDefinition, manifest, hasOauthAuthentication } from '../lib/destinations'
+import { DestinationDefinition, getManifest, hasOauthAuthentication } from '../lib/destinations'
 import type { JSONSchema4 } from 'json-schema'
 
 type BaseActionInput = Omit<DestinationMetadataActionCreateInput, 'metadataId'>
@@ -47,6 +47,7 @@ export default class Push extends Command {
 
   async run() {
     const { flags } = this.parse(Push)
+    const manifest = getManifest()
 
     const { metadataIds } = await prompt<{ metadataIds: string[] }>({
       type: 'multiselect',

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -1,6 +1,6 @@
 import { Command, flags } from '@oclif/command'
 import ora from 'ora'
-import { manifest, DestinationDefinition } from '../lib/destinations'
+import { getManifest, DestinationDefinition } from '../lib/destinations'
 
 export default class Validate extends Command {
   private spinner: ora.Ora = ora()
@@ -18,7 +18,7 @@ export default class Validate extends Command {
 
   async run() {
     // TODO validate the definition against the schema
-    const destinations = Object.values(manifest)
+    const destinations = Object.values(getManifest())
 
     for (const destination of destinations) {
       this.spinner.start(`Validating presets for ${destination.definition.name}`)


### PR DESCRIPTION
The serve command wasn't correctly running after recent changes, and we forgot to allow additional args to pass to Node. This PR fixes both issues!