### PR TITLE
Remove empty values from fields when not matching their data types

### DIFF
--- a/packages/core/src/__tests__/remove-empty-values.test.ts
+++ b/packages/core/src/__tests__/remove-empty-values.test.ts
@@ -1,0 +1,113 @@
+import { JSONSchema4 } from 'json-schema'
+import { removeEmptyValues } from '../remove-empty-values'
+
+describe(removeEmptyValues.name, () => {
+  it('removes empty strings when the schema type doesnt match', () => {
+    const input = {
+      foo: '',
+      bar: '1',
+      baz: true
+    }
+
+    const schema: JSONSchema4 = {
+      type: 'object',
+      properties: {
+        foo: { type: 'string' },
+        bar: { type: 'string' },
+        baz: { type: 'boolean' }
+      }
+    }
+
+    expect(removeEmptyValues(input, schema)).toMatchObject({
+      bar: '1',
+      baz: true
+    })
+  })
+
+  it('leaves empty objects, because we cannot know if they are acceptable', () => {
+    const input = {
+      foo: {},
+      bar: '1'
+    }
+
+    const schema: JSONSchema4 = {
+      type: 'object',
+      properties: {
+        foo: { type: 'object' },
+        bar: { type: 'string' }
+      }
+    }
+
+    expect(removeEmptyValues(input, schema)).toMatchObject({
+      foo: {},
+      bar: '1'
+    })
+  })
+
+  it('removes missing values from nested fields', () => {
+    const input = {
+      a: {
+        b: '',
+        c: null
+      }
+    }
+
+    const schema: JSONSchema4 = {
+      type: 'object',
+      properties: {
+        a: {
+          type: 'object',
+          properties: {
+            b: { type: 'string' },
+            c: { type: 'null' }
+          }
+        }
+      }
+    }
+
+    expect(removeEmptyValues(input, schema)).toMatchObject({
+      a: {
+        c: null
+      }
+    })
+  })
+
+  it('removes null when it is not explicitly accepted', () => {
+    const input = {
+      a: null,
+      b: '1'
+    }
+
+    const schema: JSONSchema4 = {
+      type: 'object',
+      properties: {
+        a: { type: 'string' },
+        b: { type: 'string' }
+      }
+    }
+
+    expect(removeEmptyValues(input, schema)).toMatchObject({
+      b: '1'
+    })
+  })
+
+  it('leaves null when it is explicitly accepted', () => {
+    const input = {
+      a: null,
+      b: '1'
+    }
+
+    const schema: JSONSchema4 = {
+      type: 'object',
+      properties: {
+        a: { type: ['string', 'null'] },
+        b: { type: 'string' }
+      }
+    }
+
+    expect(removeEmptyValues(input, schema)).toMatchObject({
+      a: null,
+      b: '1'
+    })
+  })
+})

--- a/packages/core/src/arrify.ts
+++ b/packages/core/src/arrify.ts
@@ -1,0 +1,7 @@
+import { isArray } from './real-type-of'
+
+export function arrify<T>(value: T | T[] | undefined): T[] {
+  if (value === undefined || value === null) return []
+  if (isArray(value)) return value
+  return [value]
+}

--- a/packages/core/src/remove-empty-values.ts
+++ b/packages/core/src/remove-empty-values.ts
@@ -2,7 +2,7 @@ import type { JSONSchema4 } from 'json-schema'
 import { isArray, isObject } from './real-type-of'
 import { arrify } from './arrify'
 
