### PR TITLE
feat(personas-messaging): add additional context around external ids

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -103,8 +103,8 @@ for (const environment of ['stage', 'production']) {
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
-              external_id_key: 'email',
-              external_id_value: userData.email
+              __segment_internal_external_id_key__: 'email',
+              __segment_internal_external_id_value__: userData.email
             }
           }
         ],
@@ -212,8 +212,8 @@ for (const environment of ['stage', 'production']) {
               journey_id: 'journeyId',
               journey_state_id: 'journeyStateId',
               audience_id: 'audienceId',
-              external_id_key: 'email',
-              external_id_value: userData.email
+              __segment_internal_external_id_key__: 'email',
+              __segment_internal_external_id_value__: userData.email
             }
           }
         ],
@@ -322,8 +322,8 @@ for (const environment of ['stage', 'production']) {
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
-              external_id_key: 'email',
-              external_id_value: userData.email
+              __segment_internal_external_id_key__: 'email',
+              __segment_internal_external_id_value__: userData.email
             }
           }
         ],
@@ -390,8 +390,8 @@ for (const environment of ['stage', 'production']) {
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
-              external_id_key: 'email',
-              external_id_value: userData.email
+              __segment_internal_external_id_key__: 'email',
+              __segment_internal_external_id_value__: userData.email
             }
           }
         ],
@@ -471,8 +471,8 @@ for (const environment of ['stage', 'production']) {
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
-              external_id_key: 'email',
-              external_id_value: userData.email
+              __segment_internal_external_id_key__: 'email',
+              __segment_internal_external_id_value__: userData.email
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -102,7 +102,9 @@ for (const environment of ['stage', 'production']) {
             custom_args: {
               source_id: 'sourceId',
               space_id: 'spaceId',
-              user_id: userData.userId
+              user_id: userData.userId,
+              external_id_key: 'email',
+              external_id_value: userData.email
             }
           }
         ],
@@ -209,7 +211,9 @@ for (const environment of ['stage', 'production']) {
               user_id: userData.userId,
               journey_id: 'journeyId',
               journey_state_id: 'journeyStateId',
-              audience_id: 'audienceId'
+              audience_id: 'audienceId',
+              external_id_key: 'email',
+              external_id_value: userData.email
             }
           }
         ],
@@ -292,7 +296,9 @@ for (const environment of ['stage', 'production']) {
           })
           fail('Test should throw an error')
         } catch (e) {
-          expect(e.message).toBe('Emails with gmailx.com, yahoox.com, aolx.com, and hotmailx.com domains are blocked.')
+          expect((e as unknown as any).message).toBe(
+            'Emails with gmailx.com, yahoox.com, aolx.com, and hotmailx.com domains are blocked.'
+          )
         }
       })
     }
@@ -315,7 +321,9 @@ for (const environment of ['stage', 'production']) {
             custom_args: {
               source_id: 'sourceId',
               space_id: 'spaceId',
-              user_id: userData.userId
+              user_id: userData.userId,
+              external_id_key: 'email',
+              external_id_value: userData.email
             }
           }
         ],
@@ -381,7 +389,9 @@ for (const environment of ['stage', 'production']) {
             custom_args: {
               source_id: 'sourceId',
               space_id: 'spaceId',
-              user_id: userData.userId
+              user_id: userData.userId,
+              external_id_key: 'email',
+              external_id_value: userData.email
             }
           }
         ],
@@ -402,9 +412,7 @@ for (const environment of ['stage', 'production']) {
         ]
       }
 
