### PR TITLE
Use auto publicpath

### DIFF
--- a/packages/browser-destinations/webpack.config.js
+++ b/packages/browser-destinations/webpack.config.js
@@ -7,12 +7,6 @@ const webpack = require('webpack')
 
 const files = globby.sync('./src/destinations/*/index.ts')
 const isProd = process.env.NODE_ENV === 'production'
-const assetPath =
-  process.env.ASSET_ENV === 'production'
-    ? 'https://cdn.segment.com/next-integrations/actions/'
-    : process.env.ASSET_ENV === 'stage'
-    ? 'https://cdn.segment.build/next-integrations/actions/'
-    : undefined
 
 const entries = files.reduce((acc, current) => {
   const [_dot, _src, _destinations, destination, ..._rest] = current.split('/')
@@ -48,7 +42,7 @@ module.exports = {
   output: {
     filename: process.env.NODE_ENV === 'development' ? '[name].js' : '[name]/[contenthash].js',
     path: path.resolve(__dirname, 'dist/web'),
-    publicPath: assetPath,
+    publicPath: 'auto', // Needed for customers using custom CDNs with analytics.js
     library: '[name]Destination',
     libraryTarget: 'umd',
     libraryExport: 'default'


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR changes the webpack publicPath to auto instead of being hardcoded to the segment CDN, which was breaking for customers using custom domains.

## Testing

Actions bundle is loaded from custom cdn instead of segment cdn: 
![image](https://user-images.githubusercontent.com/2866515/144492761-d59fb152-197f-4e26-a7d8-eac6e21457ff.png)

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
