### PR TITLE
Add triggerView action to Adobe Target web

### DIFF
--- a/packages/browser-destinations/index.html
+++ b/packages/browser-destinations/index.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+  <title>The Web Actions Test App</title>
   <style>
     body {
       font-family: monospace;
@@ -98,6 +99,7 @@
     <div>
       <button id="track">Track</button>
       <button id="identify">Identify</button>
+      <button id="page">Page</button>
     </div>
   </form>
 
@@ -130,6 +132,20 @@
       var contents = document.querySelector('#event').value
       var evt = JSON.parse(contents)
       var promise = window.analytics.identify(evt.name || '', evt.properties || {}, evt.options || {})
+
+      promise &&
+        promise.then &&
+        promise.then(function (ctx) {
+          document.querySelector('#logs').textContent = JSON.stringify([ctx.event, ctx.logs()], null, '  ')
+          ctx.flush()
+        })
+    })
+
+    document.querySelector('#page').addEventListener('click', function (e) {
+      e.preventDefault()
+      var contents = document.querySelector('#event').value
+      var evt = JSON.parse(contents)
+      var promise = window.analytics.page(evt.name || '', evt.properties || {}, evt.options || {})
 
       promise &&
         promise.then &&

--- a/packages/browser-destinations/src/destinations/adobe-target/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/index.ts
@@ -6,6 +6,8 @@ import { initScript } from './init-script'
 
 import upsertProfile from './upsertProfile'
 
+import triggerView from './triggerView'
+
 declare global {
   interface Window {
     adobe: Adobe
@@ -75,7 +77,8 @@ export const destination: BrowserDestinationDefinition<Settings, Adobe> = {
   },
 
   actions: {
-    upsertProfile
+    upsertProfile,
+    triggerView
   }
 }
 

--- a/packages/browser-destinations/src/destinations/adobe-target/triggerView/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/triggerView/__tests__/index.test.ts
@@ -1,0 +1,91 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import adobeTarget, { destination } from '../../index'
+import { Subscription } from '../../../../lib/browser-destinations'
+
+describe('Adobe Target Web', () => {
+  describe('#page', () => {
+    test('tracks a view with the page() parameters', async () => {
+      const subscriptions: Subscription[] = [
+        {
+          partnerAction: 'triggerView',
+          name: 'Trigger View',
+          enabled: true,
+          subscribe: 'type = "page"',
+          mapping: {
+            viewName: { '@path': '$.name' },
+            pageParameters: { '@path': '$.properties' },
+            sendNotification: true,
+            traits: {
+              '@path': '$.traits'
+            }
+          }
+        }
+      ]
+
+      const targetSettings = {
+        client_code: 'segmentexchangepartn',
+        admin_number: '10',
+        version: '2.8.0',
+        cookie_domain: 'segment.com',
+        mbox_name: 'target-global-mbox'
+      }
+
+      const pageParams = {
+        name: 'The Test Suite',
+        properties: {
+          language: 'ES',
+          currency: 'MXN',
+          region: {
+            country_code: 'MX',
+            state: 'Mich'
+          }
+        }
+      }
+
+      const [event] = await adobeTarget({
+        ...targetSettings,
+        subscriptions
+      })
+
+      jest.spyOn(destination, 'initialize')
+
+      destination.actions.triggerView.perform = jest.fn(destination.actions.triggerView.perform)
+
+      await event.load(Context.system(), {} as Analytics)
+      expect(destination.initialize).toHaveBeenCalled()
+
+      await event.page?.(
+        new Context({
+          type: 'page',
+          ...pageParams
+        })
+      )
+
+      expect(destination.actions.triggerView.perform).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          payload: {
+            viewName: 'The Test Suite',
+            pageParameters: {
+              currency: 'MXN',
+              language: 'ES',
+              region: { country_code: 'MX', state: 'Mich' }
+            },
+            sendNotification: true
+          }
+        })
+      )
+
+      expect(window.pageParams).toEqual({
+        page: {
+          language: 'ES',
+          currency: 'MXN',
+          region: {
+            country_code: 'MX',
+            state: 'Mich'
+          }
+        }
+      })
+    })
+  })
+})

--- a/packages/browser-destinations/src/destinations/adobe-target/triggerView/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/triggerView/generated-types.ts
@@ -1,0 +1,18 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Name of thew view or page.
+   */
+  viewName: string
+  /**
+   * Parameters specific to the view or page.
+   */
+  pageParameters?: {
+    [k: string]: unknown
+  }
+  /**
+   * By default, notifications are sent to the Adobe Target backend for incrementing impression count.  If false, notifications are not sent for incrementing impression count.
+   */
+  sendNotification?: boolean
+}

