### PR TITLE
Add two possible solutions

### DIFF
--- a/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
+++ b/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
@@ -194,8 +194,10 @@ const action: ActionDefinition<Settings, Payload> = {
       description: `The user's first name`,
       type: 'string',
       allowNull: true,
+      // First Solution: set the defaults in the first_name and last_name fields to
+      // $.traits.first_name && $.traits.last_name
       default: {
-        '@path': '$.traits.firstName'
+        '@path': '$.traits.first_name'
       }
     },
     gender: {
@@ -237,8 +239,10 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Last Name',
       description: "The user's last name",
       type: 'string',
+      // First Solution: set the defaults in the first_name and last_name fields to
+      // $.traits.first_name && $.traits.last_name
       default: {
-        '@path': '$.traits.lastName'
+        '@path': '$.traits.last_name'
       }
     },
     marked_email_as_spam_at: {
@@ -357,6 +361,9 @@ const action: ActionDefinition<Settings, Payload> = {
     // potentially send a value from `custom_attributes` that conflicts with their mappings.
     const reservedKeys = Object.keys(action.fields)
     const customAttrs = omit(payload.custom_attributes, reservedKeys)
+
+    // Second solution: Add 'lastName' and 'firstName' attributes to the reservedKeys list
+    // reservedKeys.push('firstName', 'lastName')
 
     return request(`${settings.endpoint}/users/track`, {
       method: 'post',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

Hello, I wanted to get opinions on two possible solutions to this [JIRA](https://segment.atlassian.net/browse/BE-619) ticket.

## The Issue

The issue arises from these lines:
![Screen Shot 2022-02-28 at 4 32 18 PM](https://user-images.githubusercontent.com/98849774/156084509-e2085b43-fb9c-4786-9137-ddaa62ed428d.png)
- first, a string array called reservedKeys is created that loops through the action's fields and inserts their names into it. 
- second, we create a customAttrs object that omits all key:value pairs that have a matching key name in the reservedKeys array - trying to ensure only truly custom attributes are included
- finally, the customAttrs that were not reserved keys are sent in the request to braze

The problem with this is that the first name and last name action fields are named as `firstName` and `lastName` when they are sent in the event (as seen in the image below)

Thus, when making the list of keys that should be in the reservedKeys array, `first_name` and `last_name` are included, but not `firstName` and `lastName`. Therefore when sending the event you see that they are being duplicated as both their mapped name of `firstName` -> `first_name`, and also how they are treated as being included in customAttributes as `firstName`

Update: When looking at the code even further, I noticed if the above was true, the same issue should arise from sending the `avatar` attribute. Because it is mapped from `avatar` -> `imageUrl`. So `imageUrl` should be included in the reservedKeys array, but not `avatar` and they would both be sent as well. The image below shows the results of this test to be true.

(Let me know if I explained this horribly or if it makes sense)

<img width="1187" alt="Screen Shot 2022-02-28 at 5 16 03 PM" src="https://user-images.githubusercontent.com/98849774/156087315-ca1d92b7-64fc-4e46-a1fa-2a3acbb40dec.png">

## Solutions

### Solution One - Change the defaults of `first_name` and `last_name`

![Screen Shot 2022-02-28 at 5 33 54 PM](https://user-images.githubusercontent.com/98849774/156087899-94847081-127f-42ef-b0ef-a6da423e0f01.png)

- Previously they were set as `$.traits.firstName` and `$.traits.lastName`. 
- Instead we would use `$.traits.first_name` and `$.traits.last_name` respectively
- By making this change, you would instead force the field names in the event to be `first_name` and `last_name`.

The only problem I had with this solution comes from my lack of knowledge of how segment as a whole works (more specifically how the events are sent). For example, I do not know if segment events automatically send the first name and last name fields as `firstName` and `lastName`. In other words, it is impossible for a user to rename the field from `firstName` to `first_name` as they have no control over that.

### Solution Two - simply update the reservedKeys array to have the required names

![Screen Shot 2022-02-28 at 5 40 06 PM](https://user-images.githubusercontent.com/98849774/156088740-385f74f1-9222-435b-af5a-0572e8dab1b8.png)

- We simply add the `firstName`,`lastName`, and `avatar` keywords into the reservedKeys array 
- This means they will be omitted from the customAttrs object and should not be sent
- This solution is much simpler, and the one I initially would go with. I mostly brought up solution one as a way of finding out more about how segment works. 