### PR TITLE
update file path name on init

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -108,7 +108,8 @@ export default class Init extends Command {
     }
 
     // For now, include the slug in the path, but when we support external repos, we'll have to change this
-    const relativePath = path.join(directory, args.path || slug)
+    const slugWithoutActions = String(slug).replace('actions-', '')
+    const relativePath = path.join(directory, args.path || slugWithoutActions)
     const targetDirectory = path.join(process.cwd(), relativePath)
     const templatePath = path.join(__dirname, '../../templates/destinations', template)
     const snapshotPath = path.join(__dirname, '../../templates/actions/snapshot')


### PR DESCRIPTION
When running `./bin/run init` in action-destinations, a new folder is generated with the prefix `actions-`. This is no longer the naming convention. For example, initializing a new definition called abcd should create a new folder called `abcd`, not `actions-abcd`. However, the suggested slug should remain actions-abcd.

<img width="653" alt="Screen Shot 2022-02-16 at 12 17 04 PM" src="https://user-images.githubusercontent.com/87985289/154323158-edced580-e364-417d-9ccb-3a9f2b38e6f7.png">


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
