### PR TITLE
GEC Missing updated generated-types

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/generated-types.ts
@@ -2,21 +2,21 @@
 
 export interface Payload {
   /**
-   * The Google Ads conversion label. You can find it in your Google Ads account using the instructions in the article [Google Ads conversions](https://support.google.com/tagmanager/answer/6105160?hl=en)
+   * The Google Ads conversion label. You can find it in your Google Ads account using the instructions in the article [Google Ads conversions](https://support.google.com/tagmanager/answer/6105160?hl=en).
    */
   conversion_label: string
   /**
-   * Email address of the customer who triggered the conversion event.
+   * Email address of the individual who triggered the conversion event.
    */
   email: string
   /**
-   * Order ID of the conversion event. Google requires an Order ID even if the event is not an ecommerce event.
+   * Order ID or Transaction ID of the conversion event. Google requires an Order ID even if the event is not an ecommerce event. Learn more in the article [Use a transaction ID to minimize duplicate conversions](https://support.google.com/google-ads/answer/6386790?hl=en&ref_topic=3165803).
    */
   transaction_id: string
   /**
-   * User Agent of the customer who triggered the conversion event.
+   * User agent of the individual who triggered the conversion event. This should match the user agent of the request that sent the original conversion so the conversion and its enhancement are either both attributed as same-device or both attributed as cross-device. This field is optional but recommended.
    */
-  user_agent: string
+  user_agent?: string
   /**
    * Timestamp of the conversion event.
    */
@@ -26,11 +26,11 @@ export interface Payload {
    */
   value?: number
   /**
-   * Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.
+   * Currency of the purchase or items associated with the conversion event, in 3-letter ISO 4217 format.
    */
   currency_code?: string
   /**
-   * Phone number of the purchaser, in E.164 standard format, e.g. +14150000000
+   * Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000.
    */
   phone_number?: string
   /**
@@ -54,7 +54,7 @@ export interface Payload {
    */
   region?: string
   /**
-   * Post code of the individual who triggered the conversion event.
+   * Postal code of the individual who triggered the conversion event.
    */
   post_code?: string
   /**


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This generated-types file update wasn't merged in when I changed some field descriptions. Doing that now.

It's causing some [issues with /publish-canary](https://github.com/segmentio/action-destinations/pull/122#issuecomment-967566367)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
