### PR TITLE
Talon.One new destination and new actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-    pull_request:
+  pull_request:
 
 jobs:
   test-and-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
+    pull_request:
 
 jobs:
   test-and-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
 
 jobs:
   test-and-build:

--- a/.github/workflows/ext.yml
+++ b/.github/workflows/ext.yml
@@ -2,9 +2,9 @@ name: Test External
 
 on:
   push:
-    branches:
-      - main
-    pull_request:
+#    branches:
+#      - main
+#    pull_request:
 
 jobs:
   install-and-test:

--- a/.github/workflows/ext.yml
+++ b/.github/workflows/ext.yml
@@ -2,6 +2,9 @@ name: Test External
 
 on:
   push:
+    branches:
+      - main
+    pull_request:
 
 jobs:
   install-and-test:

--- a/.github/workflows/ext.yml
+++ b/.github/workflows/ext.yml
@@ -2,9 +2,6 @@ name: Test External
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
 
 jobs:
   install-and-test:

--- a/.github/workflows/ext.yml
+++ b/.github/workflows/ext.yml
@@ -2,9 +2,9 @@ name: Test External
 
 on:
   push:
-#    branches:
-#      - main
-#    pull_request:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   install-and-test:

--- a/packages/destination-actions/src/destinations/talon-one/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/talon-one/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for talon-one destination: createAudience action - all fields 1`] = `
+Object {
+  "audience_id": "Xunf2QoIA0MWf)kFQ",
+  "audience_name": "Xunf2QoIA0MWf)kFQ",
+}
+`;
+
+exports[`Testing snapshot for talon-one destination: createAudience action - required fields 1`] = `
+Object {
+  "audience_id": "Xunf2QoIA0MWf)kFQ",
+  "audience_name": "Xunf2QoIA0MWf)kFQ",
+}
+`;
+
+exports[`Testing snapshot for talon-one destination: trackEvent action - all fields 1`] = `
+Object {
+  "customer_profile_id": "TePOjI",
+  "event_attributes": Object {
+    "testType": "TePOjI",
+  },
+  "event_type": "TePOjI",
+  "type": "TePOjI",
+}
+`;
+
+exports[`Testing snapshot for talon-one destination: trackEvent action - required fields 1`] = `
+Object {
+  "customer_profile_id": "TePOjI",
+  "event_type": "TePOjI",
+  "type": "TePOjI",
+}
+`;
+
+exports[`Testing snapshot for talon-one destination: updateAudience action - all fields 1`] = `
+Object {
+  "audience_name": "XE[HNHsL(",
+}
+`;
+
+exports[`Testing snapshot for talon-one destination: updateAudience action - required fields 1`] = `
+Object {
+  "audience_name": "XE[HNHsL(",
+}
+`;

--- a/packages/destination-actions/src/destinations/talon-one/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/talon-one/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -14,6 +14,26 @@ Object {
 }
 `;
 