-      const s3Request = nock('https://s3.com')
-        .get('/body.txt')
-        .reply(200, '{"unlayer":true}')
+      const s3Request = nock('https://s3.com').get('/body.txt').reply(200, '{"unlayer":true}')
 
       const unlayerRequest = nock('https://api.unlayer.com')
         .post('/v2/export/html', {
@@ -462,7 +470,9 @@ for (const environment of ['stage', 'production']) {
             custom_args: {
               source_id: 'sourceId',
               space_id: 'spaceId',
-              user_id: userData.userId
+              user_id: userData.userId,
+              external_id_key: 'email',
+              external_id_value: userData.email
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -124,6 +124,8 @@ interface Profile {
   traits: Record<string, string>
 }
 
+const EXTERNAL_ID_KEY = 'email'
+
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Email',
   description: 'Sends Email to a user powered by SendGrid',
@@ -192,7 +194,7 @@ const action: ActionDefinition<Settings, Payload> = {
     previewText: {
       label: 'Preview Text',
       description: 'Preview Text',
-      type: 'string',
+      type: 'string'
     },
     subject: {
       label: 'Subject',
@@ -284,7 +286,7 @@ const action: ActionDefinition<Settings, Payload> = {
     return request('https://api.sendgrid.com/v3/mail/send', {
       method: 'post',
       headers: {
-        'authorization': `Bearer ${settings.sendGridApiKey}`
+        authorization: `Bearer ${settings.sendGridApiKey}`
       },
       json: {
         personalizations: [
@@ -300,7 +302,10 @@ const action: ActionDefinition<Settings, Payload> = {
               ...payload.customArgs,
               source_id: settings.sourceId,
               space_id: settings.spaceId,
-              user_id: payload.userId
+              user_id: payload.userId,
+              // This is to help disambiguate in the case it's email or email_address.
+              external_id_key: EXTERNAL_ID_KEY,
+              external_id_value: profile[EXTERNAL_ID_KEY]
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -304,8 +304,8 @@ const action: ActionDefinition<Settings, Payload> = {
               space_id: settings.spaceId,
               user_id: payload.userId,
               // This is to help disambiguate in the case it's email or email_address.
-              external_id_key: EXTERNAL_ID_KEY,
-              external_id_value: profile[EXTERNAL_ID_KEY]
+              __segment_internal_external_id_key__: EXTERNAL_ID_KEY,
+              __segment_internal_external_id_value__: profile[EXTERNAL_ID_KEY]
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/__tests__/send-sms.test.ts
@@ -118,7 +118,7 @@ for (const environment of ['stage', 'production']) {
         Body: 'Hello world, jane!',
         From: '+1234567890',
         To: '+1234567891',
-        StatusCallback: 'http://localhost/?foo=bar#rp=all&rc=5'
+        StatusCallback: 'http://localhost/?foo=bar&external_id_key=phone&external_id_value=%2B1234567891#rp=all&rc=5'
       })
 
       const actionInputData = {
@@ -130,7 +130,7 @@ for (const environment of ['stage', 'production']) {
         settings: {
           ...settings,
           webhookUrl: 'http://localhost',
-          connectionOverrides: "rp=all&rc=5"
+          connectionOverrides: 'rp=all&rc=5'
         },
         mapping: {
           userId: { '@path': '$.userId' },

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/__tests__/send-sms.test.ts
@@ -118,7 +118,8 @@ for (const environment of ['stage', 'production']) {
         Body: 'Hello world, jane!',
         From: '+1234567890',
         To: '+1234567891',
-        StatusCallback: 'http://localhost/?foo=bar&external_id_key=phone&external_id_value=%2B1234567891#rp=all&rc=5'
+        StatusCallback:
+          'http://localhost/?foo=bar&__segment_internal_external_id_key__=phone&__segment_internal_external_id_value__=%2B1234567891#rp=all&rc=5'
       })
 
       const actionInputData = {

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
@@ -149,8 +149,8 @@ const action: ActionDefinition<Settings, Payload> = {
     const connectionOverrides = settings.connectionOverrides
     const customArgs: Record<string, string | undefined> = {
       ...payload.customArgs,
-      external_id_key: EXTERNAL_ID_KEY,
-      external_id_value: profile[EXTERNAL_ID_KEY]
+      __segment_internal_external_id_key__: EXTERNAL_ID_KEY,
+      __segment_internal_external_id_value__: profile[EXTERNAL_ID_KEY]
     }
 
     if (webhookUrl && customArgs) {

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
@@ -62,7 +62,9 @@ interface Profile {
   traits: Record<string, string>
 }
 
-const DEFAULT_CONNECTION_OVERRIDES  = "rp=all&rc=5"
+const EXTERNAL_ID_KEY = 'phone'
+
+const DEFAULT_CONNECTION_OVERRIDES = 'rp=all&rc=5'
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send SMS',
   description: 'Send SMS using Twilio',
@@ -100,7 +102,8 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     connectionOverrides: {
       label: 'Connection Overrides',
-      description: 'Connection overrides are configuration supported by twilio webhook services. Must be passed as fragments on the callback url',
+      description:
+        'Connection overrides are configuration supported by twilio webhook services. Must be passed as fragments on the callback url',
       type: 'string',
       required: false
     },
@@ -144,7 +147,12 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const webhookUrl = settings.webhookUrl
     const connectionOverrides = settings.connectionOverrides
-    const customArgs = payload.customArgs
+    const customArgs: Record<string, string | undefined> = {
+      ...payload.customArgs,
+      external_id_key: EXTERNAL_ID_KEY,
+      external_id_value: profile[EXTERNAL_ID_KEY]
+    }
+
     if (webhookUrl && customArgs) {
       // Webhook URL parsing has a potential of failing. I think it's better that
       // we fail out of any invocation than silently not getting analytics


### PR DESCRIPTION
As a potential consumer of webhooks for SMS and email it seems necessary that we'd want to know how the phone number or email was chosen to be sent to. Since in the current implementation are grabbing it potentially off the profile we should include the actual external id value since it may not match what Twilio/SendGrid tells us, as well as the profile object key.

GRAMA-283

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
