### PR TITLE
[braze web] remove unnecessary service worker load

### DIFF
--- a/packages/browser-destinations/src/destinations/braze/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/index.ts
@@ -239,12 +239,8 @@ export const destination: BrowserDestinationDefinition<Settings, typeof appboy> 
         'By default, sessions time out after 30 minutes of inactivity. Provide a value for this configuration option to override that default with a value of your own.'
     }
   },
-  initialize: async ({ settings }, dependencies) => {
+  initialize: async ({ settings }, _dependencies) => {
     const { endpoint, api_key, ...expectedConfig } = settings
-
-    const sdkVersion = settings.sdkVersion?.length ? settings.sdkVersion : '3.3'
-
-    await dependencies.loadScript(`https://js.appboycdn.com/web-sdk/${sdkVersion}/service-worker.js`)
 
     const initialized = appboy.initialize(settings.api_key, { baseUrl: endpoint, ...expectedConfig })
     if (!initialized) {


### PR DESCRIPTION
We received feedback from Braze's team that loading appboy's service worker is not necessary for the browser destination action.

This PR removes the log that loads the service worker.

## Testing

- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)

https://user-images.githubusercontent.com/484013/137937233-0bfe409d-a412-48ad-a16c-ab1b10f65fa6.mov

- [ ] [Segmenters] Tested in the staging environment
_WIP_