### PR TITLE
New metronome API url

### DIFF
--- a/packages/destination-actions/src/destinations/metronome/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/metronome/__tests__/index.test.ts
@@ -9,29 +9,24 @@ const testDestination = createTestIntegration(Definition)
 describe('Metronome', () => {
   describe('testAuthentication', () => {
     it('should validate valid auth tokens', async () => {
-      nock('https://api.getmetronome.com')
-        .matchHeader('content-type', 'application/json')
-        .post('/v1/ingest').reply(400, {
-          message: "[array is too short: must have at least 1 elements but instance has 0 elements]"
-        });
+      nock('https://api.metronome.com').matchHeader('content-type', 'application/json').post('/v1/ingest').reply(400, {
+        message: '[array is too short: must have at least 1 elements but instance has 0 elements]'
+      })
 
       const authData: Settings = {
-        apiToken: "mock-token"
+        apiToken: 'mock-token'
       }
 
       await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
     })
 
     it('should throw an error for invalid auth tokens', async () => {
-      nock('https://api.getmetronome.com')
-        .post('/v1/ingest')
-        .matchHeader('content-type', 'application/json')
-        .reply(403, {
-          "message": "Unauthorized"
-        });
+      nock('https://api.metronome.com').post('/v1/ingest').matchHeader('content-type', 'application/json').reply(403, {
+        message: 'Unauthorized'
+      })
 
       const authData: Settings = {
-        apiToken: "mock-token"
+        apiToken: 'mock-token'
       }
 
       await expect(testDestination.testAuthentication(authData)).rejects.toThrowError()

--- a/packages/destination-actions/src/destinations/metronome/index.ts
+++ b/packages/destination-actions/src/destinations/metronome/index.ts
@@ -19,7 +19,7 @@ const destination: DestinationDefinition<Settings> = {
       }
     },
     testAuthentication: async (request) => {
-      const response = await request('https://api.getmetronome.com/v1/ingest', {
+      const response = await request('https://api.metronome.com/v1/ingest', {
         method: 'post',
         json: [],
         throwHttpErrors: false

--- a/packages/destination-actions/src/destinations/metronome/sendEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/metronome/sendEvent/__tests__/index.test.ts
@@ -4,29 +4,27 @@ import Destination from '../../index'
 const testDestination = createTestIntegration(Destination)
 
 describe('Metronome.sendEvent', () => {
-  describe("process", () => {
+  describe('process', () => {
     it('should send an event', async () => {
       const event = createTestEvent({
         context: {
-          groupId: "mock-group-id", // have to provide a groupId since this function doesn't create one by default
+          groupId: 'mock-group-id' // have to provide a groupId since this function doesn't create one by default
         }
-      });
+      })
 
-      nock('https://api.getmetronome.com')
-        .matchHeader('content-type', 'application/json')
-        .post('/v1/ingest').reply(200)
+      nock('https://api.metronome.com').matchHeader('content-type', 'application/json').post('/v1/ingest').reply(200)
 
       const responses = await testDestination.testAction('sendEvent', {
         event,
         useDefaultMappings: true,
         settings: {
-          apiToken: "mock-api-token",
+          apiToken: 'mock-api-token'
         },
         mapping: {
-          event_type: { '@path': "$.event" },
-          properties: { '@path': "$.context" },
-        },
-      });
+          event_type: { '@path': '$.event' },
+          properties: { '@path': '$.context' }
+        }
+      })
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
@@ -54,35 +52,32 @@ describe('Metronome.sendEvent', () => {
           customer_id: event?.context?.groupId,
           properties: event.context,
           transaction_id: event.messageId,
-          timestamp: new Date(event.timestamp ?? "").toISOString(),
+          timestamp: new Date(event.timestamp ?? '').toISOString()
         }
       ])
     })
 
-
     it('should convert a non rfc3999 timestamp', async () => {
       const event = createTestEvent({
-        timestamp: "2021-01-01",
+        timestamp: '2021-01-01',
         context: {
-          groupId: "mock-group-id", // have to provide a groupId since this function doesn't create one by default
+          groupId: 'mock-group-id' // have to provide a groupId since this function doesn't create one by default
         }
-      });
+      })
 
-      nock('https://api.getmetronome.com')
-        .matchHeader('content-type', 'application/json')
-        .post('/v1/ingest').reply(200)
+      nock('https://api.metronome.com').matchHeader('content-type', 'application/json').post('/v1/ingest').reply(200)
 
       const responses = await testDestination.testAction('sendEvent', {
         event,
         useDefaultMappings: true,
         settings: {
-          apiToken: "mock-api-token",
+          apiToken: 'mock-api-token'
         },
         mapping: {
-          event_type: { '@path': "$.event" },
-          properties: { '@path': "$.context" },
-        },
-      });
+          event_type: { '@path': '$.event' },
+          properties: { '@path': '$.context' }
+        }
+      })
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
@@ -109,7 +104,7 @@ describe('Metronome.sendEvent', () => {
           customer_id: event?.context?.groupId,
           properties: event.context,
           transaction_id: event.messageId,
-          timestamp: "2021-01-01T00:00:00.000Z",
+          timestamp: '2021-01-01T00:00:00.000Z'
         }
       ])
     })
@@ -117,29 +112,27 @@ describe('Metronome.sendEvent', () => {
     it('should convert an epoch timestamp', async () => {
       const event = createTestEvent({
         properties: {
-          epoch_timestamp: 1625895431000, // 2021-07-10 05:37:11
+          epoch_timestamp: 1625895431000 // 2021-07-10 05:37:11
         },
         context: {
-          groupId: "mock-group-id", // have to provide a groupId since this function doesn't create one by default
+          groupId: 'mock-group-id' // have to provide a groupId since this function doesn't create one by default
         }
-      });
+      })
 
-      nock('https://api.getmetronome.com')
-        .matchHeader('content-type', 'application/json')
-        .post('/v1/ingest').reply(200)
+      nock('https://api.metronome.com').matchHeader('content-type', 'application/json').post('/v1/ingest').reply(200)
 
       const responses = await testDestination.testAction('sendEvent', {
         event,
         useDefaultMappings: true,
         settings: {
-          apiToken: "mock-api-token",
+          apiToken: 'mock-api-token'
         },
         mapping: {
-          event_type: { '@path': "$.event" },
-          properties: { '@path': "$.context" },
-          timestamp: { '@path': "$.properties.epoch_timestamp" },
-        },
-      });
+          event_type: { '@path': '$.event' },
+          properties: { '@path': '$.context' },
+          timestamp: { '@path': '$.properties.epoch_timestamp' }
+        }
+      })
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
@@ -148,7 +141,7 @@ describe('Metronome.sendEvent', () => {
       // when in practice it is an instance of Headers. Until this is fixed,
       // we'll use a snapshot to check the headers. Ideally this check could just be
       // `expect(responses[0].options.headers.get("authorization")).toBe("Bearer mock-api-token")`
-      expect((responses[0].options.headers)).toMatchInlineSnapshot(`
+      expect(responses[0].options.headers).toMatchInlineSnapshot(`
         Headers {
           Symbol(map): Object {
             "authorization": Array [
@@ -166,7 +159,7 @@ describe('Metronome.sendEvent', () => {
           customer_id: event?.context?.groupId,
           properties: event.context,
           transaction_id: event.messageId,
-          timestamp: "2021-07-10T05:37:11.000Z",
+          timestamp: '2021-07-10T05:37:11.000Z'
         }
       ])
     })

--- a/packages/destination-actions/src/destinations/metronome/sendEvent/index.ts
+++ b/packages/destination-actions/src/destinations/metronome/sendEvent/index.ts
@@ -16,7 +16,7 @@ function serializeEvent(event: Payload) {
     //
     // Ideally Segment would just pass any date-time values as Date objects not have this loose
     // coupling to dayjs parse formats but, this is fine for now.
-    timestamp: dayjs.utc(event.timestamp).toISOString(),
+    timestamp: dayjs.utc(event.timestamp).toISOString()
   }
 }
 
@@ -27,7 +27,8 @@ const action: ActionDefinition<Settings, Payload> = {
     transaction_id: {
       type: 'string',
       label: 'transaction_id',
-      description: 'The Metronome transaction ID uniquely identifies an event to ensure Metronome only processes each event once.',
+      description:
+        'The Metronome transaction ID uniquely identifies an event to ensure Metronome only processes each event once.',
       required: true,
       default: {
         '@path': '$.messageId'
@@ -68,17 +69,15 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.properties'
       }
-    },
+    }
   },
   perform: (request, { payload }) => {
     // Auth is injected by extendRequest in the destination root
-    return request('https://api.getmetronome.com/v1/ingest', {
+    return request('https://api.metronome.com/v1/ingest', {
       method: 'post',
-      json: [
-        serializeEvent(payload)
-      ]
+      json: [serializeEvent(payload)]
     })
-  },
+  }
   // We'd like to be able to use performBatch, but we run into complexity when 1 event in the batch
   // fails validation, causing the entire batch to fail. We've decided to just send 1 event at a time
   // for now, which allows normal 4XX and 5XX semantics to be used and bubble errors up into the Segment


### PR DESCRIPTION
Metronome is in the process of moving our api from `https://api.getmetronome.com` to `https://api.metronome.com` This PR updates the metronome action destination accordingly.

## Testing
✅ Unit tests


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
