### PR TITLE
Removed tiktok token rule, it was false-positiving too much

### DIFF
--- a/.husky/gitleaks-rules.toml
+++ b/.husky/gitleaks-rules.toml
@@ -16,14 +16,6 @@ description = "Facebook System User Access Token"
 regex = '''EAA[0-9A-Za-z]{100,}'''
 tags = ["token", "Facebook Token"]
 
-[[rules]]
-description = "Tik-Tok accessToken"
-regex = '''[0-9A-Za-z]{40}'''
-tags = ["token", "Tik-Tok"]
-[[rules.entropies]]
-Max = "4.5"
-Min = "3.5"
-
 # Default gitleaks rules (from https://raw.githubusercontent.com/zricethezav/gitleaks/master/config/gitleaks.toml)
 
 # Gitleaks rules are defined by regular expressions and entropy ranges.


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Removes TikTok access token rule from our Gitleaks rules. TikTok tokens are random 40 char long strings and so the rule was throwing false positives on various hashed values we have in unit tests. 

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
