### PR TITLE
Change test authKey value to make it obvious it's a dummy value.

### DIFF
--- a/packages/destination-actions/src/destinations/friendbuy/__tests__/cloudUtil.mock.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/__tests__/cloudUtil.mock.ts
@@ -2,7 +2,7 @@ import nock from 'nock'
 
 import { defaultMapiBaseUrl } from '../cloudUtil'
 
-export const authKey = 'f3e0da8c-4e92-4b4c-af64-c0c1c2f873f2'
+export const authKey = '00000000-0000-0000-0000-000000000000' // not a real secret
 export const authSecret = 'mapi secret'
 const token = 'mapi auth token'
 const expires = new Date(Date.now() + 300 * 1000).toISOString()


### PR DESCRIPTION
The Friendbuy tests define a dummy `authKey` value to use in the unit tests that was flagged as a secret. This PR changes its value to make it more obvious it's not a real secret. It still has the format of a UUID so that it will pass validation.

## Testing

This is just a value that is used in the unit tests. I verified that the unit tests still pass but no other testing is necessary.
