### PR TITLE
[browser-destinations] add support for IE 11

### DIFF
--- a/packages/browser-destinations/package.json
+++ b/packages/browser-destinations/package.json
@@ -16,8 +16,12 @@
     "analyze": "NODE_ENV=production webpack --profile --json > stats.json && webpack-bundle-analyzer --port 4200 stats.json",
     "build": "yarn clean && yarn build-ts && yarn build-web",
     "build-ts": "yarn tsc -b tsconfig.build.json",
-    "build-web": "NODE_ENV=production ASSET_ENV=production yarn webpack -c webpack.config.js",
-    "build-web-stage": "NODE_ENV=production ASSET_ENV=stage yarn webpack -c webpack.config.js",
+    "build-web-es2015": "NODE_ENV=production ASSET_ENV=production yarn webpack -c webpack.config.js",
+    "build-web-es5": "NODE_ENV=production ASSET_ENV=production yarn webpack -c webpack.config.es5.js",
+    "build-web": "yarn build-web-es2015 && yarn build-web-es5",
+    "build-web-es2015-stage": "NODE_ENV=production ASSET_ENV=stage yarn webpack -c webpack.config.js",
+    "build-web-es5-stage": "NODE_ENV=production ASSET_ENV=stage yarn webpack -c webpack.config.es5.js",
+    "build-web-stage": "yarn build-web-es2015-stage && yarn build-web-es5-stage",
     "deploy-prod": "yarn build-web && aws s3 sync ./dist/web/ s3://segment-ajs-next-destinations-production/next-integrations/actions --grants read=id=$npm_config_prod_cdn_oai,id=$npm_config_prod_custom_domain_oai",
     "deploy-stage": "yarn build-web-stage && aws-okta exec plat-write -- aws s3 sync ./dist/web/ s3://segment-ajs-next-destinations-stage/next-integrations/actions --grants read=id=$npm_config_stage_cdn_oai,id=$npm_config_stage_custom_domain_oai",
     "clean": "tsc -b tsconfig.build.json --clean",
@@ -25,7 +29,9 @@
     "prepublishOnly": "yarn build",
     "test": "jest",
     "typecheck": "tsc -p tsconfig.build.json --noEmit",
-    "dev": "NODE_ENV=development concurrently \"webpack serve --open\" \"webpack -c webpack.config.js --watch\""
+    "dev-build-es2015": "NODE_ENV=development webpack -c webpack.config.js",
+    "dev-build-es5": "NODE_ENV=development webpack -c webpack.config.es5.js",
+    "dev": "yarn dev-build-es2015 && yarn dev-build-es5 && NODE_ENV=development concurrently \"webpack serve -c webpack.config.es5.js --stats-error-details --open\""
   },
   "dependencies": {
     "@braze/web-sdk": "^3.3.0",
@@ -40,6 +46,7 @@
   "devDependencies": {
     "@babel/core": "^7.13.16",
     "@babel/plugin-proposal-class-properties": "^7.13.0",
+    "@babel/plugin-proposal-unicode-property-regex": "^7.16.7",
     "@babel/plugin-transform-modules-commonjs": "^7.13.8",
     "@babel/preset-env": "^7.13.10",
     "@babel/preset-typescript": "^7.13.0",
@@ -47,11 +54,14 @@
     "@types/amplitude-js": "^7.0.1",
     "@types/jest": "^27.0.0",
     "babel-jest": "^27.3.1",
+    "babel-loader": "^8.2.3",
+    "browserslist": "^4.19.1",
     "compression-webpack-plugin": "^7.1.2",
     "concurrently": "^6.3.0",
     "globby": "^11.0.2",
     "jest": "^27.3.1",
     "serve": "^12.0.1",
+    "source-map-loader": "^3.0.1",
     "terser-webpack-plugin": "^5.1.1",
     "ts-loader": "^9.2.6",
     "webpack": "^5.36.1",
@@ -83,5 +93,8 @@
       "<rootDir>/test/setup-after-env.ts"
     ],
     "forceExit": true
-  }
+  },
+  "browserslist": [
+    "ie 11"
+  ]
 }

--- a/packages/browser-destinations/tsconfig.build.es5.json
+++ b/packages/browser-destinations/tsconfig.build.es5.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "CommonJS",
+    "allowJs": true,
+    "importHelpers": true,
+    "lib": ["es2020", "dom"],
+    "baseUrl": ".",
+    "sourceMap": true
+  },
+  "files": ["./dist/web/**/*.js"],
+  "exclude": ["**/__tests__/**/*.ts"],
+  "include": ["dist/web/**/*.js"]
+}

--- a/packages/browser-destinations/tsconfig.build.json
+++ b/packages/browser-destinations/tsconfig.build.json
@@ -1,13 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "module": "esnext",
+    "target": "es5",
+    "module": "CommonJS",
     "composite": true,
     "outDir": "dist",
     "rootDir": "src",
     "allowJs": true,
     "importHelpers": true,
     "lib": ["es2020", "dom"],
