### PR TITLE
add @arrayPath directive to resolve arrays and transform item shapes

### DIFF
--- a/packages/core/src/mapping-kit/README.md
+++ b/packages/core/src/mapping-kit/README.md
@@ -62,6 +62,7 @@ Output:
   - [@path](#path)
   - [@template](#template)
   - [@literal](#literal)
+  - [@arrayPath](#array-path)
 
 <!-- tocstop -->
 
@@ -443,4 +444,57 @@ n/a
 
 Mappings:
 { "@literal": true } => true
+```
+
+### @arrayPath
+
+The @arrayPath directive resolves an array value at a given path (much like @path), but allows you to specify the shape of each item in the resulting array. You can use directives for each key in the given shape, relative to the root array.
+
+Input:
+```json
+{
+  "properties": {
+    "products": [{ "productId": 1 }, { "productId": 2 }]
+  }
+}
+```
+
+Mapping:
+```json
+{
+  "@arrayPath": ["$.properties.products"]
+}
+```
+
+Result:
+```json
+[
+  {
+    "productId": 1
+  },
+  {
+    "productId": 2
+  }
+]
+```
+
+Mappings with item shape:
+```json
+{
+  "@arrayPath": ["$.properties.products", {
+    "some_other_key": { "@path": "$.productId" }
+  }]
+}
+```
+
+Result:
+```json
+[
+  {
+    "some_other_key": 1
+  },
+  {
+    "some_other_key": 2
+  }
+]
 ```

--- a/packages/core/src/mapping-kit/__tests__/index.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.test.ts
@@ -141,6 +141,67 @@ describe('@if', () => {
   })
 })
 
+describe('@arrayPath', () => {
+  const data = {
+    products: [
+      {
+        productId: '123',
+        price: 0.5
+      },
+      {
+        productId: '456',
+        price: 0.99
+      }
+    ]
+  }
+
+  test('simple', () => {
+    const output = transform({ neat: { '@arrayPath': ['$.products'] } }, data)
+    expect(output).toStrictEqual({ neat: data.products })
+  })
+
+  test('relative object shape', () => {
+    const mapping = {
+      neat: {
+        '@arrayPath': [
+          '$.products',
+          {
+            product_id: { '@path': '$.productId' },
+            monies: { '@path': '$.price' }
+          }
+        ]
+      }
+    }
+
+    const output = transform(mapping, data)
+    expect(output).toStrictEqual({
+      neat: [
+        { product_id: '123', monies: 0.5 },
+        { product_id: '456', monies: 0.99 }
+      ]
+    })
+  })
+
+  test('not an array', () => {
+    const mapping = {
+      neat: {
+        '@arrayPath': [
+          '$.products',
+          {
+            product_id: { '@path': '$.productId' },
+            monies: { '@path': '$.price' }
+          }
+        ]
+      }
+    }
+
+    const output = transform(mapping, { products: { notAnArray: true } })
+    expect(output).toStrictEqual({
+      neat: { notAnArray: true }
+    })
+  })
+})
+
 describe('@path', () => {
   test('simple', () => {
     const output = transform({ neat: { '@path': '$.foo' } }, { foo: 'bar' })

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -82,7 +82,7 @@ registerDirective('@arrayPath', (data, payload) => {
 
   // If a shape has been provided, resolve each item in the array with this shape
   if (isArray(root) && realTypeOf(itemShape) === 'object' && Object.keys(itemShape as JSONObject).length > 0) {
-    return root.map((item) => resolve({ ...itemShape }, item as JSONObject))
+    return root.map((item) => resolve(itemShape, item as JSONObject))
   }
 
   return root

--- a/packages/core/src/mapping-kit/schema-fixtures/invalid/@array-path-not-array.json
+++ b/packages/core/src/mapping-kit/schema-fixtures/invalid/@array-path-not-array.json
@@ -1,0 +1,6 @@
+{
+  "mapping": {
+    "@arrayPath": "nope"
+  },
+  "expectError": "/@arrayPath should be an array but it is a string."
+}

--- a/packages/core/src/mapping-kit/schema-fixtures/valid/@array-path-item-shape.json
+++ b/packages/core/src/mapping-kit/schema-fixtures/valid/@array-path-item-shape.json
@@ -1,0 +1,15 @@
+{
+  "mapping": {
+    "@arrayPath": [
+      "$.products",
+      {
+        "cash_money": {
+          "@path": "$.price"
+        },
+        "product_id": {
+          "@path": "$.productId"
+        }
+      }
+    ]
+  }
+}

--- a/packages/core/src/mapping-kit/schema-fixtures/valid/@array-path-simple.json
+++ b/packages/core/src/mapping-kit/schema-fixtures/valid/@array-path-simple.json
@@ -1,0 +1,7 @@
+{
+  "mapping": {
+    "@arrayPath": [
+      "$.foo.bar"
+    ]
+  }
+}

--- a/packages/core/src/mapping-kit/validate.ts
+++ b/packages/core/src/mapping-kit/validate.ts
@@ -210,6 +210,13 @@ directive('@if', (v, stack) => {
   )
 })
 
+directive('@arrayPath', (v, stack) => {
+  const data = v as [unknown, unknown]
+  validateArray(data, stack)
+  validateDirectiveOrString(data[0], stack)
+  validate(data[1], stack)
+})
+
 directive('@path', (v, stack) => {
   validateDirectiveOrString(v, stack)
 })


### PR DESCRIPTION
This PR introduces a new directive with the same ol' jsonpath-like syntax for not only looking up an array path, but also remapping the keys with directives/raw values of their own.

You can do stuff like this:


Input:
```json
{
  "properties": {
    "products": [{ "productId": 1 }, { "productId": 2 }]
  }
}
```

Simple mapping (not really any different that `@path`):
```json
{
  "@arrayPath": ["$.properties.products"]
}
```

Result:
```json
[
  {
    "productId": 1
  },
  {
    "productId": 2
  }
]
```

Mappings with item shape:
```json
{
  "@arrayPath": ["$.properties.products", {
    "some_other_key": { "@path": "$.productId" }
  }]
}
```

Result:
```json
[
  {
    "some_other_key": 1
  },
  {
    "some_other_key": 2
  }
]
```


## Testing

Tested locally and via CI unit tests.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
