### PR TITLE
Add flags to Close Destination Action

### DIFF
--- a/packages/destination-actions/src/destinations/close/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/close/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -21,6 +21,11 @@ Object {
     "lead_status_id": "Bbzz5]ZQl",
   },
   "settings": Object {
+    "allow_creating_duplicate_contacts": true,
+    "allow_creating_new_contacts": true,
+    "allow_creating_new_leads": true,
+    "allow_updating_existing_contacts": true,
+    "allow_updating_existing_leads": true,
     "contact_custom_field_id_for_user_id": "Bbzz5]ZQl",
     "lead_custom_field_id_for_company_id": "Bbzz5]ZQl",
   },

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -21,6 +21,11 @@ Object {
     "lead_status_id": "AY$s*K8XPu",
   },
   "settings": Object {
+    "allow_creating_duplicate_contacts": true,
+    "allow_creating_new_contacts": true,
+    "allow_creating_new_leads": true,
+    "allow_updating_existing_contacts": true,
+    "allow_updating_existing_leads": true,
     "contact_custom_field_id_for_user_id": "AY$s*K8XPu",
     "lead_custom_field_id_for_company_id": "AY$s*K8XPu",
   },

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/__tests__/index.test.ts
@@ -38,7 +38,12 @@ describe('Close.createUpdateContactAndLead', () => {
         },
         settings: {
           contact_custom_field_id_for_user_id: 'cf_external_user_id',
-          lead_custom_field_id_for_company_id: 'cf_external_company_id'
+          lead_custom_field_id_for_company_id: 'cf_external_company_id',
+          allow_creating_new_leads: true,
+          allow_updating_existing_leads: true,
+          allow_creating_new_contacts: true,
+          allow_updating_existing_contacts: true,
+          allow_creating_duplicate_contacts: true
         }
       })
       .matchHeader('Authorization', 'Basic YXBpX2tleWlkLmtleXNlY3JldDo=')
@@ -80,7 +85,12 @@ describe('Close.createUpdateContactAndLead', () => {
         },
         settings: {
           contact_custom_field_id_for_user_id: 'cf_external_user_id',
-          lead_custom_field_id_for_company_id: 'cf_external_company_id'
+          lead_custom_field_id_for_company_id: 'cf_external_company_id',
+          allow_creating_new_leads: false,
+          allow_updating_existing_leads: false,
+          allow_creating_new_contacts: false,
+          allow_updating_existing_contacts: false,
+          allow_creating_duplicate_contacts: false
         }
       })
       .matchHeader('Authorization', 'Basic YXBpX2tleWlkLmtleXNlY3JldDo=')
@@ -115,7 +125,12 @@ describe('Close.createUpdateContactAndLead', () => {
       },
       lead_status_id: {
         '@path': '$.traits.lead_status_id'
-      }
+      },
+      allow_creating_new_leads: false,
+      allow_updating_existing_leads: false,
+      allow_creating_new_contacts: false,
+      allow_updating_existing_contacts: false,
+      allow_creating_duplicate_contacts: false
     }
     await testDestination.testAction('createUpdateContactAndLead', {
       event,

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/generated-types.ts
@@ -53,4 +53,24 @@ export interface Payload {
   contact_custom_fields?: {
     [k: string]: unknown
   }
+  /**
+   * Whether the integration is allowed to create new Leads.
+   */
+  allow_creating_new_leads?: boolean
+  /**
+   * Whether the integration is allowed to create new Leads.
+   */
+  allow_updating_existing_leads?: boolean
+  /**
+   * Whether the integration is allowed to create new Contacts.
+   */
+  allow_creating_new_contacts?: boolean
+  /**
+   * Whether the integration is allowed to update existing Contacts.
+   */
+  allow_updating_existing_contacts?: boolean
+  /**
+   * Whether the integration is allowed to create duplicate Contact (same email or Contact User ID) under a different Lead (different Lead Company ID).
+   */
+  allow_creating_duplicate_contacts?: boolean
 }

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/index.ts
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/index.ts
@@ -113,17 +113,62 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'Custom Fields to set on the Contact. Key should be Custom Field ID (`cf_xxxx`).',
       type: 'object',
       required: false
+    },
+    allow_creating_new_leads: {
+      label: 'Allow creating new Leads',
+      description: 'Whether the integration is allowed to create new Leads.',
+      type: 'boolean',
+      default: true
+    },
+    allow_updating_existing_leads: {
+      label: 'Allow creating new Leads',
+      description: 'Whether the integration is allowed to create new Leads.',
+      type: 'boolean',
+      default: true
+    },
+    allow_creating_new_contacts: {
+      label: 'Allow creating new Contacts',
+      description: 'Whether the integration is allowed to create new Contacts.',
+      type: 'boolean',
+      default: true
+    },
+    allow_updating_existing_contacts: {
+      label: 'Allow updating existing Contacts',
+      description: 'Whether the integration is allowed to update existing Contacts.',
+      type: 'boolean',
+      default: true
+    },
+    allow_creating_duplicate_contacts: {
+      label: 'Allow creating duplicate Contacts under different Lead',
+      description:
+        'Whether the integration is allowed to create duplicate Contact (same email or Contact User ID) under a different Lead (different Lead Company ID).',
+      type: 'boolean',
+      default: true
     }
   },
 
   perform: (request, data) => {
     const settings = {
       contact_custom_field_id_for_user_id: data.settings.contact_custom_field_id_for_user_id,
-      lead_custom_field_id_for_company_id: data.settings.lead_custom_field_id_for_company_id
+      lead_custom_field_id_for_company_id: data.settings.lead_custom_field_id_for_company_id,
+      allow_creating_new_leads: data.payload.allow_creating_new_leads,
+      allow_updating_existing_leads: data.payload.allow_updating_existing_leads,
+      allow_creating_new_contacts: data.payload.allow_creating_new_contacts,
+      allow_updating_existing_contacts: data.payload.allow_updating_existing_contacts,
+      allow_creating_duplicate_contacts: data.payload.allow_creating_duplicate_contacts
     }
+    const action_payload = { ...data.payload }
+    // Following fields are defined on action, but are sent as settings to
+    // Close API.
+    delete action_payload.allow_creating_new_leads
+    delete action_payload.allow_updating_existing_leads
+    delete action_payload.allow_creating_new_contacts
+    delete action_payload.allow_updating_existing_contacts
+    delete action_payload.allow_creating_duplicate_contacts
+
     return request('https://services.close.com/webhooks/segment/actions/create-update-contact-and-lead/', {
       method: 'post',
-      json: { action_payload: data.payload, settings }
+      json: { action_payload, settings }
     })
   }
 }


### PR DESCRIPTION


<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Add flags allow_creating_new_leads, allow_updating_existing_leads, allow_creating_new_contacts, allow_updating_existing_contacts, allow_creating_duplicate_contacts. It is important for some users that for example want to only create new leads, but not update existing ones.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
