### PR TITLE
Add page_title field to GA4 Page View Action

### DIFF
--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
@@ -44,6 +44,9 @@ describe('GA4', () => {
           },
           page_location: {
             '@path': '$.properties.custom_url'
+          },
+          page_title: {
+            '@path': '$.properties.page_title'
           }
         },
         useDefaultMappings: true
@@ -120,7 +123,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"http://www.example.com/home\\",\\"page_referrer\\":\\"https://segment.com/academy/\\"}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"http://www.example.com/home\\",\\"page_referrer\\":\\"https://segment.com/academy/\\",\\"page_title\\":\\"Analytics Academy\\"}}]}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/generated-types.ts
@@ -18,6 +18,10 @@ export interface Payload {
    */
   page_referrer?: string
   /**
+   * The current page title
+   */
+  page_title?: string
+  /**
    * The event parameters to send to Google
    */
   params?: {

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
@@ -26,6 +26,14 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.context.page.referrer'
       }
     },
+    page_title: {
+      label: 'Page Title',
+      type: 'string',
+      description: 'The current page title',
+      default: {
+        '@path': '$.context.page.title'
+      }
+    },
     params: params
   },
   perform: (request, { payload }) => {
@@ -40,6 +48,7 @@ const action: ActionDefinition<Settings, Payload> = {
             params: {
               page_location: payload.page_location,
               page_referrer: payload.page_referrer,
+              page_title: payload.page_title,
               ...payload.params
             }
           }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

This PR addresses [STRATCONN-1297](https://segment.atlassian.net/browse/STRATCONN-1297) to add a mapping to the Page View action in GA4 for Page Title.

<img width="1053" alt="Screen Shot 2022-04-11 at 1 13 08 PM" src="https://user-images.githubusercontent.com/99763167/162824035-aed7bc0b-ee57-4b70-a891-8444f0a73139.png">


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
