### PR TITLE
GA4 - Apply keyvalue default UI to event parameters

### DIFF
--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-properties.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-properties.ts
@@ -4,7 +4,8 @@ export const params: InputField = {
   label: 'Event Parameters',
   description: 'The event parameters to send to Google',
   type: 'object',
-  additionalProperties: true
+  additionalProperties: true,
+  defaultObjectUI: 'keyvalue'
 }
 export const user_id: InputField = {
   label: 'User ID',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Applies a `keyvalue` default to the GA4 event parameters object.

## Testing

Tested in stage, it correctly defaults

<img width="1459" alt="image" src="https://user-images.githubusercontent.com/27820201/157932968-e70d9bcb-5885-4866-b0be-ce493f48bdf9.png">

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