+exports[`Testing snapshot for talon-one destination: deleteAudience action - all fields 1`] = `""`;
+
+exports[`Testing snapshot for talon-one destination: deleteAudience action - required fields 1`] = `""`;
+
+exports[`Testing snapshot for talon-one destination: deleteAudience action - required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "ApiKey-v1 YJSS]PGSZ&%5",
+    ],
+    "destination-hostname": Array [
+      "YJSS]PGSZ&%5",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
 exports[`Testing snapshot for talon-one destination: trackEvent action - all fields 1`] = `
 Object {
   "customer_profile_id": "TePOjI",

--- a/packages/destination-actions/src/destinations/talon-one/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/talon-one/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -22,7 +22,7 @@ exports[`Testing snapshot for talon-one destination: deleteAudience action - req
 Headers {
   Symbol(map): Object {
     "authorization": Array [
-      "ApiKey-v1 YJSS]PGSZ&%5",
+      "ApiKey-v1 some_api_key",
     ],
     "destination-hostname": Array [
       "YJSS]PGSZ&%5",

--- a/packages/destination-actions/src/destinations/talon-one/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/__tests__/index.test.ts
@@ -19,7 +19,6 @@ describe('Talon One', () => {
       }
 
       await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()
-      expect(nock.isDone()).toBe(true)
     })
 
     it('invalidate auth token', async () => {
@@ -34,7 +33,6 @@ describe('Talon One', () => {
       }
 
       await expect(testDestination.testAuthentication(settings)).rejects.toThrowError()
-      expect(nock.isDone()).toBe(true)
     })
   })
 })

--- a/packages/destination-actions/src/destinations/talon-one/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/__tests__/index.test.ts
@@ -1,0 +1,40 @@
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+import type { Settings } from '../generated-types'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Talon One', () => {
+  describe('testAuthentication', () => {
+    it('valid auth token', async () => {
+      nock('https://something.europe-west1.talon.one')
+        .get('/v2/authping')
+        .matchHeader('Authorization', 'ApiKey-v1 some_api_key')
+        .reply(204, {})
+
+      const settings: Settings = {
+        api_key: 'some_api_key',
+        deployment: 'https://something.europe-west1.talon.one'
+      }
+
+      await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()
+      expect(nock.isDone()).toBe(true)
+    })
+
+    it('invalidate auth token', async () => {
+      nock('https://something.europe-west1.talon.one')
+        .get('/v2/authping')
+        .matchHeader('Authorization', 'ApiKey-v1 some_api_key')
+        .reply(401, {})
+
+      const settings: Settings = {
+        api_key: 'some_api_key',
+        deployment: 'https://something.europe-west1.talon.one'
+      }
+
+      await expect(testDestination.testAuthentication(settings)).rejects.toThrowError()
+      expect(nock.isDone()).toBe(true)
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/talon-one/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/__tests__/snapshot.test.ts
@@ -25,7 +25,10 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
       const responses = await testDestination.testAction(actionSlug, {
         event: event,
         mapping: event.properties,
-        settings: settingsData,
+        settings: {
+          api_key: 'some_api_key',
+          deployment: settingsData.deployment
+        },
         auth: undefined
       })
 
@@ -60,7 +63,10 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
       const responses = await testDestination.testAction(actionSlug, {
         event: event,
         mapping: event.properties,
-        settings: settingsData,
+        settings: {
+          api_key: 'some_api_key',
+          deployment: settingsData.deployment
+        },
         auth: undefined
       })
 

--- a/packages/destination-actions/src/destinations/talon-one/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/__tests__/snapshot.test.ts
@@ -16,6 +16,7 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
       nock(/.*/).persist().get(/.*/).reply(200)
       nock(/.*/).persist().post(/.*/).reply(200)
       nock(/.*/).persist().put(/.*/).reply(200)
+      nock(/.*/).persist().delete(/.*/).reply(200)
 
       const event = createTestEvent({
         properties: eventData
@@ -50,6 +51,7 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
       nock(/.*/).persist().get(/.*/).reply(200)
       nock(/.*/).persist().post(/.*/).reply(200)
       nock(/.*/).persist().put(/.*/).reply(200)
+      nock(/.*/).persist().delete(/.*/).reply(200)
 
       const event = createTestEvent({
         properties: eventData

--- a/packages/destination-actions/src/destinations/talon-one/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'talon-one'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/talon-one/createAudience/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/talon-one/createAudience/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for TalonOne's createAudience destination action: all fields 1`] = `
+Object {
+  "audience_id": "my[JK",
+  "audience_name": "my[JK",
+}
+`;
+
+exports[`Testing snapshot for TalonOne's createAudience destination action: required fields 1`] = `
+Object {
+  "audience_id": "my[JK",
+  "audience_name": "my[JK",
+}
+`;

--- a/packages/destination-actions/src/destinations/talon-one/createAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/createAudience/__tests__/index.test.ts
@@ -1,0 +1,58 @@
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('TalonOne.createAudience', () => {
+  it('audience_id is missing', async () => {
+    try {
+      await testDestination.testAction('createAudience', {
+        settings: {
+          api_key: 'some_api_key',
+          deployment: 'https://internal.europe-west1.talon.one'
+        }
+      })
+    } catch (err) {
+      expect(err.message).toContain("missing the required field 'audience_id'.")
+    }
+  })
+
+  it('audience_name is missing', async () => {
+    try {
+      await testDestination.testAction('createAudience', {
+        settings: {
+          api_key: 'some_api_key',
+          deployment: 'https://something.europe-west1.talon.one'
+        },
+        mapping: {
+          audience_id: 'some_audience_id'
+        }
+      })
+    } catch (err) {
+      expect(err.message).toContain("missing the required field 'audience_name'.")
+    }
+  })
+
+  it('should work', async () => {
+    nock('https://integration.talon.one')
+      .post('/segment/audiences', {
+        audience_id: 'some_audience_id',
+        audience_name: 'some_audience_name'
+      })
+      .matchHeader('Authorization', 'ApiKey-v1 some_api_key')
+      .matchHeader('destination-hostname', 'https://something.europe-west1.talon.one')
+      .reply(200)
+
+    await testDestination.testAction('createAudience', {
+      settings: {
+        api_key: 'some_api_key',
+        deployment: 'https://something.europe-west1.talon.one'
+      },
+      mapping: {
+        audience_id: 'some_audience_id',
+        audience_name: 'some_audience_name'
+      }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/talon-one/createAudience/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/createAudience/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'createAudience'
+const destinationSlug = 'TalonOne'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/talon-one/createAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/talon-one/createAudience/generated-types.ts
@@ -1,0 +1,12 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Segment Audience ID (Third party audience id)
+   */
+  audience_id: string
+  /**
+   * Segment Audience Name (Third party audience name)
+   */
+  audience_name: string
+}

--- a/packages/destination-actions/src/destinations/talon-one/createAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/talon-one/createAudience/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Payload {
   /**
-   * Segment Audience ID (Third party audience id)
+   * You should get this audience ID from Segment.
    */
   audience_id: string
   /**
-   * Segment Audience Name (Third party audience name)
+   * You should get this audience name from Segment.
    */
   audience_name: string
 }

--- a/packages/destination-actions/src/destinations/talon-one/createAudience/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/createAudience/index.ts
@@ -1,0 +1,34 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Create Audience',
+  description: 'Create Audience in Talon.One',
+  fields: {
+    audience_id: {
+      label: 'audience_id',
+      description: 'Segment Audience ID (Third party audience id)',
+      type: 'string',
+      required: true
+    },
+    audience_name: {
+      label: 'audience_name',
+      description: 'Segment Audience Name (Third party audience name)',
+      type: 'string',
+      required: true
+    }
+  },
+  perform: (request, { payload }) => {
+    // Make your partner api request here!
+    return request(`https://integration.talon.one/segment/audiences`, {
+      method: 'post',
+      json: {
+        audience_id: payload.audience_id,
+        audience_name: payload.audience_name
+      }
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/talon-one/createAudience/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/createAudience/index.ts
@@ -4,17 +4,17 @@ import type { Payload } from './generated-types'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Create Audience',
-  description: 'Create Audience in Talon.One',
+  description: 'This creates a new audience entity in Talon.One.',
   fields: {
     audience_id: {
       label: 'audience_id',
-      description: 'Segment Audience ID (Third party audience id)',
+      description: 'You should get this audience ID from Segment.',
       type: 'string',
       required: true
     },
     audience_name: {
       label: 'audience_name',
-      description: 'Segment Audience Name (Third party audience name)',
+      description: 'You should get this audience name from Segment.',
       type: 'string',
       required: true
     }

--- a/packages/destination-actions/src/destinations/talon-one/deleteAudience/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/talon-one/deleteAudience/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -8,7 +8,7 @@ exports[`Testing snapshot for TalonOne's deleteAudience destination action: requ
 Headers {
   Symbol(map): Object {
     "authorization": Array [
-      "ApiKey-v1 I&DFrgw",
+      "ApiKey-v1 some_api_key",
     ],
     "destination-hostname": Array [
       "I&DFrgw",

--- a/packages/destination-actions/src/destinations/talon-one/deleteAudience/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/talon-one/deleteAudience/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for TalonOne's deleteAudience destination action: all fields 1`] = `""`;
+
+exports[`Testing snapshot for TalonOne's deleteAudience destination action: required fields 1`] = `""`;
+
+exports[`Testing snapshot for TalonOne's deleteAudience destination action: required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "ApiKey-v1 I&DFrgw",
+    ],
+    "destination-hostname": Array [
+      "I&DFrgw",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;

--- a/packages/destination-actions/src/destinations/talon-one/deleteAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/deleteAudience/__tests__/index.test.ts
@@ -4,10 +4,10 @@ import nock from 'nock'
 
 const testDestination = createTestIntegration(Destination)
 
-describe('TalonOne.createAudience', () => {
+describe('TalonOne.deleteAudience', () => {
   it('audience_id is missing', async () => {
     try {
-      await testDestination.testAction('createAudience', {
+      await testDestination.testAction('deleteAudience', {
         settings: {
           api_key: 'some_api_key',
           deployment: 'https://internal.europe-west1.talon.one'
@@ -18,40 +18,20 @@ describe('TalonOne.createAudience', () => {
     }
   })
 
-  it('audience_name is missing', async () => {
-    try {
-      await testDestination.testAction('createAudience', {
-        settings: {
-          api_key: 'some_api_key',
-          deployment: 'https://something.europe-west1.talon.one'
-        },
-        mapping: {
-          audience_id: 'some_audience_id'
-        }
-      })
-    } catch (err) {
-      expect(err.message).toContain("missing the required field 'audience_name'.")
-    }
-  })
-
   it('should work', async () => {
     nock('https://integration.talon.one')
-      .post('/segment/audiences', {
-        audience_id: 'some_audience_id',
-        audience_name: 'some_audience_name'
-      })
+      .delete('/segment/audiences/some_audience_id')
       .matchHeader('Authorization', 'ApiKey-v1 some_api_key')
       .matchHeader('destination-hostname', 'https://something.europe-west1.talon.one')
-      .reply(201)
+      .reply(204)
 
-    await testDestination.testAction('createAudience', {
+    await testDestination.testAction('deleteAudience', {
       settings: {
         api_key: 'some_api_key',
         deployment: 'https://something.europe-west1.talon.one'
       },
       mapping: {
-        audience_id: 'some_audience_id',
-        audience_name: 'some_audience_name'
+        audience_id: 'some_audience_id'
       }
     })
   })

--- a/packages/destination-actions/src/destinations/talon-one/deleteAudience/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/deleteAudience/__tests__/snapshot.test.ts
@@ -25,7 +25,10 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const responses = await testDestination.testAction(actionSlug, {
       event: event,
       mapping: event.properties,
-      settings: settingsData,
+      settings: {
+        api_key: 'some_api_key',
+        deployment: settingsData.deployment
+      },
       auth: undefined
     })
 
@@ -59,7 +62,10 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const responses = await testDestination.testAction(actionSlug, {
       event: event,
       mapping: event.properties,
-      settings: settingsData,
+      settings: {
+        api_key: 'some_api_key',
+        deployment: settingsData.deployment
+      },
       auth: undefined
     })
 

--- a/packages/destination-actions/src/destinations/talon-one/deleteAudience/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/deleteAudience/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'deleteAudience'
+const destinationSlug = 'TalonOne'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/talon-one/deleteAudience/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/deleteAudience/__tests__/snapshot.test.ts
@@ -16,6 +16,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     nock(/.*/).persist().get(/.*/).reply(200)
     nock(/.*/).persist().post(/.*/).reply(200)
     nock(/.*/).persist().put(/.*/).reply(200)
+    nock(/.*/).persist().delete(/.*/).reply(200)
 
     const event = createTestEvent({
       properties: eventData
@@ -49,6 +50,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     nock(/.*/).persist().get(/.*/).reply(200)
     nock(/.*/).persist().post(/.*/).reply(200)
     nock(/.*/).persist().put(/.*/).reply(200)
+    nock(/.*/).persist().delete(/.*/).reply(200)
 
     const event = createTestEvent({
       properties: eventData

--- a/packages/destination-actions/src/destinations/talon-one/deleteAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/talon-one/deleteAudience/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * Segment Audience ID (Third party audience id)
+   * You should get this audience ID from Segment.
    */
   audience_id: string
 }

--- a/packages/destination-actions/src/destinations/talon-one/deleteAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/talon-one/deleteAudience/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Segment Audience ID (Third party audience id)
+   */
+  audience_id: string
+}

--- a/packages/destination-actions/src/destinations/talon-one/deleteAudience/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/deleteAudience/index.ts
@@ -4,7 +4,8 @@ import type { Payload } from './generated-types'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Delete Audience',
-  description: '',
+  description:
+    'Deletepackages/destination-actions/src/destinations/talon-one/deleteAudience/index.ts Audience in Talon.One',
   fields: {
     audience_id: {
       label: 'audience_id',

--- a/packages/destination-actions/src/destinations/talon-one/deleteAudience/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/deleteAudience/index.ts
@@ -1,0 +1,22 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Delete Audience',
+  description: '',
+  fields: {
+    audience_id: {
+      label: 'audience_id',
+      description: 'Segment Audience ID (Third party audience id)',
+      type: 'string',
+      required: true
+    }
+  },
+  perform: (request, { payload }) => {
+    // Make your partner api request here!
+    return request(`https://integration.talon.one/segment/audiences/${payload.audience_id}`, { method: 'delete' })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/talon-one/deleteAudience/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/deleteAudience/index.ts
@@ -4,11 +4,11 @@ import type { Payload } from './generated-types'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Delete Audience',
-  description: 'Delete Audience in Talon.One',
+  description: 'This deletes the audience entity in Talon.One.',
   fields: {
     audience_id: {
       label: 'audience_id',
-      description: 'Segment Audience ID (Third party audience id)',
+      description: 'You should get this audience ID from Segment.',
       type: 'string',
       required: true
     }

--- a/packages/destination-actions/src/destinations/talon-one/deleteAudience/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/deleteAudience/index.ts
@@ -4,8 +4,7 @@ import type { Payload } from './generated-types'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Delete Audience',
-  description:
-    'Deletepackages/destination-actions/src/destinations/talon-one/deleteAudience/index.ts Audience in Talon.One',
+  description: 'Delete Audience in Talon.One',
   fields: {
     audience_id: {
       label: 'audience_id',

--- a/packages/destination-actions/src/destinations/talon-one/generated-types.ts
+++ b/packages/destination-actions/src/destinations/talon-one/generated-types.ts
@@ -1,0 +1,12 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Created under Developer Settings in the Talon.One Campaign Manager.
+   */
+  api_key: string
+  /**
+   * The base URL of your Talon.One deployment.
+   */
+  deployment: string
+}

--- a/packages/destination-actions/src/destinations/talon-one/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/index.ts
@@ -1,0 +1,49 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import createAudience from './createAudience'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Talon One',
+  slug: 'talon-one',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      api_key: {
+        label: 'API Key',
+        description: 'Created under Developer Settings in the Talon.One Campaign Manager.',
+        type: 'string',
+        required: true
+      },
+      deployment: {
+        type: 'string',
+        label: 'Deployment',
+        description: 'The base URL of your Talon.One deployment.',
+        required: true
+      }
+    },
+    testAuthentication: (request, { settings }) => {
+      // Return a request that tests/validates the user's credentials.
+      // If you do not have a way to validate the authentication fields safely,
+      // you can remove the `testAuthentication` function, though discouraged.
+      return request(`${settings.deployment}/v2/authping`, { method: 'GET' })
+    }
+  },
+
+  extendRequest({ settings }) {
+    return {
+      headers: {
+        Authorization: `ApiKey-v1 ${settings.api_key}`,
+        'destination-hostname': `${settings.deployment}`
+      }
+    }
+  },
+
+  actions: {
+    createAudience
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/talon-one/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/index.ts
@@ -2,6 +2,9 @@ import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
 import createAudience from './createAudience'
+import updateAudience from './updateAudience'
+import deleteAudience from './deleteAudience'
+import trackEvent from './trackEvent'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Talon One',
@@ -42,7 +45,10 @@ const destination: DestinationDefinition<Settings> = {
   },
 
   actions: {
-    createAudience
+    createAudience,
+    updateAudience,
+    deleteAudience,
+    trackEvent
   }
 }
 

--- a/packages/destination-actions/src/destinations/talon-one/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/index.ts
@@ -7,7 +7,7 @@ import deleteAudience from './deleteAudience'
 import trackEvent from './trackEvent'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Talon One',
+  name: 'Talon.One',
   slug: 'talon-one',
   mode: 'cloud',
 

--- a/packages/destination-actions/src/destinations/talon-one/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/talon-one/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for TalonOne's trackEvent destination action: all fields 1`] = `
+Object {
+  "customer_profile_id": "Q5oo3QY5I2",
+  "event_attributes": Object {
+    "testType": "Q5oo3QY5I2",
+  },
+  "event_type": "Q5oo3QY5I2",
+  "type": "Q5oo3QY5I2",
+}
+`;
+
+exports[`Testing snapshot for TalonOne's trackEvent destination action: required fields 1`] = `
+Object {
+  "customer_profile_id": "Q5oo3QY5I2",
+  "event_type": "Q5oo3QY5I2",
+  "type": "Q5oo3QY5I2",
+}
+`;

--- a/packages/destination-actions/src/destinations/talon-one/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/trackEvent/__tests__/index.test.ts
@@ -56,7 +56,11 @@ describe('TalonOne.trackEvent', () => {
       .put('/segment/event', {
         customer_profile_id: 'some_customer_profile_id',
         event_type: 'event_type',
-        type: 'string'
+        type: 'string',
+        event_attributes: {
+          favoriteProduct: 'fruits',
+          isDogLover: true
+        }
       })
       .matchHeader('Authorization', 'ApiKey-v1 some_api_key')
       .matchHeader('destination-hostname', 'https://something.europe-west1.talon.one')
@@ -70,7 +74,11 @@ describe('TalonOne.trackEvent', () => {
       mapping: {
         customer_profile_id: 'some_customer_profile_id',
         event_type: 'event_type',
-        type: 'string'
+        type: 'string',
+        event_attributes: {
+          favoriteProduct: 'fruits',
+          isDogLover: true
+        }
       }
     })
   })

--- a/packages/destination-actions/src/destinations/talon-one/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/trackEvent/__tests__/index.test.ts
@@ -1,0 +1,77 @@
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('TalonOne.trackEvent', () => {
+  it('customer_profile_id is missing', async () => {
+    try {
+      await testDestination.testAction('trackEvent', {
+        settings: {
+          api_key: 'some_api_key',
+          deployment: 'https://internal.europe-west1.talon.one'
+        }
+      })
+    } catch (err) {
+      expect(err.message).toContain("missing the required field 'customer_profile_id'.")
+    }
+  })
+
+  it('event_type is missing', async () => {
+    try {
+      await testDestination.testAction('trackEvent', {
+        settings: {
+          api_key: 'some_api_key',
+          deployment: 'https://internal.europe-west1.talon.one'
+        },
+        mapping: {
+          customer_profile_id: 'some_customer_profile_id'
+        }
+      })
+    } catch (err) {
+      expect(err.message).toContain("missing the required field 'event_type'.")
+    }
+  })
+
+  it('type is missing', async () => {
+    try {
+      await testDestination.testAction('trackEvent', {
+        settings: {
+          api_key: 'some_api_key',
+          deployment: 'https://internal.europe-west1.talon.one'
+        },
+        mapping: {
+          customer_profile_id: 'some_customer_profile_id',
+          event_type: 'event_type'
+        }
+      })
+    } catch (err) {
+      expect(err.message).toContain("missing the required field 'type'.")
+    }
+  })
+
+  it('should work', async () => {
+    nock('https://integration.talon.one')
+      .put('/segment/event', {
+        customer_profile_id: 'some_customer_profile_id',
+        event_type: 'event_type',
+        type: 'string'
+      })
+      .matchHeader('Authorization', 'ApiKey-v1 some_api_key')
+      .matchHeader('destination-hostname', 'https://something.europe-west1.talon.one')
+      .reply(200)
+
+    await testDestination.testAction('trackEvent', {
+      settings: {
+        api_key: 'some_api_key',
+        deployment: 'https://something.europe-west1.talon.one'
+      },
+      mapping: {
+        customer_profile_id: 'some_customer_profile_id',
+        event_type: 'event_type',
+        type: 'string'
+      }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/talon-one/trackEvent/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/trackEvent/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'trackEvent'
+const destinationSlug = 'TalonOne'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/talon-one/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/talon-one/trackEvent/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Payload {
   /**
-   * ID of the customer profile as used in Talon.One
+   * Unique identifier of the customer profile associated to the event.
    */
   customer_profile_id: string
   /**
-   * Name of the custom attribute of type `event`
+   * It's just the name of your event.
    */
   event_type: string
   /**

--- a/packages/destination-actions/src/destinations/talon-one/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/talon-one/trackEvent/generated-types.ts
@@ -1,0 +1,22 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * ID of the customer profile as used in Talon.One
+   */
+  customer_profile_id: string
+  /**
+   * Name of the custom attribute of type `event`
+   */
+  event_type: string
+  /**
+   * Type of event. Can be only `string`, `time`, `number`, `boolean`, `location`
+   */
+  type: string
+  /**
+   * Arbitrary additional JSON data associated with the event
+   */
+  event_attributes?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/talon-one/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/trackEvent/index.ts
@@ -4,17 +4,17 @@ import type { Payload } from './generated-types'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track Event',
-  description: 'Track Event in Talon.One',
+  description: 'This records a custom event in Talon.One.',
   fields: {
     customer_profile_id: {
       label: 'customer_profile_id',
-      description: 'ID of the customer profile as used in Talon.One',
+      description: 'Unique identifier of the customer profile associated to the event.',
       type: 'string',
       required: true
     },
     event_type: {
       label: 'event_type',
-      description: 'Name of the custom attribute of type `event`',
+      description: "It's just the name of your event.",
       type: 'string',
       required: true
     },

--- a/packages/destination-actions/src/destinations/talon-one/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/trackEvent/index.ts
@@ -1,0 +1,48 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Track Event',
+  description: 'Track Event in Talon.One',
+  fields: {
+    customer_profile_id: {
+      label: 'customer_profile_id',
+      description: 'ID of the customer profile as used in Talon.One',
+      type: 'string',
+      required: true
+    },
+    event_type: {
+      label: 'event_type',
+      description: 'Name of the custom attribute of type `event`',
+      type: 'string',
+      required: true
+    },
+    type: {
+      label: 'type',
+      description: 'Type of event. Can be only `string`, `time`, `number`, `boolean`, `location`',
+      type: 'string',
+      required: true
+    },
+    event_attributes: {
+      label: 'type',
+      description: 'Arbitrary additional JSON data associated with the event',
+      type: 'object',
+      required: false
+    }
+  },
+  perform: (request, { payload }) => {
+    // Make your partner api request here!
+    return request(`https://integration.talon.one/segment/event`, {
+      method: 'put',
+      json: {
+        customer_profile_id: payload.customer_profile_id,
+        event_type: payload.event_type,
+        type: payload.type,
+        event_attributes: payload.event_attributes
+      }
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/talon-one/updateAudience/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/talon-one/updateAudience/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for TalonOne's updateAudience destination action: all fields 1`] = `
+Object {
+  "audience_name": "O6swM%XrC",
+}
+`;
+
+exports[`Testing snapshot for TalonOne's updateAudience destination action: required fields 1`] = `
+Object {
+  "audience_name": "O6swM%XrC",
+}
+`;

--- a/packages/destination-actions/src/destinations/talon-one/updateAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateAudience/__tests__/index.test.ts
@@ -4,10 +4,10 @@ import nock from 'nock'
 
 const testDestination = createTestIntegration(Destination)
 
-describe('TalonOne.createAudience', () => {
+describe('TalonOne.updateAudience', () => {
   it('audience_id is missing', async () => {
     try {
-      await testDestination.testAction('createAudience', {
+      await testDestination.testAction('updateAudience', {
         settings: {
           api_key: 'some_api_key',
           deployment: 'https://internal.europe-west1.talon.one'
@@ -20,7 +20,7 @@ describe('TalonOne.createAudience', () => {
 
   it('audience_name is missing', async () => {
     try {
-      await testDestination.testAction('createAudience', {
+      await testDestination.testAction('updateAudience', {
         settings: {
           api_key: 'some_api_key',
           deployment: 'https://something.europe-west1.talon.one'
@@ -36,15 +36,14 @@ describe('TalonOne.createAudience', () => {
 
   it('should work', async () => {
     nock('https://integration.talon.one')
-      .post('/segment/audiences', {
-        audience_id: 'some_audience_id',
+      .put('/segment/audiences/some_audience_id', {
         audience_name: 'some_audience_name'
       })
       .matchHeader('Authorization', 'ApiKey-v1 some_api_key')
       .matchHeader('destination-hostname', 'https://something.europe-west1.talon.one')
-      .reply(201)
+      .reply(200)
 
-    await testDestination.testAction('createAudience', {
+    await testDestination.testAction('updateAudience', {
       settings: {
         api_key: 'some_api_key',
         deployment: 'https://something.europe-west1.talon.one'

--- a/packages/destination-actions/src/destinations/talon-one/updateAudience/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateAudience/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'updateAudience'
+const destinationSlug = 'TalonOne'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/talon-one/updateAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateAudience/generated-types.ts
@@ -1,0 +1,12 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Segment Audience ID (Third party audience id)
+   */
+  audience_id: string
+  /**
+   * Segment Audience Name (Third party audience name)
+   */
+  audience_name: string
+}

--- a/packages/destination-actions/src/destinations/talon-one/updateAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateAudience/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Payload {
   /**
-   * Segment Audience ID (Third party audience id)
+   * You should get this audience ID from Segment.
    */
   audience_id: string
   /**
-   * Segment Audience Name (Third party audience name)
+   * You should get this audience name from Segment.
    */
   audience_name: string
 }

--- a/packages/destination-actions/src/destinations/talon-one/updateAudience/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateAudience/index.ts
@@ -1,0 +1,33 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Update Audience',
+  description: 'Update Audience in Talon.One',
+  fields: {
+    audience_id: {
+      label: 'audience_id',
+      description: 'Segment Audience ID (Third party audience id)',
+      type: 'string',
+      required: true
+    },
+    audience_name: {
+      label: 'audience_name',
+      description: 'Segment Audience Name (Third party audience name)',
+      type: 'string',
+      required: true
+    }
+  },
+  perform: (request, { payload }) => {
+    // Make your partner api request here!
+    return request(`https://integration.talon.one/segment/audiences/${payload.audience_id}`, {
+      method: 'put',
+      json: {
+        audience_name: payload.audience_name
+      }
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/talon-one/updateAudience/index.ts
+++ b/packages/destination-actions/src/destinations/talon-one/updateAudience/index.ts
@@ -4,17 +4,17 @@ import type { Payload } from './generated-types'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Update Audience',
-  description: 'Update Audience in Talon.One',
+  description: 'This synchronizes audience data if there is an existing audience entity.',
   fields: {
     audience_id: {
       label: 'audience_id',
-      description: 'Segment Audience ID (Third party audience id)',
+      description: 'You should get this audience ID from Segment.',
       type: 'string',
       required: true
     },
     audience_name: {
       label: 'audience_name',
-      description: 'Segment Audience Name (Third party audience name)',
+      description: 'You should get this audience name from Segment.',
       type: 'string',
       required: true
     }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

- Add a new destination `Talon.One`
- Add authorization and unit tests for it
- Add new actions `createAudience`, `updateAudience`, `deleteAudience`, `trackEvent` and unit tests

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
