### PR TITLE
allow other directives for arrayPath root

### DIFF
--- a/packages/core/src/get.ts
+++ b/packages/core/src/get.ts
@@ -2,11 +2,11 @@
  * Lightweight alternative to lodash.get with similar coverage
  * Supports basic path lookup via dot notation `'foo.bar[0].baz'` or an array ['foo', 'bar', '0', 'baz']
  */
-export function get<T = unknown, Default = undefined>(
+export function get<T = unknown>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   obj: any,
   path: string | string[]
-): T | Default | undefined {
+): T | undefined {
   // Root value
   if (path === '' || path === '.') return obj
 

--- a/packages/core/src/mapping-kit/__tests__/index.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.test.ts
@@ -182,6 +182,34 @@ describe('@arrayPath', () => {
     })
   })
 
+  test('relative object shape with directive', () => {
+    const mapping = {
+      neat: {
+        '@arrayPath': [
+          {
+            '@if': {
+              exists: { '@path': '$.products' },
+              then: { '@path': '$.products' },
+              else: []
+            }
+          },
+          {
+            product_id: { '@path': '$.productId' },
+            monies: { '@path': '$.price' }
+          }
+        ]
+      }
+    }
+
+    const output = transform(mapping, data)
+    expect(output).toStrictEqual({
+      neat: [
+        { product_id: '123', monies: 0.5 },
+        { product_id: '456', monies: 0.99 }
+      ]
+    })
+  })
+
   test('not an array', () => {
     const mapping = {
       neat: {

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -74,11 +74,7 @@ registerDirective('@arrayPath', (data, payload) => {
   }
 
   const [path, itemShape] = data as [string, undefined | JSONObject]
-  if (typeof path !== 'string') {
-    throw new Error(`@arrayPath expected args[0] to be string, got ${realTypeOf(path)}`)
-  }
-
-  const root = get(payload, path.replace('$.', '')) as JSONLike
+  const root = typeof path === 'string' ? (get(payload, path.replace('$.', '')) as JSONLike) : resolve(path, payload)
 
   // If a shape has been provided, resolve each item in the array with this shape
   if (isArray(root) && realTypeOf(itemShape) === 'object' && Object.keys(itemShape as JSONObject).length > 0) {


### PR DESCRIPTION
I realized that we should allow users to use if/else, path, etc to produce a valid root object. This will treat strings as `@path` directives, and other objects will resolve like any other directive/literal would.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
