### PR TITLE
Update Criteo slug to actions-criteo-audiences.

### DIFF
--- a/packages/destination-actions/src/destinations/criteo-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/criteo-audiences/index.ts
@@ -7,7 +7,7 @@ import type { ClientCredentials } from './criteo-audiences'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Criteo Audiences',
-  slug: 'criteo-audiences',
+  slug: 'actions-criteo-audiences',
   description: 'Add/remove users to/from Criteo Audiences using Criteo API',
   mode: 'cloud',
   authentication: {


### PR DESCRIPTION
- `criteo-audiences` slug is already taken, so updating the slug to `actions-criteo-audiences`.

## Testing
- Testing not required, as this is not a functional change. The destination hasn't been registered in the control-plane-db yet.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
