### PR TITLE
Add event source parameter to FS browser-destination

### DIFF
--- a/packages/browser-destinations/src/destinations/fullstory/__tests__/fullstory.test.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/__tests__/fullstory.test.ts
@@ -103,7 +103,7 @@ describe('#track', () => {
 
     expect(fs).toHaveBeenCalledWith('hello!', {
       banana: '📞'
-    })
+    }, 'segment-browser-actions')
   })
 })
 
@@ -130,7 +130,7 @@ describe('#identify', () => {
 
     expect(fs).toHaveBeenCalled()
     expect(fsId).not.toHaveBeenCalled()
-    expect(fs).toHaveBeenCalledWith({ segmentAnonymousId_str: 'anon', testProp: false })
+    expect(fs).toHaveBeenCalledWith({ segmentAnonymousId_str: 'anon', testProp: false }, 'segment-browser-actions')
   }),
     it('should send an id', async () => {
       const [_, identifyUser] = await fullstory({
@@ -141,7 +141,7 @@ describe('#identify', () => {
       const fsId = jest.spyOn(window.FS, 'identify')
 
       await identifyUser.identify?.(new Context({ type: 'identify', userId: 'id' }))
-      expect(fsId).toHaveBeenCalledWith('id', {})
+      expect(fsId).toHaveBeenCalledWith('id', {}, 'segment-browser-actions')
     }),
     it('should camelCase custom traits', async () => {
       const [_, identifyUser] = await fullstory({
@@ -162,7 +162,7 @@ describe('#identify', () => {
           }
         })
       )
-      expect(fsId).toHaveBeenCalledWith('id', { notCameled: false, firstName: 'John', lastName: 'Doe' })
+      expect(fsId).toHaveBeenCalledWith('id', { notCameled: false, firstName: 'John', lastName: 'Doe' }, 'segment-browser-actions')
     })
 
   it('can set user vars', async () => {
@@ -190,6 +190,6 @@ describe('#identify', () => {
       email: 'thegoat@world',
       height: '50cm',
       name: 'Hasbulla'
-    })
+    }, 'segment-browser-actions')
   })
 })

--- a/packages/browser-destinations/src/destinations/fullstory/identifyUser/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/identifyUser/index.ts
@@ -3,6 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import type { FS } from '../types'
 import camelCase from 'lodash/camelCase'
+import { segmentEventSource } from '..'
 
 // Change from unknown to the partner SDK types
 const action: BrowserActionDefinition<Settings, FS, Payload> = {
@@ -75,13 +76,13 @@ const action: BrowserActionDefinition<Settings, FS, Payload> = {
     }
 
     if (event.payload.userId) {
-      FS.identify(event.payload.userId, newTraits)
+      FS.identify(event.payload.userId, newTraits, segmentEventSource)
     } else {
       FS.setUserVars({
         ...newTraits,
         ...(event.payload.email !== undefined && { email: event.payload.email }),
         ...(event.payload.displayName !== undefined && { displayName: event.payload.displayName })
-      })
+      }, segmentEventSource)
     }
   }
 }

--- a/packages/browser-destinations/src/destinations/fullstory/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/index.ts
@@ -14,6 +14,8 @@ declare global {
   }
 }
 
+export const segmentEventSource = 'segment-browser-actions'
+
 export const destination: BrowserDestinationDefinition<Settings, FS> = {
   name: 'Fullstory (Actions)',
   slug: 'actions-fullstory',

--- a/packages/browser-destinations/src/destinations/fullstory/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/trackEvent/index.ts
@@ -2,6 +2,7 @@ import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import type { FS } from '../types'
+import { segmentEventSource } from '..'
 
 const action: BrowserActionDefinition<Settings, FS, Payload> = {
   title: 'Track Event',
@@ -29,7 +30,7 @@ const action: BrowserActionDefinition<Settings, FS, Payload> = {
     }
   },
   perform: (FS, event) => {
-    FS.event(event.payload.name, event.payload.properties ?? {})
+    FS.event(event.payload.name, event.payload.properties ?? {}, segmentEventSource)
   }
 }
 

--- a/packages/browser-destinations/src/destinations/fullstory/types.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/types.ts
@@ -2,5 +2,8 @@ import * as FullStory from '@fullstory/browser'
 
 export type FS = typeof FullStory & {
   // setVars is not available on the FS client yet.
-  setVars: (eventName: string, eventProperties: object) => {}
+  setVars: (eventName: string, eventProperties: object, source: string) => {}
+  setUserVars: (eventProperties: object, source: string) => void
+  event: (eventName: string, eventProperties: { [key: string]: unknown }, source: string) => void;
+  identify: (uid: string, customVars: FullStory.UserVars, source: string) => void;
 }

--- a/packages/browser-destinations/src/destinations/fullstory/viewedPage/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/viewedPage/index.ts
@@ -2,6 +2,7 @@ import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import type { FS } from '../types'
+import { segmentEventSource } from '..'
 
 const action: BrowserActionDefinition<Settings, FS, Payload> = {
   title: 'Viewed Page',
@@ -34,9 +35,9 @@ const action: BrowserActionDefinition<Settings, FS, Payload> = {
   },
   perform: (FS, event) => {
     if (event.payload.pageName) {
-      FS.setVars('page', { pageName: event.payload.pageName, ...event.payload.properties })
+      FS.setVars('page', { pageName: event.payload.pageName, ...event.payload.properties }, segmentEventSource)
     } else if (event.payload.properties) {
-      FS.setVars('page', event.payload.properties)
+      FS.setVars('page', event.payload.properties, segmentEventSource)
     }
   }
 }


### PR DESCRIPTION
This pull request modifies the function signatures for`FS.setVars()`, `FS.identify()`, `FS.event()`, `FS.setUserVars()` to include the event source parameter. This parameter is undocumented in the Fullstory API, and allows us to differentiate the classic Segment integration (source parameter 'segment'). The custom event was recording in Fullstory's staging enviornment: `["Custom Event A","{\"summon_str\":\"soup\"}","segment-browser-actions"]`. New functionality was added, but no new unit tests were added. Existing unit tests were modified to include the new parameter.

## Testing

- [x] ~Added~ Updated [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
