### PR TITLE
use native globals, specify mainFields

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,6 +64,7 @@ module.exports = {
     {
       files: ['packages/cli/**/*.ts'],
       rules: {
+        'lodash/import-scope': ['error', 'member'],
         '@typescript-eslint/no-var-requires': 'off'
       }
     },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,8 +17,9 @@ module.exports = {
     'prettier/@typescript-eslint',
     'prettier'
   ],
-  plugins: ['@typescript-eslint'],
+  plugins: ['@typescript-eslint', 'lodash'],
   rules: {
+    'lodash/import-scope': ['error', 'method'],
     '@typescript-eslint/ban-types': 'off',
     '@typescript-eslint/ban-ts-comment': [
       'error',

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint": "^7.25.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-jest": "^24.3.6",
+    "eslint-plugin-lodash": "^7.3.0",
     "husky": "^4.3.8",
     "jest": "^27.0.0",
     "lerna": "^4.0.0",

--- a/packages/browser-destinations/package.json
+++ b/packages/browser-destinations/package.json
@@ -73,6 +73,9 @@
     "transformIgnorePatterns": [
       "/node_modules/(?!@segment/analytics-next).+\\.js$"
     ],
+    "setupFilesAfterEnv": [
+      "<rootDir>/test/setup-after-env.ts"
+    ],
     "forceExit": true
   }
 }

--- a/packages/browser-destinations/package.json
+++ b/packages/browser-destinations/package.json
@@ -24,7 +24,7 @@
     "prepublishOnly": "yarn build",
     "test": "jest",
     "typecheck": "tsc -p tsconfig.build.json --noEmit",
-    "dev": "NODE_ENV=development concurrently \"webpack serve\" \"webpack -c webpack.config.js --watch\""
+    "dev": "NODE_ENV=development concurrently \"webpack serve --open\" \"webpack -c webpack.config.js --watch\""
   },
   "dependencies": {
     "@braze/web-sdk": "^3.3.0",

--- a/packages/browser-destinations/src/destinations/amplitude-plugins/sessionId/__tests__/sessionId.test.ts
+++ b/packages/browser-destinations/src/destinations/amplitude-plugins/sessionId/__tests__/sessionId.test.ts
@@ -1,5 +1,4 @@
 import { Analytics, Context, Plugin } from '@segment/analytics-next'
-import * as jsdom from 'jsdom'
 import browserPluginsDestination from '../..'
 import { Subscription } from '../../../../lib/browser-destinations'
 
@@ -41,28 +40,6 @@ let sessionIdPlugin: Plugin
 let ajs: Analytics
 
 beforeEach(async () => {
-  jest.restoreAllMocks()
-  jest.resetAllMocks()
-
-  const html = `
-  <!DOCTYPE html>
-    <head>
-      <script>'hi'</script>
-    </head>
-    <body>
-    </body>
-  </html>
-  `.trim()
-
-  const jsd = new jsdom.JSDOM(html, {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'https://localhost'
-  })
-
-  const windowSpy = jest.spyOn(window, 'window', 'get')
-  windowSpy.mockImplementation(() => jsd.window as unknown as Window & typeof globalThis)
-
   browserActions = await browserPluginsDestination({ subscriptions: example })
   sessionIdPlugin = browserActions[0]
 

--- a/packages/browser-destinations/src/destinations/braze/__tests__/debounce.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/debounce.test.ts
@@ -46,6 +46,8 @@ describe('debounce', () => {
     const [debounce] = await brazeDestination({
       api_key: 'b_123',
       endpoint: 'endpoint',
+      doNotLoadFontAwesome: true,
+      sdkVersion: '3.3',
       subscriptions: [
         {
           partnerAction: 'debounce',
@@ -74,6 +76,8 @@ describe('debounce', () => {
     const [debounce] = await brazeDestination({
       api_key: 'b_123',
       endpoint: 'endpoint',
+      doNotLoadFontAwesome: true,
+      sdkVersion: '3.3',
       subscriptions: [
         {
           partnerAction: 'debounce',
@@ -102,6 +106,8 @@ describe('debounce', () => {
     const [debounce] = await brazeDestination({
       api_key: 'b_123',
       endpoint: 'endpoint',
+      doNotLoadFontAwesome: true,
+      sdkVersion: '3.3',
       subscriptions: [
         {
           partnerAction: 'debounce',
@@ -126,6 +132,8 @@ describe('debounce', () => {
     const [debounce] = await brazeDestination({
       api_key: 'b_123',
       endpoint: 'endpoint',
+      doNotLoadFontAwesome: true,
+      sdkVersion: '3.3',
       subscriptions: [
         {
           partnerAction: 'debounce',

--- a/packages/browser-destinations/src/destinations/braze/__tests__/debounce.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/debounce.test.ts
@@ -1,42 +1,10 @@
 import { Analytics, Context } from '@segment/analytics-next'
-import * as jsdom from 'jsdom'
 import brazeDestination from '../index'
 
 let ajs: Analytics
 
 describe('debounce', () => {
   beforeEach(async () => {
-    jest.restoreAllMocks()
-    jest.resetAllMocks()
-
-    const html = `
-  <!DOCTYPE html>
-    <head>
-      <script>'hi'</script>
-    </head>
-    <body>
-    </body>
-  </html>
-  `.trim()
-
-    const jsd = new jsdom.JSDOM(html, {
-      runScripts: 'dangerously',
-      resources: 'usable',
-      url: 'https://segment.com'
-    })
-
-    const windowSpy = jest.spyOn(global, 'window', 'get')
-    const documentSpy = jest.spyOn(global, 'document', 'get')
-
-    windowSpy.mockImplementation(() => {
-      return jsd.window as unknown as Window & typeof globalThis
-    })
-
-    documentSpy.mockImplementation(() => jsd.window.document as unknown as Document)
-    global.document.domain = 'segment.com'
-
-    jest.spyOn(console, 'error').mockImplementation(() => {})
-
     ajs = new Analytics({
       writeKey: 'w_123'
     })

--- a/packages/browser-destinations/src/destinations/braze/__tests__/initialization.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/initialization.test.ts
@@ -1,6 +1,5 @@
 import appboy from '@braze/web-sdk'
 import { Analytics, Context } from '@segment/analytics-next'
-import * as jsdom from 'jsdom'
 import brazeDestination from '../index'
 
 describe('initialization', () => {
@@ -24,28 +23,6 @@ describe('initialization', () => {
   }
 
   beforeEach(async () => {
-    jest.restoreAllMocks()
-    jest.resetAllMocks()
-
-    const html = `
-  <!DOCTYPE html>
-    <head>
-      <script>'hi'</script>
-    </head>
-    <body>
-    </body>
-  </html>
-  `.trim()
-
-    const jsd = new jsdom.JSDOM(html, {
-      runScripts: 'dangerously',
-      resources: 'usable',
-      url: 'https://segment.com'
-    })
-
-    const windowSpy = jest.spyOn(window, 'window', 'get')
-    windowSpy.mockImplementation(() => jsd.window as unknown as Window & typeof globalThis)
-
     // we're not really testing that appboy loads here, so we'll just mock it out
     jest.spyOn(appboy, 'initialize').mockImplementation(() => true)
     jest.spyOn(appboy, 'openSession').mockImplementation(() => true)

--- a/packages/browser-destinations/src/destinations/braze/__tests__/integration.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/integration.test.ts
@@ -55,7 +55,9 @@ test('can load braze', async () => {
   const [trackEvent] = await braze({
     api_key: 'api_key',
     endpoint: 'sdk.iad-01.braze.com',
-    subscriptions: example
+    subscriptions: example,
+    doNotLoadFontAwesome: true,
+    sdkVersion: '3.3'
   })
 
   jest.spyOn(destination.actions.trackEvent, 'perform')
@@ -81,7 +83,9 @@ test('loads the braze service worker', async () => {
   const [trackEvent] = await braze({
     api_key: 'api_key',
     endpoint: 'sdk.iad-01.braze.com',
-    subscriptions: example
+    subscriptions: example,
+    doNotLoadFontAwesome: true,
+    sdkVersion: '3.3'
   })
 
   await trackEvent.load(Context.system(), {} as Analytics)
@@ -103,6 +107,7 @@ describe('loads different versions of braze service worker', () => {
       api_key: 'api_key',
       endpoint: 'sdk.iad-01.braze.com',
       sdkVersion: '3.0',
+      doNotLoadFontAwesome: true,
       subscriptions: example
     })
 
@@ -124,6 +129,7 @@ describe('loads different versions of braze service worker', () => {
       api_key: 'api_key',
       endpoint: 'sdk.iad-01.braze.com',
       sdkVersion: '3.1',
+      doNotLoadFontAwesome: true,
       subscriptions: example
     })
 
@@ -145,6 +151,7 @@ describe('loads different versions of braze service worker', () => {
       api_key: 'api_key',
       endpoint: 'sdk.iad-01.braze.com',
       sdkVersion: '3.2',
+      doNotLoadFontAwesome: true,
       subscriptions: example
     })
 
@@ -166,6 +173,7 @@ describe('loads different versions of braze service worker', () => {
       api_key: 'api_key',
       endpoint: 'sdk.iad-01.braze.com',
       sdkVersion: '3.3',
+      doNotLoadFontAwesome: true,
       subscriptions: example
     })
 

--- a/packages/browser-destinations/src/destinations/braze/__tests__/integration.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/integration.test.ts
@@ -1,5 +1,4 @@
 import { Analytics, Context } from '@segment/analytics-next'
-import * as jsdom from 'jsdom'
 import braze, { destination } from '..'
 import type { Subscription } from '../../../lib/browser-destinations'
 
@@ -19,37 +18,6 @@ const example: Subscription[] = [
     }
   }
 ]
-
-beforeEach(async () => {
-  jest.restoreAllMocks()
-  jest.resetAllMocks()
-
-  const html = `
-  <!DOCTYPE html>
-    <head>
-      <script>'hi'</script>
-    </head>
-    <body>
-    </body>
-  </html>
-  `.trim()
-
-  const jsd = new jsdom.JSDOM(html, {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'https://segment.com'
-  })
-
-  const windowSpy = jest.spyOn(global, 'window', 'get')
-  const documentSpy = jest.spyOn(global, 'document', 'get')
-
-  windowSpy.mockImplementation(() => {
-    return jsd.window as unknown as Window & typeof globalThis
-  })
-
-  documentSpy.mockImplementation(() => jsd.window.document as unknown as Document)
-  global.document.domain = 'segment.com'
-})
 
 test('can load braze', async () => {
   const [trackEvent] = await braze({

--- a/packages/browser-destinations/src/destinations/braze/__tests__/trackEvent.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/trackEvent.test.ts
@@ -1,32 +1,9 @@
 import appboy from '@braze/web-sdk'
 import { Analytics, Context } from '@segment/analytics-next'
-import * as jsdom from 'jsdom'
 import brazeDestination from '../index'
 
 describe('trackEvent', () => {
   beforeEach(async () => {
-    jest.restoreAllMocks()
-    jest.resetAllMocks()
-
-    const html = `
-  <!DOCTYPE html>
-    <head>
-      <script>'hi'</script>
-    </head>
-    <body>
-    </body>
-  </html>
-  `.trim()
-
-    const jsd = new jsdom.JSDOM(html, {
-      runScripts: 'dangerously',
-      resources: 'usable',
-      url: 'https://segment.com'
-    })
-
-    const windowSpy = jest.spyOn(window, 'window', 'get')
-    windowSpy.mockImplementation(() => jsd.window as unknown as Window & typeof globalThis)
-
     // we're not really testing that appboy loads here, so we'll just mock it out
     jest.spyOn(appboy, 'initialize').mockImplementation(() => true)
     jest.spyOn(appboy, 'openSession').mockImplementation(() => true)

--- a/packages/browser-destinations/src/destinations/braze/__tests__/trackEvent.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/trackEvent.test.ts
@@ -39,6 +39,7 @@ describe('trackEvent', () => {
       api_key: 'b_123',
       endpoint: 'endpoint',
       sdkVersion: '3.3',
+      doNotLoadFontAwesome: true,
       subscriptions: [
         {
           partnerAction: 'trackEvent',

--- a/packages/browser-destinations/src/destinations/braze/__tests__/trackPurchase.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/trackPurchase.test.ts
@@ -1,31 +1,6 @@
 import appboy from '@braze/web-sdk'
 import { Analytics, Context } from '@segment/analytics-next'
-import * as jsdom from 'jsdom'
 import brazeDestination from '../index'
-
-beforeEach(async () => {
-  jest.restoreAllMocks()
-  jest.resetAllMocks()
-
-  const html = `
-  <!DOCTYPE html>
-    <head>
-      <script>'hi'</script>
-    </head>
-    <body>
-    </body>
-  </html>
-  `.trim()
-
-  const jsd = new jsdom.JSDOM(html, {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'https://segment.com'
-  })
-
-  const windowSpy = jest.spyOn(window, 'window', 'get')
-  windowSpy.mockImplementation(() => jsd.window as unknown as Window & typeof globalThis)
-})
 
 beforeEach(() => {
   // we're not really testing that appboy loads here, so we'll just mock it out

--- a/packages/browser-destinations/src/destinations/braze/__tests__/trackPurchase.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/trackPurchase.test.ts
@@ -40,6 +40,7 @@ test('reports products when present', async () => {
     api_key: 'b_123',
     endpoint: 'endpoint',
     sdkVersion: '3.3',
+    doNotLoadFontAwesome: true,
     subscriptions: [
       {
         partnerAction: 'trackPurchase',

--- a/packages/browser-destinations/src/destinations/braze/__tests__/updateUserProfile.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/updateUserProfile.test.ts
@@ -83,6 +83,8 @@ describe('updateUserProfile', () => {
     const [trackPurchase] = await brazeDestination({
       api_key: 'b_123',
       endpoint: 'endpoint',
+      sdkVersion: '3.3',
+      doNotLoadFontAwesome: true,
       subscriptions: [
         {
           partnerAction: 'updateUserProfile',
@@ -115,6 +117,8 @@ describe('updateUserProfile', () => {
     const [trackPurchase] = await brazeDestination({
       api_key: 'b_123',
       endpoint: 'endpoint',
+      sdkVersion: '3.3',
+      doNotLoadFontAwesome: true,
       subscriptions
     })
 
@@ -167,6 +171,8 @@ describe('updateUserProfile', () => {
     const [trackPurchase] = await brazeDestination({
       api_key: 'b_123',
       endpoint: 'endpoint',
+      sdkVersion: '3.3',
+      doNotLoadFontAwesome: true,
       subscriptions
     })
 

--- a/packages/browser-destinations/src/destinations/braze/__tests__/updateUserProfile.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/updateUserProfile.test.ts
@@ -1,6 +1,5 @@
 import appboy from '@braze/web-sdk'
 import { Analytics, Context } from '@segment/analytics-next'
-import * as jsdom from 'jsdom'
 import brazeDestination from '../index'
 
 describe('updateUserProfile', () => {
@@ -32,28 +31,6 @@ describe('updateUserProfile', () => {
   ]
 
   beforeEach(async () => {
-    jest.restoreAllMocks()
-    jest.resetAllMocks()
-
-    const html = `
-  <!DOCTYPE html>
-    <head>
-      <script>'hi'</script>
-    </head>
-    <body>
-    </body>
-  </html>
-  `.trim()
-
-    const jsd = new jsdom.JSDOM(html, {
-      runScripts: 'dangerously',
-      resources: 'usable',
-      url: 'https://segment.com'
-    })
-
-    const windowSpy = jest.spyOn(window, 'window', 'get')
-    windowSpy.mockImplementation(() => jsd.window as unknown as Window & typeof globalThis)
-
     // we're not really testing that appboy loads here, so we'll just mock it out
     userMock = {
       setAvatarImageUrl: jest.fn(),

--- a/packages/browser-destinations/src/destinations/fullstory/__tests__/fullstory.test.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/__tests__/fullstory.test.ts
@@ -1,6 +1,4 @@
-import * as FullStory from '@fullstory/browser'
 import { Analytics, Context } from '@segment/analytics-next'
-import * as jsdom from 'jsdom'
 import fullstory, { destination } from '..'
 import { Subscription } from '../../../lib/browser-destinations'
 
@@ -44,30 +42,6 @@ const example: Subscription[] = [
   }
 ]
 
-beforeEach(async () => {
-  jest.restoreAllMocks()
-  jest.resetAllMocks()
-
-  const html = `
-  <!DOCTYPE html>
-    <head>
-      <script>'hi'</script>
-    </head>
-    <body>
-    </body>
-  </html>
-  `.trim()
-
-  const jsd = new jsdom.JSDOM(html, {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'https://fullstory.com'
-  })
-
-  const windowSpy = jest.spyOn(window, 'window', 'get')
-  windowSpy.mockImplementation(() => jsd.window as unknown as Window & typeof globalThis)
-})
-
 test('can load fullstory', async () => {
   const [event] = await fullstory({
     orgId: 'thefullstory.com',
@@ -109,14 +83,14 @@ test('can load fullstory', async () => {
 
 describe('#track', () => {
   it('sends record events to fullstory on "event"', async () => {
-    const fs = jest.spyOn(FullStory, 'event')
-
     const [event] = await fullstory({
       orgId: 'thefullstory.com',
       subscriptions: example
     })
 
     await event.load(Context.system(), {} as Analytics)
+    const fs = jest.spyOn(window.FS, 'event')
+
     await event.track?.(
       new Context({
         type: 'track',
@@ -141,8 +115,8 @@ describe('#identify', () => {
     })
 
     await identifyUser.load(Context.system(), {} as Analytics)
-    const fs = jest.spyOn(FullStory, 'setUserVars')
-    const fsId = jest.spyOn(FullStory, 'identify')
+    const fs = jest.spyOn(window.FS, 'setUserVars')
+    const fsId = jest.spyOn(window.FS, 'identify')
 
     await identifyUser.identify?.(
       new Context({
@@ -164,7 +138,7 @@ describe('#identify', () => {
         subscriptions: example
       })
       await identifyUser.load(Context.system(), {} as Analytics)
-      const fsId = jest.spyOn(FullStory, 'identify')
+      const fsId = jest.spyOn(window.FS, 'identify')
 
       await identifyUser.identify?.(new Context({ type: 'identify', userId: 'id' }))
       expect(fsId).toHaveBeenCalledWith('id', {})
@@ -175,7 +149,7 @@ describe('#identify', () => {
         subscriptions: example
       })
       await identifyUser.load(Context.system(), {} as Analytics)
-      const fsId = jest.spyOn(FullStory, 'identify')
+      const fsId = jest.spyOn(window.FS, 'identify')
 
       await identifyUser.identify?.(
         new Context({
@@ -192,14 +166,14 @@ describe('#identify', () => {
     })
 
   it('can set user vars', async () => {
-    const fs = jest.spyOn(FullStory, 'setUserVars')
-
     const [_, identifyUser] = await fullstory({
       orgId: 'thefullstory.com',
       subscriptions: example
     })
 
     await identifyUser.load(Context.system(), {} as Analytics)
+    const fs = jest.spyOn(window.FS, 'setUserVars')
+
     await identifyUser.identify?.(
       new Context({
         type: 'identify',

--- a/packages/browser-destinations/src/destinations/fullstory/identifyUser/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/identifyUser/index.ts
@@ -1,11 +1,11 @@
 import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import * as FullStory from '@fullstory/browser'
-import { camelCase } from 'lodash'
+import type { FS } from '../types'
+import camelCase from 'lodash/camelCase'
 
 // Change from unknown to the partner SDK types
-const action: BrowserActionDefinition<Settings, typeof FullStory, Payload> = {
+const action: BrowserActionDefinition<Settings, FS, Payload> = {
   title: 'Identify User',
   description: 'Sets user identity variables',
   platform: 'web',
@@ -57,7 +57,7 @@ const action: BrowserActionDefinition<Settings, typeof FullStory, Payload> = {
       }
     }
   },
-  perform: (client, event) => {
+  perform: (FS, event) => {
     let newTraits: Record<string, unknown> = {}
 
     if (event.payload.traits) {
@@ -75,9 +75,9 @@ const action: BrowserActionDefinition<Settings, typeof FullStory, Payload> = {
     }
 
     if (event.payload.userId) {
-      client.identify(event.payload.userId, newTraits)
+      FS.identify(event.payload.userId, newTraits)
     } else {
-      client.setUserVars({
+      FS.setUserVars({
         ...newTraits,
         ...(event.payload.email !== undefined && { email: event.payload.email }),
         ...(event.payload.displayName !== undefined && { displayName: event.payload.displayName })

--- a/packages/browser-destinations/src/destinations/fullstory/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/index.ts
@@ -1,4 +1,4 @@
-import * as FullStory from '@fullstory/browser'
+import type { FS } from './types'
 import type { BrowserDestinationDefinition } from '../../lib/browser-destinations'
 import { browserDestination } from '../../runtime/shim'
 import type { Settings } from './generated-types'
@@ -8,7 +8,13 @@ import identifyUser from './identifyUser'
 import viewedPage from './viewedPage'
 import { defaultValues } from '@segment/actions-core'
 
-export const destination: BrowserDestinationDefinition<Settings, typeof FullStory> = {
+declare global {
+  interface Window {
+    FS: FS
+  }
+}
+
+export const destination: BrowserDestinationDefinition<Settings, FS> = {
   name: 'Fullstory (Actions)',
   slug: 'actions-fullstory',
   mode: 'device',
@@ -50,7 +56,7 @@ export const destination: BrowserDestinationDefinition<Settings, typeof FullStor
     initScript({ debug: settings.debug, org: settings.orgId })
     await dependencies.loadScript('https://edge.fullstory.com/s/fs.js')
     await dependencies.resolveWhen(() => Object.prototype.hasOwnProperty.call(window, 'FS'), 100)
-    return FullStory
+    return window.FS
   }
 }
 

--- a/packages/browser-destinations/src/destinations/fullstory/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/trackEvent/index.ts
@@ -1,10 +1,9 @@
 import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import * as FullStory from '@fullstory/browser'
-// import { IntegrationError } from '@segment/actions-core'
+import type { FS } from '../types'
 
-const action: BrowserActionDefinition<Settings, typeof FullStory, Payload> = {
+const action: BrowserActionDefinition<Settings, FS, Payload> = {
   title: 'Track Event',
   description: 'Track events',
   platform: 'web',
@@ -29,8 +28,8 @@ const action: BrowserActionDefinition<Settings, typeof FullStory, Payload> = {
       }
     }
   },
-  perform: (client, event) => {
-    client.event(event.payload.name, event.payload.properties ?? {})
+  perform: (FS, event) => {
+    FS.event(event.payload.name, event.payload.properties ?? {})
   }
 }
 

--- a/packages/browser-destinations/src/destinations/fullstory/types.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/types.ts
@@ -1,0 +1,6 @@
+import * as FullStory from '@fullstory/browser'
+
+export type FS = typeof FullStory & {
+  // setVars is not available on the FS client yet.
+  setVars: (eventName: string, eventProperties: object) => {}
+}

--- a/packages/browser-destinations/src/destinations/fullstory/viewedPage/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/viewedPage/index.ts
@@ -1,18 +1,9 @@
 import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import * as FullStory from '@fullstory/browser'
-declare global {
-  interface Window {
-    // setVars is not available on the FS client yet.
-    FS: {
-      setVars: (eventName: string, eventProperties: object) => {}
-    }
-  }
-}
+import type { FS } from '../types'
 
-// Change from unknown to the partner SDK types
-const action: BrowserActionDefinition<Settings, typeof FullStory, Payload> = {
+const action: BrowserActionDefinition<Settings, FS, Payload> = {
   title: 'Viewed Page',
   description: 'Sets page properties events',
   defaultSubscription: 'type = "page"',
@@ -41,11 +32,11 @@ const action: BrowserActionDefinition<Settings, typeof FullStory, Payload> = {
       }
     }
   },
-  perform: (_, event) => {
+  perform: (FS, event) => {
     if (event.payload.pageName) {
-      window.FS.setVars('page', { pageName: event.payload.pageName, ...event.payload.properties })
+      FS.setVars('page', { pageName: event.payload.pageName, ...event.payload.properties })
     } else if (event.payload.properties) {
-      window.FS.setVars('page', event.payload.properties)
+      FS.setVars('page', event.payload.properties)
     }
   }
 }

--- a/packages/browser-destinations/test/setup-after-env.ts
+++ b/packages/browser-destinations/test/setup-after-env.ts
@@ -1,0 +1,33 @@
+import * as jsdom from 'jsdom'
+
+let jsd: jsdom.JSDOM
+
+const html = `
+<!DOCTYPE html>
+  <head>
+    <script>'hi'</script>
+  </head>
+  <body>
+  </body>
+</html>
+`.trim()
+
+beforeEach(() => {
+  jest.restoreAllMocks()
+  jest.resetAllMocks()
+
+  jsd = new jsdom.JSDOM(html, {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'https://segment.com'
+  })
+
+  jest.spyOn(window, 'window', 'get').mockImplementation(() => jsd.window as unknown as Window & typeof globalThis)
+  jest.spyOn(global, 'document', 'get').mockImplementation(() => jsd.window.document as unknown as Document)
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+  global.document.domain = 'segment.com'
+})
+
+afterEach(() => {
+  if (jsd) jsd.window.close()
+})

--- a/packages/browser-destinations/tsconfig.build.json
+++ b/packages/browser-destinations/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "module": "esnext",
     "composite": true,
     "outDir": "dist",
     "rootDir": "src",

--- a/packages/browser-destinations/webpack.config.js
+++ b/packages/browser-destinations/webpack.config.js
@@ -76,6 +76,7 @@ module.exports = {
       path.resolve(__dirname, 'node_modules'),
       'node_modules'
     ],
+    mainFields: ['exports', 'module', 'browser', 'main'],
     extensions: ['.ts', '.js'],
     fallback: {
       vm: require.resolve('vm-browserify')

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
     "directory": "packages/cli"
   },
   "engines": {
-    "node": "^14.16"
+    "node": "^14.17"
   },
   "engineStrict": true,
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,13 +12,11 @@
   "exports": {
     ".": {
       "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.js",
-      "default": "./dist/cjs/index.js"
+      "default": "./dist/esm/index.js"
     },
     "./mapping-kit": {
       "require": "./dist/cjs/mapping-kit/index.js",
-      "import": "./dist/esm/mapping-kit/index.js",
-      "default": "./dist/cjs/mapping-kit/index.js"
+      "default": "./dist/esm/mapping-kit/index.js"
     }
   },
   "types": "dist/esm/index.d.ts",
@@ -27,7 +25,7 @@
     "package.json"
   ],
   "engines": {
-    "node": "^14.16"
+    "node": "^14.17"
   },
   "engineStrict": true,
   "license": "MIT",

--- a/packages/core/src/__tests__/request-client.test.ts
+++ b/packages/core/src/__tests__/request-client.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import AbortController from 'abort-controller'
 import createTestServer from 'create-test-server'
-import { URLSearchParams } from 'url'
 import createInstance from '../request-client'
 import { Response } from '../fetch'
 

--- a/packages/core/src/request-client.ts
+++ b/packages/core/src/request-client.ts
@@ -1,6 +1,5 @@
 import AbortController from 'abort-controller'
 import { CustomError } from 'ts-custom-error'
-import { URL, URLSearchParams } from 'url'
 import fetch, { Headers, Request, Response } from './fetch'
 import { isObject } from './real-type-of'
 

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
+    "module": "esnext",
     "outDir": "dist/esm",
     "rootDir": "src"
   },

--- a/packages/destination-actions/package.json
+++ b/packages/destination-actions/package.json
@@ -14,7 +14,7 @@
     "package.json"
   ],
   "engines": {
-    "node": "^14.16"
+    "node": "^14.17"
   },
   "engineStrict": true,
   "license": "MIT",

--- a/packages/destination-actions/src/destinations/amplitude/groupIdentifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/groupIdentifyUser/index.ts
@@ -1,4 +1,3 @@
-import { URLSearchParams } from 'url'
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'

--- a/packages/destination-actions/src/destinations/amplitude/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/identifyUser/index.ts
@@ -1,4 +1,3 @@
-import { URLSearchParams } from 'url'
 import { ActionDefinition, omit, removeUndefined } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'

--- a/packages/destination-actions/src/destinations/amplitude/mapUser/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/mapUser/index.ts
@@ -1,4 +1,3 @@
-import { URLSearchParams } from 'url'
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'

--- a/packages/destination-actions/src/destinations/mixpanel/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/identifyUser/index.ts
@@ -1,4 +1,3 @@
-import { URLSearchParams } from 'url'
 import { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'

--- a/packages/destination-actions/src/destinations/twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/twilio/sendSms/index.ts
@@ -1,4 +1,3 @@
-import { URLSearchParams } from 'url'
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'

--- a/yarn.lock
+++ b/yarn.lock
@@ -5877,6 +5877,13 @@ eslint-plugin-jest@^24.3.6:
   dependencies:
     "@typescript-eslint/experimental-utils" "^4.0.1"
 
+eslint-plugin-lodash@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash/-/eslint-plugin-lodash-7.3.0.tgz#02bbb2c39a8b28f73daf01f99b2d83bcc7f11a79"
+  integrity sha512-FQM8HklruJzulPawX3uZqWbeyN3bQT4hjVCpFYMrWo0Hdz1qDCwp1v3JS4zjhdssAXdwCxdnyrNMCZJK70GeUQ==
+  dependencies:
+    lodash "^4.17.21"
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
This PR focuses on optimizing our webpack bundles.

| How it started | How it's going |
|---|---|
|<img width="896" alt="Screen Shot 2021-10-19 at 4 05 17 PM" src="https://user-images.githubusercontent.com/710752/137990444-accae7ed-fde8-4abb-9bd5-a22f5e12277e.png">|<img width="896" alt="Screen Shot 2021-10-19 at 4 05 36 PM" src="https://user-images.githubusercontent.com/710752/137990479-6f0ff694-8e26-431b-8bfa-72632edc3a49.png">|

## Testing

Tested locally with the webpack bundle analyzer

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
