### PR TITLE
Update twilio destination action to consume subscription information

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/__tests__/send-sms.test.ts
@@ -5,7 +5,7 @@ import Twilio from '..'
 const twilio = createTestIntegration(Twilio)
 const timestamp = new Date().toISOString()
 
-for (const environment of ['stage', 'production']) {
+describe.each(['stage', 'production'])('%s environment', (environment) => {
   const settings = {
     twilioAccountId: 'a',
     twilioAuthToken: 'b',
@@ -28,19 +28,8 @@ for (const environment of ['stage', 'production']) {
     nock.cleanAll()
   })
 
-  describe(`${environment} - send SMS`, () => {
-    it('should abort when there is no `phone` external ID', async () => {
-      nock(`${endpoint}/v1/spaces/d/collections/users/profiles/user_id:jane`)
-        .get('/external_ids?limit=25')
-        .reply(200, {
-          data: [
-            {
-              type: 'user_id',
-              id: 'jane'
-            }
-          ]
-        })
-
+  describe('send SMS', () => {
+    it('should abort when there is no `phone` external ID in the payload', async () => {
       const responses = await twilio.testAction('sendSms', {
         event: createTestEvent({
           timestamp,
@@ -52,42 +41,15 @@ for (const environment of ['stage', 'production']) {
           userId: { '@path': '$.userId' },
           from: 'MG1111222233334444',
           body: 'Hello world, {{profile.user_id}}!',
-          send: true
+          send: true,
+          externalIds: [
+            { type: 'email', id: 'test@twilio.com', subscriptionStatus: 'subscribed' }
+          ]
         }
       })
 
-      expect(responses.length).toEqual(2)
+      expect(responses.length).toEqual(0)
     })
-
-    const testSendSms = async (expectedTwilioRequest: any, actionInputData: any) => {
-      nock(`${endpoint}/v1/spaces/d/collections/users/profiles/user_id:jane`)
-        .get('/external_ids?limit=25')
-        .reply(200, {
-          data: [
-            {
-              type: 'user_id',
-              id: 'jane'
-            },
-            {
-              type: 'phone',
-              id: '+1234567891'
-            }
-          ]
-        })
-
-      const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
-        .post('/Messages.json', expectedTwilioRequest.toString())
-        .reply(201, {})
-
-      const responses = await twilio.testAction('sendSms', actionInputData)
-
-      expect(responses.map((response) => response.url)).toStrictEqual([
-        `${endpoint}/v1/spaces/d/collections/users/profiles/user_id:jane/traits?limit=200`,
-        `${endpoint}/v1/spaces/d/collections/users/profiles/user_id:jane/external_ids?limit=25`,
-        'https://api.twilio.com/2010-04-01/Accounts/a/Messages.json'
-      ])
-      expect(twilioRequest.isDone()).toEqual(true)
-    }
 
     it('should send SMS', async () => {
       const expectedTwilioRequest = new URLSearchParams({
@@ -95,6 +57,11 @@ for (const environment of ['stage', 'production']) {
         From: 'MG1111222233334444',
         To: '+1234567891'
       })
+
+      const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
+        .post('/Messages.json', expectedTwilioRequest.toString())
+        .reply(201, {})
+
       const actionInputData = {
         event: createTestEvent({
           timestamp,
@@ -106,11 +73,20 @@ for (const environment of ['stage', 'production']) {
           userId: { '@path': '$.userId' },
           from: 'MG1111222233334444',
           body: 'Hello world, {{profile.user_id}}!',
-          send: true
+          send: true,
+          externalIds: [
+            { type: 'email', id: 'test@twilio.com', subscriptionStatus: 'subscribed' },
+            { type: 'phone', id: '+1234567891', subscriptionStatus: 'subscribed' }
+          ]
         }
       }
 
-      await testSendSms(expectedTwilioRequest, actionInputData)
+      const responses = await twilio.testAction('sendSms', actionInputData)
+      expect(responses.map((response) => response.url)).toStrictEqual([
+        `${endpoint}/v1/spaces/d/collections/users/profiles/user_id:jane/traits?limit=200`,
+        'https://api.twilio.com/2010-04-01/Accounts/a/Messages.json'
+      ])
+      expect(twilioRequest.isDone()).toEqual(true)
     })
 
     it('should send SMS with custom metadata', async () => {
@@ -121,6 +97,9 @@ for (const environment of ['stage', 'production']) {
         StatusCallback:
           'http://localhost/?foo=bar&__segment_internal_external_id_key__=phone&__segment_internal_external_id_value__=%2B1234567891#rp=all&rc=5'
       })
+      const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
+        .post('/Messages.json', expectedTwilioRequest.toString())
+        .reply(201, {})
 
       const actionInputData = {
         event: createTestEvent({
@@ -140,29 +119,24 @@ for (const environment of ['stage', 'production']) {
           customArgs: {
             foo: 'bar'
           },
-          send: true
+          send: true,
+          externalIds: [
+            { type: 'email', id: 'test@twilio.com', subscriptionStatus: 'subscribed' },
+            { type: 'phone', id: '+1234567891', subscriptionStatus: 'subscribed' }
+          ]
         }
       }
 
-      await testSendSms(expectedTwilioRequest, actionInputData)
+      const responses = await twilio.testAction('sendSms', actionInputData)
+
+      expect(responses.map((response) => response.url)).toStrictEqual([
+        `${endpoint}/v1/spaces/d/collections/users/profiles/user_id:jane/traits?limit=200`,
+        'https://api.twilio.com/2010-04-01/Accounts/a/Messages.json'
+      ])
+      expect(twilioRequest.isDone()).toEqual(true)
     })
 
     it('should fail on invalid webhook url', async () => {
-      nock(`${endpoint}/v1/spaces/d/collections/users/profiles/user_id:jane`)
-        .get('/external_ids?limit=25')
-        .reply(200, {
-          data: [
-            {
-              type: 'user_id',
-              id: 'jane'
-            },
-            {
-              type: 'phone',
-              id: '+1234567891'
-            }
-          ]
-        })
-
       const actionInputData = {
         event: createTestEvent({
           timestamp,
@@ -180,10 +154,126 @@ for (const environment of ['stage', 'production']) {
           customArgs: {
             foo: 'bar'
           },
-          send: true
+          send: true,
+          externalIds: [
+            { type: 'email', id: 'test@twilio.com', subscriptionStatus: 'subscribed' },
+            { type: 'phone', id: '+1234567891', subscriptionStatus: 'subscribed' }
+          ]
         }
       }
       await expect(twilio.testAction('sendSms', actionInputData)).rejects.toHaveProperty('code', 'ERR_INVALID_URL')
     })
   })
-}
+  describe('subscription handling', () => {
+    it.each(['subscribed', true])('sends an SMS when subscriptonStatus ="%s"', async (subscriptionStatus) => {
+      const expectedTwilioRequest = new URLSearchParams({
+        Body: 'Hello world, jane!',
+        From: 'MG1111222233334444',
+        To: '+1234567891'
+      })
+
+      const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
+        .post('/Messages.json', expectedTwilioRequest.toString())
+        .reply(201, {})
+
+      const actionInputData = {
+        event: createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          userId: 'jane'
+        }),
+        settings,
+        mapping: {
+          userId: { '@path': '$.userId' },
+          from: 'MG1111222233334444',
+          body: 'Hello world, {{profile.user_id}}!',
+          send: true,
+          externalIds: [
+            { type: 'phone', id: '+1234567891', subscriptionStatus }
+          ]
+        }
+      }
+
+      const responses = await twilio.testAction('sendSms', actionInputData)
+      expect(responses.map((response) => response.url)).toStrictEqual([
+        `${endpoint}/v1/spaces/d/collections/users/profiles/user_id:jane/traits?limit=200`,
+        'https://api.twilio.com/2010-04-01/Accounts/a/Messages.json'
+      ])
+      expect(twilioRequest.isDone()).toEqual(true)
+    })
+
+    it.each([
+      'unsubscribed',
+      'did not subscribed',
+      false,
+      null
+    ])('does NOT send an SMS when subscriptonStatus ="%s"', async (subscriptionStatus) => {
+      const expectedTwilioRequest = new URLSearchParams({
+        Body: 'Hello world, jane!',
+        From: 'MG1111222233334444',
+        To: '+1234567891'
+      })
+
+      const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
+        .post('/Messages.json', expectedTwilioRequest.toString())
+        .reply(201, {})
+
+      const actionInputData = {
+        event: createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          userId: 'jane'
+        }),
+        settings,
+        mapping: {
+          userId: { '@path': '$.userId' },
+          from: 'MG1111222233334444',
+          body: 'Hello world, {{profile.user_id}}!',
+          send: true,
+          externalIds: [
+            { type: 'phone', id: '+1234567891', subscriptionStatus }
+          ]
+        }
+      }
+
+      const responses = await twilio.testAction('sendSms', actionInputData)
+      expect(responses).toHaveLength(0)
+      expect(twilioRequest.isDone()).toEqual(false)
+    })
+
+    it('throws an error when subscriptionStatus is unrecognizable"', async () => {
+      const randomSubscriptionStatusPhrase = 'some-subscription-enum'
+
+      const expectedTwilioRequest = new URLSearchParams({
+        Body: 'Hello world, jane!',
+        From: 'MG1111222233334444',
+        To: '+1234567891'
+      })
+
+      nock('https://api.twilio.com/2010-04-01/Accounts/a')
+        .post('/Messages.json', expectedTwilioRequest.toString())
+        .reply(201, {})
+
+      const actionInputData = {
+        event: createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          userId: 'jane'
+        }),
+        settings,
+        mapping: {
+          userId: { '@path': '$.userId' },
+          from: 'MG1111222233334444',
+          body: 'Hello world, {{profile.user_id}}!',
+          send: true,
+          externalIds: [
+            { type: 'phone', id: '+1234567891', subscriptionStatus: randomSubscriptionStatusPhrase }
+          ]
+        }
+      }
+
+      const response = twilio.testAction('sendSms', actionInputData)
+      await expect(response).rejects.toThrowError(`Failed to recognize the subscriptionStatus in the payload: "${randomSubscriptionStatusPhrase}".`)
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/generated-types.ts
@@ -31,4 +31,21 @@ export interface Payload {
    * Whether or not the message should actually get sent.
    */
   send?: boolean
+  /**
+   * An array of user profile identity information.
+   */
+  externalIds?: {
+    /**
+     * A unique identifier for the collection.
+     */
+    id?: string
+    /**
+     * The external ID contact type.
+     */
+    type?: string
+    /**
+     * The subscription status for the identity.
+     */
+    subscriptionStatus?: string
+  }[]
 }

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
@@ -2,6 +2,7 @@ import Mustache from 'mustache'
 import type { ActionDefinition, RequestOptions } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+import { IntegrationError } from '@segment/actions-core'
 
 const getProfileApiEndpoint = (environment: string): string => {
   return `https://profiles.segment.${environment === 'production' ? 'com' : 'build'}`
@@ -27,39 +28,6 @@ const fetchProfileTraits = async (
 
   const body = await response.json()
   return body.traits
-}
-
-const fetchProfileExternalIds = async (
-  request: RequestFn,
-  settings: Settings,
-  profileId: string
-): Promise<Record<string, string>> => {
-  const endpoint = getProfileApiEndpoint(settings.profileApiEnvironment)
-  const response = await request(
-    `${endpoint}/v1/spaces/${settings.spaceId}/collections/users/profiles/user_id:${profileId}/external_ids?limit=25`,
-    {
-      headers: {
-        authorization: `Basic ${Buffer.from(settings.profileApiAccessToken + ':').toString('base64')}`,
-        'content-type': 'application/json'
-      }
-    }
-  )
-
-  const body = await response.json()
-  const externalIds: Record<string, string> = {}
-
-  for (const externalId of body.data) {
-    externalIds[externalId.type] = externalId.id
-  }
-
-  return externalIds
-}
-
-interface Profile {
-  user_id?: string
-  anonymous_id?: string
-  phone?: string
-  traits: Record<string, string>
 }
 
 const EXTERNAL_ID_KEY = 'phone'
@@ -113,31 +81,70 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'boolean',
       required: false,
       default: false
+    },
+    externalIds: {
+      label: 'External IDs',
+      description: 'An array of user profile identity information.',
+      type: 'object',
+      multiple: true,
+      properties: {
+        id: {
+          label: 'ID',
+          description: 'A unique identifier for the collection.',
+          type: 'string'
+        },
+        type: {
+          label: 'type',
+          description: 'The external ID contact type.',
+          type: 'string'
+        },
+        subscriptionStatus: {
+          label: 'ID',
+          description: 'The subscription status for the identity.',
+          type: 'string'
+        }
+      },
+      default: {
+        '@arrayPath': [
+          '$.external_ids',
+          {
+            id: {
+              '@path': '$.id'
+            },
+            type: {
+              '@path': '$.type'
+            },
+            subscriptionStatus: {
+              '@path': '$.isSubscribed'
+            }
+          }
+        ]
+      }
     }
   },
   perform: async (request, { settings, payload }) => {
     if (!payload.send) {
       return
     }
-    const [traits, externalIds] = await Promise.all([
-      fetchProfileTraits(request, settings, payload.userId),
-      fetchProfileExternalIds(request, settings, payload.userId)
-    ])
-
-    const profile: Profile = {
-      ...externalIds,
-      traits
-    }
-
-    const phone = payload.toNumber || profile.phone
-
-    if (!phone) {
+    const externalId = payload.externalIds?.find(({ type }) => type === 'phone')
+    if (!externalId?.subscriptionStatus || ['unsubscribed', 'did not subscribed', 'false'].includes(externalId.subscriptionStatus)) {
       return
-    }
+    } else if (['subscribed', 'true'].includes(externalId.subscriptionStatus)) {
+      const traits = await fetchProfileTraits(request, settings, payload.userId)
 
-    // TODO: GROW-259 remove this when we can extend the request
-    // and we no longer need to call the profiles API first
-    const token = Buffer.from(`${settings.twilioAccountId}:${settings.twilioAuthToken}`).toString('base64')
+      const phone = payload.toNumber || externalId.id
+      if (!phone) {
+        return
+      }
+      const profile = {
+        user_id: payload.userId,
+        phone,
+        traits
+      }
+
+      // TODO: GROW-259 remove this when we can extend the request
+      // and we no longer need to call the profiles API first
+      const token = Buffer.from(`${settings.twilioAccountId}:${settings.twilioAuthToken}`).toString('base64')
 
     const body = new URLSearchParams({
       Body: Mustache.render(payload.body, { profile }),
@@ -145,35 +152,42 @@ const action: ActionDefinition<Settings, Payload> = {
       To: phone
     })
 
-    const webhookUrl = settings.webhookUrl
-    const connectionOverrides = settings.connectionOverrides
-    const customArgs: Record<string, string | undefined> = {
-      ...payload.customArgs,
-      __segment_internal_external_id_key__: EXTERNAL_ID_KEY,
-      __segment_internal_external_id_value__: profile[EXTERNAL_ID_KEY]
-    }
-
-    if (webhookUrl && customArgs) {
-      // Webhook URL parsing has a potential of failing. I think it's better that
-      // we fail out of any invocation than silently not getting analytics
-      // data if that's what we're expecting.
-      const webhookUrlWithParams = new URL(webhookUrl)
-      for (const key of Object.keys(customArgs)) {
-        webhookUrlWithParams.searchParams.append(key, String(customArgs[key]))
+      const webhookUrl = settings.webhookUrl
+      const connectionOverrides = settings.connectionOverrides
+      const customArgs: Record<string, string | undefined> = {
+        ...payload.customArgs,
+        __segment_internal_external_id_key__: EXTERNAL_ID_KEY,
+        __segment_internal_external_id_value__: phone
       }
 
-      webhookUrlWithParams.hash = connectionOverrides || DEFAULT_CONNECTION_OVERRIDES
+      if (webhookUrl && customArgs) {
+        // Webhook URL parsing has a potential of failing. I think it's better that
+        // we fail out of any invocation than silently not getting analytics
+        // data if that's what we're expecting.
+        const webhookUrlWithParams = new URL(webhookUrl)
+        for (const key of Object.keys(customArgs)) {
+          webhookUrlWithParams.searchParams.append(key, String(customArgs[key]))
+        }
 
-      body.append('StatusCallback', webhookUrlWithParams.toString())
+        webhookUrlWithParams.hash = connectionOverrides || DEFAULT_CONNECTION_OVERRIDES
+
+        body.append('StatusCallback', webhookUrlWithParams.toString())
+      }
+
+      return request(`https://api.twilio.com/2010-04-01/Accounts/${settings.twilioAccountId}/Messages.json`, {
+        method: 'POST',
+        headers: {
+          authorization: `Basic ${token}`
+        },
+        body
+      })
+    } else {
+      throw new IntegrationError(
+        `Failed to recognize the subscriptionStatus in the payload: "${externalId.subscriptionStatus}".`,
+        'Invalid subscriptionStatus value',
+        400
+      )
     }
-
-    return request(`https://api.twilio.com/2010-04-01/Accounts/${settings.twilioAccountId}/Messages.json`, {
-      method: 'POST',
-      headers: {
-        authorization: `Basic ${token}`
-      },
-      body
-    })
   }
 }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Replaces the use of `fetchProfileExternalIds` API with the `externalIds` payload provided in the request body:

Unit test coverage:
<img width="738" alt="image" src="https://user-images.githubusercontent.com/13429481/155603337-c8dadfc1-7947-459d-a486-a470fc5201b1.png">

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
