### PR TITLE
[cli] Set default regions to US only

### DIFF
--- a/packages/cli-internal/src/commands/push.ts
+++ b/packages/cli-internal/src/commands/push.ts
@@ -275,7 +275,8 @@ export default class Push extends Command {
             advancedOptions: [], // make sure this gets cleared out since we don't use advancedOptions in Actions
             basicOptions,
             options,
-            platforms
+            platforms,
+            supportedRegions: ['us-west-2'] // always default to US until regional action destinations are supported
           }),
           updateDestinationMetadataActions(actionsToUpdate),
           createDestinationMetadataActions(actionsToCreate)


### PR DESCRIPTION
This pull request sets the default supported regions to `us-west-2` when pushing destination definitions. Action destinations do not support multi-region deployments at the time of writing this.

Note that it will **always** overwrite the current value, so if a change in Partner Portal is made it will be overwritten.

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
