### PR TITLE
Close fix api key auth request for larger organizations

### DIFF
--- a/packages/destination-actions/src/destinations/close/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/close/__tests__/index.test.ts
@@ -8,7 +8,7 @@ describe('Close', () => {
   describe('testAuthentication', () => {
     it('should validate valid api key', async () => {
       nock('https://api.close.com/')
-        .get('/api/v1/me/')
+        .get('/api/v1/me/?_fields=id')
         .matchHeader('Authorization', 'Basic YXBpX2tleWlkLmtleXNlY3JldDo=')
         .reply(200, {})
 
@@ -22,7 +22,7 @@ describe('Close', () => {
 
     it('should not validate invalid api key', async () => {
       nock('https://api.close.com/')
-        .get('/api/v1/me/')
+        .get('/api/v1/me/?_fields=id')
         .matchHeader('Authorization', 'Basic YXBpX2tleWlkLmtleXNlY3JldDo=')
         .reply(401, {
           error:

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/generated-types.ts
@@ -58,7 +58,7 @@ export interface Payload {
    */
   allow_creating_new_leads?: boolean
   /**
-   * Whether the integration is allowed to create new Leads.
+   * Whether the integration is allowed to update existing Leads.
    */
   allow_updating_existing_leads?: boolean
   /**

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/index.ts
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/index.ts
@@ -121,8 +121,8 @@ const action: ActionDefinition<Settings, Payload> = {
       default: true
     },
     allow_updating_existing_leads: {
-      label: 'Allow creating new Leads',
-      description: 'Whether the integration is allowed to create new Leads.',
+      label: 'Allow updating existing Leads',
+      description: 'Whether the integration is allowed to update existing Leads.',
       type: 'boolean',
       default: true
     },

--- a/packages/destination-actions/src/destinations/close/index.ts
+++ b/packages/destination-actions/src/destinations/close/index.ts
@@ -47,7 +47,7 @@ const destination: DestinationDefinition<Settings> = {
       }
     },
     testAuthentication: (request) => {
-      return request(`https://api.close.com/api/v1/me/`)
+      return request(`https://api.close.com/api/v1/me/?_fields=id`)
     }
   },
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Segment UI times out with `GraphQL error: Timeout awaiting 'request' for 6000ms` when doing API key validity check for organizations that have larger response (70kb+) on `/api/v1/me/` endpoint. The response time from Close API is still about 1s, but Segment probably does some processing (parsing?) of the response that causes it to time out. I am adding `?_fields=id` param to reduce the response size and hopefully avoid the timeout.

![Screenshot 2022-04-07 at 10 20 46](https://user-images.githubusercontent.com/3979716/162159249-fca8b629-eddf-4e06-8b6c-3f690b210039.png)



Unrelated to that, I am also fixing one wrong label of input field.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
