### PR TITLE
Coerce values to an array when the field is an array

### DIFF
--- a/packages/core/src/__tests__/schema-validation.test.ts
+++ b/packages/core/src/__tests__/schema-validation.test.ts
@@ -39,6 +39,26 @@ const schema = fieldsToJsonSchema({
       }
     }
   },
+  array: {
+    label: 'array',
+    type: 'string',
+    description: 'array',
+    multiple: true
+  },
+  object: {
+    label: 'object',
+    type: 'object',
+    description: 'object',
+    multiple: true,
+    properties: {
+      key: {
+        type: 'string',
+        label: 'key',
+        description: 'key',
+        required: true
+      }
+    }
+  }
 })
 
 describe('validateSchema', () => {
@@ -107,6 +127,58 @@ describe('validateSchema', () => {
         "a": "1234",
         "e": true,
         "f": 123,
+      }
+    `)
+  })
+
+  it('should coerce non-arrays into arrays', () => {
+    const payload = {
+      array: 'value'
+    }
+
+    validateSchema(payload, schema, { schemaKey: `testSchema` })
+    expect(payload).toMatchInlineSnapshot(`
+      Object {
+        "array": Array [
+          "value",
+        ],
+      }
+    `)
+  })
+
+  it('should coerce non-arrays of objects into arrays of objects', () => {
+    const payload = {
+      object: {
+        key: 'Value'
+      }
+    }
+
+    validateSchema(payload, schema, { schemaKey: `testSchema` })
+    expect(payload).toMatchInlineSnapshot(`
+      Object {
+        "object": Array [
+          Object {
+            "key": "Value",
+          },
+        ],
+      }
+    `)
+  })
+
+  it('should validate coerced arrays', () => {
+    const payload = {
+      object: {
+        another_key: 'value2'
+      }
+    }
+
+    const validated = validateSchema(payload, schema, { schemaKey: `testSchema`, throwIfInvalid: false })
+    expect(validated).toBe(false)
+    expect(payload).toMatchInlineSnapshot(`
+      Object {
+        "object": Array [
+          Object {},
+        ],
       }
     `)
   })

--- a/packages/core/src/arrify.ts
+++ b/packages/core/src/arrify.ts
@@ -1,7 +1,32 @@
-import { isArray } from './real-type-of'
+import type { JSONSchema4 } from 'json-schema'
+import { isArray, isObject } from './real-type-of'
 
-export function arrify<T>(value: T | T[] | undefined): T[] {
-  if (value === undefined || value === null) return []
+export function arrify<T>(value: T | T[] | undefined | null, treatNullAsEmpty?: true): T[]
+export function arrify<T>(value: T | T[] | undefined | null, treatNullAsEmpty: false): T[] | undefined | null
+export function arrify<T>(value: T | T[] | undefined | null, treatNullAsEmpty = true): T[] | undefined | null {
+  if (value === undefined || value === null) return treatNullAsEmpty ? [] : (value as undefined | null)
   if (isArray(value)) return value
   return [value]
+}
+
+// Coerces non-arrays into arrays based on the jsonschema.
+// Mutates the original object
+export function arrifyFields(obj: unknown, schema: JSONSchema4 = {}): unknown {
+  if (!isObject(obj)) {
+    return obj
+  }
+
+  if (!schema.properties) return obj
+
+  for (const key of Object.keys(obj)) {
+    const fieldSchema = schema.properties[key]
+    if (!fieldSchema) continue
+    if (Array.isArray(fieldSchema.type)) continue
+
+    if (fieldSchema.type === 'array') {
+      obj[key] = arrify(obj[key], false)
+    }
+  }
+
+  return obj
 }

--- a/packages/core/src/arrify.ts
+++ b/packages/core/src/arrify.ts
@@ -21,7 +21,6 @@ export function arrifyFields(obj: unknown, schema: JSONSchema4 = {}): unknown {
   for (const key of Object.keys(obj)) {
     const fieldSchema = schema.properties[key]
     if (!fieldSchema) continue
-    if (Array.isArray(fieldSchema.type)) continue
 
     if (fieldSchema.type === 'array') {
       obj[key] = arrify(obj[key], false)

--- a/packages/core/src/schema-validation.ts
+++ b/packages/core/src/schema-validation.ts
@@ -3,12 +3,13 @@ import Ajv, { ValidateFunction } from 'ajv'
 import addFormats from 'ajv-formats'
 import dayjs from 'dayjs'
 import type { JSONSchema4 } from 'json-schema'
+import { arrifyFields } from './arrify'
 
 // `addFormats` includes many standard formats we use like `uri`, `date`, `email`, etc.
 const ajv = addFormats(
   new Ajv({
     // Coerce types to be a bit more liberal.
-    coerceTypes: true,
+    coerceTypes: 'array',
     // Return all validation errors, not just the first.
     allErrors: true,
     // Allow multiple non-null types in `type` keyword.
@@ -57,6 +58,8 @@ export function validateSchema(obj: unknown, schema: JSONSchema4, options?: Vali
     validate = ajv.compile(schema)
   }
 
+  // Ajv's `coerceTypes: 'array'` only works on scalars, so we need to manually arrify ourselves!
+  arrifyFields(obj, schema)
   const isValid = validate(obj)
 
   if (throwIfInvalid && !isValid && validate.errors) {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This change coerces single values to arrays of that single value when a builder has specified: `multiple: true` in the field properties.

Ex:
```    
externalId: {
      label: 'External ID',
      type: 'string',
     multiple: true
    },
```
Input: 
```
{
  externalId: 'abc123'
}
```
Output:
```
{
 externalId: ['abc123']
}
```

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
