### PR TITLE
Enable batch local testing

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -45,9 +45,7 @@ curl --location --request POST 'http://localhost:3000/search' \
 
 ### Testing Batches
 
-Actions destinations that support batching can also be tested locally. An Actions destination that supports batching should have the `performBatch`
-handler implemented. Test events should be formatted similarly to the example above, with the exception that `payload` will be an array. Here is an
-example of `webhook`'s `send` action:
+Actions destinations that support batching, i.e. that have a `performBatch` handler implemented, can also be tested locally. Test events should be formatted similarly to the example above, with the exception that `payload` will be an array. Here is an example of `webhook`'s `send` action, with a batch `payload`.
 
 ```sh
 curl --location --request POST 'http://localhost:3000/send' \

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -43,6 +43,28 @@ curl --location --request POST 'http://localhost:3000/search' \
 }'
 ```
 
+### Testing Batches
+
+Actions destinations that support batching can also be tested locally. An Actions destination that supports batching should have the `performBatch`
+handler implemented. Test events should be formatted similarly to the example above, with the exception that `payload` will be an array. Here is an
+example of `webhook`'s `send` action:
+
+```sh
+curl --location --request POST 'http://localhost:3000/send' \
+--header 'Content-Type: application/json' \
+--data '{
+    "payload": [{
+        "url": "https://www.example.com",
+        "method": "PUT",
+        "data": {
+            "cool": true
+        }
+    }],
+    "settings": {},
+    "auth": {}
+}'
+```
+
 ## Unit Testing
 
 When building a destination action, you should write unit and end-to-end tests to ensure your action is working as intended. Tests are automatically run on every commit in Github Actions. Pull requests that do not include relevant tests will not be approved.
@@ -152,7 +174,6 @@ Once the actions under a new destination are complete, developers can run the fo
 ```
 yarn jest --testPathPattern='./packages/destination-actions/src/destinations/<DESTINATION SLUG>' --updateSnapshot
 ```
-
 
 ## Canary Testing
 

--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -176,6 +176,9 @@ function setupRoutes(def: DestinationDefinition | null): void {
           }
 
           if (Array.isArray(eventParams.data)) {
+            // We assume that the the first payload in the data array
+            // provided for testing contains all actions mappings
+            eventParams.mapping = eventParams.data[0]
             await action.executeBatch(eventParams)
           } else {
             await action.execute(eventParams)

--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -168,12 +168,18 @@ function setupRoutes(def: DestinationDefinition | null): void {
             return res.status(400).send(msg)
           }
 
-          await action.execute({
+          const eventParams = {
             data: req.body.payload || {},
             settings: req.body.settings || {},
             mapping: req.body.payload || {},
             auth: req.body.auth || {}
-          })
+          }
+
+          if (Array.isArray(eventParams.data)) {
+            await action.executeBatch(eventParams)
+          } else {
+            await action.execute(eventParams)
+          }
 
           const debug = await getExchanges(destination.responses)
           return res.status(200).json(debug)

--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -178,7 +178,7 @@ function setupRoutes(def: DestinationDefinition | null): void {
           if (Array.isArray(eventParams.data)) {
             // We assume that the the first payload in the data array
             // provided for testing contains all actions mappings
-            eventParams.mapping = eventParams.data[0]
+            eventParams.mapping = eventParams.data[0] || {}
             await action.executeBatch(eventParams)
           } else {
             await action.execute(eventParams)


### PR DESCRIPTION
- Adds support for local testing with batches. Batches are now handled with the `executeBatch` method in the local testing server.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment