### PR TITLE
diff presets in `push`

### DIFF
--- a/packages/cli/src/lib/control-plane-client.ts
+++ b/packages/cli/src/lib/control-plane-client.ts
@@ -63,6 +63,22 @@ export async function updateDestinationMetadata(
   return data.metadata
 }
 
+export async function getSubscriptionPresets(metadataIds: string[]) {
+  const { data, error } = await controlPlaneService.getDestinationSubscriptionPresets(NOOP_CONTEXT, {
+    metadataIds
+  })
+
+  if (error) {
+    throw error
+  }
+
+  if (!data) {
+    throw new Error('Could not load subscription presets')
+  }
+
+  return data.presets
+}
+
 export async function setSubscriptionPresets(metadataId: string, presets: DestinationSubscriptionPresetInput[]) {
   const { data, error } = await controlPlaneService.setDestinationSubscriptionPresets(NOOP_CONTEXT, {
     metadataId,
@@ -70,7 +86,6 @@ export async function setSubscriptionPresets(metadataId: string, presets: Destin
   })
 
   if (error) {
-    console.log(error)
     throw error
   }
 
@@ -91,7 +106,6 @@ export async function createDestinationMetadataActions(
   })
 
   if (error) {
-    console.log(error)
     throw error
   }
 


### PR DESCRIPTION
Previously we weren't catching `presets` diffs, so we may have missed an update to the destination definition.

![Screen Shot 2021-10-12 at 11 27 56 AM](https://user-images.githubusercontent.com/710752/136995046-c421d931-d43c-4176-b032-c4b39b0e1a12.png)
