### PR TITLE
Use creation name as remote plugin name

### DIFF
--- a/packages/browser-destinations/src/destinations/braze/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/index.ts
@@ -44,7 +44,7 @@ const presets: DestinationDefinition['presets'] = [
 ]
 
 export const destination: BrowserDestinationDefinition<Settings, typeof appboy> = {
-  name: 'Braze Web Device Mode (Actions)',
+  name: 'Braze Web Mode (Actions)',
   slug: 'actions-braze-web',
   mode: 'device',
   settings: {

--- a/packages/cli-internal/src/commands/push-browser-destinations.ts
+++ b/packages/cli-internal/src/commands/push-browser-destinations.ts
@@ -87,7 +87,9 @@ export default class PushBrowserDestinations extends Command {
 
       const input = {
         metadataId: metadata.id,
-        name: metadata.name,
+        // The name of the remote plugin should match the creationName for consistency with our other systems,
+        // as users might rely on the name of the name of the remote plugin in the integrations object.
+        name: metadata.creationName,
         // This MUST match the way webpack exports the libraryName in the umd bundle
         // TODO make this more automatic for consistency
         libraryName: `${entry.directory}Destination`,
@@ -98,10 +100,10 @@ export default class PushBrowserDestinations extends Command {
       // `metadataId` is guaranteed to be unique
       const existingPlugin = remotePlugins.find((p) => p.metadataId === metadata.id)
 
-      if (metadata.name !== entry.definition.name) {
+      if (metadata.creationName !== entry.definition.name) {
         this.spinner.fail()
         throw new Error(
-          `The definition name '${entry.definition.name}' should always match the control plane name '${metadata.name}'.`
+          `The definition name '${entry.definition.name}' should always match the control plane creationName '${metadata.creationName}'.`
         )
       }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR makes sure we compare against the creation name of the destination instead of the current name when updating browser destinations. This matches how classic integrations are handled, and how the push command validates action destinations.

## Testing
Testing done on stage.
Trying to update a browser destination with a non-matching name:
<img width="1016" alt="image" src="https://user-images.githubusercontent.com/2866515/158691236-fa523c54-5459-4537-b704-544f5680fba4.png">

After updating the name to match creationName:
<img width="706" alt="image" src="https://user-images.githubusercontent.com/2866515/158691327-a84bba96-2a81-4d27-b89e-d561a0b0081c.png">

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
