### PR TITLE
Friendbuy browser destination (#250)

### DIFF
--- a/packages/browser-destinations/src/destinations/friendbuy/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/__tests__/index.test.ts
@@ -1,0 +1,38 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import friendbuyDestination, { destination } from '../index'
+import nock from 'nock'
+
+const subscriptions = [
+  {
+    partnerAction: 'trackCustomer',
+    name: 'Track Customer',
+    enabled: true,
+    subscribe: 'type = "identify"',
+    mapping: {}
+  }
+]
+
+describe('Friendbuy', () => {
+  const merchantId = '0ebece2e-b04c-4504-97f2-16cd9f423612'
+
+  test('loading', async () => {
+    jest.spyOn(destination, 'initialize')
+
+    nock('https://static.fbot.me').get('/friendbuy.js').reply(200, {})
+    nock('https://campaign.fbot.me')
+      .get(/^\/[^/]*\/campaigns.js$/)
+      .reply(200, {})
+
+    const [event] = await friendbuyDestination({
+      merchantId,
+      subscriptions
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+    expect(destination.initialize).toHaveBeenCalled()
+
+    const expectedFriendbuyAPI = [['merchant', merchantId]] as any
+    expectedFriendbuyAPI.merchantId = merchantId
+    expect(window.friendbuyAPI).toEqual(expectedFriendbuyAPI)
+  })
+})

--- a/packages/browser-destinations/src/destinations/friendbuy/__tests__/util.test.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/__tests__/util.test.ts
@@ -1,0 +1,120 @@
+import { createFriendbuyPayload, filterFriendbuyAttributes, isEmpty, parseDate } from '../util'
+
+describe('isEmpty', () => {
+  test('isEmpty', () => {
+    expect(isEmpty({})).toBe(true)
+    expect(isEmpty([])).toBe(true)
+    expect(isEmpty(null)).toBe(false)
+    expect(isEmpty(0)).toBe(false)
+    expect(isEmpty('')).toBe(false)
+    expect(isEmpty({ a: 'apple' })).toBe(false)
+    expect(isEmpty(false)).toBe(false)
+    expect(isEmpty(undefined)).toBe(false)
+  })
+})
+
+describe('createFriendbuyPayload', () => {
+  test('simple', () => {
+    expect(
+      createFriendbuyPayload([
+        ['string', 'hello'],
+        ['number', 42],
+        ['boolean', true],
+        ['object1', {}],
+        ['object2', { a: 'apple' }],
+        ['array1', []],
+        ['array2', [1, 2, 3]]
+      ])
+    ).toEqual({
+      string: 'hello',
+      number: 42,
+      boolean: true,
+      object1: {},
+      object2: { a: 'apple' },
+      array1: [],
+      array2: [1, 2, 3]
+    })
+  })
+
+  test('dropEmpty', () => {
+    expect(
+      createFriendbuyPayload(
+        [
+          ['string', 'hello'],
+          ['number', 42],
+          ['boolean', true],
+          ['object1', {}],
+          ['object2', { a: 'apple' }],
+          ['array1', []],
+          ['array2', [1, 2, 3]]
+        ],
+        { dropEmpty: true }
+      )
+    ).toEqual({
+      string: 'hello',
+      number: 42,
+      boolean: true,
+      object2: { a: 'apple' },
+      array2: [1, 2, 3]
+    })
+  })
+})
+
+describe('filterFriendbuyAttributes', () => {
+  test('simple', () => {
+    expect(
+      filterFriendbuyAttributes({
+        attribute1: 'string1',
+        attribute2: 42,
+        attribute3: 'string2',
+        attribute4: { type: 'object' },
+        attribute5: true
+      })
+    ).toEqual([
+      ['attribute1', 'string1'],
+      ['attribute3', 'string2']
+    ])
+  })
+
+  test('birthday', () => {
+    expect(
+      filterFriendbuyAttributes({
+        birthday: '2000-01-02'
+      })
+    ).toEqual([['birthday', { year: 2000, month: 1, day: 2 }]])
+  })
+})
+
+describe('parseDate', () => {
+  test('YYYY-MM-DD', () => {
+    expect(parseDate('2000-01-02')).toEqual({ year: 2000, month: 1, day: 2 })
+    expect(parseDate('0000-01-02')).toEqual({ month: 1, day: 2 }) // Year "0000" is ignored.
+    expect(parseDate('2001-02-03T00:00:00.000Z')).toEqual({ year: 2001, month: 2, day: 3 }) // Time part is ignored.
+  })
+  test('MM-DD', () => {
+    expect(parseDate('03-10')).toEqual({ month: 3, day: 10 })
+    expect(parseDate('99-98')).toEqual({ month: 99, day: 98 })
+    expect(parseDate('02-03 23:59:59')).toEqual({ month: 2, day: 3 }) // Time part is ignored.
+    expect(parseDate('9-10')).toBe(undefined) // Not enough digits in day.
+    expect(parseDate('10-9')).toBe(undefined) // Not enough digits in month.
+    expect(parseDate('99-100')).toBe(undefined) // Too many digits in day.
+    expect(parseDate('100-99')).toBe(undefined) // Too many digits in month.
+  })
+})
+
+describe('parseDate', () => {
+  test('YYYY-MM-DD', () => {
+    expect(parseDate('2000-01-02')).toEqual({ year: 2000, month: 1, day: 2 })
+    expect(parseDate('0000-01-02')).toEqual({ month: 1, day: 2 }) // Year "0000" is ignored.
+    expect(parseDate('2001-02-03T00:00:00.000Z')).toEqual({ year: 2001, month: 2, day: 3 }) // Time part is ignored.
+  })
+  test('MM-DD', () => {
+    expect(parseDate('03-10')).toEqual({ month: 3, day: 10 })
+    expect(parseDate('99-98')).toEqual({ month: 99, day: 98 })
+    expect(parseDate('02-03 23:59:59')).toEqual({ month: 2, day: 3 }) // Time part is ignored.
+    expect(parseDate('9-10')).toBe(undefined) // Not enough digits in day.
+    expect(parseDate('10-9')).toBe(undefined) // Not enough digits in month.
+    expect(parseDate('99-100')).toBe(undefined) // Too many digits in day.
+    expect(parseDate('100-99')).toBe(undefined) // Too many digits in month.
+  })
+})

--- a/packages/browser-destinations/src/destinations/friendbuy/commonFields.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/commonFields.ts
@@ -1,0 +1,131 @@
+import type { InputField } from '@segment/actions-core'
+import type { FriendbuyPayloadItem } from './util'
+
+import { getName } from './util'
+
+export function commonCustomerFields(requireIdAndEmail: boolean): Record<string, InputField> {
+  // If we want to associate an event such as a purchase with an existing
+  // customer then the customerId is required.  If we want to create a new
+  // customer from the event if one doesn't already exist then additionally an
+  // email address is required.
+  return {
+    customerId: {
+      label: 'Customer ID',
+      description: "The user's customer ID.",
+      type: 'string',
+      required: requireIdAndEmail,
+      default: {
+        // We hope that we have a userId because analytics.identify has been
+        // called but, if not, allow a customerId to be specified in the
+        // event.  If one is specified, it overrides the one from the identify
+        // call.
+        '@if': {
+          exists: { '@path': '$.properties.customerId' },
+          then: { '@path': '$.properties.customerId' },
+          else: { '@path': '$.userId' }
+        }
+      }
+    },
+    anonymousId: {
+      label: 'Anonymous ID',
+      description: "The user's anonymous ID.",
+      type: 'string',
+      required: false,
+      default: { '@path': '$.anonymousId' }
+    },
+    email: {
+      label: 'Email',
+      description: "The user's email address.",
+      type: 'string',
+      required: requireIdAndEmail,
+      default: { '@path': '$.properties.email' }
+    },
+    firstName: {
+      label: 'First Name',
+      description: "The user's given name.",
+      type: 'string',
+      required: false,
+      default: { '@path': '$.properties.first_name' }
+    },
+    lastName: {
+      label: 'Last Name',
+      description: "The user's surname.",
+      type: 'string',
+      required: false,
+      default: { '@path': '$.properties.last_name' }
+    },
+    name: {
+      label: 'Name',
+      description: "The user's full name.",
+      type: 'string',
+      required: false,
+      default: { '@path': '$.properties.name' }
+    },
+    age: {
+      label: 'Age',
+      description: "The user's age.",
+      type: 'number',
+      required: false,
+      default: { '@path': '$.properties.age' }
+    },
+    loyaltyStatus: {
+      label: 'Loyalty Program Status',
+      description: 'The status of the user in your loyalty program. Valid values are "in", "out", or "blocked".',
+      type: 'string',
+      required: false,
+      default: { '@path': '$.properties.loyaltyStatus' }
+    }
+  }
+}
+
+export interface CommonCustomerPayload {
+  customerId?: string
+  anonymousId?: string
+  email?: string
+  firstName?: string
+  lastName?: string
+  name?: string
+  age?: number
+  loyaltyStatus?: string
+}
+
+/**
+ * Extracts the customer fields from a payload and returns a tuple whose first
+ * element is the payload without the customer fields, and second element is
+ * the customer attributes.
+ */
+export function commonCustomerAttributes<T extends CommonCustomerPayload>(
+  payload: T
+): [Omit<T, keyof CommonCustomerPayload>, FriendbuyPayloadItem[]] {
+  const payloadWithoutCustomer = { ...payload }
+  const customerAttributes: FriendbuyPayloadItem[] = []
+
+  const copyField = (from: keyof CommonCustomerPayload, to?: string) => {
+    if (from in payloadWithoutCustomer) {
+      if (payloadWithoutCustomer[from] !== undefined) {
+        customerAttributes.push([to || from, payloadWithoutCustomer[from]])
+      }
+      delete payloadWithoutCustomer[from]
+    }
+  }
+
+  const name = getName(payload)
+
+  copyField('customerId', 'id')
+  copyField('email')
+  copyField('firstName')
+  copyField('lastName')
+  if (name) {
+    customerAttributes.push(['name', name])
+  }
+  copyField('age')
+  copyField('loyaltyStatus')
+  // custom properties
+  copyField('anonymousId')
+
+  return [
+    payloadWithoutCustomer,
+    // Don't send any customer data unless we have at least a customer ID.
+    typeof payload.customerId !== 'string' || payload.customerId === '' ? [] : customerAttributes
+  ]
+}

--- a/packages/browser-destinations/src/destinations/friendbuy/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Find your Friendbuy Merchant ID by logging in to your [Friendbuy account](https://retailer.friendbuy.io/) and going to Developer Center > Friendbuy Code.
+   */
+  merchantId: string
+}

--- a/packages/browser-destinations/src/destinations/friendbuy/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/index.ts
@@ -1,0 +1,90 @@
+import type { BrowserDestinationDefinition } from '../../lib/browser-destinations'
+import type { DestinationDefinition } from '@segment/actions-core'
+import { browserDestination } from '../../runtime/shim'
+import { defaultValues } from '@segment/actions-core'
+
+import type { Settings } from './generated-types'
+import type { FriendbuyAPI } from './types'
+import trackCustomer, { trackCustomerDefaultSubscription, trackCustomerFields } from './trackCustomer'
+import trackPurchase, { trackPurchaseDefaultSubscription, trackPurchaseFields } from './trackPurchase'
+import trackSignUp, { trackSignUpDefaultSubscription, trackSignUpFields } from './trackSignUp'
+import trackPage, { trackPageDefaultSubscription, trackPageFields } from './trackPage'
+import trackCustomEvent from './trackCustomEvent'
+
+declare global {
+  interface Window {
+    friendbuyAPI?: FriendbuyAPI
+    friendbuyBaseHost?: string
+  }
+}
+
+// Presets are shown in Segment configuration flow as "Pre-Built Subscriptions".
+const presets: DestinationDefinition['presets'] = [
+  {
+    name: 'Track Customer',
+    subscribe: trackCustomerDefaultSubscription,
+    partnerAction: 'trackCustomer',
+    mapping: defaultValues(trackCustomerFields)
+  },
+  {
+    name: 'Track Purchase',
+    subscribe: trackPurchaseDefaultSubscription,
+    partnerAction: 'trackPurchase',
+    mapping: defaultValues(trackPurchaseFields)
+  },
+  {
+    name: 'Track Sign Up',
+    subscribe: trackSignUpDefaultSubscription,
+    partnerAction: 'trackSignUp',
+    mapping: defaultValues(trackSignUpFields)
+  },
+  {
+    name: 'Track Page',
+    subscribe: trackPageDefaultSubscription,
+    partnerAction: 'trackPage',
+    mapping: defaultValues(trackPageFields)
+  }
+]
+
+export const destination: BrowserDestinationDefinition<Settings, FriendbuyAPI> = {
+  name: 'Friendbuy Web Device Mode (Actions)',
+  slug: 'actions-friendbuy-web',
+  mode: 'device',
+
+  settings: {
+    merchantId: {
+      label: 'Friendbuy Merchant ID',
+      description:
+        'Find your Friendbuy Merchant ID by logging in to your [Friendbuy account](https://retailer.friendbuy.io/) and going to Developer Center > Friendbuy Code.',
+      type: 'string',
+      format: 'uuid',
+      required: true
+    }
+  },
+
+  initialize: async ({ settings /* , analytics */ }, dependencies) => {
+    let friendbuyAPI: FriendbuyAPI
+    window.friendbuyAPI = friendbuyAPI = window.friendbuyAPI || ([] as unknown as FriendbuyAPI)
+    const friendbuyBaseHost = window.friendbuyBaseHost ?? 'fbot.me'
+
+    friendbuyAPI.merchantId = settings.merchantId
+    friendbuyAPI.push(['merchant', settings.merchantId])
+
+    // The Friendbuy JavaScript can be loaded asynchronously.
+    void dependencies.loadScript(`https://static.${friendbuyBaseHost}/friendbuy.js`),
+      void dependencies.loadScript(`https://campaign.${friendbuyBaseHost}/${settings.merchantId}/campaigns.js`)
+
+    return friendbuyAPI
+  },
+
+  presets,
+  actions: {
+    trackCustomer,
+    trackPurchase,
+    trackSignUp,
+    trackPage,
+    trackCustomEvent
+  }
+}
+
+export default browserDestination(destination)

--- a/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/__tests__/index.test.ts
@@ -1,0 +1,96 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import friendbuyDestination from '../../index'
+import trackCustomEventObject, { trackCustomEventFields } from '../index'
+
+import { loadScript } from '../../../../runtime/load-script'
+jest.mock('../../../../runtime/load-script')
+beforeEach(async () => {
+  // Prevent friendbuy.js and campaigns.js from being loaded.
+  ;(loadScript as jest.Mock).mockResolvedValue(true)
+})
+
+describe('Friendbuy.trackCustomEvent', () => {
+  const subscriptions = [
+    {
+      partnerAction: 'trackCustomEvent',
+      name: trackCustomEventObject.title,
+      enabled: true,
+      subscribe: 'type = "track" and event = "download"',
+      mapping: Object.fromEntries(Object.entries(trackCustomEventFields).map(([name, value]) => [name, value.default]))
+    }
+  ]
+
+  test('all fields', async () => {
+    const merchantId = '1993d0f1-8206-4336-8c88-64e170f2419e'
+
+    const [trackCustomEvent] = await friendbuyDestination({
+      merchantId,
+      subscriptions
+    })
+    // console.log('trackCustomEvent', JSON.stringify(trackCustomEvent, null, 2), trackCustomEvent)
+    expect(trackCustomEvent).toBeDefined()
+
+    await trackCustomEvent.load(Context.system(), {} as Analytics)
+
+    // console.log(window.friendbuyAPI)
+    jest.spyOn(window.friendbuyAPI as any, 'push')
+
+    {
+      // Non-download events are not sent.
+      const context1 = new Context({
+        type: 'track',
+        event: 'upload',
+        properties: { type: 'application', fileId: 'MyApp', deduplicationId: '1234' }
+      })
+
+      trackCustomEvent.track?.(context1)
+
+      expect(window.friendbuyAPI?.push).not.toHaveBeenCalled()
+    }
+
+    {
+      // Download events are sent.
+      const context2 = new Context({
+        type: 'track',
+        event: 'download',
+        properties: { type: 'application', fileId: 'MyApp', deduplicationId: '1234' }
+      })
+
+      trackCustomEvent.track?.(context2)
+
+      expect(window.friendbuyAPI?.push).toHaveBeenNthCalledWith(1, [
+        'track',
+        'download',
+        { type: 'application', fileId: 'MyApp', deduplicationId: '1234' }
+      ])
+    }
+
+    {
+      // Customer is sent if customer fields are present.
+      const userId = 'john-doe-1234'
+      const anonymousId = '960efa33-6d3b-4eb9-a4e7-d95412d9829e'
+      const email = 'john.doe@example.com'
+      const firstName = 'John'
+      const lastName = 'Doe'
+      const context3 = new Context({
+        type: 'track',
+        event: 'download',
+        userId,
+        anonymousId,
+        properties: { type: 'application', fileId: 'MyApp', email, firstName, lastName }
+      })
+
+      trackCustomEvent.track?.(context3)
+
+      expect(window.friendbuyAPI?.push).toHaveBeenNthCalledWith(2, [
+        'track',
+        'download',
+        {
+          type: 'application',
+          fileId: 'MyApp',
+          customer: { id: userId, anonymousId, email, firstName, lastName, name: `${firstName} ${lastName}` }
+        }
+      ])
+    }
+  })
+})

--- a/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/generated-types.ts
@@ -1,0 +1,26 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The name of the event to track.
+   */
+  eventName: string
+  /**
+   * Hash of other properties for the event being tracked. All of the fields in this object will be sent in the root of the Friendbuy track event.
+   */
+  eventProperties: {
+    [k: string]: unknown
+  }
+  /**
+   * An identifier for the event being tracked to prevent the same event from being rewarded more than once.
+   */
+  deduplicationId?: string
+  /**
+   * The user's customerId.
+   */
+  customerId: string
+  /**
+   * The user's anonymous id
+   */
+  anonymousId?: string
+}

--- a/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/index.ts
@@ -1,0 +1,76 @@
+import type { InputField } from '@segment/actions-core'
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+
+import type { FriendbuyAPI } from '../types'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { commonCustomerAttributes } from '../commonFields'
+import { createFriendbuyPayload, filterFriendbuyAttributes } from '../util'
+
+// https://segment.com/docs/connections/spec/ecommerce/v2/#order-completed
+export const trackCustomEventFields: Record<string, InputField> = {
+  eventName: {
+    type: 'string',
+    required: true,
+    description: 'The name of the event to track.',
+    label: 'Event Name',
+    default: { '@path': '$.event' }
+  },
+  eventProperties: {
+    type: 'object',
+    required: true,
+    description:
+      'Hash of other properties for the event being tracked. All of the fields in this object will be sent in the root of the Friendbuy track event.',
+    label: 'Event Properties',
+    default: { '@path': '$.properties' }
+  },
+  deduplicationId: {
+    type: 'string',
+    required: false,
+    description:
+      'An identifier for the event being tracked to prevent the same event from being rewarded more than once.',
+    label: 'Event ID',
+    default: { '@path': '$.properties.deduplicationId' }
+  },
+  customerId: {
+    label: 'Customer ID',
+    description: "The user's customerId.",
+    type: 'string',
+    required: true,
+    default: { '@path': '$.userId' }
+  },
+  anonymousId: {
+    label: 'Anonymous ID',
+    description: "The user's anonymous id",
+    type: 'string',
+    required: false,
+    default: { '@path': '$.anonymousId' }
+  }
+}
+
+const action: BrowserActionDefinition<Settings, FriendbuyAPI, Payload> = {
+  title: 'Track Custom Event',
+  description: 'Record when a customer completes any custom event.',
+  // trackCustomEvent has no default subscription.
+  platform: 'web',
+  fields: trackCustomEventFields,
+
+  perform: (friendbuyAPI, data) => {
+    const [nonCustomerPayload, customerAttributes] = commonCustomerAttributes({
+      customerId: data.payload.customerId,
+      anonymousId: data.payload.anonymousId,
+      ...data.payload.eventProperties});
+
+    const friendbuyPayload = createFriendbuyPayload(
+      [
+        ...filterFriendbuyAttributes(nonCustomerPayload),
+        ['deduplicationId', data.payload.deduplicationId],
+        ['customer', createFriendbuyPayload(customerAttributes)],
+      ],
+      { dropEmpty: true }
+    )
+    friendbuyAPI.push(['track', data.payload.eventName, friendbuyPayload])
+  }
+}
+
+export default action

--- a/packages/browser-destinations/src/destinations/friendbuy/trackCustomer/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackCustomer/__tests__/index.test.ts
@@ -1,0 +1,154 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import friendbuyDestination from '../../index'
+import trackCustomerObject, { trackCustomerDefaultSubscription, trackCustomerFields } from '../index'
+
+import { loadScript } from '../../../../runtime/load-script'
+jest.mock('../../../../runtime/load-script')
+beforeEach(async () => {
+  // Prevent friendbuy.js and campaigns.js from being loaded.
+  ;(loadScript as jest.Mock).mockResolvedValue(true)
+})
+
+describe('Friendbuy.trackCustomer', () => {
+  // console.log('trackCustomer', JSON.stringify(trackCustomer, null, 2))
+
+  const subscriptions = [
+    {
+      partnerAction: 'trackCustomer',
+      name: trackCustomerObject.title,
+      enabled: true,
+      subscribe: trackCustomerDefaultSubscription,
+      mapping: Object.fromEntries(
+        Object.entries(trackCustomerFields)
+          .map(([name, value]) => [name, value.default])
+          .concat(
+            ['customerSince', 'loyaltyStatus', 'isNewCustomer'].map((name) => [name, { '@path': `$.traits.${name}` }])
+          )
+      )
+    }
+  ]
+
+  // console.log('subscriptions', JSON.stringify(subscriptions, null, 2))
+
+  test('all fields', async () => {
+    const merchantId = '1993d0f1-8206-4336-8c88-64e170f2419e'
+    const userId = 'john-doe-12345'
+    const anonymousId = '18aedb99-e756-40fa-8e83-d35f90998fb4'
+    const firstName = 'John'
+    const lastName = 'Doe'
+    const name = `${firstName} ${lastName}`
+    const email = 'john.doe@example.com'
+    const age = 55
+    const customerSince = '2021-10-20T14:20:15Z'
+    const loyaltyStatus = 'in'
+    const isNewCustomer = false
+    const friendbuyAttributes = { custom1: 'custom1', custom2: 'custom2', birthday: '1996-02-29' }
+
+    const [trackCustomer] = await friendbuyDestination({
+      merchantId,
+      subscriptions
+    })
+    // console.log('trackCustomer', JSON.stringify(trackCustomer, null, 2), trackCustomer)
+    expect(trackCustomer).toBeDefined()
+
+    await trackCustomer.load(Context.system(), {} as Analytics)
+
+    // console.log(window.friendbuyAPI)
+    jest.spyOn(window.friendbuyAPI as any, 'push')
+
+    {
+      // all fields
+      const context1 = new Context({
+        type: 'identify',
+        userId,
+        anonymousId,
+        traits: {
+          email,
+          firstName,
+          lastName,
+          name,
+          age,
+          customerSince,
+          loyaltyStatus,
+          isNewCustomer,
+          friendbuyAttributes
+        }
+      })
+      // console.log('context1', JSON.stringify(context1, null, 2))
+
+      trackCustomer.identify?.(context1)
+
+      // console.log('trackCustomer request', JSON.stringify(window.friendbuyAPI.push.mock.calls[0], null, 2))
+      expect(window.friendbuyAPI?.push).toHaveBeenNthCalledWith(1, [
+        'track',
+        'customer',
+        {
+          id: userId,
+          email,
+          firstName,
+          lastName,
+          name,
+          age,
+          customerSince,
+          loyaltyStatus,
+          isNewCustomer,
+          anonymousId,
+          ...friendbuyAttributes,
+          birthday: { year: 1996, month: 2, day: 29 }
+        },
+        true
+      ])
+    }
+
+    {
+      // name derived from firstName and lastName
+      const context2 = new Context({
+        type: 'identify',
+        userId,
+        traits: {
+          firstName,
+          lastName
+        }
+      })
+
+      trackCustomer.identify?.(context2)
+
+      expect(window.friendbuyAPI?.push).toHaveBeenNthCalledWith(2, [
+        'track',
+        'customer',
+        {
+          id: userId,
+          firstName,
+          lastName,
+          name
+        },
+        true
+      ])
+    }
+
+    {
+      // name without firstName and lastName
+      const context3 = new Context({
+        type: 'identify',
+        userId,
+        traits: {
+          email,
+          name
+        }
+      })
+
+      trackCustomer.identify?.(context3)
+
+      expect(window.friendbuyAPI?.push).toHaveBeenNthCalledWith(3, [
+        'track',
+        'customer',
+        {
+          id: userId,
+          email,
+          name
+        },
+        true
+      ])
+    }
+  })
+})

--- a/packages/browser-destinations/src/destinations/friendbuy/trackCustomer/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackCustomer/generated-types.ts
@@ -1,0 +1,50 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The user's customer ID.
+   */
+  customerId: string
+  /**
+   * The user's anonymous id.
+   */
+  anonymousId?: string
+  /**
+   * The user's email address.
+   */
+  email: string
+  /**
+   * The user's given name.
+   */
+  firstName?: string
+  /**
+   * The user's surname.
+   */
+  lastName?: string
+  /**
+   * The user's full name. If the name trait doesn't exist then it will be automatically derived from the firstName and lastName traits if they are defined.
+   */
+  name?: string
+  /**
+   * The user's age.
+   */
+  age?: number
+  /**
+   * The date the user became a customer.
+   */
+  customerSince?: string
+  /**
+   * The status of the user in your loyalty program. Valid values are "in", "out", or "blocked".
+   */
+  loyaltyStatus?: string
+  /**
+   * Flag to indicate whether the user is a new customer.
+   */
+  isNewCustomer?: boolean
+  /**
+   * Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.
+   */
+  friendbuyAttributes?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/src/destinations/friendbuy/trackCustomer/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackCustomer/index.ts
@@ -1,0 +1,123 @@
+import type { InputField } from '@segment/actions-core'
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+
+import type { FriendbuyAPI } from '../types'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { createFriendbuyPayload, filterFriendbuyAttributes, getName } from '../util'
+
+// see https://segment.com/docs/config-api/fql/
+export const trackCustomerDefaultSubscription = 'type = "identify"'
+
+// https://segment.com/docs/connections/spec/identify/
+// https://segment.com/docs/connections/spec/common/
+export const trackCustomerFields: Record<string, InputField> = {
+  customerId: {
+    label: 'Customer ID',
+    description: "The user's customer ID.",
+    type: 'string',
+    required: true,
+    default: { '@path': '$.userId' }
+  },
+  anonymousId: {
+    label: 'Anonymous ID',
+    description: "The user's anonymous id.",
+    type: 'string',
+    required: false,
+    default: { '@path': '$.anonymousId' }
+  },
+  email: {
+    label: 'Email',
+    description: "The user's email address.",
+    type: 'string',
+    required: true,
+    default: { '@path': '$.traits.email' }
+  },
+  firstName: {
+    label: 'First Name',
+    description: "The user's given name.",
+    type: 'string',
+    required: false,
+    default: { '@path': '$.traits.firstName' }
+  },
+  lastName: {
+    label: 'Last Name',
+    description: "The user's surname.",
+    type: 'string',
+    required: false,
+    default: { '@path': '$.traits.lastName' }
+  },
+  name: {
+    label: 'Name',
+    description:
+      "The user's full name. If the name trait doesn't exist then it will be automatically derived from the firstName and lastName traits if they are defined.",
+    type: 'string',
+    required: false,
+    default: { '@path': '$.traits.name' }
+  },
+  age: {
+    label: 'Age',
+    description: "The user's age.",
+    type: 'number',
+    required: false,
+    default: { '@path': '$.traits.age' }
+  },
+  customerSince: {
+    label: 'Customer Since',
+    description: 'The date the user became a customer.',
+    type: 'string',
+    format: 'date-time',
+    required: false,
+    default: { '@path': '$.traits.customerSince' }
+  },
+  loyaltyStatus: {
+    label: 'Loyalty Status',
+    description: 'The status of the user in your loyalty program. Valid values are "in", "out", or "blocked".',
+    type: 'string',
+    required: false,
+    default: { '@path': '$.traits.loyaltyStatus' }
+  },
+  isNewCustomer: {
+    label: 'New Customer Flag',
+    description: 'Flag to indicate whether the user is a new customer.',
+    type: 'boolean',
+    required: false,
+    default: { '@path': '$.traits.isNewCustomer' }
+  },
+  friendbuyAttributes: {
+    label: 'Custom Attributes',
+    description:
+      'Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.',
+    type: 'object',
+    required: false,
+    default: { '@path': '$.traits.friendbuyAttributes' }
+  }
+}
+
+const action: BrowserActionDefinition<Settings, FriendbuyAPI, Payload> = {
+  title: 'Track Customer',
+  description: 'Create a new customer profile or update an existing customer profile.',
+  defaultSubscription: trackCustomerDefaultSubscription,
+  platform: 'web',
+  fields: trackCustomerFields,
+
+  perform: (friendbuyAPI, data) => {
+    const friendbuyPayload = createFriendbuyPayload([
+      ['id', data.payload.customerId],
+      ['email', data.payload.email],
+      ['firstName', data.payload.firstName],
+      ['lastName', data.payload.lastName],
+      ['name', getName(data.payload)],
+      ['age', data.payload.age],
+      ['customerSince', data.payload.customerSince],
+      ['loyaltyStatus', data.payload.loyaltyStatus],
+      ['isNewCustomer', data.payload.isNewCustomer],
+      // custom properties
+      ['anonymousId', data.payload.anonymousId],
+      ...filterFriendbuyAttributes(data.payload.friendbuyAttributes)
+    ])
+    friendbuyAPI.push(['track', 'customer', friendbuyPayload, true])
+  }
+}
+
+export default action

--- a/packages/browser-destinations/src/destinations/friendbuy/trackPage/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackPage/__tests__/index.test.ts
@@ -1,0 +1,63 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import friendbuyDestination from '../../index'
+import trackPageObject, { trackPageDefaultSubscription, trackPageFields } from '../index'
+
+import { loadScript } from '../../../../runtime/load-script'
+jest.mock('../../../../runtime/load-script')
+beforeEach(async () => {
+  // Prevent friendbuy.js and campaigns.js from being loaded.
+  ;(loadScript as jest.Mock).mockResolvedValue(true)
+})
+
+describe('Friendbuy.trackPage', () => {
+  const subscriptions = [
+    {
+      partnerAction: 'trackPage',
+      name: trackPageObject.title,
+      enabled: true,
+      subscribe: trackPageDefaultSubscription,
+      mapping: Object.fromEntries(Object.entries(trackPageFields).map(([name, value]) => [name, value.default]))
+    }
+  ]
+
+  test('all fields', async () => {
+    const merchantId = '1993d0f1-8206-4336-8c88-64e170f2419e'
+    const name = 'Page Name'
+    const category = 'Page Category'
+    const title = 'Page Title'
+
+    const [trackPage] = await friendbuyDestination({
+      merchantId,
+      subscriptions
+    })
+    expect(trackPage).toBeDefined()
+
+    await trackPage.load(Context.system(), {} as Analytics)
+
+    jest.spyOn(window.friendbuyAPI as any, 'push')
+
+    const context = new Context({
+      type: 'page',
+      name,
+      category,
+      properties: {
+        title
+      }
+    })
+    // console.log('context', JSON.stringify(context, null, 2))
+
+    trackPage.page?.(context)
+
+    // console.log('trackSignUp request', JSON.stringify(window.friendbuyAPI.push.mock.calls[0], null, 2))
+    expect(window.friendbuyAPI?.push).toHaveBeenCalledWith([
+      'track',
+      'page',
+      {
+        name,
+        category,
+        title
+      },
+      true
+    ])
+  })
+})

--- a/packages/browser-destinations/src/destinations/friendbuy/trackPage/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackPage/generated-types.ts
@@ -1,0 +1,16 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The page name.
+   */
+  name?: string
+  /**
+   * The page category.
+   */
+  category?: string
+  /**
+   * The page title.
+   */
+  title?: string
+}

--- a/packages/browser-destinations/src/destinations/friendbuy/trackPage/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackPage/index.ts
@@ -1,0 +1,57 @@
+import type { InputField } from '@segment/actions-core'
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+
+import type { FriendbuyAPI } from '../types'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { createFriendbuyPayload } from '../util'
+
+export const trackPageDefaultSubscription = 'type = "page"'
+
+// https://segment.com/docs/connections/spec/page/
+export const trackPageFields: Record<string, InputField> = {
+  name: {
+    label: 'Page Name',
+    description: 'The page name.',
+    type: 'string',
+    required: false,
+    default: { '@path': '$.name' }
+  },
+  category: {
+    label: 'Page Category',
+    description: 'The page category.',
+    type: 'string',
+    required: false,
+    default: { '@path': '$.category' }
+  },
+  title: {
+    label: 'Page Title',
+    description: 'The page title.',
+    type: 'string',
+    required: false,
+    default: { '@path': '$.properties.title' }
+  }
+}
+
+const action: BrowserActionDefinition<Settings, FriendbuyAPI, Payload> = {
+  title: 'Track Page',
+  description: 'Record when a customer visits a new page. Allow Friendbuy widget targeting by Page Name instead of URL.',
+  defaultSubscription: trackPageDefaultSubscription,
+  platform: 'web',
+  fields: trackPageFields,
+
+  perform: (friendbuyAPI, data) => {
+    // If the page name is not defined then track the page with the name
+    // "undefined".  This is intended to allow merchants to target their widgets
+    // using page names when not all of their `analytics.page` calls include the
+    // page name.
+    const friendbuyPayload = createFriendbuyPayload([
+      ['name', data.payload.name || 'undefined'],
+      ['category', data.payload.category],
+      ['title', data.payload.title]
+    ])
+    friendbuyAPI.push(['track', 'page', friendbuyPayload, true])
+  }
+}
+
+export default action

--- a/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/__tests__/index.test.ts
@@ -1,0 +1,172 @@
+import { Analytics, Context, JSONValue } from '@segment/analytics-next'
+import friendbuyDestination from '../../index'
+import trackPurchaseObject, { trackPurchaseDefaultSubscription, trackPurchaseFields } from '../index'
+
+import { loadScript } from '../../../../runtime/load-script'
+jest.mock('../../../../runtime/load-script')
+beforeEach(async () => {
+  // Prevent friendbuy.js and campaigns.js from being loaded.
+  ;(loadScript as jest.Mock).mockResolvedValue(true)
+})
+
+describe('Friendbuy.trackPurchase', () => {
+  const subscriptions = [
+    {
+      partnerAction: 'trackPurchase',
+      name: trackPurchaseObject.title,
+      enabled: true,
+      subscribe: trackPurchaseDefaultSubscription,
+      mapping: Object.fromEntries(Object.entries(trackPurchaseFields).map(([name, value]) => [name, value.default]))
+    }
+  ]
+
+  test('all fields', async () => {
+    const orderId = 'my order'
+    const products = [
+      { sku: 'sku1', name: 'shorts', price: 19.99, quantity: 2 },
+      { price: 5.99 },
+      {
+        sku: 'sku3',
+        name: 'tshirt',
+        price: 24.99,
+        description: 'Black T-Shirt',
+        category: 'shirts',
+        url: 'https://example.com/sku3',
+        image_url: 'https://example.com/sku3/image.jpg'
+      }
+    ]
+
+    const merchantId = '1993d0f1-8206-4336-8c88-64e170f2419e'
+    const userId = 'john-doe-12345'
+    const anonymousId = 'cbce64f6-a45a-4d9c-a63d-4c7b42773276'
+    const currency = 'USD'
+    const coupon = 'coupon-xyzzy'
+    const giftCardCodes = ['card-a', 'card-b']
+    const friendbuyAttributes = { referralCode: 'ref-plugh' }
+    const email = 'john.doe@example.com'
+    const name = 'John Doe'
+
+    const [trackPurchase] = await friendbuyDestination({
+      merchantId,
+      subscriptions
+    })
+    // console.log('trackPurchase', JSON.stringify(trackPurchase, null, 2), trackPurchase)
+    expect(trackPurchase).toBeDefined()
+
+    await trackPurchase.load(Context.system(), {} as Analytics)
+
+    // console.log(window.friendbuyAPI)
+    jest.spyOn(window.friendbuyAPI as any, 'push')
+
+    const expectedProducts = products.map((p) => {
+      p = { quantity: 1, ...p }
+      if (p.image_url) {
+        p.imageUrl = p.image_url;
+        delete p.image_url;
+      }
+      return p;
+    })
+    const amount = expectedProducts.reduce((acc, p) => acc + p.price * p.quantity, 0)
+
+    {
+      // all fields
+      const context1 = new Context({
+        type: 'track',
+        event: 'Order Completed',
+        userId,
+        anonymousId,
+        properties: {
+          order_id: orderId,
+          revenue: amount,
+          subtotal: amount + 1,
+          total: amount + 2,
+          currency,
+          coupon,
+          giftCardCodes,
+          products: products as JSONValue,
+          email,
+          name,
+          friendbuyAttributes
+        }
+      })
+      // console.log('context1', JSON.stringify(context1, null, 2))
+
+      trackPurchase.track?.(context1)
+
+      // console.log('trackPurchase request', JSON.stringify(window.friendbuyAPI.push.mock.calls[0], null, 2))
+      expect(window.friendbuyAPI?.push).toHaveBeenNthCalledWith(1, [
+        'track',
+        'purchase',
+        {
+          id: orderId,
+          amount: amount + 2, // amount defaults to total
+          currency,
+          couponCode: coupon,
+          giftCardCodes,
+          customer: { id: userId, anonymousId, email, name },
+          products: expectedProducts,
+          ...friendbuyAttributes
+        },
+        true
+      ])
+      expect(window.friendbuyAPI.push.mock.calls[0][0][2].products[1].quantity).toBe(1);
+      expect(window.friendbuyAPI.push.mock.calls[0][0][2].products[2].imageUrl).toBe(products[2].image_url);
+    }
+
+    {
+      // minimal event
+      const context2 = new Context({
+        type: 'track',
+        event: 'Order Completed',
+        properties: {
+          order_id: orderId,
+          total: amount,
+          currency
+        }
+      })
+
+      trackPurchase.track?.(context2)
+
+      expect(window.friendbuyAPI?.push).toHaveBeenNthCalledWith(2, [
+        'track',
+        'purchase',
+        {
+          id: orderId,
+          amount,
+          currency
+        },
+        true
+      ])
+    }
+
+    {
+      // customer is dropped if no userId/customerId
+      // giftCardCodes is dropped if list is empty
+      const context3 = new Context({
+        type: 'track',
+        event: 'Order Completed',
+        properties: {
+          order_id: orderId,
+          total: amount,
+          currency,
+          giftCardCodes: [],
+          email,
+          name
+        }
+      })
+
+      trackPurchase.track?.(context3)
+
+      expect(window.friendbuyAPI?.push).toHaveBeenNthCalledWith(3, [
+        'track',
+        'purchase',
+        {
+          id: orderId,
+          amount,
+          currency
+        },
+        true
+      ])
+    }
+  })
+})

--- a/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/generated-types.ts
@@ -1,0 +1,75 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The order ID.
+   */
+  orderId: string
+  /**
+   * Purchase amount to be considered when evaluating reward rules.
+   */
+  amount: number
+  /**
+   * The currency of the purchase amount.
+   */
+  currency: string
+  /**
+   * The coupon code of any coupon redeemed with the order.
+   */
+  coupon?: string
+  /**
+   * An array of gift card codes applied to the order.
+   */
+  giftCardCodes?: string[]
+  /**
+   * Products purchased.
+   */
+  products?: {
+    sku?: string
+    name?: string
+    quantity?: number
+    price: number
+    description?: string
+    category?: string
+    url?: string
+    image_url?: string
+  }[]
+  /**
+   * The user's customer ID.
+   */
+  customerId?: string
+  /**
+   * The user's anonymous ID.
+   */
+  anonymousId?: string
+  /**
+   * The user's email address.
+   */
+  email?: string
+  /**
+   * The user's given name.
+   */
+  firstName?: string
+  /**
+   * The user's surname.
+   */
+  lastName?: string
+  /**
+   * The user's full name.
+   */
+  name?: string
+  /**
+   * The user's age.
+   */
+  age?: number
+  /**
+   * The status of the user in your loyalty program. Valid values are "in", "out", or "blocked".
+   */
+  loyaltyStatus?: string
+  /**
+   * Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.
+   */
+  friendbuyAttributes?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/index.ts
@@ -1,0 +1,163 @@
+import type { InputField } from '@segment/actions-core'
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+
+import type { FriendbuyAPI } from '../types'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { commonCustomerAttributes, commonCustomerFields } from '../commonFields'
+import { createFriendbuyPayload, filterFriendbuyAttributes } from '../util'
+
+// see https://segment.com/docs/config-api/fql/
+export const trackPurchaseDefaultSubscription = 'event = "Order Completed"'
+
+// https://segment.com/docs/connections/spec/ecommerce/v2/#order-completed
+export const trackPurchaseFields: Record<string, InputField> = {
+  orderId: {
+    label: 'Order ID',
+    description: 'The order ID.',
+    type: 'string',
+    required: true,
+    default: { '@path': '$.properties.order_id' }
+  },
+
+  amount: {
+    // Values available for amount:
+    // - `revenue` is the sum of the costs of the items being ordered.
+    // - `subtotal` is `revenue` minus any discount.
+    // - `total` is `subtotal` plus tax and shipping.
+    label: 'Amount Source',
+    description: 'Purchase amount to be considered when evaluating reward rules.',
+    type: 'number',
+    required: true,
+    default: { '@path': '$.properties.total' }
+  },
+  currency: {
+    label: 'Currency',
+    description: 'The currency of the purchase amount.',
+    type: 'string',
+    required: true,
+    default: { '@path': '$.properties.currency' }
+  },
+  coupon: {
+    // Might be used to establish attribution.
+    label: 'Coupon',
+    description: 'The coupon code of any coupon redeemed with the order.',
+    type: 'string',
+    required: false,
+    default: { '@path': '$.properties.coupon' }
+  },
+  giftCardCodes: {
+    // Might be used to establish attribution.
+    label: 'Gift Card Codes',
+    description: 'An array of gift card codes applied to the order.',
+    type: 'string',
+    multiple: true,
+    required: false,
+    default: { '@path': '$.properties.giftCardCodes' }
+  },
+
+  products: {
+    label: 'Products',
+    description: 'Products purchased.',
+    type: 'object',
+    multiple: true,
+    required: false,
+    properties: {
+      sku: {
+        label: 'Product SKU',
+        type: 'string',
+        required: false
+      },
+      name: {
+        label: 'Product Name',
+        type: 'string',
+        required: false
+      },
+      quantity: {
+        label: 'Quantity (default 1)',
+        type: 'integer',
+        required: false
+      },
+      price: {
+        label: 'Price',
+        type: 'number',
+        required: true
+      },
+      description: {
+        label: 'Product Description',
+        type: 'string',
+        required: false
+      },
+      category: {
+        label: 'Product Category',
+        type: 'string',
+        required: false
+      },
+      url: {
+        label: 'Product URL',
+        type: 'string',
+        required: false
+      },
+      image_url: {
+        label: 'Product Image URL',
+        type: 'string',
+        required: false
+      }
+    },
+    default: { '@path': '$.properties.products' }
+  },
+
+  ...commonCustomerFields(false),
+
+  friendbuyAttributes: {
+    label: 'Custom Attributes',
+    description:
+      'Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.',
+    type: 'object',
+    required: false,
+    default: { '@path': '$.properties.friendbuyAttributes' }
+  }
+}
+
+const action: BrowserActionDefinition<Settings, FriendbuyAPI, Payload> = {
+  title: 'Track Purchase',
+  description: 'Record when a customer makes a purchase.',
+  defaultSubscription: trackPurchaseDefaultSubscription,
+  platform: 'web',
+  fields: trackPurchaseFields,
+
+  perform: (friendbuyAPI, data) => {
+    const products =
+      data.payload.products && data.payload.products.length > 0
+        ? data.payload.products.map(normalizeProduct)
+        : undefined
+
+    const [nonCustomerPayload, customerAttributes] = commonCustomerAttributes(data.payload)
+    const friendbuyPayload = createFriendbuyPayload(
+      [
+        ['id', nonCustomerPayload.orderId],
+        ['amount', nonCustomerPayload.amount],
+        ['currency', nonCustomerPayload.currency],
+        ['couponCode', nonCustomerPayload.coupon],
+        ['giftCardCodes', nonCustomerPayload.giftCardCodes],
+        ['customer', createFriendbuyPayload(customerAttributes)],
+        ['products', products],
+        // custom properties
+        ...filterFriendbuyAttributes(nonCustomerPayload.friendbuyAttributes)
+      ],
+      { dropEmpty: true }
+    )
+    friendbuyAPI.push(['track', 'purchase', friendbuyPayload, true])
+  }
+}
+
+function normalizeProduct<T extends { image_url?: string }>(p: T) {
+  const p2: T & { quantity: number; imageUrl?: string } = { quantity: 1, ...p }
+  if (p.image_url !== undefined) {
+    p2.imageUrl = p.image_url
+    delete p2.image_url
+  }
+  return p2
+}
+
+export default action

--- a/packages/browser-destinations/src/destinations/friendbuy/trackSignUp/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackSignUp/__tests__/index.test.ts
@@ -1,0 +1,85 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import friendbuyDestination from '../../index'
+import trackSignUpObject, { trackSignUpDefaultSubscription, trackSignUpFields } from '../index'
+
+import { loadScript } from '../../../../runtime/load-script'
+jest.mock('../../../../runtime/load-script')
+beforeEach(async () => {
+  // Prevent friendbuy.js and campaigns.js from being loaded.
+  ;(loadScript as jest.Mock).mockResolvedValue(true)
+})
+
+describe('Friendbuy.trackSignUp', () => {
+  const subscriptions = [
+    {
+      partnerAction: 'trackSignUp',
+      name: trackSignUpObject.title,
+      enabled: true,
+      subscribe: trackSignUpDefaultSubscription,
+      mapping: Object.fromEntries(Object.entries(trackSignUpFields).map(([name, value]) => [name, value.default]))
+    }
+  ]
+
+  test('all fields', async () => {
+    const merchantId = '1993d0f1-8206-4336-8c88-64e170f2419e'
+    const userId = 'john-doe-12345'
+    const anonymousId = '6afc2ff2-cf54-414f-9a99-b3adb054ae31'
+    const firstName = 'John'
+    const lastName = 'Doe'
+    const name = `${firstName} ${lastName}`
+    const email = 'john.doe@example.com'
+    const age = 42
+    const loyaltyStatus = 'in'
+    const friendbuyAttributes = { custom1: 'custom1', custom2: 'custom2', birthday: '12-31' }
+
+    const [trackSignUp] = await friendbuyDestination({
+      merchantId,
+      subscriptions
+    })
+    // console.log('trackSignUp', JSON.stringify(trackSignUp, null, 2), trackSignUp)
+    expect(trackSignUp).toBeDefined()
+
+    await trackSignUp.load(Context.system(), {} as Analytics)
+
+    // console.log(window.friendbuyAPI)
+    jest.spyOn(window.friendbuyAPI as any, 'push')
+
+    const context = new Context({
+      type: 'track',
+      event: 'Signed Up',
+      userId,
+      anonymousId,
+      properties: {
+        first_name: firstName,
+        last_name: lastName,
+        name,
+        email,
+        age,
+        loyaltyStatus,
+        friendbuyAttributes
+      }
+    })
+    // console.log('context', JSON.stringify(context, null, 2))
+
+    trackSignUp.track?.(context)
+
+    // console.log('trackSignUp request', JSON.stringify(window.friendbuyAPI.push.mock.calls[0], null, 2))
+    expect(window.friendbuyAPI?.push).toHaveBeenCalledWith([
+      'track',
+      'sign_up',
+      {
+        id: userId,
+        email,
+        firstName,
+        lastName,
+        name,
+        age,
+        loyaltyStatus,
+        anonymousId,
+        ...friendbuyAttributes,
+        birthday: { month: 12, day: 31 }
+      },
+      true
+    ])
+  })
+})

--- a/packages/browser-destinations/src/destinations/friendbuy/trackSignUp/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackSignUp/generated-types.ts
@@ -1,0 +1,42 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The user's customer ID.
+   */
+  customerId: string
+  /**
+   * The user's anonymous ID.
+   */
+  anonymousId?: string
+  /**
+   * The user's email address.
+   */
+  email: string
+  /**
+   * The user's given name.
+   */
+  firstName?: string
+  /**
+   * The user's surname.
+   */
+  lastName?: string
+  /**
+   * The user's full name.
+   */
+  name?: string
+  /**
+   * The user's age.
+   */
+  age?: number
+  /**
+   * The status of the user in your loyalty program. Valid values are "in", "out", or "blocked".
+   */
+  loyaltyStatus?: string
+  /**
+   * Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.
+   */
+  friendbuyAttributes?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/src/destinations/friendbuy/trackSignUp/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackSignUp/index.ts
@@ -1,0 +1,46 @@
+import type { InputField } from '@segment/actions-core'
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+
+import type { FriendbuyAPI } from '../types'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { commonCustomerAttributes, commonCustomerFields } from '../commonFields'
+import { createFriendbuyPayload, filterFriendbuyAttributes } from '../util'
+
+// see https://segment.com/docs/config-api/fql/
+export const trackSignUpDefaultSubscription = 'event = "Signed Up"'
+
+// https://segment.com/docs/connections/spec/b2b-saas/#signed-up
+export const trackSignUpFields: Record<string, InputField> = {
+  ...commonCustomerFields(true),
+  friendbuyAttributes: {
+    label: 'Custom Attributes',
+    description:
+      'Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.',
+    type: 'object',
+    required: false,
+    default: { '@path': '$.properties.friendbuyAttributes' }
+  }
+}
+
+const action: BrowserActionDefinition<Settings, FriendbuyAPI, Payload> = {
+  title: 'Track Sign Up',
+  description: 'Record when a customer signs up for a service.',
+  defaultSubscription: trackSignUpDefaultSubscription,
+  platform: 'web',
+  fields: trackSignUpFields,
+
+  perform: (friendbuyAPI, data) => {
+    // The track sign_up call is like track customer in that customer
+    // properties are passed in the root of the event.
+    const [nonCustomerPayload, customerAttributes] = commonCustomerAttributes(data.payload)
+    const friendbuyPayload = createFriendbuyPayload([
+      ...customerAttributes,
+      // custom properties
+      ...filterFriendbuyAttributes(nonCustomerPayload.friendbuyAttributes)
+    ])
+    friendbuyAPI.push(['track', 'sign_up', friendbuyPayload, true])
+  }
+}
+
+export default action

--- a/packages/browser-destinations/src/destinations/friendbuy/types.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/types.ts
@@ -1,0 +1,3 @@
+export interface FriendbuyAPI extends Array<unknown> {
+  merchantId: string
+}

--- a/packages/browser-destinations/src/destinations/friendbuy/util.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/util.ts
@@ -1,0 +1,105 @@
+export interface GetNameParams {
+  name?: string
+  firstName?: string
+  lastName?: string
+}
+
+export function getName(payload: GetNameParams): string | undefined {
+  // prettier-ignore
+  return (
+    payload.name                          ? payload.name :
+    payload.firstName && payload.lastName ? `${payload.firstName} ${payload.lastName}`
+    :                                       undefined
+  )
+}
+
+/**
+ * Returns true if the argument is an empty object or array.
+ */
+export function isEmpty(o: unknown) {
+  if (typeof o !== 'object') {
+    return false
+  }
+  for (const _e in o) {
+    return false
+  }
+  // Not dropping `null` as empty to allow it being used in the future to
+  // erase existing properties.
+  if (o === null) {
+    return false
+  }
+  return true
+}
+
+export type FriendbuyPayloadValue = string | number | boolean | object
+export type FriendbuyPayloadItem = [string, FriendbuyPayloadValue | undefined]
+
+export interface CreateFriendbuyPayloadFlags {
+  dropEmpty?: boolean
+}
+
+/**
+ * Creates an object from a list of key/value pairs, dropping items for which
+ * the value is undefined or an empty string.  If the `dropEmpty` flag is
+ * specified then values which are empty objects or arrays will also be
+ * dropped.
+ */
+export function createFriendbuyPayload(
+  payloadItems: FriendbuyPayloadItem[],
+  flags: CreateFriendbuyPayloadFlags = {}
+) {
+  const friendbuyPayload: Record<string, FriendbuyPayloadValue> = {}
+  payloadItems.forEach(([k, v]) => {
+    if (!(v === undefined || v === '' || (flags.dropEmpty && isEmpty(v)))) {
+      friendbuyPayload[k] = v
+    }
+  })
+  return friendbuyPayload
+}
+
+export interface DateRecord {
+  year?: number
+  month: number
+  day: number
+}
+
+/**
+ * Filter non-string values out of friendbuyAttributes, and convert from object
+ * to entries list form required by `createFriendbuyPayload`. Includes special
+ * handling for `birthday` attribute, which is converted to a DateRecord.
+ */
+export function filterFriendbuyAttributes(
+  friendbuyAttributes: Record<string, unknown> | undefined
+): [string, string | DateRecord][] {
+  const filteredAttributes: [string, string | DateRecord][] = []
+  if (friendbuyAttributes) {
+    Object.entries(friendbuyAttributes).forEach((attribute) => {
+      if (typeof attribute[1] === 'string') {
+        if (attribute[0] === 'birthday') {
+          const dateRecord = parseDate(attribute[1])
+          if (dateRecord) {
+            filteredAttributes.push([attribute[0], dateRecord])
+          }
+        } else {
+          filteredAttributes.push(attribute as [string, string])
+        }
+      }
+    })
+  }
+  return filteredAttributes
+}
+
+const dateRegexp = /^(?:(\d\d\d\d)-)?(\d\d)-(\d\d)(?:[^\d]|$)/
+export function parseDate(date: string): DateRecord | undefined {
+  if (typeof date !== 'string') {
+    return undefined
+  }
+
+  const match = dateRegexp.exec(date)
+  if (!match) {
+    return undefined
+  }
+
+  const year = match[1] && match[1] !== '0000' ? { year: parseInt(match[1], 10) } : {}
+  return { month: parseInt(match[2], 10), day: parseInt(match[3], 10), ...year }
+}


### PR DESCRIPTION
* ./bin/run init -n Friendbuy -s friendbuy -t browser

* Friendbuy browser destination.

* ./bin/run generate:action trackCustomer browser -t "Track Customer" -d packages/browser-destinations/src/destinations/friendbuy

* Add Friendbuy trackCustomer browser action.

* ./bin/run generate:action trackPurchase browser -t "Track Purchase" -d packages/browser-destinations/src/destinations/friendbuy

* Add Friendbuy trackPurchase browser action.

* Add test for Friendbuy browser destination initialization.

* Don't require products in Friendbuy browser destination trackPurchases action.

* Use mapping-kit to pick amount value for Friendbuy browser destination trackPurchase action.

* Change any to unknown to make eslint happy.

* Silence most type complaints.

* Don't set trackCustomer name from firstName and lastName.

* Remove unused base64 module.

* Make email required in trackCustomer event.

* Fix firstName and lastName labels for trackCustomer call.

* Add Friendbuy trackSignUp browser action.

* Add Friendbuy trackCustomEvent browser action.

* Make customerId field on Friendbuy trackPurchase event optional.

* Add coupon code to Friendbuy trackPurchase test.

* If name is not supplied, derive it from firstName and lastName.

* Add age fields to Friendbuy trackCustomer and trackSignUp browser actions.

* Simplify trackPurchase default amount definition.

The Segment UI does not currently support multilevel conditionals so don't
use one for the trackPurchase amount field's default.

* Add customerSince, loyaltyStatus, and isNewCustomer fields to Friendbuy trackCustomer browser action.

* Rename friendbuy slug to actions-friendbuy.

The old Friendbuy FBOY Segment browser destination is already named "friendbuy".

Co-authored-by: Julio Farah <julio.farah@gmail.com>

* Protect against sending undefined properties in Friendbuy track calls.

* Add Friendbuy browser destination trackPage action.

./bin/run generate:action trackPage browser -t "Track Page" -d packages/browser-destinations/src/destinations/friendbuy

* Add anonymousId as a custom attribute on track calls.

* Add friendbuyAttributes field as as way to send custom attributes on track calls.

* Clean up action field descriptions.

* Parse birthday in friendbuyAttributes.

The trackCustomer call fails if `birthday` is a string.

* Add defaults for all trackCustomer fields.

* Remove commented-out console.log calls.

* Load Friendbuy JavaScript asynchronously in browser destination initialize function.

* Clean up imports.

* Don't require page name in Friendbuy trackPage browser action.

If the `analytics.page` call is made without a page name, do a Friendbuy
track page with the name "undefined".  This is intended to allow merchants
to target their widgets using page names when not all of their
`analytics.page` calls include the page name.

* Link to Friendbuy Code page in Friendbuy Merchant Id description.

* Update trackCustomer default path to use traits instead of properties for all fields.

The `trackCustomer` call is intended to be used with Segment `identify`
calls, not `track` calls, and `identify` calls have only traits, not
properties.

* Update trackCustomEvent to pass customer ID as customer.id.

Pass.

* Update action descriptions and labels.

* Update createFriendbuyPayload dropEmpty flag to also drop empty arrays.

* Add missing trackPurchase fields and normalize customer fields.

* Update trackCustomEvent to use common customer code.

This also means that any other customer fields that are passed in the
Analytics.js properties will automatically be included in the Friendbuy
payload's customer object.

* Set customerId field from customerId property if userId trait is not set.

* Update Friendbuy browser destination name.

Co-authored-by: Julio Farah <julio.farah@gmail.com>

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
