### PR TITLE
[STRATCONN-1195] Address QA comments for Adobe Target Web 

### DIFF
--- a/packages/browser-destinations/src/destinations/adobe-target/__tests__/utils.test.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/__tests__/utils.test.ts
@@ -1,0 +1,22 @@
+import { serializeProperties } from '../utils'
+
+describe('Utils', () => {
+  describe('serializeProperties', () => {
+    test('converts array properties to string', async () => {
+      const tags = ['leonardo', 'michelangelo', 'donatello', 'raphael']
+      const properties = {
+        eventName: 'purchase',
+        total: 42.42,
+        item: 'car',
+        itemTags: tags
+      }
+
+      expect(serializeProperties(properties)).toEqual({
+        eventName: 'purchase',
+        total: 42.42,
+        item: 'car',
+        itemTags: '["leonardo","michelangelo","donatello","raphael"]'
+      })
+    })
+  })
+})

--- a/packages/browser-destinations/src/destinations/adobe-target/trackEvent/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/trackEvent/generated-types.ts
@@ -2,13 +2,13 @@
 
 export interface Payload {
   /**
-   * This will be sent to Adobe Target as an event parameter called "event_name".
-   */
-  event_name?: string
-  /**
    * The event type. Please ensure the type entered here is registered and available.
    */
   type?: string
+  /**
+   * This will be sent to Adobe Target as an event parameter called "event_name".
+   */
+  eventName?: string
   /**
    * Parameters specific to the event.
    */

--- a/packages/browser-destinations/src/destinations/adobe-target/trackEvent/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/trackEvent/generated-types.ts
@@ -15,4 +15,8 @@ export interface Payload {
   properties?: {
     [k: string]: unknown
   }
+  /**
+   * A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.
+   */
+  userId?: string
 }

--- a/packages/browser-destinations/src/destinations/adobe-target/trackEvent/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/trackEvent/generated-types.ts
@@ -2,7 +2,11 @@
 
 export interface Payload {
   /**
-   * Event type or name.
+   * This will be sent to Adobe Target as an event parameter called "event_name".
+   */
+  event_name?: string
+  /**
+   * The event type. Please ensure the type entered here is registered and available.
    */
   type?: string
   /**

--- a/packages/browser-destinations/src/destinations/adobe-target/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/trackEvent/index.ts
@@ -7,23 +7,23 @@ const TARGET_EVENT_TYPE = 'click'
 
 const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   title: 'Track Event',
-  description: 'Track an event',
+  description: 'Send user actions, such as clicks and conversions, to Adobe Target.',
   platform: 'web',
   defaultSubscription: 'type = "track"',
   fields: {
-    event_name: {
+    type: {
+      label: 'Event Type',
+      description: 'The event type. Please ensure the type entered here is registered and available.',
+      type: 'string',
+      default: TARGET_EVENT_TYPE
+    },
+    eventName: {
       label: 'Event Name',
       description: 'This will be sent to Adobe Target as an event parameter called "event_name".',
       type: 'string',
       default: {
         '@path': '$.event'
       }
-    },
-    type: {
-      label: 'Event Type',
-      description: 'The event type. Please ensure the type entered here is registered and available.',
-      type: 'string',
-      default: TARGET_EVENT_TYPE
     },
     properties: {
       label: 'Event Parameters',
@@ -36,16 +36,17 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   },
   perform: (Adobe, event) => {
     // Adobe Target only takes certain event types as valid parameters. We are defaulting to "click".
+    const payload = event.payload
     const event_params = {
-      ...event.payload.properties,
-      event_name: event.payload.event_name
+      ...payload.properties,
+      event_name: payload.eventName
     }
 
     const params = {
       mbox: event.settings.mbox_name,
       preventDefault: true,
       params: event_params,
-      type: TARGET_EVENT_TYPE
+      type: payload.type
     }
 
     Adobe.target.trackEvent(params)

--- a/packages/browser-destinations/src/destinations/adobe-target/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/trackEvent/index.ts
@@ -2,7 +2,7 @@ import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { Adobe } from '../types'
-import { setMbox3rdPartyId } from '../utils'
+import { setMbox3rdPartyId, serializeProperties } from '../utils'
 
 // Adobe Target only takes certain event types as valid parameters. We are defaulting to "click".
 const TARGET_EVENT_TYPE = 'click'
@@ -53,26 +53,8 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
     const payload = event.payload
     setMbox3rdPartyId(payload.userId)
 
-    // Track does not accept arrays as valid properties, therefore we are stringifying them.
-    const serialize_properties = (props: { [key: string]: unknown } | undefined) => {
-      if (props === undefined) {
-        return {}
-      }
-
-      const serialized: { [key: string]: unknown } = {}
-
-      for (const key in props) {
-        serialized[key] = props[key]
-        if (Array.isArray(props[key])) {
-          serialized[key] = JSON.stringify(props[key])
-        }
-      }
-
-      return serialized
-    }
-
     const event_params = {
-      ...serialize_properties(payload.properties),
+      ...serializeProperties(payload.properties),
       event_name: payload.eventName
     }
 

--- a/packages/browser-destinations/src/destinations/adobe-target/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/trackEvent/index.ts
@@ -3,6 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { Adobe } from '../types'
 
+// Adobe Target only takes certain event types as valid parameters. We are defaulting to "click".
 const TARGET_EVENT_TYPE = 'click'
 
 const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
@@ -35,10 +36,28 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
     }
   },
   perform: (Adobe, event) => {
-    // Adobe Target only takes certain event types as valid parameters. We are defaulting to "click".
     const payload = event.payload
+
+    // Track does not accept arrays as valid properties, therefore we are stringifying them.
+    const serialize_properties = (props: { [key: string]: unknown } | undefined) => {
+      if (props === undefined) {
+        return {}
+      }
+
+      const serialized: { [key: string]: unknown } = {}
+
+      for (const key in props) {
+        serialized[key] = props[key]
+        if (Array.isArray(props[key])) {
+          serialized[key] = JSON.stringify(props[key])
+        }
+      }
+
+      return serialized
+    }
+
     const event_params = {
-      ...payload.properties,
+      ...serialize_properties(payload.properties),
       event_name: payload.eventName
     }
 

--- a/packages/browser-destinations/src/destinations/adobe-target/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/trackEvent/index.ts
@@ -2,6 +2,7 @@ import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { Adobe } from '../types'
+import { setMbox3rdPartyId } from '../utils'
 
 // Adobe Target only takes certain event types as valid parameters. We are defaulting to "click".
 const TARGET_EVENT_TYPE = 'click'
@@ -33,10 +34,24 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
       default: {
         '@path': '$.properties'
       }
+    },
+    userId: {
+      type: 'string',
+      description:
+        'A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.',
+      label: 'Mbox 3rd Party ID',
+      default: {
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      }
     }
   },
   perform: (Adobe, event) => {
     const payload = event.payload
+    setMbox3rdPartyId(payload.userId)
 
     // Track does not accept arrays as valid properties, therefore we are stringifying them.
     const serialize_properties = (props: { [key: string]: unknown } | undefined) => {

--- a/packages/browser-destinations/src/destinations/adobe-target/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/trackEvent/index.ts
@@ -3,19 +3,27 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { Adobe } from '../types'
 
+const TARGET_EVENT_TYPE = 'click'
+
 const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   title: 'Track Event',
   description: 'Track an event',
   platform: 'web',
   defaultSubscription: 'type = "track"',
   fields: {
-    type: {
+    event_name: {
       label: 'Event Name',
-      description: 'Event type or name.',
+      description: 'This will be sent to Adobe Target as an event parameter called "event_name".',
       type: 'string',
       default: {
-        '@path': '$.type'
+        '@path': '$.event'
       }
+    },
+    type: {
+      label: 'Event Type',
+      description: 'The event type. Please ensure the type entered here is registered and available.',
+      type: 'string',
+      default: TARGET_EVENT_TYPE
     },
     properties: {
       label: 'Event Parameters',
@@ -28,10 +36,9 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   },
   perform: (Adobe, event) => {
     // Adobe Target only takes certain event types as valid parameters. We are defaulting to "click".
-    const TARGET_EVENT_TYPE = 'click'
     const event_params = {
       ...event.payload.properties,
-      event_name: event.payload.type
+      event_name: event.payload.event_name
     }
 
     const params = {

--- a/packages/browser-destinations/src/destinations/adobe-target/triggerView/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/triggerView/generated-types.ts
@@ -15,4 +15,8 @@ export interface Payload {
    * By default, notifications are sent to the Adobe Target backend for incrementing impression count.  If false, notifications are not sent for incrementing impression count.
    */
   sendNotification?: boolean
+  /**
+   * A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.
+   */
+  userId?: string
 }

--- a/packages/browser-destinations/src/destinations/adobe-target/triggerView/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/triggerView/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * Name of thew view or page.
+   * Name of the view or page.
    */
   viewName: string
   /**

--- a/packages/browser-destinations/src/destinations/adobe-target/triggerView/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/triggerView/index.ts
@@ -2,7 +2,7 @@ import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { Adobe } from '../types'
-import { setPageParams } from '../utils'
+import { setPageParams, setMbox3rdPartyId } from '../utils'
 
 const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   title: 'Trigger View',
@@ -33,11 +33,26 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
         'By default, notifications are sent to the Adobe Target backend for incrementing impression count.  If false, notifications are not sent for incrementing impression count. ',
       label: 'Send Notifications to Adobe Target.',
       default: true
+    },
+    userId: {
+      type: 'string',
+      description:
+        'A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.',
+      label: 'Mbox 3rd Party ID',
+      default: {
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      }
     }
   },
   perform: (Adobe, event) => {
     const sendNotification = event.payload.sendNotification
     const pageParams = event.payload.pageParameters
+
+    setMbox3rdPartyId(event.payload.userId)
 
     /*
       NOTE:

--- a/packages/browser-destinations/src/destinations/adobe-target/triggerView/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/triggerView/index.ts
@@ -12,7 +12,7 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   fields: {
     viewName: {
       type: 'string',
-      description: 'Name of thew view or page.',
+      description: 'Name of the view or page.',
       label: 'View Name',
       default: {
         '@path': '$.name'

--- a/packages/browser-destinations/src/destinations/adobe-target/triggerView/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/triggerView/index.ts
@@ -6,7 +6,8 @@ import { setPageParams } from '../utils'
 
 const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   title: 'Trigger View',
-  description: 'Record a view',
+  defaultSubscription: 'type = "page"',
+  description: 'Send page-level data to Adobe Target.',
   platform: 'web',
   fields: {
     viewName: {

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/__tests__/index.test.ts
@@ -12,11 +12,18 @@ describe('Adobe Target Web', () => {
           enabled: true,
           subscribe: 'type = "identify"',
           mapping: {
-            anonymousId: {
-              '@path': '$.anonymousId'
-            },
             userId: {
-              '@path': '$.userId'
+              '@if': {
+                exists: {
+                  '@path': '$.userId'
+                },
+                then: {
+                  '@path': '$.userId'
+                },
+                else: {
+                  '@path': '$.anonymousId'
+                }
+              }
             },
             traits: {
               '@path': '$.traits'
@@ -67,7 +74,7 @@ describe('Adobe Target Web', () => {
         expect.anything(),
         expect.objectContaining({
           payload: {
-            anonymousId: 'random-id-42',
+            userId: 'random-id-42',
             traits: {
               favorite_color: 'blue',
               location: {
@@ -104,7 +111,6 @@ describe('Adobe Target Web', () => {
         expect.objectContaining({
           payload: {
             userId: 'The-Real-ID',
-            anonymousId: 'random-id-42',
             traits: {
               favorite_color: 'blue',
               location: {

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/generated-types.ts
@@ -4,7 +4,7 @@ export interface Payload {
   /**
    * A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.
    */
-  mbox3rdpartyid?: string
+  userId?: string
   /**
    * Profile parameters specific to a user.
    */

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/generated-types.ts
@@ -4,11 +4,7 @@ export interface Payload {
   /**
    * A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.
    */
-  userId?: string
-  /**
-   * Anonymous identifier for the user
-   */
-  anonymousId: string
+  mbox3rdpartyid?: string
   /**
    * Profile parameters specific to a user.
    */

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
@@ -10,26 +10,17 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   platform: 'web',
   defaultSubscription: 'type = "identify"',
   fields: {
-    userId: {
+    mbox3rdpartyid: {
       type: 'string',
       description:
         'A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.',
-      label: 'User ID',
+      label: 'Mbox 3rd Party ID',
       default: {
         '@if': {
           exists: { '@path': '$.userId' },
           then: { '@path': '$.userId' },
           else: { '@path': '$.anonymousId' }
         }
-      }
-    },
-    anonymousId: {
-      type: 'string',
-      required: true,
-      description: 'Anonymous identifier for the user',
-      label: 'Anonymous ID',
-      default: {
-        '@path': '$.anonymousId'
       }
     },
     traits: {

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
@@ -10,7 +10,7 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   platform: 'web',
   defaultSubscription: 'type = "identify"',
   fields: {
-    mbox3rdpartyid: {
+    userId: {
       type: 'string',
       description:
         'A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.',
@@ -27,7 +27,7 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
       type: 'object',
       required: true,
       description: 'Profile parameters specific to a user.',
-      label: 'User Attributes',
+      label: 'Profile Attributes',
       default: {
         '@path': '$.traits'
       }
@@ -39,11 +39,7 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
        identify() and track() actions leverage the same function (adobe.target.trackEvent()) to send data to Adobe.
        identify does not pass an event name, track does.
     */
-
-    setMbox3rdPartyId(event.payload.anonymousId)
-    if (event.payload.userId) {
-      setMbox3rdPartyId(event.payload.userId)
-    }
+    setMbox3rdPartyId(event.payload.userId)
 
     /*
       NOTE:

--- a/packages/browser-destinations/src/destinations/adobe-target/utils.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/utils.ts
@@ -12,3 +12,21 @@ export function setPageParams(params) {
 export function setMbox3rdPartyId(id) {
   setPageParams({ mbox3rdPartyId: id })
 }
+
+// Track does not accept arrays as valid properties, therefore we are stringifying them.
+export function serializeProperties(props: { [key: string]: unknown } | undefined) {
+  if (props === undefined) {
+    return {}
+  }
+
+  const serialized: { [key: string]: unknown } = {}
+
+  for (const key in props) {
+    serialized[key] = props[key]
+    if (Array.isArray(props[key])) {
+      serialized[key] = JSON.stringify(props[key])
+    }
+  }
+
+  return serialized
+}


### PR DESCRIPTION
This PR addresses the issues that were discovered in our first round of QA.

- [x] triggerView: The default event trigger (subscription) should be event type = page
- [x] upsertProfile: This should not have separate fields for anonymousId and userId
- [x] trackEvent: There should be two separate fields for "Event Name" and "Event Type"

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
