### PR TITLE
[Customer.io] Don't validate Account Region as a uri

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/index.ts
@@ -32,9 +32,8 @@ const destination: DestinationDefinition<Settings> = {
         description: 'Learn about [Account Regions](https://customer.io/docs/data-centers/).',
         label: 'Account Region',
         type: 'string',
-        format: 'uri',
         choices: Object.values(AccountRegion).map((dc) => ({ label: dc, value: dc })),
-        default: 'US 🇺🇸'
+        default: AccountRegion.US
       }
     },
     testAuthentication: (request) => {


### PR DESCRIPTION
Back when `accountRegion` was the actual URL rather than the abstracted display value, I added `format: 'uri'` to make sure it was a url. Since we changed to the abstracted display value, it's no longer a valid URI and validation fails, causing an error.

This removes `format` and also changed the default to be from the official `AccountRegion` enum for extra safety.

Tests were already using the enum, so I'm guessing format isn't validated/run during tests.