### PR TITLE
Add connection overrides on twilio sms status callback url

### DIFF
--- a/packages/browser-destinations/src/destinations/braze/__tests__/__snapshots__/integration.test.ts.snap
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/__snapshots__/integration.test.ts.snap
@@ -50,53 +50,6 @@ NodeList [
 exports[`loads different versions from CDN undefined version: 
       NodeList [
         <script
-          src="https://js.appboycdn.com/web-sdk/3.0/appboy.min.js"
-          type="text/javascript"
-        />,
-        <script>
-          // the emptiness
-        </script>,
-      ]
-     1`] = `
-NodeList [
-  <script
-    src="https://js.appboycdn.com/web-sdk/3.3/appboy.min.js"
-    status="loading"
-    type="text/javascript"
-  />,
-  <script>
-    // the emptiness
-  </script>,
-]
-`;
-
-exports[`loads different versions from CDN undefined version: 
-      NodeList [
-        <script
-          src="https://js.appboycdn.com/web-sdk/3.1/appboy.min.js"
-          status="loaded"
-          type="text/javascript"
-        />,
-        <script>
-          // the emptiness
-        </script>,
-      ]
-     1`] = `
-NodeList [
-  <script
-    src="https://js.appboycdn.com/web-sdk/3.3/appboy.min.js"
-    status="loading"
-    type="text/javascript"
-  />,
-  <script>
-    // the emptiness
-  </script>,
-]
-`;
-
-exports[`loads different versions from CDN undefined version: 
-      NodeList [
-        <script
           src="https://js.appboycdn.com/web-sdk/3.3/appboy.min.js"
           status="loaded"
           type="text/javascript"

--- a/packages/browser-destinations/src/destinations/braze/__tests__/__snapshots__/integration.test.ts.snap
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/__snapshots__/integration.test.ts.snap
@@ -50,6 +50,53 @@ NodeList [
 exports[`loads different versions from CDN undefined version: 
       NodeList [
         <script
+          src="https://js.appboycdn.com/web-sdk/3.0/appboy.min.js"
+          type="text/javascript"
+        />,
+        <script>
+          // the emptiness
+        </script>,
+      ]
+     1`] = `
+NodeList [
+  <script
+    src="https://js.appboycdn.com/web-sdk/3.3/appboy.min.js"
+    status="loading"
+    type="text/javascript"
+  />,
+  <script>
+    // the emptiness
+  </script>,
+]
+`;
+
+exports[`loads different versions from CDN undefined version: 
+      NodeList [
+        <script
+          src="https://js.appboycdn.com/web-sdk/3.1/appboy.min.js"
+          status="loaded"
+          type="text/javascript"
+        />,
+        <script>
+          // the emptiness
+        </script>,
+      ]
+     1`] = `
+NodeList [
+  <script
+    src="https://js.appboycdn.com/web-sdk/3.3/appboy.min.js"
+    status="loading"
+    type="text/javascript"
+  />,
+  <script>
+    // the emptiness
+  </script>,
+]
+`;
+
+exports[`loads different versions from CDN undefined version: 
+      NodeList [
+        <script
           src="https://js.appboycdn.com/web-sdk/3.3/appboy.min.js"
           status="loaded"
           type="text/javascript"

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/__tests__/send-sms.test.ts
@@ -129,7 +129,8 @@ for (const environment of ['stage', 'production']) {
         }),
         settings: {
           ...settings,
-          webhookUrl: 'http://localhost'
+          webhookUrl: 'http://localhost',
+          connectionOverrides: "rp=all&rc=5"
         },
         mapping: {
           userId: { '@path': '$.userId' },

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/__tests__/send-sms.test.ts
@@ -118,7 +118,7 @@ for (const environment of ['stage', 'production']) {
         Body: 'Hello world, jane!',
         From: '+1234567890',
         To: '+1234567891',
-        StatusCallback: 'http://localhost/?foo=bar'
+        StatusCallback: 'http://localhost/?foo=bar#rp=all&rc=5'
       })
 
       const actionInputData = {

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/generated-types.ts
@@ -30,7 +30,7 @@ export interface Settings {
    */
   webhookUrl?: string
   /**
-   * Connection overrides are frasgments that will append on webhook url
+   * Connection overrides are configuration supported by twilio webhook services. Must be passed as fragments on the callback url
    */
   connectionOverrides?: string
 }

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/generated-types.ts
@@ -29,4 +29,8 @@ export interface Settings {
    * Webhook URL that will receive all events for the sent message
    */
   webhookUrl?: string
+  /**
+   * Connection overrides are frasgments that will append on webhook url
+   */
+  connectionOverrides?: string
 }

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
@@ -55,7 +55,7 @@ const destination: DestinationDefinition<Settings> = {
       },
       connectionOverrides: {
         label: 'Connection Overrides',
-        description: 'Connection overrides are fragments that will append on webhook url',
+        description: 'Connection overrides are configuration supported by twilio webhook services. Must be passed as fragments on the callback url',
         type: 'string',
         required: false,
         default: "rp=all&rc=5"

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
@@ -52,6 +52,13 @@ const destination: DestinationDefinition<Settings> = {
         type: 'string',
         format: 'uri',
         required: false
+      },
+      connectionOverrides: {
+        label: 'Connection Overrides',
+        description: 'Connection overrides are frasgments that will append on webhook url',
+        type: 'string',
+        required: false,
+        default: "rp=all&rc=5"
       }
     },
     testAuthentication: (request) => {

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
@@ -55,7 +55,7 @@ const destination: DestinationDefinition<Settings> = {
       },
       connectionOverrides: {
         label: 'Connection Overrides',
-        description: 'Connection overrides are frasgments that will append on webhook url',
+        description: 'Connection overrides are fragments that will append on webhook url',
         type: 'string',
         required: false,
         default: "rp=all&rc=5"

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
@@ -1,6 +1,80 @@
-import type { DestinationDefinition } from '@segment/actions-core'
+import type { DestinationDefinition, InputField } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import sendSms from './sendSms'
+
+const getRange = (val: number): { value: number; label: string }[] => {
+  return Array(val)
+    .fill(1)
+    .map((x, y) => ({ value: x + y, label: `${x + y}` }))
+}
+
+const ConnectionOverridesProperties: Record<string, InputField> = {
+  ct: {
+    label: 'Connection timeout',
+    description: 'The timeout in milliseconds Twilio will wait to establish its TCP connection to your webserver',
+    type: 'number',
+    default: 5000,
+    choices: getRange(10000)
+  },
+  rt: {
+    label: 'Read timeout',
+    description:
+      'The amount of time in milliseconds after sending your webhook an HTTP request that Twilio will wait for the initial HTTP response packet',
+    type: 'number',
+    default: 15000,
+    choices: getRange(15000)
+  },
+  tt: {
+    label: 'Total timeout',
+    description: 'The total time allowed for all timeouts including retries',
+    type: 'number',
+    default: 15000,
+    choices: getRange(15000)
+  },
+  rc: {
+    label: 'Retry count',
+    description: 'The number of retry attempts Twilio will make if its connection to your webhook fails',
+    type: 'number',
+    default: 1,
+    choices: getRange(5)
+  },
+  rp: {
+    label: 'Retry policy',
+    description: 'The type of failure to retry on',
+    type: 'string',
+    default: 'ct',
+    choices: ['ct', '4xx', '5xx', 'rt', 'all']
+  },
+  sni: {
+    label: 'SNI',
+    description: 'The type of failure to retry on',
+    type: 'string',
+    default: 'unset',
+    choices: ['y', 'n', 'unser']
+  },
+  e: {
+    label: 'Edge location',
+    description:
+      'The Twilio edge location where webhooks egress. This can be a list and we rotate through the list as retries happen.',
+    type: 'string',
+    default: 'ashburn',
+    choices: [
+      'ashburn',
+      'ashburn-ix',
+      'dublin',
+      'frankfurt',
+      'frankfurt-ix',
+      'sao-paulo',
+      'singapore',
+      'sydney',
+      'tokyo',
+      'umatilla',
+      'london-ix',
+      'san-jose-ix',
+      'singapore-ix'
+    ]
+  }
+}
 
 const destination: DestinationDefinition<Settings> = {
   //The name below is creation name however in partner portal this is Actions Personas Messaging Twilio
@@ -55,10 +129,12 @@ const destination: DestinationDefinition<Settings> = {
       },
       connectionOverrides: {
         label: 'Connection Overrides',
-        description: 'Connection overrides are configuration supported by twilio webhook services. Must be passed as fragments on the callback url',
+        description:
+          'Connection overrides are configuration supported by twilio webhook services. Must be passed as fragments on the callback url',
         type: 'string',
         required: false,
-        default: "rp=all&rc=5"
+        default: 'rp=all&rc=5',
+        properties: ConnectionOverridesProperties
       }
     },
     testAuthentication: (request) => {

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/generated-types.ts
@@ -24,6 +24,10 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
+   * Connection overrides are configuration supported by twilio webhook services. Must be passed as fragments on the callback url
+   */
+  connectionOverrides?: string
+  /**
    * Whether or not the message should actually get sent.
    */
   send?: boolean

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
@@ -136,6 +136,7 @@ const action: ActionDefinition<Settings, Payload> = {
     })
 
     const webhookUrl = settings.webhookUrl
+    const connectionOverrides = settings.connectionOverrides
     const customArgs = payload.customArgs
     if (webhookUrl && customArgs) {
       // Webhook URL parsing has a potential of failing. I think it's better that
@@ -145,7 +146,9 @@ const action: ActionDefinition<Settings, Payload> = {
       for (const key of Object.keys(customArgs)) {
         webhookUrlWithParams.searchParams.append(key, String(customArgs[key]))
       }
-      webhookUrlWithParams.hash = "rp=all&rc=5"
+      if(connectionOverrides) {
+        webhookUrlWithParams.hash = connectionOverrides
+      }
       body.append('StatusCallback', webhookUrlWithParams.toString())
     }
 

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
@@ -62,6 +62,7 @@ interface Profile {
   traits: Record<string, string>
 }
 
+const DEFAULT_CONNECTION_OVERRIDES  = "rp=all&rc=5"
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send SMS',
   description: 'Send SMS using Twilio',
@@ -95,6 +96,12 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Custom Arguments',
       description: 'Additional custom arguments that will be opaquely sent back on webhook events',
       type: 'object',
+      required: false
+    },
+    connectionOverrides: {
+      label: 'Connection Overrides',
+      description: 'Connection overrides are configuration supported by twilio webhook services. Must be passed as fragments on the callback url',
+      type: 'string',
       required: false
     },
     send: {
@@ -146,9 +153,9 @@ const action: ActionDefinition<Settings, Payload> = {
       for (const key of Object.keys(customArgs)) {
         webhookUrlWithParams.searchParams.append(key, String(customArgs[key]))
       }
-      if (connectionOverrides) {
-        webhookUrlWithParams.hash = connectionOverrides
-      }
+
+      webhookUrlWithParams.hash = connectionOverrides || DEFAULT_CONNECTION_OVERRIDES
+
       body.append('StatusCallback', webhookUrlWithParams.toString())
     }
 

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
@@ -146,7 +146,7 @@ const action: ActionDefinition<Settings, Payload> = {
       for (const key of Object.keys(customArgs)) {
         webhookUrlWithParams.searchParams.append(key, String(customArgs[key]))
       }
-      if(connectionOverrides) {
+      if (connectionOverrides) {
         webhookUrlWithParams.hash = connectionOverrides
       }
       body.append('StatusCallback', webhookUrlWithParams.toString())

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
@@ -145,6 +145,7 @@ const action: ActionDefinition<Settings, Payload> = {
       for (const key of Object.keys(customArgs)) {
         webhookUrlWithParams.searchParams.append(key, String(customArgs[key]))
       }
+      webhookUrlWithParams.hash = "rp=all&rc=5"
       body.append('StatusCallback', webhookUrlWithParams.toString())
     }
 


### PR DESCRIPTION
JIRA: https://segment.atlassian.net/browse/GRAMA-169

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Adding connection overrides on Twilio Webhook status callback for Twilio sms service to retry on failed policy.

* Retry policy on 5xx, 4xx, connection timeout, and request timeout
* Max retries 5

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
