### PR TITLE
[StratConn-1286] Adobe Target - WEB - Change default event type to display

### DIFF
--- a/packages/browser-destinations/src/destinations/adobe-target/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/trackEvent/index.ts
@@ -4,8 +4,10 @@ import type { Payload } from './generated-types'
 import { Adobe } from '../types'
 import { setMbox3rdPartyId, serializeProperties } from '../utils'
 
-// Adobe Target only takes certain event types as valid parameters. We are defaulting to "click".
-const TARGET_EVENT_TYPE = 'click'
+// Adobe Target only takes certain event types as valid parameters. We are defaulting to "display".
+// Beware of changing it since other event types drop the event properties from AT's audience builder.
+
+const TARGET_EVENT_TYPE = 'display'
 
 const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   title: 'Track Event',


### PR DESCRIPTION
We are changing the default event type used in Adobe Target's trackEvent action. We are moving away from "click" to "display" because event properties are being dropped when using "click" as event type.

## Testing

Tested successfully in localhost.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