-export function removeEmptyValues(obj: unknown, schema: JSONSchema4) {
+export function removeEmptyValues(obj: unknown, schema: JSONSchema4 = {}): unknown {
   if (isArray(obj)) {
     return obj.filter((item) => removeEmptyValues(item, schema) !== undefined)
   }
@@ -11,7 +11,7 @@ export function removeEmptyValues(obj: unknown, schema: JSONSchema4) {
     const newObj = { ...obj }
 
     for (const key of Object.keys(newObj)) {
-      newObj[key] = removeEmptyValues(newObj[key], schema.properties?.[key] ?? {})
+      newObj[key] = removeEmptyValues(newObj[key], schema.properties?.[key])
 
       // Remove undefined keys
       if (newObj[key] === undefined) {
@@ -23,10 +23,15 @@ export function removeEmptyValues(obj: unknown, schema: JSONSchema4) {
   }
 
   const schemaType = arrify(schema.type)
+
+  // Only remove `null` when the schema doesn't allow 'null'
+  // because it may not be coercible to a valid value in Ajv
   if (obj === 'null' && !schemaType.includes('null')) {
     return undefined
   }
 
+  // Only remove empty strings if the schema type is not 'string'
+  // because it may not be coercible to a valid value in Ajv
   if (obj === '' && !schemaType.includes('string')) {
     return undefined
   }

--- a/packages/core/src/remove-empty-values.ts
+++ b/packages/core/src/remove-empty-values.ts
@@ -1,0 +1,35 @@
+import type { JSONSchema4 } from 'json-schema'
+import { isArray, isObject } from './real-type-of'
+import { arrify } from './arrify'
+
+export function removeEmptyValues(obj: unknown, schema: JSONSchema4) {
+  if (isArray(obj)) {
+    return obj.filter((item) => removeEmptyValues(item, schema) !== undefined)
+  }
+
+  if (isObject(obj)) {
+    const newObj = { ...obj }
+
+    for (const key of Object.keys(newObj)) {
+      newObj[key] = removeEmptyValues(newObj[key], schema.properties?.[key] ?? {})
+
+      // Remove undefined keys
+      if (newObj[key] === undefined) {
+        delete newObj[key]
+      }
+    }
+
+    return newObj
+  }
+
+  const schemaType = arrify(schema.type)
+  if (obj === 'null' && !schemaType.includes('null')) {
+    return undefined
+  }
+
+  if (obj === '' && !schemaType.includes('string')) {
+    return undefined
+  }
+
+  return obj
+}

--- a/packages/core/src/schema-validation.ts
+++ b/packages/core/src/schema-validation.ts
@@ -2,20 +2,23 @@ import { AggregateAjvError } from '@segment/ajv-human-errors'
 import Ajv, { ValidateFunction } from 'ajv'
 import addFormats from 'ajv-formats'
 import dayjs from 'dayjs'
+import type { JSONSchema4 } from 'json-schema'
 
 // `addFormats` includes many standard formats we use like `uri`, `date`, `email`, etc.
-const ajv = addFormats(new Ajv({
-  // Coerce types to be a bit more liberal.
-  coerceTypes: true,
-  // Return all validation errors, not just the first.
-  allErrors: true,
-  // Allow multiple non-null types in `type` keyword.
-  allowUnionTypes: true,
-  // Include reference to schema and data in error values.
-  verbose: true,
-  // Remove properties not defined the schema object
-  removeAdditional: true
-}))
+const ajv = addFormats(
+  new Ajv({
+    // Coerce types to be a bit more liberal.
+    coerceTypes: true,
+    // Return all validation errors, not just the first.
+    allErrors: true,
+    // Allow multiple non-null types in `type` keyword.
+    allowUnionTypes: true,
+    // Include reference to schema and data in error values.
+    verbose: true,
+    // Remove properties not defined the schema object
+    removeAdditional: true
+  })
+)
 
 // Extend with additional supported formats for action `fields`
 ajv.addFormat('text', true)
@@ -43,7 +46,7 @@ interface ValidationOptions {
  * Validates an object against a json schema
  * and caches the schema for subsequent validations when a key is provided
  */
-export function validateSchema(obj: unknown, schema: object, options?: ValidationOptions) {
+export function validateSchema(obj: unknown, schema: JSONSchema4, options?: ValidationOptions) {
   const { schemaKey, throwIfInvalid = true } = options ?? {}
   let validate: ValidateFunction
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR introduces some logic to _remove empty values like `null` `undefined` or `''`_ when the field's type doesn't support them. This is because Ajv coerces values to match the allowed data type of a field, but in some cases cannot coerce values in a sensible way. 

We need to decide if it makes more sense to reject messages because of uncoercible empty values, or to strip them out. Optional fields would pass when they get stripped out, while required fields would obviously fail.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
