### PR TITLE
[Criteo Audiences] fixed getAudienceId function

### DIFF
--- a/packages/destination-actions/src/destinations/criteo-audiences/addUserToAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/criteo-audiences/addUserToAudience/__tests__/index.test.ts
@@ -51,6 +51,17 @@ const AUDIENCE_CREATION_RESPONSE = {
   "warnings": []
 }
 
+const DUPLICATE_AUDIENCE_ERROR = {
+  "errors": [
+    {
+      "type": "validation",
+      "code": "invalid-audience-name-duplicated",
+      "title": "Duplicate name",
+      "detail": "Audience name test_audience already exists for advertiser x on audience 1234"
+    }
+  ]
+}
+
 describe('addUserToAudience', () => {
   it('should throw error if no access to the audiences of the advertiser', async () => {
     const settings = VALID_SETTINGS;
@@ -81,33 +92,6 @@ describe('addUserToAudience', () => {
         useDefaultMappings: true
       })
     ).rejects.toThrowError('The Advertiser ID should be a number')
-  })
-
-  it('should throw error if failing to create a new audience', async () => {
-    const settings = VALID_SETTINGS;
-    nock('https://api.criteo.com').persist().post('/oauth2/token').reply(200, MOCK_TOKEN_RESPONSE)
-    nock('https://api.criteo.com').get(/^\/\d{4}-\d{2}\/audiences$/).query({ "advertiser-id": settings.advertiser_id }).reply(200, {
-      "data": [
-        {
-          "id": "1234",
-          "attributes": {
-            "advertiserId": VALID_ADVERTISER_ID,
-            "name": "OTHER AUDIENCE NAME"
-          }
-        }
-      ]
-    }
-    )
-    // The audience key is not present in the list of the advertiser's audiences so a new audience needs to be created
-    nock('https://api.criteo.com').post(/^\/\d{4}-\d{2}\/audiences$/).reply(403)
-
-    await expect(
-      testDestination.testAction('addUserToAudience', {
-        event,
-        settings,
-        useDefaultMappings: true
-      })
-    ).rejects.toThrowError("Forbidden")
   })
 
   it('should not throw an error if the audience creation and the patch requests succeed', async () => {
@@ -152,4 +136,32 @@ describe('addUserToAudience', () => {
       })
     ).resolves.not.toThrowError()
   })
+
+  it('should not throw an error in case of concurrent audience creation attempt', async () => {
+    const settings = VALID_SETTINGS;
+    nock('https://api.criteo.com').persist().post('/oauth2/token').reply(200, MOCK_TOKEN_RESPONSE)
+    nock('https://api.criteo.com').persist().get(/^\/\d{4}-\d{2}\/audiences$/).query({ "advertiser-id": settings.advertiser_id }).reply(200, {
+      "data": [
+        {
+          "id": "5678",
+          "attributes": {
+            "advertiserId": VALID_ADVERTISER_ID,
+            "name": "OTHER AUDIENCE NAME"
+          }
+        }
+      ]
+    }
+    )
+    nock('https://api.criteo.com').post(/^\/\d{4}-\d{2}\/audiences$/).reply(400, DUPLICATE_AUDIENCE_ERROR)
+    nock('https://api.criteo.com').patch(/^\/\d{4}-\d{2}\/audiences\/\d+\/contactlist$/).reply(200)
+
+    await expect(
+      testDestination.testAction('addUserToAudience', {
+        event,
+        settings,
+        useDefaultMappings: true
+      })
+    ).resolves.not.toThrowError()
+  })
 })
+

--- a/packages/destination-actions/src/destinations/criteo-audiences/criteo-audiences.ts
+++ b/packages/destination-actions/src/destinations/criteo-audiences/criteo-audiences.ts
@@ -223,7 +223,7 @@ export const createAudience = async (
     }
 
     const response = await request(
-        endpoint, { method: 'POST', headers: headers, json: payload }
+        endpoint, { method: 'POST', headers: headers, json: payload, throwHttpErrors: false }
     )
     const body = await response.json()
 


### PR DESCRIPTION
- This Partner PR adds support for handling concurrent audience creation attempts in the `actions-criteo-audiences` destination.
- Original Partner PR (reviewed and approved): https://github.com/segmentio/action-destinations/pull/539

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment