### PR TITLE
fix Braze sending unwanted custom fields

### DIFF
--- a/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
+++ b/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
@@ -356,6 +356,8 @@ const action: ActionDefinition<Settings, Payload> = {
     // to respect the customers mappings that might resolve `undefined`, without this we'd
     // potentially send a value from `custom_attributes` that conflicts with their mappings.
     const reservedKeys = Object.keys(action.fields)
+    // push additional default keys so they are not added as custom attributes
+    reservedKeys.push('firstName', 'lastName', 'avatar')
     const customAttrs = omit(payload.custom_attributes, reservedKeys)
 
     return request(`${settings.endpoint}/users/track`, {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

This PR addresses [JIRA-619](https://segment.atlassian.net/browse/BE-619)

Previously, when identify events were being sent to braze containing the firstName and lastName fields, those fields were being reproduced as both the correct field `first_name`, and as a custom attribute `firstName`. This can be seen in the images below

The request being sent from segment
![braze_event_tester](https://user-images.githubusercontent.com/98849774/156268351-a55424a8-6f87-4386-9753-be2716fe1434.png)

The object being created in braze with unwanted custom attributes
![user_custom_reserved_attributes](https://user-images.githubusercontent.com/98849774/156268459-691d4b4a-465d-4480-ab56-a64aef98ce7a.png)

This PR fixes this problem for both the `firstName` & `lastName` fields, as well as the `avatar` field which was also shown to have the same problem during testing.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

Testing was completed successfully in stage as can be seen from the images below

The request being sent from segment with no extra fields
<img width="1513" alt="Screen Shot 2022-03-01 at 3 50 44 PM" src="https://user-images.githubusercontent.com/98849774/156268425-dc459143-b86c-4a7d-aefa-7b80447762e7.png">

The object being created in braze without any unwanted custom attributes
<img width="1499" alt="Screen Shot 2022-03-01 at 3 37 21 PM" src="https://user-images.githubusercontent.com/98849774/156268431-c540d20e-b32d-4feb-98af-34d1f157cabd.png">

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
