### PR TITLE
enable subscription tracking for mail sends with personas

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -120,7 +120,13 @@ for (const environment of ['stage', 'production']) {
             type: 'text/html',
             value: `Hi ${userData.firstName}, Welcome to segment`
           }
-        ]
+        ],
+        tracking_settings: {
+          subscription_tracking: {
+            enable: true,
+            substitution_tag: '[unsubscribe]'
+          }
+        }
       }
 
       const sendGridRequest = nock('https://api.sendgrid.com')
@@ -402,9 +408,7 @@ for (const environment of ['stage', 'production']) {
         ]
       }
 
-      const s3Request = nock('https://s3.com')
-        .get('/body.txt')
-        .reply(200, '{"unlayer":true}')
+      const s3Request = nock('https://s3.com').get('/body.txt').reply(200, '{"unlayer":true}')
 
       const unlayerRequest = nock('https://api.unlayer.com')
         .post('/v2/export/html', {

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -233,7 +233,13 @@ for (const environment of ['stage', 'production']) {
             type: 'text/html',
             value: 'Welcome to segment'
           }
-        ]
+        ],
+        tracking_settings: {
+          subscription_tracking: {
+            enable: true,
+            substitution_tag: '[unsubscribe]'
+          }
+        }
       }
 
       const sendGridRequest = nock('https://api.sendgrid.com')
@@ -339,7 +345,13 @@ for (const environment of ['stage', 'production']) {
             type: 'text/html',
             value: `Hi ${userData.firstName}, welcome to Segment`
           }
-        ]
+        ],
+        tracking_settings: {
+          subscription_tracking: {
+            enable: true,
+            substitution_tag: '[unsubscribe]'
+          }
+        }
       }
 
       const s3Request = nock('https://s3.com')
@@ -405,7 +417,13 @@ for (const environment of ['stage', 'production']) {
             type: 'text/html',
             value: `<h1>Hi ${userData.firstName}, welcome to Segment</h1>`
           }
-        ]
+        ],
+        tracking_settings: {
+          subscription_tracking: {
+            enable: true,
+            substitution_tag: '[unsubscribe]'
+          }
+        }
       }
 
       const s3Request = nock('https://s3.com').get('/body.txt').reply(200, '{"unlayer":true}')
@@ -494,7 +512,13 @@ for (const environment of ['stage', 'production']) {
               '  Hi First Name, welcome to Segment</body></html>'
             ].join('\n')
           }
-        ]
+        ],
+        tracking_settings: {
+          subscription_tracking: {
+            enable: true,
+            substitution_tag: '[unsubscribe]'
+          }
+        }
       }
 
       const s3Request = nock('https://s3.com')

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -318,7 +318,13 @@ const action: ActionDefinition<Settings, Payload> = {
             type: 'text/html',
             value: Mustache.render(bodyHtml, { profile })
           }
-        ]
+        ],
+        tracking_settings: {
+          subscription_tracking: {
+            enable: true,
+            substitution_tag: "[unsubscribe]"
+          }
+        }
       }
     })
   }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

The Journeys Email Builder by default populates some unsubscribe fields. The unsubscribe link doesn't work at the moment. It's configured to `[unsubscribe]` but the emails being sent don't enable subscription tracking. This PR aims to do that, making it so the unsubscribe URL will actually work.

![image](https://user-images.githubusercontent.com/1095661/151861421-07bdc8f9-9aa4-47fc-8998-ead6b783ecbe.png)


## Testing

- [x] ~Added~ Updated [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
