### PR TITLE
[STRATCONN] Fix Mbox3rdpartyid on Adobe Target Web

### DIFF
--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/__tests__/index.test.ts
@@ -80,8 +80,8 @@ describe('Adobe Target Web', () => {
       )
 
       expect(window.pageParams).toEqual({
+        mbox3rdPartyId: 'random-id-42',
         profile: {
-          mbox3rdpartyid: 'random-id-42',
           favorite_color: 'blue',
           location: {
             country_code: 'MX',
@@ -117,8 +117,8 @@ describe('Adobe Target Web', () => {
       )
 
       expect(window.pageParams).toEqual({
+        mbox3rdPartyId: 'The-Real-ID',
         profile: {
-          mbox3rdpartyid: 'The-Real-ID',
           favorite_color: 'blue',
           location: {
             country_code: 'MX',

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
@@ -2,7 +2,7 @@ import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
 import type { Settings } from '../generated-types'
 import { Adobe } from '../types'
 import type { Payload } from './generated-types'
-import { setPageParams } from '../utils'
+import { setPageParams, setMbox3rdPartyId } from '../utils'
 
 const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   title: 'Upsert Profile',
@@ -48,11 +48,10 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
        identify() and track() actions leverage the same function (adobe.target.trackEvent()) to send data to Adobe.
        identify does not pass an event name, track does.
     */
-    const user = {
-      mbox3rdpartyid: event.payload.anonymousId
-    }
+
+    setMbox3rdPartyId(event.payload.anonymousId)
     if (event.payload.userId) {
-      user.mbox3rdpartyid = event.payload.userId
+      setMbox3rdPartyId(event.payload.userId)
     }
 
     /*
@@ -62,8 +61,7 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
     */
     setPageParams({
       profile: {
-        ...event.payload.traits,
-        ...user
+        ...event.payload.traits
       }
     })
 

--- a/packages/browser-destinations/src/destinations/adobe-target/utils.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/utils.ts
@@ -8,3 +8,7 @@ export function getPageParams() {
 export function setPageParams(params) {
   return (window.pageParams = { ...window.pageParams, ...params })
 }
+
+export function setMbox3rdPartyId(id) {
+  setPageParams({ mbox3rdPartyId: id })
+}


### PR DESCRIPTION
# What

This PR updates the way we handle userIds to leverage the MBox3rdPartyId feature of AT.JS. This will allow us to create/update users with a known ID by Segment.

## Testing

# When userId is passed

![Screen Shot 2022-02-23 at 4 01 19 PM](https://user-images.githubusercontent.com/316711/155432834-020aba72-b691-4744-a592-5e2ea9105b83.png)

# When no userId is passed

Defaults to Segment User ID

![Screen Shot 2022-02-23 at 4 04 15 PM](https://user-images.githubusercontent.com/316711/155432924-541a79a5-3a0d-4c1d-b531-7e8cfad32cbe.png)


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
