### PR TITLE
Friendbuy cloud destination fixes

### DIFF
--- a/packages/actions-shared/src/friendbuy/commonFields.ts
+++ b/packages/actions-shared/src/friendbuy/commonFields.ts
@@ -2,7 +2,12 @@ import type { InputField } from '@segment/actions-core'
 
 export type FriendbuyAPI = 'pub' | 'mapi'
 
-export function commonCustomerFields(requireIdAndEmail: boolean): Record<string, InputField> {
+export interface FieldConfig {
+  requireCustomerId?: boolean
+  requireEmail?: boolean
+}
+
+export function commonCustomerFields(fieldConfig: FieldConfig): Record<string, InputField> {
   // If we want to associate an event such as a purchase with an existing
   // customer then the customerId is required.  If we want to create a new
   // customer from the event if one doesn't already exist then additionally an
@@ -12,7 +17,7 @@ export function commonCustomerFields(requireIdAndEmail: boolean): Record<string,
       label: 'Customer ID',
       description: "The user's customer ID.",
       type: 'string',
-      required: requireIdAndEmail,
+      required: Boolean(fieldConfig.requireCustomerId),
       default: {
         // We hope that we have a userId because analytics.identify has been
         // called but, if not, allow a customerId to be specified in the
@@ -36,7 +41,7 @@ export function commonCustomerFields(requireIdAndEmail: boolean): Record<string,
       label: 'Email',
       description: "The user's email address.",
       type: 'string',
-      required: requireIdAndEmail,
+      required: Boolean(fieldConfig.requireEmail),
       default: { '@path': '$.properties.email' }
     },
     isNewCustomer: {

--- a/packages/actions-shared/src/friendbuy/sharedCustomEvent.ts
+++ b/packages/actions-shared/src/friendbuy/sharedCustomEvent.ts
@@ -26,7 +26,7 @@ export const trackCustomEventFields: Record<string, InputField> = {
   },
   customerId: {
     label: 'Customer ID',
-    description: "The user's customerId.",
+    description: "The user's customer ID.",
     type: 'string',
     required: true,
     default: { '@path': '$.userId' }
@@ -37,5 +37,12 @@ export const trackCustomEventFields: Record<string, InputField> = {
     type: 'string',
     required: false,
     default: { '@path': '$.anonymousId' }
+  },
+  email: {
+    label: 'Email',
+    description: "The user's email address.",
+    type: 'string',
+    required: true,
+    default: { '@path': '$.properties.email' }
   }
 }

--- a/packages/actions-shared/src/friendbuy/sharedCustomEvent.ts
+++ b/packages/actions-shared/src/friendbuy/sharedCustomEvent.ts
@@ -29,7 +29,17 @@ export const trackCustomEventFields: Record<string, InputField> = {
     description: "The user's customer ID.",
     type: 'string',
     required: true,
-    default: { '@path': '$.userId' }
+    default: {
+      // We hope that we have a userId because analytics.identify has been
+      // called but, if not, allow a customerId to be specified in the
+      // event.  If one is specified, it overrides the one from the identify
+      // call.
+      '@if': {
+        exists: { '@path': '$.properties.customerId' },
+        then: { '@path': '$.properties.customerId' },
+        else: { '@path': '$.userId' }
+      }
+    }
   },
   anonymousId: {
     label: 'Anonymous ID',

--- a/packages/actions-shared/src/friendbuy/sharedCustomEvent.ts
+++ b/packages/actions-shared/src/friendbuy/sharedCustomEvent.ts
@@ -1,6 +1,7 @@
 import type { InputField } from '@segment/actions-core'
+import type { FieldConfig } from './commonFields'
 
-export const trackCustomEventFields: Record<string, InputField> = {
+export const trackCustomEventFields = (fieldConfig: FieldConfig): Record<string, InputField> => ({
   eventType: {
     type: 'string',
     required: true,
@@ -52,7 +53,7 @@ export const trackCustomEventFields: Record<string, InputField> = {
     label: 'Email',
     description: "The user's email address.",
     type: 'string',
-    required: true,
+    required: Boolean(fieldConfig.requireEmail),
     default: { '@path': '$.properties.email' }
   }
-}
+})

--- a/packages/actions-shared/src/friendbuy/sharedPurchase.ts
+++ b/packages/actions-shared/src/friendbuy/sharedPurchase.ts
@@ -39,6 +39,20 @@ export const trackPurchaseFields = (fieldConfig: FieldConfig): Record<string, In
     required: false,
     default: { '@path': '$.properties.coupon' }
   },
+  attributionId: {
+    label: 'Friendbuy Attribution ID',
+    description: 'Friendbuy attribution ID that associates the purchase with the advocate who referred the purchaser.',
+    type: 'string',
+    required: false,
+    default: { '@path': '$.properties.attributionId' }
+  },
+  referralCode: {
+    label: 'Friendbuy Referral ID',
+    description: 'Friendbuy referral code that associates the purchase with the advocate who referred the purchaser.',
+    type: 'string',
+    required: false,
+    default: { '@path': '$.properties.referralCode' }
+  },
   giftCardCodes: {
     // Might be used to establish attribution.
     label: 'Gift Card Codes',

--- a/packages/actions-shared/src/friendbuy/sharedPurchase.ts
+++ b/packages/actions-shared/src/friendbuy/sharedPurchase.ts
@@ -1,9 +1,10 @@
 import type { InputField } from '@segment/actions-core'
+import type { FieldConfig } from './commonFields'
 
 import { commonCustomerFields } from './commonFields'
 
 // https://segment.com/docs/connections/spec/ecommerce/v2/#order-completed
-export const trackPurchaseFields: Record<string, InputField> = {
+export const trackPurchaseFields = (fieldConfig: FieldConfig): Record<string, InputField> => ({
   orderId: {
     label: 'Order ID',
     description: 'The order ID.',
@@ -99,7 +100,7 @@ export const trackPurchaseFields: Record<string, InputField> = {
     default: { '@path': '$.properties.products' }
   },
 
-  ...commonCustomerFields(false),
+  ...commonCustomerFields(fieldConfig),
 
   friendbuyAttributes: {
     label: 'Custom Attributes',
@@ -109,4 +110,4 @@ export const trackPurchaseFields: Record<string, InputField> = {
     required: false,
     default: { '@path': '$.properties.friendbuyAttributes' }
   }
-}
+})

--- a/packages/actions-shared/src/friendbuy/sharedSignUp.ts
+++ b/packages/actions-shared/src/friendbuy/sharedSignUp.ts
@@ -5,6 +5,29 @@ import { commonCustomerFields } from './commonFields'
 // https://segment.com/docs/connections/spec/b2b-saas/#signed-up
 export const trackSignUpFields: Record<string, InputField> = {
   ...commonCustomerFields(true),
+  coupon: {
+    label: 'Coupon Code',
+    description: 'Coupon code that customer supplied when they signed up.',
+    type: 'string',
+    required: false,
+    default: { '@path': '$.properties.coupon' }
+  },
+  attributionId: {
+    label: 'Friendbuy Attribution ID',
+    description:
+      'Friendbuy attribution ID that associates the customer who is signing up with the advocate who referred them.',
+    type: 'string',
+    required: false,
+    default: { '@path': '$.properties.attributionId' }
+  },
+  referralCode: {
+    label: 'Friendbuy Referral ID',
+    description:
+      'Friendbuy referral code that associates the customer who is signing up with the advocate who referred them.',
+    type: 'string',
+    required: false,
+    default: { '@path': '$.properties.referralCode' }
+  },
   friendbuyAttributes: {
     label: 'Custom Attributes',
     description:

--- a/packages/actions-shared/src/friendbuy/sharedSignUp.ts
+++ b/packages/actions-shared/src/friendbuy/sharedSignUp.ts
@@ -1,10 +1,11 @@
 import type { InputField } from '@segment/actions-core'
+import type { FieldConfig } from './commonFields'
 
 import { commonCustomerFields } from './commonFields'
 
 // https://segment.com/docs/connections/spec/b2b-saas/#signed-up
-export const trackSignUpFields: Record<string, InputField> = {
-  ...commonCustomerFields(true),
+export const trackSignUpFields = (fieldConfig: FieldConfig): Record<string, InputField> => ({
+  ...commonCustomerFields(fieldConfig),
   coupon: {
     label: 'Coupon Code',
     description: 'Coupon code that customer supplied when they signed up.',
@@ -36,4 +37,4 @@ export const trackSignUpFields: Record<string, InputField> = {
     required: false,
     default: { '@path': '$.properties.friendbuyAttributes' }
   }
-}
+})

--- a/packages/browser-destinations/src/destinations/friendbuy/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/index.ts
@@ -49,7 +49,7 @@ const presets: DestinationDefinition['presets'] = [
 
 export const destination: BrowserDestinationDefinition<Settings, FriendbuyAPI> = {
   name: 'Friendbuy Web Device Mode (Actions)',
-  slug: 'actions-friendbuy-web',
+  slug: 'actions-friendbuy',
   mode: 'device',
 
   settings: {

--- a/packages/browser-destinations/src/destinations/friendbuy/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/index.ts
@@ -6,13 +6,11 @@ import { defaultValues } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import type { FriendbuyAPI } from './types'
 import trackCustomer, { trackCustomerDefaultSubscription } from './trackCustomer'
-import trackPurchase, { trackPurchaseDefaultSubscription } from './trackPurchase'
-import trackSignUp, { trackSignUpDefaultSubscription } from './trackSignUp'
+import trackPurchase, { browserTrackPurchaseFields, trackPurchaseDefaultSubscription } from './trackPurchase'
+import trackSignUp, { browserTrackSignUpFields, trackSignUpDefaultSubscription } from './trackSignUp'
 import trackPage, { trackPageDefaultSubscription, trackPageFields } from './trackPage'
 import trackCustomEvent from './trackCustomEvent'
 import { trackCustomerFields } from '@segment/actions-shared'
-import { trackPurchaseFields } from '@segment/actions-shared'
-import { trackSignUpFields } from '@segment/actions-shared'
 
 declare global {
   interface Window {
@@ -33,13 +31,13 @@ const presets: DestinationDefinition['presets'] = [
     name: 'Track Purchase',
     subscribe: trackPurchaseDefaultSubscription,
     partnerAction: 'trackPurchase',
-    mapping: defaultValues(trackPurchaseFields)
+    mapping: defaultValues(browserTrackPurchaseFields)
   },
   {
     name: 'Track Sign Up',
     subscribe: trackSignUpDefaultSubscription,
     partnerAction: 'trackSignUp',
-    mapping: defaultValues(trackSignUpFields)
+    mapping: defaultValues(browserTrackSignUpFields)
   },
   {
     name: 'Track Page',

--- a/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/__tests__/index.test.ts
@@ -1,7 +1,6 @@
 import { Analytics, Context } from '@segment/analytics-next'
 import friendbuyDestination from '../../index'
-import trackCustomEventObject from '../index'
-import { trackCustomEventFields } from '@segment/actions-shared'
+import trackCustomEventObject, { browserTrackCustomEventFields } from '../index'
 
 import { loadScript } from '../../../../runtime/load-script'
 jest.mock('../../../../runtime/load-script')
@@ -17,7 +16,9 @@ describe('Friendbuy.trackCustomEvent', () => {
       name: trackCustomEventObject.title,
       enabled: true,
       subscribe: 'type = "track" and event = "download"',
-      mapping: Object.fromEntries(Object.entries(trackCustomEventFields).map(([name, value]) => [name, value.default]))
+      mapping: Object.fromEntries(
+        Object.entries(browserTrackCustomEventFields).map(([name, value]) => [name, value.default])
+      )
     }
   ]
 

--- a/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/generated-types.ts
@@ -26,5 +26,5 @@ export interface Payload {
   /**
    * The user's email address.
    */
-  email: string
+  email?: string
 }

--- a/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/generated-types.ts
@@ -16,11 +16,15 @@ export interface Payload {
    */
   deduplicationId?: string
   /**
-   * The user's customerId.
+   * The user's customer ID.
    */
   customerId: string
   /**
    * The user's anonymous id
    */
   anonymousId?: string
+  /**
+   * The user's email address.
+   */
+  email: string
 }

--- a/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/index.ts
@@ -9,6 +9,8 @@ import { AnalyticsPayload, COPY, DROP, ROOT, mapEvent } from '@segment/actions-s
 import { trackCustomEventFields } from '@segment/actions-shared'
 import { addName, moveEventPropertiesToRoot, parseDate } from '@segment/actions-shared'
 
+export const browserTrackCustomEventFields = trackCustomEventFields({}) // @@ email required?
+
 const trackCustomEventPub: EventMap = {
   fields: {
     eventType: DROP,
@@ -33,7 +35,7 @@ const action: BrowserActionDefinition<Settings, FriendbuyAPI, Payload> = {
   description: 'Record when a customer completes any custom event that you define.',
   // trackCustomEvent has no default subscription.
   platform: 'web',
-  fields: trackCustomEventFields,
+  fields: browserTrackCustomEventFields,
 
   perform: (friendbuyAPI, { payload }) => {
     const analyticsPayload = moveEventPropertiesToRoot(payload as unknown as AnalyticsPayload)

--- a/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/index.ts
@@ -30,7 +30,7 @@ const trackCustomEventPub: EventMap = {
 
 const action: BrowserActionDefinition<Settings, FriendbuyAPI, Payload> = {
   title: 'Track Custom Event',
-  description: 'Record when a customer completes any custom event.',
+  description: 'Record when a customer completes any custom event that you define.',
   // trackCustomEvent has no default subscription.
   platform: 'web',
   fields: trackCustomEventFields,

--- a/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/index.ts
@@ -15,6 +15,7 @@ const trackCustomEventPub: EventMap = {
   fields: {
     eventType: DROP,
     deduplicationId: COPY,
+
     // CUSTOMER FIELDS
     customerId: { name: ['customer', 'id'] },
     anonymousId: { name: ['customer', 'anonymousId'] },

--- a/packages/browser-destinations/src/destinations/friendbuy/trackCustomer/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackCustomer/index.ts
@@ -23,6 +23,7 @@ const trackCustomerPub: EventMap = {
     lastName: COPY,
     name: COPY,
     age: COPY,
+    // fbt-merchant-api complains about birthday being an object but passes it anyway.
     birthday: { convert: parseDate as ConvertFun },
     language: COPY,
     addressCountry: { name: 'country' },

--- a/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/__tests__/index.test.ts
@@ -43,8 +43,10 @@ describe('Friendbuy.trackPurchase', () => {
     const anonymousId = 'cbce64f6-a45a-4d9c-a63d-4c7b42773276'
     const currency = 'USD'
     const coupon = 'coupon-xyzzy'
+    const attributionId = '878123ed-0439-4a73-b2fe-72c4f09ec64f'
+    const referralCode = 'ref-plugh'
     const giftCardCodes = ['card-a', 'card-b']
-    const friendbuyAttributes = { referralCode: 'ref-plugh' }
+    const friendbuyAttributes = { promotion: 'fall 2021' }
     const email = 'john.doe@example.com'
     const name = 'John Doe'
 
@@ -84,6 +86,8 @@ describe('Friendbuy.trackPurchase', () => {
           total: amount + 2,
           currency,
           coupon,
+          attributionId,
+          referralCode,
           giftCardCodes,
           products: products as JSONValue,
           email,
@@ -104,6 +108,8 @@ describe('Friendbuy.trackPurchase', () => {
           amount: amount + 2, // amount defaults to total
           currency,
           couponCode: coupon,
+          attributionId,
+          referralCode,
           giftCardCodes,
           customer: { id: userId, anonymousId, email, name },
           products: expectedProducts,

--- a/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/__tests__/index.test.ts
@@ -1,7 +1,6 @@
 import { Analytics, Context, JSONValue } from '@segment/analytics-next'
 import friendbuyDestination from '../../index'
-import trackPurchaseObject, { trackPurchaseDefaultSubscription } from '../index'
-import { trackPurchaseFields } from '@segment/actions-shared'
+import trackPurchaseObject, { browserTrackPurchaseFields, trackPurchaseDefaultSubscription } from '../index'
 
 import { loadScript } from '../../../../runtime/load-script'
 jest.mock('../../../../runtime/load-script')
@@ -17,7 +16,9 @@ describe('Friendbuy.trackPurchase', () => {
       name: trackPurchaseObject.title,
       enabled: true,
       subscribe: trackPurchaseDefaultSubscription,
-      mapping: Object.fromEntries(Object.entries(trackPurchaseFields).map(([name, value]) => [name, value.default]))
+      mapping: Object.fromEntries(
+        Object.entries(browserTrackPurchaseFields).map(([name, value]) => [name, value.default])
+      )
     }
   ]
 

--- a/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/generated-types.ts
@@ -18,6 +18,14 @@ export interface Payload {
    */
   coupon?: string
   /**
+   * Friendbuy attribution ID that associates the purchase with the advocate who referred the purchaser.
+   */
+  attributionId?: string
+  /**
+   * Friendbuy referral code that associates the purchase with the advocate who referred the purchaser.
+   */
+  referralCode?: string
+  /**
    * An array of gift card codes applied to the order.
    */
   giftCardCodes?: string[]

--- a/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/index.ts
@@ -9,6 +9,8 @@ import { COPY, ROOT, mapEvent } from '@segment/actions-shared'
 import { trackPurchaseFields } from '@segment/actions-shared'
 import { addName, parseDate, removeCustomerIfNoId } from '@segment/actions-shared'
 
+export const browserTrackPurchaseFields = trackPurchaseFields({})
+
 // see https://segment.com/docs/config-api/fql/
 export const trackPurchaseDefaultSubscription = 'event = "Order Completed"'
 
@@ -63,7 +65,7 @@ const action: BrowserActionDefinition<Settings, FriendbuyAPI, Payload> = {
   description: 'Record when a customer makes a purchase.',
   defaultSubscription: trackPurchaseDefaultSubscription,
   platform: 'web',
-  fields: trackPurchaseFields,
+  fields: browserTrackPurchaseFields,
 
   perform: (friendbuyAPI, { payload }) => {
     addName(payload)

--- a/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/index.ts
@@ -41,7 +41,7 @@ const trackPurchasePub: EventMap = {
       }
     },
 
-    // Customer fields.
+    // CUSTOMER FIELDS
     customerId: { name: ['customer', 'id'] },
     anonymousId: { name: ['customer', 'anonymousId'] },
     email: { name: ['customer', 'email'] },
@@ -51,6 +51,7 @@ const trackPurchasePub: EventMap = {
     lastName: { name: ['customer', 'lastName'] },
     name: { name: ['customer', 'name'] },
     age: { name: ['customer', 'age'] },
+    // fbt-merchant-api complains about birthday being an object but passes it anyway.
     birthday: { name: ['customer', 'birthday'], convert: parseDate as ConvertFun }
   },
   unmappedFieldObject: ROOT,

--- a/packages/browser-destinations/src/destinations/friendbuy/trackSignUp/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackSignUp/__tests__/index.test.ts
@@ -1,7 +1,6 @@
 import { Analytics, Context } from '@segment/analytics-next'
 import friendbuyDestination from '../../index'
-import trackSignUpObject, { trackSignUpDefaultSubscription } from '../index'
-import { trackSignUpFields } from '@segment/actions-shared'
+import trackSignUpObject, { browserTrackSignUpFields, trackSignUpDefaultSubscription } from '../index'
 
 import { loadScript } from '../../../../runtime/load-script'
 jest.mock('../../../../runtime/load-script')
@@ -17,7 +16,9 @@ describe('Friendbuy.trackSignUp', () => {
       name: trackSignUpObject.title,
       enabled: true,
       subscribe: trackSignUpDefaultSubscription,
-      mapping: Object.fromEntries(Object.entries(trackSignUpFields).map(([name, value]) => [name, value.default]))
+      mapping: Object.fromEntries(
+        Object.entries(browserTrackSignUpFields).map(([name, value]) => [name, value.default])
+      )
     }
   ]
 

--- a/packages/browser-destinations/src/destinations/friendbuy/trackSignUp/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackSignUp/generated-types.ts
@@ -42,6 +42,18 @@ export interface Payload {
    */
   birthday?: string
   /**
+   * Coupon code that customer supplied when they signed up.
+   */
+  coupon?: string
+  /**
+   * Friendbuy attribution ID that associates the customer who is signing up with the advocate who referred them.
+   */
+  attributionId?: string
+  /**
+   * Friendbuy referral code that associates the customer who is signing up with the advocate who referred them.
+   */
+  referralCode?: string
+  /**
    * Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.
    */
   friendbuyAttributes?: {

--- a/packages/browser-destinations/src/destinations/friendbuy/trackSignUp/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackSignUp/index.ts
@@ -9,6 +9,8 @@ import { COPY, ROOT, mapEvent } from '@segment/actions-shared'
 import { trackSignUpFields } from '@segment/actions-shared'
 import { addName, parseDate } from '@segment/actions-shared'
 
+export const browserTrackSignUpFields = trackSignUpFields({ requireCustomerId: true, requireEmail: true })
+
 // see https://segment.com/docs/config-api/fql/
 export const trackSignUpDefaultSubscription = 'event = "Signed Up"'
 
@@ -44,7 +46,7 @@ const action: BrowserActionDefinition<Settings, FriendbuyAPI, Payload> = {
   description: 'Record when a customer signs up for a service.',
   defaultSubscription: trackSignUpDefaultSubscription,
   platform: 'web',
-  fields: trackSignUpFields,
+  fields: browserTrackSignUpFields,
 
   perform: (friendbuyAPI, { payload }) => {
     addName(payload)

--- a/packages/browser-destinations/src/destinations/friendbuy/trackSignUp/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackSignUp/index.ts
@@ -30,13 +30,7 @@ const trackSignUpPub: EventMap = {
     lastName: COPY,
     name: COPY,
     age: COPY,
-    birthday: { convert: parseDate as ConvertFun },
-
-    // CONTEXT FIELDS
-    ipAddress: COPY,
-    userAgent: COPY
-    // pageUrl (unmapped)
-    // pageTitle (unmapped)
+    birthday: { convert: parseDate as ConvertFun }
   },
   unmappedFieldObject: ROOT
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -28,8 +28,7 @@
       "@segment/action-destinations": ["../destination-actions/src"],
       "@segment/ajv-human-errors": ["../ajv-human-errors/src"],
       "@segment/browser-destinations": ["../browser-destinations/src"],
-      "@segment/destination-subscriptions": ["../destination-subscriptions/src"],
-      "@friendbuy/shared/*": ["../browser-destinations/src/destinations/friendbuy/shared/*"]
+      "@segment/destination-subscriptions": ["../destination-subscriptions/src"]
     }
   },
   "include": ["src"]

--- a/packages/destination-actions/package.json
+++ b/packages/destination-actions/package.json
@@ -56,8 +56,7 @@
       "@segment/ajv-human-errors": "<rootDir>/../ajv-human-errors/src",
       "@segment/actions-core": "<rootDir>/../core/src",
       "@segment/actions-shared": "<rootDir>/../actions-shared/src",
-      "@segment/destination-subscriptions": "<rootDir>/../destination-subscriptions/src",
-      "@friendbuy/shared(.*)": "<rootDir>/../browser-destinations/src/destinations/friendbuy/shared$1"
+      "@segment/destination-subscriptions": "<rootDir>/../destination-subscriptions/src"
     },
     "setupFilesAfterEnv": [
       "<rootDir>/test/setup-after-env.ts"

--- a/packages/destination-actions/src/destinations/cordial/generated-types.ts
+++ b/packages/destination-actions/src/destinations/cordial/generated-types.ts
@@ -6,7 +6,7 @@ export interface Settings {
    */
   apiKey: string
   /**
-   * Cordial API endpoint. Leave default, unless you've been provided with another one
+   * Cordial API endpoint. Leave default, unless you've been provided with another one. [See more details](https://support.cordial.com/hc/en-us/sections/200553578-REST-API-Introduction-and-Overview)
    */
   endpoint: string
 }

--- a/packages/destination-actions/src/destinations/friendbuy/__tests__/cloudUtil.mock.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/__tests__/cloudUtil.mock.ts
@@ -1,14 +1,15 @@
 import nock from 'nock'
 
-import { mapiUrl } from '../cloudUtil'
+import { defaultMapiBaseUrl } from '../cloudUtil'
 
 export const authKey = 'f3e0da8c-4e92-4b4c-af64-c0c1c2f873f2'
 export const authSecret = 'mapi secret'
 const token = 'mapi auth token'
 const expires = new Date(Date.now() + 300 * 1000).toISOString()
 
+// Mock the authentication token request for other tests.
 export function nockAuth() {
-  nock(mapiUrl).post('/v1/authorization').reply(200, { token, expires })
+  nock(defaultMapiBaseUrl).post('/v1/authorization').reply(200, { token, expires })
 }
 
 // Empty test so that jest will not complain.

--- a/packages/destination-actions/src/destinations/friendbuy/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock'
 import { /* createTestEvent, */ createTestIntegration } from '@segment/actions-core'
 import Definition from '../index'
-import { mapiUrl } from '../cloudUtil'
+import { defaultMapiBaseUrl, getMapiBaseUrl } from '../cloudUtil'
 import { authKey, authSecret } from './cloudUtil.mock'
 
 const testDestination = createTestIntegration(Definition)
@@ -13,15 +13,24 @@ describe('Friendbuy', () => {
 
   describe('testAuthentication', () => {
     test('valid merchantId', async () => {
-      nock(mapiUrl).post('/v1/authorization').reply(200, { token, expires })
+      nock(defaultMapiBaseUrl).post('/v1/authorization').reply(200, { token, expires })
 
       await expect(testDestination.testAuthentication({ authKey, authSecret })).resolves.not.toThrowError()
     })
 
     test('invalid merchantId', async () => {
-      nock(mapiUrl).post('/v1/authorization').reply(403, {})
+      nock(defaultMapiBaseUrl).post('/v1/authorization').reply(403, {})
 
       await expect(testDestination.testAuthentication({ authKey, authSecret: badSecret })).rejects.toThrowError()
     })
+  })
+})
+
+describe('getMapiBaseUrl', () => {
+  test('production', () => {
+    expect(getMapiBaseUrl('secret')).toEqual(['secret', defaultMapiBaseUrl])
+  })
+  test('sandbox', () => {
+    expect(getMapiBaseUrl('sandbox:secret')).toEqual(['secret', 'https://mapi.fbot-sandbox.me'])
   })
 })

--- a/packages/destination-actions/src/destinations/friendbuy/index.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/index.ts
@@ -5,7 +5,7 @@ import trackCustomer from './trackCustomer'
 import trackPurchase from './trackPurchase'
 import trackSignUp from './trackSignUp'
 import trackCustomEvent from './trackCustomEvent'
-import { mapiUrl } from './cloudUtil'
+import { defaultMapiBaseUrl } from './cloudUtil'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Friendbuy (Cloud Destination)',
@@ -22,6 +22,8 @@ const destination: DestinationDefinition<Settings> = {
         format: 'uuid',
         required: true
       },
+      // For testing the Segment integration in a non-production environment,
+      // prepend the environment name followed by a colon to the authSecret value.
       authSecret: {
         label: 'Friendbuy MAPI Secret',
         description: 'See Friendbuy MAPI Key.',
@@ -31,7 +33,7 @@ const destination: DestinationDefinition<Settings> = {
     },
     testAuthentication: (request, { settings }) => {
       // Verify that the merchantId is valid.
-      return request(`${mapiUrl}/v1/authorization`, {
+      return request(`${defaultMapiBaseUrl}/v1/authorization`, {
         method: 'POST',
         json: { key: settings.authKey, secret: settings.authSecret }
       })
@@ -44,12 +46,12 @@ const destination: DestinationDefinition<Settings> = {
     // implement this function and should remove it completely.
     return !payload.userId
       ? true
-      : request(`${mapiUrl}/v1/user-data`, {
-        method: 'DELETE',
-        searchParams: {
-          customerId: payload.userId
-        }
-      })
+      : request(`${defaultMapiBaseUrl}/v1/user-data`, {
+          method: 'DELETE',
+          searchParams: {
+            customerId: payload.userId
+          }
+        })
   },
 
   actions: {

--- a/packages/destination-actions/src/destinations/friendbuy/trackCustomEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackCustomEvent/__tests__/index.test.ts
@@ -2,8 +2,7 @@ import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 
-import { mapiUrl } from '../../cloudUtil'
-// import { get } from '@segment/actions-core'
+import { defaultMapiBaseUrl } from '../../cloudUtil'
 import { nockAuth, authKey, authSecret } from '../../__tests__/cloudUtil.mock'
 
 const testDestination = createTestIntegration(Destination)
@@ -11,7 +10,7 @@ const testDestination = createTestIntegration(Destination)
 describe('Friendbuy.trackCustomEvent', () => {
   test('all fields', async () => {
     nockAuth()
-    nock(mapiUrl).persist().post('/v1/event/custom').reply(200, {})
+    nock(defaultMapiBaseUrl).persist().post('/v1/event/custom').reply(200, {})
 
     const userId = 'john-doe-1234'
     const anonymousId = '960efa33-6d3b-4eb9-a4e7-d95412d9829e'

--- a/packages/destination-actions/src/destinations/friendbuy/trackCustomEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackCustomEvent/__tests__/index.test.ts
@@ -34,6 +34,7 @@ describe('Friendbuy.trackCustomEvent', () => {
       expect(r[r.length - 1].options.json).toEqual(expectedPayload)
     }
 
+    const email = 'john.doe@example.com'
     const couponCode = 'coupon-thx1138'
     const attributionId = '526f8824-984c-4ba3-aa4b-feb5cbdc1c3f'
     const referralCode = 'referral-luh3417'
@@ -46,6 +47,7 @@ describe('Friendbuy.trackCustomEvent', () => {
         properties: {
           type: 'application',
           fileId: 'MyApp',
+          email,
           deduplicationId: '1234',
           coupon: couponCode,
           attributionId,
@@ -54,6 +56,7 @@ describe('Friendbuy.trackCustomEvent', () => {
       },
       {
         eventType: 'Download',
+        email,
         deduplicationId: '1234',
         couponCode,
         attributionId,
@@ -64,14 +67,11 @@ describe('Friendbuy.trackCustomEvent', () => {
           anonymousId,
           customerId: userId,
           fileId: 'MyApp',
-          pageTitle: expect.any(String),
-          pageUrl: expect.any(String),
           type: 'application'
         }
       }
     )
 
-    const email = 'john.doe@example.com'
     const isNewCustomer = false
     const firstName = 'John'
     const lastName = 'Doe'
@@ -102,8 +102,6 @@ describe('Friendbuy.trackCustomEvent', () => {
           anonymousId,
           customerId: userId,
           fileId: 'video-1234',
-          pageTitle: expect.any(String),
-          pageUrl: expect.any(String),
           type: 'video'
         }
       }

--- a/packages/destination-actions/src/destinations/friendbuy/trackCustomEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackCustomEvent/generated-types.ts
@@ -16,13 +16,17 @@ export interface Payload {
    */
   deduplicationId?: string
   /**
-   * The user's customerId.
+   * The user's customer ID.
    */
   customerId: string
   /**
    * The user's anonymous id
    */
   anonymousId?: string
+  /**
+   * The user's email address.
+   */
+  email: string
   /**
    * The URL of the web page the event was generated on.
    */

--- a/packages/destination-actions/src/destinations/friendbuy/trackCustomEvent/index.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackCustomEvent/index.ts
@@ -5,7 +5,7 @@ import type { EventMap } from '@segment/actions-shared'
 
 import { createMapiRequest } from '../cloudUtil'
 import { contextFields } from '@segment/actions-shared'
-import { AnalyticsPayload, COPY, mapEvent } from '@segment/actions-shared'
+import { AnalyticsPayload, COPY, DROP, mapEvent } from '@segment/actions-shared'
 import { trackCustomEventFields } from '@segment/actions-shared'
 import { moveEventPropertiesToRoot } from '@segment/actions-shared'
 
@@ -26,16 +26,16 @@ const trackCustomEventMapi: EventMap = {
 
     // CONTEXT FIELDS
     ipAddress: COPY,
-    userAgent: COPY
-    // pageUrl (unmapped)
-    // pageTitle (unmapped)
+    userAgent: COPY,
+    pageUrl: DROP,
+    pageTitle: DROP
   },
   unmappedFieldObject: 'additionalProperties'
 }
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track Custom Event',
-  description: 'Record when a customer completes any custom event.',
+  description: 'Record when a customer completes any custom event that you define.',
   fields: Object.assign({}, trackCustomEventFields, contextFields),
 
   perform: async (request, { settings, payload }) => {

--- a/packages/destination-actions/src/destinations/friendbuy/trackCustomEvent/index.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackCustomEvent/index.ts
@@ -9,6 +9,8 @@ import { AnalyticsPayload, COPY, DROP, mapEvent } from '@segment/actions-shared'
 import { trackCustomEventFields } from '@segment/actions-shared'
 import { moveEventPropertiesToRoot } from '@segment/actions-shared'
 
+const cloudTrackCustomEventFields = { ...trackCustomEventFields({ requireEmail: true }), ...contextFields }
+
 const trackCustomEventMapi: EventMap = {
   fields: {
     eventType: COPY,
@@ -36,7 +38,7 @@ const trackCustomEventMapi: EventMap = {
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track Custom Event',
   description: 'Record when a customer completes any custom event that you define.',
-  fields: Object.assign({}, trackCustomEventFields, contextFields),
+  fields: cloudTrackCustomEventFields,
 
   perform: async (request, { settings, payload }) => {
     const payload1 = moveEventPropertiesToRoot(payload as unknown as AnalyticsPayload)

--- a/packages/destination-actions/src/destinations/friendbuy/trackCustomEvent/index.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackCustomEvent/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import type { EventMap } from '@segment/actions-shared'
 
-import { createRequestParams, mapiUrl } from '../cloudUtil'
+import { createMapiRequest } from '../cloudUtil'
 import { contextFields } from '@segment/actions-shared'
 import { AnalyticsPayload, COPY, mapEvent } from '@segment/actions-shared'
 import { trackCustomEventFields } from '@segment/actions-shared'
@@ -41,8 +41,8 @@ const action: ActionDefinition<Settings, Payload> = {
   perform: async (request, { settings, payload }) => {
     const payload1 = moveEventPropertiesToRoot(payload as unknown as AnalyticsPayload)
     const friendbuyPayload = mapEvent(trackCustomEventMapi, payload1)
-    const requestParams = await createRequestParams(request, settings, friendbuyPayload)
-    return request(`${mapiUrl}/v1/event/custom`, requestParams)
+    const [requestUrl, requestParams] = await createMapiRequest('v1/event/custom', request, settings, friendbuyPayload)
+    return request(requestUrl, requestParams)
   }
 }
 

--- a/packages/destination-actions/src/destinations/friendbuy/trackCustomer/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackCustomer/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 
-import { mapiUrl } from '../../cloudUtil'
+import { defaultMapiBaseUrl } from '../../cloudUtil'
 import { nockAuth, authKey, authSecret } from '../../__tests__/cloudUtil.mock'
 
 const testDestination = createTestIntegration(Destination)
@@ -11,7 +11,7 @@ describe('Friendbuy.trackCustomer', () => {
   test('all fields', async () => {
     nockAuth()
     const nockRequests: any[] /* (typeof nock.ReplyFnContext.req)[] */ = []
-    nock(mapiUrl)
+    nock(defaultMapiBaseUrl)
       .post('/v1/customer')
       .reply(200, function (_uri, _requestBody) {
         nockRequests.push(this.req)

--- a/packages/destination-actions/src/destinations/friendbuy/trackCustomer/index.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackCustomer/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import type { AnalyticsPayload, ConvertFun, EventMap } from '@segment/actions-shared'
 
-import { createRequestParams, mapiUrl } from '../cloudUtil'
+import { createMapiRequest } from '../cloudUtil'
 import { contextFields } from '@segment/actions-shared'
 import { COPY, DROP, mapEvent } from '@segment/actions-shared'
 import { trackCustomerFields } from '@segment/actions-shared'
@@ -46,8 +46,8 @@ const action: ActionDefinition<Settings, Payload> = {
 
   perform: async (request, { settings, payload }) => {
     const friendbuyPayload = mapEvent(trackCustomerMapi, payload as unknown as AnalyticsPayload)
-    const requestParams = await createRequestParams(request, settings, friendbuyPayload)
-    return request(`${mapiUrl}/v1/customer`, requestParams)
+    const [requestUrl, requestParams] = await createMapiRequest('v1/customer', request, settings, friendbuyPayload)
+    return request(requestUrl, requestParams)
   }
 }
 

--- a/packages/destination-actions/src/destinations/friendbuy/trackCustomer/index.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackCustomer/index.ts
@@ -9,6 +9,8 @@ import { COPY, DROP, mapEvent } from '@segment/actions-shared'
 import { trackCustomerFields } from '@segment/actions-shared'
 import { parseDate } from '@segment/actions-shared'
 
+const cloudTrackCustomerFields = { ...trackCustomerFields, ...contextFields }
+
 const trackCustomerMapi: EventMap = {
   fields: {
     customerId: COPY,
@@ -42,7 +44,7 @@ const trackCustomerMapi: EventMap = {
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track Customer',
   description: 'Create a new customer profile or update an existing customer profile.',
-  fields: Object.assign({}, trackCustomerFields, contextFields),
+  fields: cloudTrackCustomerFields,
 
   perform: async (request, { settings, payload }) => {
     const friendbuyPayload = mapEvent(trackCustomerMapi, payload as unknown as AnalyticsPayload)

--- a/packages/destination-actions/src/destinations/friendbuy/trackPurchase/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackPurchase/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import nock from 'nock'
 import { createTestEvent, createTestIntegration, JSONValue } from '@segment/actions-core'
 import Destination from '../../index'
 
-import { mapiUrl } from '../../cloudUtil'
+import { defaultMapiBaseUrl } from '../../cloudUtil'
 import { nockAuth, authKey, authSecret } from '../../__tests__/cloudUtil.mock'
 
 const testDestination = createTestIntegration(Destination)
@@ -10,7 +10,7 @@ const testDestination = createTestIntegration(Destination)
 describe('Friendbuy.trackPurchase', () => {
   test('all fields', async () => {
     nockAuth()
-    nock(mapiUrl).post('/v1/event/purchase').reply(200, {})
+    nock(defaultMapiBaseUrl).post('/v1/event/purchase').reply(200, {})
 
     const orderId = 'my order'
     const products = [

--- a/packages/destination-actions/src/destinations/friendbuy/trackPurchase/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackPurchase/__tests__/index.test.ts
@@ -35,6 +35,7 @@ describe('Friendbuy.trackPurchase', () => {
     const name = `${firstName} ${lastName}`
     const age = 42
     const birthday = '0000-12-25'
+    const promotion = 'winter 2022'
 
     const event = createTestEvent({
       type: 'track',
@@ -47,6 +48,7 @@ describe('Friendbuy.trackPurchase', () => {
         currency,
         coupon,
         attributionId,
+        referralCode,
         giftCardCodes,
         products: products as JSONValue,
         email,
@@ -57,7 +59,7 @@ describe('Friendbuy.trackPurchase', () => {
         name,
         age,
         birthday,
-        friendbuyAttributes: { attributionId, referralCode }
+        friendbuyAttributes: { promotion }
       },
       timestamp: '2021-10-05T15:30:35Z'
     })
@@ -91,6 +93,7 @@ describe('Friendbuy.trackPurchase', () => {
       additionalProperties: {
         // age, // dropped because not string.
         anonymousId,
+        promotion,
         name,
         // birthday: { month: 12, day: 25 }, // dropped because not string.
         loyaltyStatus

--- a/packages/destination-actions/src/destinations/friendbuy/trackPurchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackPurchase/generated-types.ts
@@ -18,6 +18,14 @@ export interface Payload {
    */
   coupon?: string
   /**
+   * Friendbuy attribution ID that associates the purchase with the advocate who referred the purchaser.
+   */
+  attributionId?: string
+  /**
+   * Friendbuy referral code that associates the purchase with the advocate who referred the purchaser.
+   */
+  referralCode?: string
+  /**
    * An array of gift card codes applied to the order.
    */
   giftCardCodes?: string[]

--- a/packages/destination-actions/src/destinations/friendbuy/trackPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackPurchase/index.ts
@@ -4,10 +4,11 @@ import type { Payload } from './generated-types'
 import type { AnalyticsPayload, EventMap } from '@segment/actions-shared'
 
 import { createMapiRequest } from '../cloudUtil'
-import { commonCustomerFields } from '@segment/actions-shared'
 import { contextFields } from '@segment/actions-shared'
 import { COPY, DROP, mapEvent } from '@segment/actions-shared'
 import { trackPurchaseFields } from '@segment/actions-shared'
+
+const cloudTrackPurchaseFields = { ...trackPurchaseFields({}), ...contextFields }
 
 const trackPurchaseMapi: EventMap = {
   fields: {
@@ -58,7 +59,7 @@ const trackPurchaseMapi: EventMap = {
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track Purchase',
   description: 'Record when a customer makes a purchase.',
-  fields: Object.assign({}, trackPurchaseFields, commonCustomerFields(false), contextFields),
+  fields: cloudTrackPurchaseFields,
 
   perform: async (request, { settings, payload }) => {
     const friendbuyPayload = mapEvent(trackPurchaseMapi, payload as unknown as AnalyticsPayload)

--- a/packages/destination-actions/src/destinations/friendbuy/trackPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackPurchase/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import type { AnalyticsPayload, EventMap } from '@segment/actions-shared'
 
-import { createRequestParams, mapiUrl } from '../cloudUtil'
+import { createMapiRequest } from '../cloudUtil'
 import { commonCustomerFields } from '@segment/actions-shared'
 import { contextFields } from '@segment/actions-shared'
 import { COPY, DROP, mapEvent } from '@segment/actions-shared'
@@ -62,8 +62,13 @@ const action: ActionDefinition<Settings, Payload> = {
 
   perform: async (request, { settings, payload }) => {
     const friendbuyPayload = mapEvent(trackPurchaseMapi, payload as unknown as AnalyticsPayload)
-    const requestParams = await createRequestParams(request, settings, friendbuyPayload)
-    return request(`${mapiUrl}/v1/event/purchase`, requestParams)
+    const [requestUrl, requestParams] = await createMapiRequest(
+      'v1/event/purchase',
+      request,
+      settings,
+      friendbuyPayload
+    )
+    return request(requestUrl, requestParams)
   }
 }
 

--- a/packages/destination-actions/src/destinations/friendbuy/trackPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackPurchase/index.ts
@@ -35,7 +35,7 @@ const trackPurchaseMapi: EventMap = {
       }
     },
 
-    // Customer fields.
+    // CUSTOMER FIELDS
     customerId: COPY,
     // anonymousID (unmapped)
     email: COPY,
@@ -47,7 +47,7 @@ const trackPurchaseMapi: EventMap = {
     age: DROP, // currently not handled properly at root or in additionalProperties
     birthday: DROP, // currently not handled properly at root or in additionalProperties
 
-    // Context fields.
+    // CONTEXT FIELDS
     ipAddress: COPY,
     userAgent: COPY,
     pageUrl: DROP,

--- a/packages/destination-actions/src/destinations/friendbuy/trackSignUp/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackSignUp/__tests__/index.test.ts
@@ -22,6 +22,9 @@ describe('Friendbuy.trackSignUp', () => {
     const loyaltyStatus = 'in'
     const age = 42
     const birthday = '2001-05-01'
+    const couponCode = 'coupon-123'
+    const attributionId = 'adc507d9-0ace-4ae3-a572-986d022645a0'
+    const referralCode = 'ref12345'
     const friendbuyAttributes = { custom1: 'custom1', custom2: 'custom2' }
 
     const event = createTestEvent({
@@ -33,6 +36,9 @@ describe('Friendbuy.trackSignUp', () => {
         email,
         isNewCustomer,
         loyaltyStatus,
+        coupon: couponCode,
+        attributionId,
+        referralCode,
         firstName,
         lastName,
         name,
@@ -60,13 +66,15 @@ describe('Friendbuy.trackSignUp', () => {
       loyaltyStatus,
       firstName,
       lastName,
+      couponCode,
+      attributionId,
+      referralCode,
       age,
       birthday: { year: 2001, month: 5, day: 1 },
       ipAddress: event?.context?.ip,
       userAgent: event?.context?.userAgent,
       additionalProperties: {
         ...friendbuyAttributes,
-        // age, // dropped because not string
         anonymousId,
         name
       }

--- a/packages/destination-actions/src/destinations/friendbuy/trackSignUp/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackSignUp/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 
-import { mapiUrl } from '../../cloudUtil'
+import { defaultMapiBaseUrl } from '../../cloudUtil'
 import { nockAuth, authKey, authSecret } from '../../__tests__/cloudUtil.mock'
 
 const testDestination = createTestIntegration(Destination)
@@ -10,7 +10,7 @@ const testDestination = createTestIntegration(Destination)
 describe('Friendbuy.trackSignUp', () => {
   test('all fields', async () => {
     nockAuth()
-    nock(mapiUrl).post('/v1/event/account-sign-up').reply(200, {})
+    nock(defaultMapiBaseUrl).post('/v1/event/account-sign-up').reply(200, {})
 
     const userId = 'john-doe-12345'
     const anonymousId = '6afc2ff2-cf54-414f-9a99-b3adb054ae31'

--- a/packages/destination-actions/src/destinations/friendbuy/trackSignUp/generated-types.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackSignUp/generated-types.ts
@@ -42,6 +42,18 @@ export interface Payload {
    */
   birthday?: string
   /**
+   * Coupon code that customer supplied when they signed up.
+   */
+  coupon?: string
+  /**
+   * Friendbuy attribution ID that associates the customer who is signing up with the advocate who referred them.
+   */
+  attributionId?: string
+  /**
+   * Friendbuy referral code that associates the customer who is signing up with the advocate who referred them.
+   */
+  referralCode?: string
+  /**
    * Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.
    */
   friendbuyAttributes?: {

--- a/packages/destination-actions/src/destinations/friendbuy/trackSignUp/index.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackSignUp/index.ts
@@ -9,6 +9,11 @@ import { COPY, DROP, mapEvent } from '@segment/actions-shared'
 import { trackSignUpFields } from '@segment/actions-shared'
 import { parseDate } from '@segment/actions-shared'
 
+const cloudTrackSignUpFields = {
+  ...trackSignUpFields({ requireCustomerId: true, requireEmail: true }),
+  ...contextFields
+}
+
 const trackSignUpMapi: EventMap = {
   fields: {
     coupon: { name: 'couponCode' },
@@ -39,7 +44,7 @@ const trackSignUpMapi: EventMap = {
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track Sign Up',
   description: 'Record when a customer signs up for a service.',
-  fields: Object.assign({}, trackSignUpFields, contextFields),
+  fields: cloudTrackSignUpFields,
 
   perform: async (request, { settings, payload }) => {
     const friendbuyPayload = mapEvent(trackSignUpMapi, payload as unknown as AnalyticsPayload)

--- a/packages/destination-actions/src/destinations/friendbuy/trackSignUp/index.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackSignUp/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import type { AnalyticsPayload, ConvertFun, EventMap } from '@segment/actions-shared'
 
-import { createRequestParams, mapiUrl } from '../cloudUtil'
+import { createMapiRequest } from '../cloudUtil'
 import { contextFields } from '@segment/actions-shared'
 import { COPY, DROP, mapEvent } from '@segment/actions-shared'
 import { trackSignUpFields } from '@segment/actions-shared'
@@ -43,8 +43,13 @@ const action: ActionDefinition<Settings, Payload> = {
 
   perform: async (request, { settings, payload }) => {
     const friendbuyPayload = mapEvent(trackSignUpMapi, payload as unknown as AnalyticsPayload)
-    const requestParams = await createRequestParams(request, settings, friendbuyPayload)
-    return request(`${mapiUrl}/v1/event/account-sign-up`, requestParams)
+    const [requestUrl, requestParams] = await createMapiRequest(
+      'v1/event/account-sign-up',
+      request,
+      settings,
+      friendbuyPayload
+    )
+    return request(requestUrl, requestParams)
   }
 }
 

--- a/packages/destination-actions/tsconfig.build.json
+++ b/packages/destination-actions/tsconfig.build.json
@@ -3,12 +3,9 @@
   "compilerOptions": {
     "composite": true,
     "rootDir": "src",
-    "outDir": "dist",
-    "paths": {
-      "@friendbuy/shared/*": ["../browser-destinations/src/destinations/friendbuy/shared/*"]
-    }
+    "outDir": "dist"
   },
   "exclude": ["**/__tests__/**/*.ts"],
   "include": ["src"],
-  "references": [{ "path": "../core/tsconfig.build.json" }, { "path": "../browser-destinations/tsconfig.build.json" }]
+  "references": [{ "path": "../core/tsconfig.build.json" }]
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR has fixes for the Friendbuy cloud and web destinations.

Also, the old version of the Friendbuy cloud destination send data to our sandbox environment. That is fixed to send data to our production environment (with a way to override that in the UI).

## Testing

I have tested the cloud destination by making REST requests to the local server (`./bin/run serve -d friendbuy`).

I have tested the web destination by running the `yarn browser dev`, loading the default subscriptions for each of my actions, and making `analytics.identify` and `analytics.track` calls in the browser.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
