### PR TITLE
add event name matching for order completed behavior

### DIFF
--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -13,6 +13,8 @@ export interface Result {
 }
 
 export interface ExecuteInput<Settings, Payload> {
+  /** The raw input data (usually a Segment event), you should avoid using this */
+  readonly rawData?: unknown
   /** The subscription mapping definition */
   readonly mapping?: JSONObject
   /** The global destination settings */

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   trackRevenuePerProduct?: boolean
   /**
+   * When a subscribed event also has this name, track order completed and product purchased details
+   */
+  orderCompletedEventName?: string
+  /**
    * A readable ID specified by you. Must have a minimum length of 5 characters. Required unless device ID is present. **Note:** If you send a request with a user ID that is not in the Amplitude system yet, then the user tied to that ID will not be marked new until their first event.
    */
   user_id?: string | null


### PR DESCRIPTION
This PR lets customers define which event name should include the track revenue / product purchased behavior for Amplitude. It's a little hacky in that we have to add the `rawData` to the types, and now you can access it (as `unknown`). Open to suggestions!

## Testing

Tested locally and there is already a unit test for this.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
