### PR TITLE
add authenticate endpoint to local server and better logs

### DIFF
--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -247,7 +247,7 @@ export class Destination<Settings = JSONObject> {
     try {
       await this.authentication.testAuthentication(requestClient, data)
     } catch (error) {
-      throw new Error('Credentials are invalid')
+      throw new Error(`Credentials are invalid: ${error.message}`)
     }
   }
 

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -247,7 +247,8 @@ export class Destination<Settings = JSONObject> {
     try {
       await this.authentication.testAuthentication(requestClient, data)
     } catch (error) {
-      throw new Error(`Credentials are invalid: ${error.message}`)
+      const statusCode = error?.response?.status ?? ''
+      throw new Error(`Credentials are invalid: ${statusCode} ${error.message}`)
     }
   }
 


### PR DESCRIPTION
This adds the `/authenticate` endpoint to the local server, adds better request/response logging.

```
➜  action-destinations git:(main) ✗ ./bin/run serve
✔ Which destination? › amplitude
Watching required files for changes ..

INFO: Listening at http://localhost:3000 ->
  POST /delete
  POST /authenticate
  POST /logEvent
  POST /identifyUser
  POST /mapUser
  POST /groupIdentifyUser

INFO: 💬 200 POST /authenticate - 48ms
  duration: 48.445536
  ip: '::1'
  path: /authenticate
  method: POST
  statusCode: 200
  url: /authenticate
^C
INFO: Server stopping...

INFO: Server stopped
```

## Testing

Tested locally. Not a production code change.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
