### PR TITLE
updates name of Cordial destination-action to Actions Cordial

### DIFF
--- a/packages/destination-actions/src/destinations/cordial/index.ts
+++ b/packages/destination-actions/src/destinations/cordial/index.ts
@@ -7,7 +7,7 @@ import addContactToList from './addContactToList'
 import removeContactFromList from './removeContactFromList'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Cordial',
+  name: 'Actions Cordial',
   description: 'Sync Segment Users, Groups and Events to Cordial',
   slug: 'actions-cordial',
   mode: 'cloud',
@@ -23,7 +23,8 @@ const destination: DestinationDefinition<Settings> = {
       },
       endpoint: {
         label: 'Endpoint',
-        description: "Cordial API endpoint. Leave default, unless you've been provided with another one. [See more details](https://support.cordial.com/hc/en-us/sections/200553578-REST-API-Introduction-and-Overview)",
+        description:
+          "Cordial API endpoint. Leave default, unless you've been provided with another one. [See more details](https://support.cordial.com/hc/en-us/sections/200553578-REST-API-Introduction-and-Overview)",
         type: 'string',
         required: true,
         format: 'uri',

--- a/packages/destination-actions/src/destinations/cordial/index.ts
+++ b/packages/destination-actions/src/destinations/cordial/index.ts
@@ -7,7 +7,7 @@ import addContactToList from './addContactToList'
 import removeContactFromList from './removeContactFromList'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Actions Cordial',
+  name: 'Cordial (Actions)',
   description: 'Sync Segment Users, Groups and Events to Cordial',
   slug: 'actions-cordial',
   mode: 'cloud',


### PR DESCRIPTION
Updates `Cordial` destination-action name to `Actions Cordial`.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
