### PR TITLE
[Customer.io] Use created_at trait over property

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/createUpdatePerson/generated-types.ts
+++ b/packages/destination-actions/src/destinations/customerio/createUpdatePerson/generated-types.ts
@@ -14,7 +14,7 @@ export interface Payload {
    */
   email?: string
   /**
-   * A timestamp of when the person was created. Default is the created_at trait.
+   * A timestamp of when the person was created.
    */
   created_at?: string
   /**

--- a/packages/destination-actions/src/destinations/customerio/createUpdatePerson/generated-types.ts
+++ b/packages/destination-actions/src/destinations/customerio/createUpdatePerson/generated-types.ts
@@ -14,7 +14,7 @@ export interface Payload {
    */
   email?: string
   /**
-   * A timestamp of when the person was created. Default is current date and time.
+   * A timestamp of when the person was created. Default is the created_at trait.
    */
   created_at?: string
   /**

--- a/packages/destination-actions/src/destinations/customerio/createUpdatePerson/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/createUpdatePerson/index.ts
@@ -38,10 +38,10 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     created_at: {
       label: 'Created At',
-      description: 'A timestamp of when the person was created. Default is current date and time.',
+      description: 'A timestamp of when the person was created. Default is the created_at trait.',
       type: 'string',
       default: {
-        '@path': '$.timestamp'
+        '@template': '{{traits.created_at}}'
       }
     },
     custom_attributes: {
@@ -63,19 +63,23 @@ const action: ActionDefinition<Settings, Payload> = {
 
   perform: (request, { settings, payload }) => {
     let createdAt: string | number | undefined = payload.created_at
+    const body: Record<string, unknown> = {
+      ...payload.custom_attributes,
+      email: payload.email,
+      anonymous_id: payload.anonymous_id
+    }
 
     if (createdAt && payload.convert_timestamp !== false) {
       createdAt = dayjs.utc(createdAt).unix()
     }
 
+    if (createdAt) {
+      body.created_at = createdAt
+    }
+
     return request(`${trackApiEndpoint(settings.accountRegion)}/api/v1/customers/${payload.id}`, {
       method: 'put',
-      json: {
-        ...payload.custom_attributes,
-        email: payload.email,
-        created_at: createdAt,
-        anonymous_id: payload.anonymous_id
-      }
+      json: body
     })
   }
 }

--- a/packages/destination-actions/src/destinations/customerio/createUpdatePerson/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/createUpdatePerson/index.ts
@@ -38,7 +38,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     created_at: {
       label: 'Created At',
-      description: 'A timestamp of when the person was created. Default is the created_at trait.',
+      description: 'A timestamp of when the person was created.',
       type: 'string',
       default: {
         '@template': '{{traits.created_at}}'


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

We've gotten a few support tickets in at Customer.io with customers confused as to why `created_at` is constantly being updated, even though it's the same person being identified. The problem is that the `created_at` property seems to be the creation time of the event, not of the identified user.

This changes the `createUpdatePerson` action to use `traits.created_at`, which is set by the user. If the request goes out without a `created_at`, customer.io uses the current date and time if it's a new person. Otherwise, it's ignored.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
