### PR TITLE
add support for test_evet_code feature

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-conversions/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/__tests__/index.test.ts
@@ -79,7 +79,7 @@ describe('Tiktok Conversions', () => {
       })
     })
 
-    it('should send contents arrray properties to TikTok', async () => {
+    it('should send contents array properties to TikTok', async () => {
       const event = createTestEvent({
         timestamp: timestamp,
         event: 'Checkout Started',
@@ -205,6 +205,73 @@ describe('Tiktok Conversions', () => {
       expect(responses[0].status).toBe(200)
       expect(responses[0].options.body).toMatchInlineSnapshot(
         `"{\\"pixel_code\\":\\"test\\",\\"event\\":\\"AddToCart\\",\\"event_id\\":\\"corey123_seg\\",\\"timestamp\\":\\"2021-09-2T15:21:15.449Z\\",\\"context\\":{\\"user\\":{\\"external_id\\":\\"481f202262e9c5ccc48d24e60798fadaa5f6ff1f8369f7ab927c04c3aa682a7f\\",\\"phone_number\\":\\"910a625c4ba147b544e6bd2f267e130ae14c591b6ba9c25cb8573322dedbebd0\\",\\"email\\":\\"eb9869a32b532840dd6aa714f7a872d21d6f650fc5aa933d9feefc64708969c7\\"},\\"ad\\":{\\"callback\\":\\"12345\\"},\\"page\\":{\\"url\\":\\"https://segment.com/\\",\\"referrer\\":\\"https://google.com/\\"},\\"ip\\":\\"0.0.0.0\\",\\"user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57\\"},\\"properties\\":{\\"contents\\":[{\\"price\\":100,\\"quantity\\":2,\\"content_type\\":\\"Air Force One (Size S)\\",\\"content_id\\":\\"abc123\\"}],\\"currency\\":\\"USD\\",\\"value\\":100,\\"query\\":\\"shoes\\"}}"`
+      )
+    })
+
+    it('should send test_event_code if present in mapping', async () => {
+      const event = createTestEvent({
+        timestamp: timestamp,
+        event: 'Checkout Started',
+        messageId: 'corey123',
+        type: 'track',
+        properties: {
+          email: 'coreytest1231@gmail.com',
+          phone: '+1555-555-5555',
+          ttclid: '12345',
+          currency: 'USD',
+          value: 100,
+          query: 'shoes',
+          price: 100,
+          quantity: 2,
+          category: 'Air Force One (Size S)',
+          product_id: 'abc123'
+        },
+        context: {
+          page: {
+            url: 'https://segment.com/',
+            referrer: 'https://google.com/'
+          },
+          userAgent:
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57',
+          ip: '0.0.0.0'
+        },
+        userId: 'testId123'
+      })
+
+      nock('https://business-api.tiktok.com/open_api/v1.2/pixel/track').post('/').reply(200, {})
+      const responses = await testDestination.testAction('reportWebEvent', {
+        event,
+        settings,
+        useDefaultMappings: true,
+        mapping: {
+          event: 'AddToCart',
+          test_event_code: 'TEST04030',
+          contents: {
+            '@arrayPath': [
+              '$.properties',
+              {
+                price: {
+                  '@path': '$.price'
+                },
+                quantity: {
+                  '@path': '$.quantity'
+                },
+                content_type: {
+                  '@path': '$.category'
+                },
+                content_id: {
+                  '@path': '$.product_id'
+                }
+              }
+            ]
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"pixel_code\\":\\"test\\",\\"event\\":\\"AddToCart\\",\\"event_id\\":\\"corey123_seg\\",\\"timestamp\\":\\"2021-09-2T15:21:15.449Z\\",\\"test_event_code\\":\\"TEST04030\\",\\"context\\":{\\"user\\":{\\"external_id\\":\\"481f202262e9c5ccc48d24e60798fadaa5f6ff1f8369f7ab927c04c3aa682a7f\\",\\"phone_number\\":\\"910a625c4ba147b544e6bd2f267e130ae14c591b6ba9c25cb8573322dedbebd0\\",\\"email\\":\\"eb9869a32b532840dd6aa714f7a872d21d6f650fc5aa933d9feefc64708969c7\\"},\\"ad\\":{\\"callback\\":\\"12345\\"},\\"page\\":{\\"url\\":\\"https://segment.com/\\",\\"referrer\\":\\"https://google.com/\\"},\\"ip\\":\\"0.0.0.0\\",\\"user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57\\"},\\"properties\\":{\\"contents\\":[{\\"price\\":100,\\"quantity\\":2,\\"content_type\\":\\"Air Force One (Size S)\\",\\"content_id\\":\\"abc123\\"}],\\"currency\\":\\"USD\\",\\"value\\":100,\\"query\\":\\"shoes\\"}}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/tiktok-conversions/reportWebEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/reportWebEvent/generated-types.ts
@@ -82,4 +82,8 @@ export interface Payload {
    * The text string that was searched for.
    */
   query?: string
+  /**
+   * Use this field to specify that events should be test events rather than actual traffic.
+   */
+  test_event_code?: string
 }

--- a/packages/destination-actions/src/destinations/tiktok-conversions/reportWebEvent/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/reportWebEvent/index.ts
@@ -177,6 +177,11 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.properties.query'
       }
+    },
+    test_event_code: {
+      label: 'Test Event Code',
+      type: 'string',
+      description: 'Use this field to specify that events should be test events rather than actual traffic.'
     }
   },
   perform: (request, { payload, settings }) => {
@@ -194,6 +199,7 @@ const action: ActionDefinition<Settings, Payload> = {
         event: payload.event,
         event_id: payload.event_id ? `${payload.event_id}_seg` : undefined,
         timestamp: payload.timestamp,
+        test_event_code: payload.test_event_code,
         context: {
           user: {
             external_id: userData.hashedExternalId,


### PR DESCRIPTION
This PR adds support for TikTok's [Test Event](https://ads.tiktok.com/marketing_api/docs?rid=p41a33fdhon&id=1724255493685249) feature. 

Based on what I could tell, it's hard to see realtime events come into the TikTok Events Manager as it only lets you view events that came in the day before. In order to help customers see that events are coming through when they create a connection to TikTok through Segment and to help them test their events, Segment needs to allow a field called `test_event_code`. 

The `test_event_code` field needs to be in the top-level request body and the value needs to be the one TikTok provides in their Test Events UI:
<img width="766" alt="image" src="https://user-images.githubusercontent.com/23665784/153727142-c0b0e3ba-5f8b-4045-8b45-ea7b15103784.png">

This PR creates that support so that customers can add in their `test_event_code` into specific mappings. 

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment

