### PR TITLE
Remove unused properties warning

### DIFF
--- a/packages/browser-destinations/src/destinations/braze/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/index.ts
@@ -249,7 +249,17 @@ export const destination: BrowserDestinationDefinition<Settings, typeof appboy> 
   },
   initialize: async ({ settings }, dependencies) => {
     try {
-      const { endpoint, api_key, sdkVersion, automaticallyDisplayMessages, ...expectedConfig } = settings
+      const {
+        endpoint,
+        api_key,
+        sdkVersion,
+        automaticallyDisplayMessages,
+        // @ts-expect-error versionSettings is not part of the settings object but they are injected by Analytics 2.0, making Braze SDK raise a warning when we initialize it.
+        versionSettings,
+        // @ts-expect-error same as above.
+        subscriptions,
+        ...expectedConfig
+      } = settings
       const version = sdkVersion ?? '3.3'
 
       resetUserCache()

--- a/packages/cli-internal/package.json
+++ b/packages/cli-internal/package.json
@@ -52,7 +52,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1",
-    "@oclif/plugin-help": "^3",
+    "@oclif/plugin-help": "^3.3",
     "@segment/action-destinations": "^3.27.2",
     "@segment/actions-core": "^3.19.1",
     "chalk": "^4.1.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1",
-    "@oclif/plugin-help": "^3",
+    "@oclif/plugin-help": "^3.3",
     "@segment/action-destinations": "^3.27.2",
     "@segment/actions-core": "^3.19.1",
     "chalk": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2048,6 +2048,29 @@
     is-wsl "^2.1.1"
     tslib "^2.0.0"
 
+"@oclif/core@^0.5.28":
+  version "0.5.41"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-0.5.41.tgz#54ab600b1b6017f3849e629401eafd4f4e3a5c2e"
+  integrity sha512-zEYbpxSQr80t7MkLMHOmZr8QCrCIbVrI7fLSZWlsvD2AEM0vvzuhWymjo9/kHy2/kNfxwu7NTI4i2a0zoHu11w==
+  dependencies:
+    "@oclif/linewrap" "^1.0.0"
+    chalk "^4.1.0"
+    clean-stack "^3.0.0"
+    cli-ux "^5.1.0"
+    debug "^4.1.1"
+    fs-extra "^9.0.1"
+    get-package-type "^0.1.0"
+    globby "^11.0.1"
+    indent-string "^4.0.0"
+    is-wsl "^2.1.1"
+    lodash.template "^4.4.0"
+    semver "^7.3.2"
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    tslib "^2.0.0"
+    widest-line "^3.1.0"
+    wrap-ansi "^7.0.0"
+
 "@oclif/dev-cli@^1":
   version "1.26.0"
   resolved "https://registry.yarnpkg.com/@oclif/dev-cli/-/dev-cli-1.26.0.tgz#e3ec294b362c010ffc8948003d3770955c7951fd"
@@ -2108,6 +2131,13 @@
     strip-ansi "^6.0.0"
     widest-line "^3.1.0"
     wrap-ansi "^4.0.0"
+
+"@oclif/plugin-help@^3.3":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@oclif/plugin-help/-/plugin-help-3.3.0.tgz#ccaebdd31faeddb67501cce29f61922151b586c2"
+  integrity sha512-+eYQZXsWnc54IM5Hv2+IoKBTKUSDt+vRbwf5I8w+DaXvzOmx0VzAbLgL1ciJzYh66CknjWMUJf/hxoc8ykJHaQ==
+  dependencies:
+    "@oclif/core" "^0.5.28"
 
 "@oclif/screen@^1.0.3":
   version "1.0.4"
@@ -4228,7 +4258,7 @@ cli-truncate@^2.1.0:
     slice-ansi "^3.0.0"
     string-width "^4.2.0"
 
-cli-ux@^5.2.1:
+cli-ux@^5.1.0, cli-ux@^5.2.1:
   version "5.6.3"
   resolved "https://registry.yarnpkg.com/cli-ux/-/cli-ux-5.6.3.tgz#eecdb2e0261171f2b28f2be6b18c490291c3a287"
   integrity sha512-/oDU4v8BiDjX2OKcSunGH0iGDiEtj2rZaGyqNuv9IT4CgcSMyVWAMfn0+rEHaOc4n9ka78B0wo1+N1QX89f7mw==
@@ -6240,7 +6270,7 @@ fs-extra@^8.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.1.0:
+fs-extra@^9.0.1, fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
@@ -8887,6 +8917,7 @@ minipass-fetch@^1.3.0, minipass-fetch@^1.3.2:
   resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-1.3.4.tgz#63f5af868a38746ca7b33b03393ddf8c291244fe"
   integrity sha512-TielGogIzbUEtd1LsjZFs47RWuHHfhl6TiCx1InVxApBAmQ8bL0dL5ilkLGcRvuyW/A9nE+Lvn855Ewz8S0PnQ==
   dependencies:
+    encoding "^0.1.12"
     minipass "^3.1.0"
     minipass-sized "^1.0.3"
     minizlib "^2.0.0"


### PR DESCRIPTION
This PR removes unnecessary fields from Braze's initialization.
These fields are not defined on the `Settings` type but are passed by either AJS 2.0 or the action destination engine itself during the plugin initialization.

## Testing
Before:
![Screen Shot 2021-11-15 at 11 36 04 AM](https://user-images.githubusercontent.com/484013/141844725-f0cc3bf4-c04b-44e7-8024-bcae3b69cc4e.png)

After:
![Screen Shot 2021-11-15 at 11 39 51 AM](https://user-images.githubusercontent.com/484013/141844740-efef1fcd-4861-49ed-bcfe-57d3146d0f81.png)

- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
