### PR TITLE
Move gitleaks setup to postinstall script

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,24 +3,4 @@
 . "$(dirname "$0")/_/husky.sh"
 set -ex
 
-if ! command -v gitleaks -h &> /dev/null
-then
-
-    set +ex
-    if [ ! "$(uname)" == "Darwin" ]
-    then
-        echo "To run this pre-commit hook install gitleaks or commit with the --no-verify flag."
-        echo "https://github.com/zricethezav/gitleaks#installation"
-        exit 1
-    fi
-    set -ex
-
-    if ! command -v brew -v &> /dev/null
-    then
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-    fi
-
-    brew install gitleaks
-fi
-
 yarn lint-staged -c lint-staged.config.js

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test": "lerna run test --stream",
     "typecheck": "lerna run typecheck --stream",
     "alpha": "lerna publish prerelease --pre-dist-tag next --allow-branch '**' --no-git-tag-version",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "postinstall": "./scripts/install-gitleaks.sh"
   },
   "devDependencies": {
     "@types/chance": "^1.1.3",

--- a/scripts/install-gitleaks.sh
+++ b/scripts/install-gitleaks.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if ! command -v gitleaks -h &> /dev/null
+then
+
+    set +ex
+    if [ ! "$(uname)" == "Darwin" ]
+    then
+        echo "To run this pre-commit hook install gitleaks or commit with the --no-verify flag."
+        echo "https://github.com/zricethezav/gitleaks#installation"
+        exit 1
+    fi
+    set -ex
+
+    if ! command -v brew -v &> /dev/null
+    then
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    fi
+
+    brew install gitleaks
+fi


### PR DESCRIPTION
This pull request moves the `gitleaks` installation to a script that runs on NPM's `postinstall` hook, rather than on every commit.

`postinstall:`
![image](https://user-images.githubusercontent.com/11635476/139474799-be135d78-a45a-4233-909d-ec68c0dd1199.png)

`precommit`:
![image](https://user-images.githubusercontent.com/11635476/139474830-b22db032-c41e-42d9-a22c-723b451192e9.png)


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
