### PR TITLE
[Customer.io] Only convert ISO 8601 dates

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/utils.ts
+++ b/packages/destination-actions/src/destinations/customerio/utils.ts
@@ -18,6 +18,43 @@ const isRecord = (value: unknown): value is Record<string, unknown> => {
   return isPlainObject(value)
 }
 
+// DayJS' docs say,
+//   > Parse the given string in ISO 8601 format and return a Day.js object instance.
+// but that's not actually true. It will parse non-ISO 8601 date formats just fine,
+// which we don't want in this action. Thus, we want to only provide ISO 8601 format
+// strings for dayJS to parse with.
+const validDateFormats = [
+  'YYYY',
+  'YYYY-MM',
+  'YYYY-MM-DD',
+  'YYYY-MM-DDTHH',
+  'YYYY-MM-DDTHH:mm',
+  'YYYY-MM-DDTHH:mm:ss',
+  'YYYY-MM-DDTHH:mm:ss.S',
+  'YYYY-MM-DDTHH:mm:ss.SS',
+  'YYYY-MM-DDTHH:mm:ss.SSS',
+  'YYYY-MM-DDTHHZ',
+  'YYYY-MM-DDTHH:mmZ',
+  'YYYY-MM-DDTHH:mm:ssZ',
+  'YYYY-MM-DDTHH:mm:ss.SZ',
+  'YYYY-MM-DDTHH:mm:ss.SSZ',
+  'YYYY-MM-DDTHH:mm:ss.SSSZ',
+  // dayJS doesn't handle `Z` correctly for ISO 8601 dates. This adds `Z` as a literal character
+  // https://github.com/iamkun/dayjs/issues/1729
+  'YYYY-MM-DDTHH[Z]',
+  'YYYY-MM-DDTHH:mm[Z]',
+  'YYYY-MM-DDTHH:mm:ss[Z]',
+  'YYYY-MM-DDTHH:mm:ss.S[Z]',
+  'YYYY-MM-DDTHH:mm:ss.SS[Z]',
+  'YYYY-MM-DDTHH:mm:ss.SSS[Z]',
+  'YYYY-MM-DDTHHZZ',
+  'YYYY-MM-DDTHH:mmZZ',
+  'YYYY-MM-DDTHH:mm:ssZZ',
+  'YYYY-MM-DDTHH:mm:ss.SZZ',
+  'YYYY-MM-DDTHH:mm:ss.SSZZ',
+  'YYYY-MM-DDTHH:mm:ss.SSSZZ'
+]
+
 // Recursively walk through an object and try to convert any strings into dates
 export const convertAttributeTimestamps = (payload: Record<string, unknown>): Record<string, unknown> => {
   const clone: Record<string, unknown> = {}
@@ -27,10 +64,17 @@ export const convertAttributeTimestamps = (payload: Record<string, unknown>): Re
     const value = payload[key]
 
     if (typeof value === 'string') {
-      const maybeDate = dayjs.utc(value)
+      // Parse only ISO 8601 date formats in strict mode
+      const maybeDate = dayjs(value, validDateFormats, true)
 
       if (maybeDate.isValid()) {
-        clone[key] = maybeDate.unix()
+        // Since dayJS thinks `Z` is a literal character and not shorthand for UTC, we need to
+        // convert the date to UTC manually.
+        if (value.endsWith('Z')) {
+          clone[key] = maybeDate.utc(true).unix()
+        } else {
+          clone[key] = maybeDate.unix()
+        }
 
         return
       }

--- a/packages/destination-actions/src/lib/dayjs.ts
+++ b/packages/destination-actions/src/lib/dayjs.ts
@@ -1,8 +1,10 @@
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import advancedFormat from 'dayjs/plugin/advancedFormat'
+import customParseFormat from 'dayjs/plugin/customParseFormat'
 
 dayjs.extend(utc)
 dayjs.extend(advancedFormat)
+dayjs.extend(customParseFormat)
 
 export default dayjs


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

A few of our customers have written in since #386 that too many of their attributes are being mistakenly converted to unix timestamps. They want us to replicate the functionality of the original customer.io action, which was developed by the Segment team. After talking with them, it seems like only ISO 8601 dates were converted.

This PR limits timestamp conversion to only ISO 8601 strings. Unfortunately day.js doesn't really support this use case well in a strict way, so there are a few hacks to get valid + strict ISO 8601 parsing into the new destination action.

## Testing

For testing, I included a set of date/time strings that the Customer.io team used back in 2019 for testing timestamp conversion with the old segment action. I expanded it a bit to handle strings with the `Z` UTC offset, custom UTC offsets, and no offsets at all.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
