### PR TITLE
[STRATCONN-1245] Update upsertProfile

### DIFF
--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/generated-types.ts
@@ -8,7 +8,7 @@ export interface Payload {
   /**
    * Profile parameters specific to a user.
    */
-  traits: {
+  traits?: {
     [k: string]: unknown
   }
 }

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   userId?: string
   /**
-   * Profile parameters specific to a user.
+   * Profile parameters specific to a user. Please note, Adobe recommends that PII is hashed prior to sending to Adobe.
    */
   traits?: {
     [k: string]: unknown

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
@@ -53,7 +53,7 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
     const params = {
       mbox: event.settings.mbox_name,
       params: {
-        type: 'profile_update' // DO NOT CHANGE. profile_update is used to differentiate between track and identify calls.
+        event_name: 'profile_update' // DO NOT CHANGE. profile_update is used to differentiate between track and identify calls.
       }
     }
 

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
@@ -25,7 +25,6 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
     },
     traits: {
       type: 'object',
-      required: true,
       description: 'Profile parameters specific to a user.',
       label: 'Profile Attributes',
       defaultObjectUI: 'keyvalue'

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
@@ -27,7 +27,8 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
       type: 'object',
       required: true,
       description: 'Profile parameters specific to a user.',
-      label: 'Profile Attributes'
+      label: 'Profile Attributes',
+      defaultObjectUI: 'keyvalue'
     }
   },
   perform: (Adobe, event) => {

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
@@ -27,10 +27,7 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
       type: 'object',
       required: true,
       description: 'Profile parameters specific to a user.',
-      label: 'Profile Attributes',
-      default: {
-        '@path': '$.traits'
-      }
+      label: 'Profile Attributes'
     }
   },
   perform: (Adobe, event) => {

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
@@ -25,7 +25,8 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
     },
     traits: {
       type: 'object',
-      description: 'Profile parameters specific to a user.',
+      description:
+        'Profile parameters specific to a user. Please note, Adobe recommends that PII is hashed prior to sending to Adobe.',
       label: 'Profile Attributes',
       defaultObjectUI: 'keyvalue'
     }


### PR DESCRIPTION
This PR brings new changes to the `upsertProfile`. 

- [x] No default for “Profile Attributes” in the Upsert Profile action in Adobe Target Web (remove traits as default)
- [x] Change default object view to be key-value (defaultObjectView: keyvalue)
- [x] Remove requiredness on “Profile Attributes” 
- [x] Update description for “Profile Attributes”
- [x] Rename type to event_name

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
