### PR TITLE
simplify publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,12 @@ on:
       - synchronize
       - closed
     paths:
+      - yarn.lock
+      - tsconfig.json
       - packages/**
+      - '!packages/cli/**'
+      - '!packages/cli-internal/**'
+      - '!packages/browser-destinations/**'
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
This change simplifies the workflow to use the built-in `actions/cache` support in `setup-node`

## Testing

TBD