### PR TITLE
Update action destination register to default on in EU

### DIFF
--- a/packages/cli-internal/src/commands/push.ts
+++ b/packages/cli-internal/src/commands/push.ts
@@ -276,7 +276,7 @@ export default class Push extends Command {
             basicOptions,
             options,
             platforms,
-            supportedRegions: ['us-west-2'] // always default to US until regional action destinations are supported
+            supportedRegions: ['us-west-2', 'eu-west-1'] // always default to US until regional action destinations are supported
           }),
           updateDestinationMetadataActions(actionsToUpdate),
           createDestinationMetadataActions(actionsToCreate)


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

This PR adresses [BE-581](https://segment.atlassian.net/browse/BE-581) JIRA ticket.

Currently in Actions one of our deployment steps (see [doc](https://paper.dropbox.com/doc/Partner-PR-Review-Process--Bb9l_TmBFUGjBAgBjgsUcPlSAg-9vnqDsZMk8Cb8OYtSiNaD#:h2=New-and-existing-destinations) for more detail) involves the push command. Push essentially makes calls directly to the control-plane-service to write our action definitions to the database. 

The previous push command currently hardcodes the supported region of the action to only `us-west-2`  With this update, it now also default includes `eu-west-1`.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
