### PR TITLE
Update fqlExpression to be able to handle new == operator for booleans

### DIFF
--- a/packages/destination-subscriptions/src/generate-fql.ts
+++ b/packages/destination-subscriptions/src/generate-fql.ts
@@ -1,146 +1,138 @@
 import {
-	Subscription,
-	GroupCondition,
-	EventTypeCondition,
-	EventCondition,
-	EventPropertyCondition,
-	EventTraitCondition,
-	EventContextCondition,
-	EventUserIdCondition,
-	EventNameCondition,
-	Operator,
-	ErrorCondition
+  Subscription,
+  GroupCondition,
+  EventTypeCondition,
+  EventCondition,
+  EventPropertyCondition,
+  EventTraitCondition,
+  EventContextCondition,
+  EventUserIdCondition,
+  EventNameCondition,
+  Operator,
+  ErrorCondition
 } from './types'
 
-const stringifyValue = (
-	value: string | boolean | number | undefined
-): string => {
-	if (typeof value === 'boolean' || typeof value === 'number') {
-		return String(value)
-	}
+const stringifyValue = (value: string | boolean | number | undefined): string => {
+  if (typeof value === 'boolean' || typeof value === 'number') {
+    return String(value)
+  }
 
-	return `"${value}"`
+  return `"${value}"`
 }
 
-const fqlExpression = (
-	name: string,
-	operator: Operator,
-	value: string | boolean | number | undefined
-): string => {
-	switch (operator) {
-		case 'contains':
-			return `contains(${name}, ${stringifyValue(value)})`
-		case 'not_contains':
-			return `!contains(${name}, ${stringifyValue(value)})`
-		case 'exists':
-			return `${name} != null`
-		case 'not_exists':
-			return `${name} = null`
-		case 'starts_with':
-			return `match(${name}, "${String(value)}*")`
-		case 'not_starts_with':
-			return `!match(${name}, "${String(value)}*")`
-		case 'ends_with':
-			return `match(${name}, "*${String(value)}")`
-		case 'not_ends_with':
-			return `!match(${name}, "*${String(value)}")`
-		case '<':
-		case '>':
-		case '<=':
-		case '>=':
-			return `${name} ${operator} ${Number(value)}`
-		default:
-			return `${name} ${operator} ${stringifyValue(value)}`
-	}
+const fqlExpression = (name: string, operator: Operator, value: string | boolean | number | undefined): string => {
+  switch (operator) {
+    case 'contains':
+      return `contains(${name}, ${stringifyValue(value)})`
+    case 'not_contains':
+      return `!contains(${name}, ${stringifyValue(value)})`
+    case 'exists':
+      return `${name} != null`
+    case 'not_exists':
+      return `${name} = null`
+    case 'starts_with':
+      return `match(${name}, "${String(value)}*")`
+    case 'not_starts_with':
+      return `!match(${name}, "${String(value)}*")`
+    case 'ends_with':
+      return `match(${name}, "*${String(value)}")`
+    case 'not_ends_with':
+      return `!match(${name}, "*${String(value)}")`
+    case '==':
+      return `${name} = ${Boolean(value)}`
+    case '<':
+    case '>':
+    case '<=':
+    case '>=':
+      return `${name} ${operator} ${Number(value)}`
+    default:
+      return `${name} ${operator} ${stringifyValue(value)}`
+  }
 }
 
 const stringifyGroupNode = (node: GroupCondition): string => {
-	return node.children
-		.map(childNode => {
-			if (childNode.type === 'group') {
-				return `(${stringifyGroupNode(childNode)})`
-			}
+  return node.children
+    .map((childNode) => {
+      if (childNode.type === 'group') {
+        return `(${stringifyGroupNode(childNode)})`
+      }
 
-			return stringifyChildNode(childNode)
-		})
-		.join(` ${node.operator} `)
+      return stringifyChildNode(childNode)
+    })
+    .join(` ${node.operator} `)
 }
 
 const stringifyChildNode = (
-	node:
-		| EventTypeCondition
-		| EventCondition
-		| EventPropertyCondition
-		| EventTraitCondition
-		| EventContextCondition
-		| EventUserIdCondition
-		| EventNameCondition
+  node:
+    | EventTypeCondition
+    | EventCondition
+    | EventPropertyCondition
+    | EventTraitCondition
+    | EventContextCondition
+    | EventUserIdCondition
+    | EventNameCondition
 ): string => {
-	let result = ''
+  let result = ''
 
-	switch (node.type) {
-		case 'name':
-		case 'userId':
-		case 'event': {
-			result += fqlExpression(node.type, node.operator, node.value)
-			break
-		}
+  switch (node.type) {
+    case 'name':
+    case 'userId':
+    case 'event': {
+      result += fqlExpression(node.type, node.operator, node.value)
+      break
+    }
 
-		case 'event-type': {
-			result += fqlExpression('type', node.operator, node.value)
-			break
-		}
+    case 'event-type': {
+      result += fqlExpression('type', node.operator, node.value)
+      break
+    }
 
-		case 'event-property': {
-			result += fqlExpression(
-				`properties.${node.name}`,
-				node.operator,
-				node.value
-			)
-			break
-		}
+    case 'event-property': {
+      result += fqlExpression(`properties.${node.name}`, node.operator, node.value)
+      break
+    }
 
-		case 'event-trait': {
-			result += fqlExpression(`traits.${node.name}`, node.operator, node.value)
-			break
-		}
+    case 'event-trait': {
+      result += fqlExpression(`traits.${node.name}`, node.operator, node.value)
+      break
+    }
 
-		case 'event-context': {
-			result += fqlExpression(`context.${node.name}`, node.operator, node.value)
-			break
-		}
+    case 'event-context': {
+      result += fqlExpression(`context.${node.name}`, node.operator, node.value)
+      break
+    }
 
-		default:
-			throw new Error('Unknown condition type')
-	}
+    default:
+      throw new Error('Unknown condition type')
+  }
 
-	return result
+  return result
 }
 
 const numberOfParens = (string: string): number => {
-	let parens = 0
+  let parens = 0
 
-	for (const char of string.split('')) {
-		if (char === '(' || char === ')') {
-			parens++
-		}
-	}
+  for (const char of string.split('')) {
+    if (char === '(' || char === ')') {
+      parens++
+    }
+  }
 
-	return parens
+  return parens
 }
 
 const generateFql = (ast: Subscription): string => {
-	if ((ast as ErrorCondition).error) {
-		throw (ast as ErrorCondition).error
-	}
+  if ((ast as ErrorCondition).error) {
+    throw (ast as ErrorCondition).error
+  }
 
-	const fql = stringifyGroupNode(ast as GroupCondition)
+  const fql = stringifyGroupNode(ast as GroupCondition)
 
-	if (fql.startsWith('(') && fql.endsWith(')') && numberOfParens(fql) === 2) {
-		return fql.slice(1, -1)
-	}
+  if (fql.startsWith('(') && fql.endsWith(')') && numberOfParens(fql) === 2) {
+    return fql.slice(1, -1)
+  }
 
-	return fql
+  return fql
 }
 
 export default generateFql

--- a/packages/destination-subscriptions/src/types.ts
+++ b/packages/destination-subscriptions/src/types.ts
@@ -1,95 +1,96 @@
 export type Subscription = ErrorCondition | GroupCondition
 export interface GroupCondition<T = Condition> {
-	type: 'group'
-	operator: GroupConditionOperator
-	children: T[]
+  type: 'group'
+  operator: GroupConditionOperator
+  children: T[]
 }
 
 export interface ErrorCondition {
-	error: Error
+  error: Error
 }
 
 export type Condition =
-	| GroupCondition
-	| EventTypeCondition
-	| EventCondition
-	| EventPropertyCondition
-	| EventTraitCondition
-	| EventContextCondition
-	| EventUserIdCondition
-	| EventNameCondition
+  | GroupCondition
+  | EventTypeCondition
+  | EventCondition
+  | EventPropertyCondition
+  | EventTraitCondition
+  | EventContextCondition
+  | EventUserIdCondition
+  | EventNameCondition
 
 export type GroupConditionOperator = 'and' | 'or'
 
 export interface EventTypeCondition {
-	type: 'event-type'
-	operator: Operator
-	value?: string
+  type: 'event-type'
+  operator: Operator
+  value?: string
 }
 
 export interface EventCondition {
-	type: 'event'
-	operator: Operator
-	value?: string
+  type: 'event'
+  operator: Operator
+  value?: string
 }
 
 export interface EventUserIdCondition {
-	type: 'userId'
-	operator: Operator
-	value?: string
+  type: 'userId'
+  operator: Operator
+  value?: string
 }
 
 export interface EventNameCondition {
-	type: 'name'
-	operator: Operator
-	value?: string
+  type: 'name'
+  operator: Operator
+  value?: string
 }
 
 export interface EventPropertyCondition {
-	type: 'event-property'
-	name: string
-	operator: Operator
-	value?: string | boolean | number
+  type: 'event-property'
+  name: string
+  operator: Operator
+  value?: string | boolean | number
 }
 
 export interface EventTraitCondition {
-	type: 'event-trait'
-	name: string
-	operator: Operator
-	value?: string | boolean | number
+  type: 'event-trait'
+  name: string
+  operator: Operator
+  value?: string | boolean | number
 }
 
 export interface EventContextCondition {
-	type: 'event-context'
-	name: string
-	operator: Operator
-	value?: string | boolean | number
+  type: 'event-context'
+  name: string
+  operator: Operator
+  value?: string | boolean | number
 }
 
 export type Operator =
-	| '='
-	| '!='
-	| '<'
-	| '<='
-	| '>'
-	| '>='
-	| 'contains'
-	| 'not_contains'
-	| 'starts_with'
-	| 'not_starts_with'
-	| 'ends_with'
-	| 'not_ends_with'
-	| 'exists'
-	| 'not_exists'
+  | '='
+  | '=='
+  | '!='
+  | '<'
+  | '<='
+  | '>'
+  | '>='
+  | 'contains'
+  | 'not_contains'
+  | 'starts_with'
+  | 'not_starts_with'
+  | 'ends_with'
+  | 'not_ends_with'
+  | 'exists'
+  | 'not_exists'
 
 export type ConditionType =
-	| 'group'
-	| 'event-type'
-	| 'event'
-	| 'event-property'
-	| 'event-trait'
-	| 'event-context'
-	| 'name'
-	| 'userId'
+  | 'group'
+  | 'event-type'
+  | 'event'
+  | 'event-property'
+  | 'event-trait'
+  | 'event-context'
+  | 'name'
+  | 'userId'
 
 export type PropertyConditionType = 'event-property' | 'event-context'


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

This PR address [JIRA-617](https://segment.atlassian.net/browse/BE-617)

In it, we are attempting to include a new possible operator `==` as well as update the fqlExpression that is generated when the given case operator is `==`. In app, this will allow us to uniquely identify the two mapping operators `is (string)` and `is (boolean)`. Currently, we only have `is` which treats the input as a string in every instance, even when the user actually wants it as a boolean.

Desired effect in app:
<img width="281" alt="Screen Shot 2022-03-17 at 5 28 23 PM" src="https://user-images.githubusercontent.com/98849774/158915082-5d572e97-d112-44b0-a169-1153dec273c1.png">

Without this change, all values sent to fqlExpression will be returned as strings instead of their desired effect as a boolean.

This PR goes hand in hand with [this]() PR in app (currently not ready)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
