### PR TITLE
Remove URL restriction on Webhooks

### DIFF
--- a/packages/destination-actions/src/destinations/webhook/__test__/webhook.test.ts
+++ b/packages/destination-actions/src/destinations/webhook/__test__/webhook.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { createTestEvent, createTestIntegration, IntegrationError } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Webhook from '../index'
 
 const testDestination = createTestIntegration(Webhook)
@@ -8,7 +8,7 @@ const timestamp = new Date().toISOString()
 describe('Webhook', () => {
   describe('send', () => {
     it('should work with default mapping', async () => {
-      const url = 'https://mme-e2e.segment.com'
+      const url = 'https://example.com'
       const event = createTestEvent({
         timestamp,
         event: 'Test Event'
@@ -31,7 +31,7 @@ describe('Webhook', () => {
     })
 
     it('supports customizations', async () => {
-      const url = 'https://mme-e2e.segment.build'
+      const url = 'https://example.build'
 
       const event = createTestEvent({
         timestamp,
@@ -55,7 +55,7 @@ describe('Webhook', () => {
     })
 
     it('supports customizations', async () => {
-      const url = 'https://mme-e2e.segment.build'
+      const url = 'https://example.build'
       const event = createTestEvent({
         timestamp,
         event: 'Test Event'
@@ -75,34 +75,6 @@ describe('Webhook', () => {
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
-    })
-
-    it('restricts usage to mme-e2e urls', async () => {
-      const url = 'https://api.acme.com/webhook'
-      const event = createTestEvent({
-        timestamp,
-        event: 'Test Event'
-      })
-      const data = { cool: true }
-
-      nock(url).put('/', data).reply(200)
-
-      try {
-        await testDestination.testAction('send', {
-          event,
-          mapping: {
-            url,
-            method: 'PUT',
-            data: { cool: true }
-          }
-        })
-        fail('expected testAction to reject')
-      } catch (err) {
-        const error = err as IntegrationError
-        expect(error.status).toBe(400)
-        expect(error.code).toBe('Bad Request')
-        expect(error.message).toBe("invalid url 'https://api.acme.com/webhook'")
-      }
     })
   })
 })

--- a/packages/destination-actions/src/destinations/webhook/send/index.ts
+++ b/packages/destination-actions/src/destinations/webhook/send/index.ts
@@ -1,13 +1,8 @@
-import { ActionDefinition, IntegrationError } from '@segment/actions-core'
+import { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
 type RequestMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
-
-const MME_E2E_URLS = [
-  'https://mme-e2e.segment.com',
-  'https://mme-e2e.segment.build'
-]
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send',
@@ -42,10 +37,6 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: (request, { payload }) => {
-    if (!MME_E2E_URLS.includes(payload.url)) {
-      throw new IntegrationError(`invalid url '${payload.url}'`, 'Bad Request', 400)
-    }
-
     return request(payload.url, {
       method: payload.method as RequestMethod,
       json: payload.data
@@ -54,10 +45,6 @@ const action: ActionDefinition<Settings, Payload> = {
   performBatch: (request, { payload }) => {
     // Expect these to be the same across the payloads
     const { url, method } = payload[0]
-
-    if (!MME_E2E_URLS.includes(url)) {
-      throw new IntegrationError(`invalid url '${url}'`, 'Bad Request', 400)
-    }
 
     return request(url, {
       method: method as RequestMethod,


### PR DESCRIPTION
This PR removes the `mme-e2e` restriction on the Webhook action now that the underlying issues have been resolved.

## Testing

_Include any additional information about the testing you have completed to ensure your changes behave as expected. For a speedy review, please check any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
