### PR TITLE
fix types and set readOnly: false

### DIFF
--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -110,7 +110,7 @@ export default class Push extends Command {
             )
           }
 
-          let choices: null | { label: string; value: string } = null
+          let choices: DestinationMetadataActionFieldCreateInput['choices'] = null
           if (Array.isArray(field.choices) && field.choices.length > 0) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             choices = field.choices.map((choice: string | { label: string; value: string }) => {
@@ -375,6 +375,7 @@ export function getOptions(definition: DestinationDefinition): DestinationMetada
         label: choice.label,
         text: choice.label
       })),
+      readOnly: false,
       validators
     }
   }


### PR DESCRIPTION
During `push`, the property `readOnly` often appears in diffs, when it shouldn't (it isn't being changed, it's just omitted).

Here we are explicitly setting it, so it won't appear in the diff anymore.

I also fixed a type def.