### PR TITLE
Add recordOnlyThisIFrame setting to FullStory (isOuterScript)

### DIFF
--- a/packages/browser-destinations/src/destinations/fullstory/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/generated-types.ts
@@ -9,4 +9,8 @@ export interface Settings {
    * Enables FullStory debug mode.
    */
   debug?: boolean
+  /**
+   * Enables FullStory inside an iframe.
+   */
+  recordOnlyThisIFrame?: boolean
 }

--- a/packages/browser-destinations/src/destinations/fullstory/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/index.ts
@@ -47,6 +47,13 @@ export const destination: BrowserDestinationDefinition<Settings, FS> = {
       type: 'boolean',
       required: false,
       default: false
+    },
+    recordOnlyThisIFrame: {
+      description: 'Enables FullStory inside an iframe.',
+      label: 'Record only this iframe',
+      type: 'boolean',
+      required: false,
+      default: false
     }
   },
   actions: {


### PR DESCRIPTION
According to our needs running Segment fullstory integration inside an iframe is very valuable feature for us.
Previous PR with the same feature was not merged:
https://github.com/segmentio/analytics.js-integrations/pull/625

So our team decided to ask you about adding recordOnlyThisIFrame feature in new version of the library.

Despite line breaks issues I was ale to run tests locally and generate needed types as well.

Thanks