### PR TITLE
[BE-293] cli -  preserve existing tags on push

### DIFF
--- a/packages/cli-internal/src/commands/push.ts
+++ b/packages/cli-internal/src/commands/push.ts
@@ -397,11 +397,11 @@ export function getOptions(
       }
     }
 
-    // Preserve existing tags
+    // Preserve existing properties unless specified by the action field definition
     const existing = existingOptions[fieldKey]
-    const tags = existing?.tags ?? []
 
     options[fieldKey] = {
+      ...existing,
       default: schema.default ?? '',
       description: schema.description,
       encrypt: schema.type === 'password',
@@ -416,8 +416,7 @@ export function getOptions(
         text: choice.label
       })),
       readOnly: false,
-      validators,
-      tags
+      validators
     }
   }
 


### PR DESCRIPTION
We recently discovered that because we aren't specifying `tags` for options metadata on `push`, they will get stripped out even when they were manually set in Partner Portal.

The reason is simple: Control Plane Service always deletes the previous options metadata and creates brand new records any time you include options with a metadata update. 

I don't believe we should change the behavior in CPS because it could impact other services in unexpected ways, so instead I opted to preserve those tags when an existing option with the same key exists.

## Testing

Tested locally against staging

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
