### PR TITLE
Update batch size documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ This will give customers the ability to opt-in to batching (there may be trade-o
 Keep in mind a few important things about how batching works:
 
 - Batching can add latency while Segment accumulates events in batches internally. This can be up to a minute, currently, but this is subject to change at any time. Latency is lower when you send a higher volume of events.
-- Batches may have to up 50 events, currently. This, too, is subject to change.
+- Batches may have to up 1,000 events, currently. This, too, is subject to change.
 - Batch sizes are not guaranteed. Due to the way that batches are accumulated internally, you may see smaller batch sizes than you expect when sending low rates of events.
 
 Additionally, you’ll need to coordinate with Segment’s R&D team for the time being. Please reach out to us in your dedicated Slack channel!


### PR DESCRIPTION
We now support batches of up to 1,000 events.

## Testing

No testing required because this is a documentation-only change.
