### PR TITLE
[BE-480] - Update pre-commit hook to be compatible with gitleaks 8 cli api

### DIFF
--- a/.husky/gitleaks-rules.toml
+++ b/.husky/gitleaks-rules.toml
@@ -1,20 +1,565 @@
 title = "Action-Destination Custom Additional Rules"
 
-[[rules]]
-  description = "Facebook System User Access Token"
-  regex = '''EAA[0-9A-Za-z]{100,}'''
-  tags = ["token", "Facebook Token"]
-
-[[rules]]
-  description = "Tik-Tok accessToken"
-  tags = ["token", "Tik-Tok"]
-  regex = '''[0-9A-Za-z]{40}'''
-  [[rules.entropies]]
-    Min = "3.5"
-    Max = "4.5"
-
 [allowlist]
-  description = "Allowlisted files"
-  files = [
-    '''yarn.lock'''
-  ]
+description = "global allow lists"
+files = [
+  '''yarn.lock''',
+]
+paths = [
+  '''gitleaks.toml''',
+  '''(.*?)(jpg|gif|doc|pdf|bin|svg|socket)$''',
+]
+regexes = ['''219-09-9999''', '''078-05-1120''', '''(9[0-9]{2}|666)-\d{2}-\d{4}''']
+
+[[rules]]
+description = "Facebook System User Access Token"
+regex = '''EAA[0-9A-Za-z]{100,}'''
+tags = ["token", "Facebook Token"]
+
+[[rules]]
+description = "Tik-Tok accessToken"
+regex = '''[0-9A-Za-z]{40}'''
+tags = ["token", "Tik-Tok"]
+[[rules.entropies]]
+Max = "4.5"
+Min = "3.5"
+
+# Default gitleaks rules (from https://raw.githubusercontent.com/zricethezav/gitleaks/master/config/gitleaks.toml)
+
+# Gitleaks rules are defined by regular expressions and entropy ranges.
+# Some secrets have unique signatures which make detecting those secrets easy.
+# Examples of those secrets would be Gitlab Personal Access Tokens, AWS keys, and Github Access Tokens.
+# All these examples have defined prefixes like `glpat`, `AKIA`, `ghp_`, etc.
+#
+# Other secrets might just be a hash which means we need to write more complex rules to verify
+# that what we are matching is a secret.
+#
+# Here is an example of a semi-generic secret
+#
+#   discord_client_secret = "8dyfuiRyq=vVc3RRr_edRk-fK__JItpZ"
+#
+# We can write a regular expression to capture the variable name (identifier),
+# the assignment symbol (like '=' or ':='), and finally the actual secret.
+# The structure of a rule to match this example secret is below:
+#
+#                                                           Beginning string
+#                                                               quotation
+#                                                                   │            End string quotation
+#                                                                   │                      │
+#                                                                   ▼                      ▼
+#    (?i)(discord[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-z0-9=_\-]{32})['\"]
+#
+#                   ▲                              ▲                                ▲
+#                   │                              │                                │
+#                   │                              │                                │
+#              identifier                  assignment symbol
+#                                                                                Secret
+#
+[[rules]]
+description = "GitLab Personal Access Token"
+id = "gitlab-pat"
+regex = '''glpat-[0-9a-zA-Z\-]{20}'''
+
+[[rules]]
+description = "AWS"
+id = "aws-access-token"
+regex = '''(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
+
+# Cryptographic keys
+[[rules]]
+description = "PKCS8 private key"
+id = "PKCS8-PK"
+regex = '''-----BEGIN PRIVATE KEY-----'''
+
+[[rules]]
+description = "RSA private key"
+id = "RSA-PK"
+regex = '''-----BEGIN RSA PRIVATE KEY-----'''
+
+[[rules]]
+description = "SSH private key"
+id = "OPENSSH-PK"
+regex = '''-----BEGIN OPENSSH PRIVATE KEY-----'''
+
+[[rules]]
+description = "PGP private key"
+id = "PGP-PK"
+regex = '''-----BEGIN PGP PRIVATE KEY BLOCK-----'''
+
+[[rules]]
+description = "Github Personal Access Token"
+id = "github-pat"
+regex = '''ghp_[0-9a-zA-Z]{36}'''
+
+[[rules]]
+description = "Github OAuth Access Token"
+id = "github-oauth"
+regex = '''gho_[0-9a-zA-Z]{36}'''
+
+[[rules]]
+description = "SSH (DSA) private key"
+id = "SSH-DSA-PK"
+regex = '''-----BEGIN DSA PRIVATE KEY-----'''
+
+[[rules]]
+description = "SSH (EC) private key"
+id = "SSH-EC-PK"
+regex = '''-----BEGIN EC PRIVATE KEY-----'''
+
+[[rules]]
+description = "Github App Token"
+id = "github-app-token"
+regex = '''(ghu|ghs)_[0-9a-zA-Z]{36}'''
+
+[[rules]]
+description = "Github Refresh Token"
+id = "github-refresh-token"
+regex = '''ghr_[0-9a-zA-Z]{76}'''
+
+[[rules]]
+description = "Shopify shared secret"
+id = "shopify-shared-secret"
+regex = '''shpss_[a-fA-F0-9]{32}'''
+
+[[rules]]
+description = "Shopify access token"
+id = "shopify-access-token"
+regex = '''shpat_[a-fA-F0-9]{32}'''
+
+[[rules]]
+description = "Shopify custom app access token"
+id = "shopify-custom-access-token"
+regex = '''shpca_[a-fA-F0-9]{32}'''
+
+[[rules]]
+description = "Shopify private app access token"
+id = "shopify-private-app-access-token"
+regex = '''shppa_[a-fA-F0-9]{32}'''
+
+[[rules]]
+description = "Slack token"
+id = "slack-access-token"
+regex = '''xox[baprs]-([0-9a-zA-Z]{10,48})?'''
+
+[[rules]]
+description = "Stripe"
+id = "stripe-access-token"
+regex = '''(?i)(sk|pk)_(test|live)_[0-9a-z]{10,32}'''
+
+[[rules]]
+description = "PyPI upload token"
+id = "pypi-upload-token"
+regex = '''pypi-AgEIcHlwaS5vcmc[A-Za-z0-9-_]{50,1000}'''
+
+[[rules]]
+description = "Google (GCP) Service-account"
+id = "gcp-service-account"
+regex = '''\"type\": \"service_account\"'''
+
+[[rules]]
+description = "Heroku API Key"
+id = "heroku-api-key"
+regex = ''' (?i)(heroku[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Slack Webhook"
+id = "slack-web-hook"
+regex = '''https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8,12}/[a-zA-Z0-9_]{24}'''
+
+[[rules]]
+description = "Twilio API Key"
+id = "twilio-api-key"
+regex = '''SK[0-9a-fA-F]{32}'''
+
+[[rules]]
+description = "Age secret key"
+id = "age-secret-key"
+regex = '''AGE-SECRET-KEY-1[QPZRY9X8GF2TVDW0S3JN54KHCE6MUA7L]{58}'''
+
+[[rules]]
+description = "Facebook token"
+id = "facebook-token"
+regex = '''(?i)(facebook[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-f0-9]{32})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Twitter token"
+id = "twitter-token"
+regex = '''(?i)(twitter[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-f0-9]{35,44})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Adobe Client ID (Oauth Web)"
+id = "adobe-client-id"
+regex = '''(?i)(adobe[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-f0-9]{32})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Adobe Client Secret"
+id = "adobe-client-secret"
+regex = '''(p8e-)(?i)[a-z0-9]{32}'''
+
+[[rules]]
+description = "Alibaba AccessKey ID"
+id = "alibaba-access-key-id"
+regex = '''(LTAI)(?i)[a-z0-9]{20}'''
+
+[[rules]]
+description = "Alibaba Secret Key"
+id = "alibaba-secret-key"
+regex = '''(?i)(alibaba[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-z0-9]{30})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Asana Client ID"
+id = "asana-client-id"
+regex = '''(?i)(asana[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([0-9]{16})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Asana Client Secret"
+id = "asana-client-secret"
+regex = '''(?i)(asana[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-z0-9]{32})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Atlassian API token"
+id = "atlassian-api-token"
+regex = '''(?i)(atlassian[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-z0-9]{24})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Bitbucket client ID"
+id = "bitbucket-client-id"
+regex = '''(?i)(bitbucket[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-z0-9]{32})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Bitbucket client secret"
+id = "bitbucket-client-secret"
+regex = '''(?i)(bitbucket[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-z0-9_\-]{64})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Beamer API token"
+id = "beamer-api-token"
+regex = '''(?i)(beamer[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](b_[a-z0-9=_\-]{44})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Clojars API token"
+id = "clojars-api-token"
+regex = '''(CLOJARS_)(?i)[a-z0-9]{60}'''
+
+[[rules]]
+description = "Contentful delivery API token"
+id = "contentful-delivery-api-token"
+regex = '''(?i)(contentful[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-z0-9\-=_]{43})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Contentful preview API token"
+id = "contentful-preview-api-token"
+regex = '''(?i)(contentful[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-z0-9\-=_]{43})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Databricks API token"
+id = "databricks-api-token"
+regex = '''dapi[a-h0-9]{32}'''
+
+[[rules]]
+description = "Discord API key"
+id = "discord-api-token"
+regex = '''(?i)(discord[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-h0-9]{64})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Discord client ID"
+id = "discord-client-id"
+regex = '''(?i)(discord[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([0-9]{18})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Discord client secret"
+id = "discord-client-secret"
+regex = '''(?i)(discord[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-z0-9=_\-]{32})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Doppler API token"
+id = "doppler-api-token"
+regex = '''['\"](dp\.pt\.)(?i)[a-z0-9]{43}['\"]'''
+
+[[rules]]
+description = "Dropbox API secret/key"
+id = "dropbox-api-secret"
+regex = '''(?i)(dropbox[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-z0-9]{15})['\"]'''
+
+[[rules]]
+description = "Dropbox API secret/key"
+id = "dropbox--api-key"
+regex = '''(?i)(dropbox[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-z0-9]{15})['\"]'''
+
+[[rules]]
+description = "Dropbox short lived API token"
+id = "dropbox-short-lived-api-token"
+regex = '''(?i)(dropbox[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](sl\.[a-z0-9\-=_]{135})['\"]'''
+
+[[rules]]
+description = "Dropbox long lived API token"
+id = "dropbox-long-lived-api-token"
+regex = '''(?i)(dropbox[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"][a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43}['\"]'''
+
+[[rules]]
+description = "Duffel API token"
+id = "duffel-api-token"
+regex = '''['\"]duffel_(test|live)_(?i)[a-z0-9_-]{43}['\"]'''
+
+[[rules]]
+description = "Dynatrace API token"
+id = "dynatrace-api-token"
+regex = '''['\"]dt0c01\.(?i)[a-z0-9]{24}\.[a-z0-9]{64}['\"]'''
+
+[[rules]]
+description = "EasyPost API token"
+id = "easypost-api-token"
+regex = '''['\"]EZAK(?i)[a-z0-9]{54}['\"]'''
+
+[[rules]]
+description = "EasyPost test API token"
+id = "easypost-test-api-token"
+regex = '''['\"]EZTK(?i)[a-z0-9]{54}['\"]'''
+
+[[rules]]
+description = "Fastly API token"
+id = "fastly-api-token"
+regex = '''(?i)(fastly[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-z0-9\-=_]{32})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Finicity client secret"
+id = "finicity-client-secret"
+regex = '''(?i)(finicity[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-z0-9]{20})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Finicity API token"
+id = "finicity-api-token"
+regex = '''(?i)(finicity[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-f0-9]{32})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Flutterweave public key"
+id = "flutterweave-public-key"
+regex = '''FLWPUBK_TEST-(?i)[a-h0-9]{32}-X'''
+
+[[rules]]
+description = "Flutterweave secret key"
+id = "flutterweave-secret-key"
+regex = '''FLWSECK_TEST-(?i)[a-h0-9]{32}-X'''
+
+[[rules]]
+description = "Flutterweave encrypted key"
+id = "flutterweave-enc-key"
+regex = '''FLWSECK_TEST[a-h0-9]{12}'''
+
+[[rules]]
+description = "Frame.io API token"
+id = "frameio-api-token"
+regex = '''fio-u-(?i)[a-z0-9-_=]{64}'''
+
+[[rules]]
+description = "GoCardless API token"
+id = "gocardless-api-token"
+regex = '''['\"]live_(?i)[a-z0-9-_=]{40}['\"]'''
+
+[[rules]]
+description = "Grafana API token"
+id = "grafana-api-token"
+regex = '''['\"]eyJrIjoi(?i)[a-z0-9-_=]{72,92}['\"]'''
+
+[[rules]]
+description = "Hashicorp Terraform user/org API token"
+id = "hashicorp-tf-api-token"
+regex = '''['\"](?i)[a-z0-9]{14}\.atlasv1\.[a-z0-9-_=]{60,70}['\"]'''
+
+[[rules]]
+description = "Hubspot API token"
+id = "hubspot-api-token"
+regex = '''(?i)(hubspot[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-h0-9]{8}-[a-h0-9]{4}-[a-h0-9]{4}-[a-h0-9]{4}-[a-h0-9]{12})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Intercom API token"
+id = "intercom-api-token"
+regex = '''(?i)(intercom[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-z0-9=_]{60})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Intercom client secret/ID"
+id = "intercom-client-secret"
+regex = '''(?i)(intercom[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-h0-9]{8}-[a-h0-9]{4}-[a-h0-9]{4}-[a-h0-9]{4}-[a-h0-9]{12})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Ionic API token"
+id = "ionic-api-token"
+regex = '''(?i)(ionic[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](ion_[a-z0-9]{42})['\"]'''
+
+[[rules]]
+description = "Linear API token"
+id = "linear-api-token"
+regex = '''lin_api_(?i)[a-z0-9]{40}'''
+
+[[rules]]
+description = "Linear client secret/ID"
+id = "linear-client-secret"
+regex = '''(?i)(linear[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-f0-9]{32})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Lob API Key"
+id = "lob-api-key"
+regex = '''(?i)(lob[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]((live|test)_[a-f0-9]{35})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Lob Publishable API Key"
+id = "lob-pub-api-key"
+regex = '''(?i)(lob[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]((test|live)_pub_[a-f0-9]{31})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Mailchimp API key"
+id = "mailchimp-api-key"
+regex = '''(?i)(mailchimp[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-f0-9]{32}-us20)['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Mailgun private API token"
+id = "mailgun-private-api-token"
+regex = '''(?i)(mailgun[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](key-[a-f0-9]{32})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Mailgun public validation key"
+id = "mailgun-pub-key"
+regex = '''(?i)(mailgun[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](pubkey-[a-f0-9]{32})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Mailgun webhook signing key"
+id = "mailgun-signing-key"
+regex = '''(?i)(mailgun[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Mapbox API token"
+id = "mapbox-api-token"
+regex = '''(?i)(pk\.[a-z0-9]{60}\.[a-z0-9]{22})'''
+
+[[rules]]
+description = "MessageBird API token"
+id = "messagebird-api-token"
+regex = '''(?i)(messagebird[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-z0-9]{25})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "MessageBird API client ID"
+id = "messagebird-client-id"
+regex = '''(?i)(messagebird[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-h0-9]{8}-[a-h0-9]{4}-[a-h0-9]{4}-[a-h0-9]{4}-[a-h0-9]{12})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "New Relic user API Key"
+id = "new-relic-user-api-key"
+regex = '''['\"](NRAK-[A-Z0-9]{27})['\"]'''
+
+[[rules]]
+description = "New Relic user API ID"
+id = "new-relic-user-api-id"
+regex = '''(?i)(newrelic[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([A-Z0-9]{64})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "New Relic ingest browser API token"
+id = "new-relic-browser-api-token"
+regex = '''['\"](NRJS-[a-f0-9]{19})['\"]'''
+
+[[rules]]
+description = "npm access token"
+id = "npm-access-token"
+regex = '''['\"](npm_(?i)[a-z0-9]{36})['\"]'''
+
+[[rules]]
+description = "Planetscale password"
+id = "planetscale-password"
+regex = '''pscale_pw_(?i)[a-z0-9\-_\.]{43}'''
+
+[[rules]]
+description = "Planetscale API token"
+id = "planetscale-api-token"
+regex = '''pscale_tkn_(?i)[a-z0-9\-_\.]{43}'''
+
+[[rules]]
+description = "Postman API token"
+id = "postman-api-token"
+regex = '''PMAK-(?i)[a-f0-9]{24}\-[a-f0-9]{34}'''
+
+[[rules]]
+description = "Pulumi API token"
+id = "pulumi-api-token"
+regex = '''pul-[a-f0-9]{40}'''
+
+[[rules]]
+description = "Rubygem API token"
+id = "rubygems-api-token"
+regex = '''rubygems_[a-f0-9]{48}'''
+
+[[rules]]
+description = "Sendgrid API token"
+id = "sendgrid-api-token"
+regex = '''SG\.(?i)[a-z0-9_\-\.]{66}'''
+
+[[rules]]
+description = "Sendinblue API token"
+id = "sendinblue-api-token"
+regex = '''xkeysib-[a-f0-9]{64}\-(?i)[a-z0-9]{16}'''
+
+[[rules]]
+description = "Shippo API token"
+id = "shippo-api-token"
+regex = '''shippo_(live|test)_[a-f0-9]{40}'''
+
+[[rules]]
+description = "Linkedin Client secret"
+id = "linedin-client-secret"
+regex = '''(?i)(linkedin[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-z]{16})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Linkedin Client ID"
+id = "linedin-client-id"
+regex = '''(?i)(linkedin[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-z0-9]{14})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Twitch API token"
+id = "twitch-api-token"
+regex = '''(?i)(twitch[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-z0-9]{30})['\"]'''
+secretGroup = 3
+
+[[rules]]
+description = "Typeform API token"
+id = "typeform-api-token"
+regex = '''(?i)(typeform[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}(tfp_[a-z0-9\-_\.=]{59})'''
+secretGroup = 3
+
+[[rules]]
+description = "Generic API Key"
+entropy = 3.7
+id = "generic-api-key"
+regex = '''(?i)((key|api|token|secret|password)[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([0-9a-zA-Z\-_=]{8,64})['\"]'''
+secretGroup = 4

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -18,7 +18,7 @@ exec("git branch --show-current", (error, stdout, stderr) => {
 
 module.exports = {
     '*': () => {
-        return `gitleaks protect -v --staged`
+        return `gitleaks protect --config=.husky/gitleaks-rules.toml -v`
     },
     ...config
 }

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -18,7 +18,7 @@ exec("git branch --show-current", (error, stdout, stderr) => {
 
 module.exports = {
     '*': () => {
-        return `gitleaks --repo-url=.git -v --additional-config=.husky/gitleaks-rules.toml --unstaged --branch=${branch}`
+        return `gitleaks protect -v`
     },
     ...config
 }

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -18,7 +18,7 @@ exec("git branch --show-current", (error, stdout, stderr) => {
 
 module.exports = {
     '*': () => {
-        return `gitleaks protect -v`
+        return `gitleaks protect -v --staged`
     },
     ...config
 }

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -18,7 +18,7 @@ exec("git branch --show-current", (error, stdout, stderr) => {
 
 module.exports = {
     '*': () => {
-        return `gitleaks protect --config=.husky/gitleaks-rules.toml -v`
+        return `gitleaks protect --config=.husky/gitleaks-rules.toml --staged -v`
     },
     ...config
 }


### PR DESCRIPTION
Update pre-commit hook to be compatible with gitleaks 8 cli api - closes https://github.com/segmentio/action-destinations/issues/369

## Testing


- Introduce `discord_client_secret` to `destinations/` code
```typescript
const discord_client_secret = '8dyfuiRyq=vVc3RRr_edRk-fK__JItpZ'
```
- `git add .` to stage changes

- `'git commit -m "seecrit"` to attempt to commit secret
- Pre-commit hooks prevents the commit with the following message:

```
✖ gitleaks protect -v --staged:

    ○
    │╲
    │ ○
    ○ ░
    ░    gitleaks

12:59PM WRN leaks found: 1
12:59PM INF scan duration: 56.64925ms
{
	"Description": "Discord client secret",
	"StartLine": 5,
	"EndLine": 5,
	"StartColumn": 8,
	"EndColumn": 65,
	"Match": "discord_client_secret = '8dyfuiRyq=vVc3RRr_edRk-fK__JItpZ'",
	"Secret": "8dyfuiRyq=vVc3RRr_edRk-fK__JItpZ",
	"File": "packages/destination-actions/src/destinations/actions-test/index.ts",
	"Commit": "",
	"Entropy": 0,
	"Author": "",
	"Email": "",
	"Date": "0001-01-01T00:00:00Z",
	"Message": "",
	"Tags": [],
	"RuleID": "discord-client-secret"
}
```


*n.b. - the `additional-config` switch in v8 of gitleaks will now replace the entire default ruleset with the one it points to (instead of extending) - they have an open issue to track support for that here https://github.com/zricethezav/gitleaks/issues/741 - for now, the default rules have been inlined*