### PR TITLE
Cordial POC

### DIFF
--- a/packages/destination-actions/src/destinations/cordial/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/cordial/__tests__/index.test.ts
@@ -1,0 +1,31 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Cordial', () => {
+  describe('testAuthentication', () => {
+    it('should authenticate with Cordial API key', async () => {
+      nock('https://integrations.cordial.io/segment').post('').reply(400, { message: 'Incompatible type'})
+
+      const settings = {
+        apiKey: 'cordialApiKey',
+        endpoint: 'https://integrations.cordial.io/segment'
+      }
+
+      await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()
+    })
+
+    it('should throw error on invalid Cordial API key', async () => {
+      nock('https://integrations.cordial.io/segment').post('').reply(401, { error: 'Access Denied: Authentication Failure'})
+
+      const settings = {
+        apiKey: 'cordialApiKey',
+        endpoint: 'https://integrations.cordial.io/segment'
+      }
+
+      await expect(testDestination.testAuthentication(settings)).rejects.toThrowError('Credentials are invalid: 401 {"error":"Access Denied: Authentication Failure"}')
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/cordial/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/cordial/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-cordial'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/cordial/generated-types.ts
+++ b/packages/destination-actions/src/destinations/cordial/generated-types.ts
@@ -1,0 +1,12 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your Cordial API Key
+   */
+  apiKey: string
+  /**
+   * Cordial Segment integration endpoint. Leave default, unless you've been provided with another one
+   */
+  endpoint: string
+}

--- a/packages/destination-actions/src/destinations/cordial/group/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/cordial/group/__tests__/index.test.ts
@@ -1,0 +1,26 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Cordial.group', () => {
+  it('should work with default mappings', async () => {
+    nock('https://integrations.cordial.io/segment').post('/group').reply(200, {});
+
+    const event = createTestEvent({ type: 'group' });
+    const settings = {
+      apiKey: 'cordialApiKey',
+      endpoint: 'https://integrations.cordial.io/segment' as const
+    }
+
+    const responses = await testDestination.testAction('group', {
+      event,
+      settings,
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+  })
+})

--- a/packages/destination-actions/src/destinations/cordial/group/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/cordial/group/__tests__/index.test.ts
@@ -9,6 +9,7 @@ describe('Cordial.group', () => {
     nock('https://integrations.cordial.io/segment').post('/group').reply(200, {});
 
     const event = createTestEvent({ type: 'group' });
+    event.groupId = 'test group';
     const settings = {
       apiKey: 'cordialApiKey',
       endpoint: 'https://integrations.cordial.io/segment' as const

--- a/packages/destination-actions/src/destinations/cordial/group/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/cordial/group/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'group'
+const destinationSlug = 'Cordial'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/cordial/group/generated-types.ts
+++ b/packages/destination-actions/src/destinations/cordial/group/generated-types.ts
@@ -1,0 +1,22 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Segment User ID
+   */
+  user_id: string
+  /**
+   * Segment Anonymous ID
+   */
+  anonymous_id?: string
+  /**
+   * Segment Group ID
+   */
+  group_id: string
+  /**
+   * Segment contact attributes
+   */
+  traits?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/cordial/group/index.ts
+++ b/packages/destination-actions/src/destinations/cordial/group/index.ts
@@ -43,11 +43,11 @@ const action: ActionDefinition<Settings, Payload> = {
     },
   },
   perform: (request, { settings, payload }) => {
-    const groupEndpoint = `${settings.endpoint}/group`
+    const groupEndpoint = `${settings.endpoint}/group`;
     return request(groupEndpoint, {
       method: 'post',
       json: payload
-    })
+    });
   }
 }
 

--- a/packages/destination-actions/src/destinations/cordial/group/index.ts
+++ b/packages/destination-actions/src/destinations/cordial/group/index.ts
@@ -1,0 +1,54 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Group',
+  description: 'Assign Cordial contact to a list',
+  defaultSubscription: 'type = "group"',
+  fields: {
+    user_id: {
+      label: 'Segment ID',
+      description: 'Segment User ID',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    anonymous_id: {
+      label: 'Anonymous ID',
+      description: 'Segment Anonymous ID',
+      type: 'string',
+      default: {
+        '@path': '$.anonymousId'
+      }
+    },
+    group_id: {
+      label: 'Group ID',
+      description: 'Segment Group ID',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.groupId'
+      }
+    },
+    traits: {
+      label: 'Segment traits',
+      description: 'Segment contact attributes',
+      type: 'object',
+      default: {
+        '@path': '$.traits'
+      }
+    },
+  },
+  perform: (request, { settings, payload }) => {
+    const groupEndpoint = `${settings.endpoint}/group`
+    return request(groupEndpoint, {
+      method: 'post',
+      json: payload
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/cordial/identify/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/cordial/identify/__tests__/index.test.ts
@@ -1,0 +1,26 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('ActionsCordial.identify', () => {
+  it('should work with default mappings', async () => {
+    nock('https://integrations.cordial.io/segment').post('/identify').reply(200, {});
+
+    const event = createTestEvent({ type: 'identify' });
+    const settings = {
+      apiKey: 'cordialApiKey',
+      endpoint: 'https://integrations.cordial.io/segment' as const
+    }
+
+    const responses = await testDestination.testAction('identify', {
+      event,
+      settings,
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+  })
+})

--- a/packages/destination-actions/src/destinations/cordial/identify/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/cordial/identify/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'identifyUser'
+const destinationSlug = 'ActionsCordial'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/cordial/identify/generated-types.ts
+++ b/packages/destination-actions/src/destinations/cordial/identify/generated-types.ts
@@ -1,0 +1,18 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Segment User ID
+   */
+  user_id: string
+  /**
+   * Segment Anonymous ID
+   */
+  anonymous_id?: string
+  /**
+   * Segment contact attributes
+   */
+  traits: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/cordial/identify/index.ts
+++ b/packages/destination-actions/src/destinations/cordial/identify/index.ts
@@ -1,0 +1,46 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Identify',
+  description: 'Upsert contact to Cordial',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    user_id: {
+      label: 'Segment ID',
+      description: 'Segment User ID',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    anonymous_id: {
+      label: 'Anonymous ID',
+      description: 'Segment Anonymous ID',
+      type: 'string',
+      default: {
+        '@path': '$.anonymousId'
+      }
+    },
+    traits: {
+      label: 'Segment traits',
+      description: 'Segment contact attributes',
+      type: 'object',
+      required: true,
+      default: {
+        '@path': '$.traits'
+      }
+    },
+  },
+  perform: (request, { settings, payload }) => {
+    const identifyEndpoint = `${settings.endpoint}/identify`
+    return request(identifyEndpoint, {
+      method: 'post',
+      json: payload
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/cordial/identify/index.ts
+++ b/packages/destination-actions/src/destinations/cordial/identify/index.ts
@@ -35,11 +35,11 @@ const action: ActionDefinition<Settings, Payload> = {
     },
   },
   perform: (request, { settings, payload }) => {
-    const identifyEndpoint = `${settings.endpoint}/identify`
+    const identifyEndpoint = `${settings.endpoint}/identify`;
     return request(identifyEndpoint, {
       method: 'post',
       json: payload
-    })
+    });
   }
 }
 

--- a/packages/destination-actions/src/destinations/cordial/index.ts
+++ b/packages/destination-actions/src/destinations/cordial/index.ts
@@ -1,0 +1,64 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import identify from './identify'
+
+import group from './group'
+
+import track from './track'
+
+import page from './page'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Cordial',
+  description: 'Sync Segment Users, Groups and Events to Cordial',
+  slug: 'actions-cordial',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'basic',
+    fields: {
+      apiKey: {
+        label: 'API Key',
+        description: 'Your Cordial API Key',
+        type: 'string',
+        required: true
+      },
+      endpoint: {
+        label: 'Endpoint',
+        description:
+          "Cordial Segment integration endpoint. Leave default, unless you've been provided with another one",
+        type: 'string',
+        required: true,
+        default: 'https://integrations.cordial.io/segment'
+      }
+    },
+    testAuthentication: (request, { settings }) => {
+      return request(settings.endpoint, {
+        username: settings.apiKey,
+        method: 'post',
+        throwHttpErrors: false
+      }).then((response) => {
+        return response?.status === 400 && response?.content === '{"message":"Incompatible type"}'
+          ? true
+          : Promise.reject({
+              message: response?.content ?? 'unknown error',
+              response: { status: response?.status ?? 'unknown status' }
+            })
+      })
+    }
+  },
+
+  extendRequest({ settings }) {
+    return { username: settings.apiKey }
+  },
+
+  actions: {
+    identify,
+    group,
+    track,
+    page
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/cordial/index.ts
+++ b/packages/destination-actions/src/destinations/cordial/index.ts
@@ -2,11 +2,8 @@ import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
 import identify from './identify'
-
 import group from './group'
-
 import track from './track'
-
 import page from './page'
 
 const destination: DestinationDefinition<Settings> = {
@@ -45,7 +42,7 @@ const destination: DestinationDefinition<Settings> = {
               message: response?.content ?? 'unknown error',
               response: { status: response?.status ?? 'unknown status' }
             })
-      })
+      });
     }
   },
 

