### PR TITLE
[Customer.io] Check if timestamps are valid before converting

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/__tests__/createUpdateDevice.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/createUpdateDevice.test.ts
@@ -53,6 +53,49 @@ describe('CustomerIO', () => {
       })
     })
 
+    it("should not convert last_used if it's invalid", async () => {
+      const settings: Settings = {
+        siteId: '12345',
+        apiKey: 'abcde',
+        accountRegion: AccountRegion.US
+      }
+      const userId = 'abc123'
+      const deviceId = 'device_123'
+      const deviceType = 'ios'
+      const timestamp = '2018-03-04T12:08:56.235 PDT'
+      trackService.put(`/customers/${userId}/devices`).reply(200, {}, { 'x-customerio-region': 'US' })
+      const event = createTestEvent({
+        userId,
+        timestamp,
+        context: {
+          device: {
+            token: deviceId,
+            type: deviceType
+          }
+        }
+      })
+      const responses = await testDestination.testAction('createUpdateDevice', {
+        event,
+        settings,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].headers.toJSON()).toMatchObject({
+        'x-customerio-region': 'US',
+        'content-type': 'application/json'
+      })
+      expect(responses[0].data).toMatchObject({})
+      expect(responses[0].options.json).toMatchObject({
+        device: {
+          id: deviceId,
+          platform: deviceType,
+          last_used: timestamp
+        }
+      })
+    })
+
     it('should not convert last_used to a unix timestamp when convert_timestamp is false', async () => {
       const settings: Settings = {
         siteId: '12345',

--- a/packages/destination-actions/src/destinations/customerio/__tests__/createUpdateDevice.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/createUpdateDevice.test.ts
@@ -82,11 +82,6 @@ describe('CustomerIO', () => {
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
-      expect(responses[0].headers.toJSON()).toMatchObject({
-        'x-customerio-region': 'US',
-        'content-type': 'application/json'
-      })
-      expect(responses[0].data).toMatchObject({})
       expect(responses[0].options.json).toMatchObject({
         device: {
           id: deviceId,

--- a/packages/destination-actions/src/destinations/customerio/__tests__/createUpdatePerson.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/createUpdatePerson.test.ts
@@ -150,6 +150,36 @@ describe('CustomerIO', () => {
       })
     })
 
+    it("should not convert created_at if it's already a number", async () => {
+      const settings: Settings = {
+        siteId: '12345',
+        apiKey: 'abcde',
+        accountRegion: AccountRegion.US
+      }
+      const userId = 'abc123'
+      const timestamp = dayjs.utc().toISOString()
+      const testTimestamps = {
+        created_at: dayjs.utc(timestamp).unix().toString()
+      }
+      trackDeviceService.put(`/customers/${userId}`).reply(200, {}, { 'x-customerio-region': 'US' })
+      const event = createTestEvent({
+        userId,
+        timestamp,
+        traits: testTimestamps
+      })
+      const responses = await testDestination.testAction('createUpdatePerson', {
+        event,
+        settings,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        created_at: testTimestamps.created_at
+      })
+    })
+
     it('should not convert attributes to unix timestamps when convert_timestamp is false', async () => {
       const settings: Settings = {
         siteId: '12345',

--- a/packages/destination-actions/src/destinations/customerio/__tests__/createUpdatePerson.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/createUpdatePerson.test.ts
@@ -71,6 +71,7 @@ describe('CustomerIO', () => {
       const userId = 'abc123'
       const timestamp = dayjs.utc().toISOString()
       const testTimestamps = {
+        created_at: timestamp,
         date01: '25 Mar 2015',
         date02: 'Mar 25 2015',
         date03: '01/01/2019',
@@ -80,7 +81,11 @@ describe('CustomerIO', () => {
         date07: '2006-01-02T18:04:07+01:00',
         date08: '2006-01-02T15:04:05.007',
         date09: '2006-01-02T15:04:05.007Z',
-        date10: '2006-01-02T15:04:05.007+01:00'
+        date10: '2006-01-02T15:04:05.007+01:00',
+        date11: '2018-03-04T12:08:56 PDT',
+        date12: '2018-03-04T12:08:56.235 PDT',
+        date13: '15/MAR/18',
+        date14: '11-Jan-18'
       }
       trackDeviceService.put(`/customers/${userId}`).reply(200, {}, { 'x-customerio-region': 'US' })
       const event = createTestEvent({
@@ -97,6 +102,7 @@ describe('CustomerIO', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       expect(responses[0].options.json).toMatchObject({
+        created_at: dayjs(timestamp).unix(),
         date01: testTimestamps.date01,
         date02: testTimestamps.date02,
         date03: testTimestamps.date03,
@@ -106,7 +112,41 @@ describe('CustomerIO', () => {
         date07: dayjs(testTimestamps.date07).unix(),
         date08: dayjs(testTimestamps.date08).unix(),
         date09: dayjs(testTimestamps.date09).unix(),
-        date10: dayjs(testTimestamps.date10).unix()
+        date10: dayjs(testTimestamps.date10).unix(),
+        date11: testTimestamps.date11,
+        date12: testTimestamps.date12,
+        date13: testTimestamps.date13,
+        date14: testTimestamps.date14
+      })
+    })
+
+    it("should not convert created_at if it's invalid", async () => {
+      const settings: Settings = {
+        siteId: '12345',
+        apiKey: 'abcde',
+        accountRegion: AccountRegion.US
+      }
+      const userId = 'abc123'
+      const timestamp = dayjs.utc().toISOString()
+      const testTimestamps = {
+        created_at: '2018-03-04T12:08:56.235 PDT'
+      }
+      trackDeviceService.put(`/customers/${userId}`).reply(200, {}, { 'x-customerio-region': 'US' })
+      const event = createTestEvent({
+        userId,
+        timestamp,
+        traits: testTimestamps
+      })
+      const responses = await testDestination.testAction('createUpdatePerson', {
+        event,
+        settings,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        created_at: testTimestamps.created_at
       })
     })
 

--- a/packages/destination-actions/src/destinations/customerio/__tests__/trackEvent.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/trackEvent.test.ts
@@ -118,6 +118,40 @@ describe('CustomerIO', () => {
       }
     })
 
+    it("should not convert timestamp if it's invalid", async () => {
+      const settings: Settings = {
+        siteId: '12345',
+        apiKey: 'abcde',
+        accountRegion: AccountRegion.US
+      }
+      const userId = 'abc123'
+      const name = 'testEvent'
+      const timestamp = '2018-03-04T12:08:56.235 PDT'
+      const data = {
+        property1: 'this is a test'
+      }
+      trackEventService.post(`/customers/${userId}/events`).reply(200, {}, { 'x-customerio-region': 'US' })
+      const event = createTestEvent({
+        event: name,
+        userId,
+        properties: data,
+        timestamp
+      })
+      const responses = await testDestination.testAction('trackEvent', {
+        event,
+        settings,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        name,
+        data,
+        timestamp
+      })
+    })
+
     it('should not convert dates to unix timestamps when convert_timestamp is false', async () => {
       const settings: Settings = {
         siteId: '12345',

--- a/packages/destination-actions/src/destinations/customerio/__tests__/trackPageView.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/trackPageView.test.ts
@@ -116,6 +116,41 @@ describe('CustomerIO', () => {
       }
     })
 
+    it("should not convert timestamp if it's invalid", async () => {
+      const settings: Settings = {
+        siteId: '12345',
+        apiKey: 'abcde',
+        accountRegion: AccountRegion.US
+      }
+      const userId = 'abc123'
+      const url = 'https://example.com/page-one'
+      const timestamp = '2018-03-04T12:08:56.235 PDT'
+      const data = {
+        property1: 'this is a test',
+        url
+      }
+      trackPageViewService.post(`/customers/${userId}/events`).reply(200, {}, { 'x-customerio-region': 'US' })
+      const event = createTestEvent({
+        userId,
+        properties: data,
+        timestamp
+      })
+      const responses = await testDestination.testAction('trackPageView', {
+        event,
+        settings,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        name: url,
+        type,
+        data,
+        timestamp
+      })
+    })
+
     it('should not convert dates to unix timestamps when convert_timestamp is false', async () => {
       const settings: Settings = {
         siteId: '12345',

--- a/packages/destination-actions/src/destinations/customerio/__tests__/trackScreenView.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/trackScreenView.test.ts
@@ -129,6 +129,43 @@ describe('CustomerIO', () => {
       }
     })
 
+    it("should not convert timestamp if it's invalid", async () => {
+      const settings: Settings = {
+        siteId: '12345',
+        apiKey: 'abcde',
+        accountRegion: AccountRegion.US
+      }
+      const userId = 'abc123'
+      const screen = 'Page One'
+      const timestamp = '2018-03-04T12:08:56.235 PDT'
+      const data = {
+        property1: 'this is a test',
+        screen
+      }
+      trackScreenViewService.post(`/customers/${userId}/events`).reply(200, {}, { 'x-customerio-region': 'US' })
+      const event = createTestEvent({
+        type: 'screen',
+        name: screen,
+        userId,
+        properties: data,
+        timestamp
+      })
+      const responses = await testDestination.testAction('trackScreenView', {
+        event,
+        settings,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        name: screen,
+        type,
+        data,
+        timestamp
+      })
+    })
+
     it('should not convert dates to unix timestamps when convert_timestamp is false', async () => {
       const settings: Settings = {
         siteId: '12345',

--- a/packages/destination-actions/src/destinations/customerio/createUpdateDevice/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/createUpdateDevice/index.ts
@@ -1,8 +1,7 @@
-import dayjs from '../../../lib/dayjs'
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { trackApiEndpoint } from '../utils'
+import { convertValidTimestamp, trackApiEndpoint } from '../utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Create or Update Device',
@@ -56,7 +55,7 @@ const action: ActionDefinition<Settings, Payload> = {
     let lastUsed: string | number | undefined = payload.last_used
 
     if (lastUsed && payload.convert_timestamp !== false) {
-      lastUsed = dayjs.utc(lastUsed).unix()
+      lastUsed = convertValidTimestamp(lastUsed)
     }
 
     return request(`${trackApiEndpoint(settings.accountRegion)}/api/v1/customers/${payload.person_id}/devices`, {

--- a/packages/destination-actions/src/destinations/customerio/createUpdatePerson/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/createUpdatePerson/index.ts
@@ -1,8 +1,7 @@
-import dayjs from '../../../lib/dayjs'
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { convertAttributeTimestamps, trackApiEndpoint } from '../utils'
+import { convertAttributeTimestamps, convertValidTimestamp, trackApiEndpoint } from '../utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Create or Update Person',
@@ -67,7 +66,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
     if (payload.convert_timestamp !== false) {
       if (createdAt) {
-        createdAt = dayjs.utc(createdAt).unix()
+        createdAt = convertValidTimestamp(createdAt)
       }
 
       if (customAttributes) {

--- a/packages/destination-actions/src/destinations/customerio/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackEvent/index.ts
@@ -1,7 +1,6 @@
-import dayjs from '../../../lib/dayjs'
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
-import { convertAttributeTimestamps, trackApiEndpoint } from '../utils'
+import { convertAttributeTimestamps, convertValidTimestamp, trackApiEndpoint } from '../utils'
 import type { Payload } from './generated-types'
 
 interface TrackEventPayload {
@@ -75,7 +74,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
     if (payload.convert_timestamp !== false) {
       if (timestamp) {
-        timestamp = dayjs.utc(timestamp).unix()
+        timestamp = convertValidTimestamp(timestamp)
       }
 
       if (data) {

--- a/packages/destination-actions/src/destinations/customerio/trackPageView/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackPageView/index.ts
@@ -1,7 +1,6 @@
-import dayjs from '../../../lib/dayjs'
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
-import { convertAttributeTimestamps, trackApiEndpoint } from '../utils'
+import { convertAttributeTimestamps, convertValidTimestamp, trackApiEndpoint } from '../utils'
 import type { Payload } from './generated-types'
 
 interface TrackPageViewPayload {
@@ -74,7 +73,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
     if (payload.convert_timestamp !== false) {
       if (timestamp) {
-        timestamp = dayjs.utc(timestamp).unix()
+        timestamp = convertValidTimestamp(timestamp)
       }
 
       if (data) {

--- a/packages/destination-actions/src/destinations/customerio/trackScreenView/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackScreenView/index.ts
@@ -1,7 +1,6 @@
-import dayjs from '../../../lib/dayjs'
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
-import { convertAttributeTimestamps, trackApiEndpoint } from '../utils'
+import { convertAttributeTimestamps, convertValidTimestamp, trackApiEndpoint } from '../utils'
 import type { Payload } from './generated-types'
 
 interface TrackScreenViewPayload {
@@ -74,7 +73,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
     if (payload.convert_timestamp !== false) {
       if (timestamp) {
-        timestamp = dayjs.utc(timestamp).unix()
+        timestamp = convertValidTimestamp(timestamp)
       }
 
       if (data) {

--- a/packages/destination-actions/src/destinations/customerio/utils.ts
+++ b/packages/destination-actions/src/destinations/customerio/utils.ts
@@ -32,7 +32,11 @@ const isIsoDate = (value: string): boolean => {
 }
 
 export const convertValidTimestamp = <Value = unknown>(value: Value): Value | number => {
-  if (typeof value !== 'string') {
+  // Timestamps may be on a `string` field, so check if the string is only
+  // numbers. If it is, ignore it since it's probably already a unix timestamp.
+  // DayJS doesn't parse unix timestamps correctly outside of the `.unix()`
+  // initializer.
+  if (typeof value !== 'string' || /^\d+$/.test(value)) {
     return value
   }
 

--- a/packages/destination-actions/src/destinations/customerio/utils.ts
+++ b/packages/destination-actions/src/destinations/customerio/utils.ts
@@ -31,6 +31,20 @@ const isIsoDate = (value: string): boolean => {
   return typeof value === 'string' && matcher.test(value) && !isNaN(Date.parse(value))
 }
 
+export const convertValidTimestamp = <Value = unknown>(value: Value): Value | number => {
+  if (typeof value !== 'string') {
+    return value
+  }
+
+  const maybeDate = dayjs.utc(value)
+
+  if (maybeDate.isValid()) {
+    return maybeDate.unix()
+  }
+
+  return value
+}
+
 // Recursively walk through an object and try to convert any strings into dates
 export const convertAttributeTimestamps = (payload: Record<string, unknown>): Record<string, unknown> => {
   const clone: Record<string, unknown> = {}


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

There's currently a bug where if an invalid date is passed in for `created_at` and other special dates, it will end up being converted to `NaN` by `dayjs`, and will be removed from the payload before being sent to customer.io. This adds a check to make sure the timestamp is valid—if not, it maintains the original value rather than converting to `NaN`.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment