### PR TITLE
Enjoin/coerce some values to the proper types.

### DIFF
--- a/packages/actions-shared/src/friendbuy/__tests__/util.test.ts
+++ b/packages/actions-shared/src/friendbuy/__tests__/util.test.ts
@@ -1,4 +1,12 @@
-import { createFriendbuyPayload, filterFriendbuyAttributes, isNonEmpty, parseDate } from '../util'
+import {
+  createFriendbuyPayload,
+  enjoinInteger,
+  enjoinNumber,
+  enjoinString,
+  filterFriendbuyAttributes,
+  isNonEmpty,
+  parseDate
+} from '../util'
 
 describe('isEmpty', () => {
   test('isEmpty', () => {
@@ -108,5 +116,41 @@ describe('parseDate', () => {
     expect(parseDate('10-9')).toBe(undefined) // Not enough digits in month.
     expect(parseDate('99-100')).toBe(undefined) // Too many digits in day.
     expect(parseDate('100-99')).toBe(undefined) // Too many digits in month.
+  })
+})
+
+describe('enjoin', () => {
+  test('enjoinInteger', () => {
+    expect(enjoinInteger('123')).toBe(123)
+    expect(enjoinInteger('-987')).toBe(-987)
+    expect(enjoinInteger('123.45')).toBe('123.45')
+    expect(enjoinInteger('0')).toBe(0)
+    expect(enjoinInteger('.123')).toBe('.123')
+    expect(enjoinInteger('1.')).toBe('1.')
+    expect(enjoinInteger(123)).toBe(123)
+    expect(enjoinInteger(123.45)).toBe(123.45)
+    expect(enjoinInteger('hello')).toBe('hello')
+  })
+
+  test('enjoinNumber', () => {
+    expect(enjoinNumber('123')).toBe(123)
+    expect(enjoinNumber('-987')).toBe(-987)
+    expect(enjoinNumber('123.45')).toBe(123.45)
+    expect(enjoinNumber('-1.11')).toBe(-1.11)
+    expect(enjoinNumber('0')).toBe(0)
+    expect(enjoinNumber('.123')).toBe('.123')
+    expect(enjoinNumber('1.')).toBe('1.')
+    expect(enjoinNumber('1.0')).toBe(1)
+    expect(enjoinNumber(123)).toBe(123)
+    expect(enjoinNumber(123.45)).toBe(123.45)
+    expect(enjoinNumber('hello')).toBe('hello')
+  })
+
+  test('enjoinString', () => {
+    expect(enjoinString('123')).toBe('123')
+    expect(enjoinString('-987')).toBe('-987')
+    expect(enjoinString(123)).toBe('123')
+    expect(enjoinString(123.45)).toBe('123.45')
+    expect(enjoinString('hello')).toBe('hello')
   })
 })

--- a/packages/actions-shared/src/friendbuy/util.ts
+++ b/packages/actions-shared/src/friendbuy/util.ts
@@ -153,3 +153,38 @@ export function parseDate(date: string | DateRecord | undefined): DateRecord | u
   const year = match[1] && match[1] !== '0000' ? { year: parseInt(match[1], 10) } : {}
   return { month: parseInt(match[2], 10), day: parseInt(match[3], 10), ...year }
 }
+
+// Matches a (non-exponential-form) JSON integer.
+const integerRegexp = /^-?(?:0|[1-9][0-9]*)$/
+
+// Matches a (non-exponential-form) JSON number.
+const floatRegexp = /^-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$/
+
+/**
+ * Converts an input that is a integer-format string to a number; otherwise
+ * returns the input unaltered.
+ *
+ * This is intended to be used in front of a function that strictly validates
+ * the types of its inputs when you want to a allow string representation of
+ * an integer to be allowed for the corresponding integer (that is, "123" for
+ * 123).
+ */
+export function enjoinInteger(input: unknown): unknown {
+  return typeof input === 'string' && integerRegexp.test(input) ? parseInt(input) : input
+}
+
+/**
+ * Converts an input that is a float-format string to a number; otherwise
+ * returns the input unaltered.
+ */
+export function enjoinNumber(input: unknown): unknown {
+  return typeof input === 'string' && floatRegexp.test(input) ? parseFloat(input) : input
+}
+
+/**
+ * Converts an input that is a number to a string; otherwise returns the input
+ * unaltered.
+ */
+export function enjoinString(input: unknown): unknown {
+  return typeof input === 'number' ? input.toString() : input
+}

--- a/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackCustomEvent/index.ts
@@ -7,7 +7,7 @@ import type { ConvertFun, EventMap } from '@segment/actions-shared'
 
 import { AnalyticsPayload, COPY, DROP, ROOT, mapEvent } from '@segment/actions-shared'
 import { trackCustomEventFields } from '@segment/actions-shared'
-import { addName, moveEventPropertiesToRoot, parseDate } from '@segment/actions-shared'
+import { addName, enjoinInteger, enjoinString, moveEventPropertiesToRoot, parseDate } from '@segment/actions-shared'
 
 export const browserTrackCustomEventFields = trackCustomEventFields({}) // @@ email required?
 
@@ -17,7 +17,7 @@ const trackCustomEventPub: EventMap = {
     deduplicationId: COPY,
 
     // CUSTOMER FIELDS
-    customerId: { name: ['customer', 'id'] },
+    customerId: { name: ['customer', 'id'], convert: enjoinString as ConvertFun },
     anonymousId: { name: ['customer', 'anonymousId'] },
     email: { name: ['customer', 'email'] },
     isNewCustomer: { name: ['customer', 'isNewCustomer'] },
@@ -25,7 +25,7 @@ const trackCustomEventPub: EventMap = {
     firstName: { name: ['customer', 'firstName'] },
     lastName: { name: ['customer', 'lastName'] },
     name: { name: ['customer', 'name'] },
-    age: { name: ['customer', 'age'] },
+    age: { name: ['customer', 'age'], convert: enjoinInteger as ConvertFun },
     birthday: { name: ['customer', 'birthday'], convert: parseDate as ConvertFun }
   },
   unmappedFieldObject: ROOT

--- a/packages/browser-destinations/src/destinations/friendbuy/trackCustomer/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackCustomer/__tests__/index.test.ts
@@ -165,5 +165,32 @@ describe('Friendbuy.trackCustomer', () => {
         true
       ])
     }
+
+    {
+      // enjoined fields are converted
+      const context4 = new Context({
+        type: 'identify',
+        userId: 12345,
+        traits: {
+          email,
+          age: '44',
+          address: { postalCode: 90210 }
+        }
+      })
+
+      trackCustomer.identify?.(context4)
+
+      expect(window.friendbuyAPI?.push).toHaveBeenNthCalledWith(4, [
+        'track',
+        'customer',
+        {
+          id: '12345',
+          email,
+          age: 44,
+          zipCode: '90210'
+        },
+        true
+      ])
+    }
   })
 })

