### PR TITLE
fix for braze deletes on non 01 endpoints

### DIFF
--- a/packages/destination-actions/src/destinations/braze/__tests__/braze.test.ts
+++ b/packages/destination-actions/src/destinations/braze/__tests__/braze.test.ts
@@ -217,5 +217,24 @@ describe(Braze.name, () => {
         expect(resp.data).toMatchObject({})
       }
     })
+
+    it('should support alternate endpoints for user deletions', async () => {
+      nock('https://rest.iad-06.braze.com').post('/users/delete').reply(200, {})
+      expect(testDestination.onDelete).toBeDefined()
+
+      if (testDestination.onDelete) {
+        const event = createTestEvent({
+          type: 'delete',
+          userId: 'sloth@segment.com'
+        })
+
+        const localSettings = { ...settings, endpoint: 'https://rest.iad-06.braze.com' }
+
+        const response = await testDestination.onDelete(event, localSettings)
+        const resp = response as DecoratedResponse
+        expect(resp.status).toBe(200)
+        expect(resp.data).toMatchObject({})
+      }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/braze/index.ts
+++ b/packages/destination-actions/src/destinations/braze/index.ts
@@ -48,8 +48,8 @@ const destination: DestinationDefinition<Settings> = {
       }
     }
   },
-  onDelete: async (request, { payload }) => {
-    return request('https://rest.iad-01.braze.com/users/delete', {
+  onDelete: async (request, { payload, settings }) => {
+    return request(`${settings.endpoint}/users/delete`, {
       method: 'post',
       json: {
         external_ids: [payload.userId]


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

[BE-706] Honor endpoint settings for braze cloud deletes

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment


[BE-706]: https://segment.atlassian.net/browse/BE-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