### PR TITLE
add name/userId to subscription IR validation

### DIFF
--- a/packages/destination-subscriptions/src/validate.ts
+++ b/packages/destination-subscriptions/src/validate.ts
@@ -48,6 +48,14 @@ const validateCondition = (condition: Condition, data: any): boolean => {
 		return validateValue(data.event, condition.operator, condition.value)
 	}
 
+	if (condition.type === 'name') {
+		return validateValue(data.name, condition.operator, condition.value)
+	}
+
+	if (condition.type === 'userId') {
+		return validateValue(data.userId, condition.operator, condition.value)
+	}
+
 	if (condition.type === 'event-property') {
 		const properties = ['identify', 'group'].includes(data.type)
 			? data.traits


### PR DESCRIPTION
Spencer discovered that `name` matching wasn't working. And indeed it wasn't. The FQL is legit, but in JS (in the app and in the actions core runtime) we are validating the IR not the FQL!!