### PR TITLE
make user_alias props optional and validate manually

### DIFF
--- a/packages/destination-actions/src/destinations/braze/__tests__/userAlias.test.ts
+++ b/packages/destination-actions/src/destinations/braze/__tests__/userAlias.test.ts
@@ -1,4 +1,4 @@
-import { isValidUserAlias, getUserAlias } from './userAlias'
+import { isValidUserAlias, getUserAlias } from '../userAlias'
 
 describe(isValidUserAlias.name.toString(), () => {
   it('should return true for valid user_alias objects', () => {

--- a/packages/destination-actions/src/destinations/braze/__tests__/userAlias.test.ts
+++ b/packages/destination-actions/src/destinations/braze/__tests__/userAlias.test.ts
@@ -1,0 +1,45 @@
+import { isValidUserAlias, getUserAlias } from './userAlias'
+
+describe(isValidUserAlias.name.toString(), () => {
+  it('should return true for valid user_alias objects', () => {
+    const alias = {
+      alias_label: 'segment-anon-id',
+      alias_name: 'anon-123'
+    }
+    expect(isValidUserAlias(alias)).toBe(true)
+  })
+
+  it('should return false for invalid values', () => {
+    expect(isValidUserAlias(null)).toBe(false)
+    expect(isValidUserAlias(undefined)).toBe(false)
+    expect(isValidUserAlias(true)).toBe(false)
+    expect(isValidUserAlias(123)).toBe(false)
+    expect(isValidUserAlias({})).toBe(false)
+    expect(isValidUserAlias({ alias_label: 'hello' })).toBe(false)
+    expect(isValidUserAlias({ alias_label: '', alias_name: '' })).toBe(false)
+  })
+})
+
+describe(getUserAlias.name.toString(), () => {
+  it('should return a valid user_alias object when possible', () => {
+    const alias = {
+      alias_label: 'segment-anon-id',
+      alias_name: 'anon-123',
+      something_else: 'ignored'
+    }
+    expect(getUserAlias(alias)).toEqual({
+      alias_label: 'segment-anon-id',
+      alias_name: 'anon-123'
+    })
+  })
+
+  it('should return undefined for everything else', () => {
+    expect(getUserAlias(null)).toBe(undefined)
+    expect(getUserAlias(undefined)).toBe(undefined)
+    expect(getUserAlias(true)).toBe(undefined)
+    expect(getUserAlias(123)).toBe(undefined)
+    expect(getUserAlias({})).toBe(undefined)
+    expect(getUserAlias({ alias_label: 'hello' })).toBe(undefined)
+    expect(getUserAlias({ alias_label: '', alias_name: '' })).toBe(undefined)
+  })
+})

--- a/packages/destination-actions/src/destinations/braze/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/braze/trackEvent/generated-types.ts
@@ -9,8 +9,8 @@ export interface Payload {
    * A user alias object. See [the docs](https://www.braze.com/docs/api/objects_filters/user_alias_object/).
    */
   user_alias?: {
-    alias_name: string
-    alias_label: string
+    alias_name?: string
+    alias_label?: string
   }
   /**
    * The unique user identifier

--- a/packages/destination-actions/src/destinations/braze/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/braze/trackEvent/index.ts
@@ -3,6 +3,7 @@ import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import dayjs from '../../../lib/dayjs'
+import { getUserAlias } from '../userAlias'
 
 type DateInput = string | Date | number | null | undefined
 type DateOutput = string | undefined | null
@@ -37,13 +38,11 @@ const action: ActionDefinition<Settings, Payload> = {
       properties: {
         alias_name: {
           label: 'Alias Name',
-          type: 'string',
-          required: true
+          type: 'string'
         },
         alias_label: {
           label: 'Alias Label',
-          type: 'string',
-          required: true
+          type: 'string'
         }
       }
     },
@@ -91,7 +90,10 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: (request, { settings, payload }) => {
-    const { braze_id, user_alias, external_id } = payload
+    const { braze_id, external_id } = payload
+
+    // Extract valid user_alias shape. Since it is optional (oneOf braze_id, external_id) we need to only include it if fully formed.
+    const user_alias = getUserAlias(payload.user_alias)
 
     if (!braze_id && !user_alias && !external_id) {
       throw new IntegrationError(

--- a/packages/destination-actions/src/destinations/braze/trackPurchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/braze/trackPurchase/generated-types.ts
@@ -9,8 +9,8 @@ export interface Payload {
    * A user alias object. See [the docs](https://www.braze.com/docs/api/objects_filters/user_alias_object/).
    */
   user_alias?: {
-    alias_name: string
-    alias_label: string
+    alias_name?: string
+    alias_label?: string
   }
   /**
    * The unique user identifier

--- a/packages/destination-actions/src/destinations/braze/trackPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/braze/trackPurchase/index.ts
@@ -3,6 +3,7 @@ import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import dayjs from '../../../lib/dayjs'
+import { getUserAlias } from '../userAlias'
 
 type DateInput = string | Date | number | null | undefined
 type DateOutput = string | undefined | null
@@ -37,13 +38,11 @@ const action: ActionDefinition<Settings, Payload> = {
       properties: {
         alias_name: {
           label: 'Alias Name',
-          type: 'string',
-          required: true
+          type: 'string'
         },
         alias_label: {
           label: 'Alias Label',
-          type: 'string',
-          required: true
+          type: 'string'
         }
       }
     },
@@ -112,7 +111,10 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: (request, { settings, payload }) => {
-    const { braze_id, user_alias, external_id } = payload
+    const { braze_id, external_id } = payload
+
+    // Extract valid user_alias shape. Since it is optional (oneOf braze_id, external_id) we need to only include it if fully formed.
+    const user_alias = getUserAlias(payload.user_alias)
 
     if (!braze_id && !user_alias && !external_id) {
       throw new IntegrationError(

--- a/packages/destination-actions/src/destinations/braze/updateUserProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/braze/updateUserProfile/generated-types.ts
@@ -9,8 +9,8 @@ export interface Payload {
    * A user alias object. See [the docs](https://www.braze.com/docs/api/objects_filters/user_alias_object/).
    */
   user_alias?: {
-    alias_name: string
-    alias_label: string
+    alias_name?: string
+    alias_label?: string
   }
   /**
    * The unique user identifier

--- a/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
+++ b/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
@@ -3,6 +3,7 @@ import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import dayjs from '../../../lib/dayjs'
+import { getUserAlias } from '../userAlias'
 
 type DateInput = string | Date | number | null | undefined
 type DateOutput = string | undefined | null
@@ -77,13 +78,11 @@ const action: ActionDefinition<Settings, Payload> = {
       properties: {
         alias_name: {
           label: 'Alias Name',
-          type: 'string',
-          required: true
+          type: 'string'
         },
         alias_label: {
           label: 'Alias Label',
-          type: 'string',
-          required: true
+          type: 'string'
         }
       }
     },
@@ -340,7 +339,10 @@ const action: ActionDefinition<Settings, Payload> = {
   },
 
   perform: (request, { settings, payload }) => {
-    const { braze_id, user_alias, external_id } = payload
+    const { braze_id, external_id } = payload
+
+    // Extract valid user_alias shape. Since it is optional (oneOf braze_id, external_id) we need to only include it if fully formed.
+    const user_alias = getUserAlias(payload.user_alias)
 
     if (!braze_id && !user_alias && !external_id) {
       throw new IntegrationError(

--- a/packages/destination-actions/src/destinations/braze/userAlias.ts
+++ b/packages/destination-actions/src/destinations/braze/userAlias.ts
@@ -1,0 +1,23 @@
+interface UserAlias {
+  alias_name: string
+  alias_label: string
+}
+
+export function isValidUserAlias(userAlias: unknown): userAlias is UserAlias {
+  if (userAlias && typeof userAlias === 'object' && userAlias.alias_label && userAlias.alias_name) {
+    return true
+  }
+
+  return false
+}
+
+export function getUserAlias(alias: unknown): UserAlias | undefined {
+  if (isValidUserAlias(alias)) {
+    return {
+      alias_label: alias.alias_label,
+      alias_name: alias.alias_name
+    }
+  }
+
+  return undefined
+}

--- a/packages/destination-actions/src/destinations/braze/userAlias.ts
+++ b/packages/destination-actions/src/destinations/braze/userAlias.ts
@@ -4,7 +4,7 @@ interface UserAlias {
 }
 
 export function isValidUserAlias(userAlias: unknown): userAlias is UserAlias {
-  if (userAlias && typeof userAlias === 'object' && userAlias.alias_label && userAlias.alias_name) {
+  if (userAlias && typeof userAlias === 'object' && (userAlias as UserAlias).alias_label && (userAlias as UserAlias).alias_name) {
     return true
   }
 

--- a/packages/destination-actions/src/destinations/tiktok-conversions/reportWebEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/reportWebEvent/generated-types.ts
@@ -36,7 +36,7 @@ export interface Payload {
    */
   external_id: string
   /**
-   * The value of ttclid used to match website visitor events with TikTok ads. The ttclid is valid for 7 days. See [Set up](https://ads.tiktok.com/marketing_api/docs?rid=4eezrhr6lg4&id=1681728034437121) ttclid for details.
+   * The value of the ttclid used to match website visitor events with TikTok ads. The ttclid is valid for 7 days. See [Set up ttclid](https://ads.tiktok.com/marketing_api/docs?rid=4eezrhr6lg4&id=1681728034437121) for details.
    */
   ttclid?: string
 }


### PR DESCRIPTION
This PR takes a more nuanced approach for Braze's `user_alias` object. We need to ensure that messages are not rejected when this field is invalid (but present). Instead, we want to manually validate and extract the proper shape of this object before sending it to Braze.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
