### PR TITLE
default group key

### DIFF
--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Payload {
   /**
-   * The group key
+   * The group key. If this is not set, it is defaulted to "name".
    */
-  group_key: string
+  group_key?: string
   /**
-   * Properties to set on the group profile
+   * Properties to set on the group profile. Make sure to have a field that corresponds to the above group key.
    */
   traits?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
@@ -10,15 +10,14 @@ const action: ActionDefinition<Settings, Payload> = {
     group_key: {
       label: 'Group Key',
       type: 'string',
-      description: 'The group key',
-      required: true,
-      default: 'company'
+      description: 'The group key. If this is not set, it is defaulted to "name".',
+      default: 'name'
     },
     traits: {
       label: 'Group Properties',
       type: 'object',
-      description: 'Properties to set on the group profile',
-      required: true,
+      description:
+        'Properties to set on the group profile. Make sure to have a field that corresponds to the above group key.',
       default: {
         '@path': '$.traits'
       }

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
@@ -11,7 +11,8 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Group Key',
       type: 'string',
       description: 'The group key',
-      required: true
+      required: true,
+      default: 'company'
     },
     traits: {
       label: 'Group Properties',

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
@@ -11,6 +11,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Group Key',
       type: 'string',
       description: 'The group key. If this is not set, it is defaulted to "name".',
+      required: true,
       default: 'name'
     },
     traits: {

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
@@ -1,4 +1,4 @@
-import type { ActionDefinition } from '@segment/actions-core'
+import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
@@ -18,6 +18,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Group Properties',
       type: 'object',
       description: 'Properties to set on the group profile',
+      required: true,
       default: {
         '@path': '$.traits'
       }
@@ -25,10 +26,10 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: (request, { payload, settings }) => {
     if (!payload.traits) {
-      throw new Error('No group traits were passed')
+      throw new IntegrationError('"traits" is a required field', 'Missing required fields')
     }
     if (!payload.traits[payload.group_key]) {
-      throw new Error('Group traits does not include proper group key')
+      throw new IntegrationError('Group traits does not include proper group key', 'Misconfigured required field')
     }
     const data = {
       $token: settings.projectToken,

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
@@ -11,7 +11,6 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Group Key',
       type: 'string',
       description: 'The group key. If this is not set, it is defaulted to "name".',
-      required: true,
       default: 'name'
     },
     traits: {

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
@@ -24,16 +24,17 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: (request, { payload, settings }) => {
+    const group_key = payload.group_key || 'name'
     if (!payload.traits) {
       throw new IntegrationError('"traits" is a required field', 'Missing required fields')
     }
-    if (!payload.traits[payload.group_key]) {
+    if (!payload.traits[group_key]) {
       throw new IntegrationError('Group traits does not include proper group key', 'Misconfigured required field')
     }
     const data = {
       $token: settings.projectToken,
-      $group_key: payload.group_key,
-      $group_id: payload.traits[payload.group_key],
+      $group_key: group_key,
+      $group_id: payload.traits[group_key],
       $set: payload.traits
     }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Per https://mixpanel.slack.com/archives/C02D9DFHFC2/p1637281794002300?thread_ts=1637275909.001900&cid=C02D9DFHFC2, invalid presets for quick setup actions have been changed to throw an error now. So a solution was to provide a default value, which is now `company`.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