--- a/packages/browser-destinations/src/destinations/friendbuy/trackCustomer/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackCustomer/index.ts
@@ -7,14 +7,14 @@ import type { AnalyticsPayload, ConvertFun, EventMap } from '@segment/actions-sh
 
 import { COPY, ROOT, mapEvent } from '@segment/actions-shared'
 import { trackCustomerFields } from '@segment/actions-shared'
-import { addName, parseDate } from '@segment/actions-shared'
+import { addName, enjoinInteger, enjoinString, parseDate } from '@segment/actions-shared'
 
 // see https://segment.com/docs/config-api/fql/
 export const trackCustomerDefaultSubscription = 'type = "identify"'
 
 const trackCustomerPub: EventMap = {
   fields: {
-    customerId: { name: 'id' },
+    customerId: { name: 'id', convert: enjoinString as ConvertFun },
     anonymousID: COPY,
     email: COPY,
     isNewCustomer: COPY,
@@ -22,14 +22,14 @@ const trackCustomerPub: EventMap = {
     firstName: COPY,
     lastName: COPY,
     name: COPY,
-    age: COPY,
+    age: { convert: enjoinInteger as ConvertFun },
     // fbt-merchant-api complains about birthday being an object but passes it anyway.
     birthday: { convert: parseDate as ConvertFun },
     language: COPY,
     addressCountry: { name: 'country' },
     addressState: { name: 'state' },
     addressCity: { name: 'city' },
-    addressPostalCode: { name: 'zipCode' }
+    addressPostalCode: { name: 'zipCode', convert: enjoinString as ConvertFun }
   },
   unmappedFieldObject: ROOT
 }

--- a/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/__tests__/index.test.ts
@@ -176,5 +176,36 @@ describe('Friendbuy.trackPurchase', () => {
         true
       ])
     }
