### PR TITLE
implement destination with tests for voyage

### DIFF
--- a/packages/destination-actions/src/destinations/voyage/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/voyage/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for voyage destination: trackOrderPlaced action - all fields 1`] = `
+Object {
+  "eventMeta": Object {
+    "CustomerId": "g4Y8hDsoLI[^l]yE",
+    "DateCreated": "2021-02-01T00:00:00.000Z",
+    "Email": "g4Y8hDsoLI[^l]yE",
+    "FirstName": "g4Y8hDsoLI[^l]yE",
+    "HomepageUrl": "g4Y8hDsoLI[^l]yE",
+    "LastUpdated": "2021-02-01T00:00:00.000Z",
+    "LinkReference": "g4Y8hDsoLI[^l]yE",
+    "OrderNumber": "g4Y8hDsoLI[^l]yE",
+    "OrderTotal": 34762578324357.12,
+    "Phone": "g4Y8hDsoLI[^l]yE",
+    "ProductImageUrl": "g4Y8hDsoLI[^l]yE",
+    "SourceId": "g4Y8hDsoLI[^l]yE",
+    "TokenId": "g4Y8hDsoLI[^l]yE",
+    "TotalSpent": 34762578324357.12,
+    "Url": "g4Y8hDsoLI[^l]yE",
+    "Zip": "g4Y8hDsoLI[^l]yE",
+    "lastName": "g4Y8hDsoLI[^l]yE",
+  },
+  "eventTypeId": 7310,
+  "phone": "g4Y8hDsoLI[^l]yE",
+}
+`;
+
+exports[`Testing snapshot for voyage destination: trackOrderPlaced action - required fields 1`] = `
+Object {
+  "eventMeta": Object {
+    "CustomerId": "g4Y8hDsoLI[^l]yE",
+    "DateCreated": "2021-02-01T00:00:00.000Z",
+    "OrderTotal": 34762578324357.12,
+    "Phone": "g4Y8hDsoLI[^l]yE",
+    "TotalSpent": 34762578324357.12,
+    "Url": "g4Y8hDsoLI[^l]yE",
+    "Zip": "g4Y8hDsoLI[^l]yE",
+  },
+  "eventTypeId": 7310,
+  "phone": "g4Y8hDsoLI[^l]yE",
+}
+`;

--- a/packages/destination-actions/src/destinations/voyage/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/voyage/__tests__/index.test.ts
@@ -1,0 +1,18 @@
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../index'
+import type {Settings} from '../generated-types'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Voyage', () => {
+  describe('testAuthentication', () => {
+    it('should validate authentication inputs', async () => {
+      // This should match your authentication.fields
+      const settings: Settings = {
+        apiKey: 'api-key-123'
+      }
+
+      await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/voyage/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/voyage/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'voyage'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/voyage/generated-types.ts
+++ b/packages/destination-actions/src/destinations/voyage/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Voyage API key. You can create a new API key or find your existing API key in the Advanced section of your [Settings page](https://app.voyagetext.com/dashboard/settings/advanced).
+   */
+  apiKey: string
+}

--- a/packages/destination-actions/src/destinations/voyage/index.ts
+++ b/packages/destination-actions/src/destinations/voyage/index.ts
@@ -1,0 +1,59 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+import { defaultValues } from '@segment/actions-core'
+import trackOrderPlaced from './trackOrderPlaced'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Voyage',
+  slug: 'actions-voyage',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      apiKey: {
+        label: 'API Key',
+        description:
+          'Voyage API key. You can create a new API key or find your existing API key in the Advanced section of your [Settings page](https://app.voyagetext.com/dashboard/settings/advanced).',
+        type: 'string',
+        required: true
+      }
+    },
+    testAuthentication: () => {
+      // Return a request that tests/validates the user's credentials.
+      // If you do not have a way to validate the authentication fields safely,
+      // you can remove the `testAuthentication` function, though discouraged.
+      return true
+    }
+  },
+
+  extendRequest: ({ settings }) => {
+    return {
+      headers: {
+        'x-api-key': settings.apiKey
+      }
+    }
+  },
+
+  onDelete: async () => {
+    // Return a request that performs a GDPR delete for the provided Segment userId or anonymousId
+    // provided in the payload. If your destination does not support GDPR deletion you should not
+    // implement this function and should remove it completely.
+    return true
+  },
+
+  presets: [
+    {
+      name: 'Track Order Placed Event',
+      subscribe: 'type = "track"',
+      partnerAction: 'trackOrderPlaced',
+      mapping: defaultValues(trackOrderPlaced.fields)
+    }
+  ],
+
+  actions: {
+    trackOrderPlaced
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/voyage/trackOrderPlaced/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/voyage/trackOrderPlaced/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Voyage's trackOrderPlaced destination action: all fields 1`] = `
+Object {
+  "eventMeta": Object {
+    "CustomerId": "2[K9H6FjJTLriL4e3h",
+    "DateCreated": "2021-02-01T00:00:00.000Z",
+    "Email": "2[K9H6FjJTLriL4e3h",
+    "FirstName": "2[K9H6FjJTLriL4e3h",
+    "HomepageUrl": "2[K9H6FjJTLriL4e3h",
+    "LastUpdated": "2021-02-01T00:00:00.000Z",
+    "LinkReference": "2[K9H6FjJTLriL4e3h",
+    "OrderNumber": "2[K9H6FjJTLriL4e3h",
+    "OrderTotal": 63010121889873.92,
+    "Phone": "2[K9H6FjJTLriL4e3h",
+    "ProductImageUrl": "2[K9H6FjJTLriL4e3h",
+    "SourceId": "2[K9H6FjJTLriL4e3h",
+    "TokenId": "2[K9H6FjJTLriL4e3h",
+    "TotalSpent": 63010121889873.92,
+    "Url": "2[K9H6FjJTLriL4e3h",
+    "Zip": "2[K9H6FjJTLriL4e3h",
+    "lastName": "2[K9H6FjJTLriL4e3h",
+  },
+  "eventTypeId": 7310,
+  "phone": "2[K9H6FjJTLriL4e3h",
+}
+`;
+
+exports[`Testing snapshot for Voyage's trackOrderPlaced destination action: required fields 1`] = `
+Object {
+  "eventMeta": Object {
+    "CustomerId": "2[K9H6FjJTLriL4e3h",
+    "DateCreated": "2021-02-01T00:00:00.000Z",
+    "OrderTotal": 63010121889873.92,
+    "Phone": "2[K9H6FjJTLriL4e3h",
+    "TotalSpent": 63010121889873.92,
+    "Url": "2[K9H6FjJTLriL4e3h",
+    "Zip": "2[K9H6FjJTLriL4e3h",
+  },
+  "eventTypeId": 7310,
+  "phone": "2[K9H6FjJTLriL4e3h",
+}
+`;

