### PR TITLE
[STRATCONN-1244 & 1248] Update updateProfile action & nestedObjects function

### DIFF
--- a/packages/destination-actions/src/destinations/adobe-target/adobeTarget_operations.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/adobeTarget_operations.ts
@@ -3,7 +3,7 @@ import { RequestClient, IntegrationError } from '@segment/actions-core'
 function getNestedObjects(obj: { [x: string]: any }, objectPath = '', attributes: { [x: string]: string } = {}) {
   Object.keys(obj).forEach((key) => {
     const currObjectPath = objectPath ? `${objectPath}.${key}` : key
-    if (typeof obj[key] !== 'object' && obj[key]) {
+    if (typeof obj[key] !== 'object') {
       attributes[currObjectPath] = obj[key].toString()
     } else {
       getNestedObjects(obj[key], currObjectPath, attributes)

--- a/packages/destination-actions/src/destinations/adobe-target/updateProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/updateProfile/__tests__/index.test.ts
@@ -234,7 +234,31 @@ describe('AdobeTarget', () => {
     const responses = await testDestination.testAction('updateProfile', {
       event,
       settings,
-      useDefaultMappings: true
+      useDefaultMappings: true,
+      mapping: {
+        traits: {
+          address: {
+            city: {
+              '@path': '$.traits.address.city'
+            },
+            zipCode: {
+              '@path': '$.traits.address.zipCode'
+            }
+          },
+          name: {
+            '@path': '$.traits.name'
+          },
+          age: {
+            '@path': '$.traits.age'
+          },
+          param1: {
+            '@path': '$.traits.param1'
+          },
+          param2: {
+            '@path': '$.traits.param2'
+          }
+        }
+      }
     })
     expect(responses.length).toBe(2)
     expect(responses[0].status).toBe(200)

--- a/packages/destination-actions/src/destinations/adobe-target/updateProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/updateProfile/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   user_id: string
   /**
-   * Profile parameters specific to a user.
+   * Profile parameters specific to a user. Please note, Adobe recommends that PII is hashed prior to sending to Adobe.
    */
   traits: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/adobe-target/updateProfile/index.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/updateProfile/index.ts
@@ -24,12 +24,11 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     traits: {
       label: 'Profile Attributes',
-      description: 'Profile parameters specific to a user.',
+      description:
+        'Profile parameters specific to a user. Please note, Adobe recommends that PII is hashed prior to sending to Adobe.',
       type: 'object',
       required: true,
-      default: {
-        '@path': '$.traits'
-      }
+      defaultObjectUI: 'keyvalue'
     }
   },
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR changes the defualt object view to be key-value `defualtObjectView: keyvalue` and updates the logic of the nestedObject function to properly process actions that send false in the traits field. 

## Testing

Testing completed in stage. 

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
