### PR TITLE
permit singular object roots for arrayPath

### DIFF
--- a/packages/core/src/mapping-kit/README.md
+++ b/packages/core/src/mapping-kit/README.md
@@ -448,7 +448,11 @@ Mappings:
 
 ### @arrayPath
 
-The @arrayPath directive resolves an array value at a given path (much like @path), but allows you to specify the shape of each item in the resulting array. You can use directives for each key in the given shape, relative to the root array.
+The @arrayPath directive resolves a value at a given path (much like @path), but allows you to specify the shape of each item in the resulting array. You can use directives for each key in the given shape, relative to the root object. 
+
+Typically, the root object is expected to be an array, which will be iterated to produce the resulting array from the specified item shape. It is not required that the root object be an array. 
+
+For the item shape to be respected, the root object must be either an array of plain objects OR a singular plain object. If the root object is a singular plain object, it will be arrified into an array of 1.
 
 Input:
 ```json

--- a/packages/core/src/mapping-kit/__tests__/index.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.test.ts
@@ -225,7 +225,32 @@ describe('@arrayPath', () => {
 
     const output = transform(mapping, { products: { notAnArray: true } })
     expect(output).toStrictEqual({
-      neat: { notAnArray: true }
+      neat: [{}]
+    })
+  })
+
+  test('singular objects', () => {
+    const mapping = {
+      neat: {
+        '@arrayPath': [
+          '$.properties',
+          {
+            product_id: { '@path': '$.productId' },
+            monies: { '@path': '$.price' }
+          }
+        ]
+      }
+    }
+
+    const output = transform(mapping, {
+      properties: {
+        productId: '123',
+        price: 0.5
+      }
+    })
+
+    expect(output).toStrictEqual({
+      neat: [{ product_id: '123', monies: 0.5 }]
     })
   })
 })

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -5,6 +5,7 @@ import { render } from './placeholders'
 import { realTypeOf, isObject, isArray } from '../real-type-of'
 import { removeUndefined } from '../remove-undefined'
 import validate from './validate'
+import { arrify } from '../arrify'
 
 type Directive = (options: JSONValue, payload: JSONObject) => JSONLike
 type StringDirective = (value: string, payload: JSONObject) => JSONLike
@@ -77,8 +78,12 @@ registerDirective('@arrayPath', (data, payload) => {
   const root = typeof path === 'string' ? (get(payload, path.replace('$.', '')) as JSONLike) : resolve(path, payload)
 
   // If a shape has been provided, resolve each item in the array with this shape
-  if (isArray(root) && realTypeOf(itemShape) === 'object' && Object.keys(itemShape as JSONObject).length > 0) {
-    return root.map((item) => resolve(itemShape, item as JSONObject))
+  if (
+    ['object', 'array'].includes(realTypeOf(root)) &&
+    realTypeOf(itemShape) === 'object' &&
+    Object.keys(itemShape as JSONObject).length > 0
+  ) {
+    return arrify(root).map((item) => resolve(itemShape, item as JSONObject))
   }
 
   return root
@@ -168,4 +173,3 @@ export function transformBatch(mapping: JSONLikeObject, data: Array<InputData> |
   // Cast because we know there are no `undefined` values after `removeUndefined`
   return removeUndefined(resolved) as JSONObject[]
 }
-


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This will allow arrayPath's root object to be a singular object as well, which supports some new integrations.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
