### PR TITLE
Obfuscate bundle names 2.0

### DIFF
--- a/packages/browser-destinations/webpack.config.js
+++ b/packages/browser-destinations/webpack.config.js
@@ -10,20 +10,9 @@ const isProd = process.env.NODE_ENV === 'production'
 
 const entries = files.reduce((acc, current) => {
   const [_dot, _src, _destinations, destination, ..._rest] = current.split('/')
-  const obfuscatedDestination = Buffer.from(destination).toString('base64').replace(/=/g, '');
   return {
     ...acc,
     [destination]: current,
-    [obfuscatedDestination]: current,
-  }
-}, {})
-
-const entriesToObfuscatedNameMap = files.reduce((acc, current) => {
-  const [_dot, _src, _destinations, destination, ..._rest] = current.split('/')
-  const obfuscatedDestination = Buffer.from(destination).toString('base64').replace(/=/g, '');
-  return {
-    ...acc,
-    [obfuscatedDestination]: destination,
   }
 }, {})
 
@@ -46,78 +35,91 @@ plugins.push(
   })
 )
 
-module.exports = {
-  entry: entries,
-  mode: process.env.NODE_ENV || 'development',
-  devtool: 'source-map',
-  output: {
-    filename: (file) => {
-      if (entriesToObfuscatedNameMap[file.chunk.name]) {
-        return process.env.NODE_ENV === 'development' ? '[name].js' : '[name]/[name].js'
-      }
-      return process.env.NODE_ENV === 'development' ? '[name].js' : '[name]/[contenthash].js'
+const outputTempalte = (options) => (
+  {
+    entry: entries,
+    mode: process.env.NODE_ENV || 'development',
+    devtool: 'source-map',
+    output: {
+      filename: options.filename,
+      path: path.resolve(__dirname, 'dist/web'),
+      publicPath: 'auto', // Needed for customers using custom CDNs with analytics.js
+      library: '[name]Destination',
+      libraryTarget: 'umd',
+      libraryExport: 'default'
     },
-    path: path.resolve(__dirname, 'dist/web'),
-    publicPath: 'auto', // Needed for customers using custom CDNs with analytics.js
-    library: '[name]Destination',
-    libraryTarget: 'umd',
-    libraryExport: 'default'
-  },
-  module: {
-    rules: [
-      {
-        test: /\.ts$/,
-        use: [
-          {
-            loader: 'ts-loader',
-            options: {
-              configFile: 'tsconfig.build.json',
-              projectReferences: true,
-              transpileOnly: true
+    module: {
+      rules: [
+        {
+          test: /\.ts$/,
+          use: [
+            {
+              loader: 'ts-loader',
+              options: {
+                configFile: 'tsconfig.build.json',
+                projectReferences: true,
+                transpileOnly: true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    resolve: {
+      modules: [
+        // use current node_modules directory first (e.g. for tslib)
+        path.resolve(__dirname, 'node_modules'),
+        'node_modules'
+      ],
+      mainFields: ['exports', 'module', 'browser', 'main'],
+      extensions: ['.ts', '.js'],
+      fallback: {
+        vm: require.resolve('vm-browserify')
+      }
+    },
+    devServer: {
+      liveReload: true,
+      port: 9000,
+      static: {
+        directory: path.resolve(__dirname)
+      }
+    },
+    performance: {
+      hints: 'warning'
+    },
+    optimization: {
+      moduleIds: 'deterministic',
+      minimize: isProd,
+      minimizer: [
+        new TerserPlugin({
+          extractComments: false,
+          terserOptions: {
+            ecma: '2015',
+            mangle: true,
+            compress: true,
+            output: {
+              comments: false
             }
           }
-        ]
-      }
-    ]
-  },
-  resolve: {
-    modules: [
-      // use current node_modules directory first (e.g. for tslib)
-      path.resolve(__dirname, 'node_modules'),
-      'node_modules'
-    ],
-    mainFields: ['exports', 'module', 'browser', 'main'],
-    extensions: ['.ts', '.js'],
-    fallback: {
-      vm: require.resolve('vm-browserify')
-    }
-  },
-  devServer: {
-    liveReload: true,
-    port: 9000,
-    static: {
-      directory: path.resolve(__dirname)
-    }
-  },
-  performance: {
-    hints: 'warning'
-  },
-  optimization: {
-    moduleIds: 'deterministic',
-    minimize: isProd,
-    minimizer: [
-      new TerserPlugin({
-        extractComments: false,
-        terserOptions: {
-          ecma: '2015',
-          mangle: true,
-          compress: true,
-          output: {
-            comments: false
-          }
-        }
-      })
-    ]
-  },
-  plugins
+        })
+      ]
+    },
+    plugins
+  }
+)
+
+const unobfuscatedOutputOptions = {
+  filename: (file) => process.env.NODE_ENV === 'development' ? `${file.chunk.name}.js` : `${file.chunk.name}/[contenthash].js`
 }
+
+const obfuscatedOutputOptions = {
+  filename: (file) => {
+    const obfuscatedOutput = Buffer.from(file.chunk.name).toString('base64').replace(/=/g, '');
+    return process.env.NODE_ENV === 'development' ? `${obfuscatedOutput}.js` : `${obfuscatedOutput}/[contenthash].js`
+  }
+}
+
+const unobfuscatedOutput = outputTempalte(unobfuscatedOutputOptions)
+const obfuscatedOutput = outputTempalte(obfuscatedOutputOptions)
+
+module.exports = [unobfuscatedOutput, obfuscatedOutput]

--- a/packages/browser-destinations/webpack.config.js
+++ b/packages/browser-destinations/webpack.config.js
@@ -107,77 +107,14 @@ const unobfuscatedOutput = {
 }
 
 const obfuscatedOutput = {
-  entry: entries,
-  mode: process.env.NODE_ENV || 'development',
-  devtool: 'source-map',
+  ...unobfuscatedOutput,
   output: {
-    filename: (file) => {
-      const obfuscatedOutput = Buffer.from(file.chunk.name).toString('base64').replace(/=/g, '');
-      return process.env.NODE_ENV === 'development' ? `${obfuscatedOutput}.js` : `${obfuscatedOutput}/[contenthash].js`
-    },
-    path: path.resolve(__dirname, 'dist/web'),
-    publicPath: 'auto', // Needed for customers using custom CDNs with analytics.js
-    library: '[name]Destination',
-    libraryTarget: 'umd',
-    libraryExport: 'default'
-  },
-  module: {
-    rules: [
-      {
-        test: /\.ts$/,
-        use: [
-          {
-            loader: 'ts-loader',
-            options: {
-              configFile: 'tsconfig.build.json',
-              projectReferences: true,
-              transpileOnly: true
-            }
-          }
-        ]
-      }
-    ]
-  },
-  resolve: {
-    modules: [
-      // use current node_modules directory first (e.g. for tslib)
-      path.resolve(__dirname, 'node_modules'),
-      'node_modules'
-    ],
-    mainFields: ['exports', 'module', 'browser', 'main'],
-    extensions: ['.ts', '.js'],
-    fallback: {
-      vm: require.resolve('vm-browserify')
-    }
-  },
-  devServer: {
-    liveReload: true,
-    port: 9000,
-    static: {
-      directory: path.resolve(__dirname)
-    }
-  },
-  performance: {
-    hints: 'warning'
-  },
-  optimization: {
-    moduleIds: 'deterministic',
-    minimize: isProd,
-    minimizer: [
-      new TerserPlugin({
-        extractComments: false,
-        terserOptions: {
-          ecma: '2015',
-          mangle: true,
-          compress: true,
-          output: {
-            comments: false
-          }
-        }
-      })
-    ]
-  },
-  plugins
-}
+    ...unobfuscatedOutput.output,
+     filename: (file) => {
+       const obfuscatedOutputName = Buffer.from(file.chunk.name).toString('base64').replace(/=/g, '');
+       return process.env.NODE_ENV === 'development' ? `${obfuscatedOutputName}.js` : `${obfuscatedOutputName}/[contenthash].js`
+     },
+  }
+ }
 
 module.exports = [unobfuscatedOutput, obfuscatedOutput]

--- a/packages/browser-destinations/webpack.config.js
+++ b/packages/browser-destinations/webpack.config.js
@@ -35,91 +35,149 @@ plugins.push(
   })
 )
 
-const outputTemplate = (options) => (
-  {
-    entry: entries,
-    mode: process.env.NODE_ENV || 'development',
-    devtool: 'source-map',
-    output: {
-      filename: options.filename,
-      path: path.resolve(__dirname, 'dist/web'),
-      publicPath: 'auto', // Needed for customers using custom CDNs with analytics.js
-      library: '[name]Destination',
-      libraryTarget: 'umd',
-      libraryExport: 'default'
-    },
-    module: {
-      rules: [
-        {
-          test: /\.ts$/,
-          use: [
-            {
-              loader: 'ts-loader',
-              options: {
-                configFile: 'tsconfig.build.json',
-                projectReferences: true,
-                transpileOnly: true
-              }
-            }
-          ]
-        }
-      ]
-    },
-    resolve: {
-      modules: [
-        // use current node_modules directory first (e.g. for tslib)
-        path.resolve(__dirname, 'node_modules'),
-        'node_modules'
-      ],
-      mainFields: ['exports', 'module', 'browser', 'main'],
-      extensions: ['.ts', '.js'],
-      fallback: {
-        vm: require.resolve('vm-browserify')
-      }
-    },
-    devServer: {
-      liveReload: true,
-      port: 9000,
-      static: {
-        directory: path.resolve(__dirname)
-      }
-    },
-    performance: {
-      hints: 'warning'
-    },
-    optimization: {
-      moduleIds: 'deterministic',
-      minimize: isProd,
-      minimizer: [
-        new TerserPlugin({
-          extractComments: false,
-          terserOptions: {
-            ecma: '2015',
-            mangle: true,
-            compress: true,
-            output: {
-              comments: false
+const unobfuscatedOutput = {
+  entry: entries,
+  mode: process.env.NODE_ENV || 'development',
+  devtool: 'source-map',
+  output: {
+    filename: (file) => process.env.NODE_ENV === 'development' ? `${file.chunk.name}.js` : `${file.chunk.name}/[contenthash].js`,
+    path: path.resolve(__dirname, 'dist/web'),
+    publicPath: 'auto', // Needed for customers using custom CDNs with analytics.js
+    library: '[name]Destination',
+    libraryTarget: 'umd',
+    libraryExport: 'default'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        use: [
+          {
+            loader: 'ts-loader',
+            options: {
+              configFile: 'tsconfig.build.json',
+              projectReferences: true,
+              transpileOnly: true
             }
           }
-        })
-      ]
+        ]
+      }
+    ]
+  },
+  resolve: {
+    modules: [
+      // use current node_modules directory first (e.g. for tslib)
+      path.resolve(__dirname, 'node_modules'),
+      'node_modules'
+    ],
+    mainFields: ['exports', 'module', 'browser', 'main'],
+    extensions: ['.ts', '.js'],
+    fallback: {
+      vm: require.resolve('vm-browserify')
+    }
+  },
+  devServer: {
+    liveReload: true,
+    port: 9000,
+    static: {
+      directory: path.resolve(__dirname)
+    }
+  },
+  performance: {
+    hints: 'warning'
+  },
+  optimization: {
+    moduleIds: 'deterministic',
+    minimize: isProd,
+    minimizer: [
+      new TerserPlugin({
+        extractComments: false,
+        terserOptions: {
+          ecma: '2015',
+          mangle: true,
+          compress: true,
+          output: {
+            comments: false
+          }
+        }
+      })
+    ]
+  },
+  plugins
+}
+
+const obfuscatedOutput = {
+  entry: entries,
+  mode: process.env.NODE_ENV || 'development',
+  devtool: 'source-map',
+  output: {
+    filename: (file) => {
+      const obfuscatedOutput = Buffer.from(file.chunk.name).toString('base64').replace(/=/g, '');
+      return process.env.NODE_ENV === 'development' ? `${obfuscatedOutput}.js` : `${obfuscatedOutput}/[contenthash].js`
     },
-    plugins
-  }
-)
-
-const unobfuscatedOutputOptions = {
-  filename: (file) => process.env.NODE_ENV === 'development' ? `${file.chunk.name}.js` : `${file.chunk.name}/[contenthash].js`
+    path: path.resolve(__dirname, 'dist/web'),
+    publicPath: 'auto', // Needed for customers using custom CDNs with analytics.js
+    library: '[name]Destination',
+    libraryTarget: 'umd',
+    libraryExport: 'default'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        use: [
+          {
+            loader: 'ts-loader',
+            options: {
+              configFile: 'tsconfig.build.json',
+              projectReferences: true,
+              transpileOnly: true
+            }
+          }
+        ]
+      }
+    ]
+  },
+  resolve: {
+    modules: [
+      // use current node_modules directory first (e.g. for tslib)
+      path.resolve(__dirname, 'node_modules'),
+      'node_modules'
+    ],
+    mainFields: ['exports', 'module', 'browser', 'main'],
+    extensions: ['.ts', '.js'],
+    fallback: {
+      vm: require.resolve('vm-browserify')
+    }
+  },
+  devServer: {
+    liveReload: true,
+    port: 9000,
+    static: {
+      directory: path.resolve(__dirname)
+    }
+  },
+  performance: {
+    hints: 'warning'
+  },
+  optimization: {
+    moduleIds: 'deterministic',
+    minimize: isProd,
+    minimizer: [
+      new TerserPlugin({
+        extractComments: false,
+        terserOptions: {
+          ecma: '2015',
+          mangle: true,
+          compress: true,
+          output: {
+            comments: false
+          }
+        }
+      })
+    ]
+  },
+  plugins
 }
-
-const obfuscatedOutputOptions = {
-  filename: (file) => {
-    const obfuscatedOutput = Buffer.from(file.chunk.name).toString('base64').replace(/=/g, '');
-    return process.env.NODE_ENV === 'development' ? `${obfuscatedOutput}.js` : `${obfuscatedOutput}/[contenthash].js`
-  }
-}
-
-const unobfuscatedOutput = outputTemplate(unobfuscatedOutputOptions)
-const obfuscatedOutput = outputTemplate(obfuscatedOutputOptions)
 
 module.exports = [unobfuscatedOutput, obfuscatedOutput]

--- a/packages/browser-destinations/webpack.config.js
+++ b/packages/browser-destinations/webpack.config.js
@@ -35,7 +35,7 @@ plugins.push(
   })
 )
 
-const outputTempalte = (options) => (
+const outputTemplate = (options) => (
   {
     entry: entries,
     mode: process.env.NODE_ENV || 'development',
@@ -119,7 +119,7 @@ const obfuscatedOutputOptions = {
   }
 }
 
-const unobfuscatedOutput = outputTempalte(unobfuscatedOutputOptions)
-const obfuscatedOutput = outputTempalte(obfuscatedOutputOptions)
+const unobfuscatedOutput = outputTemplate(unobfuscatedOutputOptions)
+const obfuscatedOutput = outputTemplate(obfuscatedOutputOptions)
 
 module.exports = [unobfuscatedOutput, obfuscatedOutput]

--- a/packages/browser-destinations/webpack.config.js
+++ b/packages/browser-destinations/webpack.config.js
@@ -18,7 +18,7 @@ const entries = files.reduce((acc, current) => {
   }
 }, {})
 
-const entiresToObfuscatedNameMap = files.reduce((acc, current) => {
+const entriesToObfuscatedNameMap = files.reduce((acc, current) => {
   const [_dot, _src, _destinations, destination, ..._rest] = current.split('/')
   const obfuscatedDestination = Buffer.from(destination).toString('base64').replace(/=/g, '');
   return {

--- a/packages/browser-destinations/webpack.config.js
+++ b/packages/browser-destinations/webpack.config.js
@@ -52,7 +52,7 @@ module.exports = {
   devtool: 'source-map',
   output: {
     filename: (file) => {
-      if (entiresToObfuscatedNameMap[file.chunk.name]) {
+      if (entriesToObfuscatedNameMap[file.chunk.name]) {
         return process.env.NODE_ENV === 'development' ? '[name].js' : '[name]/[name].js'
       }
       return process.env.NODE_ENV === 'development' ? '[name].js' : '[name]/[contenthash].js'

--- a/packages/cli-internal/src/commands/push-browser-destinations.ts
+++ b/packages/cli-internal/src/commands/push-browser-destinations.ts
@@ -96,17 +96,6 @@ export default class PushBrowserDestinations extends Command {
         url: `${path}/${entry.directory}/${webBundles()[entry.directory]}`
       }
 
-      const obfuscatedDestination = Buffer.from(entry.directory).toString('base64').replace(/=/g, '')
-
-      const obfuscatedInput = {
-        metadataId: metadata.id,
-        name: metadata.name,
-        // This MUST match the way webpack exports the libraryName in the umd bundle
-        // TODO make this more automatic for consistency
-        libraryName: `${entry.directory}Destination`,
-        url: `${path}/${obfuscatedDestination}/${webBundles()[obfuscatedDestination]}`
-      }
-
       // We expect that each definition produces a single Remote Plugin bundle
       // `metadataId` is guaranteed to be unique
       const existingPlugin = remotePlugins.find((p) => p.metadataId === metadata.id)
@@ -119,9 +108,9 @@ export default class PushBrowserDestinations extends Command {
       }
 
       if (existingPlugin) {
-        pluginsToUpdate.push(input, obfuscatedInput)
+        pluginsToUpdate.push(input)
       } else {
-        pluginsToCreate.push(input, obfuscatedInput)
+        pluginsToCreate.push(input)
       }
     }
 


### PR DESCRIPTION
Hooks into the webpack build process to generate predictable bundle names for us to consume on the frontend without needing to make database changes for the metadata of each action-destination.

## Testing

Manual testing - uploaded to S3, made API request from ajs 2.0 successfully.
