### PR TITLE
[Customer.io] Convert all potential timestamps in payloads/traits

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/__tests__/createUpdatePerson.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/createUpdatePerson.test.ts
@@ -19,10 +19,16 @@ describe('CustomerIO', () => {
       const userId = 'abc123'
       const anonymousId = 'unknown_123'
       const timestamp = dayjs.utc().toISOString()
+      const birthdate = dayjs.utc('1990-01-01T00:00:00Z').toISOString()
       const traits = {
         full_name: 'Test User',
         email: 'test@example.com',
-        created_at: timestamp
+        created_at: timestamp,
+        person: {
+          over18: true,
+          identification: 'valid',
+          birthdate
+        }
       }
       trackDeviceService.put(`/customers/${userId}`).reply(200, {}, { 'x-customerio-region': 'US' })
       const event = createTestEvent({
@@ -48,11 +54,15 @@ describe('CustomerIO', () => {
         ...traits,
         email: traits.email,
         created_at: dayjs.utc(timestamp).unix(),
-        anonymous_id: anonymousId
+        anonymous_id: anonymousId,
+        person: {
+          ...traits.person,
+          birthdate: dayjs.utc(birthdate).unix()
+        }
       })
     })
 
-    it('should not convert created_at to a unix timestamp when convert_timestamp is false', async () => {
+    it('should not convert attributes to unix timestamps when convert_timestamp is false', async () => {
       const settings: Settings = {
         siteId: '12345',
         apiKey: 'abcde',
@@ -61,10 +71,16 @@ describe('CustomerIO', () => {
       const userId = 'abc123'
       const anonymousId = 'unknown_123'
       const timestamp = dayjs.utc().toISOString()
+      const birthdate = dayjs.utc('1990-01-01T00:00:00Z').toISOString()
       const traits = {
         full_name: 'Test User',
         email: 'test@example.com',
-        created_at: timestamp
+        created_at: timestamp,
+        person: {
+          over18: true,
+          identification: 'valid',
+          birthdate
+        }
       }
       trackDeviceService.put(`/customers/${userId}`).reply(200, {})
       const event = createTestEvent({

--- a/packages/destination-actions/src/destinations/customerio/__tests__/trackEvent.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/trackEvent.test.ts
@@ -19,8 +19,14 @@ describe('CustomerIO', () => {
       const userId = 'abc123'
       const name = 'testEvent'
       const timestamp = dayjs.utc().toISOString()
+      const birthdate = dayjs.utc('1990-01-01T00:00:00Z').toISOString()
       const data = {
-        property1: 'this is a test'
+        property1: 'this is a test',
+        person: {
+          over18: true,
+          identification: 'valid',
+          birthdate
+        }
       }
       trackEventService.post(`/customers/${userId}/events`).reply(200, {}, { 'x-customerio-region': 'US' })
       const event = createTestEvent({
@@ -40,8 +46,14 @@ describe('CustomerIO', () => {
       expect(responses[0].data).toMatchObject({})
       expect(responses[0].options.json).toMatchObject({
         name,
-        data,
-        timestamp: dayjs.utc(timestamp).unix()
+        timestamp: dayjs.utc(timestamp).unix(),
+        data: {
+          ...data,
+          person: {
+            ...data.person,
+            birthdate: dayjs.utc(birthdate).unix()
+          }
+        }
       })
     })
 
@@ -106,7 +118,7 @@ describe('CustomerIO', () => {
       }
     })
 
-    it('should not convert tiemstamp to a unix timestamp when convert_timestamp is false', async () => {
+    it('should not convert dates to unix timestamps when convert_timestamp is false', async () => {
       const settings: Settings = {
         siteId: '12345',
         apiKey: 'abcde',
@@ -115,8 +127,14 @@ describe('CustomerIO', () => {
       const userId = 'abc123'
       const name = 'testEvent'
       const timestamp = dayjs.utc().toISOString()
+      const birthdate = dayjs.utc('1990-01-01T00:00:00Z').toISOString()
       const data = {
-        property1: 'this is a test'
+        property1: 'this is a test',
+        person: {
+          over18: true,
+          identification: 'valid',
+          birthdate
+        }
       }
       trackEventService.post(`/customers/${userId}/events`).reply(200, {}, { 'x-customerio-region': 'US' })
       const event = createTestEvent({

--- a/packages/destination-actions/src/destinations/customerio/__tests__/trackPageView.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/trackPageView.test.ts
@@ -20,9 +20,15 @@ describe('CustomerIO', () => {
       const userId = 'abc123'
       const url = 'https://example.com/page-one'
       const timestamp = dayjs.utc().toISOString()
+      const birthdate = dayjs.utc('1990-01-01T00:00:00Z').toISOString()
       const data = {
         property1: 'this is a test',
-        url
+        url,
+        person: {
+          over18: true,
+          identification: 'valid',
+          birthdate
+        }
       }
       trackPageViewService.post(`/customers/${userId}/events`).reply(200, {}, { 'x-customerio-region': 'US' })
       const event = createTestEvent({
@@ -42,8 +48,14 @@ describe('CustomerIO', () => {
       expect(responses[0].options.json).toMatchObject({
         name: url,
         type,
-        data,
-        timestamp: dayjs.utc(timestamp).unix()
+        timestamp: dayjs.utc(timestamp).unix(),
+        data: {
+          ...data,
+          person: {
+            ...data.person,
+            birthdate: dayjs.utc(birthdate).unix()
+          }
+        }
       })
     })
 
@@ -104,7 +116,7 @@ describe('CustomerIO', () => {
       }
     })
 
-    it('should not convert tiemstamp to a unix timestamp when convert_timestamp is false', async () => {
+    it('should not convert dates to unix timestamps when convert_timestamp is false', async () => {
       const settings: Settings = {
         siteId: '12345',
         apiKey: 'abcde',
@@ -113,9 +125,15 @@ describe('CustomerIO', () => {
       const userId = 'abc123'
       const url = 'https://example.com/page-one'
       const timestamp = dayjs.utc().toISOString()
+      const birthdate = dayjs.utc('1990-01-01T00:00:00Z').toISOString()
       const data = {
         property1: 'this is a test',
-        url
+        url,
+        person: {
+          over18: true,
+          identification: 'valid',
+          birthdate
+        }
       }
       trackPageViewService.post(`/customers/${userId}/events`).reply(200, {}, { 'x-customerio-region': 'US' })
       const event = createTestEvent({

--- a/packages/destination-actions/src/destinations/customerio/__tests__/trackScreenView.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/trackScreenView.test.ts
@@ -20,9 +20,15 @@ describe('CustomerIO', () => {
       const userId = 'abc123'
       const screen = 'Page One'
       const timestamp = dayjs.utc().toISOString()
+      const birthdate = dayjs.utc('1990-01-01T00:00:00Z').toISOString()
       const data = {
         property1: 'this is a test',
-        screen
+        screen,
+        person: {
+          over18: true,
+          identification: 'valid',
+          birthdate
+        }
       }
       trackScreenViewService.post(`/customers/${userId}/events`).reply(200, {}, { 'x-customerio-region': 'US' })
       const event = createTestEvent({
@@ -48,8 +54,14 @@ describe('CustomerIO', () => {
       expect(responses[0].options.json).toMatchObject({
         name: screen,
         type,
-        data,
-        timestamp: dayjs.utc(timestamp).unix()
+        timestamp: dayjs.utc(timestamp).unix(),
+        data: {
+          ...data,
+          person: {
+            ...data.person,
+            birthdate: dayjs.utc(birthdate).unix()
+          }
+        }
       })
     })
 
@@ -117,7 +129,7 @@ describe('CustomerIO', () => {
       }
     })
 
-    it('should not convert tiemstamp to a unix timestamp when convert_timestamp is false', async () => {
+    it('should not convert dates to unix timestamps when convert_timestamp is false', async () => {
       const settings: Settings = {
         siteId: '12345',
         apiKey: 'abcde',
@@ -126,9 +138,15 @@ describe('CustomerIO', () => {
       const userId = 'abc123'
       const screen = 'Page One'
       const timestamp = dayjs.utc().toISOString()
+      const birthdate = dayjs.utc('1990-01-01T00:00:00Z').toISOString()
       const data = {
         property1: 'this is a test',
-        screen
+        screen,
+        person: {
+          over18: true,
+          identification: 'valid',
+          birthdate
+        }
       }
       trackScreenViewService.post(`/customers/${userId}/events`).reply(200, {}, { 'x-customerio-region': 'US' })
       const event = createTestEvent({

--- a/packages/destination-actions/src/destinations/customerio/createUpdateDevice/generated-types.ts
+++ b/packages/destination-actions/src/destinations/customerio/createUpdateDevice/generated-types.ts
@@ -18,7 +18,7 @@ export interface Payload {
    */
   last_used?: string
   /**
-   * Convert `last_used` to a Unix timestamp (seconds since Epoch).
+   * Convert dates to Unix timestamps (seconds since Epoch).
    */
   convert_timestamp?: boolean
 }

--- a/packages/destination-actions/src/destinations/customerio/createUpdateDevice/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/createUpdateDevice/index.ts
@@ -46,7 +46,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     convert_timestamp: {
       label: 'Convert Timestamps',
-      description: 'Convert `last_used` to a Unix timestamp (seconds since Epoch).',
+      description: 'Convert dates to Unix timestamps (seconds since Epoch).',
       type: 'boolean',
       default: true
     }

--- a/packages/destination-actions/src/destinations/customerio/createUpdatePerson/generated-types.ts
+++ b/packages/destination-actions/src/destinations/customerio/createUpdatePerson/generated-types.ts
@@ -24,7 +24,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * Convert `created_at` to a Unix timestamp (seconds since Epoch).
+   * Convert dates to Unix timestamps (seconds since Epoch).
    */
   convert_timestamp?: boolean
 }

--- a/packages/destination-actions/src/destinations/customerio/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackEvent/generated-types.ts
@@ -24,7 +24,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * Convert `timestamp` to a Unix timestamp (seconds since Epoch).
+   * Convert dates to Unix timestamps (seconds since Epoch).
    */
   convert_timestamp?: boolean
 }

--- a/packages/destination-actions/src/destinations/customerio/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackEvent/index.ts
@@ -1,7 +1,7 @@
 import dayjs from '../../../lib/dayjs'
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
-import { trackApiEndpoint } from '../utils'
+import { convertAttributeTimestamps, trackApiEndpoint } from '../utils'
 import type { Payload } from './generated-types'
 
 interface TrackEventPayload {
@@ -63,7 +63,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     convert_timestamp: {
       label: 'Convert Timestamps',
-      description: 'Convert `timestamp` to a Unix timestamp (seconds since Epoch).',
+      description: 'Convert dates to Unix timestamps (seconds since Epoch).',
       type: 'boolean',
       default: true
     }
@@ -71,14 +71,21 @@ const action: ActionDefinition<Settings, Payload> = {
 
   perform: (request, { settings, payload }) => {
     let timestamp: string | number | undefined = payload.timestamp
+    let data = payload.data
 
-    if (timestamp && payload.convert_timestamp !== false) {
-      timestamp = dayjs.utc(timestamp).unix()
+    if (payload.convert_timestamp !== false) {
+      if (timestamp) {
+        timestamp = dayjs.utc(timestamp).unix()
+      }
+
+      if (data) {
+        data = convertAttributeTimestamps(data)
+      }
     }
 
     const body: TrackEventPayload = {
       name: payload.name,
-      data: payload.data,
+      data,
       timestamp
     }
 

--- a/packages/destination-actions/src/destinations/customerio/trackPageView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackPageView/generated-types.ts
@@ -24,7 +24,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * Convert `timestamp` to a Unix timestamp (seconds since Epoch).
+   * Convert dates to Unix timestamps (seconds since Epoch).
    */
   convert_timestamp?: boolean
 }

--- a/packages/destination-actions/src/destinations/customerio/trackPageView/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackPageView/index.ts
@@ -1,7 +1,7 @@
 import dayjs from '../../../lib/dayjs'
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
-import { trackApiEndpoint } from '../utils'
+import { convertAttributeTimestamps, trackApiEndpoint } from '../utils'
 import type { Payload } from './generated-types'
 
 interface TrackPageViewPayload {
@@ -63,22 +63,29 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     convert_timestamp: {
       label: 'Convert Timestamps',
-      description: 'Convert `timestamp` to a Unix timestamp (seconds since Epoch).',
+      description: 'Convert dates to Unix timestamps (seconds since Epoch).',
       type: 'boolean',
       default: true
     }
   },
   perform: (request, { settings, payload }) => {
     let timestamp: string | number | undefined = payload.timestamp
+    let data = payload.data
 
-    if (timestamp && payload.convert_timestamp !== false) {
-      timestamp = dayjs.utc(timestamp).unix()
+    if (payload.convert_timestamp !== false) {
+      if (timestamp) {
+        timestamp = dayjs.utc(timestamp).unix()
+      }
+
+      if (data) {
+        data = convertAttributeTimestamps(data)
+      }
     }
 
     const body: TrackPageViewPayload = {
       name: payload.url,
       type: 'page',
-      data: payload.data,
+      data,
       timestamp
     }
 

--- a/packages/destination-actions/src/destinations/customerio/trackScreenView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackScreenView/generated-types.ts
@@ -24,7 +24,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * Convert `timestamp` to a Unix timestamp (seconds since Epoch).
+   * Convert dates to Unix timestamps (seconds since Epoch).
    */
   convert_timestamp?: boolean
 }

--- a/packages/destination-actions/src/destinations/customerio/trackScreenView/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackScreenView/index.ts
@@ -1,7 +1,7 @@
 import dayjs from '../../../lib/dayjs'
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
-import { trackApiEndpoint } from '../utils'
+import { convertAttributeTimestamps, trackApiEndpoint } from '../utils'
 import type { Payload } from './generated-types'
 
 interface TrackScreenViewPayload {
@@ -63,22 +63,29 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     convert_timestamp: {
       label: 'Convert Timestamps',
-      description: 'Convert `timestamp` to a Unix timestamp (seconds since Epoch).',
+      description: 'Convert dates to Unix timestamps (seconds since Epoch).',
       type: 'boolean',
       default: true
     }
   },
   perform: (request, { settings, payload }) => {
     let timestamp: string | number | undefined = payload.timestamp
+    let data = payload.data
 
-    if (timestamp && payload.convert_timestamp !== false) {
-      timestamp = dayjs.utc(timestamp).unix()
+    if (payload.convert_timestamp !== false) {
+      if (timestamp) {
+        timestamp = dayjs.utc(timestamp).unix()
+      }
+
+      if (data) {
+        data = convertAttributeTimestamps(data)
+      }
     }
 
     const body: TrackScreenViewPayload = {
       name: payload.name,
       type: 'screen',
-      data: payload.data,
+      data,
       timestamp
     }
 

--- a/packages/destination-actions/src/destinations/customerio/utils.ts
+++ b/packages/destination-actions/src/destinations/customerio/utils.ts
@@ -1,3 +1,6 @@
+import dayjs from '../../lib/dayjs'
+import isPlainObject from 'lodash/isPlainObject'
+
 export const trackApiEndpoint = (accountRegion?: string) => {
   if (accountRegion === AccountRegion.EU) {
     return 'https://track-eu.customer.io'
@@ -9,4 +12,38 @@ export const trackApiEndpoint = (accountRegion?: string) => {
 export enum AccountRegion {
   US = 'US 🇺🇸',
   EU = 'EU 🇪🇺'
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return isPlainObject(value)
+}
+
+// Recursively walk through an object and try to convert any strings into dates
+export const convertAttributeTimestamps = (payload: Record<string, unknown>): Record<string, unknown> => {
+  const clone: Record<string, unknown> = {}
+  const keys = Object.keys(payload)
+
+  keys.forEach((key) => {
+    const value = payload[key]
+
+    if (typeof value === 'string') {
+      const maybeDate = dayjs.utc(value)
+
+      if (maybeDate.isValid()) {
+        clone[key] = maybeDate.unix()
+
+        return
+      }
+    }
+
+    if (isRecord(value)) {
+      clone[key] = convertAttributeTimestamps(value)
+
+      return
+    }
+
+    clone[key] = value
+  })
+
+  return clone
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

We've had at least one customer notice that the old customer.io action in Segment.io would convert _all_ timestamps from a string to a unix timestamp, and that the new destination action only converts specific known dates.

We've decided as a team that it's more useful to try and convert everything, so this PR extends the `convert_timestamp` flag to try and convert all possible dates to unix timestamps. This is accomplished with a recursive function that will walk the entire tree of the data object being parsed.

**Note**: It looks like `gitleaks` recently made quite a few breaking changes, and no longer works with the existing configs. I've skipped that verification step with this work. The change is unrelated and should probably be managed by y'all instead 😄 

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment