### PR TITLE
[Customer.io] Parse ISO 8601 time offsets without a `:`

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/__tests__/createUpdatePerson.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/createUpdatePerson.test.ts
@@ -85,7 +85,10 @@ describe('CustomerIO', () => {
         date11: '2018-03-04T12:08:56 PDT',
         date12: '2018-03-04T12:08:56.235 PDT',
         date13: '15/MAR/18',
-        date14: '11-Jan-18'
+        date14: '11-Jan-18',
+        date15: '2006-01-02T15:04:05-0800',
+        date16: '2006-01-02T15:04:05.07-0800',
+        date17: '2006-01-02T15:04:05.007-0800'
       }
       trackDeviceService.put(`/customers/${userId}`).reply(200, {}, { 'x-customerio-region': 'US' })
       const event = createTestEvent({
@@ -116,7 +119,10 @@ describe('CustomerIO', () => {
         date11: testTimestamps.date11,
         date12: testTimestamps.date12,
         date13: testTimestamps.date13,
-        date14: testTimestamps.date14
+        date14: testTimestamps.date14,
+        date15: dayjs(testTimestamps.date15).unix(),
+        date16: dayjs(testTimestamps.date16).unix(),
+        date17: dayjs(testTimestamps.date17).unix()
       })
     })
 

--- a/packages/destination-actions/src/destinations/customerio/utils.ts
+++ b/packages/destination-actions/src/destinations/customerio/utils.ts
@@ -24,7 +24,7 @@ const isIsoDate = (value: string): boolean => {
     '^\\d{4}-\\d{2}-\\d{2}' + // Match YYYY-MM-DD
     '((T\\d{2}:\\d{2}(:\\d{2})?)' + // Match THH:mm:ss
     '(\\.\\d{1,6})?' + // Match .sssss
-    '(Z|(\\+|-)\\d{2}:?\\d{2})?)?$' // Time zone (Z or ±hh:mm or ±hhmm or ±hh)
+    '(Z|(\\+|-)\\d{2}:?\\d{2})?)?$' // Time zone (Z or ±hh:mm or ±hhmm)
 
   const matcher = new RegExp(isoformat)
 

--- a/packages/destination-actions/src/destinations/customerio/utils.ts
+++ b/packages/destination-actions/src/destinations/customerio/utils.ts
@@ -24,7 +24,7 @@ const isIsoDate = (value: string): boolean => {
     '^\\d{4}-\\d{2}-\\d{2}' + // Match YYYY-MM-DD
     '((T\\d{2}:\\d{2}(:\\d{2})?)' + // Match THH:mm:ss
     '(\\.\\d{1,6})?' + // Match .sssss
-    '(Z|(\\+|-)\\d{2}:\\d{2})?)?$' // Time zone (Z or +hh:mm)
+    '(Z|(\\+|-)\\d{2}:?\\d{2})?)?$' // Time zone (Z or ±hh:mm or ±hhmm or ±hh)
 
   const matcher = new RegExp(isoformat)
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

We got another bug report/feature request from one of our customers who was using ISO8601 date strings in a way that we initially hadn't supported. They were using time zone offsets without a `:`, which is supported per [wikipedia](https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC):

> The UTC offset is appended to the time in the same way that 'Z' was above, in the form ±[hh]:[mm], ±[hh][mm], or ±[hh].

I also tried to add support for just `±[hh]`, but `dayjs`/`Date` doesn't support that format, so I've left it out for now.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment