### PR TITLE
GA4 - Add userID and params parameters to every action

### DIFF
--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
@@ -300,5 +300,88 @@ describe('GA4', () => {
         expect(e.message).toBe('One of item-level currency or top-level currency is required.')
       }
     })
+
+    it('should correctly append params', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Payment Info Entered',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          products: [
+            {
+              product_id: '12345abcde',
+              name: 'Quadruple Stack Oreos, 52 ct',
+              currency: 'USD',
+              price: 12.99,
+              quantity: 1
+            }
+          ]
+        }
+      })
+
+      const responses = await testDestination.testAction('addPaymentInfo', {
+        event,
+        settings: {
+          apiSecret,
+          measurementId
+        },
+        mapping: {
+          client_id: {
+            '@path': '$.anonymousId'
+          },
+          user_id: {
+            '@path': '$.userId'
+          },
+          params: {
+            Test_key: 'test_value'
+          },
+          items: [
+            {
+              item_name: {
+                '@path': `$.properties.products.0.name`
+              },
+              item_id: {
+                '@path': `$.properties.products.0.product_id`
+              },
+              currency: {
+                '@path': `$.properties.products.0.currency`
+              },
+              price: {
+                '@path': `$.properties.products.0.price`
+              },
+              quantity: {
+                '@path': `$.properties.products.0.quantity`
+              }
+            }
+          ]
+        },
+        useDefaultMappings: false
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].request.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "content-type": Array [
+              "application/json",
+            ],
+            "user-agent": Array [
+              "Segment (Actions)",
+            ],
+          },
+        }
+      `)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"client_id\\":\\"anon-2134\\",\\"user_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"add_payment_info\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"Test_key\\":\\"test_value\\"}}]}"`
+      )
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
@@ -40,6 +40,9 @@ describe('GA4', () => {
           client_id: {
             '@path': '$.anonymousId'
           },
+          user_id: {
+            '@path': '$.userId'
+          },
           items: [
             {
               item_name: {
@@ -80,7 +83,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"add_payment_info\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}]}}]}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"user_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"add_payment_info\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}]}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/generated-types.ts
@@ -106,4 +106,10 @@ export interface Payload {
      */
     quantity?: number
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
@@ -3,7 +3,16 @@ import { CURRENCY_ISO_CODES } from '../constants'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { user_id, client_id, currency, value, coupon, payment_type, items_multi_products } from '../ga4-properties'
+import {
+  user_id,
+  client_id,
+  currency,
+  value,
+  coupon,
+  payment_type,
+  items_multi_products,
+  params
+} from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Add Payment Info',
@@ -19,7 +28,8 @@ const action: ActionDefinition<Settings, Payload> = {
     items: {
       ...items_multi_products,
       required: true
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.includes(payload.currency)) {
@@ -77,7 +87,8 @@ const action: ActionDefinition<Settings, Payload> = {
               value: payload.value,
               coupon: payload.coupon,
               payment_type: payload.payment_type,
-              items: googleItems
+              items: googleItems,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
@@ -3,7 +3,7 @@ import { CURRENCY_ISO_CODES } from '../constants'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { client_id, currency, value, coupon, payment_type, items_multi_products } from '../ga4-properties'
+import { user_id, client_id, currency, value, coupon, payment_type, items_multi_products } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Add Payment Info',
@@ -11,6 +11,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Payment Info Entered"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     currency: { ...currency },
     value: { ...value },
     coupon: { ...coupon },
@@ -67,6 +68,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'add_payment_info',

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/generated-types.ts
@@ -98,4 +98,10 @@ export interface Payload {
    * The monetary value of the event.
    */
   value?: number
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { ProductItem } from '../ga4-types'
 import { CURRENCY_ISO_CODES } from '../constants'
-import { value, currency, client_id, items_single_products, user_id } from '../ga4-properties'
+import { params, value, currency, client_id, items_single_products, user_id } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Add to Cart',
@@ -17,7 +17,8 @@ const action: ActionDefinition<Settings, Payload> = {
       ...items_single_products,
       required: true
     },
-    value: { ...value }
+    value: { ...value },
+    params: params
   },
   perform: (request, { payload }) => {
     let googleItems: ProductItem[] = []
@@ -51,7 +52,8 @@ const action: ActionDefinition<Settings, Payload> = {
             params: {
               currency: payload.currency,
               items: googleItems,
-              value: payload.value
+              value: payload.value,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { ProductItem } from '../ga4-types'
 import { CURRENCY_ISO_CODES } from '../constants'
-import { value, currency, client_id, items_single_products } from '../ga4-properties'
+import { value, currency, client_id, items_single_products, user_id } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Add to Cart',
@@ -11,6 +11,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Product Added"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     currency: { ...currency },
     items: {
       ...items_single_products,
@@ -43,6 +44,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'add_to_cart',

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/generated-types.ts
@@ -98,4 +98,10 @@ export interface Payload {
      */
     quantity?: number
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
@@ -3,7 +3,7 @@ import { CURRENCY_ISO_CODES } from '../constants'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { value, currency, client_id, items_single_products, user_id } from '../ga4-properties'
+import { params, value, currency, client_id, items_single_products, user_id } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Add to Wishlist',
@@ -17,7 +17,8 @@ const action: ActionDefinition<Settings, Payload> = {
     items: {
       ...items_single_products,
       required: true
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     // Make your partner api request here!
@@ -74,7 +75,8 @@ const action: ActionDefinition<Settings, Payload> = {
             params: {
               currency: payload.currency,
               value: payload.value,
-              items: googleItems
+              items: googleItems,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
@@ -3,7 +3,7 @@ import { CURRENCY_ISO_CODES } from '../constants'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { value, currency, client_id, items_single_products } from '../ga4-properties'
+import { value, currency, client_id, items_single_products, user_id } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Add to Wishlist',
@@ -11,6 +11,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Product Added to Wishlist"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     currency: { ...currency },
     value: { ...value },
     items: {
@@ -66,6 +67,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'add_to_wishlist',

--- a/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Coupon code used for a purchase.
    */
   coupon?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/generated-types.ts
@@ -102,4 +102,10 @@ export interface Payload {
    * The monetary value of the event.
    */
   value?: number
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
@@ -1,6 +1,6 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from '../constants'
-import { coupon, currency, client_id, value, items_multi_products, user_id } from '../ga4-properties'
+import { params, coupon, currency, client_id, value, items_multi_products, user_id } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -20,7 +20,8 @@ const action: ActionDefinition<Settings, Payload> = {
       ...items_multi_products,
       required: true
     },
-    value: { ...value }
+    value: { ...value },
+    params: params
   },
   perform: (request, { payload }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.includes(payload.currency)) {
@@ -59,7 +60,8 @@ const action: ActionDefinition<Settings, Payload> = {
               coupon: payload.coupon,
               currency: payload.currency,
               items: googleItems,
-              value: payload.value
+              value: payload.value,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
@@ -1,6 +1,6 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from '../constants'
-import { coupon, currency, client_id, value, items_multi_products } from '../ga4-properties'
+import { coupon, currency, client_id, value, items_multi_products, user_id } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -11,6 +11,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Checkout Started"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     coupon: { ...coupon, default: { '@path': '$.properties.coupon' } },
     currency: { ...currency },
     // Google does not have anything to map position, url and image url fields (Segment spec) to
@@ -50,6 +51,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'begin_checkout',

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   clientId: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * The unique name of the custom event created in GA4. GA4 does not accept spaces in event names so Segment will replace any spaces with underscores. More information about GA4 event name rules is available in [their docs](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article).
    */
   name: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { client_id } from '../ga4-properties'
+import { client_id, user_id } from '../ga4-properties'
 
 const normalizeEventName = (name: string, lowercase: boolean | undefined): string => {
   name = name.trim()
@@ -19,6 +19,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track"',
   fields: {
     clientId: { ...client_id },
+    user_id: { ...user_id },
     name: {
       label: 'Event Name',
       description:
@@ -50,6 +51,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.clientId,
+        user_id: payload.user_id,
         events: [
           {
             name: event_name,

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { client_id, user_id } from '../ga4-properties'
+import { params, client_id, user_id } from '../ga4-properties'
 
 const normalizeEventName = (name: string, lowercase: boolean | undefined): string => {
   name = name.trim()
@@ -37,13 +37,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'boolean',
       default: false
     },
-    params: {
-      label: 'Event Parameters',
-      description: 'The event parameters to send to Google',
-      type: 'object',
-      additionalProperties: true,
-      default: { '@path': '$.properties' }
-    }
+    params: { ...params, default: { '@path': '$.properties' } }
   },
   perform: (request, { payload }) => {
     const event_name = normalizeEventName(payload.name, payload.lowercase)

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-properties.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-properties.ts
@@ -1,5 +1,11 @@
 import { InputField } from '@segment/actions-core/src/destination-kit/types'
 
+export const params: InputField = {
+  label: 'Event Parameters',
+  description: 'The event parameters to send to Google',
+  type: 'object',
+  additionalProperties: true
+}
 export const user_id: InputField = {
   label: 'User ID',
   type: 'string',

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-properties.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-properties.ts
@@ -1,5 +1,12 @@
 import { InputField } from '@segment/actions-core/src/destination-kit/types'
 
+export const user_id: InputField = {
+  label: 'User ID',
+  type: 'string',
+  description:
+    "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier."
+}
+
 export const promotion_id: InputField = {
   label: 'Promotion ID',
   type: 'string',

--- a/packages/destination-actions/src/destinations/google-analytics-4/generateLead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/generateLead/generated-types.ts
@@ -17,4 +17,10 @@ export interface Payload {
    * The monetary value of the event.
    */
   value?: number
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/generateLead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/generateLead/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
@@ -2,7 +2,7 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from '../constants'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { client_id, currency, value } from '../ga4-properties'
+import { client_id, user_id, currency, value } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Generate Lead',
@@ -10,6 +10,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     currency: { ...currency },
     value: { ...value }
   },
@@ -27,6 +28,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'generate_lead',

--- a/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
@@ -2,7 +2,7 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from '../constants'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { client_id, user_id, currency, value } from '../ga4-properties'
+import { params, client_id, user_id, currency, value } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Generate Lead',
@@ -12,7 +12,8 @@ const action: ActionDefinition<Settings, Payload> = {
     client_id: { ...client_id },
     user_id: { ...user_id },
     currency: { ...currency },
-    value: { ...value }
+    value: { ...value },
+    params: params
   },
   perform: (request, { payload }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.includes(payload.currency)) {
@@ -34,7 +35,8 @@ const action: ActionDefinition<Settings, Payload> = {
             name: 'generate_lead',
             params: {
               currency: payload.currency,
-              value: payload.value
+              value: payload.value,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/login/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/login/generated-types.ts
@@ -13,4 +13,10 @@ export interface Payload {
    * The method used to login.
    */
   method?: string
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/login/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/login/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * The method used to login.
    */
   method?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { client_id } from '../ga4-properties'
+import { user_id, client_id } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Login',
@@ -9,6 +9,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Signed In"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     method: {
       label: 'Method',
       type: 'string',
@@ -21,6 +22,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'login',

--- a/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { user_id, client_id } from '../ga4-properties'
+import { params, user_id, client_id } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Login',
@@ -14,7 +14,8 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Method',
       type: 'string',
       description: 'The method used to login.'
-    }
+    },
+    params: params
   },
 
   perform: (request, { payload }) => {
@@ -27,7 +28,8 @@ const action: ActionDefinition<Settings, Payload> = {
           {
             name: 'login',
             params: {
-              method: payload.method
+              method: payload.method,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/generated-types.ts
@@ -17,4 +17,10 @@ export interface Payload {
    * Previous page URL
    */
   page_referrer?: string
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   clientId: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * The current page URL
    */
   page_location?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { client_id } from '../ga4-properties'
+import { user_id, client_id } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Page View',
@@ -9,6 +9,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "page"',
   fields: {
     clientId: { ...client_id },
+    user_id: { ...user_id },
     page_location: {
       label: 'Page Location',
       type: 'string',
@@ -31,6 +32,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.clientId,
+        user_id: payload.user_id,
         events: [
           {
             name: 'page_view',

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { user_id, client_id } from '../ga4-properties'
+import { params, user_id, client_id } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Page View',
@@ -25,7 +25,8 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.context.page.referrer'
       }
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     return request('https://www.google-analytics.com/mp/collect', {
@@ -38,7 +39,8 @@ const action: ActionDefinition<Settings, Payload> = {
             name: 'page_view',
             params: {
               page_location: payload.page_location,
-              page_referrer: payload.page_referrer
+              page_referrer: payload.page_referrer,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Store or affiliation from which this transaction occurred (e.g. Google Store).
    */
   affiliation?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/generated-types.ts
@@ -118,4 +118,10 @@ export interface Payload {
    * The monetary value of the event.
    */
   value?: number
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
@@ -9,6 +9,7 @@ import {
   transaction_id,
   value,
   client_id,
+  user_id,
   affiliation,
   shipping,
   tax,
@@ -23,6 +24,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Order Completed"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     affiliation: { ...affiliation },
     coupon: { ...coupon, default: { '@path': '$.properties.coupon' } },
     currency: { ...currency, required: true },
@@ -66,6 +68,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'purchase',

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
@@ -13,7 +13,8 @@ import {
   affiliation,
   shipping,
   tax,
-  items_multi_products
+  items_multi_products,
+  params
 } from '../ga4-properties'
 
 // https://segment.com/docs/connections/spec/ecommerce/v2/#order-completed
@@ -37,7 +38,8 @@ const action: ActionDefinition<Settings, Payload> = {
     transaction_id: { ...transaction_id, required: true },
     shipping: { ...shipping },
     tax: { ...tax },
-    value: { ...value, default: { '@path': '$.properties.total' } }
+    value: { ...value, default: { '@path': '$.properties.total' } },
+    params: params
   },
   perform: (request, { payload }) => {
     if (!CURRENCY_ISO_CODES.includes(payload.currency)) {
@@ -80,7 +82,8 @@ const action: ActionDefinition<Settings, Payload> = {
               transaction_id: payload.transaction_id,
               shipping: payload.shipping,
               value: payload.value,
-              tax: payload.tax
+              tax: payload.tax,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/generated-types.ts
@@ -118,4 +118,10 @@ export interface Payload {
      */
     quantity?: number
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
@@ -9,7 +9,8 @@ import {
   value,
   affiliation,
   shipping,
-  items_multi_products
+  items_multi_products,
+  params
 } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -35,7 +36,8 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     items: {
       ...items_multi_products
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.includes(payload.currency)) {
@@ -96,7 +98,8 @@ const action: ActionDefinition<Settings, Payload> = {
               coupon: payload.coupon,
               shipping: payload.shipping,
               tax: payload.tax,
-              items: googleItems
+              items: googleItems,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
@@ -4,6 +4,7 @@ import {
   coupon,
   transaction_id,
   client_id,
+  user_id,
   currency,
   value,
   affiliation,
@@ -20,6 +21,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Order Refunded"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     currency: { ...currency },
     transaction_id: { ...transaction_id, required: true },
     value: { ...value, default: { '@path': '$.properties.total' } },
@@ -82,6 +84,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'refund',

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/generated-types.ts
@@ -98,4 +98,10 @@ export interface Payload {
      */
     quantity?: number
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
@@ -1,6 +1,6 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from '../constants'
-import { value, client_id, currency, items_single_products } from '../ga4-properties'
+import { value, user_id, client_id, currency, items_single_products } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -11,6 +11,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Product Removed"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     currency: { ...currency },
     value: { ...value },
     items: {
@@ -65,6 +66,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'remove_from_cart',

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
@@ -1,6 +1,6 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from '../constants'
-import { value, user_id, client_id, currency, items_single_products } from '../ga4-properties'
+import { params, value, user_id, client_id, currency, items_single_products } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -17,7 +17,8 @@ const action: ActionDefinition<Settings, Payload> = {
     items: {
       ...items_single_products,
       required: true
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.includes(payload.currency)) {
@@ -73,7 +74,8 @@ const action: ActionDefinition<Settings, Payload> = {
             params: {
               currency: payload.currency,
               value: payload.value,
-              items: googleItems
+              items: googleItems,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/search/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/search/generated-types.ts
@@ -13,4 +13,10 @@ export interface Payload {
    * The term that was searched for.
    */
   search_term: string
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/search/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/search/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * The term that was searched for.
    */
   search_term: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { user_id, client_id } from '../ga4-properties'
+import { params, user_id, client_id } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Search',
@@ -18,7 +18,8 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': `$.properties.query`
       }
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     return request('https://www.google-analytics.com/mp/collect', {
@@ -30,7 +31,8 @@ const action: ActionDefinition<Settings, Payload> = {
           {
             name: 'search',
             params: {
-              search_term: payload.search_term
+              search_term: payload.search_term,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { client_id } from '../ga4-properties'
+import { user_id, client_id } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Search',
@@ -9,6 +9,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Products Searched"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     search_term: {
       label: 'Search Term',
       type: 'string',
@@ -24,6 +25,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'search',

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * The name of the list in which the item was presented to the user.
    */
   item_list_name?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/generated-types.ts
@@ -98,4 +98,10 @@ export interface Payload {
      */
     quantity?: number
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
@@ -3,7 +3,7 @@ import { CURRENCY_ISO_CODES } from '../constants'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { user_id, client_id, items_single_products } from '../ga4-properties'
+import { params, user_id, client_id, items_single_products } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Select Item',
@@ -25,7 +25,8 @@ const action: ActionDefinition<Settings, Payload> = {
     items: {
       ...items_single_products,
       required: true
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     let googleItems: ProductItem[] = []
@@ -59,7 +60,8 @@ const action: ActionDefinition<Settings, Payload> = {
             params: {
               items: googleItems,
               item_list_name: payload.item_list_name,
-              item_list_id: payload.item_list_id
+              item_list_id: payload.item_list_id,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
@@ -3,7 +3,7 @@ import { CURRENCY_ISO_CODES } from '../constants'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { client_id, items_single_products } from '../ga4-properties'
+import { user_id, client_id, items_single_products } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Select Item',
@@ -11,6 +11,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Product Clicked"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     item_list_name: {
       label: 'Item List Name',
       description: 'The name of the list in which the item was presented to the user.',
@@ -51,6 +52,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'select_item',

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * The name of the promotional creative.
    */
   creative_name?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/generated-types.ts
@@ -126,4 +126,10 @@ export interface Payload {
      */
     promotion_id?: string
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
@@ -3,6 +3,7 @@ import { CURRENCY_ISO_CODES } from '../constants'
 import {
   creative_name,
   client_id,
+  user_id,
   creative_slot,
   promotion_id,
   promotion_name,
@@ -19,6 +20,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Promotion Clicked"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     creative_name: { ...creative_name },
     creative_slot: { ...creative_slot, default: { '@path': '$.properties.creative' } },
     location_id: {
@@ -80,6 +82,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'select_promotion',

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
@@ -8,7 +8,8 @@ import {
   promotion_id,
   promotion_name,
   minimal_items,
-  items_single_products
+  items_single_products,
+  params
 } from '../ga4-properties'
 import { PromotionProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -47,7 +48,8 @@ const action: ActionDefinition<Settings, Payload> = {
           ...promotion_id
         }
       }
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     let googleItems: PromotionProductItem[] = []
@@ -92,7 +94,8 @@ const action: ActionDefinition<Settings, Payload> = {
               location_id: payload.location_id,
               promotion_id: payload.promotion_id,
               promotion_name: payload.promotion_name,
-              items: googleItems
+              items: googleItems,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/signUp/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/signUp/generated-types.ts
@@ -13,4 +13,10 @@ export interface Payload {
    * The method used for sign up.
    */
   method?: string
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/signUp/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/signUp/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * The method used for sign up.
    */
   method?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { client_id } from '../ga4-properties'
+import { user_id, client_id } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Sign Up',
@@ -9,6 +9,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Signed Up"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     method: {
       label: 'Method',
       description: 'The method used for sign up.',
@@ -23,6 +24,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'sign_up',

--- a/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { user_id, client_id } from '../ga4-properties'
+import { params, user_id, client_id } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Sign Up',
@@ -17,7 +17,8 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': `$.properties.type`
       }
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     return request('https://www.google-analytics.com/mp/collect', {
@@ -29,7 +30,8 @@ const action: ActionDefinition<Settings, Payload> = {
           {
             name: 'sign_up',
             params: {
-              method: payload.method
+              method: payload.method,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/generated-types.ts
@@ -98,4 +98,10 @@ export interface Payload {
      */
     quantity?: number
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
@@ -1,6 +1,6 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from '../constants'
-import { currency, value, user_id, client_id, items_multi_products } from '../ga4-properties'
+import { params, currency, value, user_id, client_id, items_multi_products } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -17,7 +17,8 @@ const action: ActionDefinition<Settings, Payload> = {
     items: {
       ...items_multi_products,
       required: true
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.includes(payload.currency)) {
@@ -68,7 +69,8 @@ const action: ActionDefinition<Settings, Payload> = {
             params: {
               currency: payload.currency,
               value: payload.value,
-              items: googleItems
+              items: googleItems,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
@@ -1,6 +1,6 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from '../constants'
-import { currency, value, client_id, items_multi_products } from '../ga4-properties'
+import { currency, value, user_id, client_id, items_multi_products } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -11,6 +11,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Cart Viewed"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     currency: { ...currency },
     value: { ...value },
     items: {
@@ -60,6 +61,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'view_cart',

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/generated-types.ts
@@ -98,4 +98,10 @@ export interface Payload {
      */
     quantity?: number
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
@@ -1,6 +1,6 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from '../constants'
-import { currency, client_id, value, items_single_products } from '../ga4-properties'
+import { currency, user_id, client_id, value, items_single_products } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -11,6 +11,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event =  "Product Viewed"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     currency: { ...currency },
     value: { ...value },
     items: {
@@ -59,6 +60,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'view_item',

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
@@ -1,6 +1,6 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from '../constants'
-import { currency, user_id, client_id, value, items_single_products } from '../ga4-properties'
+import { params, currency, user_id, client_id, value, items_single_products } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -17,7 +17,8 @@ const action: ActionDefinition<Settings, Payload> = {
     items: {
       ...items_single_products,
       required: true
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.includes(payload.currency)) {
@@ -67,7 +68,8 @@ const action: ActionDefinition<Settings, Payload> = {
             params: {
               currency: payload.currency,
               items: googleItems,
-              value: payload.value
+              value: payload.value,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * The ID of the list in which the item was presented to the user.
    */
   item_list_id?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/generated-types.ts
@@ -98,4 +98,10 @@ export interface Payload {
      */
     quantity?: number
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
@@ -1,6 +1,6 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from '../constants'
-import { client_id, items_multi_products } from '../ga4-properties'
+import { user_id, client_id, items_multi_products } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -15,6 +15,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Product List Viewed"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     item_list_id: {
       label: 'Item List ID',
       type: 'string',
@@ -61,6 +62,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'view_item_list',

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
@@ -1,6 +1,6 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from '../constants'
-import { user_id, client_id, items_multi_products } from '../ga4-properties'
+import { params, user_id, client_id, items_multi_products } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -35,7 +35,8 @@ const action: ActionDefinition<Settings, Payload> = {
     items: {
       ...items_multi_products,
       required: true
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     let googleItems: ProductItem[] = []
@@ -69,7 +70,8 @@ const action: ActionDefinition<Settings, Payload> = {
             params: {
               item_list_id: payload.item_list_id,
               item_list_name: payload.item_list_name,
-              items: googleItems
+              items: googleItems,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * The name of the promotional creative.
    */
   creative_name?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/generated-types.ts
@@ -126,4 +126,10 @@ export interface Payload {
      */
     promotion_id?: string
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
@@ -6,6 +6,7 @@ import {
   promotion_id,
   promotion_name,
   client_id,
+  user_id,
   minimal_items,
   items_single_products
 } from '../ga4-properties'
@@ -23,6 +24,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Promotion Viewed"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     creative_name: { ...creative_name },
     creative_slot: { ...creative_slot, default: { '@path': '$.properties.creative' } },
     location_id: {
@@ -77,6 +79,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'view_promotion',

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
@@ -8,7 +8,8 @@ import {
   client_id,
   user_id,
   minimal_items,
-  items_single_products
+  items_single_products,
+  params
 } from '../ga4-properties'
 import { PromotionProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -55,7 +56,8 @@ const action: ActionDefinition<Settings, Payload> = {
           ...promotion_id
         }
       }
-    }
+    },
+    params: params
   },
 
   perform: (request, { payload }) => {
@@ -89,7 +91,8 @@ const action: ActionDefinition<Settings, Payload> = {
               location_id: payload.location_id,
               promotion_id: payload.promotion_id,
               promotion_name: payload.promotion_name,
-              items: googleItems
+              items: googleItems,
+              ...payload.params
             }
           }
         ]


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR adds `userID` and `params` parameters to every GA4 action and sends those parameters to Google.

## Testing
Added unit tests for `userID` and `params`.
Testing was successful in stage, events were sent including the custom params.
<img width="988" alt="Screen Shot 2022-02-07 at 4 43 17 PM" src="https://user-images.githubusercontent.com/27820201/152897193-18207467-9047-442d-9e59-ff16d19b6cf6.png">
<img width="1000" alt="Screen Shot 2022-02-07 at 4 44 05 PM" src="https://user-images.githubusercontent.com/27820201/152897205-bcf2edfb-ca63-4f70-8b5c-ef442ca7c850.png">
<img width="1416" alt="Screen Shot 2022-02-07 at 4 48 41 PM" src="https://user-images.githubusercontent.com/27820201/152897215-0cafa689-280e-4957-8b45-75cec0834ecc.png">


_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
