### PR TITLE
Facebook Conversions API: Add customData to all actions

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
@@ -21,7 +21,12 @@ describe('FacebookConversionsApi', () => {
           action_source: 'email',
           currency: 'USD',
           value: 12.12,
-          email: 'nicholas.aguilar@segment.com'
+          email: 'nicholas.aguilar@segment.com',
+          traits: {
+            city: 'Gotham',
+            country: 'United States',
+            last_name: 'Wayne'
+          }
         }
       })
 
@@ -45,12 +50,19 @@ describe('FacebookConversionsApi', () => {
           },
           event_time: {
             '@path': '$.timestamp'
+          },
+          custom_data: {
+            '@path': '$.properties.traits'
           }
         }
       })
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"AddToCart\\",\\"event_time\\":\\"1631210000\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"city\\":\\"Gotham\\",\\"country\\":\\"United States\\",\\"last_name\\":\\"Wayne\\",\\"currency\\":\\"USD\\",\\"value\\":12.12}}]}"`
+      )
     })
 
     it('should throw an error for invalid currency values', async () => {
@@ -120,6 +132,10 @@ describe('FacebookConversionsApi', () => {
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"AddToCart\\",\\"event_time\\":\\"2022-03-08T00:18:54.304Z\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"1c505335-3da0-4a09-b243-5c5ad8a3c0e2\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"external_id\\":\\"831c237928e6212bedaa4451a514ace3174562f6761f6a157a2fe5082b36e2fb\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":100,\\"contents\\":[{\\"id\\":\\"abc12345\\",\\"quantity\\":1,\\"item_price\\":100}]}}]}"`
+      )
     })
 
     it('should throw an error if no id parameter is included in contents array objects', async () => {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
@@ -112,10 +112,11 @@ describe('FacebookConversionsApi', () => {
 
       const event = createTestEvent({
         event: 'Product Added',
+        timestamp: '1631210020',
+        messageId: 'test',
         properties: {
           userId: 'testuser1234',
           action_source: 'email',
-          timestamp: '1631210020',
           currency: 'USD',
           product_id: 'abc12345',
           quantity: 1,
@@ -134,7 +135,7 @@ describe('FacebookConversionsApi', () => {
       expect(responses[0].status).toBe(201)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"data\\":[{\\"event_name\\":\\"AddToCart\\",\\"event_time\\":\\"2022-03-08T00:18:54.304Z\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"1c505335-3da0-4a09-b243-5c5ad8a3c0e2\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"external_id\\":\\"831c237928e6212bedaa4451a514ace3174562f6761f6a157a2fe5082b36e2fb\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":100,\\"contents\\":[{\\"id\\":\\"abc12345\\",\\"quantity\\":1,\\"item_price\\":100}]}}]}"`
+        `"{\\"data\\":[{\\"event_name\\":\\"AddToCart\\",\\"event_time\\":\\"1631210020\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"test\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"external_id\\":\\"831c237928e6212bedaa4451a514ace3174562f6761f6a157a2fe5082b36e2fb\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":100,\\"contents\\":[{\\"id\\":\\"abc12345\\",\\"quantity\\":1,\\"item_price\\":100}]}}]}"`
       )
     })
 
@@ -189,7 +190,7 @@ describe('FacebookConversionsApi', () => {
             }
           }
         })
-      ).rejects.toThrowError("Contents objects must include an 'id' parameter.")
+      ).rejects.toThrowError("contents[0] must include an 'id' parameter.")
     })
 
     it('should throw an error if contents.delivery_category is not supported', async () => {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/custom.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/custom.test.ts
@@ -142,12 +142,17 @@ describe('FacebookConversionsApi', () => {
         settings,
         useDefaultMappings: true,
         mapping: {
-          action_source: { '@path': '$.properties.action_source' }
+          action_source: { '@path': '$.properties.action_source' },
+          custom_data: { '@path': '$.properties' }
         }
       })
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"identify\\",\\"event_time\\":\\"2015-02-23T22:28:55.111Z\\",\\"action_source\\":\\"website\\",\\"event_id\\":\\"022bb90c-bbac-11e4-8dfc-aa07a5b093db\\",\\"user_data\\":{\\"external_id\\":\\"df73b86ff613b9d7008c175ae3c3aa3f2c1ea1674a80cac85274d58048e44127\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36\\"},\\"custom_data\\":{\\"action_source\\":\\"website\\",\\"timestamp\\":\\"1633473963\\"}}]}"`
+      )
     })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/initiateCheckout.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/initiateCheckout.test.ts
