### PR TITLE
[BE-276] add Create Alias action to braze

### DIFF
--- a/packages/destination-actions/src/destinations/braze/createAlias/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/braze/createAlias/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Braze's createAlias destination action: all fields 1`] = `
+Object {
+  "user_aliases": Array [
+    Object {
+      "alias_label": "#HMCBuX*",
+      "alias_name": "#HMCBuX*",
+      "external_id": "#HMCBuX*",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for Braze's createAlias destination action: required fields 1`] = `
+Object {
+  "user_aliases": Array [
+    Object {
+      "alias_label": "#HMCBuX*",
+      "alias_name": "#HMCBuX*",
+      "external_id": "#HMCBuX*",
+    },
+  ],
+}
+`;

--- a/packages/destination-actions/src/destinations/braze/createAlias/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/braze/createAlias/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'createAlias'
+const destinationSlug = 'Braze'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/braze/createAlias/generated-types.ts
+++ b/packages/destination-actions/src/destinations/braze/createAlias/generated-types.ts
@@ -1,0 +1,16 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The external ID of the user to create an alias for.
+   */
+  external_id?: string | null
+  /**
+   * The alias identifier
+   */
+  alias_name: string
+  /**
+   * A label indicating the type of alias
+   */
+  alias_label: string
+}

--- a/packages/destination-actions/src/destinations/braze/createAlias/index.ts
+++ b/packages/destination-actions/src/destinations/braze/createAlias/index.ts
@@ -1,0 +1,45 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Create Alias',
+  description: 'Create new user aliases for existing identified users, or to create new unidentified users.',
+  defaultSubscription: 'event = "Create Alias"',
+  fields: {
+    external_id: {
+      label: 'External ID',
+      description: 'The external ID of the user to create an alias for.',
+      type: 'string',
+      allowNull: true
+    },
+    alias_name: {
+      label: 'Alias Name',
+      description: 'The alias identifier',
+      type: 'string',
+      required: true
+    },
+    alias_label: {
+      label: 'Alias Label',
+      description: 'A label indicating the type of alias',
+      type: 'string',
+      required: true
+    }
+  },
+  perform: (request, { settings, payload }) => {
+    return request(`${settings.endpoint}/users/alias/new`, {
+      method: 'post',
+      json: {
+        user_aliases: [
+          {
+            external_id: payload.external_id ?? undefined,
+            alias_name: payload.alias_name,
+            alias_label: payload.alias_label
+          }
+        ]
+      }
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/braze/index.ts
+++ b/packages/destination-actions/src/destinations/braze/index.ts
@@ -1,9 +1,10 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import { defaultValues } from '@segment/actions-core'
-import updateUserProfile from './updateUserProfile'
+import createAlias from './createAlias'
 import trackEvent from './trackEvent'
 import trackPurchase from './trackPurchase'
+import updateUserProfile from './updateUserProfile'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Braze Cloud Mode',
@@ -56,7 +57,8 @@ const destination: DestinationDefinition<Settings> = {
   actions: {
     updateUserProfile,
     trackEvent,
-    trackPurchase
+    trackPurchase,
+    createAlias
   },
   presets: [
     {


### PR DESCRIPTION
This adds a new action to Braze Cloud to support creating user aliases per [their docs](https://www.braze.com/docs/api/endpoints/user_data/post_user_alias/#request-parameters)

## Testing

Tested against local dev server that I can invoke the createAlias action.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
