### PR TITLE
Add obfuscated url to original plugin input

### DIFF
--- a/packages/cli-internal/src/commands/push-browser-destinations.ts
+++ b/packages/cli-internal/src/commands/push-browser-destinations.ts
@@ -85,6 +85,8 @@ export default class PushBrowserDestinations extends Command {
       this.spinner.start(`Saving remote plugin for ${metadata.name}`)
       const entry = manifest[metadata.id]
 
+      const obfuscatedDestination = Buffer.from(entry.directory).toString('base64').replace(/=/g, '')
+
       const input = {
         metadataId: metadata.id,
         // The name of the remote plugin should match the creationName for consistency with our other systems,
@@ -93,18 +95,8 @@ export default class PushBrowserDestinations extends Command {
         // This MUST match the way webpack exports the libraryName in the umd bundle
         // TODO make this more automatic for consistency
         libraryName: `${entry.directory}Destination`,
-        url: `${path}/${entry.directory}/${webBundles()[entry.directory]}`
-      }
-
-      const obfuscatedDestination = Buffer.from(entry.directory).toString('base64').replace(/=/g, '')
-
-      const obfuscatedInput = {
-        metadataId: metadata.id,
-        name: metadata.name,
-        // This MUST match the way webpack exports the libraryName in the umd bundle
-        // TODO make this more automatic for consistency
-        libraryName: `${entry.directory}Destination`,
-        url: `${path}/${obfuscatedDestination}/${webBundles()[obfuscatedDestination]}`
+        url: `${path}/${entry.directory}/${webBundles()[entry.directory]}`,
+        obfuscatedUrl: `${path}/${obfuscatedDestination}/${webBundles()[obfuscatedDestination]}`
       }
 
       // We expect that each definition produces a single Remote Plugin bundle
@@ -119,9 +111,9 @@ export default class PushBrowserDestinations extends Command {
       }
 
       if (existingPlugin) {
-        pluginsToUpdate.push(input, obfuscatedInput)
+        pluginsToUpdate.push(input)
       } else {
-        pluginsToCreate.push(input, obfuscatedInput)
+        pluginsToCreate.push(input)
       }
     }
 


### PR DESCRIPTION
A slight modification to my original approach for this problem. Originally I was planning on following a similar approach to integration obfuscation and loading, but action-destinations are uploaded and exposed in a different manner. If I went down that path, I would need to introduce a lot more changes across a greater surface area that I think over-complicate the problem.

My new approach is to attach a new field to each action destination, and then expose it [here](https://github.com/segmentio/ajs-renderer/blob/8a65fdcb075bfb7741704e82b9faa3ab0893712b/src/builder/remote-plugins.ts#L74). At the ajs-next level, we'll just need to do some short logic [here](https://github.com/segmentio/analytics-next/blob/master/src/plugins/remote-loader/index.ts#L61) to determine which url to use for the script loading.

## Testing

Manual testing for this at this point - files are uploaded to S3, but API exposure is required before I can confirm the process will work.