@@ -50,6 +50,10 @@ describe('FacebookConversionsApi', () => {
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"InitiateCheckout\\",\\"event_time\\":\\"1631210000\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12}}]}"`
+      )
     })
 
     it('should throw an error for invalid currency values', async () => {
@@ -121,6 +125,10 @@ describe('FacebookConversionsApi', () => {
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"InitiateCheckout\\",\\"event_time\\":\\"2022-03-08T00:27:00.678Z\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"9da7c0b1-47fe-454a-9f4b-3a5f8cbd16a7\\",\\"user_data\\":{\\"external_id\\":\\"831c237928e6212bedaa4451a514ace3174562f6761f6a157a2fe5082b36e2fb\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"contents\\":[{\\"id\\":\\"123\\",\\"quantity\\":1,\\"item_price\\":100},{\\"id\\":\\"345\\",\\"quantity\\":2,\\"item_price\\":50}]}}]}"`
+      )
     })
 
     it('should throw an error if no user_data keys are included', async () => {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/initiateCheckout.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/initiateCheckout.test.ts
@@ -103,10 +103,11 @@ describe('FacebookConversionsApi', () => {
 
       const event = createTestEvent({
         event: 'Checkout Started',
+        timestamp: '1631210020',
+        messageId: 'test',
         properties: {
           userId: 'testuser1234',
           action_source: 'email',
-          timestamp: '1631210020',
           currency: 'USD',
           revenue: 12.12,
           products: [
@@ -127,7 +128,7 @@ describe('FacebookConversionsApi', () => {
       expect(responses[0].status).toBe(201)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"data\\":[{\\"event_name\\":\\"InitiateCheckout\\",\\"event_time\\":\\"2022-03-08T00:27:00.678Z\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"9da7c0b1-47fe-454a-9f4b-3a5f8cbd16a7\\",\\"user_data\\":{\\"external_id\\":\\"831c237928e6212bedaa4451a514ace3174562f6761f6a157a2fe5082b36e2fb\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"contents\\":[{\\"id\\":\\"123\\",\\"quantity\\":1,\\"item_price\\":100},{\\"id\\":\\"345\\",\\"quantity\\":2,\\"item_price\\":50}]}}]}"`
+        `"{\\"data\\":[{\\"event_name\\":\\"InitiateCheckout\\",\\"event_time\\":\\"1631210020\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"test\\",\\"user_data\\":{\\"external_id\\":\\"831c237928e6212bedaa4451a514ace3174562f6761f6a157a2fe5082b36e2fb\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"contents\\":[{\\"id\\":\\"123\\",\\"quantity\\":1,\\"item_price\\":100},{\\"id\\":\\"345\\",\\"quantity\\":2,\\"item_price\\":50}]}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/pageView.test.ts
@@ -16,6 +16,8 @@ describe('FacebookConversionsApi', () => {
       const event = createTestEvent({
         type: 'page',
         userId: 'abc123',
+        timestamp: '1631210020',
+        messageId: 'test',
         properties: {
           timestamp: 1631210000,
           action_source: 'email',
@@ -34,7 +36,7 @@ describe('FacebookConversionsApi', () => {
       expect(responses[0].status).toBe(201)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"data\\":[{\\"event_name\\":\\"PageView\\",\\"event_time\\":\\"2022-03-08T00:29:43.256Z\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"c8bbf89a-ccf3-4b04-bda6-b2032828d4e3\\",\\"user_data\\":{\\"external_id\\":\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"}}]}"`
+        `"{\\"data\\":[{\\"event_name\\":\\"PageView\\",\\"event_time\\":\\"1631210020\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"test\\",\\"user_data\\":{\\"external_id\\":\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"}}]}"`
       )
     })
 
@@ -77,10 +79,11 @@ describe('FacebookConversionsApi', () => {
 
       const event = createTestEvent({
         event: 'Product Added',
+        timestamp: '1631210020',
+        messageId: 'test',
         properties: {
           userId: 'testuser1234',
-          action_source: 'email',
-          timestamp: 1631210020
+          action_source: 'email'
         }
       })
 
@@ -95,7 +98,7 @@ describe('FacebookConversionsApi', () => {
       expect(responses[0].status).toBe(201)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"data\\":[{\\"event_name\\":\\"PageView\\",\\"event_time\\":\\"2022-03-08T00:29:43.364Z\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"7da6b203-2828-44e3-82ee-796eaf20810e\\",\\"user_data\\":{\\"external_id\\":\\"831c237928e6212bedaa4451a514ace3174562f6761f6a157a2fe5082b36e2fb\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"}}]}"`
+        `"{\\"data\\":[{\\"event_name\\":\\"PageView\\",\\"event_time\\":\\"1631210020\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"test\\",\\"user_data\\":{\\"external_id\\":\\"831c237928e6212bedaa4451a514ace3174562f6761f6a157a2fe5082b36e2fb\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/pageView.test.ts
@@ -32,6 +32,10 @@ describe('FacebookConversionsApi', () => {
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"PageView\\",\\"event_time\\":\\"2022-03-08T00:29:43.256Z\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"c8bbf89a-ccf3-4b04-bda6-b2032828d4e3\\",\\"user_data\\":{\\"external_id\\":\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"}}]}"`
+      )
     })
 
     it('should throw an error when action_source is website and no client_user_agent', async () => {
@@ -89,6 +93,10 @@ describe('FacebookConversionsApi', () => {
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"PageView\\",\\"event_time\\":\\"2022-03-08T00:29:43.364Z\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"7da6b203-2828-44e3-82ee-796eaf20810e\\",\\"user_data\\":{\\"external_id\\":\\"831c237928e6212bedaa4451a514ace3174562f6761f6a157a2fe5082b36e2fb\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"}}]}"`
+      )
     })
 
     it('should throw an error if no user_data keys are included', async () => {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/purchase.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/purchase.test.ts
@@ -74,6 +74,10 @@ describe('purchase', () => {
 
     expect(responses.length).toBe(1)
     expect(responses[0].status).toBe(201)
+
+    expect(responses[0].options.body).toMatchInlineSnapshot(
+      `"{\\"data\\":[{\\"event_name\\":\\"Purchase\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"content_ids\\":[\\"ABC123\\",\\"XYZ789\\"],\\"content_name\\":\\"Shoes\\",\\"content_type\\":\\"product\\",\\"contents\\":[{\\"id\\":\\"ABC123\\",\\"quantity\\":2},{\\"id\\":\\"XYZ789\\",\\"quantity\\":3}],\\"num_items\\":2}}]}"`
+    )
   })
 
   it('should handle default mappings', async () => {
@@ -103,6 +107,10 @@ describe('purchase', () => {
 
     expect(responses.length).toBe(1)
     expect(responses[0].status).toBe(201)
+
+    expect(responses[0].options.body).toMatchInlineSnapshot(
+      `"{\\"data\\":[{\\"event_name\\":\\"Purchase\\",\\"event_time\\":\\"2022-03-08T00:29:32.427Z\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"a2113a32-9e24-4efb-a846-017569ccb134\\",\\"user_data\\":{\\"external_id\\":\\"831c237928e6212bedaa4451a514ace3174562f6761f6a157a2fe5082b36e2fb\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"contents\\":[{\\"id\\":\\"123\\",\\"quantity\\":1,\\"item_price\\":100},{\\"id\\":\\"345\\",\\"quantity\\":2,\\"item_price\\":50}]}}]}"`
+    )
   })
 
   it('should throw an error when currency and value are missing', async () => {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/purchase.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/purchase.test.ts
@@ -85,10 +85,11 @@ describe('purchase', () => {
 
     const event = createTestEvent({
       event: 'Order Completed',
+      messageId: 'test',
+      timestamp: '1631210063',
       properties: {
         userId: 'testuser1234',
         action_source: 'email',
-        timestamp: '1631210020',
         currency: 'USD',
         revenue: 12.12,
         products: [
@@ -109,7 +110,7 @@ describe('purchase', () => {
     expect(responses[0].status).toBe(201)
 
     expect(responses[0].options.body).toMatchInlineSnapshot(
-      `"{\\"data\\":[{\\"event_name\\":\\"Purchase\\",\\"event_time\\":\\"2022-03-08T00:29:32.427Z\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"a2113a32-9e24-4efb-a846-017569ccb134\\",\\"user_data\\":{\\"external_id\\":\\"831c237928e6212bedaa4451a514ace3174562f6761f6a157a2fe5082b36e2fb\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"contents\\":[{\\"id\\":\\"123\\",\\"quantity\\":1,\\"item_price\\":100},{\\"id\\":\\"345\\",\\"quantity\\":2,\\"item_price\\":50}]}}]}"`
+      `"{\\"data\\":[{\\"event_name\\":\\"Purchase\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"test\\",\\"user_data\\":{\\"external_id\\":\\"831c237928e6212bedaa4451a514ace3174562f6761f6a157a2fe5082b36e2fb\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"contents\\":[{\\"id\\":\\"123\\",\\"quantity\\":1,\\"item_price\\":100},{\\"id\\":\\"345\\",\\"quantity\\":2,\\"item_price\\":50}]}}]}"`
     )
   })
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/search.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/search.test.ts
@@ -80,6 +80,7 @@ describe('FacebookConversionsApi', () => {
 
       const event = createTestEvent({
         event: 'Products Searched',
+        messageId: 'test',
         userId: 'abc123',
         timestamp: '1631210063',
         properties: {
@@ -103,7 +104,7 @@ describe('FacebookConversionsApi', () => {
       expect(responses[0].status).toBe(201)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"data\\":[{\\"event_name\\":\\"Search\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"event_id\\":\\"9622c849-f20f-4d10-bced-227381f11905\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"user_data\\":{\\"external_id\\":\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"contents\\":[{\\"id\\":\\"tsla_s_2021\\",\\"quantity\\":1,\\"item_price\\":120000}],\\"search_string\\":\\"Tesla Model S\\"}}]}"`
+        `"{\\"data\\":[{\\"event_name\\":\\"Search\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"event_id\\":\\"test\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"user_data\\":{\\"external_id\\":\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"contents\\":[{\\"id\\":\\"tsla_s_2021\\",\\"quantity\\":1,\\"item_price\\":120000}],\\"search_string\\":\\"Tesla Model S\\"}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/search.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/search.test.ts
@@ -69,6 +69,10 @@ describe('FacebookConversionsApi', () => {
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"Search\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"content_ids\\":[\\"ABC123\\",\\"XYZ789\\"],\\"contents\\":[{\\"id\\":\\"ABC123\\",\\"quantity\\":2},{\\"id\\":\\"XYZ789\\",\\"quantity\\":3}],\\"content_category\\":\\"Cookies\\",\\"value\\":12.12,\\"search_string\\":\\"Oreo\`s Quadruple Stack\\"}}]}"`
+      )
     })
 
     it('should handle default mappings', async () => {
@@ -97,6 +101,10 @@ describe('FacebookConversionsApi', () => {
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"Search\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"event_id\\":\\"9622c849-f20f-4d10-bced-227381f11905\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"user_data\\":{\\"external_id\\":\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"contents\\":[{\\"id\\":\\"tsla_s_2021\\",\\"quantity\\":1,\\"item_price\\":120000}],\\"search_string\\":\\"Tesla Model S\\"}}]}"`
+      )
     })
 
     it('should throw an error if no user_data keys are included', async () => {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/viewContent.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/viewContent.test.ts
@@ -76,6 +76,10 @@ describe('FacebookConversionsApi', () => {
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"ViewContent\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"content_ids\\":[\\"ABC123\\",\\"XYZ789\\"],\\"content_name\\":\\"Oreo's Quadruple Stack\\",\\"content_type\\":\\"product\\",\\"contents\\":[{\\"id\\":\\"ABC123\\",\\"quantity\\":2},{\\"id\\":\\"XYZ789\\",\\"quantity\\":3}]}}]}"`
+      )
     })
 
     it('should handle default mappings', async () => {
@@ -104,6 +108,10 @@ describe('FacebookConversionsApi', () => {
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"ViewContent\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"event_id\\":\\"b2498afd-281c-4371-983e-67d433d6cade\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"user_data\\":{\\"external_id\\":\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":120000,\\"content_ids\\":[\\"tsla_s_2021\\"],\\"contents\\":[{\\"id\\":\\"tsla_s_2021\\",\\"quantity\\":1,\\"item_price\\":120000}]}}]}"`
+      )
     })
 
     it('should throw an error if no user_data keys are included', async () => {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/viewContent.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/viewContent.test.ts
@@ -89,6 +89,7 @@ describe('FacebookConversionsApi', () => {
         event: 'Product Viewed',
         userId: 'abc123',
         timestamp: '1631210063',
+        messageId: 'test',
         properties: {
           action_source: 'email',
           currency: 'USD',
@@ -110,7 +111,7 @@ describe('FacebookConversionsApi', () => {
       expect(responses[0].status).toBe(201)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"data\\":[{\\"event_name\\":\\"ViewContent\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"event_id\\":\\"b2498afd-281c-4371-983e-67d433d6cade\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"user_data\\":{\\"external_id\\":\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":120000,\\"content_ids\\":[\\"tsla_s_2021\\"],\\"contents\\":[{\\"id\\":\\"tsla_s_2021\\",\\"quantity\\":1,\\"item_price\\":120000}]}}]}"`
+        `"{\\"data\\":[{\\"event_name\\":\\"ViewContent\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"event_id\\":\\"test\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"user_data\\":{\\"external_id\\":\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":120000,\\"content_ids\\":[\\"tsla_s_2021\\"],\\"contents\\":[{\\"id\\":\\"tsla_s_2021\\",\\"quantity\\":1,\\"item_price\\":120000}]}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
@@ -135,4 +135,10 @@ export interface Payload {
    * The value of a user performing this event to the business.
    */
   value?: number
+  /**
+   * The custom data object which can be used to pass custom properties. See [here](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/custom-data) for more information
+   */
+  custom_data?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
@@ -93,6 +93,7 @@ const action: ActionDefinition<Settings, Payload> = {
             action_source: payload.action_source,
             user_data: hash_user_data({ user_data: payload.user_data }),
             custom_data: {
+              ...payload.custom_data,
               currency: payload.currency,
               value: payload.value,
               content_ids: payload.content_ids,

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
@@ -6,12 +6,14 @@ import {
   content_name,
   content_type,
   contents,
+  validateContents,
   currency,
   value,
   action_source,
   event_time,
   event_source_url,
-  event_id
+  event_id,
+  custom_data
 } from '../fb-capi-properties'
 import { CURRENCY_ISO_CODES, API_VERSION } from '../constants'
 import { hash_user_data, user_data_field } from '../fb-capi-user-data'
@@ -50,7 +52,8 @@ const action: ActionDefinition<Settings, Payload> = {
     currency: currency,
     event_id: event_id,
     event_source_url: event_source_url,
-    value: { ...value, default: { '@path': '$.properties.price' } }
+    value: { ...value, default: { '@path': '$.properties.price' } },
+    custom_data: custom_data
   },
   perform: (request, { payload, settings }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.has(payload.currency)) {
@@ -73,25 +76,9 @@ const action: ActionDefinition<Settings, Payload> = {
       )
     }
 
-    const valid_delivery_categories = ['in_store', 'curbside', 'home_delivery']
     if (payload.contents) {
-      payload.contents.forEach((obj, index) => {
-        if (!obj.id) {
-          throw new IntegrationError(
-            "Contents objects must include an 'id' parameter.",
-            'Misconfigured required field',
-            400
-          )
-        }
-
-        if (obj.delivery_category && !valid_delivery_categories.includes(obj.delivery_category)) {
-          throw new IntegrationError(
-            `contents[${index}].delivery_category must be one of {in_store, home_delivery, curbside}.`,
-            'Misconfigured field',
-            400
-          )
-        }
-      })
+      const err = validateContents(payload.contents)
+      if (err) throw err
     }
 
     return request(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}/events`, {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { action_source, event_id, event_source_url, event_time } from '../fb-capi-properties'
+import { action_source, custom_data, event_id, event_source_url, event_time } from '../fb-capi-properties'
 import { hash_user_data, user_data_field } from '../fb-capi-user-data'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -20,12 +20,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     event_time: { ...event_time, required: true },
     user_data: user_data_field,
-    custom_data: {
-      label: 'Custom Data',
-      description:
-        'The custom data object which can be used to pass custom properties. See [here](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/custom-data) for more information',
-      type: 'object'
-    },
+    custom_data: custom_data,
     event_id: event_id,
     event_source_url: event_source_url
   },

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
@@ -92,23 +92,21 @@ type Content = {
 export const validateContents = (contents: Content[]): IntegrationError | false => {
   const valid_delivery_categories = ['in_store', 'curbside', 'home_delivery']
 
-  contents.forEach((obj, index) => {
-    if (!obj.id) {
-      return new IntegrationError(
-        "Contents objects must include an 'id' parameter.",
-        'Misconfigured required field',
-        400
-      )
+  for (let i = 0; i < contents.length; i++) {
+    const item = contents[i]
+
+    if (!item.id) {
+      return new IntegrationError(`contents[${i}] must include an 'id' parameter.`, 'Misconfigured required field', 400)
     }
 
-    if (obj.delivery_category && !valid_delivery_categories.includes(obj.delivery_category)) {
+    if (item.delivery_category && !valid_delivery_categories.includes(item.delivery_category)) {
       return new IntegrationError(
-        `contents[${index}].delivery_category must be one of {in_store, home_delivery, curbside}.`,
+        `contents[${i}].delivery_category must be one of {in_store, home_delivery, curbside}.`,
         'Misconfigured field',
         400
       )
     }
-  })
+  }
 
   return false
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
@@ -1,8 +1,16 @@
 import { InputField } from '@segment/actions-core/src/destination-kit/types'
+import { IntegrationError } from '@segment/actions-core'
 
 // Implementation of the facebook pixel object properties.
 // https://developers.facebook.com/docs/facebook-pixel/reference#object-properties
 // Only implemented properties that are shared between more than one action.
+
+export const custom_data: InputField = {
+  label: 'Custom Data',
+  description:
+    'The custom data object which can be used to pass custom properties. See [here](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/custom-data) for more information',
+  type: 'object'
+}
 
 export const currency: InputField = {
   label: 'Currency',
@@ -16,7 +24,7 @@ export const currency: InputField = {
 export const value: InputField = {
   label: 'Value',
   description: 'The value of a user performing this event to the business.',
-  type: 'number',
+  type: 'number'
 }
 
 export const content_category: InputField = {
@@ -29,7 +37,7 @@ export const content_ids: InputField = {
   label: 'Content IDs',
   description: 'Product IDs associated with the event, such as SKUs (e.g. ["ABC123", "XYZ789"]).',
   type: 'string',
-  multiple: true,
+  multiple: true
 }
 
 export const content_name: InputField = {
@@ -46,19 +54,20 @@ export const content_type: InputField = {
 
 export const contents: InputField = {
   label: 'Contents',
-  description: 'An array of JSON objects that contains the quantity and the International Article Number (EAN) when applicable, or other product or content identifier(s). id and quantity are the required fields.',
+  description:
+    'An array of JSON objects that contains the quantity and the International Article Number (EAN) when applicable, or other product or content identifier(s). id and quantity are the required fields.',
   type: 'object',
   multiple: true,
   properties: {
     id: {
       label: 'ID',
       description: 'ID of the purchased item.',
-      type: 'string',
+      type: 'string'
     },
     quantity: {
       label: 'Quantity',
       description: 'The number of items purchased.',
-      type: 'integer',
+      type: 'integer'
     },
     item_price: {
       label: 'Item Price',
@@ -67,10 +76,40 @@ export const contents: InputField = {
     },
     delivery_category: {
       label: 'Delivery Category',
-      description: 'Type of delivery for a purchase event. Supported values are "in_store", "curbside", "home_delivery".',
+      description:
+        'Type of delivery for a purchase event. Supported values are "in_store", "curbside", "home_delivery".',
       type: 'string'
     }
   }
+}
+
+type Content = {
+  id?: string
+  delivery_category?: string
+}
+
+export const validateContents = (contents: Content[]): IntegrationError | false => {
+  const valid_delivery_categories = ['in_store', 'curbside', 'home_delivery']
+
+  contents.forEach((obj, index) => {
+    if (!obj.id) {
+      return new IntegrationError(
+        "Contents objects must include an 'id' parameter.",
+        'Misconfigured required field',
+        400
+      )
+    }
+
+    if (obj.delivery_category && !valid_delivery_categories.includes(obj.delivery_category)) {
+      return new IntegrationError(
+        `contents[${index}].delivery_category must be one of {in_store, home_delivery, curbside}.`,
+        'Misconfigured field',
+        400
+      )
+    }
+  })
+
+  return false
 }
 
 export const num_items: InputField = {
@@ -99,7 +138,8 @@ export const action_source: InputField = {
 
 export const event_source_url: InputField = {
   label: 'Event Source URL',
-  description: 'The browser URL where the event happened. The URL must begin with http:// or https:// and should match the verified domain. event_source_url is required if action_source = “website”; however it is strongly recommended that you include it for any action_source.',
+  description:
+    'The browser URL where the event happened. The URL must begin with http:// or https:// and should match the verified domain. event_source_url is required if action_source = “website”; however it is strongly recommended that you include it for any action_source.',
   type: 'string',
   default: {
     '@path': '$.context.page.url'
@@ -108,7 +148,8 @@ export const event_source_url: InputField = {
 
 export const event_id: InputField = {
   label: 'Event ID',
-  description: 'This ID can be any unique string chosen by the advertiser. event_id is used to deduplicate events sent by both Facebook Pixel and Conversions API.',
+  description:
+    'This ID can be any unique string chosen by the advertiser. event_id is used to deduplicate events sent by both Facebook Pixel and Conversions API.',
   type: 'string',
   default: {
     '@path': '$.messageId'

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
@@ -5,6 +5,11 @@ import { IntegrationError } from '@segment/actions-core'
 // https://developers.facebook.com/docs/facebook-pixel/reference#object-properties
 // Only implemented properties that are shared between more than one action.
 
+type Content = {
+  id?: string
+  delivery_category?: string
+}
+
 export const custom_data: InputField = {
   label: 'Custom Data',
   description:
@@ -82,11 +87,6 @@ export const contents: InputField = {
       type: 'string'
     }
   }
-}
-
-type Content = {
-  id?: string
-  delivery_category?: string
 }
 
 export const validateContents = (contents: Content[]): IntegrationError | false => {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
@@ -9,7 +9,8 @@ export const custom_data: InputField = {
   label: 'Custom Data',
   description:
     'The custom data object which can be used to pass custom properties. See [here](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/custom-data) for more information',
-  type: 'object'
+  type: 'object',
+  defaultObjectUI: 'keyvalue'
 }
 
 export const currency: InputField = {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
@@ -135,4 +135,10 @@ export interface Payload {
    * The value of a user performing this event to the business.
    */
   value?: number
+  /**
+   * The custom data object which can be used to pass custom properties. See [here](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/custom-data) for more information
+   */
+  custom_data?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
@@ -96,6 +96,7 @@ const action: ActionDefinition<Settings, Payload> = {
             event_id: payload.event_id,
             user_data: hash_user_data({ user_data: payload.user_data }),
             custom_data: {
+              ...payload.custom_data,
               currency: payload.currency,
               value: payload.value,
               content_ids: payload.content_ids,

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
@@ -6,10 +6,12 @@ import {
   currency,
   value,
   contents,
+  validateContents,
   num_items,
   content_ids,
   event_time,
   action_source,
+  custom_data,
   content_category,
   event_source_url,
   event_id
@@ -53,7 +55,8 @@ const action: ActionDefinition<Settings, Payload> = {
     value: {
       ...value,
       default: { '@path': '$.properties.revenue' }
-    }
+    },
+    custom_data: custom_data
   },
   perform: (request, { payload, settings }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.has(payload.currency)) {
@@ -76,25 +79,9 @@ const action: ActionDefinition<Settings, Payload> = {
       )
     }
 
-    const valid_delivery_categories = ['in_store', 'curbside', 'home_delivery']
     if (payload.contents) {
-      payload.contents.forEach((obj, index) => {
-        if (!obj.id) {
-          throw new IntegrationError(
-            "Contents objects must include an 'id' parameter.",
-            'Misconfigured required field',
-            400
-          )
-        }
-
-        if (obj.delivery_category && !valid_delivery_categories.includes(obj.delivery_category)) {
-          throw new IntegrationError(
-            `contents[${index}].delivery_category must be one of {in_store, home_delivery, curbside}.`,
-            'Misconfigured field',
-            400
-          )
-        }
-      })
+      const err = validateContents(payload.contents)
+      if (err) throw err
     }
 
     return request(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}/events`, {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
@@ -94,4 +94,10 @@ export interface Payload {
    * The browser URL where the event happened. The URL must begin with http:// or https:// and should match the verified domain. event_source_url is required if action_source = “website”; however it is strongly recommended that you include it for any action_source.
    */
   event_source_url?: string
+  /**
+   * The custom data object which can be used to pass custom properties. See [here](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/custom-data) for more information
+   */
+  custom_data?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/index.ts
@@ -1,5 +1,5 @@
-import  { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { action_source, event_time, event_id, event_source_url } from '../fb-capi-properties'
+import { ActionDefinition, IntegrationError } from '@segment/actions-core'
+import { action_source, custom_data, event_time, event_id, event_source_url } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -13,7 +13,8 @@ const action: ActionDefinition<Settings, Payload> = {
     event_time: { ...event_time, required: true },
     user_data: user_data_field,
     event_id: event_id,
-    event_source_url: event_source_url
+    event_source_url: event_source_url,
+    custom_data: custom_data
   },
   perform: (request, { payload, settings }) => {
     if (!payload.user_data) {
@@ -37,7 +38,7 @@ const action: ActionDefinition<Settings, Payload> = {
             action_source: payload.action_source,
             event_source_url: payload.event_source_url,
             event_id: payload.event_id,
-            user_data: hash_user_data({user_data: payload.user_data})
+            user_data: hash_user_data({ user_data: payload.user_data })
           }
         ]
       }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
@@ -139,4 +139,10 @@ export interface Payload {
    * The number of items when checkout was initiated.
    */
   num_items?: number
+  /**
+   * The custom data object which can be used to pass custom properties. See [here](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/custom-data) for more information
+   */
+  custom_data?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
@@ -99,6 +99,7 @@ const action: ActionDefinition<Settings, Payload> = {
             event_id: payload.event_id,
             user_data: hash_user_data({ user_data: payload.user_data }),
             custom_data: {
+              ...payload.custom_data,
               currency: payload.currency,
               value: payload.value,
               content_ids: payload.content_ids,

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
@@ -8,6 +8,8 @@ import {
   content_name,
   content_type,
   contents,
+  validateContents,
+  custom_data,
   num_items,
   content_ids,
   event_time,
@@ -56,7 +58,8 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     event_id: event_id,
     event_source_url: event_source_url,
-    num_items: num_items
+    num_items: num_items,
+    custom_data: custom_data
   },
   perform: (request, { payload, settings }) => {
     if (!CURRENCY_ISO_CODES.has(payload.currency)) {
@@ -79,25 +82,9 @@ const action: ActionDefinition<Settings, Payload> = {
       )
     }
 
-    const valid_delivery_categories = ['in_store', 'curbside', 'home_delivery']
     if (payload.contents) {
-      payload.contents.forEach((obj, index) => {
-        if (!obj.id) {
-          throw new IntegrationError(
-            "Contents objects must include an 'id' parameter.",
-            'Misconfigured required field',
-            400
-          )
-        }
-
-        if (obj.delivery_category && !valid_delivery_categories.includes(obj.delivery_category)) {
-          throw new IntegrationError(
-            `contents[${index}].delivery_category must be one of {in_store, home_delivery, curbside}.`,
-            'Misconfigured field',
-            400
-          )
-        }
-      })
+      const err = validateContents(payload.contents)
+      if (err) throw err
     }
 
     return request(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}/events`, {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
@@ -135,4 +135,10 @@ export interface Payload {
    * The value of a user performing this event to the business.
    */
   value?: number
+  /**
+   * The custom data object which can be used to pass custom properties. See [here](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/custom-data) for more information
+   */
+  custom_data?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
@@ -99,6 +99,7 @@ const action: ActionDefinition<Settings, Payload> = {
             event_source_url: payload.event_source_url,
             user_data: hash_user_data({ user_data: payload.user_data }),
             custom_data: {
+              ...payload.custom_data,
               currency: payload.currency,
               content_ids: payload.content_ids,
               contents: payload.contents,

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
@@ -6,7 +6,9 @@ import {
   currency,
   value,
   contents,
+  validateContents,
   content_ids,
+  custom_data,
   event_time,
   action_source,
   content_category,
@@ -56,7 +58,8 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.properties.query'
       }
     },
-    value: value
+    value: value,
+    custom_data: custom_data
   },
   perform: (request, { payload, settings }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.has(payload.currency)) {
@@ -79,25 +82,9 @@ const action: ActionDefinition<Settings, Payload> = {
       )
     }
 
-    const valid_delivery_categories = ['in_store', 'curbside', 'home_delivery']
     if (payload.contents) {
-      payload.contents.forEach((obj, index) => {
-        if (!obj.id) {
-          throw new IntegrationError(
-            "Contents objects must include an 'id' parameter.",
-            'Misconfigured required field',
-            400
-          )
-        }
-
-        if (obj.delivery_category && !valid_delivery_categories.includes(obj.delivery_category)) {
-          throw new IntegrationError(
-            `contents[${index}].delivery_category must be one of {in_store, home_delivery, curbside}.`,
-            'Misconfigured field',
-            400
-          )
-        }
-      })
+      const err = validateContents(payload.contents)
+      if (err) throw err
     }
 
     return request(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}/events`, {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
@@ -139,4 +139,10 @@ export interface Payload {
    * The value of a user performing this event to the business.
    */
   value?: number
+  /**
+   * The custom data object which can be used to pass custom properties. See [here](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/custom-data) for more information
+   */
+  custom_data?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
@@ -95,6 +95,7 @@ const action: ActionDefinition<Settings, Payload> = {
             event_source_url: payload.event_source_url,
             user_data: hash_user_data({ user_data: payload.user_data }),
             custom_data: {
+              ...payload.custom_data,
               currency: payload.currency,
               value: payload.value,
               content_ids: payload.content_ids,

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
@@ -2,11 +2,13 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import {
   action_source,
   contents,
+  validateContents,
   content_category,
   content_ids,
   content_name,
   content_type,
   currency,
+  custom_data,
   event_id,
   event_source_url,
   event_time,
@@ -52,7 +54,8 @@ const action: ActionDefinition<Settings, Payload> = {
     currency: currency,
     event_id: event_id,
     event_source_url: event_source_url,
-    value: { ...value, default: { '@path': '$.properties.price' } }
+    value: { ...value, default: { '@path': '$.properties.price' } },
+    custom_data: custom_data
   },
   perform: (request, { payload, settings }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.has(payload.currency)) {
@@ -75,25 +78,9 @@ const action: ActionDefinition<Settings, Payload> = {
       )
     }
 
-    const valid_delivery_categories = ['in_store', 'curbside', 'home_delivery']
     if (payload.contents) {
-      payload.contents.forEach((obj, index) => {
-        if (!obj.id) {
-          throw new IntegrationError(
-            "Contents objects must include an 'id' parameter.",
-            'Misconfigured required field',
-            400
-          )
-        }
-
-        if (obj.delivery_category && !valid_delivery_categories.includes(obj.delivery_category)) {
-          throw new IntegrationError(
-            `contents[${index}].delivery_category must be one of {in_store, home_delivery, curbside}.`,
-            'Misconfigured field',
-            400
-          )
-        }
-      })
+      const err = validateContents(payload.contents)
+      if (err) throw err
     }
 
     return request(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}/events`, {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR adds a `customData` object to all FB CAPI actions, bringing it to parity with Classic FB CAPI.

In addition it:
* Refactors contents array validation to reduce code copied between all actions.
* Updates unit tests with snapshots, and eliminates random outputs from those snapshots.

Ticket: https://segment.atlassian.net/browse/STRATCONN-1138
## Testing

Tested successfully in stage by using the customData object and sending events to FB.
<img width="1768" alt="Screen Shot 2022-03-07 at 4 21 51 PM" src="https://user-images.githubusercontent.com/27820201/157142973-dd3639f6-8cc9-4c84-a74c-1c805e1aed8f.png">

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
