### PR TITLE
Updates to Google Enhanced Conversions fields

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/google-enhanced-conversions.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/google-enhanced-conversions.test.ts
@@ -55,5 +55,54 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
     })
+
+    it('should accept an event without context.userAgent', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        properties: {
+          email: 'janedoe@gmail.com',
+          orderId: '123',
+          firstName: 'Bob John',
+          lastName: 'Smith',
+          phone: '14150000000',
+          address: {
+            street: '123 Market Street',
+            city: 'San Francisco',
+            state: 'CA',
+            postalCode: '94000',
+            country: 'USA'
+          }
+        }
+      })
+      
+      if (event?.context?.userAgent) { delete event.context.userAgent }
+
+      nock('https://www.google.com/ads/event/api/v1')
+        .post(`?conversion_tracking_id=${conversionTrackingId}`)
+        .reply(201, {})
+
+      const responses = await testDestination.testAction('postConversion', {
+        event,
+        mapping: { conversion_label: conversionLabel },
+        useDefaultMappings: true,
+        settings: {
+          conversionTrackingId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"pii_data\\":{\\"hashed_email\\":\\"1hFzBkhe0OUK-rOshx6Y-BaZFR8wKBUn1j_18jNlbGk=\\",\\"hashed_phone_number\\":[\\"5pAiami9y4LWCmP12H9fXJpoqrnOFRL7u9q1pkqlMmI=\\"],\\"address\\":[{\\"hashed_first_name\\":\\"IGT0sXMskUo9vWuqGeOhA-RylOG2Oj_IcIX2Zr5f7GU=\\",\\"hashed_last_name\\":\\"ZieDX5iOLF5QUz1JEWMHLT9PQfXIsEYwFQ3rs3Isot0=\\",\\"hashed_street_address\\":\\"tHP71r8-GY59XKpmdb6ssI3fd7TIBB6E6aCWN06RGBw=\\",\\"city\\":\\"sanfrancisco\\",\\"region\\":\\"ca\\",\\"postcode\\":\\"94000\\",\\"country\\":\\"USA\\"}]},\\"oid\\":\\"123\\",\\"conversion_time\\":1623348484000000,\\"label\\":\\"_conversion_\\"}"`
+      )
+
+      expect(responses[0].options.searchParams).toMatchInlineSnapshot(`
+        Object {
+          "conversion_tracking_id": "_conversion_id_",
+        }
+      `)
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
@@ -62,9 +62,8 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     user_agent: {
       label: 'User Agent',
-      description: 'User Agent of the customer who triggered the conversion event.',
+      description: 'User Agent of the customer who triggered the conversion event. This field is optional but recommended.',
       type: 'string',
-      required: true,
       default: {
         '@path': '$.context.userAgent'
       }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
@@ -31,14 +31,14 @@ const action: ActionDefinition<Settings, Payload> = {
     conversion_label: {
       label: 'Conversion Label',
       description:
-        'The Google Ads conversion label. You can find it in your Google Ads account using the instructions in the article [Google Ads conversions](https://support.google.com/tagmanager/answer/6105160?hl=en)',
+        'The Google Ads conversion label. You can find it in your Google Ads account using the instructions in the article [Google Ads conversions](https://support.google.com/tagmanager/answer/6105160?hl=en).',
       type: 'string',
       required: true,
       default: ''
     },
     email: {
       label: 'Email',
-      description: 'Email address of the customer who triggered the conversion event.',
+      description: 'Email address of the individual who triggered the conversion event.',
       type: 'string',
       required: true,
       format: 'email',
@@ -53,7 +53,7 @@ const action: ActionDefinition<Settings, Payload> = {
     transaction_id: {
       label: 'Order ID',
       description:
-        'Order ID of the conversion event. Google requires an Order ID even if the event is not an ecommerce event.',
+        'Order ID or Transaction ID of the conversion event. Google requires an Order ID even if the event is not an ecommerce event. Learn more in the article [Use a transaction ID to minimize duplicate conversions](https://support.google.com/google-ads/answer/6386790?hl=en&ref_topic=3165803){:target="_blank"}',
       type: 'string',
       required: true,
       default: {
@@ -62,7 +62,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     user_agent: {
       label: 'User Agent',
-      description: 'User Agent of the customer who triggered the conversion event. This field is optional but recommended.',
+      description: 'User agent of the individual who triggered the conversion event. This should match the user agent of the request that sent the original conversion so the conversion and its enhancement are either both attributed as same-device or both attributed as cross-device.',
       type: 'string',
       default: {
         '@path': '$.context.userAgent'
@@ -88,7 +88,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     currency_code: {
       label: 'Currency Code',
-      description: 'Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.',
+      description: 'Currency of the purchase or items associated with the conversion event, in 3-letter ISO 4217 format.',
       type: 'string',
       default: {
         '@path': '$.properties.currency'
@@ -97,7 +97,7 @@ const action: ActionDefinition<Settings, Payload> = {
     // PII Fields - These fields must be hashed using SHA 256 and encoded as websafe-base64.
     phone_number: {
       label: 'Phone Number',
-      description: 'Phone number of the purchaser, in E.164 standard format, e.g. +14150000000',
+      description: 'Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000.',
       type: 'string',
       default: {
         '@if': {
@@ -169,7 +169,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     post_code: {
       label: 'Post Code',
-      description: 'Post code of the individual who triggered the conversion event.',
+      description: 'Postal code of the individual who triggered the conversion event.',
       type: 'string',
       default: {
         '@if': {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
@@ -168,7 +168,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     post_code: {
-      label: 'Post Code',
+      label: 'Postal Code',
       description: 'Postal code of the individual who triggered the conversion event.',
       type: 'string',
       default: {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR updates Google Enhanced Conversions field descriptions and makes the `user_agent` field optional.
[User Agent Ticket](https://segment.atlassian.net/browse/STRATCONN-1004)
[Descriptions Ticket](https://segment.atlassian.net/browse/STRATCONN-1007)

## Testing

Added a unit test for the optional `user_agent` setting.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
