### PR TITLE
[STRATCONN-1079] Upgrade FB CAPI Actions to Marketing API v12.0 

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
@@ -11,7 +11,7 @@ const settings = {
 describe('FacebookConversionsApi', () => {
   describe('AddToCart', () => {
     it('should handle a basic event', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Added',
@@ -54,7 +54,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error for invalid currency values', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Added',
@@ -96,7 +96,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should handle default mappings', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Added',
@@ -123,7 +123,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error if no id parameter is included in contents array objects', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Added',
@@ -177,7 +177,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error if contents.delivery_category is not supported', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Added',
@@ -235,7 +235,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error if no user_data keys are included', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Added',

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/custom.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/custom.test.ts
@@ -11,7 +11,7 @@ const settings = {
 describe('FacebookConversionsApi', () => {
   describe('Custom', () => {
     it('should fail if no event_name is passed', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         userId: 'abc123',
@@ -39,7 +39,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should fail if an empty event_name is passed', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: '',
@@ -68,7 +68,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error for an invalid action_source', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'custom',
@@ -102,7 +102,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should map a standard identify event to a custom event', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         anonymousId: '507f191e810c19729de860ea',

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/initiateCheckout.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/initiateCheckout.test.ts
@@ -10,7 +10,7 @@ const settings = {
 describe('FacebookConversionsApi', () => {
   describe('InitiateCheckout', () => {
     it('should handle basic mapping overrides', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Checkout Started',
@@ -53,7 +53,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error for invalid currency values', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Checkout Started',
@@ -95,7 +95,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should handle default mappings', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Checkout Started',
@@ -124,7 +124,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error if no user_data keys are included', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Checkout Started',

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/pageView.test.ts
@@ -11,9 +11,7 @@ const settings = {
 describe('FacebookConversionsApi', () => {
   describe('PageView', () => {
     it('should handle a basic event', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`)
-      .post(`/events`)
-      .reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         type: 'page',
@@ -29,7 +27,7 @@ describe('FacebookConversionsApi', () => {
         event,
         settings,
         useDefaultMappings: true,
-        mapping: { action_source: { '@path': '$.properties.action_source'} }
+        mapping: { action_source: { '@path': '$.properties.action_source' } }
       })
 
       expect(responses.length).toBe(1)
@@ -37,9 +35,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error when action_source is website and no client_user_agent', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`)
-      .post(`/events`)
-      .reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         type: 'page',
@@ -51,29 +47,29 @@ describe('FacebookConversionsApi', () => {
         }
       })
 
-      await expect(testDestination.testAction('pageView', {
-        event,
-        settings,
-        mapping: {
-          action_source: {
-            '@path': '$.properties.action_source'
-          },
-          event_time: {
-            '@path': '$.properties.timestamp'
-          },
-          user_data: {
-            email: {
-              '@path': '$.properties.email'
+      await expect(
+        testDestination.testAction('pageView', {
+          event,
+          settings,
+          mapping: {
+            action_source: {
+              '@path': '$.properties.action_source'
+            },
+            event_time: {
+              '@path': '$.properties.timestamp'
+            },
+            user_data: {
+              email: {
+                '@path': '$.properties.email'
+              }
             }
           }
-        }
-      })).rejects.toThrowError('If action source is "Website" then client_user_agent must be defined')
+        })
+      ).rejects.toThrowError('If action source is "Website" then client_user_agent must be defined')
     })
 
     it('should handle default mappings', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`)
-      .post(`/events`)
-      .reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Added',
@@ -83,23 +79,21 @@ describe('FacebookConversionsApi', () => {
           timestamp: 1631210020
         }
       })
-      
+
       const responses = await testDestination.testAction('pageView', {
         event,
         settings,
         useDefaultMappings: true,
-        mapping: { action_source: { '@path': '$.properties.action_source'} }
+        mapping: { action_source: { '@path': '$.properties.action_source' } }
       })
-      
+
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
     })
 
     it('should throw an error if no user_data keys are included', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`)
-      .post(`/events`)
-      .reply(201, {})
-  
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+
       const event = createTestEvent({
         event: 'Product Added',
         userId: 'abc123',
@@ -108,26 +102,28 @@ describe('FacebookConversionsApi', () => {
           action_source: 'email'
         }
       })
-  
-      await expect(testDestination.testAction('pageView', {
-        event,
-        settings,
-        mapping: {
-          currency: {
-            '@path': '$.properties.currency'
-          },
-          value: {
-            '@path': '$.properties.value'
-          },
-          action_source: {
-            '@path': '$.properties.action_source'
-          },
-          event_time: {
-            '@path': '$.properties.timestamp'
+
+      await expect(
+        testDestination.testAction('pageView', {
+          event,
+          settings,
+          mapping: {
+            currency: {
+              '@path': '$.properties.currency'
+            },
+            value: {
+              '@path': '$.properties.value'
+            },
+            action_source: {
+              '@path': '$.properties.action_source'
+            },
+            event_time: {
+              '@path': '$.properties.timestamp'
+            }
+            // No user data mapping included. This should cause action to fail.
           }
-          // No user data mapping included. This should cause action to fail.
-        }
-      })).rejects.toThrowError("The root value is missing the required field 'user_data'.")
+        })
+      ).rejects.toThrowError("The root value is missing the required field 'user_data'.")
     })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/purchase.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/purchase.test.ts
@@ -11,7 +11,7 @@ const settings = {
 
 describe('purchase', () => {
   it('should handle a basic event', async () => {
-    nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+    nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
     const event = createTestEvent({
       event: 'Order Completed',
@@ -77,7 +77,7 @@ describe('purchase', () => {
   })
 
   it('should handle default mappings', async () => {
-    nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+    nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
     const event = createTestEvent({
       event: 'Order Completed',
@@ -106,7 +106,7 @@ describe('purchase', () => {
   })
 
   it('should throw an error when currency and value are missing', async () => {
-    nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+    nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
     const event = createTestEvent({
       event: 'Order Completed',
@@ -147,7 +147,7 @@ describe('purchase', () => {
   })
 
   it('should throw an error if no user_data keys are included', async () => {
-    nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+    nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
     const event = createTestEvent({
       event: 'Order Completed',

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/search.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/search.test.ts
@@ -10,7 +10,7 @@ const settings = {
 describe('FacebookConversionsApi', () => {
   describe('Search', () => {
     it('should handle a basic event', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Products Searched',
@@ -72,7 +72,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should handle default mappings', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Products Searched',
@@ -100,7 +100,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error if no user_data keys are included', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Products Searched',

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/viewContent.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/viewContent.test.ts
@@ -10,7 +10,7 @@ const settings = {
 describe('FacebookConversionsApi', () => {
   describe('ViewContent', () => {
     it('should handle a basic event', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Viewed',
@@ -79,7 +79,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should handle default mappings', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Viewed',
@@ -107,7 +107,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error if no user_data keys are included', async () => {
-      nock(`https://graph.facebook.com/v11.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Viewed',

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/constants.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/constants.ts
@@ -1,4 +1,4 @@
-export const API_VERSION = '11.0'
+export const API_VERSION = '12.0'
 export const CURRENCY_ISO_CODES = new Set([
   'AED',
   'AFN',
@@ -231,7 +231,7 @@ export const US_STATE_CODES = new Map<string, string>([
   ['washington', 'wa'],
   ['westvirginia', 'wv'],
   ['wisconsin', 'wi'],
-  ['wyoming', 'wy'],
+  ['wyoming', 'wy']
 ])
 
 export const COUNTRY_CODES = new Map<string, string>([
@@ -479,5 +479,5 @@ export const COUNTRY_CODES = new Map<string, string>([
   ['westernsahara', 'eh'],
   ['yemen', 'ye'],
   ['zambia', 'zm'],
-  ['zimbabwe', 'zw'],
+  ['zimbabwe', 'zw']
 ])


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Facebook is deprecating all versions of the Marketing API prior to v12.0 on Feb 23. This PR updates the API version from 11.0 to 12.0. 

## Testing

[Testing Doc](https://paper.dropbox.com/doc/STRATCONN-1079-Upgrade-FB-CAPI-Actions-to-Marketing-API-v12.0--BbfjH9wJKipB~j0rrIToYFLlAg-LX8uHcP5z9l7C6wcuKL7e)


- [ x] Updated [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ x] [Segmenters] Tested in the staging environment
