### PR TITLE
GRAMA-107: adding write key to custom_args

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/generated-types.ts
@@ -21,4 +21,8 @@ export interface Settings {
    * Source ID
    */
   sourceId: string
+  /**
+   * For Twilio Engage, where to send incoming SendGrid events to.
+   */
+  writeKey?: string
 }

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/index.ts
@@ -38,6 +38,12 @@ const destination: DestinationDefinition<Settings> = {
         description: 'Source ID',
         type: 'string',
         required: true
+      },
+      writeKey: {
+        label: 'Segment Write Key',
+        description: 'For Twilio Engage, where to send incoming SendGrid events to.',
+        type: 'string',
+        required: false
       }
     },
     testAuthentication: (request) => {

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -217,7 +217,6 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     const bcc = JSON.parse(payload.bcc ?? '[]')
-
     return request('https://api.sendgrid.com/v3/mail/send', {
       method: 'post',
       json: {
@@ -234,7 +233,8 @@ const action: ActionDefinition<Settings, Payload> = {
               ...payload.customArgs,
               source_id: settings.sourceId,
               space_id: settings.spaceId,
-              user_id: payload.userId
+              user_id: payload.userId,
+              __segment_write_key__: settings.writeKey
             }
           }
         ],


### PR DESCRIPTION
Adding Segment write key which will be used to direct incoming events from SendGrid back to Segment.

[GRAMA-107](https://segment.atlassian.net/browse/GRAMA-107)

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
