### PR TITLE
Update sessionID plugin

### DIFF
--- a/packages/browser-destinations/src/destinations/amplitude-plugins/sessionId/__tests__/sessionId.test.ts
+++ b/packages/browser-destinations/src/destinations/amplitude-plugins/sessionId/__tests__/sessionId.test.ts
@@ -66,6 +66,47 @@ describe('ajs-integration', () => {
     expect(updatedCtx?.event.integrations['Actions Amplitude']?.session_id).not.toBeUndefined()
   })
 
+  test('updates the original eveent when All: false but Actions Amplitude: true', async () => {
+    await sessionIdPlugin.load(Context.system(), ajs)
+
+    const ctx = new Context({
+      type: 'track',
+      event: 'greet',
+      properties: {
+        greeting: 'Oi!'
+      },
+      integrations: {
+        All: false,
+        'Actions Amplitude': true
+      }
+    })
+
+    const updatedCtx = await sessionIdPlugin.track?.(ctx)
+
+    // @ts-expect-error Need to fix ajs-next types to allow for complex objects in `integrations`
+    expect(updatedCtx?.event.integrations['Actions Amplitude']?.session_id).not.toBeUndefined()
+  })
+
+  test('doesnt update the original event with a session id when All: false', async () => {
+    await sessionIdPlugin.load(Context.system(), ajs)
+
+    const ctx = new Context({
+      type: 'track',
+      event: 'greet',
+      properties: {
+        greeting: 'Oi!'
+      },
+      integrations: {
+        All: false
+      }
+    })
+
+    const updatedCtx = await sessionIdPlugin.track?.(ctx)
+
+    // @ts-expect-error Need to fix ajs-next types to allow for complex objects in `integrations`
+    expect(updatedCtx?.event.integrations['Actions Amplitude']?.session_id).toBeUndefined()
+  })
+
   test('runs as an enrichment middleware', async () => {
     await ajs.register(sessionIdPlugin)
     jest.spyOn(sessionIdPlugin, 'track')

--- a/packages/browser-destinations/src/destinations/amplitude-plugins/sessionId/index.ts
+++ b/packages/browser-destinations/src/destinations/amplitude-plugins/sessionId/index.ts
@@ -57,7 +57,10 @@ const action: BrowserActionDefinition<Settings, {}, Payload> = {
 
     ls.setItem('analytics_session_id.last_access', newSession.toString())
 
-    context.updateEvent('integrations.Actions Amplitude.session_id', id)
+    if (context.event.integrations?.All !== false || context.event.integrations['Actions Amplitude']) {
+      context.updateEvent('integrations.Actions Amplitude', {})
+      context.updateEvent('integrations.Actions Amplitude.session_id', id)
+    }
 
     return
   }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR updates amplitude session ID plugin to not add the session ID to the integration object when All: false

## Testing

Session ID not populated when all: false
![image](https://user-images.githubusercontent.com/2866515/144297990-aff3486e-4270-41e5-99f3-bb01193dc721.png)
Session ID populated when all != false
![image](https://user-images.githubusercontent.com/2866515/144298057-1943ac73-d60c-4cde-a9e1-295151be1dc3.png)
Session ID populated when All: false and Actions Amplitude: true
![image](https://user-images.githubusercontent.com/2866515/144298250-78670c4a-8a99-42bf-90b5-64cf2431c930.png)


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
