### PR TITLE
Fix Salesforce access_token key

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/index.ts
@@ -1,6 +1,10 @@
-import type { DestinationDefinition, RefreshAccessTokenResult } from '@segment/actions-core'
+import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import lead from './lead'
+
+interface RefreshTokenResponse {
+  access_token: string
+}
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Salesforce (Actions)',
@@ -20,7 +24,7 @@ const destination: DestinationDefinition<Settings> = {
     },
     refreshAccessToken: async (request, { auth }) => {
       // Return a request that refreshes the access_token if the API supports it
-      const res = await request<RefreshAccessTokenResult>('https://login.salesforce.com/services/oauth2/token', {
+      const res = await request<RefreshTokenResponse>('https://login.salesforce.com/services/oauth2/token', {
         method: 'POST',
         body: new URLSearchParams({
           refresh_token: auth.refreshToken,
@@ -29,7 +33,7 @@ const destination: DestinationDefinition<Settings> = {
           grant_type: 'refresh_token'
         })
       })
-      return { accessToken: res.data.accessToken }
+      return { accessToken: res.data.access_token }
     }
   },
   extendRequest({ auth }) {


### PR DESCRIPTION
- Fixes the Salesforce Actions `refresh_token` flow. Salesforce responds with an `access_token`, rather than an `accessToken`. Parseing Salesforce response for `accessToken`, as we did previously, resulted in new `accessToken`s not being passed correctly in the response.

## Testing
- Testing completed successfully in stage by deploying `integration-actions` service. See `integrations` stage draft PR here: https://github.com/segmentio/integrations/pull/2181
- I sent test events to a test instance of Salesforce Actions in stage. The `access_token` for the instance was expired. Actions service was successfully able to fetch a new token and deliver requests to Salesforce.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
