### PR TITLE
Increase actions-cli test timeouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
   },
   "jest": {
     "preset": "ts-jest",
-    "testTimeout": 10000,
     "globals": {
       "ts-jest": {
         "isolatedModules": true

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   },
   "jest": {
     "preset": "ts-jest",
+    "testTimeout": 10000,
     "globals": {
       "ts-jest": {
         "isolatedModules": true

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -110,6 +110,11 @@
       "@segment/actions-core": "<rootDir>/../core/src",
       "@segment/ajv-human-errors": "<rootDir>/../ajv-human-errors/src",
       "@segment/destination-subscriptions": "<rootDir>/../destination-subscriptions/src"
-    }
+    },
+    "globals": {
+      "ts-jest": {
+          "isolatedModules": true
+      }
+  }
   }
 }

--- a/packages/cli/src/hooks/init.ts
+++ b/packages/cli/src/hooks/init.ts
@@ -3,7 +3,6 @@ import { dirname } from 'path'
 
 const hook: Hook<'init'> = async function ({ config }) {
   if (process.env.NODE_ENV === 'test') {
-    // console.warn('skipping cli-internal plugin because of tests')
     return
   }
 

--- a/packages/cli/src/hooks/init.ts
+++ b/packages/cli/src/hooks/init.ts
@@ -3,7 +3,7 @@ import { dirname } from 'path'
 
 const hook: Hook<'init'> = async function ({ config }) {
   if (process.env.NODE_ENV === 'test') {
-    console.warn('skipping cli-internal plugin because of tests')
+    // console.warn('skipping cli-internal plugin because of tests')
     return
   }
 


### PR DESCRIPTION
I've noticed that the `actions-cli` tests have been shaky in the main branch due to constant timeouts -- the first test pushes close to the current 5s timeout.

This pull request adds `isolatedModules` to the cli's jest config (see [SOF](https://stackoverflow.com/questions/45087018/jest-simple-tests-are-slow)). It also removes a `console.warn` call which seems to cause some unnecessary and incorrect error logs in the test output.

As a follow up, we should consider moving away from ts-jest.

Example test run which completes in ~4.7s:
![image](https://user-images.githubusercontent.com/11635476/142260875-1bd598f0-bb14-4189-8850-649c1ec13eef.png)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
