### PR TITLE
Add onDelete support to Customer.io

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/__tests__/delete.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/delete.test.ts
@@ -8,7 +8,7 @@ const testDestination = createTestIntegration(CustomerIO)
 
 describe('Customer.io', () => {
     describe('onDelete', () => {
-        it('should support user deletions, defaulting to us', async () => {
+        it('should support user deletions, defaulting to the US', async () => {
             nock('https://track.customer.io').delete('/api/v1/customers/sloth@segment.com').reply(200, {})
             expect(testDestination.onDelete).toBeDefined()
 

--- a/packages/destination-actions/src/destinations/customerio/__tests__/delete.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/delete.test.ts
@@ -1,0 +1,41 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import CustomerIO from '../index'
+import { DecoratedResponse } from '@segment/actions-core'
+import { AccountRegion } from '../utils'
+
+const testDestination = createTestIntegration(CustomerIO)
+
+describe('Customer.io', () => {
+    describe('onDelete', () => {
+        it('should support user deletions, defaulting to us', async () => {
+            nock('https://track.customer.io').delete('/api/v1/customers/sloth@segment.com').reply(200, {})
+            expect(testDestination.onDelete).toBeDefined()
+
+            if (testDestination.onDelete) {
+                const response = await testDestination?.onDelete(
+                    { type: 'track', userId: 'sloth@segment.com' },
+                    { siteId: 'foo', apiKey: 'bar' }
+                )
+                const resp = response as DecoratedResponse
+                expect(resp.status).toBe(200)
+                expect(resp.data).toMatchObject({})
+            }
+        })
+
+        it('should support regional user deletions', async () => {
+            nock('https://track-eu.customer.io').delete('/api/v1/customers/sloth@segment.com').reply(200, {})
+            expect(testDestination.onDelete).toBeDefined()
+
+            if (testDestination.onDelete) {
+                const response = await testDestination?.onDelete(
+                    { type: 'track', userId: 'sloth@segment.com' },
+                    { siteId: 'foo', apiKey: 'bar', accountRegion: AccountRegion.EU }
+                )
+                const resp = response as DecoratedResponse
+                expect(resp.status).toBe(200)
+                expect(resp.data).toMatchObject({})
+            }
+        })
+    })
+})

--- a/packages/destination-actions/src/destinations/customerio/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/index.ts
@@ -6,7 +6,7 @@ import trackEvent from './trackEvent'
 import trackPageView from './trackPageView'
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
-import { AccountRegion } from './utils'
+import { AccountRegion, trackApiEndpoint } from './utils'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Customer.io',
@@ -87,7 +87,18 @@ const destination: DestinationDefinition<Settings> = {
       partnerAction: 'trackPageView',
       mapping: defaultValues(trackPageView.fields)
     }
-  ]
+  ],
+
+  onDelete(request, { settings, payload }) {
+    const { accountRegion } = settings
+    const { userId } = payload
+
+    const url = `${trackApiEndpoint(accountRegion)}/api/v1/customers/${userId}`
+
+    return request(url, {
+      method: 'DELETE'
+    })
+  }
 }
 
 export default destination


### PR DESCRIPTION
This pull request adds an `onDelete` handler to the Customer.io destination in order to support Segment's [User Deletion](https://segment.com/docs/privacy/user-deletion-and-suppression/) feature.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
