### PR TITLE
define window.UserLeap for backwards compatibility

### DIFF
--- a/packages/browser-destinations/src/destinations/sprig-web/index.ts
+++ b/packages/browser-destinations/src/destinations/sprig-web/index.ts
@@ -11,6 +11,7 @@ import { defaultValues } from '@segment/actions-core'
 declare global {
   interface Window {
     Sprig: Sprig
+    UserLeap: Sprig
   }
 }
 
@@ -79,6 +80,7 @@ export const destination: BrowserDestinationDefinition<Settings, Sprig> = {
       S.debugMode = !!settings.debugMode
       S._queue = []
       S._segment = 1
+      window.UserLeap = S
       await deps.loadScript(`https://cdn.sprig.com/shim.js?id=${S.envId}`)
     }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Define `window.UserLeap` as well as `window.Sprig` during initialization, for better backwards compatibility with older installations.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- existing tests passed, and used lerna testing suite against our staging environment to ensure installation/actions continue to work.
- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