--- a/packages/destination-actions/src/destinations/cordial/page/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/cordial/page/__tests__/index.test.ts
@@ -1,0 +1,26 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Cordial.page', () => {
+  it('should work with default mappings', async () => {
+    nock('https://integrations.cordial.io/segment').post('/page').reply(200, {});
+
+    const event = createTestEvent({ type: 'page' });
+    const settings = {
+      apiKey: 'cordialApiKey',
+      endpoint: 'https://integrations.cordial.io/segment' as const
+    }
+
+    const responses = await testDestination.testAction('page', {
+      event,
+      settings,
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+  })
+})

--- a/packages/destination-actions/src/destinations/cordial/page/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/cordial/page/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'page'
+const destinationSlug = 'Cordial'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/cordial/page/generated-types.ts
+++ b/packages/destination-actions/src/destinations/cordial/page/generated-types.ts
@@ -10,9 +10,13 @@ export interface Payload {
    */
   anonymous_id?: string
   /**
-   * Segment event name
+   * Segment page name
    */
-  event: string
+  name?: string
+  /**
+   * Segment event channel
+   */
+  channel?: string
   /**
    * Segment event sentAt
    */

--- a/packages/destination-actions/src/destinations/cordial/page/generated-types.ts
+++ b/packages/destination-actions/src/destinations/cordial/page/generated-types.ts
@@ -1,0 +1,32 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Segment User ID
+   */
+  user_id: string
+  /**
+   * Segment Anonymous ID
+   */
+  anonymous_id?: string
+  /**
+   * Segment event name
+   */
+  event: string
+  /**
+   * Segment event sentAt
+   */
+  sentAt?: string | number
+  /**
+   * Segment event context
+   */
+  context?: {
+    [k: string]: unknown
+  }
+  /**
+   * Segment event properties
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/cordial/page/index.ts
+++ b/packages/destination-actions/src/destinations/cordial/page/index.ts
@@ -1,0 +1,69 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Page',
+  description: 'Create Cordial PageView',
+  fields: {
+    user_id: {
+      label: 'Segment ID',
+      description: 'Segment User ID',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    anonymous_id: {
+      label: 'Anonymous ID',
+      description: 'Segment Anonymous ID',
+      type: 'string',
+      default: {
+        '@path': '$.anonymousId'
+      }
+    },
+    event: {
+      label: 'Event name',
+      description: 'Segment event name',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.event'
+      }
+    },
+    sentAt: {
+      label: 'Event sentAt',
+      description: 'Segment event sentAt',
+      type: 'datetime',
+      default: {
+        '@path': '$.sentAt'
+      }
+    },
+    context: {
+      label: 'Event context',
+      description: 'Segment event context',
+      type: 'object',
+      default: {
+        '@path': '$.context'
+      }
+    },
+    properties: {
+      label: 'Event properties',
+      description: 'Segment event properties',
+      type: 'object',
+      default: {
+        '@path': '$.properties'
+      }
+    },
+  },
+  perform: (request, { settings, payload }) => {
+    const pageEndpoint = `${settings.endpoint}/page`
+    return request(pageEndpoint, {
+      method: 'post',
+      json: payload
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/cordial/page/index.ts
+++ b/packages/destination-actions/src/destinations/cordial/page/index.ts
@@ -5,6 +5,7 @@ import type { Payload } from './generated-types'
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Page',
   description: 'Create Cordial PageView',
+  defaultSubscription: 'type = "page"',
   fields: {
     user_id: {
       label: 'Segment ID',
@@ -23,13 +24,20 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.anonymousId'
       }
     },
-    event: {
-      label: 'Event name',
-      description: 'Segment event name',
+    name: {
+      label: 'Page name',
+      description: 'Segment page name',
       type: 'string',
-      required: true,
       default: {
-        '@path': '$.event'
+        '@path': '$.name'
+      }
+    },
+    channel: {
+      label: 'Event channel',
+      description: 'Segment event channel',
+      type: 'string',
+      default: {
+        '@path': '$.channel'
       }
     },
     sentAt: {
@@ -58,11 +66,11 @@ const action: ActionDefinition<Settings, Payload> = {
     },
   },
   perform: (request, { settings, payload }) => {
-    const pageEndpoint = `${settings.endpoint}/page`
+    const pageEndpoint = `${settings.endpoint}/page`;
     return request(pageEndpoint, {
       method: 'post',
       json: payload
-    })
+    });
   }
 }
 

--- a/packages/destination-actions/src/destinations/cordial/track/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/cordial/track/__tests__/index.test.ts
@@ -1,0 +1,26 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Cordial.track', () => {
+  it('should work with default mappings', async () => {
+    nock('https://integrations.cordial.io/segment').post('/track').reply(200, {});
+
+    const event = createTestEvent({ type: 'track' });
+    const settings = {
+      apiKey: 'cordialApiKey',
+      endpoint: 'https://integrations.cordial.io/segment' as const
+    }
+
+    const responses = await testDestination.testAction('track', {
+      event,
+      settings,
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+  })
+})

--- a/packages/destination-actions/src/destinations/cordial/track/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/cordial/track/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'track'
+const destinationSlug = 'Cordial'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/cordial/track/generated-types.ts
+++ b/packages/destination-actions/src/destinations/cordial/track/generated-types.ts
@@ -1,0 +1,32 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Segment User ID
+   */
+  user_id: string
+  /**
+   * Segment Anonymous ID
+   */
+  anonymous_id?: string
+  /**
+   * Segment event name
+   */
+  event: string
+  /**
+   * Segment event sentAt
+   */
+  sentAt?: string | number
+  /**
+   * Segment event context
+   */
+  context?: {
+    [k: string]: unknown
+  }
+  /**
+   * Segment event properties
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/cordial/track/index.ts
+++ b/packages/destination-actions/src/destinations/cordial/track/index.ts
@@ -1,0 +1,69 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Track',
+  description: 'Create Cordial ContactActivity',
+  fields: {
+    user_id: {
+      label: 'Segment ID',
+      description: 'Segment User ID',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    anonymous_id: {
+      label: 'Anonymous ID',
+      description: 'Segment Anonymous ID',
+      type: 'string',
+      default: {
+        '@path': '$.anonymousId'
+      }
+    },
+    event: {
+      label: 'Event name',
+      description: 'Segment event name',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.event'
+      }
+    },
+    sentAt: {
+      label: 'Event sentAt',
+      description: 'Segment event sentAt',
+      type: 'datetime',
+      default: {
+        '@path': '$.sentAt'
+      }
+    },
+    context: {
+      label: 'Event context',
+      description: 'Segment event context',
+      type: 'object',
+      default: {
+        '@path': '$.context'
+      }
+    },
+    properties: {
+      label: 'Event properties',
+      description: 'Segment event properties',
+      type: 'object',
+      default: {
+        '@path': '$.properties'
+      }
+    },
+  },
+  perform: (request, { settings, payload }) => {
+    const trackEndpoint = `${settings.endpoint}/track`
+    return request(trackEndpoint, {
+      method: 'post',
+      json: payload
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/cordial/track/index.ts
+++ b/packages/destination-actions/src/destinations/cordial/track/index.ts
@@ -5,6 +5,7 @@ import type { Payload } from './generated-types'
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track',
   description: 'Create Cordial ContactActivity',
+  defaultSubscription: 'type = "track"',
   fields: {
     user_id: {
       label: 'Segment ID',
@@ -58,11 +59,11 @@ const action: ActionDefinition<Settings, Payload> = {
     },
   },
   perform: (request, { settings, payload }) => {
-    const trackEndpoint = `${settings.endpoint}/track`
+    const trackEndpoint = `${settings.endpoint}/track`;
     return request(trackEndpoint, {
       method: 'post',
       json: payload
-    })
+    });
   }
 }
 


### PR DESCRIPTION
POC of switching current implementation of Segment Integration in Cordial to Segment Destination Actions

However, I'm unable to generate snapshots with `yarn jest --testPathPattern='./packages/destination-actions/src/destinations/cordial' --updateSnapshot`, it throws errors like:
![image](https://user-images.githubusercontent.com/740658/144065642-56be4cfc-1740-45d3-9d9d-08a25e439c9c.png)

Please suggest what I'm doing wrong.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
