### PR TITLE
GA4 - Remove default for custom event params

### DIFF
--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
@@ -66,7 +66,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"params\\":{\\"affiliation\\":\\"TI Online Store\\",\\"order_id\\":\\"5678dd9087-78\\",\\"coupon\\":\\"SUMMER_FEST\\",\\"currency\\":\\"EUR\\",\\"products\\":[{\\"product_id\\":\\"pid-123456\\",\\"sku\\":\\"SKU-123456\\",\\"name\\":\\"Tour t-shirt\\",\\"quantity\\":2,\\"coupon\\":\\"MOUNTAIN\\",\\"brand\\":\\"Canvas\\",\\"category\\":\\"T-Shirt\\",\\"variant\\":\\"Black\\",\\"price\\":19.98}]}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\"}]}"`
       )
     })
 
@@ -109,7 +109,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"params\\":{}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\"}]}"`
       )
     })
 
@@ -209,7 +209,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"Order_Completed\\",\\"params\\":{}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"Order_Completed\\"}]}"`
       )
     })
 
@@ -240,20 +240,20 @@ describe('GA4', () => {
       expect(responses[0].status).toBe(201)
 
       expect(responses[0].request.headers).toMatchInlineSnapshot(`
-      Headers {
-        Symbol(map): Object {
-          "content-type": Array [
-            "application/json",
-          ],
-          "user-agent": Array [
-            "Segment (Actions)",
-          ],
-        },
-      }
-    `)
+              Headers {
+                Symbol(map): Object {
+                  "content-type": Array [
+                    "application/json",
+                  ],
+                  "user-agent": Array [
+                    "Segment (Actions)",
+                  ],
+                },
+              }
+          `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"order_completed\\",\\"params\\":{}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"order_completed\\"}]}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
@@ -37,7 +37,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'boolean',
       default: false
     },
-    params: { ...params, default: { '@path': '$.properties' } }
+    params: { ...params }
   },
   perform: (request, { payload }) => {
     const event_name = normalizeEventName(payload.name, payload.lowercase)


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Removes defaulting to `$.properties` for the `params` field on the GA4 custom event action. There were PII concerns with that default. Will not affect actions which have already been configured.
Details: https://github.com/segmentio/action-destinations/pull/453#discussion_r802135552

## Testing

Updated unit tests.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
