### PR TITLE
GA4 - Updated currency checking

### DIFF
--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
@@ -34,7 +34,7 @@ const action: ActionDefinition<Settings, Payload> = {
      * If set at the event level, item-level currency is ignored. If event-level currency is not set then
      * currency from the first item in items is used.
      */
-    if (payload.currency === undefined && payload.items && payload.items[0].currency === undefined) {
+    if (payload.currency === undefined && (!payload.items || !payload.items[0] || !payload.items[0].currency)) {
       throw new IntegrationError(
         'One of item-level currency or top-level currency is required.',
         'Misconfigured required field',

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
@@ -50,7 +50,7 @@ const action: ActionDefinition<Settings, Payload> = {
      * If set at the event level, item-level currency is ignored. If event-level currency is not set then
      * currency from the first item in items is used.
      */
-    if (payload.currency === undefined && payload.items && payload.items[0].currency === undefined) {
+    if (payload.currency === undefined && (!payload.items || !payload.items[0] || !payload.items[0].currency)) {
       throw new IntegrationError(
         'One of item-level currency or top-level currency is required.',
         'Misconfigured required field',

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
@@ -33,7 +33,7 @@ const action: ActionDefinition<Settings, Payload> = {
      * If set at the event level, item-level currency is ignored. If event-level currency is not set then
      * currency from the first item in items is used.
      */
-    if (payload.currency === undefined && payload.items && payload.items[0].currency === undefined) {
+    if (payload.currency === undefined && (!payload.items || !payload.items[0] || !payload.items[0].currency)) {
       throw new IntegrationError(
         'One of item-level currency or top-level currency is required.',
         'Misconfigured required field',

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
@@ -28,7 +28,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     //Currency must exist either as a param or in the first item in items.
-    if (payload.currency === undefined && payload.items && payload.items[0].currency === undefined) {
+    if (payload.currency === undefined && (!payload.items || !payload.items[0] || !payload.items[0].currency)) {
       throw new IntegrationError(
         'One of item-level currency or top-level currency is required.',
         'Misconfigured required field',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Was seeing errors in production related to the `viewCart` action. The error:
```
TypeError: Cannot read property 'currency' of undefined
    at perform (/usr/src/integrations/node_modules/@segment/action-destinations/dist/destinations/google-analytics-4/viewCart/index.js:26:81)
```
[Sentry Link](https://sentry.io/organizations/segment/issues/2865802208/?project=1110287&query=is%3Aunresolved&statsPeriod=14d)
The error is triggered when a user passes in a payload such as:
```
	"payload": {
		"client_id": "123",
		"items": []
	}
```
Since `items[0]` is undefined we can't access `items[0].currency`

This PR updates the relevant if statement across all actions that use it.

## Testing

Deployed to staging and copied the relevant event from the customer to use as a test event. The event now correctly triggers a detailed error message rather than a vague runtime error.
<img width="1065" alt="Screen Shot 2022-01-05 at 12 28 05 PM" src="https://user-images.githubusercontent.com/27820201/148284738-ddc72614-4104-46a1-941a-1abc01180894.png">


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
