### PR TITLE
Normalization for GA4 custom event name

### DIFF
--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
@@ -171,5 +171,90 @@ describe('GA4', () => {
         `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"params\\":{\\"order_id\\":\\"5678dd9087-78\\",\\"coupon\\":\\"SUMMER_FEST\\",\\"currency\\":\\"USD\\",\\"revenue\\":11.99,\\"total\\":15.99}}]}"`
       )
     })
+
+    it('should normalize event name', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Order Completed',
+        userId: '3456fff',
+        anonymousId: 'anon-567890',
+        type: 'track'
+      })
+      const responses = await testDestination.testAction('customEvent', {
+        event,
+        settings: {
+          apiSecret,
+          measurementId
+        },
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].request.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "content-type": Array [
+              "application/json",
+            ],
+            "user-agent": Array [
+              "Segment (Actions)",
+            ],
+          },
+        }
+      `)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"Order_Completed\\",\\"params\\":{}}]}"`
+      )
+    })
+
+    it('should normalize and lowercase event name', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Order Completed',
+        userId: '3456fff',
+        anonymousId: 'anon-567890',
+        type: 'track'
+      })
+      const responses = await testDestination.testAction('customEvent', {
+        event,
+        settings: {
+          apiSecret,
+          measurementId
+        },
+        mapping: {
+          lowercase: true
+        },
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].request.headers).toMatchInlineSnapshot(`
+      Headers {
+        Symbol(map): Object {
+          "content-type": Array [
+            "application/json",
+          ],
+          "user-agent": Array [
+            "Segment (Actions)",
+          ],
+        },
+      }
+    `)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"order_completed\\",\\"params\\":{}}]}"`
+      )
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
@@ -219,7 +219,7 @@ describe('GA4', () => {
         .reply(201, {})
 
       const event = createTestEvent({
-        event: 'Order Completed',
+        event: '         Order Completed ',
         userId: '3456fff',
         anonymousId: 'anon-567890',
         type: 'track'

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   name: string
   /**
+   * If set to true, event name will be converted to lowercase before sending to Google.
+   */
+  lowercase?: boolean
+  /**
    * The event parameters to send to Google
    */
   params?: {

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/generated-types.ts
@@ -6,11 +6,11 @@ export interface Payload {
    */
   clientId: string
   /**
-   * The unique name of the custom event created in GA4.
+   * The unique name of the custom event created in GA4. GA4 does not accept spaces in event names so Segment will replace any spaces with underscores. More information about GA4 event name rules is available in [their docs](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article).
    */
   name: string
   /**
-   * If set to true, event name will be converted to lowercase before sending to Google.
+   * If true, the event name will be converted to lowercase before sending to Google. Event names are case sensitive in GA4 so enable this setting to avoid distinct events for casing differences. More information about GA4 event name rules is available in [their docs](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article).
    */
   lowercase?: boolean
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
@@ -21,7 +21,8 @@ const action: ActionDefinition<Settings, Payload> = {
     clientId: { ...client_id },
     name: {
       label: 'Event Name',
-      description: 'The unique name of the custom event created in GA4.',
+      description:
+        'The unique name of the custom event created in GA4. GA4 does not accept spaces in event names so Segment will replace any spaces with underscores. More information about GA4 event name rules is available in [their docs](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article).',
       type: 'string',
       required: true,
       default: {
@@ -30,7 +31,8 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     lowercase: {
       label: 'Lowercase Event Name',
-      description: 'If set to true, event name will be converted to lowercase before sending to Google.',
+      description:
+        'If true, the event name will be converted to lowercase before sending to Google. Event names are case sensitive in GA4 so enable this setting to avoid distinct events for casing differences. More information about GA4 event name rules is available in [their docs](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article).',
       type: 'boolean',
       default: false
     },

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
@@ -2,7 +2,14 @@ import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { client_id } from '../ga4-properties'
+const normalize_event_name = (name: string, lowercase: boolean): string => {
+  name = name.replace(/\s/g, '_')
 
+  if (lowercase === true) {
+    name = name.toLowerCase()
+  }
+  return name
+}
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Custom Event',
   description: 'Send any custom event',
@@ -18,6 +25,12 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.event'
       }
     },
+    lowercase: {
+      label: 'Lowercase Event Name',
+      description: 'If set to true, event name will be converted to lowercase before sending to Google.',
+      type: 'boolean',
+      default: false
+    },
     params: {
       label: 'Event Parameters',
       description: 'The event parameters to send to Google',
@@ -27,13 +40,14 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: (request, { payload }) => {
+    const event_name = normalize_event_name(payload.name, payload.lowercase ? payload.lowercase : false)
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {
         client_id: payload.clientId,
         events: [
           {
-            name: payload.name,
+            name: event_name,
             params: payload.params
           }
         ]
@@ -41,5 +55,4 @@ const action: ActionDefinition<Settings, Payload> = {
     })
   }
 }
-
 export default action

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
@@ -2,14 +2,17 @@ import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { client_id } from '../ga4-properties'
-const normalize_event_name = (name: string, lowercase: boolean): string => {
+
+const normalize_event_name = (name: string, lowercase: boolean | undefined): string => {
+  name = name.trim()
   name = name.replace(/\s/g, '_')
 
-  if (lowercase === true) {
+  if (lowercase) {
     name = name.toLowerCase()
   }
   return name
 }
+
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Custom Event',
   description: 'Send any custom event',
@@ -40,7 +43,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: (request, { payload }) => {
-    const event_name = normalize_event_name(payload.name, payload.lowercase ? payload.lowercase : false)
+    const event_name = normalize_event_name(payload.name, payload.lowercase)
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { client_id } from '../ga4-properties'
 
-const normalize_event_name = (name: string, lowercase: boolean | undefined): string => {
+const normalizeEventName = (name: string, lowercase: boolean | undefined): string => {
   name = name.trim()
   name = name.replace(/\s/g, '_')
 
@@ -45,7 +45,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: (request, { payload }) => {
-    const event_name = normalize_event_name(payload.name, payload.lowercase)
+    const event_name = normalizeEventName(payload.name, payload.lowercase)
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
@@ -27,14 +27,21 @@ const action: ActionDefinition<Settings, Payload> = {
       throw new IntegrationError('Currency is required if value is set.', 'Misconfigured required field', 400)
     }
 
+    console.log('30')
     //Currency must exist either as a param or in the first item in items.
-    if (payload.currency === undefined && payload.items && payload.items[0].currency === undefined) {
+    if (
+      payload.currency === undefined &&
+      payload.items &&
+      payload.items[0] &&
+      payload.items[0].currency === undefined
+    ) {
       throw new IntegrationError(
         'One of item-level currency or top-level currency is required.',
         'Misconfigured required field',
         400
       )
     }
+    console.log('39')
 
     let googleItems: ProductItem[] = []
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
@@ -27,21 +27,14 @@ const action: ActionDefinition<Settings, Payload> = {
       throw new IntegrationError('Currency is required if value is set.', 'Misconfigured required field', 400)
     }
 
-    console.log('30')
     //Currency must exist either as a param or in the first item in items.
-    if (
-      payload.currency === undefined &&
-      payload.items &&
-      payload.items[0] &&
-      payload.items[0].currency === undefined
-    ) {
+    if (payload.currency === undefined && payload.items && payload.items[0].currency === undefined) {
       throw new IntegrationError(
         'One of item-level currency or top-level currency is required.',
         'Misconfigured required field',
         400
       )
     }
-    console.log('39')
 
     let googleItems: ProductItem[] = []
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Since custom events sent to google cannot include spaces in the event name, this removes spaces before sending and introduces a toggle for users to convert the event name to lowercase. 

## Testing
 
Tested in staging and all looks good:
<img width="1542" alt="Screen Shot 2022-01-04 at 11 27 43 AM" src="https://user-images.githubusercontent.com/27820201/148114173-6f8b81d9-c243-46ab-822e-09101df541a4.png">
<img width="1066" alt="Screen Shot 2022-01-04 at 11 27 55 AM" src="https://user-images.githubusercontent.com/27820201/148114185-b6dc28f8-afc3-41a6-97ef-7063c330c358.png">


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
