### PR TITLE
use from instead of messagingServiceId for sms destination actions

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/__tests__/send-sms.test.ts
@@ -50,7 +50,7 @@ for (const environment of ['stage', 'production']) {
         settings,
         mapping: {
           userId: { '@path': '$.userId' },
-          messagingServiceId: 'MG1111222233334444',
+          from: 'MG1111222233334444',
           body: 'Hello world, {{profile.user_id}}!',
           send: true
         }
@@ -104,7 +104,7 @@ for (const environment of ['stage', 'production']) {
         settings,
         mapping: {
           userId: { '@path': '$.userId' },
-          messagingServiceId: 'MG1111222233334444',
+          from: 'MG1111222233334444',
           body: 'Hello world, {{profile.user_id}}!',
           send: true
         }
@@ -135,7 +135,7 @@ for (const environment of ['stage', 'production']) {
         },
         mapping: {
           userId: { '@path': '$.userId' },
-          messagingServiceId: 'MG1111222233334444',
+          from: 'MG1111222233334444',
           body: 'Hello world, {{profile.user_id}}!',
           customArgs: {
             foo: 'bar'
@@ -175,7 +175,7 @@ for (const environment of ['stage', 'production']) {
         },
         mapping: {
           userId: { '@path': '$.userId' },
-          messagingServiceId: 'MG1111222233334444',
+          from: 'MG1111222233334444',
           body: 'Hello world, {{profile.user_id}}!',
           customArgs: {
             foo: 'bar'

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/generated-types.ts
@@ -10,9 +10,9 @@ export interface Payload {
    */
   toNumber?: string
   /**
-   * The ID of the Twilio Messaging Service to send SMS from
+   * The Twilio Phone Number, Short Code, or Messaging Service to send SMS from.
    */
-  messagingServiceId: string
+  from: string
   /**
    * Message to send
    */

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
@@ -82,9 +82,9 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'Number to send SMS to when testing',
       type: 'string'
     },
-    messagingServiceId: {
-      label: 'Messaging Service ID',
-      description: 'The ID of the Twilio Messaging Service to send SMS from',
+    from: {
+      label: 'From',
+      description: 'The Twilio Phone Number, Short Code, or Messaging Service to send SMS from.',
       type: 'string',
       required: true
     },
@@ -141,7 +141,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const body = new URLSearchParams({
       Body: Mustache.render(payload.body, { profile }),
-      From: payload.messagingServiceId,
+      From: payload.from,
       To: phone
     })
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._
Change sms destination action to use `from` instead of `messagingServiceId`
## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] ~Added~ Updated [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
