### PR TITLE
Add presets to LaunchDarkly destination

### DIFF
--- a/packages/destination-actions/src/destinations/launchdarkly/index.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly/index.ts
@@ -1,8 +1,23 @@
-import type { DestinationDefinition } from '@segment/actions-core'
+import { defaultValues, DestinationDefinition, Subscription } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
 import aliasUser from './aliasUser'
 import trackEvent from './trackEvent'
+
+const presets: Subscription[] = [
+  {
+    name: 'Track Event',
+    subscribe: 'type = "track"',
+    partnerAction: 'trackEvent',
+    mapping: defaultValues(trackEvent.fields)
+  },
+  {
+    name: 'Alias User',
+    subscribe: 'type = "identify" or type = "alias"',
+    partnerAction: 'aliasUser',
+    mapping: defaultValues(aliasUser.fields)
+  }
+]
 
 const destination: DestinationDefinition<Settings> = {
   name: 'LaunchDarkly',
@@ -32,7 +47,7 @@ const destination: DestinationDefinition<Settings> = {
       headers: { 'User-Agent': 'SegmentDestination/2.0.0', 'Content-Type': 'application/json' }
     }
   },
-
+  presets,
   actions: {
     aliasUser,
     trackEvent


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR adds subscription presets to the LaunchDarkly destination.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
