### PR TITLE
Add metronome destination

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/generated-types.ts
@@ -2,21 +2,21 @@
 
 export interface Payload {
   /**
-   * The Google Ads conversion label. You can find it in your Google Ads account using the instructions in the article [Google Ads conversions](https://support.google.com/tagmanager/answer/6105160?hl=en)
+   * The Google Ads conversion label. You can find it in your Google Ads account using the instructions in the article [Google Ads conversions](https://support.google.com/tagmanager/answer/6105160?hl=en).
    */
   conversion_label: string
   /**
-   * Email address of the customer who triggered the conversion event.
+   * Email address of the individual who triggered the conversion event.
    */
   email: string
   /**
-   * Order ID of the conversion event. Google requires an Order ID even if the event is not an ecommerce event.
+   * Order ID or Transaction ID of the conversion event. Google requires an Order ID even if the event is not an ecommerce event. Learn more in the article [Use a transaction ID to minimize duplicate conversions](https://support.google.com/google-ads/answer/6386790?hl=en&ref_topic=3165803).
    */
   transaction_id: string
   /**
-   * User Agent of the customer who triggered the conversion event.
+   * User agent of the individual who triggered the conversion event. This should match the user agent of the request that sent the original conversion so the conversion and its enhancement are either both attributed as same-device or both attributed as cross-device. This field is optional but recommended.
    */
-  user_agent: string
+  user_agent?: string
   /**
    * Timestamp of the conversion event.
    */
@@ -26,11 +26,11 @@ export interface Payload {
    */
   value?: number
   /**
-   * Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.
+   * Currency of the purchase or items associated with the conversion event, in 3-letter ISO 4217 format.
    */
   currency_code?: string
   /**
-   * Phone number of the purchaser, in E.164 standard format, e.g. +14150000000
+   * Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000.
    */
   phone_number?: string
   /**
@@ -54,7 +54,7 @@ export interface Payload {
    */
   region?: string
   /**
-   * Post code of the individual who triggered the conversion event.
+   * Postal code of the individual who triggered the conversion event.
    */
   post_code?: string
   /**

--- a/packages/destination-actions/src/destinations/metronome/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/metronome/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for metronome destination: sendEvent action - all fields 1`] = `
+Array [
+  Object {
+    "customer_id": "nnKH5XHEoWN717R8",
+    "event_type": "nnKH5XHEoWN717R8",
+    "properties": Object {
+      "testType": "nnKH5XHEoWN717R8",
+    },
+    "timestamp": "2021-02-01T00:00:00.000Z",
+    "transaction_id": "nnKH5XHEoWN717R8",
+  },
+]
+`;
+
+exports[`Testing snapshot for metronome destination: sendEvent action - required fields 1`] = `
+Array [
+  Object {
+    "customer_id": "nnKH5XHEoWN717R8",
+    "event_type": "nnKH5XHEoWN717R8",
+    "properties": Object {
+      "testType": "nnKH5XHEoWN717R8",
+    },
+    "timestamp": "2021-02-01T00:00:00.000Z",
+    "transaction_id": "nnKH5XHEoWN717R8",
+  },
+]
+`;

--- a/packages/destination-actions/src/destinations/metronome/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/metronome/__tests__/index.test.ts
@@ -1,0 +1,35 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+
+import type { Settings } from '../generated-types'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Metronome', () => {
+  describe('testAuthentication', () => {
+    it('should validate valid auth tokens', async () => {
+      nock('https://api.getmetronome.com').post('/v1/ingest').reply(400, {
+        message: "[array is too short: must have at least 1 elements but instance has 0 elements]"
+      });
+
+      const authData: Settings = {
+        apiToken: "mock-token"
+      }
+
+      await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
+    })
+
+    it('should throw an error for invalid auth tokens', async () => {
+      nock('https://api.getmetronome.com').post('/v1/ingest').reply(403, {
+        "message": "Unauthorized"
+      });
+
+      const authData: Settings = {
+        apiToken: "mock-token"
+      }
+
+      await expect(testDestination.testAuthentication(authData)).rejects.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/metronome/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/metronome/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'metronome'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/metronome/generated-types.ts
+++ b/packages/destination-actions/src/destinations/metronome/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your Metronome API Token
+   */
+  apiToken: string
+}

--- a/packages/destination-actions/src/destinations/metronome/index.ts
+++ b/packages/destination-actions/src/destinations/metronome/index.ts
@@ -6,6 +6,7 @@ import sendEvent from './sendEvent'
 const destination: DestinationDefinition<Settings> = {
   name: 'Metronome',
   mode: 'cloud',
+  slug: 'metronome-actions',
 
   authentication: {
     scheme: 'custom',

--- a/packages/destination-actions/src/destinations/metronome/index.ts
+++ b/packages/destination-actions/src/destinations/metronome/index.ts
@@ -1,0 +1,52 @@
+import { defaultValues, DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import sendEvent from './sendEvent'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Metronome',
+  slug: 'metronome',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      apiToken: {
+        type: 'string',
+        label: 'API Token',
+        description: 'Your Metronome API Token',
+        required: true
+      }
+    },
+    testAuthentication: async (request) => {
+      const response = await request('https://api.getmetronome.com/v1/ingest', {
+        method: 'post',
+        body: JSON.stringify([]),
+        throwHttpErrors: false
+      })
+      // An empty set of events will return a 400 response whereas a bad token will return a 403.
+      if (response.status === 400) {
+        return true
+      }
+      throw new Error('Invalid API Token')
+    }
+  },
+  extendRequest: ({ settings }) => {
+    return {
+      headers: { Authorization: `Bearer ${settings.apiToken}` }
+    }
+  },
+  actions: {
+    sendEvent
+  },
+  presets: [
+    {
+      name: 'Send track events to Metronome',
+      subscribe: 'type = "track"',
+      partnerAction: 'sendEvent',
+      mapping: defaultValues(sendEvent.fields)
+    },
+  ]
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/metronome/index.ts
+++ b/packages/destination-actions/src/destinations/metronome/index.ts
@@ -5,7 +5,6 @@ import sendEvent from './sendEvent'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Metronome',
-  slug: 'metronome',
   mode: 'cloud',
 
   authentication: {

--- a/packages/destination-actions/src/destinations/metronome/sendEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/metronome/sendEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Metronome's sendEvent destination action: all fields 1`] = `
+Array [
+  Object {
+    "customer_id": "RJt2@i$vhb)WXT",
+    "event_type": "RJt2@i$vhb)WXT",
+    "properties": Object {
+      "testType": "RJt2@i$vhb)WXT",
+    },
+    "timestamp": "2021-02-01T00:00:00.000Z",
+    "transaction_id": "RJt2@i$vhb)WXT",
+  },
+]
+`;
+
+exports[`Testing snapshot for Metronome's sendEvent destination action: required fields 1`] = `
+Array [
+  Object {
+    "customer_id": "RJt2@i$vhb)WXT",
+    "event_type": "RJt2@i$vhb)WXT",
+    "properties": Object {
+      "testType": "RJt2@i$vhb)WXT",
+    },
+    "timestamp": "2021-02-01T00:00:00.000Z",
+    "transaction_id": "RJt2@i$vhb)WXT",
+  },
+]
+`;

--- a/packages/destination-actions/src/destinations/metronome/sendEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/metronome/sendEvent/__tests__/index.test.ts
@@ -1,0 +1,150 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Metronome.sendEvent', () => {
+  describe("process", () => {
+    it('should send an event', async () => {
+      const event = createTestEvent();
+
+      nock('https://api.getmetronome.com').post('/v1/ingest').reply(200)
+
+      const responses = await testDestination.testAction('sendEvent', {
+        event,
+        useDefaultMappings: true,
+        settings: {
+          apiToken: "mock-api-token",
+        },
+        mapping: {
+          event_type: { '@path': "$.event" },
+          properties: { '@path': "$.context" },
+        },
+      });
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+
+      // TODO: Feels like there should be a lighter weight to do this check
+      expect(responses[0].options.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "authorization": Array [
+              "Bearer mock-api-token",
+            ],
+            "user-agent": Array [
+              "Segment (Actions)",
+            ],
+          },
+        }
+      `)
+
+      expect(responses[0].options.json).toEqual([
+        {
+          event_type: event.event,
+          customer_id: event?.context?.groupId ?? event.userId ?? event.anonymousId,
+          properties: event.context,
+          transaction_id: event.messageId,
+          timestamp: new Date(event.timestamp ?? "").toISOString(),
+        }
+      ])
+    })
+
+
+    it('should convert a non rfc3999 timestamp', async () => {
+      const event = createTestEvent({
+        timestamp: "2021-01-01"
+      });
+
+      nock('https://api.getmetronome.com').post('/v1/ingest').reply(200)
+
+      const responses = await testDestination.testAction('sendEvent', {
+        event,
+        useDefaultMappings: true,
+        settings: {
+          apiToken: "mock-api-token",
+        },
+        mapping: {
+          event_type: { '@path': "$.event" },
+          properties: { '@path': "$.context" },
+        },
+      });
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+
+      // TODO: Feels like there should be a lighter weight to do this check
+      expect(responses[0].options.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "authorization": Array [
+              "Bearer mock-api-token",
+            ],
+            "user-agent": Array [
+              "Segment (Actions)",
+            ],
+          },
+        }
+      `)
+      expect(responses[0].options.json).toEqual([
+        {
+          event_type: event.event,
+          customer_id: event?.context?.groupId ?? event.userId ?? event.anonymousId,
+          properties: event.context,
+          transaction_id: event.messageId,
+          timestamp: "2021-01-01T00:00:00.000Z",
+        }
+      ])
+    })
+
+    it('should convert an epoch timestamp', async () => {
+      const event = createTestEvent({
+        properties: {
+          epoch_timestamp: 1625895431000 // 2021-07-10 05:37:11
+        }
+      });
+
+      nock('https://api.getmetronome.com').post('/v1/ingest').reply(200)
+
+      const responses = await testDestination.testAction('sendEvent', {
+        event,
+        useDefaultMappings: true,
+        settings: {
+          apiToken: "mock-api-token",
+        },
+        mapping: {
+          event_type: { '@path': "$.event" },
+          properties: { '@path': "$.context" },
+          timestamp: { '@path': "$.properties.epoch_timestamp" },
+        },
+      });
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+
+      // TODO: Feels like there should be a lighter weight to do this check
+      expect(responses[0].options.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "authorization": Array [
+              "Bearer mock-api-token",
+            ],
+            "user-agent": Array [
+              "Segment (Actions)",
+            ],
+          },
+        }
+      `)
+      expect(responses[0].options.json).toEqual([
+        {
+          event_type: event.event,
+          customer_id: event?.context?.groupId ?? event.userId ?? event.anonymousId,
+          properties: event.context,
+          transaction_id: event.messageId,
+          timestamp: "2021-07-10T05:37:11.000Z",
+        }
+      ])
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/metronome/sendEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/metronome/sendEvent/__tests__/index.test.ts
@@ -35,7 +35,6 @@ describe('Metronome.sendEvent', () => {
       // when in practice it is an instance of Headers. Until this is fixed,
       // we'll use a snapshot to check the headers. Ideally this check could just be
       // `expect(responses[0].options.headers.get("authorization")).toBe("Bearer mock-api-token")`
-      console.log(responses[0].options.headers instanceof Headers)
       expect(responses[0].options.headers).toMatchInlineSnapshot(`
         Headers {
           Symbol(map): Object {

--- a/packages/destination-actions/src/destinations/metronome/sendEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/metronome/sendEvent/__tests__/index.test.ts
@@ -7,7 +7,11 @@ const testDestination = createTestIntegration(Destination)
 describe('Metronome.sendEvent', () => {
   describe("process", () => {
     it('should send an event', async () => {
-      const event = createTestEvent();
+      const event = createTestEvent({
+        context: {
+          groupId: "mock-group-id", // have to provide a groupId since this function doesn't create one by default
+        }
+      });
 
       nock('https://api.getmetronome.com')
         .matchHeader('content-type', 'application/json')
@@ -28,7 +32,10 @@ describe('Metronome.sendEvent', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
 
-      // TODO: Feels like there should be a lighter weight to do this check
+      // Segment manually the `options.headers` property incorrectly as Record<string, string>, when in 
+      // practice it is an instance of Headers. Until this is fixed, we'll use a snapshot to check the headers...
+      // ideally this check could just be
+      // `expect(responses[0].options.headers.get("authorization")).toBe("Bearer mock-api-token")`
       expect(responses[0].options.headers).toMatchInlineSnapshot(`
         Headers {
           Symbol(map): Object {
@@ -45,7 +52,7 @@ describe('Metronome.sendEvent', () => {
       expect(responses[0].options.json).toEqual([
         {
           event_type: event.event,
-          customer_id: event?.context?.groupId ?? event.userId ?? event.anonymousId,
+          customer_id: event?.context?.groupId,
           properties: event.context,
           transaction_id: event.messageId,
           timestamp: new Date(event.timestamp ?? "").toISOString(),
@@ -56,7 +63,10 @@ describe('Metronome.sendEvent', () => {
 
     it('should convert a non rfc3999 timestamp', async () => {
       const event = createTestEvent({
-        timestamp: "2021-01-01"
+        timestamp: "2021-01-01",
+        context: {
+          groupId: "mock-group-id", // have to provide a groupId since this function doesn't create one by default
+        }
       });
 
       nock('https://api.getmetronome.com')
@@ -78,7 +88,10 @@ describe('Metronome.sendEvent', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
 
-      // TODO: Feels like there should be a lighter weight to do this check
+      // Segment manually the `options.headers` property incorrectly as Record<string, string>, when in 
+      // practice it is an instance of Headers. Until this is fixed, we'll use a snapshot to check the headers...
+      // ideally this check could just be
+      // `expect(responses[0].options.headers.get("authorization")).toBe("Bearer mock-api-token")`
       expect(responses[0].options.headers).toMatchInlineSnapshot(`
         Headers {
           Symbol(map): Object {
@@ -94,7 +107,7 @@ describe('Metronome.sendEvent', () => {
       expect(responses[0].options.json).toEqual([
         {
           event_type: event.event,
-          customer_id: event?.context?.groupId ?? event.userId ?? event.anonymousId,
+          customer_id: event?.context?.groupId,
           properties: event.context,
           transaction_id: event.messageId,
           timestamp: "2021-01-01T00:00:00.000Z",
@@ -105,7 +118,10 @@ describe('Metronome.sendEvent', () => {
     it('should convert an epoch timestamp', async () => {
       const event = createTestEvent({
         properties: {
-          epoch_timestamp: 1625895431000 // 2021-07-10 05:37:11
+          epoch_timestamp: 1625895431000, // 2021-07-10 05:37:11
+        },
+        context: {
+          groupId: "mock-group-id", // have to provide a groupId since this function doesn't create one by default
         }
       });
 
@@ -129,8 +145,11 @@ describe('Metronome.sendEvent', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
 
-      // TODO: Feels like there should be a lighter weight to do this check
-      expect(responses[0].options.headers).toMatchInlineSnapshot(`
+      // Segment manually the `options.headers` property incorrectly as Record<string, string>, when in 
+      // practice it is an instance of Headers. Until this is fixed, we'll use a snapshot to check the headers...
+      // ideally this check could just be
+      // `expect(responses[0].options.headers.get("authorization")).toBe("Bearer mock-api-token")`
+      expect((responses[0].options.headers)).toMatchInlineSnapshot(`
         Headers {
           Symbol(map): Object {
             "authorization": Array [
@@ -145,7 +164,7 @@ describe('Metronome.sendEvent', () => {
       expect(responses[0].options.json).toEqual([
         {
           event_type: event.event,
-          customer_id: event?.context?.groupId ?? event.userId ?? event.anonymousId,
+          customer_id: event?.context?.groupId,
           properties: event.context,
           transaction_id: event.messageId,
           timestamp: "2021-07-10T05:37:11.000Z",

--- a/packages/destination-actions/src/destinations/metronome/sendEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/metronome/sendEvent/__tests__/index.test.ts
@@ -1,7 +1,6 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
-
 const testDestination = createTestIntegration(Destination)
 
 describe('Metronome.sendEvent', () => {
@@ -32,10 +31,11 @@ describe('Metronome.sendEvent', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
 
-      // Segment manually the `options.headers` property incorrectly as Record<string, string>, when in 
-      // practice it is an instance of Headers. Until this is fixed, we'll use a snapshot to check the headers...
-      // ideally this check could just be
+      // The `options.headers` property is incorrectly typed as Record<string, string>,
+      // when in practice it is an instance of Headers. Until this is fixed,
+      // we'll use a snapshot to check the headers. Ideally this check could just be
       // `expect(responses[0].options.headers.get("authorization")).toBe("Bearer mock-api-token")`
+      console.log(responses[0].options.headers instanceof Headers)
       expect(responses[0].options.headers).toMatchInlineSnapshot(`
         Headers {
           Symbol(map): Object {
@@ -88,9 +88,9 @@ describe('Metronome.sendEvent', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
 
-      // Segment manually the `options.headers` property incorrectly as Record<string, string>, when in 
-      // practice it is an instance of Headers. Until this is fixed, we'll use a snapshot to check the headers...
-      // ideally this check could just be
+      // The `options.headers` property is incorrectly typed as Record<string, string>,
+      // when in practice it is an instance of Headers. Until this is fixed,
+      // we'll use a snapshot to check the headers. Ideally this check could just be
       // `expect(responses[0].options.headers.get("authorization")).toBe("Bearer mock-api-token")`
       expect(responses[0].options.headers).toMatchInlineSnapshot(`
         Headers {
@@ -145,9 +145,9 @@ describe('Metronome.sendEvent', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
 
-      // Segment manually the `options.headers` property incorrectly as Record<string, string>, when in 
-      // practice it is an instance of Headers. Until this is fixed, we'll use a snapshot to check the headers...
-      // ideally this check could just be
+      // The `options.headers` property is incorrectly typed as Record<string, string>,
+      // when in practice it is an instance of Headers. Until this is fixed,
+      // we'll use a snapshot to check the headers. Ideally this check could just be
       // `expect(responses[0].options.headers.get("authorization")).toBe("Bearer mock-api-token")`
       expect((responses[0].options.headers)).toMatchInlineSnapshot(`
         Headers {

--- a/packages/destination-actions/src/destinations/metronome/sendEvent/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/metronome/sendEvent/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'sendEvent'
+const destinationSlug = 'Metronome'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/metronome/sendEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/metronome/sendEvent/generated-types.ts
@@ -1,0 +1,26 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The Metronome transaction ID uniquely identifies an event to ensure Metronome only processes each event once.
+   */
+  transaction_id: string
+  /**
+   * The Metronome customer ID or ingest alias this event should be associated with.
+   */
+  customer_id: string
+  /**
+   * The timestamp at which this event occurred.
+   */
+  timestamp: string | number
+  /**
+   * The Metronome event_type.
+   */
+  event_type: string
+  /**
+   * The Metronome properties object.
+   */
+  properties: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/metronome/sendEvent/index.ts
+++ b/packages/destination-actions/src/destinations/metronome/sendEvent/index.ts
@@ -39,18 +39,7 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'The Metronome customer ID or ingest alias this event should be associated with.',
       required: true,
       default: {
-        // By default, use the group ID if it exists, otherwise use the user ID. If neither exist, use the anonymous ID.
-        '@if': {
-          exists: { '@path': '$.context.groupId' },
-          then: { '@path': '$.context.groupId' },
-          else: {
-            '@if': {
-              exists: { '@path': '$.userId' },
-              then: { '@path': '$.userId' },
-              else: { '@path': '$.anonymousId' }
-            }
-          }
-        }
+        '@path': '$.context.groupId'
       }
     },
     timestamp: {

--- a/packages/destination-actions/src/destinations/metronome/sendEvent/index.ts
+++ b/packages/destination-actions/src/destinations/metronome/sendEvent/index.ts
@@ -65,7 +65,7 @@ const action: ActionDefinition<Settings, Payload> = {
     event_type: {
       type: 'string',
       label: 'event_type',
-      description: 'The Metronome event_type.',
+      description: 'The Metronome `event_type`.',
       required: true,
     },
     properties: {

--- a/packages/destination-actions/src/destinations/metronome/sendEvent/index.ts
+++ b/packages/destination-actions/src/destinations/metronome/sendEvent/index.ts
@@ -67,6 +67,9 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'event_type',
       description: 'The Metronome `event_type`.',
       required: true,
+      default: {
+        '@path': '$.event'
+      }
     },
     properties: {
       type: 'object',

--- a/packages/destination-actions/src/destinations/metronome/sendEvent/index.ts
+++ b/packages/destination-actions/src/destinations/metronome/sendEvent/index.ts
@@ -76,6 +76,9 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'properties',
       description: 'The Metronome properties object.',
       required: true,
+      default: {
+        '@path': '$.properties'
+      }
     },
   },
   perform: (request, { payload }) => {

--- a/packages/destination-actions/src/destinations/metronome/sendEvent/index.ts
+++ b/packages/destination-actions/src/destinations/metronome/sendEvent/index.ts
@@ -1,0 +1,95 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import dayjs from '../../../lib/dayjs'
+
+function serializeEvent(event: Payload) {
+  return {
+    ...event,
+    // convert the timestamp into rfc3999 format. We use dayjs because Segmemt promises
+    //   "By using the datetime type, you can be sure that that timestamp value passed
+    //    to your perform method will be a valid datetime value that will be parsable by dayjs.
+    // We use dayjs.utc mostly to help ensure consistent test cases. "dayjs("2021-01-01").toISOString()"
+    // will otherwise use the local time offset, which leads to inconsistent tests. It's not required
+    // for the Metronome API, in fact just doing new Date(event.timestamp).toISOString() should work just
+    // fine here.
+    //
+    // Ideally Segment would just pass any date-time values as Date objects not have this loose
+    // coupling to dayjs parse formats but, this is fine for now.
+    timestamp: dayjs.utc(event.timestamp).toISOString(),
+  }
+}
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Send Event',
+  description: 'Send an event to Metronome',
+  fields: {
+    transaction_id: {
+      type: 'string',
+      label: 'transaction_id',
+      description: 'The Metronome transaction ID uniquely identifies an event to ensure Metronome only processes each event once.',
+      required: true,
+      default: {
+        '@path': '$.messageId'
+      }
+    },
+    customer_id: {
+      type: 'string',
+      label: 'customer_id',
+      description: 'The Metronome customer ID or ingest alias this event should be associated with.',
+      required: true,
+      default: {
+        // By default, use the group ID if it exists, otherwise use the user ID. If neither exist, use the anonymous ID.
+        '@if': {
+          exists: { '@path': '$.context.groupId' },
+          then: { '@path': '$.context.groupId' },
+          else: {
+            '@if': {
+              exists: { '@path': '$.userId' },
+              then: { '@path': '$.userId' },
+              else: { '@path': '$.anonymousId' }
+            }
+          }
+        }
+      }
+    },
+    timestamp: {
+      type: 'datetime',
+      label: 'timestamp',
+      description: 'The timestamp at which this event occurred.',
+      required: true,
+      default: {
+        '@path': '$.timestamp'
+      }
+    },
+    event_type: {
+      type: 'string',
+      label: 'event_type',
+      description: 'The Metronome event_type.',
+      required: true,
+    },
+    properties: {
+      type: 'object',
+      label: 'properties',
+      description: 'The Metronome properties object.',
+      required: true,
+    },
+  },
+  perform: (request, { payload }) => {
+    // Auth is injected by extendRequest in the destination root
+    return request('https://api.getmetronome.com/v1/ingest', {
+      method: 'post',
+      json: [
+        serializeEvent(payload)
+      ]
+    })
+  },
+  // We'd like to be able to use performBatch, but we run into complexity when 1 event in the batch
+  // fails validation, causing the entire batch to fail. We've decided to just send 1 event at a time
+  // for now, which allows normal 4XX and 5XX semantics to be used and bubble errors up into the Segment
+  // UI. We can revisit this as needed.
+  //
+  // performBatch: (request, { payload }) => {},
+}
+
+export default action


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

This PR adds [Metronome](https://getmetronome.com) as a destination using the new `action-destinations` framework. For context - Metronome is a billing platform that allows companies to transform their product's raw event stream (such as `api_request.serviced` and `data.uploaded` events) into bills for their customers. This context may be useful when reviewing some of our defaults (for example, we default to `$.context.groupId` instead of `$.userId`, since our customers are usually billing organizations not end users).

Documentation for how to send events to Metronome is located [here](https://docs.getmetronome.com/getting-usage-data-into-metronome/overview), and the api endpoint specific documentation for our ingest endpoint can be found [here](https://docs.getmetronome.com/api#operation/ingest).

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

Biggest thing is - I have no idea how this is going to look or be used in the Segment UI, so I'm kinda crossing my fingers that this will cause a reasonable UX. Once it's deployed we'll try to run through it with our Segment account so we can take screenshots for our documentation. Once we do that we may make another PR with anything we want to change? Not sure if there's a better way to do that?

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
