### PR TITLE
Revert "GROW-407 - block demo workspace email domains from execution"

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,6 @@ If a CLI command fails to work properly, run the command with `DEBUG=*` at the b
 
 Refer [here](./docs/testing.md) for more information about testing your destination actions.
 
-## Debugging
-
-Pass the Node flag `--inspect` when you run the local server, and then you can attach a debugger from your IDE. The `serve` command will pass any extra args/flags to the underlying Node process. 
-
 ### Configuring
 
 Action destinations are configured using a single Destination setting (`subscriptions`) that should contain a JSON blob of all subscriptions for the destination. The format should look like this:

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -24,29 +24,6 @@ for (const environment of ['stage', 'production']) {
 
   const endpoint = `https://profiles.segment.${environment === 'production' ? 'com' : 'build'}`
 
-  const getDefaultMapping = () => {
-    return {
-      userId: { '@path': '$.userId' },
-      fromDomain: null,
-      fromEmail: 'from@example.com',
-      fromName: 'From Name',
-      replyToEmail: 'replyto@example.com',
-      replyToName: 'Test user',
-      bcc: JSON.stringify([
-        {
-          email: 'test@test.com'
-        }
-      ]),
-      previewText: '',
-      subject: 'Hello {{profile.traits.lastName}} {{profile.traits.firstName}}.',
-      body: 'Hi {{profile.traits.firstName}}, Welcome to segment',
-      bodyType: 'html',
-      bodyHtml: 'Hi {{profile.traits.firstName}}, Welcome to segment',
-      send: true,
-      toEmail: ''
-    }
-  }
-
   beforeEach(() => {
     nock(`${endpoint}/v1/spaces/spaceId/collections/users/profiles/user_id:${userData.userId}`)
       .get('/traits?limit=200')
@@ -132,16 +109,31 @@ for (const environment of ['stage', 'production']) {
           userId: userData.userId
         }),
         settings,
-        mapping: getDefaultMapping()
+        mapping: {
+          userId: { '@path': '$.userId' },
+          fromDomain: null,
+          fromEmail: 'from@example.com',
+          fromName: 'From Name',
+          replyToEmail: 'replyto@example.com',
+          replyToName: 'Test user',
+          bcc: JSON.stringify([
+            {
+              email: 'test@test.com'
+            }
+          ]),
+          previewText: '',
+          subject: 'Hello {{profile.traits.lastName}} {{profile.traits.firstName}}.',
+          body: 'Hi {{profile.traits.firstName}}, Welcome to segment',
+          bodyType: 'html',
+          bodyHtml: 'Hi {{profile.traits.firstName}}, Welcome to segment',
+          send: true
+        }
       })
 
-      expect(responses.length).toBeGreaterThan(0)
+      expect(responses.length).toEqual(3)
       expect(sendGridRequest.isDone()).toEqual(true)
     })
-
-    it('should not send email when send = false', async () => {
-      const mapping = getDefaultMapping()
-      mapping.send = false
+    it('should not send Email', async () => {
       const responses = await sendgrid.testAction('sendEmail', {
         event: createTestEvent({
           timestamp,
@@ -149,13 +141,31 @@ for (const environment of ['stage', 'production']) {
           userId: userData.userId
         }),
         settings,
-        mapping: mapping
+        mapping: {
+          userId: { '@path': '$.userId' },
+          fromDomain: null,
+          fromEmail: 'from@example.com',
+          fromName: 'From Name',
+          replyToEmail: 'replyto@example.com',
+          replyToName: 'Test user',
+          bcc: JSON.stringify([
+            {
+              email: 'test@test.com'
+            }
+          ]),
+          previewText: '',
+          subject: 'Hello {{profile.traits.lastName}} {{profile.traits.firstName}}.',
+          body: 'Hi {{profile.traits.firstName}}, Welcome to segment',
+          bodyType: 'html',
+          bodyHtml: 'Hi {{profile.traits.firstName}}, Welcome to segment',
+          send: false
+        }
       })
 
       expect(responses.length).toEqual(0)
     })
 
-    it('should not send Email when send field not in payload', async () => {
+    it('should not send Email when send field in not sent', async () => {
       const responses = await sendgrid.testAction('sendEmail', {
         event: createTestEvent({
           timestamp,
@@ -272,27 +282,5 @@ for (const environment of ['stage', 'production']) {
       ])
       expect(sendGridRequest.isDone()).toEqual(true)
     })
-
-    const restricted = ['gmailx.com', 'yahoox.com', 'aolx.com', 'hotmailx.com']
-    for (const domain of restricted) {
-      it(`should return an error when given a restricted domain - ${domain}`, async () => {
-        const mapping = getDefaultMapping()
-        mapping.toEmail = `lauren@${domain}`
-        try {
-          await sendgrid.testAction('sendEmail', {
-            event: createTestEvent({
-              timestamp,
-              event: 'Audience Entered',
-              userId: userData.userId
-            }),
-            settings,
-            mapping: mapping
-          })
-          fail('Test should throw an error')
-        } catch (e) {
-          expect(e.message).toBe('Emails with gmailx.com, yahoox.com, aolx.com, and hotmailx.com domains are blocked.')
-        }
-      })
-    }
   })
 }

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -1,4 +1,4 @@
-import { ActionDefinition, IntegrationError, RequestOptions } from '@segment/actions-core'
+import type { ActionDefinition, RequestOptions } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import Mustache from 'mustache'
@@ -54,18 +54,6 @@ const fetchProfileExternalIds = async (
   }
 
   return externalIds
-}
-
-const isRestrictedDomain = (email: string): boolean => {
-  const restricted = ['gmailx.com', 'yahoox.com', 'aolx.com', 'hotmailx.com']
-  const matches = /^.+@(.+)$/.exec(email.toLowerCase())
-
-  if (!matches) {
-    return false
-  }
-
-  const domain = matches[1]
-  return restricted.includes(domain)
 }
 
 interface Profile {
@@ -194,14 +182,6 @@ const action: ActionDefinition<Settings, Payload> = {
 
     if (!toEmail) {
       return
-    }
-
-    if (isRestrictedDomain(toEmail)) {
-      throw new IntegrationError(
-        'Emails with gmailx.com, yahoox.com, aolx.com, and hotmailx.com domains are blocked.',
-        'Invalid input',
-        400
-      )
     }
 
     let name


### PR DESCRIPTION
Reverts segmentio/action-destinations#244 as there is unexpected behavior in stage. This is to unblock the deploy of Customer.io's latest changes.