### PR TITLE
Set GH token on publish steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,6 +59,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 
+      - name: Use Github Personal Access Token
+        run: git config --global url."https://${{ secrets.GH_PAT }}@github.com/".insteadOf ssh://git@github.com/
+
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
         env:

--- a/.github/workflows/publishCanary.yml
+++ b/.github/workflows/publishCanary.yml
@@ -49,6 +49,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 
+      - name: Use Github Personal Access Token
+        run: git config --global url."https://${{ secrets.GH_PAT }}@github.com/".insteadOf ssh://git@github.com/
+
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
         env:


### PR DESCRIPTION
This pull request adds a step to the publish workflows to set the Github so that private dependencies like `control-plane-service` can be installed.

See failing job: https://github.com/segmentio/action-destinations/runs/4073447669?check_suite_focus=true#step:6:1

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
