### PR TITLE
process external ID subscription payload for "personas-messaging-sendgrid"

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -1,11 +1,11 @@
 import nock from 'nock'
-import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration, omit } from '@segment/actions-core'
 import Sendgrid from '..'
 
 const sendgrid = createTestIntegration(Sendgrid)
 const timestamp = new Date().toISOString()
 
-for (const environment of ['stage', 'production']) {
+describe.each(['stage', 'production'])('%s environment', (environment) => {
   const settings = {
     unlayerApiKey: 'unlayerApiKey',
     sendGridApiKey: 'sendGridApiKey',
@@ -24,6 +24,52 @@ for (const environment of ['stage', 'production']) {
   }
 
   const endpoint = `https://profiles.segment.${environment === 'production' ? 'com' : 'build'}`
+
+  const sendgridRequestBody = {
+    personalizations: [
+      {
+        to: [
+          {
+            email: userData.email,
+            name: `${userData.firstName} ${userData.lastName}`
+          }
+        ],
+        bcc: [
+          {
+            email: 'test@test.com'
+          }
+        ],
+        custom_args: {
+          source_id: 'sourceId',
+          space_id: 'spaceId',
+          user_id: userData.userId,
+          __segment_internal_external_id_key__: 'email',
+          __segment_internal_external_id_value__: userData.email
+        }
+      }
+    ],
+    from: {
+      email: 'from@example.com',
+      name: 'From Name'
+    },
+    reply_to: {
+      email: 'replyto@example.com',
+      name: 'Test user'
+    },
+    subject: `Hello ${userData.lastName} ${userData.firstName}.`,
+    content: [
+      {
+        type: 'text/html',
+        value: `Hi ${userData.firstName}, Welcome to segment`
+      }
+    ],
+    tracking_settings: {
+      subscription_tracking: {
+        enable: true,
+        substitution_tag: '[unsubscribe]'
+      }
+    }
+  }
 
   const getDefaultMapping = (overrides?: any) => {
     return {
@@ -45,94 +91,33 @@ for (const environment of ['stage', 'production']) {
       bodyHtml: 'Hi {{profile.traits.firstName}}, Welcome to segment',
       send: true,
       toEmail: '',
+      externalIds: [
+        { id: userData.email, type: 'email', subscriptionStatus: 'subscribed' },
+        { id: userData.phone, type: 'phone', subscriptionStatus: 'subscribed' }
+      ],
       ...overrides
     }
   }
 
-  beforeEach(() => {
-    nock(`${endpoint}/v1/spaces/spaceId/collections/users/profiles/user_id:${userData.userId}`)
-      .get('/traits?limit=200')
-      .reply(200, {
-        traits: {
-          firstName: userData.firstName,
-          lastName: userData.lastName
-        }
-      })
-
-    nock(`${endpoint}/v1/spaces/spaceId/collections/users/profiles/user_id:${userData.userId}`)
-      .get('/external_ids?limit=25')
-      .reply(200, {
-        data: [
-          {
-            type: 'user_id',
-            id: userData.userId
-          },
-          {
-            type: 'phone',
-            id: userData.phone
-          },
-          {
-            type: 'email',
-            id: userData.email
+  describe(`send Email`, () => {
+    beforeEach(() => {
+      nock(`${endpoint}/v1/spaces/spaceId/collections/users/profiles/user_id:${userData.userId}`)
+        .get('/traits?limit=200')
+        .reply(200, {
+          traits: {
+            firstName: userData.firstName,
+            lastName: userData.lastName
           }
-        ]
-      })
-  })
+        })
+    })
 
-  afterEach(() => {
-    nock.cleanAll()
-  })
+    afterEach(() => {
+      nock.cleanAll()
+    })
 
-  describe(`${environment} - send Email`, () => {
     it('should send Email', async () => {
-      const expectedSendGridRequest = {
-        personalizations: [
-          {
-            to: [
-              {
-                email: userData.email,
-                name: `${userData.firstName} ${userData.lastName}`
-              }
-            ],
-            bcc: [
-              {
-                email: 'test@test.com'
-              }
-            ],
-            custom_args: {
-              source_id: 'sourceId',
-              space_id: 'spaceId',
-              user_id: userData.userId,
-              __segment_internal_external_id_key__: 'email',
-              __segment_internal_external_id_value__: userData.email
-            }
-          }
-        ],
-        from: {
-          email: 'from@example.com',
-          name: 'From Name'
-        },
-        reply_to: {
-          email: 'replyto@example.com',
-          name: 'Test user'
-        },
-        subject: `Hello ${userData.lastName} ${userData.firstName}.`,
-        content: [
-          {
-            type: 'text/html',
-            value: `Hi ${userData.firstName}, Welcome to segment`
-          }
-        ],
-        tracking_settings: {
-          subscription_tracking: {
-            enable: true,
-            substitution_tag: '[unsubscribe]'
-          }
-        }
-      }
-
       const sendGridRequest = nock('https://api.sendgrid.com')
-        .post('/v3/mail/send', expectedSendGridRequest)
+        .post('/v3/mail/send', sendgridRequestBody)
         .reply(200, {})
 
       const responses = await sendgrid.testAction('sendEmail', {
@@ -150,9 +135,8 @@ for (const environment of ['stage', 'production']) {
     })
 
     it('should not send email when send = false', async () => {
-      const mapping = getDefaultMapping()
-      mapping.send = false
-      const responses = await sendgrid.testAction('sendEmail', {
+      const mapping = getDefaultMapping({ send: false })
+      await sendgrid.testAction('sendEmail', {
         event: createTestEvent({
           timestamp,
           event: 'Audience Entered',
@@ -161,11 +145,14 @@ for (const environment of ['stage', 'production']) {
         settings,
         mapping: mapping
       })
+      const sendGridRequest = nock('https://api.sendgrid.com')
+        .post('/v3/mail/send', sendgridRequestBody)
+        .reply(200, {})
 
-      expect(responses.length).toEqual(0)
+      expect(sendGridRequest.isDone()).toEqual(false)
     })
 
-    it('should not send Email when send field not in payload', async () => {
+    it('should not send an email when send field not in payload', async () => {
       const responses = await sendgrid.testAction('sendEmail', {
         event: createTestEvent({
           timestamp,
@@ -173,27 +160,14 @@ for (const environment of ['stage', 'production']) {
           userId: userData.userId
         }),
         settings,
-        mapping: {
-          userId: { '@path': '$.userId' },
-          fromDomain: null,
-          fromEmail: 'from@example.com',
-          fromName: 'From Name',
-          replyToEmail: 'replyto@example.com',
-          replyToName: 'Test user',
-          bcc: JSON.stringify([
-            {
-              email: 'test@test.com'
-            }
-          ]),
-          previewText: 'unused',
-          subject: 'Hello {{profile.traits.lastName}} {{profile.traits.firstName}}.',
-          body: 'Hi {{profile.traits.firstName}}, Welcome to segment',
-          bodyType: 'html',
-          bodyHtml: 'Hi {{profile.traits.firstName}}, Welcome to segment'
-        }
+        mapping: omit(getDefaultMapping(), ['send'])
       })
+      const sendGridRequest = nock('https://api.sendgrid.com')
+        .post('/v3/mail/send', sendgridRequestBody)
+        .reply(200, {})
 
       expect(responses.length).toEqual(0)
+      expect(sendGridRequest.isDone()).toEqual(false)
     })
 
     it('should send email with journey metadata', async () => {
@@ -279,41 +253,40 @@ for (const environment of ['stage', 'production']) {
           body: 'Welcome to segment',
           bodyType: 'html',
           bodyHtml: 'Welcome to segment',
-          send: true
+          send: true,
+          externalIds: [
+            { id: userData.email, type: 'email', subscriptionStatus: 'subscribed' },
+            { id: userData.phone, type: 'phone', subscriptionStatus: 'subscribed' }
+          ]
         }
       })
 
       expect(responses.map((r) => r.url)).toStrictEqual([
         `${endpoint}/v1/spaces/spaceId/collections/users/profiles/user_id:jane/traits?limit=200`,
-        `${endpoint}/v1/spaces/spaceId/collections/users/profiles/user_id:jane/external_ids?limit=25`,
         `https://api.sendgrid.com/v3/mail/send`
       ])
       expect(sendGridRequest.isDone()).toEqual(true)
     })
 
-    const restricted = ['gmailx.com', 'yahoox.com', 'aolx.com', 'hotmailx.com']
-    for (const domain of restricted) {
-      it(`should return an error when given a restricted domain - ${domain}`, async () => {
-        const mapping = getDefaultMapping()
-        mapping.toEmail = `lauren@${domain}`
-        try {
-          await sendgrid.testAction('sendEmail', {
-            event: createTestEvent({
-              timestamp,
-              event: 'Audience Entered',
-              userId: userData.userId
-            }),
-            settings,
-            mapping: mapping
-          })
-          fail('Test should throw an error')
-        } catch (e) {
-          expect((e as unknown as any).message).toBe(
-            'Emails with gmailx.com, yahoox.com, aolx.com, and hotmailx.com domains are blocked.'
-          )
-        }
-      })
-    }
+    it.each(['gmailx.com', 'yahoox.com', 'aolx.com', 'hotmailx.com'])
+    (`should return an error when given a restricted domain "%s"`, async (domain) => {
+      try {
+        await sendgrid.testAction('sendEmail', {
+          event: createTestEvent({
+            timestamp,
+            event: 'Audience Entered',
+            userId: userData.userId
+          }),
+          settings,
+          mapping: getDefaultMapping({ toEmail: `lauren@${domain}` })
+        })
+        fail('Test should throw an error')
+      } catch (e) {
+        expect((e as unknown as any).message).toBe(
+          'Emails with gmailx.com, yahoox.com, aolx.com, and hotmailx.com domains are blocked.'
+        )
+      }
+    })
 
     it('should send email where HTML body is stored in S3', async () => {
       const expectedSendGridRequest = {
@@ -476,7 +449,7 @@ for (const environment of ['stage', 'production']) {
       expect(unlayerRequest.isDone()).toEqual(true)
     })
 
-    it('insert preview text', async () => {
+    it('inserts preview text', async () => {
       const expectedSendGridRequest = {
         personalizations: [
           {
@@ -561,4 +534,101 @@ for (const environment of ['stage', 'production']) {
       expect(s3Request.isDone()).toEqual(true)
     })
   })
-}
+
+  describe('send Email subscription handling', () => {
+    beforeEach(() => {
+      nock(`${endpoint}/v1/spaces/spaceId/collections/users/profiles/user_id:${userData.userId}`)
+        .get('/traits?limit=200')
+        .reply(200, {
+          traits: {
+            firstName: userData.firstName,
+            lastName: userData.lastName
+          }
+        })
+    })
+
+    afterEach(() => {
+      nock.cleanAll()
+    })
+
+    it.each([
+      'subscribed',
+      true
+    ])('sends the email when subscriptionStatus = "%s"', async (subscriptionStatus) => {
+      const sendGridRequest = nock('https://api.sendgrid.com')
+        .post('/v3/mail/send')
+        .reply(200, {})
+
+      const responses = await sendgrid.testAction('sendEmail', {
+        event: createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          userId: userData.userId
+        }),
+        settings,
+        mapping: getDefaultMapping(
+          {
+            externalIds: [
+              { id: userData.email, type: 'email', subscriptionStatus },
+              { id: userData.phone, type: 'phone', subscriptionStatus: 'subscribed' }
+            ]
+          }
+        )
+      })
+
+      expect(responses.length).toBeGreaterThan(0)
+      expect(sendGridRequest.isDone()).toEqual(true)
+    })
+
+    it.each([
+      'unsubscribed',
+      'did not subscribed',
+      '',
+      null,
+      false
+    ])('does NOT send the email when subscriptionStatus = "%s"', async (subscriptionStatus) => {
+      await sendgrid.testAction('sendEmail', {
+        event: createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          userId: userData.userId
+        }),
+        settings,
+        mapping: getDefaultMapping({
+            externalIds: [
+              { id: userData.email, type: 'email', subscriptionStatus },
+              { id: userData.phone, type: 'phone', subscriptionStatus: 'subscribed' }
+            ]
+          }
+        )
+      })
+      const sendGridRequest = nock('https://api.sendgrid.com')
+        .post('/v3/mail/send', sendgridRequestBody)
+        .reply(200, {})
+
+      expect(sendGridRequest.isDone()).toBe(false)
+    })
+
+    it('throws an error when subscriptionStatus is unrecognizable"', async () => {
+      const subscriptionStatus = 'random-string'
+      const response = sendgrid.testAction('sendEmail', {
+        event: createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          userId: userData.userId
+        }),
+        settings,
+        mapping: getDefaultMapping(
+          {
+            externalIds: [
+              { id: userData.email, type: 'email', subscriptionStatus },
+              { id: userData.phone, type: 'phone', subscriptionStatus: 'subscribed' }
+            ]
+          }
+        )
+      })
+
+      await expect(response).rejects.toThrowError(`Failed to process the subscription state: "${subscriptionStatus}"`)
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
@@ -66,6 +66,23 @@ export interface Payload {
    */
   bodyHtml?: string
   /**
+   * An array of user profile identity information.
+   */
+  externalIds?: {
+    /**
+     * A unique identifier for the collection.
+     */
+    id?: string
+    /**
+     * The external ID contact type.
+     */
+    type?: string
+    /**
+     * The subscription status for the identity.
+     */
+    subscriptionStatus?: string
+  }[]
+  /**
    * Additional custom args that we be passed back opaquely on webhook events
    */
   customArgs?: {

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -10,11 +10,11 @@ const insertEmailPreviewText = (html: string, previewText: string): string => {
 
   // See https://www.litmus.com/blog/the-little-known-preview-text-hack-you-may-want-to-use-in-every-email/
   $('body').prepend(`
-    <div style="display: none; max-height: 0px; overflow: hidden;">
+    <div style='display: none; max-height: 0px; overflow: hidden;'>
       ${htmlEscape(previewText)}
     </div>
 
-    <div style="display: none; max-height: 0px; overflow: hidden;">
+    <div style='display: none; max-height: 0px; overflow: hidden;'>
       ${'&nbsp;&zwnj;'.repeat(13)}&nbsp;
     </div>
   `)
@@ -47,32 +47,6 @@ const fetchProfileTraits = async (
 
   const body = await response.json()
   return body.traits
-}
-
-const fetchProfileExternalIds = async (
-  request: RequestFn,
-  settings: Settings,
-  profileId: string
-): Promise<Record<string, string>> => {
-  const endpoint = getProfileApiEndpoint(settings.profileApiEnvironment)
-  const response = await request(
-    `${endpoint}/v1/spaces/${settings.spaceId}/collections/users/profiles/user_id:${profileId}/external_ids?limit=25`,
-    {
-      headers: {
-        authorization: `Basic ${Buffer.from(settings.profileApiAccessToken + ':').toString('base64')}`,
-        'content-type': 'application/json'
-      }
-    }
-  )
-
-  const body = await response.json()
-  const externalIds: Record<string, string> = {}
-
-  for (const externalId of body.data) {
-    externalIds[externalId.type] = externalId.id
-  }
-
-  return externalIds
 }
 
 const isRestrictedDomain = (email: string): boolean => {
@@ -223,115 +197,164 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'The HTML content of the body',
       type: 'string'
     },
+    externalIds: {
+      label: 'External IDs',
+      description: 'An array of user profile identity information.',
+      type: 'object',
+      multiple: true,
+      properties: {
+        id: {
+          label: 'ID',
+          description: 'A unique identifier for the collection.',
+          type: 'string'
+        },
+        type: {
+          label: 'type',
+          description: 'The external ID contact type.',
+          type: 'string'
+        },
+        subscriptionStatus: {
+          label: 'ID',
+          description: 'The subscription status for the identity.',
+          type: 'string'
+        }
+      },
+      default: {
+        '@arrayPath': [
+          '$.external_ids',
+          {
+            id: {
+              '@path': '$.id'
+            },
+            type: {
+              '@path': '$.type'
+            },
+            subscriptionStatus: {
+              '@path': '$.isSubscribed'
+            }
+          }
+        ]
+      }
+    },
     customArgs: {
       label: 'Custom Args',
       description: 'Additional custom args that we be passed back opaquely on webhook events',
       type: 'object',
       required: false
     }
+
   },
   perform: async (request, { settings, payload }) => {
     if (!payload.send) {
       return
     }
-    const [traits, externalIds] = await Promise.all([
-      fetchProfileTraits(request, settings, payload.userId),
-      fetchProfileExternalIds(request, settings, payload.userId)
-    ])
 
-    const profile: Profile = {
-      ...externalIds,
-      traits
-    }
-
-    const toEmail = payload.toEmail || profile.email
-
-    if (!toEmail) {
+    const emailProfile = payload?.externalIds?.find(meta => meta.type === 'email')
+    if (!emailProfile?.subscriptionStatus || ['unsubscribed', 'did not subscribed', 'false'].includes(emailProfile.subscriptionStatus)) {
       return
-    }
+    } else if (['subscribed', 'true'].includes(emailProfile?.subscriptionStatus)) {
+      const traits = await fetchProfileTraits(request, settings, payload.userId)
 
-    if (isRestrictedDomain(toEmail)) {
+      const profile: Profile = {
+        email: emailProfile.id,
+        traits
+      }
+
+      const toEmail = payload.toEmail || profile.email
+
+      if (!toEmail) {
+        return
+      }
+
+      if (isRestrictedDomain(toEmail)) {
+        throw new IntegrationError(
+          'Emails with gmailx.com, yahoox.com, aolx.com, and hotmailx.com domains are blocked.',
+          'Invalid input',
+          400
+        )
+      }
+
+      let name
+
+      if (traits.first_name && traits.last_name) {
+        name = `${traits.first_name} ${traits.last_name}`
+      } else if (traits.firstName && traits.lastName) {
+        name = `${traits.firstName} ${traits.lastName}`
+      } else if (traits.name) {
+        name = traits.name
+      } else {
+        name = traits.first_name || traits.last_name || traits.firstName || traits.lastName || 'User'
+      }
+
+      const bcc = JSON.parse(payload.bcc ?? '[]')
+      let bodyHtml = payload.bodyHtml ?? ''
+
+      if (payload.bodyUrl && settings.unlayerApiKey) {
+        const response = await request(payload.bodyUrl)
+        const body = await response.text()
+        bodyHtml = payload.bodyType === 'html' ? body : await generateEmailHtml(request, settings.unlayerApiKey, body)
+
+        if (payload.previewText) {
+          bodyHtml = insertEmailPreviewText(bodyHtml, payload.previewText)
+        }
+      }
+
+      return request('https://api.sendgrid.com/v3/mail/send', {
+        method: 'post',
+        headers: {
+          authorization: `Bearer ${settings.sendGridApiKey}`
+        },
+        json: {
+          personalizations: [
+            {
+              to: [
+                {
+                  email: toEmail,
+                  name: name
+                }
+              ],
+              bcc: bcc.length > 0 ? bcc : undefined,
+              custom_args: {
+                ...payload.customArgs,
+                source_id: settings.sourceId,
+                space_id: settings.spaceId,
+                user_id: payload.userId,
+                // This is to help disambiguate in the case it's email or email_address.
+                __segment_internal_external_id_key__: EXTERNAL_ID_KEY,
+                __segment_internal_external_id_value__: profile[EXTERNAL_ID_KEY]
+              }
+            }
+          ],
+          from: {
+            email: payload.fromEmail,
+            name: payload.fromName
+          },
+          reply_to: {
+            email: payload.replyToEmail,
+            name: payload.replyToName
+          },
+          subject: Mustache.render(payload.subject, { profile }),
+          content: [
+            {
+              type: 'text/html',
+              value: Mustache.render(bodyHtml, { profile })
+            }
+          ],
+          tracking_settings: {
+            subscription_tracking: {
+              enable: true,
+              substitution_tag: '[unsubscribe]'
+            }
+          }
+        }
+      })
+    } else {
       throw new IntegrationError(
-        'Emails with gmailx.com, yahoox.com, aolx.com, and hotmailx.com domains are blocked.',
-        'Invalid input',
+        `Failed to process the subscription state: "${emailProfile.subscriptionStatus}"`,
+        'Invalid subscriptionStatus value',
         400
       )
     }
-
-    let name
-
-    if (traits.first_name && traits.last_name) {
-      name = `${traits.first_name} ${traits.last_name}`
-    } else if (traits.firstName && traits.lastName) {
-      name = `${traits.firstName} ${traits.lastName}`
-    } else if (traits.name) {
-      name = traits.name
-    } else {
-      name = traits.first_name || traits.last_name || traits.firstName || traits.lastName || 'User'
-    }
-
-    const bcc = JSON.parse(payload.bcc ?? '[]')
-    let bodyHtml = payload.bodyHtml ?? ''
-
-    if (payload.bodyUrl && settings.unlayerApiKey) {
-      const response = await request(payload.bodyUrl)
-      const body = await response.text()
-      bodyHtml = payload.bodyType === 'html' ? body : await generateEmailHtml(request, settings.unlayerApiKey, body)
-
-      if (payload.previewText) {
-        bodyHtml = insertEmailPreviewText(bodyHtml, payload.previewText)
-      }
-    }
-
-    return request('https://api.sendgrid.com/v3/mail/send', {
-      method: 'post',
-      headers: {
-        authorization: `Bearer ${settings.sendGridApiKey}`
-      },
-      json: {
-        personalizations: [
-          {
-            to: [
-              {
-                email: toEmail,
-                name: name
-              }
-            ],
-            bcc: bcc.length > 0 ? bcc : undefined,
-            custom_args: {
-              ...payload.customArgs,
-              source_id: settings.sourceId,
-              space_id: settings.spaceId,
-              user_id: payload.userId,
-              // This is to help disambiguate in the case it's email or email_address.
-              __segment_internal_external_id_key__: EXTERNAL_ID_KEY,
-              __segment_internal_external_id_value__: profile[EXTERNAL_ID_KEY]
-            }
-          }
-        ],
-        from: {
-          email: payload.fromEmail,
-          name: payload.fromName
-        },
-        reply_to: {
-          email: payload.replyToEmail,
-          name: payload.replyToName
-        },
-        subject: Mustache.render(payload.subject, { profile }),
-        content: [
-          {
-            type: 'text/html',
-            value: Mustache.render(bodyHtml, { profile })
-          }
-        ],
-        tracking_settings: {
-          subscription_tracking: {
-            enable: true,
-            substitution_tag: "[unsubscribe]"
-          }
-        }
-      }
-    })
   }
 }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Updates the response body interface received from `fetchProfileExternalIds` on "personas-messaging-sendgrid" action, and processes the `isSubscribed` property from the email external ID.

Unit Tests:
<img width="715" alt="image" src="https://user-images.githubusercontent.com/13429481/155611595-186f9095-1007-4789-995a-389a86312364.png">

Local testing:
with email external ID's  `isSubscribed` set to = `subscribed`
<img width="1377" alt="image" src="https://user-images.githubusercontent.com/13429481/155215840-8215f1c7-2437-486b-8723-5b2783cfc04a.png">

with email external ID's  `isSubscribed` set to = `true`
<img width="1377" alt="image" src="https://user-images.githubusercontent.com/13429481/155215840-8215f1c7-2437-486b-8723-5b2783cfc04a.png">

with email external ID's `isSubscribed` set to `unsubscribed`:
<img width="1021" alt="image" src="https://user-images.githubusercontent.com/13429481/155216147-46dd8af1-e892-4b5b-8c61-8b668d3c43e0.png">


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
