### PR TITLE
adds metadata for friendbuy destination

### DIFF
--- a/packages/browser-destinations/src/destinations/index.ts
+++ b/packages/browser-destinations/src/destinations/index.ts
@@ -29,4 +29,5 @@ function register(id: MetadataId, destinationPath: string) {
 register('5f7dd6d21ad74f3842b1fc47', './amplitude-plugins')
 register('60fb01aec459242d3b6f20c1', './braze')
 register('60f9d0d048950c356be2e4da', './braze-cloud-plugins')
+register('6170a348128093cd0245e0ea', './friendbuy')
 register('6141153ee7500f15d3838703', './fullstory')


### PR DESCRIPTION
Adds the action destination metadata for the friendbuy destination action.

## Testing
- Pushed to stage
<img width="716" alt="Screen Shot 2021-11-30 at 11 19 52 AM" src="https://user-images.githubusercontent.com/14189820/144113432-744545a3-19a8-4e34-9263-8f5259500e39.png">


