### PR TITLE
only call browser initialize once per destination

### DIFF
--- a/packages/browser-destinations/src/runtime/__tests__/plugin.test.ts
+++ b/packages/browser-destinations/src/runtime/__tests__/plugin.test.ts
@@ -1,0 +1,62 @@
+import { BrowserDestinationDefinition } from 'src/lib/browser-destinations'
+import { generatePlugins } from '../plugin'
+
+describe('generatePlugins', () => {
+  const initializeSpy = jest.fn()
+  const destinationDefinition: BrowserDestinationDefinition<{}, unknown> = {
+    name: 'Test destination',
+    slug: 'test-web-destination',
+    mode: 'device',
+    settings: {},
+    initialize: async () => {
+      initializeSpy()
+    },
+    actions: {
+      trackEventA: {
+        title: 'Track Event',
+        description: 'Tests track events',
+        platform: 'web',
+        defaultSubscription: 'type = "track"',
+        fields: {},
+        perform: () => {}
+      },
+      trackEventB: {
+        title: 'Track Event',
+        description: 'Tests track events',
+        platform: 'web',
+        defaultSubscription: 'type = "track"',
+        fields: {},
+        perform: () => {}
+      }
+    }
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test('only loads once', async () => {
+    const plugins = generatePlugins(destinationDefinition, {}, [
+      {
+        enabled: true,
+        mapping: {},
+        name: 'a',
+        partnerAction: 'trackEventA',
+        subscribe: 'type = "track"'
+      },
+      {
+        enabled: true,
+        mapping: {},
+        name: 'b',
+        partnerAction: 'trackEventB',
+        subscribe: 'type = "track"'
+      }
+    ])
+
+    expect(plugins.length).toBe(2)
+
+    await Promise.all(plugins.map((p) => p.load({} as any, {} as any)))
+
+    expect(initializeSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/browser-destinations/src/runtime/plugin.ts
+++ b/packages/browser-destinations/src/runtime/plugin.ts
@@ -16,14 +16,21 @@ export function generatePlugins<S, C>(
   let hasInitialized = false
   let client: C
   let analytics: Analytics
+  let initializing: Promise<C> | undefined
 
   const load: Plugin['load'] = async (_ctx, analyticsInstance) => {
     if (hasInitialized) {
       return
     }
 
+    if (initializing) {
+      await initializing
+      return
+    }
+
     analytics = analyticsInstance
-    client = await def.initialize?.({ settings, analytics }, { loadScript, resolveWhen })
+    initializing = def.initialize?.({ settings, analytics }, { loadScript, resolveWhen })
+    client = await initializing
     hasInitialized = true
   }
 


### PR DESCRIPTION
Hello!

I noticed when testing the Koala browser destination that the `initialize` function gets called multiple times – once for every subscription, which is a bit counterintuitive. I believe the intention of this function is to be called once no matter how many subscriptions are active (since it does things like loading a script from a cdn, etc).

After this change, initialize will only be called once per destination, and subsequent `load` invocations will yield the same promise. After the first one finishes, the `client` and `hasInitialized` will both be set.

cc @pooyaj @dlasky

## Testing

Tested manually using `yarn dev`

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
