### PR TITLE
Fix cli tests + minor cli-internal changes

### DIFF
--- a/packages/cli-internal/package.json
+++ b/packages/cli-internal/package.json
@@ -95,8 +95,7 @@
     ],
     "moduleNameMapper": {
       "src/lib/(.*)": "<rootDir>/src/lib/$1",
-      "@segment/actions-cli": "<rootDir>/../cli/src",
-      "@segment/actions-cli-internal": "<rootDir>/../cli-internal/src"
+      "@segment/actions-cli": "<rootDir>/../cli/src"
     }
   }
 }

--- a/packages/cli-internal/package.json
+++ b/packages/cli-internal/package.json
@@ -6,15 +6,12 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",
-    "directory": "packages/cli"
+    "directory": "packages/cli-internal"
   },
   "engines": {
     "node": "^14.16"
   },
   "engineStrict": true,
-  "bin": {
-    "segment": "./bin/run"
-  },
   "files": [
     "/bin",
     "/dist",
@@ -97,7 +94,9 @@
       "<rootDir>/dist/"
     ],
     "moduleNameMapper": {
-      "src/lib/(.*)": "<rootDir>/src/lib/$1"
+      "src/lib/(.*)": "<rootDir>/src/lib/$1",
+      "@segment/actions-cli": "<rootDir>/../cli/src",
+      "@segment/actions-cli-internal": "<rootDir>/../cli-internal/src"
     }
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -106,7 +106,9 @@
       "<rootDir>/templates/"
     ],
     "moduleNameMapper": {
-      "src/lib/(.*)": "<rootDir>/src/lib/$1"
+      "src/lib/(.*)": "<rootDir>/src/lib/$1",
+      "@segment/actions-cli": "<rootDir>/../cli/src",
+      "@segment/actions-cli-internal": "<rootDir>/../cli-internal/src"
     }
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -107,7 +107,6 @@
     ],
     "moduleNameMapper": {
       "src/lib/(.*)": "<rootDir>/src/lib/$1",
-      "@segment/actions-cli": "<rootDir>/../cli/src",
       "@segment/actions-cli-internal": "<rootDir>/../cli-internal/src"
     }
   }

--- a/packages/cli/src/hooks/init.ts
+++ b/packages/cli/src/hooks/init.ts
@@ -2,7 +2,7 @@ import { Hook, Plugin } from '@oclif/config'
 import { dirname } from 'path'
 
 const hook: Hook<'init'> = async function ({ config }) {
-  if (process.env.NODE_ENV === 'TEST') {
+  if (process.env.NODE_ENV === 'test') {
     console.warn('skipping cli-internal plugin because of tests')
     return
   }
@@ -14,7 +14,7 @@ const hook: Hook<'init'> = async function ({ config }) {
     if (err.code === 'MODULE_NOT_FOUND') {
       return
     }
-  
+
     throw err
   }
 


### PR DESCRIPTION
- Fixes an issue where the internal CLI plugin was getting loaded during tests (see https://github.com/segmentio/action-destinations/runs/4050969216?check_suite_focus=true#step:11:122 for CI tests without any suppressed issues)
- Minor metadata changes to the cli-internal package

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
