### PR TITLE
Update Metronome name

### DIFF
--- a/packages/destination-actions/src/destinations/metronome/index.ts
+++ b/packages/destination-actions/src/destinations/metronome/index.ts
@@ -4,7 +4,7 @@ import type { Settings } from './generated-types'
 import sendEvent from './sendEvent'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Metronome',
+  name: 'Metronome (Actions)',
   mode: 'cloud',
   slug: 'metronome-actions',
 
@@ -45,7 +45,7 @@ const destination: DestinationDefinition<Settings> = {
       subscribe: 'type = "track"',
       partnerAction: 'sendEvent',
       mapping: defaultValues(sendEvent.fields)
-    },
+    }
   ]
 }
 

--- a/packages/destination-actions/src/destinations/metronome/sendEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/metronome/sendEvent/generated-types.ts
@@ -14,7 +14,7 @@ export interface Payload {
    */
   timestamp: string | number
   /**
-   * The Metronome event_type.
+   * The Metronome `event_type`.
    */
   event_type: string
   /**


### PR DESCRIPTION
This pull request updates the name of the Metronome destination. `Metronome` is already taken so the actions one must be different.

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
