### PR TITLE
Add upsertProfile Action to Adobe Target Web

### DIFF
--- a/packages/browser-destinations/README.md
+++ b/packages/browser-destinations/README.md
@@ -16,6 +16,14 @@ This package contains the implementations for browser destinations.
 
 See the [Actions CLI](https://github.com/segmentio/action-destinations#actions-cli) of the root directory of this repo to learn how to interact with the Actions CLI. Interacting with the actions CLI will allow you to create new destinations, actions and update your type definitions.
 
+### Types
+
+When udating the types inside of your actions remember to regenerate the types of your integration by running this command in the top level directory.
+
+```
+bin/run generate:types
+```
+
 ### Manual testing
 
 You can run a test webpage that makes every browser destination available for testing.

--- a/packages/browser-destinations/src/destinations/adobe-target/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/__tests__/index.test.ts
@@ -17,7 +17,7 @@ describe('Adobe Target Web', () => {
       client_code: 'segmentexchangepartn',
       admin_number: '10',
       version: '2.8.0',
-      cookie_domain: 'localhost',
+      cookie_domain: 'segment.com',
       mbox_name: 'target-global-mbox',
       subscriptions
     })

--- a/packages/browser-destinations/src/destinations/adobe-target/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/index.ts
@@ -9,10 +9,12 @@ import upsertProfile from './upsertProfile'
 declare global {
   interface Window {
     adobe: Adobe
+    targetPageParams: Function
+    pageParams: Object
   }
 }
 
-export const destination: BrowserDestinationDefinition<Settings, unknown> = {
+export const destination: BrowserDestinationDefinition<Settings, Adobe> = {
   name: 'Adobe Target Web',
   slug: 'actions-adobe-target-web',
   mode: 'device',

--- a/packages/browser-destinations/src/destinations/adobe-target/init-script.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/init-script.ts
@@ -1,9 +1,18 @@
 /* eslint-disable */
 // @ts-nocheck
 
+import { getPageParams } from './utils'
+
 export function initScript(settings) {
+  window.pageParams = {}
   window.targetGlobalSettings = {
     cookieDomain: settings.cookie_domain,
     enabled: true
+  }
+
+  // DO NOT RENAME. This function is required by Adobe Target.
+  // Learn More: https://experienceleague.adobe.com/docs/target/using/implement-target/client-side/at-js-implementation/functions-overview/targetpageparams.html?lang=en
+  window.targetPageParams = function () {
+    return getPageParams()
   }
 }

--- a/packages/browser-destinations/src/destinations/adobe-target/types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/types.ts
@@ -1,1 +1,7 @@
-export type Adobe = unknown
+export type Adobe = {
+  target: Target
+}
+
+type Target = {
+  trackEvent: Function
+}

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/__tests__/index.test.ts
@@ -2,45 +2,130 @@ import { Analytics, Context } from '@segment/analytics-next'
 import adobeTarget, { destination } from '../../index'
 import { Subscription } from '../../../../lib/browser-destinations'
 
-// TODO: Fill this test since it's a copy of the main test.
-
 describe('Adobe Target Web', () => {
-  test('calls identify', async () => {
-    const subscriptions: Subscription[] = [
-      {
-        partnerAction: 'upsertProfile',
-        name: 'Upsert Profile',
-        enabled: true,
-        subscribe: 'type = "identify"',
-        mapping: {}
-      }
-    ]
-    const [event] = await adobeTarget({
-      client_code: 'segmentexchangepartn',
-      admin_number: '10',
-      version: '2.8.0',
-      cookie_domain: 'localhost',
-      mbox_name: 'target-global-mbox',
-      subscriptions
-    })
-
-    jest.spyOn(destination, 'initialize')
-
-    await event.load(Context.system(), {} as Analytics)
-    expect(destination.initialize).toHaveBeenCalled()
-
-    const scripts = window.document.querySelectorAll('script')
-    expect(scripts).toMatchInlineSnapshot(`
-      NodeList [
-        <script
-          src="https://admin10.testandtarget.omniture.com/admin/rest/v1/libraries/atjs/download?client=segmentexchangepartn&version=2.8.0"
-          status="loaded"
-          type="text/javascript"
-        />,
-        <script>
-          // the emptiness
-        </script>,
+  describe('#identify', () => {
+    test('calls identify and simulates a login flow', async () => {
+      const subscriptions: Subscription[] = [
+        {
+          partnerAction: 'upsertProfile',
+          name: 'Upsert Profile',
+          enabled: true,
+          subscribe: 'type = "identify"',
+          mapping: {
+            anonymousId: {
+              '@path': '$.anonymousId'
+            },
+            userId: {
+              '@path': '$.userId'
+            },
+            traits: {
+              '@path': '$.traits'
+            }
+          }
+        }
       ]
-    `)
+
+      const targetSettings = {
+        client_code: 'segmentexchangepartn',
+        admin_number: '10',
+        version: '2.8.0',
+        cookie_domain: 'segment.com',
+        mbox_name: 'target-global-mbox'
+      }
+
+      const identifyParams = {
+        traits: {
+          favorite_color: 'blue',
+          location: {
+            country_code: 'MX',
+            state: 'Mich'
+          }
+        }
+      }
+
+      const [event] = await adobeTarget({
+        ...targetSettings,
+        subscriptions
+      })
+
+      jest.spyOn(destination, 'initialize')
+
+      destination.actions.upsertProfile.perform = jest.fn(destination.actions.upsertProfile.perform)
+
+      await event.load(Context.system(), {} as Analytics)
+      expect(destination.initialize).toHaveBeenCalled()
+
+      await event.identify?.(
+        new Context({
+          anonymousId: 'random-id-42',
+          type: 'identify',
+          ...identifyParams
+        })
+      )
+
+      expect(destination.actions.upsertProfile.perform).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          payload: {
+            anonymousId: 'random-id-42',
+            traits: {
+              favorite_color: 'blue',
+              location: {
+                country_code: 'MX',
+                state: 'Mich'
+              }
+            }
+          }
+        })
+      )
+
+      expect(window.pageParams).toEqual({
+        profile: {
+          mbox3rdpartyid: 'random-id-42',
+          favorite_color: 'blue',
+          location: {
+            country_code: 'MX',
+            state: 'Mich'
+          }
+        }
+      })
+
+      await event.identify?.(
+        new Context({
+          userId: 'The-Real-ID',
+          anonymousId: 'random-id-42',
+          type: 'identify',
+          ...identifyParams
+        })
+      )
+
+      expect(destination.actions.upsertProfile.perform).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          payload: {
+            userId: 'The-Real-ID',
+            anonymousId: 'random-id-42',
+            traits: {
+              favorite_color: 'blue',
+              location: {
+                country_code: 'MX',
+                state: 'Mich'
+              }
+            }
+          }
+        })
+      )
+
+      expect(window.pageParams).toEqual({
+        profile: {
+          mbox3rdpartyid: 'The-Real-ID',
+          favorite_color: 'blue',
+          location: {
+            country_code: 'MX',
+            state: 'Mich'
+          }
+        }
+      })
+    })
   })
 })

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/generated-types.ts
@@ -2,9 +2,17 @@
 
 export interface Payload {
   /**
-   * Hash of properties for this profile.
+   * A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.
    */
-  profile?: {
+  userId?: string
+  /**
+   * Anonymous identifier for the user
+   */
+  anonymousId: string
+  /**
+   * Profile parameters specific to a user.
+   */
+  traits: {
     [k: string]: unknown
   }
 }

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
@@ -2,6 +2,7 @@ import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
 import type { Settings } from '../generated-types'
 import { Adobe } from '../types'
 import type { Payload } from './generated-types'
+import { setPageParams } from '../utils'
 
 const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   title: 'Upsert Profile',
@@ -9,17 +10,72 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   platform: 'web',
   defaultSubscription: 'type = "identify"',
   fields: {
-    profile: {
-      type: 'object',
-      description: 'Hash of properties for this profile.',
-      label: 'Profile Properties',
+    userId: {
+      type: 'string',
+      required: false,
+      description:
+        'A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.',
+      label: 'User ID',
       default: {
-        '@path': '$.profile'
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      }
+    },
+    anonymousId: {
+      type: 'string',
+      required: true,
+      description: 'Anonymous identifier for the user',
+      label: 'Anonymous ID',
+      default: {
+        '@path': '$.anonymousId'
+      }
+    },
+    traits: {
+      type: 'object',
+      required: true,
+      description: 'Profile parameters specific to a user.',
+      label: 'User Attributes',
+      default: {
+        '@path': '$.traits'
       }
     }
   },
-  perform: () => {
-    return
+  perform: (Adobe, event) => {
+    /*
+       NOTE:
+       identify() and track() actions leverage the same function (adobe.target.trackEvent()) to send data to Adobe.
+       identify does not pass an event name, track does.
+    */
+    const user = {
+      mbox3rdpartyid: event.payload.anonymousId
+    }
+    if (event.payload.userId) {
+      user.mbox3rdpartyid = event.payload.userId
+    }
+
+    /*
+      NOTE:
+      Profile data needs to be set before the call to adobe.target.trackEvent.
+      This is because the profile data needs to be part of the global pageParams object.
+    */
+    setPageParams({
+      profile: {
+        ...event.payload.traits,
+        ...user
+      }
+    })
+
+    const params = {
+      mbox: event.settings.mbox_name,
+      params: {
+        type: 'profile_update' // DO NOT CHANGE. profile_update is used to differentiate between track and identify calls.
+      }
+    }
+
+    Adobe.target.trackEvent(params)
   }
 }
 

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
@@ -12,7 +12,6 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   fields: {
     userId: {
       type: 'string',
-      required: false,
       description:
         'A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.',
       label: 'User ID',

--- a/packages/browser-destinations/src/destinations/adobe-target/utils.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/utils.ts
@@ -1,0 +1,10 @@
+/* eslint-disable */
+// @ts-nocheck
+
+export function getPageParams() {
+  return window.pageParams
+}
+
+export function setPageParams(params) {
+  return (window.pageParams = { ...window.pageParams, ...params })
+}


### PR DESCRIPTION
This PR brings support for Segment's `identify()` inside the Adobe Target Web integration. The action subscrided to `identify()` is `upsertProfile()`.

## Testing

Settings and subscription:

```
{
  "client_code": "YOURCLIENTCODE",
  "admin_number": "YOURADMINNUMBER",
  "version": "2.8.0",
  "cookie_domain": "localhost",
  "mbox_name": "target-global-mbox",
  "subscriptions": [
    {
      "partnerAction": "upsertProfile",
      "name": "Upsert Profile",
      "enabled": true,
      "subscribe": "type = \"identify\"",
      "mapping": {
        "userId": {

   "@if": {
      "exists": {
         "@path": "$.userId"
      },
      "then": {
         "@path": "$.userId"
      },
      "else": {
         "@path": "$.anonymousId"
      }
   }
        },
        "traits": {
          "@path": "$.traits"
        }
      }
    }
  ]
}
```

Event:

```
{
 "properties": {
    "favorite_color": "blue",
    "location": {
      "country": "USA",
      "city": "OAKLAND"
    }
  }
}
```

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