+
+    {
+      // enjoined fields are converted
+      const context4 = new Context({
+        type: 'track',
+        event: 'Order Completed',
+        properties: {
+          order_id: 12345,
+          total: '129.50',
+          currency,
+          products: [{ sku: 99999, quantity: '2', price: '64.75' }],
+          customerId: 1138,
+          age: '30'
+        }
+      })
+
+      trackPurchase.track?.(context4)
+
+      expect(window.friendbuyAPI?.push).toHaveBeenNthCalledWith(4, [
+        'track',
+        'purchase',
+        {
+          id: '12345',
+          amount: 129.5,
+          currency,
+          products: [{ name: 'unknown', sku: '99999', quantity: 2, price: 64.75 }],
+          customer: { id: '1138', age: 30 }
+        },
+        true
+      ])
+    }
   })
 })

--- a/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackPurchase/index.ts
@@ -7,7 +7,14 @@ import type { AnalyticsPayload, ConvertFun, EventMap } from '@segment/actions-sh
 
 import { COPY, ROOT, mapEvent } from '@segment/actions-shared'
 import { trackPurchaseFields } from '@segment/actions-shared'
-import { addName, parseDate, removeCustomerIfNoId } from '@segment/actions-shared'
+import {
+  addName,
+  enjoinInteger,
+  enjoinNumber,
+  enjoinString,
+  parseDate,
+  removeCustomerIfNoId
+} from '@segment/actions-shared'
 
 export const browserTrackPurchaseFields = trackPurchaseFields({})
 
