### PR TITLE
Fix name mismatch for Google Enhanced Conversions

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -16,7 +16,9 @@ interface UserInfoResponse {
 */
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Actions Google Enhanced Conversions',
+  // NOTE: We need to match the name with the creation name in DB.
+  // This is not the value used in the UI.
+  name: 'Google Enhanced Conversions',
   mode: 'cloud',
   authentication: {
     scheme: 'oauth2',


### PR DESCRIPTION
Updates the creation name of Google Enhanced Conversions to follow the changes added to enforce having the correct name matching in code & db.

Fixes the errors seen when using the push command to update GEC.

```
 $ ./bin/run push
✔ Pick the definitions you would like to push to Segment: › Actions Google Enhanced Conversions
✖ Fetching existing definitions for Actions Google Enhanced Conversions...
    Error: The definition name 'Actions Google Enhanced Conversions' should always match the control plane creation name 'Google Enhanced Conversions'.
    ```
## Testing

Tested this by running the push command against staging and tests still passing.

- [-] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
