### PR TITLE
Revert "[Customer.io] Only convert ISO 8601 dates"

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/__tests__/createUpdatePerson.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/createUpdatePerson.test.ts
@@ -62,54 +62,6 @@ describe('CustomerIO', () => {
       })
     })
 
-    it('should convert only ISO-8601 strings', async () => {
-      const settings: Settings = {
-        siteId: '12345',
-        apiKey: 'abcde',
-        accountRegion: AccountRegion.US
-      }
-      const userId = 'abc123'
-      const timestamp = dayjs.utc().toISOString()
-      const testTimestamps = {
-        date01: '25 Mar 2015',
-        date02: 'Mar 25 2015',
-        date03: '01/01/2019',
-        date04: '2019-02-01',
-        date05: '2007-01-02T18:04:07',
-        date06: '2006-01-02T18:04:07Z',
-        date07: '2006-01-02T18:04:07+01:00',
-        date08: '2006-01-02T15:04:05.007',
-        date09: '2006-01-02T15:04:05.007Z',
-        date10: '2006-01-02T15:04:05.007+01:00'
-      }
-      trackDeviceService.put(`/customers/${userId}`).reply(200, {}, { 'x-customerio-region': 'US' })
-      const event = createTestEvent({
-        userId,
-        timestamp,
-        traits: testTimestamps
-      })
-      const responses = await testDestination.testAction('createUpdatePerson', {
-        event,
-        settings,
-        useDefaultMappings: true
-      })
-
-      expect(responses.length).toBe(1)
-      expect(responses[0].status).toBe(200)
-      expect(responses[0].options.json).toMatchObject({
-        date01: testTimestamps.date01,
-        date02: testTimestamps.date02,
-        date03: testTimestamps.date03,
-        date04: dayjs(testTimestamps.date04).unix(),
-        date05: dayjs(testTimestamps.date05).unix(),
-        date06: dayjs(testTimestamps.date06).unix(),
-        date07: dayjs(testTimestamps.date07).unix(),
-        date08: dayjs(testTimestamps.date08).unix(),
-        date09: dayjs(testTimestamps.date09).unix(),
-        date10: dayjs(testTimestamps.date10).unix()
-      })
-    })
-
     it('should not convert attributes to unix timestamps when convert_timestamp is false', async () => {
       const settings: Settings = {
         siteId: '12345',

--- a/packages/destination-actions/src/destinations/customerio/utils.ts
+++ b/packages/destination-actions/src/destinations/customerio/utils.ts
@@ -18,43 +18,6 @@ const isRecord = (value: unknown): value is Record<string, unknown> => {
   return isPlainObject(value)
 }
 
-// DayJS' docs say,
-//   > Parse the given string in ISO 8601 format and return a Day.js object instance.
-// but that's not actually true. It will parse non-ISO 8601 date formats just fine,
-// which we don't want in this action. Thus, we want to only provide ISO 8601 format
-// strings for dayJS to parse with.
-const validDateFormats = [
-  'YYYY',
-  'YYYY-MM',
-  'YYYY-MM-DD',
-  'YYYY-MM-DDTHH',
-  'YYYY-MM-DDTHH:mm',
-  'YYYY-MM-DDTHH:mm:ss',
-  'YYYY-MM-DDTHH:mm:ss.S',
-  'YYYY-MM-DDTHH:mm:ss.SS',
-  'YYYY-MM-DDTHH:mm:ss.SSS',
-  'YYYY-MM-DDTHHZ',
-  'YYYY-MM-DDTHH:mmZ',
-  'YYYY-MM-DDTHH:mm:ssZ',
-  'YYYY-MM-DDTHH:mm:ss.SZ',
-  'YYYY-MM-DDTHH:mm:ss.SSZ',
-  'YYYY-MM-DDTHH:mm:ss.SSSZ',
-  // dayJS doesn't handle `Z` correctly for ISO 8601 dates. This adds `Z` as a literal character
-  // https://github.com/iamkun/dayjs/issues/1729
-  'YYYY-MM-DDTHH[Z]',
-  'YYYY-MM-DDTHH:mm[Z]',
-  'YYYY-MM-DDTHH:mm:ss[Z]',
-  'YYYY-MM-DDTHH:mm:ss.S[Z]',
-  'YYYY-MM-DDTHH:mm:ss.SS[Z]',
-  'YYYY-MM-DDTHH:mm:ss.SSS[Z]',
-  'YYYY-MM-DDTHHZZ',
-  'YYYY-MM-DDTHH:mmZZ',
-  'YYYY-MM-DDTHH:mm:ssZZ',
-  'YYYY-MM-DDTHH:mm:ss.SZZ',
-  'YYYY-MM-DDTHH:mm:ss.SSZZ',
-  'YYYY-MM-DDTHH:mm:ss.SSSZZ'
-]
-
 // Recursively walk through an object and try to convert any strings into dates
 export const convertAttributeTimestamps = (payload: Record<string, unknown>): Record<string, unknown> => {
   const clone: Record<string, unknown> = {}
@@ -64,17 +27,10 @@ export const convertAttributeTimestamps = (payload: Record<string, unknown>): Re
     const value = payload[key]
 
     if (typeof value === 'string') {
-      // Parse only ISO 8601 date formats in strict mode
-      const maybeDate = dayjs(value, validDateFormats, true)
+      const maybeDate = dayjs.utc(value)
 
       if (maybeDate.isValid()) {
-        // Since dayJS thinks `Z` is a literal character and not shorthand for UTC, we need to
-        // convert the date to UTC manually.
-        if (value.endsWith('Z')) {
-          clone[key] = maybeDate.utc(true).unix()
-        } else {
-          clone[key] = maybeDate.unix()
-        }
+        clone[key] = maybeDate.unix()
 
         return
       }

--- a/packages/destination-actions/src/lib/dayjs.ts
+++ b/packages/destination-actions/src/lib/dayjs.ts
@@ -1,10 +1,8 @@
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import advancedFormat from 'dayjs/plugin/advancedFormat'
-import customParseFormat from 'dayjs/plugin/customParseFormat'
 
 dayjs.extend(utc)
 dayjs.extend(advancedFormat)
-dayjs.extend(customParseFormat)
 
 export default dayjs


### PR DESCRIPTION
Reverts segmentio/action-destinations#398

date tests failing on linux -- reverting to last good build while we investigate