### PR TITLE
[Customer.io] Support screen events to cio

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/__tests__/trackScreenView.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/trackScreenView.test.ts
@@ -26,6 +26,8 @@ describe('CustomerIO', () => {
       }
       trackScreenViewService.post(`/customers/${userId}/events`).reply(200, {}, { 'x-customerio-region': 'US' })
       const event = createTestEvent({
+        type: 'screen',
+        name: screen,
         userId,
         properties: data,
         timestamp
@@ -66,6 +68,8 @@ describe('CustomerIO', () => {
       }
       trackScreenViewService.post(`/events`).reply(200, {})
       const event = createTestEvent({
+        type: 'screen',
+        name: screen,
         anonymousId,
         properties: data,
         userId: undefined,
@@ -90,7 +94,7 @@ describe('CustomerIO', () => {
       })
     })
 
-    it('should error when the screen field is not supplied', async () => {
+    it('should error when the name field is not supplied', async () => {
       const settings: Settings = {
         siteId: '12345',
         apiKey: 'abcde',
@@ -99,6 +103,7 @@ describe('CustomerIO', () => {
       const timestamp = dayjs.utc().toISOString()
       trackScreenViewService.post(`/events`).reply(200, {})
       const event = createTestEvent({
+        type: 'screen',
         anonymousId: undefined,
         userId: undefined,
         timestamp
@@ -108,7 +113,7 @@ describe('CustomerIO', () => {
         await testDestination.testAction('trackScreenView', { event, settings, useDefaultMappings: true })
         fail('This test should have thrown an error')
       } catch (e) {
-        expect(e.message).toBe("The root value is missing the required field 'screen'.")
+        expect(e.message).toBe("The root value is missing the required field 'name'.")
       }
     })
 
@@ -127,6 +132,8 @@ describe('CustomerIO', () => {
       }
       trackScreenViewService.post(`/customers/${userId}/events`).reply(200, {}, { 'x-customerio-region': 'US' })
       const event = createTestEvent({
+        type: 'screen',
+        name: screen,
         userId,
         properties: data,
         timestamp
@@ -171,6 +178,8 @@ describe('CustomerIO', () => {
       }
       trackEUEventService.post(`/customers/${userId}/events`).reply(200, {}, { 'x-customerio-region': 'EU' })
       const event = createTestEvent({
+        type: 'screen',
+        name: screen,
         userId,
         timestamp,
         properties: data
@@ -212,6 +221,8 @@ describe('CustomerIO', () => {
         .post(`/customers/${userId}/events`)
         .reply(200, {}, { 'x-customerio-region': 'US-fallback' })
       const event = createTestEvent({
+        type: 'screen',
+        name: screen,
         userId,
         timestamp,
         properties: data

--- a/packages/destination-actions/src/destinations/customerio/__tests__/trackScreenView.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/trackScreenView.test.ts
@@ -1,0 +1,240 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import CustomerIO from '../index'
+import { Settings } from '../generated-types'
+import dayjs from '../../../lib/dayjs'
+import { AccountRegion } from '../utils'
+
+const testDestination = createTestIntegration(CustomerIO)
+const trackScreenViewService = nock('https://track.customer.io/api/v1')
+const type = 'screen'
+
+describe('CustomerIO', () => {
+  describe('trackScreenView', () => {
+    it('should work with default mappings when a userId is supplied', async () => {
+      const settings: Settings = {
+        siteId: '12345',
+        apiKey: 'abcde',
+        accountRegion: AccountRegion.US
+      }
+      const userId = 'abc123'
+      const screen = 'Page One'
+      const timestamp = dayjs.utc().toISOString()
+      const data = {
+        property1: 'this is a test',
+        screen
+      }
+      trackScreenViewService.post(`/customers/${userId}/events`).reply(200, {}, { 'x-customerio-region': 'US' })
+      const event = createTestEvent({
+        userId,
+        properties: data,
+        timestamp
+      })
+      const responses = await testDestination.testAction('trackScreenView', {
+        event,
+        settings,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].headers.toJSON()).toMatchObject({
+        'x-customerio-region': 'US',
+        'content-type': 'application/json'
+      })
+      expect(responses[0].data).toMatchObject({})
+      expect(responses[0].options.json).toMatchObject({
+        name: screen,
+        type,
+        data,
+        timestamp: dayjs.utc(timestamp).unix()
+      })
+    })
+
+    it('should work with default mappings when a anonymousId is supplied', async () => {
+      const settings: Settings = {
+        siteId: '12345',
+        apiKey: 'abcde',
+        accountRegion: AccountRegion.US
+      }
+      const anonymousId = 'anonymous123'
+      const screen = 'Page One'
+      const timestamp = dayjs.utc().toISOString()
+      const data = {
+        property1: 'this is a test',
+        screen
+      }
+      trackScreenViewService.post(`/events`).reply(200, {})
+      const event = createTestEvent({
+        anonymousId,
+        properties: data,
+        userId: undefined,
+        timestamp
+      })
+
+      const responses = await testDestination.testAction('trackScreenView', {
+        event,
+        settings,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+      expect(responses[0].options.json).toMatchObject({
+        name: screen,
+        type,
+        data,
+        anonymous_id: anonymousId,
+        timestamp: dayjs.utc(timestamp).unix()
+      })
+    })
+
+    it('should error when the screen field is not supplied', async () => {
+      const settings: Settings = {
+        siteId: '12345',
+        apiKey: 'abcde',
+        accountRegion: AccountRegion.US
+      }
+      const timestamp = dayjs.utc().toISOString()
+      trackScreenViewService.post(`/events`).reply(200, {})
+      const event = createTestEvent({
+        anonymousId: undefined,
+        userId: undefined,
+        timestamp
+      })
+
+      try {
+        await testDestination.testAction('trackScreenView', { event, settings, useDefaultMappings: true })
+        fail('This test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe("The root value is missing the required field 'screen'.")
+      }
+    })
+
+    it('should not convert tiemstamp to a unix timestamp when convert_timestamp is false', async () => {
+      const settings: Settings = {
+        siteId: '12345',
+        apiKey: 'abcde',
+        accountRegion: AccountRegion.US
+      }
+      const userId = 'abc123'
+      const screen = 'Page One'
+      const timestamp = dayjs.utc().toISOString()
+      const data = {
+        property1: 'this is a test',
+        screen
+      }
+      trackScreenViewService.post(`/customers/${userId}/events`).reply(200, {}, { 'x-customerio-region': 'US' })
+      const event = createTestEvent({
+        userId,
+        properties: data,
+        timestamp
+      })
+      const responses = await testDestination.testAction('trackScreenView', {
+        event,
+        settings,
+        useDefaultMappings: true,
+        mapping: {
+          convert_timestamp: false
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].headers.toJSON()).toMatchObject({
+        'x-customerio-region': 'US',
+        'content-type': 'application/json'
+      })
+      expect(responses[0].data).toMatchObject({})
+      expect(responses[0].options.json).toMatchObject({
+        name: screen,
+        type,
+        data,
+        timestamp
+      })
+    })
+
+    it('should work with the EU account region', async () => {
+      const trackEUEventService = nock('https://track-eu.customer.io/api/v1')
+      const settings: Settings = {
+        siteId: '12345',
+        apiKey: 'abcde',
+        accountRegion: AccountRegion.EU
+      }
+      const userId = 'abc123'
+      const screen = 'Page One'
+      const timestamp = dayjs.utc().toISOString()
+      const data = {
+        property1: 'this is a test',
+        screen
+      }
+      trackEUEventService.post(`/customers/${userId}/events`).reply(200, {}, { 'x-customerio-region': 'EU' })
+      const event = createTestEvent({
+        userId,
+        timestamp,
+        properties: data
+      })
+      const responses = await testDestination.testAction('trackScreenView', {
+        event,
+        settings,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].headers.toJSON()).toMatchObject({
+        'x-customerio-region': 'EU',
+        'content-type': 'application/json'
+      })
+      expect(responses[0].data).toMatchObject({})
+      expect(responses[0].options.json).toMatchObject({
+        name: screen,
+        type,
+        data,
+        timestamp: dayjs.utc(timestamp).unix()
+      })
+    })
+
+    it('should fall back to the US account region', async () => {
+      const settings: Settings = {
+        siteId: '12345',
+        apiKey: 'abcde'
+      }
+      const userId = 'abc123'
+      const screen = 'Page One'
+      const timestamp = dayjs.utc().toISOString()
+      const data = {
+        property1: 'this is a test',
+        screen
+      }
+      trackScreenViewService
+        .post(`/customers/${userId}/events`)
+        .reply(200, {}, { 'x-customerio-region': 'US-fallback' })
+      const event = createTestEvent({
+        userId,
+        timestamp,
+        properties: data
+      })
+      const responses = await testDestination.testAction('trackScreenView', {
+        event,
+        settings,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].headers.toJSON()).toMatchObject({
+        'x-customerio-region': 'US-fallback',
+        'content-type': 'application/json'
+      })
+      expect(responses[0].data).toMatchObject({})
+      expect(responses[0].options.json).toMatchObject({
+        name: screen,
+        type,
+        data,
+        timestamp: dayjs.utc(timestamp).unix()
+      })
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/customerio/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/index.ts
@@ -4,6 +4,7 @@ import deleteDevice from './deleteDevice'
 import createUpdatePerson from './createUpdatePerson'
 import trackEvent from './trackEvent'
 import trackPageView from './trackPageView'
+import trackScreenView from './trackScreenView'
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import { AccountRegion, trackApiEndpoint } from './utils'
@@ -53,7 +54,8 @@ const destination: DestinationDefinition<Settings> = {
     deleteDevice,
     createUpdatePerson,
     trackEvent,
-    trackPageView
+    trackPageView,
+    trackScreenView
   },
 
   presets: [
@@ -86,6 +88,12 @@ const destination: DestinationDefinition<Settings> = {
       subscribe: 'type = "page"',
       partnerAction: 'trackPageView',
       mapping: defaultValues(trackPageView.fields)
+    },
+    {
+      name: 'Track Screen View',
+      subscribe: 'type = "screen"',
+      partnerAction: 'trackScreenView',
+      mapping: defaultValues(trackScreenView.fields)
     }
   ],
 

--- a/packages/destination-actions/src/destinations/customerio/trackScreenView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackScreenView/generated-types.ts
@@ -1,0 +1,30 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID used to uniquely identify a person in Customer.io. [Learn more](https://customer.io/docs/identifying-people/#identifiers).
+   */
+  id?: string
+  /**
+   * An anonymous ID for when no Person ID exists. [Learn more](https://customer.io/docs/anonymous-events/).
+   */
+  anonymous_id?: string
+  /**
+   * The name of the screen visited.
+   */
+  name: string
+  /**
+   * A timestamp of when the event took place. Default is current date and time.
+   */
+  timestamp?: string
+  /**
+   * Optional data to include with the event.
+   */
+  data?: {
+    [k: string]: unknown
+  }
+  /**
+   * Convert `timestamp` to a Unix timestamp (seconds since Epoch).
+   */
+  convert_timestamp?: boolean
+}

--- a/packages/destination-actions/src/destinations/customerio/trackScreenView/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackScreenView/index.ts
@@ -1,0 +1,101 @@
+import dayjs from '../../../lib/dayjs'
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import { trackApiEndpoint } from '../utils'
+import type { Payload } from './generated-types'
+
+interface TrackScreenViewPayload {
+  name: string
+  type: 'screen'
+  timestamp?: string | number
+  data?: Record<string, unknown>
+  // Required for anonymous events
+  anonymous_id?: string
+}
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Track Screen View',
+  description: 'Track a screen view for a known or anonymous person.',
+  defaultSubscription: 'type = "screen"',
+  fields: {
+    id: {
+      label: 'Person ID',
+      description:
+        'The ID used to uniquely identify a person in Customer.io. [Learn more](https://customer.io/docs/identifying-people/#identifiers).',
+      type: 'string',
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    anonymous_id: {
+      label: 'Anonymous ID',
+      description:
+        'An anonymous ID for when no Person ID exists. [Learn more](https://customer.io/docs/anonymous-events/).',
+      type: 'string',
+      default: {
+        '@path': '$.anonymousId'
+      }
+    },
+    name: {
+      label: 'Screen name',
+      description: 'The name of the screen visited.',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.name'
+      }
+    },
+    timestamp: {
+      label: 'Timestamp',
+      description: 'A timestamp of when the event took place. Default is current date and time.',
+      type: 'string',
+      default: {
+        '@path': '$.timestamp'
+      }
+    },
+    data: {
+      label: 'Event Attributes',
+      description: 'Optional data to include with the event.',
+      type: 'object',
+      default: {
+        '@path': '$.properties'
+      }
+    },
+    convert_timestamp: {
+      label: 'Convert Timestamps',
+      description: 'Convert `timestamp` to a Unix timestamp (seconds since Epoch).',
+      type: 'boolean',
+      default: true
+    }
+  },
+  perform: (request, { settings, payload }) => {
+    let timestamp: string | number | undefined = payload.timestamp
+
+    if (timestamp && payload.convert_timestamp !== false) {
+      timestamp = dayjs.utc(timestamp).unix()
+    }
+
+    const body: TrackScreenViewPayload = {
+      name: payload.name,
+      type: 'screen',
+      data: payload.data,
+      timestamp
+    }
+
+    let url: string
+
+    if (payload.id) {
+      url = `${trackApiEndpoint(settings.accountRegion)}/api/v1/customers/${payload.id}/events`
+    } else {
+      url = `${trackApiEndpoint(settings.accountRegion)}/api/v1/events`
+      body.anonymous_id = payload.anonymous_id
+    }
+
+    return request(url, {
+      method: 'post',
+      json: body
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/generated-types.ts
@@ -2,21 +2,21 @@
 
 export interface Payload {
   /**
-   * The Google Ads conversion label. You can find it in your Google Ads account using the instructions in the article [Google Ads conversions](https://support.google.com/tagmanager/answer/6105160?hl=en)
+   * The Google Ads conversion label. You can find it in your Google Ads account using the instructions in the article [Google Ads conversions](https://support.google.com/tagmanager/answer/6105160?hl=en).
    */
   conversion_label: string
   /**
-   * Email address of the customer who triggered the conversion event.
+   * Email address of the individual who triggered the conversion event.
    */
   email: string
   /**
-   * Order ID of the conversion event. Google requires an Order ID even if the event is not an ecommerce event.
+   * Order ID or Transaction ID of the conversion event. Google requires an Order ID even if the event is not an ecommerce event. Learn more in the article [Use a transaction ID to minimize duplicate conversions](https://support.google.com/google-ads/answer/6386790?hl=en&ref_topic=3165803).
    */
   transaction_id: string
   /**
-   * User Agent of the customer who triggered the conversion event.
+   * User agent of the individual who triggered the conversion event. This should match the user agent of the request that sent the original conversion so the conversion and its enhancement are either both attributed as same-device or both attributed as cross-device. This field is optional but recommended.
    */
-  user_agent: string
+  user_agent?: string
   /**
    * Timestamp of the conversion event.
    */
@@ -26,11 +26,11 @@ export interface Payload {
    */
   value?: number
   /**
-   * Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.
+   * Currency of the purchase or items associated with the conversion event, in 3-letter ISO 4217 format.
    */
   currency_code?: string
   /**
-   * Phone number of the purchaser, in E.164 standard format, e.g. +14150000000
+   * Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000.
    */
   phone_number?: string
   /**
@@ -54,7 +54,7 @@ export interface Payload {
    */
   region?: string
   /**
-   * Post code of the individual who triggered the conversion event.
+   * Postal code of the individual who triggered the conversion event.
    */
   post_code?: string
   /**


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This adds support for the `screen` type for sending events to customer.io after we recently added support for it (in addition to `page`). This is basically copy/pasted from the `trackPageView` so it should be pretty straightforward. ~I'm unable to test locally due to the following error, but I'm pretty sure everything should be passing!~ **Fixed by running `yarn build`!**

```sh
projects/action-destinations on customerio-screen-type
λ yarn cloud test --testPathPattern=src/destinations/customerio
yarn run v1.22.5
$ yarn workspace @segment/action-destinations test --testPathPattern=src/destinations/customerio
$ jest --testPathPattern=src/destinations/customerio
 FAIL  src/destinations/customerio/__tests__/createUpdatePerson.test.ts
  ● Test suite failed to run

    ../core/src/schema-validation.ts:1:35 - error TS2307: Cannot find module '@segment/ajv-human-errors' or its corresponding type declarations.

    1 import { AggregateAjvError } from '@segment/ajv-human-errors'
                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
