### PR TITLE
Remove recommended from docs

### DIFF
--- a/docs/create.md
+++ b/docs/create.md
@@ -171,9 +171,6 @@ const destination = {
       // the human-friendly description of the action. supports markdown
       description: 'Post a message to a Slack channel',
 
-      // whether or not this should appear in the Quick Setup
-      recommended: true,
-
       // fql query to use for the subscription initially
       // required if using `recommended: true`
       defaultSubscription: 'type = "track"'

--- a/docs/create.md
+++ b/docs/create.md
@@ -172,7 +172,6 @@ const destination = {
       description: 'Post a message to a Slack channel',
 
       // fql query to use for the subscription initially
-      // required if using `recommended: true`
       defaultSubscription: 'type = "track"'
 
       // the set of fields that are specific to this action


### PR DESCRIPTION
This pull request removes an outdated action definition field from the docs 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
