### PR TITLE
[BE-276] add Identify User action to braze

### DIFF
--- a/packages/destination-actions/src/destinations/braze/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/braze/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Braze's identifyUser destination action: all fields 1`] = `
+Object {
+  "aliases_to_identify": Array [
+    Object {
+      "external_id": "L6iTV8uKjdSaPxy2fjx9",
+      "user_alias": Object {
+        "alias_label": "L6iTV8uKjdSaPxy2fjx9",
+        "alias_name": "L6iTV8uKjdSaPxy2fjx9",
+      },
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for Braze's identifyUser destination action: required fields 1`] = `
+Object {
+  "aliases_to_identify": Array [
+    Object {
+      "external_id": "L6iTV8uKjdSaPxy2fjx9",
+      "user_alias": Object {
+        "alias_label": "L6iTV8uKjdSaPxy2fjx9",
+        "alias_name": "L6iTV8uKjdSaPxy2fjx9",
+      },
+    },
+  ],
+}
+`;

--- a/packages/destination-actions/src/destinations/braze/identifyUser/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/braze/identifyUser/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'identifyUser'
+const destinationSlug = 'Braze'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/braze/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/braze/identifyUser/generated-types.ts
@@ -1,0 +1,15 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The external ID of the user to identify.
+   */
+  external_id: string
+  /**
+   * A user alias object. See [the docs](https://www.braze.com/docs/api/objects_filters/user_alias_object/).
+   */
+  user_alias: {
+    alias_name: string
+    alias_label: string
+  }
+}

--- a/packages/destination-actions/src/destinations/braze/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/braze/identifyUser/index.ts
@@ -1,0 +1,51 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Identify User',
+  description:
+    'Identifies an unidentified (alias-only) user. Use alongside the Create Alias action, or with user aliases you have already defined.',
+  fields: {
+    external_id: {
+      label: 'External ID',
+      description: 'The external ID of the user to identify.',
+      type: 'string',
+      required: true
+    },
+    user_alias: {
+      label: 'User Alias Object',
+      description:
+        'A user alias object. See [the docs](https://www.braze.com/docs/api/objects_filters/user_alias_object/).',
+      type: 'object',
+      required: true,
+      properties: {
+        alias_name: {
+          label: 'Alias Name',
+          type: 'string',
+          required: true
+        },
+        alias_label: {
+          label: 'Alias Label',
+          type: 'string',
+          required: true
+        }
+      }
+    }
+  },
+  perform: (request, { settings, payload }) => {
+    return request(`${settings.endpoint}/users/identify`, {
+      method: 'post',
+      json: {
+        aliases_to_identify: [
+          {
+            external_id: payload.external_id,
+            user_alias: payload.user_alias
+          }
+        ]
+      }
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/braze/index.ts
+++ b/packages/destination-actions/src/destinations/braze/index.ts
@@ -2,6 +2,7 @@ import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import { defaultValues } from '@segment/actions-core'
 import createAlias from './createAlias'
+import identifyUser from './identifyUser'
 import trackEvent from './trackEvent'
 import trackPurchase from './trackPurchase'
 import updateUserProfile from './updateUserProfile'
@@ -58,7 +59,8 @@ const destination: DestinationDefinition<Settings> = {
     updateUserProfile,
     trackEvent,
     trackPurchase,
-    createAlias
+    createAlias,
+    identifyUser
   },
   presets: [
     {

--- a/packages/destination-actions/src/destinations/braze/index.ts
+++ b/packages/destination-actions/src/destinations/braze/index.ts
@@ -8,7 +8,7 @@ import trackPurchase from './trackPurchase'
 import updateUserProfile from './updateUserProfile'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Braze Cloud Mode',
+  name: 'Braze Cloud Mode (Actions)',
   slug: 'actions-braze-cloud',
   mode: 'cloud',
   description: 'Send events server-side to the Braze REST API.',


### PR DESCRIPTION
This adds a new action to Braze Cloud to support identifying users (alias only) per [their docs](https://www.braze.com/docs/api/endpoints/user_data/post_user_identify)

## Testing

Tested against local dev server that I can invoke the identifyUser action.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
