### PR TITLE
run tests without build

### DIFF
--- a/packages/ajv-human-errors/jest.config.js
+++ b/packages/ajv-human-errors/jest.config.js
@@ -3,14 +3,9 @@ module.exports = {
   preset: 'ts-jest',
   globals: {
     'ts-jest': {
-      isolatedModules: false,
-    },
+      isolatedModules: false
+    }
   },
-  testRegex: "((\\.|/)(test))\\.(tsx?|json)$",
-  modulePathIgnorePatterns: [
-    "<rootDir>/dist/"
-  ],
-  moduleNameMapper: {
-    "src/lib/(.*)": "<rootDir>/src/lib/$1"
-  },
-};
+  testRegex: '((\\.|/)(test))\\.(tsx?|json)$',
+  modulePathIgnorePatterns: ['<rootDir>/dist/']
+}

--- a/packages/cli-internal/package.json
+++ b/packages/cli-internal/package.json
@@ -94,7 +94,6 @@
       "<rootDir>/dist/"
     ],
     "moduleNameMapper": {
-      "src/lib/(.*)": "<rootDir>/src/lib/$1",
       "@segment/actions-cli": "<rootDir>/../cli/src"
     }
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -106,8 +106,10 @@
       "<rootDir>/templates/"
     ],
     "moduleNameMapper": {
-      "src/lib/(.*)": "<rootDir>/src/lib/$1",
-      "@segment/actions-cli-internal": "<rootDir>/../cli-internal/src"
+      "@segment/actions-cli-internal": "<rootDir>/../cli-internal/src",
+      "@segment/actions-core": "<rootDir>/../core/src",
+      "@segment/ajv-human-errors": "<rootDir>/../ajv-human-errors/src",
+      "@segment/destination-subscriptions": "<rootDir>/../destination-subscriptions/src"
     }
   }
 }

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -23,6 +23,7 @@
   "include": ["src"],
   "references": [
     { "path": "../core/tsconfig.build.json" },
+    { "path": "../ajv-human-errors/tsconfig.build.json" },
     { "path": "../destination-subscriptions/tsconfig.build.json" }
   ]
 }


### PR DESCRIPTION
This PR cleans up some of our tsconfig references such that all tests should be able to run without compiling any code.

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
