### PR TITLE
Scaffold Adobe Target Cloud Destination

### DIFF
--- a/packages/destination-actions/src/destinations/adobe-target/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/__tests__/index.test.ts
@@ -1,0 +1,18 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Adobe Target Cloud Mode', () => {
+  describe('testAuthentication', () => {
+    it('should validate authentication inputs', async () => {
+      nock('https://your.destination.endpoint').get('*').reply(200, {})
+
+      // This should match your authentication.fields
+      const authData = {}
+
+      await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/adobe-target/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { createTestIntegration } from '@segment/actions-core'
 import Definition from '../index'
 
 const testDestination = createTestIntegration(Definition)

--- a/packages/destination-actions/src/destinations/adobe-target/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-adobe-target-cloud-mode'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/adobe-target/generated-types.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/generated-types.ts
@@ -1,0 +1,3 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {}

--- a/packages/destination-actions/src/destinations/adobe-target/index.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/index.ts
@@ -8,19 +8,19 @@ const destination: DestinationDefinition<Settings> = {
 
   authentication: {
     scheme: 'custom',
-    fields: {},
-    testAuthentication: (request) => {
-      // Return a request that tests/validates the user's credentials.
-      // If you do not have a way to validate the authentication fields safely,
-      // you can remove the `testAuthentication` function, though discouraged.
-    }
+    fields: {}
+    //testAuthentication: (request) => {
+    // Return a request that tests/validates the user's credentials.
+    // If you do not have a way to validate the authentication fields safely,
+    // you can remove the `testAuthentication` function, though discouraged.
+    //}
   },
 
-  onDelete: async (request, { settings, payload }) => {
-    // Return a request that performs a GDPR delete for the provided Segment userId or anonymousId
-    // provided in the payload. If your destination does not support GDPR deletion you should not
-    // implement this function and should remove it completely.
-  },
+  //onDelete: async (request, { settings, payload }) => {
+  // Return a request that performs a GDPR delete for the provided Segment userId or anonymousId
+  // provided in the payload. If your destination does not support GDPR deletion you should not
+  // implement this function and should remove it completely.
+  //},
 
   actions: {}
 }

--- a/packages/destination-actions/src/destinations/adobe-target/index.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/index.ts
@@ -1,0 +1,28 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Adobe Target Cloud Mode',
+  slug: 'actions-adobe-target-cloud',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {},
+    testAuthentication: (request) => {
+      // Return a request that tests/validates the user's credentials.
+      // If you do not have a way to validate the authentication fields safely,
+      // you can remove the `testAuthentication` function, though discouraged.
+    }
+  },
+
+  onDelete: async (request, { settings, payload }) => {
+    // Return a request that performs a GDPR delete for the provided Segment userId or anonymousId
+    // provided in the payload. If your destination does not support GDPR deletion you should not
+    // implement this function and should remove it completely.
+  },
+
+  actions: {}
+}
+
+export default destination


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

This PR adds adobe-target destinations cloud mode to the action-destinatons repo. 

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->


## Testing

No testing required, I am just scaffolding the destination into the repo.

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
