### PR TITLE
Add Adobe Target Web Destination

### DIFF
--- a/packages/browser-destinations/README.md
+++ b/packages/browser-destinations/README.md
@@ -14,7 +14,7 @@ Steps include:
 - 1. Run the web server
 
 ```
-$ yarn browser dev
+$ yarn dev
 ```
 
 - 2. Visit the webserver: [http://localhost:9000](http://localhost:9000)

--- a/packages/browser-destinations/README.md
+++ b/packages/browser-destinations/README.md
@@ -2,11 +2,21 @@
 
 This package contains the implementations for browser destinations.
 
+# Glossary
+
+- Action: A method defined by the author of the destination that's linked to a Segment event.
+- Plugin: A plugin is an action in AJS lingo. You can see the loaded plugins by typing `analytics.queue.plugins` in the browser's console.
+- Subscription: A "way-in" into an action. For example: the `updateUser` action uses a subscription of the type `identify`. See the test section for more information.
+
 ## Developing
 
-> Alert: Please develop from the root directory of this repo. Every command should be run using lerna.
+> NOTE: The shell commands mentioned below must be run with `browser-destinations` as root directory. Every command should be run using lerna.
 
-### Local testing
+### Actions CLI
+
+See the [Actions CLI](https://github.com/segmentio/action-destinations#actions-cli) of the root directory of this repo to learn how to interact with the Actions CLI. Interacting with the actions CLI will allow you to create new destinations, actions and update your type definitions.
+
+### Manual testing
 
 You can run a test webpage that makes every browser destination available for testing.
 Steps include:
@@ -14,12 +24,55 @@ Steps include:
 - 1. Run the web server
 
 ```
-$ yarn dev
+yarn dev
 ```
 
 - 2. Visit the webserver: [http://localhost:9000](http://localhost:9000)
-- 3. Select a destination from the picker and click `load`
-- 4. Make sure you have a subscription propertly set up
+- 3. Set up a subscription in the settings box. A minimum of one subscription is required to load your destination. A valid subscription and settings look like this:
+
+```
+{
+  "client_code": "segmentexchangepartn",
+  "admin_number": "10",
+  "version": "2.8.0",
+  "cookie_domain": "localhost",
+  "mbox_name": "target-global-mbox",
+  "subscriptions": [
+    {
+      "partnerAction": "upsertProfile",
+      "name": "Upsert Profile",
+      "enabled": true,
+      "subscribe": "type = \"identify\"",
+      "mapping": {}
+    }
+  ]
+}
+```
+
+- 4. Select a destination from the picker and click `load`
+
+Notes:
+
+- Be careful of matching the name and type of the subscriptions. The parser is case sensitive and also "" vs '' sensitive.
+- The `partnerAction` key must have an action that matches its value.
+
+### Automated tests
+
+Running the test suite
+
+```
+yarn test
+```
+
+Running one file at the time
+
+```
+yarn jest src/destinations/PATH-TO-YOUR-DESTINATION/__tests__/index.test.ts
+```
+
+## Deploying
+
+Coming Soon
 
 ## License
 

--- a/packages/browser-destinations/index.html
+++ b/packages/browser-destinations/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>

--- a/packages/browser-destinations/src/destinations/adobe-target/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/__tests__/index.test.ts
@@ -1,0 +1,44 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import adobeTarget, { destination } from '../index'
+import { Subscription } from '../../../lib/browser-destinations'
+
+describe('Adobe Target Web', () => {
+  test('can load ATJS', async () => {
+    const subscriptions: Subscription[] = [
+      {
+        partnerAction: 'upsertProfile',
+        name: 'Upsert Profile',
+        enabled: true,
+        subscribe: 'type = "identify"',
+        mapping: {}
+      }
+    ]
+    const [event] = await adobeTarget({
+      client_code: 'segmentexchangepartn',
+      admin_number: '10',
+      version: '2.8.0',
+      cookie_domain: 'localhost',
+      mbox_name: 'target-global-mbox',
+      subscriptions
+    })
+
+    jest.spyOn(destination, 'initialize')
+
+    await event.load(Context.system(), {} as Analytics)
+    expect(destination.initialize).toHaveBeenCalled()
+
+    const scripts = window.document.querySelectorAll('script')
+    expect(scripts).toMatchInlineSnapshot(`
+      NodeList [
+        <script
+          src="https://admin10.testandtarget.omniture.com/admin/rest/v1/libraries/atjs/download?client=segmentexchangepartn&version=2.8.0"
+          status="loaded"
+          type="text/javascript"
+        />,
+        <script>
+          // the emptiness
+        </script>,
+      ]
+    `)
+  })
+})

--- a/packages/browser-destinations/src/destinations/adobe-target/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Settings {
   /**
-   * Your client code is available at the top of the Administration > Implementation page of the Target interface.
+   * Your Adobe Target client code. To find your client code in Adobe Target, navigate to **Administration > Implementation**. The client code is shown at the top under Account Details.
    */
   client_code: string
   /**
@@ -14,11 +14,11 @@ export interface Settings {
    */
   version: string
   /**
-   * The name of the mbox to use
+   * The name of the Adobe Target mbox to use. Defaults to `target-global-mbox`.
    */
   mbox_name: string
   /**
-   * The domain of the platform that your integration will run on
+   * The domain from which you serve the mbox. Adobe Target recommends setting this value to your company's top- level domain.
    */
   cookie_domain: string
 }

--- a/packages/browser-destinations/src/destinations/adobe-target/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/generated-types.ts
@@ -18,7 +18,7 @@ export interface Settings {
    */
   mbox_name: string
   /**
-   * The domain from which you serve the mbox. Adobe Target recommends setting this value to your company's top- level domain.
+   * The domain from which you serve the mbox. Adobe Target recommends setting this value to your company's top-level domain.
    */
   cookie_domain: string
 }

--- a/packages/browser-destinations/src/destinations/adobe-target/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/generated-types.ts
@@ -1,0 +1,24 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your client code is available at the top of the Administration > Implementation page of the Target interface.
+   */
+  client_code: string
+  /**
+   * Your Adobe Target admin number. To find your admin number, please follow the instructions in [Adobe Docs](https://experienceleague.adobe.com/docs/target/using/implement-target/client-side/at-js-implementation/deploy-at-js/implementing-target-without-a-tag-manager.html).
+   */
+  admin_number: string
+  /**
+   * The version of ATJS to use. Defaults to 2.8.0.
+   */
+  version: string
+  /**
+   * The name of the mbox to use
+   */
+  mbox_name: string
+  /**
+   * The domain of the platform that your integration will run on
+   */
+  cookie_domain: string
+}

--- a/packages/browser-destinations/src/destinations/adobe-target/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/index.ts
@@ -55,7 +55,7 @@ export const destination: BrowserDestinationDefinition<Settings, unknown> = {
     cookie_domain: {
       label: 'Cookie Domain',
       description:
-        "The domain from which you serve the mbox. Adobe Target recommends setting this value to your company's top- level domain.",
+        "The domain from which you serve the mbox. Adobe Target recommends setting this value to your company's top-level domain.",
       type: 'string',
       required: true
     }

--- a/packages/browser-destinations/src/destinations/adobe-target/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/index.ts
@@ -21,7 +21,7 @@ export const destination: BrowserDestinationDefinition<Settings, unknown> = {
     client_code: {
       label: 'Client Code',
       description:
-        'Your client code is available at the top of the Administration > Implementation page of the Target interface.',
+        'Your Adobe Target client code. To find your client code in Adobe Target, navigate to **Administration > Implementation**. The client code is shown at the top under Account Details.',
       required: true,
       type: 'string'
     },
@@ -46,15 +46,16 @@ export const destination: BrowserDestinationDefinition<Settings, unknown> = {
       required: true
     },
     mbox_name: {
-      label: 'MBox Name',
-      description: 'The name of the mbox to use',
+      label: 'Mbox Name',
+      description: 'The name of the Adobe Target mbox to use. Defaults to `target-global-mbox`.',
       type: 'string',
       required: true,
       default: 'target-global-mbox'
     },
     cookie_domain: {
       label: 'Cookie Domain',
-      description: 'The domain of the platform that your integration will run on',
+      description:
+        "The domain from which you serve the mbox. Adobe Target recommends setting this value to your company's top- level domain.",
       type: 'string',
       required: true
     }

--- a/packages/browser-destinations/src/destinations/adobe-target/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/index.ts
@@ -1,0 +1,79 @@
+import type { Settings } from './generated-types'
+import type { BrowserDestinationDefinition } from '../../lib/browser-destinations'
+import { browserDestination } from '../../runtime/shim'
+import { Adobe } from './types'
+import { initScript } from './init-script'
+
+import upsertProfile from './upsertProfile'
+
+declare global {
+  interface Window {
+    adobe: Adobe
+  }
+}
+
+export const destination: BrowserDestinationDefinition<Settings, unknown> = {
+  name: 'Adobe Target Web',
+  slug: 'actions-adobe-target-web',
+  mode: 'device',
+
+  settings: {
+    client_code: {
+      label: 'Client Code',
+      description:
+        'Your client code is available at the top of the Administration > Implementation page of the Target interface.',
+      required: true,
+      type: 'string'
+    },
+    admin_number: {
+      label: 'Admin number',
+      description:
+        'Your Adobe Target admin number. To find your admin number, please follow the instructions in [Adobe Docs](https://experienceleague.adobe.com/docs/target/using/implement-target/client-side/at-js-implementation/deploy-at-js/implementing-target-without-a-tag-manager.html).',
+      required: true,
+      type: 'string'
+    },
+    version: {
+      label: 'ATJS Version',
+      description: 'The version of ATJS to use. Defaults to 2.8.0.',
+      type: 'string',
+      choices: [
+        {
+          value: '2.8.0',
+          label: '2.8.0'
+        }
+      ],
+      default: '2.8.0',
+      required: true
+    },
+    mbox_name: {
+      label: 'MBox Name',
+      description: 'The name of the mbox to use',
+      type: 'string',
+      required: true,
+      default: 'target-global-mbox'
+    },
+    cookie_domain: {
+      label: 'Cookie Domain',
+      description: 'The domain of the platform that your integration will run on',
+      type: 'string',
+      required: true
+    }
+  },
+
+  initialize: async ({ settings }, deps) => {
+    initScript(settings)
+
+    const targetUrl = 'testandtarget.omniture.com/admin/rest/v1/libraries/atjs/download'
+    const atjsUrl = `https://admin${settings.admin_number}.${targetUrl}?client=${settings.client_code}&version=${settings.version}`
+
+    await deps.loadScript(atjsUrl)
+    await deps.resolveWhen(() => Object.prototype.hasOwnProperty.call(window, 'adobe'), 100)
+    return window.adobe
+  },
+
+  actions: {
+    upsertProfile
+  }
+}
+
+export default browserDestination(destination)

--- a/packages/browser-destinations/src/destinations/adobe-target/init-script.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/init-script.ts
@@ -1,0 +1,9 @@
+/* eslint-disable */
+// @ts-nocheck
+
+export function initScript(settings) {
+  window.targetGlobalSettings = {
+    cookieDomain: settings.cookie_domain,
+    enabled: true
+  }
+}

--- a/packages/browser-destinations/src/destinations/adobe-target/types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/types.ts
@@ -1,0 +1,1 @@
+export type Adobe = unknown

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/__tests__/index.test.ts
@@ -1,0 +1,46 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import adobeTarget, { destination } from '../../index'
+import { Subscription } from '../../../../lib/browser-destinations'
+
+// TODO: Fill this test since it's a copy of the main test.
+
+describe('Adobe Target Web', () => {
+  test('calls identify', async () => {
+    const subscriptions: Subscription[] = [
+      {
+        partnerAction: 'upsertProfile',
+        name: 'Upsert Profile',
+        enabled: true,
+        subscribe: 'type = "identify"',
+        mapping: {}
+      }
+    ]
+    const [event] = await adobeTarget({
+      client_code: 'segmentexchangepartn',
+      admin_number: '10',
+      version: '2.8.0',
+      cookie_domain: 'localhost',
+      mbox_name: 'target-global-mbox',
+      subscriptions
+    })
+
+    jest.spyOn(destination, 'initialize')
+
+    await event.load(Context.system(), {} as Analytics)
+    expect(destination.initialize).toHaveBeenCalled()
+
+    const scripts = window.document.querySelectorAll('script')
+    expect(scripts).toMatchInlineSnapshot(`
+      NodeList [
+        <script
+          src="https://admin10.testandtarget.omniture.com/admin/rest/v1/libraries/atjs/download?client=segmentexchangepartn&version=2.8.0"
+          status="loaded"
+          type="text/javascript"
+        />,
+        <script>
+          // the emptiness
+        </script>,
+      ]
+    `)
+  })
+})

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/generated-types.ts
@@ -1,0 +1,10 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Hash of properties for this profile.
+   */
+  profile?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
@@ -11,7 +11,6 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   fields: {
     profile: {
       type: 'object',
-      required: false,
       description: 'Hash of properties for this profile.',
       label: 'Profile Properties',
       default: {

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
@@ -5,7 +5,7 @@ import type { Payload } from './generated-types'
 
 const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   title: 'Upsert Profile',
-  description: 'Update or Create a user profile in Adobe Target',
+  description: 'Create or update a user profile in Adobe Target.',
   platform: 'web',
   defaultSubscription: 'type = "identify"',
   fields: {

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
@@ -1,0 +1,27 @@
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+import type { Settings } from '../generated-types'
+import { Adobe } from '../types'
+import type { Payload } from './generated-types'
+
+const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
+  title: 'Upsert Profile',
+  description: 'Update or Create a user profile in Adobe Target',
+  platform: 'web',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    profile: {
+      type: 'object',
+      required: false,
+      description: 'Hash of properties for this profile.',
+      label: 'Profile Properties',
+      default: {
+        '@path': '$.profile'
+      }
+    }
+  },
+  perform: () => {
+    return
+  }
+}
+
+export default action

--- a/packages/browser-destinations/src/destinations/index.ts
+++ b/packages/browser-destinations/src/destinations/index.ts
@@ -26,6 +26,7 @@ function register(id: MetadataId, destinationPath: string) {
 }
 
 // TODO figure out if it's possible to colocate the Amplitude web action with the rest of its destination definition (in `./packages/destination-actions`)
+register('61fc2ffcc76fb3e73d85c89d', './adobe-target')
 register('5f7dd6d21ad74f3842b1fc47', './amplitude-plugins')
 register('60fb01aec459242d3b6f20c1', './braze')
 register('60f9d0d048950c356be2e4da', './braze-cloud-plugins')


### PR DESCRIPTION
This PR adds support for Adobe Target Web Mode. The capabilities added to the new destination are:

- Loading the SDK. Bring in the Adobe Target SDK into the current web app.
- Placeholder action: `upsertProfile`.

## Testing

Tested completed successfully via `yarn dev` test app.

Here are the settings & subscription I used to test:

```
{
  "client_code": "segmentexchangepartn",
  "admin_number": "10",
  "version": "2.8.0",
  "cookie_domain": "localhost",
  "mbox_name": "target-global-mbox",
  "subscriptions": [
    {
      "partnerAction": "upsertProfile",
      "name": "Upsert Profile",
      "enabled": true,
      "subscribe": "type = \"identify\"",
      "mapping": {}
    }
  ]
}
```

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