@@ -16,8 +23,8 @@ export const trackPurchaseDefaultSubscription = 'event = "Order Completed"'
 
 const trackPurchasePub: EventMap = {
   fields: {
-    orderId: { name: 'id' },
-    amount: COPY,
+    orderId: { name: 'id', convert: enjoinString as ConvertFun },
+    amount: { convert: enjoinNumber as ConvertFun },
     currency: COPY,
     coupon: { name: 'couponCode' },
     attributionId: COPY,
@@ -30,10 +37,10 @@ const trackPurchasePub: EventMap = {
       type: 'array',
       defaultObject: { sku: 'unknown', name: 'unknown', quantity: 1 },
       fields: {
-        sku: COPY,
+        sku: { convert: enjoinString as ConvertFun },
         name: COPY,
-        quantity: COPY,
-        price: COPY,
+        quantity: { convert: enjoinInteger as ConvertFun },
+        price: { convert: enjoinNumber as ConvertFun },
         description: COPY,
         category: COPY,
         url: COPY,
@@ -42,7 +49,7 @@ const trackPurchasePub: EventMap = {
     },
 
     // CUSTOMER FIELDS
-    customerId: { name: ['customer', 'id'] },
+    customerId: { name: ['customer', 'id'], convert: enjoinString as ConvertFun },
     anonymousId: { name: ['customer', 'anonymousId'] },
     email: { name: ['customer', 'email'] },
     isNewCustomer: { name: ['customer', 'isNewCustomer'] },
@@ -50,7 +57,7 @@ const trackPurchasePub: EventMap = {
     firstName: { name: ['customer', 'firstName'] },
     lastName: { name: ['customer', 'lastName'] },
     name: { name: ['customer', 'name'] },
-    age: { name: ['customer', 'age'] },
+    age: { name: ['customer', 'age'], convert: enjoinInteger as ConvertFun },
     // fbt-merchant-api complains about birthday being an object but passes it anyway.
     birthday: { name: ['customer', 'birthday'], convert: parseDate as ConvertFun }
   },

--- a/packages/browser-destinations/src/destinations/friendbuy/trackSignUp/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/trackSignUp/index.ts
@@ -7,7 +7,7 @@ import type { AnalyticsPayload, ConvertFun, EventMap } from '@segment/actions-sh
 
 import { COPY, ROOT, mapEvent } from '@segment/actions-shared'
 import { trackSignUpFields } from '@segment/actions-shared'
-import { addName, parseDate } from '@segment/actions-shared'
+import { addName, enjoinInteger, enjoinString, parseDate } from '@segment/actions-shared'
 
 export const browserTrackSignUpFields = trackSignUpFields({ requireCustomerId: true, requireEmail: true })
 
@@ -21,7 +21,7 @@ const trackSignUpPub: EventMap = {
     referralCode: COPY,
 
     // CUSTOMER FIELDS
-    customerId: { name: 'id' },
+    customerId: { name: 'id', convert: enjoinString as ConvertFun },
     anonymousID: COPY,
     isNewCustomer: COPY,
     loyaltyStatus: COPY,
@@ -29,7 +29,7 @@ const trackSignUpPub: EventMap = {
     firstName: COPY,
     lastName: COPY,
     name: COPY,
-    age: COPY,
+    age: { convert: enjoinInteger as ConvertFun },
     birthday: { convert: parseDate as ConvertFun }
   },
   unmappedFieldObject: ROOT

--- a/packages/destination-actions/src/destinations/friendbuy/trackCustomer/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackCustomer/__tests__/index.test.ts
@@ -8,7 +8,7 @@ import { nockAuth, authKey, authSecret } from '../../__tests__/cloudUtil.mock'
 const testDestination = createTestIntegration(Destination)
 
 describe('Friendbuy.trackCustomer', () => {
-  test('all fields', async () => {
+  function setUpTest() {
     nockAuth()
     const nockRequests: any[] /* (typeof nock.ReplyFnContext.req)[] */ = []
     nock(defaultMapiBaseUrl)
@@ -17,6 +17,10 @@ describe('Friendbuy.trackCustomer', () => {
         nockRequests.push(this.req)
         return {}
       })
+  }
+
+  test('all fields', async () => {
+    setUpTest()
 
     const userId = 'john-doe-12345'
     const email = 'john.doe@example.com'
@@ -89,6 +93,40 @@ describe('Friendbuy.trackCustomer', () => {
         customerSince,
         favoriteColor
       }
+    })
+  })
+
+  test('enjoined fields', async () => {
+    setUpTest()
+
+    const email = 'test@example.com'
+
+    const event = createTestEvent({
+      type: 'identify',
+      userId: 98765 as unknown as string,
+      traits: {
+        email,
+        age: '99',
+        address: { postalCode: 99999 }
+      },
+      timestamp: '2021-10-05T15:30:35Z'
+    })
+
+    const r = await testDestination.testAction('trackCustomer', {
+      event,
+      settings: { authKey, authSecret },
+      useDefaultMappings: true
+      // mapping,
+      // auth,
+    })
+
+    // console.log(JSON.stringify(r, null, 2))
+    expect(r.length).toBe(1) // (no auth request +) trackCustomer request
+    expect(r[0].options.json).toMatchObject({
+      customerId: '98765',
+      email,
+      age: 99,
+      zipCode: '99999'
     })
   })
 })

--- a/packages/destination-actions/src/destinations/friendbuy/trackCustomer/index.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackCustomer/index.ts
@@ -7,13 +7,13 @@ import { createMapiRequest } from '../cloudUtil'
 import { contextFields } from '@segment/actions-shared'
 import { COPY, DROP, mapEvent } from '@segment/actions-shared'
 import { trackCustomerFields } from '@segment/actions-shared'
-import { parseDate } from '@segment/actions-shared'
+import { enjoinInteger, enjoinString, parseDate } from '@segment/actions-shared'
 
 const cloudTrackCustomerFields = { ...trackCustomerFields, ...contextFields }
 
 const trackCustomerMapi: EventMap = {
   fields: {
-    customerId: COPY,
+    customerId: { convert: enjoinString as ConvertFun },
     // anonymousID (unmapped)
     email: COPY,
     isNewCustomer: COPY,
@@ -23,14 +23,14 @@ const trackCustomerMapi: EventMap = {
     lastName: COPY,
     // name (unmapped)
     gender: COPY,
-    age: COPY,
+    age: { convert: enjoinInteger as ConvertFun },
     birthday: { convert: parseDate as ConvertFun },
     language: COPY,
     timezone: COPY,
     addressCountry: { name: 'country' },
     addressState: { name: 'state' },
     addressCity: { name: 'city' },
-    addressPostalCode: { name: 'zipCode' },
+    addressPostalCode: { name: 'zipCode', convert: enjoinString as ConvertFun },
 
     // CONTEXT FIELDS
     ipAddress: COPY,

--- a/packages/destination-actions/src/destinations/friendbuy/trackPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackPurchase/index.ts
@@ -1,19 +1,20 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import type { AnalyticsPayload, EventMap } from '@segment/actions-shared'
+import type { AnalyticsPayload, ConvertFun, EventMap } from '@segment/actions-shared'
 
 import { createMapiRequest } from '../cloudUtil'
 import { contextFields } from '@segment/actions-shared'
 import { COPY, DROP, mapEvent } from '@segment/actions-shared'
 import { trackPurchaseFields } from '@segment/actions-shared'
+import { enjoinInteger, enjoinNumber, enjoinString } from '@segment/actions-shared'
 
 const cloudTrackPurchaseFields = { ...trackPurchaseFields({}), ...contextFields }
 
 const trackPurchaseMapi: EventMap = {
   fields: {
-    orderId: COPY,
-    amount: COPY,
+    orderId: { convert: enjoinString as ConvertFun },
+    amount: { convert: enjoinNumber as ConvertFun },
     currency: COPY,
     coupon: { name: 'couponCode' },
     attributionId: COPY,
@@ -24,10 +25,10 @@ const trackPurchaseMapi: EventMap = {
       type: 'array',
       defaultObject: { sku: 'unknown', name: 'unknown', quantity: 1 },
       fields: {
-        sku: COPY,
+        sku: { convert: enjoinString as ConvertFun },
         name: COPY,
-        quantity: COPY,
-        price: COPY,
+        quantity: { convert: enjoinInteger as ConvertFun },
+        price: { convert: enjoinNumber as ConvertFun },
         description: COPY,
         category: COPY,
         url: COPY,

--- a/packages/destination-actions/src/destinations/friendbuy/trackSignUp/index.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/trackSignUp/index.ts
@@ -7,7 +7,7 @@ import { createMapiRequest } from '../cloudUtil'
 import { contextFields } from '@segment/actions-shared'
 import { COPY, DROP, mapEvent } from '@segment/actions-shared'
 import { trackSignUpFields } from '@segment/actions-shared'
-import { parseDate } from '@segment/actions-shared'
+import { enjoinInteger, enjoinString, parseDate } from '@segment/actions-shared'
 
 const cloudTrackSignUpFields = {
   ...trackSignUpFields({ requireCustomerId: true, requireEmail: true }),
@@ -21,7 +21,7 @@ const trackSignUpMapi: EventMap = {
     referralCode: COPY,
 
     // CUSTOMER FIELDS
-    customerId: COPY,
+    customerId: { convert: enjoinString as ConvertFun },
     // anonymousID (unmapped)
     email: COPY,
     isNewCustomer: COPY,
@@ -29,7 +29,7 @@ const trackSignUpMapi: EventMap = {
     firstName: COPY,
     lastName: COPY,
     // name (unmapped)
-    age: COPY,
+    age: { convert: enjoinInteger as ConvertFun },
     birthday: { convert: parseDate as ConvertFun },
 
     // CONTEXT FIELDS


### PR DESCRIPTION
Friendbuy has merchants who are using our web destination but are passing in values of the wrong types, for example the integer `12345` for the `order_id` field of the Order Completed event, where a string is expected; or `"1"` for price field, where a number is expected.  This commit adds some code that checks to see, when the type of a passed value is is wrong for an event, if the value can be coerced to the correct type, and if the value can its does so.

## Testing

I have added and run unit tests. I tested both the web and cloud destinations minimally using the local server.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
