### PR TITLE
Revert "[BE-126] Publish prerelease from PR"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,12 +2,8 @@ name: Publish
 
 on:
   pull_request:
-    branches: 
-      - main
-    types: 
-      - opened
-      - synchronize
-      - closed
+    branches: [main]
+    types: [closed]
     paths:
       - packages/**
   workflow_dispatch:
@@ -40,28 +36,14 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: get-version
-
-    # require a version unless a PR is opened or synchronized
-    # prevents unlabeled and closed PRs from getting published
-    if: ${{ (needs.get-version.outputs.version && github.event.action == 'closed' && github.event.pull_request.merged == true) || github.event_name == 'workflow_dispatch' || github.event.action == 'opened' || github.event.action == 'synchronize' }}
+    if: ${{ needs.get-version.outputs.version }}
 
     strategy:
       matrix:
         node-version: [14.x]
 
     steps:
-      # if running from workflow_dispatch or closing a PR, checkout main
       - uses: actions/checkout@v2
-        if: ${{ github.event_name == 'workflow_dispatch' || (github.event.action == 'closed' && github.event.pull_request.merged == true) }}
-        with:
-          fetch-depth: 0  # pulls tags so lerna can compare changes
-
-      # else checkout branch
-      - uses: actions/checkout@v2
-        if: ${{ github.event.action == 'opened' || github.event.action == 'synchronize' }}
-        with:
-          ref: ${{ github.head_ref }}
-          fetch-depth: 0
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
@@ -97,12 +79,11 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: yarn test
 
-      # set to the author of the most recent commit
       - name: Set author
         run: |
           git config user.email "`git log --format='%ae' HEAD^!`"
-          git config user.name "`git log --format='%an' HEAD^!`"
           git config user.email
+          git config user.name "`git log --format='%an' HEAD^!`"
           git config user.name
 
       - name: Set NPM Token
@@ -110,10 +91,5 @@ jobs:
           npm set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_TOKEN }}
           npm whoami
 
-      - name: Publish production package
-        if: ${{ github.event_name == 'workflow_dispatch' || (github.event.action == 'closed' && github.event.pull_request.merged == true) }}
-        run: lerna publish ${{ needs.get-version.outputs.version }} --conventional-commits --no-changelog --conventional-graduate --no-verify-access --yes
-
-      - name: Publish prerelease from PR
-        if: ${{ github.event.action == 'opened' || github.event.action == 'synchronize' }}
-        run: lerna publish prerelease --canary --preid ${{ github.head_ref }} --pre-dist-tag canary --no-verify-access --yes
+      - name: Publish
+        run: lerna publish ${{ needs.get-version.outputs.version }} --no-verify-access --yes


### PR DESCRIPTION
Reverts segmentio/action-destinations#227

I found an issue where branches with slashes in their names (e.g., das/test-prerelease) cause the package publish to fail
![image](https://user-images.githubusercontent.com/14829777/137934643-408566e7-4ee7-476c-8269-e79b72d924b4.png)