### PR TITLE
Fix help cli bug

### DIFF
--- a/packages/cli-internal/src/commands/push-browser-destinations.ts
+++ b/packages/cli-internal/src/commands/push-browser-destinations.ts
@@ -22,7 +22,8 @@ export default class PushBrowserDestinations extends Command {
 
   static examples = [`$ ./bin/run push-browser-destinations`]
 
-  static flags = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static flags: flags.Input<any> = {
     help: flags.help({ char: 'h' }),
     env: flags.string({
       char: 'e',

--- a/packages/cli-internal/src/commands/push.ts
+++ b/packages/cli-internal/src/commands/push.ts
@@ -40,7 +40,8 @@ export default class Push extends Command {
 
   static examples = [`$ ./bin/run push`]
 
-  static flags = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static flags: flags.Input<any> = {
     help: flags.help({ char: 'h' }),
     force: flags.boolean({ char: 'f' })
   }

--- a/packages/cli-internal/src/commands/register.ts
+++ b/packages/cli-internal/src/commands/register.ts
@@ -17,7 +17,8 @@ export default class Register extends Command {
 
   static examples = [`$ ./bin/run register`]
 
-  static flags = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static flags: flags.Input<any> = {
     help: flags.help({ char: 'h' }),
     path: flags.string({ char: 'p', description: 'Path to the destination to register.' }),
     env: flags.enum({

--- a/packages/cli/src/commands/generate/types.ts
+++ b/packages/cli/src/commands/generate/types.ts
@@ -25,7 +25,8 @@ export default class GenerateTypes extends Command {
   // Allow variable length args (to work with tools like lint-staged)
   static strict = false
 
-  static flags = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static flags: flags.Input<any> = {
     help: flags.help({ char: 'h' }),
     path: flags.string({
       char: 'p',

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -18,7 +18,8 @@ export default class Init extends Command {
     `$ ./bin/run init my-integration --directory packages/destination-actions --template basic-auth`
   ]
 
-  static flags = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static flags: flags.Input<any> = {
     help: flags.help({ char: 'h' }),
     directory: flags.string({
       char: 'd',

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -19,7 +19,8 @@ export default class Serve extends Command {
 
   static args = []
 
-  static flags = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static flags: flags.Input<any> = {
     help: flags.help({ char: 'h' }),
     destination: flags.string({
       char: 'd',

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -12,7 +12,8 @@ export default class Validate extends Command {
 
   static examples = [`$ ./bin/run validate`]
 
-  static flags = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static flags: flags.Input<any> = {
     help: flags.help({ char: 'h' })
   }
 


### PR DESCRIPTION
Previously, we were getting the following error when running the help CLI command. This was due to an inferred type error on the `flags` static variable. Eventually, we should migrate `@oclif/command` to the newer `@oclif/core` but this works for now.

`Before`:
<img width="417" alt="Screen Shot 2022-02-16 at 11 23 30 AM" src="https://user-images.githubusercontent.com/87985289/154310402-ae1f515c-dd92-4f1b-8944-a4b6d42db9dc.png">

`With fix`:
<img width="1024" alt="Screen Shot 2022-02-16 at 11 22 57 AM" src="https://user-images.githubusercontent.com/87985289/154310443-11f76e8a-abe5-4199-ab51-322df078fc1c.png">


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
