### PR TITLE
Add onDelete support for Braze Cloud

### DIFF
--- a/packages/core/src/segment-event.ts
+++ b/packages/core/src/segment-event.ts
@@ -106,7 +106,7 @@ interface AnalyticsContext {
 export interface SegmentEvent {
   messageId?: string
 
-  type: 'track' | 'page' | 'identify' | 'group' | 'alias' | 'screen'
+  type: 'track' | 'page' | 'identify' | 'group' | 'alias' | 'screen' | 'delete'
 
   // page specific
   category?: string

--- a/packages/destination-actions/src/destinations/braze/__tests__/braze.test.ts
+++ b/packages/destination-actions/src/destinations/braze/__tests__/braze.test.ts
@@ -207,7 +207,7 @@ describe(Braze.name, () => {
 
       if (testDestination.onDelete) {
         const event = createTestEvent({
-          type: 'track',
+          type: 'delete',
           userId: 'sloth@segment.com'
         })
 

--- a/packages/destination-actions/src/destinations/braze/__tests__/braze.test.ts
+++ b/packages/destination-actions/src/destinations/braze/__tests__/braze.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration, DecoratedResponse } from '@segment/actions-core'
 import Braze from '../index'
 
 const testDestination = createTestIntegration(Braze)
@@ -197,6 +197,25 @@ describe(Braze.name, () => {
           ],
         }
       `)
+    })
+  })
+
+  describe('onDelete', () => {
+    it('should support user deletions', async () => {
+      nock('https://rest.iad-01.braze.com').post('/users/delete').reply(200, {})
+      expect(testDestination.onDelete).toBeDefined()
+
+      if (testDestination.onDelete) {
+        const event = createTestEvent({
+          type: 'track',
+          userId: 'sloth@segment.com'
+        })
+
+        const response = await testDestination.onDelete(event, settings)
+        const resp = response as DecoratedResponse
+        expect(resp.status).toBe(200)
+        expect(resp.data).toMatchObject({})
+      }
     })
   })
 })

--- a/packages/destination-actions/src/destinations/braze/index.ts
+++ b/packages/destination-actions/src/destinations/braze/index.ts
@@ -46,6 +46,14 @@ const destination: DestinationDefinition<Settings> = {
       }
     }
   },
+  onDelete: async (request, { payload }) => {
+    return request('https://rest.iad-01.braze.com/users/delete', {
+      method: 'post',
+      json: {
+        braze_ids: [payload.userId]
+      }
+    })
+  },
   extendRequest({ settings }) {
     return {
       headers: {

--- a/packages/destination-actions/src/destinations/braze/index.ts
+++ b/packages/destination-actions/src/destinations/braze/index.ts
@@ -6,7 +6,7 @@ import trackEvent from './trackEvent'
 import trackPurchase from './trackPurchase'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Braze Cloud Mode',
+  name: 'Braze Cloud Mode (Actions)',
   slug: 'actions-braze-cloud',
   mode: 'cloud',
   description: 'Send events server-side to the Braze REST API.',

--- a/packages/destination-actions/src/destinations/braze/index.ts
+++ b/packages/destination-actions/src/destinations/braze/index.ts
@@ -50,7 +50,7 @@ const destination: DestinationDefinition<Settings> = {
     return request('https://rest.iad-01.braze.com/users/delete', {
       method: 'post',
       json: {
-        braze_ids: [payload.userId]
+        external_ids: [payload.userId]
       }
     })
   },


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR adds `onDelete` support for Braze Cloud.

Successfully tested in stage:
<img width="610" alt="Screen Shot 2021-10-29 at 5 18 35 PM" src="https://user-images.githubusercontent.com/87985289/139502999-57061320-d4fe-4e54-b647-afb7bffb2358.png">

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
