### PR TITLE
Auto Generate Types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          persist-credentials: false
+          ref: ${{ github.head_ref }}
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
@@ -49,6 +49,15 @@ jobs:
 
       - name: Build
         run: NODE_ENV=production yarn build
+
+      - name: Add Generated Types
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Automatically added generated-types.ts files.
+
+          file_pattern: ./*/generated-types.ts
+
+          commit_options: '--no-verify'
 
       - name: Lint
         run: yarn lint


### PR DESCRIPTION
Added job in CI that automatically commits generated-types.ts files created by yarn build, if they are left out when pushed.

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

## Testing

Tested by creating a draft PR to this draft PR: https://github.com/segmentio/action-destinations/pull/381 . The `generated-types.ts` are left out and the CI automatically adds them:
<img width="1386" alt="Screen Shot 2021-12-03 at 2 21 59 PM" src="https://user-images.githubusercontent.com/27820201/144680986-4ec49203-436b-49f3-9c46-9de6dba718a1.png">


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
