### PR TITLE
Add trackEvent action to Adobe Target Web

### DIFF
--- a/packages/browser-destinations/index.html
+++ b/packages/browser-destinations/index.html
@@ -131,7 +131,7 @@
       e.preventDefault()
       var contents = document.querySelector('#event').value
       var evt = JSON.parse(contents)
-      var promise = window.analytics.identify(evt.name || '', evt.properties || {}, evt.options || {})
+      var promise = window.analytics.identify(evt.userId || '', evt.properties || {}, evt.options || {})
 
       promise &&
         promise.then &&
@@ -180,6 +180,7 @@
 
       const defaultEvent = {
         name: 'hi',
+        user_id: '42',
         properties: {},
         traits: {},
         options: {}

--- a/packages/browser-destinations/src/destinations/adobe-target/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/index.ts
@@ -5,8 +5,8 @@ import { Adobe } from './types'
 import { initScript } from './init-script'
 
 import upsertProfile from './upsertProfile'
-
 import triggerView from './triggerView'
+import trackEvent from './trackEvent'
 
 declare global {
   interface Window {
@@ -78,7 +78,8 @@ export const destination: BrowserDestinationDefinition<Settings, Adobe> = {
 
   actions: {
     upsertProfile,
-    triggerView
+    triggerView,
+    trackEvent
   }
 }
 

--- a/packages/browser-destinations/src/destinations/adobe-target/trackEvent/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/trackEvent/__tests__/index.test.ts
@@ -1,0 +1,85 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import adobeTarget, { destination } from '../../index'
+import { Subscription } from '../../../../lib/browser-destinations'
+
+describe('Adobe Target Web', () => {
+  describe('#track', () => {
+    test('Calls track to track events', async () => {
+      const subscriptions: Subscription[] = [
+        {
+          partnerAction: 'trackEvent',
+          name: 'Track Event',
+          enabled: true,
+          subscribe: 'type = "track"',
+          mapping: {
+            userId: {
+              '@if': {
+                exists: {
+                  '@path': '$.userId'
+                },
+                then: {
+                  '@path': '$.userId'
+                },
+                else: {
+                  '@path': '$.anonymousId'
+                }
+              }
+            },
+            type: {
+              '@path': '$.event'
+            },
+            properties: {
+              '@path': '$.properties'
+            }
+          }
+        }
+      ]
+
+      const targetSettings = {
+        client_code: 'segmentexchangepartn',
+        admin_number: '10',
+        version: '2.8.0',
+        cookie_domain: 'segment.com',
+        mbox_name: 'target-global-mbox'
+      }
+
+      const trackParams = {
+        properties: {
+          purchase_amount: 42.21,
+          currency: 'USD',
+          item: 'Shirt'
+        }
+      }
+
+      const [event] = await adobeTarget({
+        ...targetSettings,
+        subscriptions
+      })
+
+      jest.spyOn(destination, 'initialize')
+
+      destination.actions.trackEvent.perform = jest.fn(destination.actions.trackEvent.perform)
+
+      await event.load(Context.system(), {} as Analytics)
+      expect(destination.initialize).toHaveBeenCalled()
+
+      await event.track?.(
+        new Context({
+          event: 'purchase',
+          type: 'track',
+          ...trackParams
+        })
+      )
+
+      expect(destination.actions.trackEvent.perform).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          payload: {
+            ...trackParams,
+            type: 'purchase'
+          }
+        })
+      )
+    })
+  })
+})

--- a/packages/browser-destinations/src/destinations/adobe-target/trackEvent/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/trackEvent/generated-types.ts
@@ -1,0 +1,14 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Event type or name.
+   */
+  type?: string
+  /**
+   * Parameters specific to the event.
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/src/destinations/adobe-target/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/trackEvent/index.ts
@@ -1,0 +1,48 @@
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { Adobe } from '../types'
+
+const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
+  title: 'Track Event',
+  description: 'Track an event',
+  platform: 'web',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    type: {
+      label: 'Event Name',
+      description: 'Event type or name.',
+      type: 'string',
+      default: {
+        '@path': '@.type'
+      }
+    },
+    properties: {
+      label: 'Event Parameters',
+      description: 'Parameters specific to the event.',
+      type: 'object',
+      default: {
+        '@path': '@.properties'
+      }
+    }
+  },
+  perform: (Adobe, event) => {
+    // Adobe Target only takes certain event types as valid parameters. We are defaulting to "click".
+    const TARGET_EVENT_TYPE = 'click'
+    const event_params = {
+      ...event.payload.properties,
+      event_name: event.payload.type
+    }
+
+    const params = {
+      mbox: event.settings.mbox_name,
+      preventDefault: true,
+      params: event_params,
+      type: TARGET_EVENT_TYPE
+    }
+
+    Adobe.target.trackEvent(params)
+  }
+}
+
+export default action

--- a/packages/browser-destinations/src/destinations/adobe-target/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/trackEvent/index.ts
@@ -14,7 +14,7 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
       description: 'Event type or name.',
       type: 'string',
       default: {
-        '@path': '@.type'
+        '@path': '$.type'
       }
     },
     properties: {
@@ -22,7 +22,7 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
       description: 'Parameters specific to the event.',
       type: 'object',
       default: {
-        '@path': '@.properties'
+        '@path': '$.properties'
       }
     }
   },


### PR DESCRIPTION
This PR adds support for the `track()` call in the Adobe Target Web destination via the `trackEvent` action.

## Testing

Subscriptions & Settings to test this and the rest of the Target Actions:

```
{
  "client_code": "YourClientCode",
  "admin_number": "YourNumber",
  "version": "2.8.0",
  "cookie_domain": "localhost",
  "mbox_name": "target-global-mbox",
  "subscriptions": [
    {
      "partnerAction": "upsertProfile",
      "name": "Upsert Profile",
      "enabled": true,
      "subscribe": "type = \"identify\"",
      "mapping": {
        "userId": {
          "@if": {
            "exists": {
              "@path": "$.userId"
            },
            "then": {
              "@path": "$.userId"
            },
            "else": {
              "@path": "$.anonymousId"
            }
          }
        },
        "traits": {
          "@path": "$.traits"
        }
      }
    },
    {
      "partnerAction": "trackEvent",
      "name": "Track Event",
      "enabled": true,
      "subscribe": "type = \"track\"",
      "mapping": {
        "userId": {
          "@if": {
            "exists": {
              "@path": "$.userId"
            },
            "then": {
              "@path": "$.userId"
            },
            "else": {
              "@path": "$.anonymousId"
            }
          }
        },
        "type": {
          "@path": "$.event"
        },
        "properties": {
          "@path": "$.properties"
        }
      }
    }
  ]
}
```

Payload

```
{
 "userId": "ELMARLE42",
 "name": "theTestSuite",
 "properties": {
   "favorite_color": "Blue",
   "favorite_icecream": "Rocky Road"
 },
 "traits": {
    "favorite_music": "JAZZ"
  },
 "options": {}
}
```

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
