### PR TITLE
Update action-destinations to version 3.40.0

### DIFF
--- a/packages/cli-internal/package.json
+++ b/packages/cli-internal/package.json
@@ -53,7 +53,7 @@
     "@oclif/config": "^1",
     "@oclif/errors": "^1",
     "@oclif/plugin-help": "^3.3",
-    "@segment/action-destinations": "^3.39.2",
+    "@segment/action-destinations": "^3.40.0",
     "@segment/actions-core": "^3.21.1",
     "chalk": "^4.1.1",
     "chokidar": "^3.5.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,7 @@
     "@oclif/config": "^1",
     "@oclif/errors": "^1",
     "@oclif/plugin-help": "^3.3",
-    "@segment/action-destinations": "^3.39.2",
+    "@segment/action-destinations": "^3.40.0",
     "@segment/actions-core": "^3.21.1",
     "chalk": "^4.1.1",
     "chokidar": "^3.5.1",

--- a/packages/destination-actions/package.json
+++ b/packages/destination-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/action-destinations",
   "description": "Destination Actions engine and definitions.",
-  "version": "3.39.2",
+  "version": "3.40.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",


### PR DESCRIPTION
I have to update the action-destinations version to 3.40.0 due to a gitleaks error

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
