### PR TITLE
updating testing credentials & field type

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-conversions/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/__tests__/index.test.ts
@@ -10,10 +10,10 @@ describe('Tiktok Conversions', () => {
   describe('reportWebEvent', () => {
     it('should send a successful event to reportWebEvent', async () => {
       const settings: Settings = {
-        accessToken: '33266b82878009bd3d3998914a865c9ac96367ef',
-        appId: 6990028389402804225,
-        secretKey: '508507961180419b4d0df0bb3e8fc5ba5b47111b',
-        pixel_code: 'C4AUAO1U9OSI64ECBNO0'
+        accessToken: 'test',
+        appId: 'test',
+        secretKey: 'test',
+        pixel_code: 'test'
       }
 
       const event = createTestEvent({

--- a/packages/destination-actions/src/destinations/tiktok-conversions/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/generated-types.ts
@@ -12,7 +12,7 @@ export interface Settings {
   /**
    * Tiktok app id. You can find this key in the "Basic Information" tab of your Tiktok app.
    */
-  appId: number
+  appId: string
   /**
    * An ID for your Pixel. Required to send events to this pixel.
    */

--- a/packages/destination-actions/src/destinations/tiktok-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/index.ts
@@ -77,7 +77,7 @@ const destination: DestinationDefinition<Settings> = {
       appId: {
         label: 'App Id',
         description: 'Tiktok app id. You can find this key in the "Basic Information" tab of your Tiktok app.',
-        type: 'number',
+        type: 'string',
         required: true
       },
       pixel_code: {
@@ -94,7 +94,7 @@ const destination: DestinationDefinition<Settings> = {
       return request('https://business-api.tiktok.com/open_api/v1.2/oauth2/advertiser/get/', {
         json: {
           access_token: settings.accessToken,
-          app_id: settings.appId,
+          app_id: parseInt(settings.appId, 10),
           secret: settings.secretKey
         }
       })


### PR DESCRIPTION
Removing private credentials
Secondly, I discovered a bug in the actions-UI that settings of field type 'number' do not properly display. There is no module when you try and configure your actions destination

I filed a JIRA to have the team fix this: https://segment.atlassian.net/browse/BE-232

For now, I will change my field type to 'string' and cast it to an integer before I use it in the API authentication request.

This can be updated once number is supported. 