### PR TITLE
Upload normal and obfuscated destinations

### DIFF
--- a/packages/browser-destinations/webpack.config.js
+++ b/packages/browser-destinations/webpack.config.js
@@ -10,9 +10,11 @@ const isProd = process.env.NODE_ENV === 'production'
 
 const entries = files.reduce((acc, current) => {
   const [_dot, _src, _destinations, destination, ..._rest] = current.split('/')
+  const obfuscatedDestination = Buffer.from(destination).toString('base64').replace(/=/g, '');
   return {
     ...acc,
-    [destination]: current
+    [destination]: current,
+    [obfuscatedDestination]: current,
   }
 }, {})
 


### PR DESCRIPTION
Adds obfuscated directories for action destinations.

Content was already being content hashed and probably does not need to be changed with this work.