### PR TITLE
Allow null values for fromDomain personas messaging

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
@@ -16,7 +16,7 @@ export interface Payload {
   /**
    * Verified domain in Sendgrid
    */
-  fromDomain?: string
+  fromDomain?: string | null
   /**
    * From Email
    */

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -102,7 +102,8 @@ const action: ActionDefinition<Settings, Payload> = {
     fromDomain: {
       label: 'From Domain',
       description: 'Verified domain in Sendgrid',
-      type: 'string'
+      type: 'string',
+      allowNull: true
     },
     fromEmail: {
       label: 'From Email',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR allows null values for fromDomain field

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality Already Existed
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
