### PR TITLE
Modify GitHub Token Secret

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,7 @@ jobs:
           cache: 'yarn'
 
       - name: Use Github Personal Access Token
-        run: git config --global url."https://${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf ssh://git@github.com/
+        run: git config --global url."https://${{ secrets.NEW_GH_TOKEN }}@github.com/".insteadOf ssh://git@github.com/
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -84,7 +84,7 @@ jobs:
         run: |
           git config --global user.email "`git log --format='%ae' HEAD^!`"
           git config --global user.name "`git log --format='%an' HEAD^!`"
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git remote set-url origin https://x-access-token:${{ secrets.NEW_GH_TOKEN }}@github.com/${{ github.repository }}
           git config user.email
           git config user.name
 
@@ -94,4 +94,6 @@ jobs:
           npm whoami
 
       - name: Publish production package
+        env: 
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: lerna publish ${{ needs.get-version.outputs.version }} --conventional-commits --no-changelog --conventional-graduate --no-verify-access --yes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,7 @@ jobs:
           cache: 'yarn'
 
       - name: Use Github Personal Access Token
-        run: git config --global url."https://${{ secrets.NEW_GH_TOKEN }}@github.com/".insteadOf ssh://git@github.com/
+        run: git config --global url."https://${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf ssh://git@github.com/
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -84,7 +84,7 @@ jobs:
         run: |
           git config --global user.email "`git log --format='%ae' HEAD^!`"
           git config --global user.name "`git log --format='%an' HEAD^!`"
-          git remote set-url origin https://x-access-token:${{ secrets.NEW_GH_TOKEN }}@github.com/${{ github.repository }}
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git config user.email
           git config user.name
 

--- a/.github/workflows/publishCanary.yml
+++ b/.github/workflows/publishCanary.yml
@@ -51,7 +51,7 @@ jobs:
           cache: 'yarn'
 
       - name: Use Github Personal Access Token
-        run: git config --global url."https://${{ secrets.GH_PAT }}@github.com/".insteadOf ssh://git@github.com/
+        run: git config --global url."https://${{ secrets.NEW_GH_TOKEN }}@github.com/".insteadOf ssh://git@github.com/
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/publishCanary.yml
+++ b/.github/workflows/publishCanary.yml
@@ -51,7 +51,7 @@ jobs:
           cache: 'yarn'
 
       - name: Use Github Personal Access Token
-        run: git config --global url."https://${{ secrets.GH_PAT }}@github.com/".insteadOf ssh://git@github.com/
+        run: git config --global url."https://${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf ssh://git@github.com/
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/publishCanary.yml
+++ b/.github/workflows/publishCanary.yml
@@ -51,7 +51,7 @@ jobs:
           cache: 'yarn'
 
       - name: Use Github Personal Access Token
-        run: git config --global url."https://${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf ssh://git@github.com/
+        run: git config --global url."https://${{ secrets.GH_PAT }}@github.com/".insteadOf ssh://git@github.com/
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
The previous github token secret did not have the correct permissions to write. Using the standard Github token that set by default should fix this issue.

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