--- a/packages/browser-destinations/src/destinations/adobe-target/triggerView/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/triggerView/index.ts
@@ -35,7 +35,6 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
     }
   },
   perform: (Adobe, event) => {
-    const pageName = event.payload.viewName
     const sendNotification = event.payload.sendNotification
     const pageParams = event.payload.pageParameters
 
@@ -46,7 +45,7 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
     */
     setPageParams({ page: { ...pageParams } })
 
-    Adobe.target.triggerView(pageName, { page: sendNotification })
+    Adobe.target.triggerView(event.payload.viewName, { page: sendNotification })
   }
 }
 

--- a/packages/browser-destinations/src/destinations/adobe-target/triggerView/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/triggerView/index.ts
@@ -1,0 +1,53 @@
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { Adobe } from '../types'
+import { setPageParams } from '../utils'
+
+const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
+  title: 'Trigger View',
+  description: 'Record a view',
+  platform: 'web',
+  fields: {
+    viewName: {
+      type: 'string',
+      description: 'Name of thew view or page.',
+      label: 'View Name',
+      default: {
+        '@path': '$.name'
+      },
+      required: true
+    },
+    pageParameters: {
+      type: 'object',
+      description: 'Parameters specific to the view or page.',
+      label: 'Page Parameters',
+      default: {
+        '@path': '$.properties'
+      }
+    },
+    sendNotification: {
+      type: 'boolean',
+      description:
+        'By default, notifications are sent to the Adobe Target backend for incrementing impression count.  If false, notifications are not sent for incrementing impression count. ',
+      label: 'Send Notifications to Adobe Target.',
+      default: true
+    }
+  },
+  perform: (Adobe, event) => {
+    const pageName = event.payload.viewName
+    const sendNotification = event.payload.sendNotification
+    const pageParams = event.payload.pageParameters
+
+    /*
+      NOTE:
+      Page data needs to be set before the call to adobe.target.triggerView.
+      This is because the page data needs to be part of the global pageParams object.
+    */
+    setPageParams({ page: { ...pageParams } })
+
+    Adobe.target.triggerView(pageName, { page: sendNotification })
+  }
+}
+
+export default action

--- a/packages/browser-destinations/src/destinations/adobe-target/types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/types.ts
@@ -4,4 +4,5 @@ export type Adobe = {
 
 type Target = {
   trackEvent: Function
+  triggerView: Function
 }


### PR DESCRIPTION
This PR adds support for the `page()` call in the Adobe Target Web destination via the `triggerView` action.

## Testing

Subscriptions & Settings to test this and the rest of the Target Actions:

```
{
  "client_code": "YourClientCode",
  "admin_number": "YourNumber",
  "version": "2.8.0",
  "cookie_domain": "localhost",
  "mbox_name": "target-global-mbox",
  "subscriptions": [
{
      "partnerAction": "triggerView",
      "name": "Trigger View",
      "enabled": true,
      "subscribe": "type = \"page\"",
      "mapping": {
        "viewName": { "@path": "$.name"},
        "pageParameters": {"@path": "$.properties"},
        "sendNotification": true,
        "traits": {
          "@path": "$.traits"
        }
      }
    },
    {
      "partnerAction": "upsertProfile",
      "name": "Upsert Profile",
      "enabled": true,
      "subscribe": "type = \"identify\"",
      "mapping": {
        "userId": {
          "@if": {
            "exists": {
              "@path": "$.userId"
            },
            "then": {
              "@path": "$.userId"
            },
            "else": {
              "@path": "$.anonymousId"
            }
          }
        },
        "traits": {
          "@path": "$.traits"
        }
      }
    },
    {
      "partnerAction": "trackEvent",
      "name": "Track Event",
      "enabled": true,
      "subscribe": "type = \"track\"",
      "mapping": {
        "userId": {
          "@if": {
            "exists": {
              "@path": "$.userId"
            },
            "then": {
              "@path": "$.userId"
            },
            "else": {
              "@path": "$.anonymousId"
            }
          }
        },
        "type": {
          "@path": "$.event"
        },
        "properties": {
          "@path": "$.properties"
        }
      }
    }
  ]
}
```

Payload

```
{
 "userId": "ELMARLE42",
 "name": "theTestSuite",
 "properties": {
   "favorite_color": "Blue",
   "favorite_icecream": "Rocky Road"
 },
 "traits": {
    "favorite_music": "JAZZ"
  },
 "options": {}
}
```

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
