### PR TITLE
Guardrails

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!-- Hello and thank you for contributing to Segment action-destinations! -->
+
+<!-- Before opening your pull request, make sure you have added and ran unit
+     tests and tested your change locally. Refer to our documentation testing
+     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->
+
+<!-- If you have questions or issues please open a new issue or create a new discussion
+     post in Github. -->
+
+_A summary of your pull request, including the what change you're making and why._
+
+## Testing
+
+_Include any additional information about the testing you completed to
+ensure your change behaves as expected. For a speedy review, please check
+any of the tasks you completed below in during your testing._
+
+- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
+- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
+- [ ] [Segmenters] Tested in the staging environment

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -82,6 +82,21 @@ export default class Push extends Command {
       throw new Error('Number of metadatas must match number of schemas')
     }
 
+    // Guardrails to ensure action-destination definition don't
+    // deviate from stable idenfitiers in the control-plane definition.
+    // We check this to fail fast and early, before parsing actions and
+    // building request payloads.
+    for (const metadata of metadatas) {
+      const entry = manifest[metadata.id]
+      const definition = entry.definition
+
+      // Creation Name check
+      if (metadata.creationName !== definition.name) {
+        this.spinner.fail()
+        throw new Error(`The definition name '${definition.name}' should always match the control plane creation name '${metadata.creationName}'.`)
+      }
+    }
+
     this.spinner.stop()
 
     for (const metadata of metadatas) {


### PR DESCRIPTION
This pull request adds two quick-wins:

- Adds a check to `push.ts` to ensure a definition's name always matches the creation name that exists in the control plane.
- Adds a PR template.
- 
![image](https://user-images.githubusercontent.com/11635476/137351924-a3466608-bbe2-44f0-9890-8fb6c023223e.png)