+    "sourceMap": true,
     "baseUrl": ".",
     "paths": {
       "@segment/actions-core/*": ["../core/src/*"]

--- a/packages/browser-destinations/webpack.config.es5.js
+++ b/packages/browser-destinations/webpack.config.es5.js
@@ -4,7 +4,6 @@ const TerserPlugin = require('terser-webpack-plugin')
 const CompressionPlugin = require('compression-webpack-plugin')
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
 const webpack = require('webpack')
-console.log(`MODE:: ${process.env.NODE_ENV}`)
 const files = globby.sync('./dist/web/*/*.js')
 const isProd = process.env.NODE_ENV === 'production'
 

--- a/packages/browser-destinations/webpack.config.es5.js
+++ b/packages/browser-destinations/webpack.config.es5.js
@@ -4,19 +4,30 @@ const TerserPlugin = require('terser-webpack-plugin')
 const CompressionPlugin = require('compression-webpack-plugin')
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
 const webpack = require('webpack')
-
-const files = globby.sync('./src/destinations/*/index.ts')
+console.log(`MODE:: ${process.env.NODE_ENV}`)
+const files = globby.sync('./dist/web/*/*.js')
 const isProd = process.env.NODE_ENV === 'production'
 
 const entries = files.reduce((acc, current) => {
-  const [_dot, _src, _destinations, destination, ..._rest] = current.split('/')
+  const [_dot, _src, _destinations, destination, rest] = current.split('/')
+  const originalHash = rest.split('.')[0]
+  const name = originalHash ? `${destination}/${originalHash}` : destination
   return {
     ...acc,
-    [destination]: current
+    [name]: {
+      import: current,
+      library: {
+        name: `${destination}Destination`,
+        type: 'umd'
+      }
+    }
   }
 }, {})
 
 const plugins = [new webpack.DefinePlugin({ 'process.env.ASSET_ENV': JSON.stringify(process.env.ASSET_ENV) })]
+if (isProd) {
+  plugins.push(new CompressionPlugin())
+}
 
 if (process.env.ANALYZE) {
   plugins.push(
@@ -36,31 +47,49 @@ module.exports = {
   entry: entries,
   mode: process.env.NODE_ENV || 'development',
   devtool: 'source-map',
+  target: ["browserslist"],
   output: {
-    filename: process.env.NODE_ENV === 'development' ? '[name]/[name].js' : '[name]/[contenthash].js',
+    filename: (pathData) => {
+      const [ name, hash ] = pathData.chunk.name.split('/')
+
+      if (process.env.NODE_ENV === 'development' || !hash) {
+        return `${name}.js`
+      }
+
+      return `${name}/${hash}.js`
+    },
     path: path.resolve(__dirname, 'dist/web'),
     publicPath: 'auto', // Needed for customers using custom CDNs with analytics.js
-    library: {
-      name: '[name]Destination',
-      type: 'umd',
-      export: 'default'
-    }
   },
   module: {
     rules: [
       {
-        test: /\.ts$/,
+        test: /\.js$/,
         use: [
           {
             loader: 'ts-loader',
             options: {
-              configFile: 'tsconfig.build.json',
-              projectReferences: true,
+              configFile: 'tsconfig.build.es5.json',
               transpileOnly: true
             }
           }
         ]
-      }
+      },
+      {
+        test: /\.js$/,
+        use: [ // Still need babel to handle downleveling some things TypeScript doesn't handle.
+          {
+            loader: 'babel-loader',
+            options: {
+              plugins: [
+                ['@babel/plugin-proposal-unicode-property-regex', {
+                  useUnicodeFlag: false
+                }]
+              ]
+            }
+          }
+        ]
+      },
     ]
   },
   resolve: {
@@ -84,6 +113,24 @@ module.exports = {
   },
   performance: {
     hints: 'warning'
+  },
+  optimization: {
+    moduleIds: 'deterministic',
+    minimize: isProd,
+    minimizer: [
+      new TerserPlugin({
+        extractComments: false,
+        terserOptions: {
+          ecma: 'es5',
+          mangle: true,
+          compress: true,
+          sourceMap: true,
+          output: {
+            comments: false
+          }
+        }
+      })
+    ]
   },
   plugins
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3899,6 +3899,17 @@ browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.0, browserslist@^4
     node-releases "^2.0.0"
     picocolors "^1.0.0"
 
+browserslist@^4.19.1:
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.19.1.tgz#4ac0435b35ab655896c31d53018b6dd5e9e4c9a3"
+  integrity sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==
+  dependencies:
+    caniuse-lite "^1.0.30001286"
+    electron-to-chromium "^1.4.17"
+    escalade "^3.1.1"
+    node-releases "^2.0.1"
+    picocolors "^1.0.0"
+
 bs-logger@0.x:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
@@ -4073,6 +4084,11 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001265:
   version "1.0.30001269"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001269.tgz#3a71bee03df627364418f9fd31adfc7aa1cc2d56"
   integrity sha512-UOy8okEVs48MyHYgV+RdW1Oiudl1H6KolybD6ZquD0VcrPSgj25omXO1S7rDydjpqaISCwA8Pyx+jUQKZwWO5w==
+
+caniuse-lite@^1.0.30001286:
+  version "1.0.30001302"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001302.tgz#da57ce61c51177ef3661eeed7faef392d3790aaa"
+  integrity sha512-YYTMO+tfwvgUN+1ZnRViE53Ma1S/oETg+J2lISsqi/ZTNThj3ZYBOKP2rHwJc37oCsPqAzJ3w2puZHn0xlLPPw==
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"
@@ -5494,6 +5510,11 @@ electron-to-chromium@^1.3.867:
   version "1.3.872"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.872.tgz#2311a82f344d828bab6904818adc4afb57b35369"
   integrity sha512-qG96atLFY0agKyEETiBFNhpRLSXGSXOBuhXWpbkYqrLKKASpRyRBUtfkn0ZjIf/yXfA7FA4nScVOMpXSHFlUCQ==
+
+electron-to-chromium@^1.4.17:
+  version "1.4.53"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.53.tgz#5d80a91c399b44952ef485857fb5b9d4387d2e60"
+  integrity sha512-rFveSKQczlcav+H3zkKqykU6ANseFwXwkl855jOIap5/0gnEcuIhv2ecz6aoTrXavF6I/CEBeRnBnkB51k06ew==
 
 emittery@^0.8.1:
   version "0.8.1"
@@ -9339,6 +9360,11 @@ node-releases@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.0.tgz#67dc74903100a7deb044037b8a2e5f453bb05400"
   integrity sha512-aA87l0flFYMzCHpTM3DERFSYxc6lv/BltdbRTOMZuxZ0cwZCD3mejE5n9vLhSJCN++/eOqr77G1IO5uXxlQYWA==
+
+node-releases@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
+  integrity sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==
 
 node-status-codes@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR adds IE 11 support to the browser destinations.

## Background

The browser destinations don't support IE 11 prior to this change. This is due to the browser destinations and some dependencies targeting ES2015+ whereas IE 11 only supports ES5 syntax. `analytics-next` will add polyfills to the browser if needed, but can't polyfill language syntax like `class` and `=>` arrow functions.

## How does this change achieve IE 11 support?

This PR updates the build steps for the browser destinations. There are now 2 webpack build steps: 
- The 1st webpack pass creates a bundle per destination similar to what's currently done.
- The 2nd webpack pass polyfills Regex unicode support and transpiles the bundle from the 1st step to ES5 using the TypeScript compiler.

### Why are 2 webpack passes needed?

2 webpack builds greatly reduces the size of the final bundle compared to 1 build. With a single build using TypeScript to transpile every file in a bundle to ES5 tree-shaking was much less efficient. I could create a separate bundle of shared logic between destinations, but there was a significant increase in total bundle size compared to the current state.

With 2 passes, webpack is able to perform tree-shaking optimally just like it does today in the 1st pass, then in the 2nd pass it takes each destination's bundle and transpiles it. The output bundles are still larger than current state but when `gzipped` the difference is minor.

### Why is TypeScript used to down-level to ES5 instead of babel?

`regeneratorRuntime`. Babel requires `regeneratorRuntime` to be available for any generators/async-await functions that are transpiled. As a library, we don't want to add this to the global scope. There is a ponyfill that is meant for library use however it is incompatible with webpack 5.

### Any downsides?

The main downside is that sourcemaps no longer point to the original typescript files - instead they point to the webpack bundle from the 1st pass. This is due to a limitation in our tooling to merge source maps. I came across some tools that attempt to merge source maps across build steps but haven't tried some of the options yet.

### How big are the bundles?
All sizes are in bytes and are an approximation from when this work began.
| Plugin                 |   Current |       IE 11 | two-pass |
| ---------------------- | --------: | ----------: | -------: |
| amplitude              |    41,559 |      13,374 |   51,414 |
| amplitude (gz)         |    12,269 |       4,443 |   13,182 |
| braze                  |   239,580 |      61,620 |  283,812 |
| braze (gz)             |    69,909 |      17,022 |   76,477 |
| braze-cloud            |    41,419 |      13,234 |   51,274 |
| braze-cloud (gz)       |    12,220 |       4,386 |   13,134 |
| friendbuy              |   239,833 |      61,993 |  283,495 |
| friendbuy (gz)         |    68,240 |      15,307 |   74,799 |
| fullstory              |   233,110 |      55,019 |  276,571 |
| fullstory (gz)         |    68,711 |      15,802 |   75,195 |
| sprig-web              |   223,169 |      45,246 |  266,659 |
| sprig-web (gz)         |    64,763 |      11,928 |   71,275 |
| stackadapt             |   221,277 |      43,367 |  264,767 |
| stackadapt (gz)        |    64,338 |      11,546 |   70,856 |
| vendor                 |         0 |     257,029 |        0 |
| vendor (gz)            |         0 |      67,998 |        0 |
| ----------------       | --------- | ----------- | -------- |
| Min (braze-cloud (gz)) |    12,220 |      72,384 |   13,134 |
| Max (braze (gz))       |    69,909 |      85,020 |   76,477 |

## Testing

I have tested loading the plugins in Firefox/Chrome/Edge/Internet Explorer 11. I've also ran Braze through the dev site (`yarn dev`) in each browser.

- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