--- a/packages/destination-actions/src/destinations/voyage/trackOrderPlaced/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/voyage/trackOrderPlaced/__tests__/index.test.ts
@@ -1,0 +1,58 @@
+import type { Settings } from '../../generated-types'
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { EventTypeId, OrderPlacedPayload } from '../index'
+import { BaseApiUrl, EventApiUri, EventBody } from '../../utils'
+
+const apiKey = 'api_123'
+const settings: Settings = { apiKey }
+const timestamp = new Date().toISOString()
+const testDestination = createTestIntegration(Destination)
+
+const api = nock(BaseApiUrl)
+
+describe('Voyage.trackOrderPlaced', () => {
+  it('should validate action fields', async () => {
+    const response = {}
+    api.post(EventApiUri).reply(200, response, { 'x-api-key': settings.apiKey })
+
+    const properties = {
+      CustomerId: 'customer-123',
+      Url: 'http:product-url.com',
+      OrderTotal: 10,
+      TotalSpent: 100,
+      Phone: '+18732213472',
+      Zip: '84032'
+    }
+    const event = createTestEvent({
+      type: 'track',
+      userId: 'user-123',
+      event: 'OrderPlaced',
+      timestamp,
+      properties
+    })
+    const responses = await testDestination.testAction('trackOrderPlaced', {
+      event,
+      settings,
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject(response)
+    expect(responses[0].headers.toJSON()).toMatchObject({
+      'x-api-key': settings.apiKey,
+      'content-type': 'application/json'
+    })
+    expect(responses[0].options.json).toMatchObject({
+      eventTypeId: EventTypeId,
+      phone: properties.Phone,
+      eventMeta: {
+        DateCreated: timestamp,
+        LastUpdated: timestamp,
+        ...properties
+      }
+    } as EventBody<OrderPlacedPayload>)
+  })
+})

--- a/packages/destination-actions/src/destinations/voyage/trackOrderPlaced/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/voyage/trackOrderPlaced/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'trackOrderPlaced'
+const destinationSlug = 'Voyage'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/voyage/trackOrderPlaced/generated-types.ts
+++ b/packages/destination-actions/src/destinations/voyage/trackOrderPlaced/generated-types.ts
@@ -1,0 +1,72 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Date of cart creation. Default to current date and time.
+   */
+  DateCreated: string | number
+  /**
+   * Order number from e-commerce platform.
+   */
+  OrderNumber?: string
+  /**
+   * Order id from e-commerce platform (same as checkout id).
+   */
+  SourceId?: string
+  /**
+   * A reference to the order that is a string value. (Primarily used for Shopify's checkout token or Magento's entity id).
+   */
+  TokenId?: string
+  /**
+   * Customer ID from e-commerce platform.
+   */
+  CustomerId: string
+  /**
+   * Link for user to click on to see status.
+   */
+  Url: string
+  /**
+   * Total Order Value.
+   */
+  OrderTotal: number
+  /**
+   * Total customer lifetime spend.
+   */
+  TotalSpent: number
+  /**
+   * Customer's first name.
+   */
+  FirstName?: string
+  /**
+   * Customer's last name.
+   */
+  lastName?: string
+  /**
+   * Customer's phone number.
+   */
+  Phone: string
+  /**
+   * Customer's email address
+   */
+  Email?: string
+  /**
+   * Customer's postal code
+   */
+  Zip: string
+  /**
+   * The date and time when the updates interacted with.
+   */
+  LastUpdated?: string | number
+  /**
+   * URL with product image.
+   */
+  ProductImageUrl?: string
+  /**
+   * Used as a key to link events together.
+   */
+  LinkReference?: string
+  /**
+   * URL of the tenant's e-commerce homepage.
+   */
+  HomepageUrl?: string
+}

--- a/packages/destination-actions/src/destinations/voyage/trackOrderPlaced/index.ts
+++ b/packages/destination-actions/src/destinations/voyage/trackOrderPlaced/index.ts
@@ -1,0 +1,191 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+import { EventEndpoint, EventBody } from '../utils'
+
+export type OrderPlacedPayload = {
+  DateCreated: string | number
+  OrderNumber?: string
+  SourceId?: string
+  TokenId?: string
+  CustomerId: string
+  Url: string
+  OrderTotal: number
+  TotalSpent: number
+  FirstName?: string
+  LastName?: string
+  Phone: string
+  Email?: string
+  Zip: string
+  LastUpdated?: string | number
+  ProductImageUrl?: string
+  LinkReference?: string
+  HomepageUrl?: string
+}
+
+export const EventTypeId = 7310
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Track Order Placed',
+  description: 'Track when an order is placed.',
+  defaultSubscription: 'type = "track"',
+
+  fields: {
+    DateCreated: {
+      label: 'Timestamp',
+      description: 'Date of cart creation. Default to current date and time.',
+      type: 'datetime',
+      required: true,
+      default: {
+        '@path': '$.timestamp'
+      }
+    },
+    OrderNumber: {
+      label: 'Order Number',
+      description: 'Order number from e-commerce platform.',
+      type: 'string',
+      default: {
+        '@path': '$.properties.OrderNumber'
+      }
+    },
+    SourceId: {
+      label: 'Order ID',
+      description: 'Order id from e-commerce platform (same as checkout id).',
+      type: 'string',
+      default: {
+        '@path': '$.properties.SourceId'
+      }
+    },
+    TokenId: {
+      label: 'Token ID',
+      description:
+        "A reference to the order that is a string value. (Primarily used for Shopify's checkout token or Magento's entity id).",
+      type: 'string',
+      default: {
+        '@path': '$.properties.TokenId'
+      }
+    },
+    CustomerId: {
+      label: 'Customer ID',
+      description: 'Customer ID from e-commerce platform.',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.properties.CustomerId'
+      }
+    },
+    Url: {
+      label: 'Order URL',
+      description: 'Link for user to click on to see status.',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.properties.Url'
+      }
+    },
+    OrderTotal: {
+      label: 'Order Total',
+      description: 'Total Order Value.',
+      type: 'number',
+      required: true,
+      default: {
+        '@path': '$.properties.OrderTotal'
+      }
+    },
+    TotalSpent: {
+      label: 'Total Spent',
+      description: 'Total customer lifetime spend.',
+      type: 'number',
+      required: true,
+      default: {
+        '@path': '$.properties.TotalSpent'
+      }
+    },
+    FirstName: {
+      label: 'First name',
+      description: "Customer's first name.",
+      type: 'string',
+      default: {
+        '@path': '$.properties.FirstName'
+      }
+    },
+    lastName: {
+      label: 'Last name',
+      description: "Customer's last name.",
+      type: 'string',
+      default: {
+        '@path': '$.properties.lastName'
+      }
+    },
+    Phone: {
+      label: 'Phone number',
+      description: "Customer's phone number.",
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.properties.Phone'
+      }
+    },
+    Email: {
+      label: 'Email',
+      description: "Customer's email address",
+      type: 'string',
+      default: {
+        '@path': '$.properties.Email'
+      }
+    },
+    Zip: {
+      label: 'Zip code',
+      description: "Customer's postal code",
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.properties.Zip'
+      }
+    },
+    LastUpdated: {
+      label: 'Last Updated',
+      description: 'The date and time when the updates interacted with.',
+      type: 'datetime',
+      default: {
+        '@path': '$.timestamp'
+      }
+    },
+    ProductImageUrl: {
+      label: 'Product Image URL',
+      description: 'URL with product image.',
+      type: 'string',
+      default: {
+        '@path': '$.properties.ProductImageUrl'
+      }
+    },
+    LinkReference: {
+      label: 'Link reference',
+      description: 'Used as a key to link events together.',
+      type: 'string',
+      default: {
+        '@path': '$.properties.LinkReference'
+      }
+    },
+    HomepageUrl: {
+      label: 'Homepage URL',
+      description: "URL of the tenant's e-commerce homepage.",
+      type: 'string',
+      default: {
+        '@path': '$.properties.HomepageUrl'
+      }
+    }
+  },
+
+  perform: (request, { payload }) => {
+    const body: EventBody<OrderPlacedPayload> = {
+      eventTypeId: EventTypeId,
+      phone: payload.Phone,
+      eventMeta: payload
+    }
+    return request(EventEndpoint, { method: 'POST', json: body })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/voyage/utils.ts
+++ b/packages/destination-actions/src/destinations/voyage/utils.ts
@@ -1,0 +1,12 @@
+export const BaseApiUrl = 'https://api.voyagetext.com/api/v1'
+
+export const EventApiUri = '/customEvent'
+
+export const EventEndpoint = BaseApiUrl + EventApiUri
+
+export type EventBody<EventMeta> = {
+  eventTypeId: number
+  phone: string
+  subscriberId?: string
+  eventMeta: EventMeta
+}


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

<!-- _A summary of your pull request, including the what change you're making and why._ -->

_This PR is an implementation of a destination action integration for [Voyage SMS](https://voyagesms.com/) as part of the private beta for the Destination Actions feature. The implementation contains only one action `trackOrderPlaced` and will likely add more in the future._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
