### PR TITLE
Add partner name and parse ttclid from page.url when not available

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-conversions/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/__tests__/index.test.ts
@@ -138,7 +138,7 @@ describe('Tiktok Conversions', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"pixel_code\\":\\"test\\",\\"event\\":\\"InitiateCheckout\\",\\"event_id\\":\\"corey123_seg\\",\\"timestamp\\":\\"2021-09-2T15:21:15.449Z\\",\\"context\\":{\\"user\\":{\\"external_id\\":\\"481f202262e9c5ccc48d24e60798fadaa5f6ff1f8369f7ab927c04c3aa682a7f\\",\\"phone_number\\":\\"910a625c4ba147b544e6bd2f267e130ae14c591b6ba9c25cb8573322dedbebd0\\",\\"email\\":\\"eb9869a32b532840dd6aa714f7a872d21d6f650fc5aa933d9feefc64708969c7\\"},\\"ad\\":{\\"callback\\":\\"12345\\"},\\"page\\":{\\"url\\":\\"https://segment.com/\\",\\"referrer\\":\\"https://google.com/\\"},\\"ip\\":\\"0.0.0.0\\",\\"user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57\\"},\\"properties\\":{\\"contents\\":[{\\"price\\":100,\\"quantity\\":2,\\"content_type\\":\\"Air Force One (Size S)\\",\\"content_id\\":\\"abc123\\"}],\\"currency\\":\\"USD\\",\\"value\\":100,\\"query\\":\\"shoes\\"}}"`
+        `"{\\"pixel_code\\":\\"test\\",\\"event\\":\\"InitiateCheckout\\",\\"event_id\\":\\"corey123_seg\\",\\"timestamp\\":\\"2021-09-2T15:21:15.449Z\\",\\"context\\":{\\"user\\":{\\"external_id\\":\\"481f202262e9c5ccc48d24e60798fadaa5f6ff1f8369f7ab927c04c3aa682a7f\\",\\"phone_number\\":\\"910a625c4ba147b544e6bd2f267e130ae14c591b6ba9c25cb8573322dedbebd0\\",\\"email\\":\\"eb9869a32b532840dd6aa714f7a872d21d6f650fc5aa933d9feefc64708969c7\\"},\\"ad\\":{\\"callback\\":\\"12345\\"},\\"page\\":{\\"url\\":\\"https://segment.com/\\",\\"referrer\\":\\"https://google.com/\\"},\\"ip\\":\\"0.0.0.0\\",\\"user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57\\"},\\"properties\\":{\\"contents\\":[{\\"price\\":100,\\"quantity\\":2,\\"content_type\\":\\"Air Force One (Size S)\\",\\"content_id\\":\\"abc123\\"}],\\"currency\\":\\"USD\\",\\"value\\":100,\\"query\\":\\"shoes\\"},\\"partner_name\\":\\"Segment\\"}"`
       )
     })
 
@@ -204,7 +204,72 @@ describe('Tiktok Conversions', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"pixel_code\\":\\"test\\",\\"event\\":\\"AddToCart\\",\\"event_id\\":\\"corey123_seg\\",\\"timestamp\\":\\"2021-09-2T15:21:15.449Z\\",\\"context\\":{\\"user\\":{\\"external_id\\":\\"481f202262e9c5ccc48d24e60798fadaa5f6ff1f8369f7ab927c04c3aa682a7f\\",\\"phone_number\\":\\"910a625c4ba147b544e6bd2f267e130ae14c591b6ba9c25cb8573322dedbebd0\\",\\"email\\":\\"eb9869a32b532840dd6aa714f7a872d21d6f650fc5aa933d9feefc64708969c7\\"},\\"ad\\":{\\"callback\\":\\"12345\\"},\\"page\\":{\\"url\\":\\"https://segment.com/\\",\\"referrer\\":\\"https://google.com/\\"},\\"ip\\":\\"0.0.0.0\\",\\"user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57\\"},\\"properties\\":{\\"contents\\":[{\\"price\\":100,\\"quantity\\":2,\\"content_type\\":\\"Air Force One (Size S)\\",\\"content_id\\":\\"abc123\\"}],\\"currency\\":\\"USD\\",\\"value\\":100,\\"query\\":\\"shoes\\"}}"`
+        `"{\\"pixel_code\\":\\"test\\",\\"event\\":\\"AddToCart\\",\\"event_id\\":\\"corey123_seg\\",\\"timestamp\\":\\"2021-09-2T15:21:15.449Z\\",\\"context\\":{\\"user\\":{\\"external_id\\":\\"481f202262e9c5ccc48d24e60798fadaa5f6ff1f8369f7ab927c04c3aa682a7f\\",\\"phone_number\\":\\"910a625c4ba147b544e6bd2f267e130ae14c591b6ba9c25cb8573322dedbebd0\\",\\"email\\":\\"eb9869a32b532840dd6aa714f7a872d21d6f650fc5aa933d9feefc64708969c7\\"},\\"ad\\":{\\"callback\\":\\"12345\\"},\\"page\\":{\\"url\\":\\"https://segment.com/\\",\\"referrer\\":\\"https://google.com/\\"},\\"ip\\":\\"0.0.0.0\\",\\"user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57\\"},\\"properties\\":{\\"contents\\":[{\\"price\\":100,\\"quantity\\":2,\\"content_type\\":\\"Air Force One (Size S)\\",\\"content_id\\":\\"abc123\\"}],\\"currency\\":\\"USD\\",\\"value\\":100,\\"query\\":\\"shoes\\"},\\"partner_name\\":\\"Segment\\"}"`
+      )
+    })
+
+    it('should parse context.page.url ttclid if properties.ttclid not available', async () => {
+      const event = createTestEvent({
+        timestamp: timestamp,
+        event: 'Checkout Started',
+        messageId: 'corey123',
+        type: 'track',
+        properties: {
+          email: 'coreytest1231@gmail.com',
+          phone: '+1555-555-5555',
+          currency: 'USD',
+          value: 100,
+          query: 'shoes',
+          price: 100,
+          quantity: 2,
+          category: 'Air Force One (Size S)',
+          product_id: 'abc123'
+        },
+        context: {
+          page: {
+            url: 'http://demo.mywebsite.com?a=b&ttclid=123ATXSfe',
+            referrer: 'https://google.com/'
+          },
+          userAgent:
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57',
+          ip: '0.0.0.0'
+        },
+        userId: 'testId123'
+      })
+
+      nock('https://business-api.tiktok.com/open_api/v1.2/pixel/track').post('/').reply(200, {})
+      const responses = await testDestination.testAction('reportWebEvent', {
+        event,
+        settings,
+        useDefaultMappings: true,
+        mapping: {
+          event: 'AddToCart',
+          contents: {
+            '@arrayPath': [
+              '$.properties',
+              {
+                price: {
+                  '@path': '$.price'
+                },
+                quantity: {
+                  '@path': '$.quantity'
+                },
+                content_type: {
+                  '@path': '$.category'
+                },
+                content_id: {
+                  '@path': '$.product_id'
+                }
+              }
+            ]
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"pixel_code\\":\\"test\\",\\"event\\":\\"AddToCart\\",\\"event_id\\":\\"corey123_seg\\",\\"timestamp\\":\\"2021-09-2T15:21:15.449Z\\",\\"context\\":{\\"user\\":{\\"external_id\\":\\"481f202262e9c5ccc48d24e60798fadaa5f6ff1f8369f7ab927c04c3aa682a7f\\",\\"phone_number\\":\\"910a625c4ba147b544e6bd2f267e130ae14c591b6ba9c25cb8573322dedbebd0\\",\\"email\\":\\"eb9869a32b532840dd6aa714f7a872d21d6f650fc5aa933d9feefc64708969c7\\"},\\"ad\\":{\\"callback\\":\\"123ATXSfe\\"},\\"page\\":{\\"url\\":\\"http://demo.mywebsite.com?a=b&ttclid=123ATXSfe\\",\\"referrer\\":\\"https://google.com/\\"},\\"ip\\":\\"0.0.0.0\\",\\"user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57\\"},\\"properties\\":{\\"contents\\":[{\\"price\\":100,\\"quantity\\":2,\\"content_type\\":\\"Air Force One (Size S)\\",\\"content_id\\":\\"abc123\\"}],\\"currency\\":\\"USD\\",\\"value\\":100,\\"query\\":\\"shoes\\"},\\"partner_name\\":\\"Segment\\"}"`
       )
     })
 
@@ -271,7 +336,7 @@ describe('Tiktok Conversions', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"pixel_code\\":\\"test\\",\\"event\\":\\"AddToCart\\",\\"event_id\\":\\"corey123_seg\\",\\"timestamp\\":\\"2021-09-2T15:21:15.449Z\\",\\"test_event_code\\":\\"TEST04030\\",\\"context\\":{\\"user\\":{\\"external_id\\":\\"481f202262e9c5ccc48d24e60798fadaa5f6ff1f8369f7ab927c04c3aa682a7f\\",\\"phone_number\\":\\"910a625c4ba147b544e6bd2f267e130ae14c591b6ba9c25cb8573322dedbebd0\\",\\"email\\":\\"eb9869a32b532840dd6aa714f7a872d21d6f650fc5aa933d9feefc64708969c7\\"},\\"ad\\":{\\"callback\\":\\"12345\\"},\\"page\\":{\\"url\\":\\"https://segment.com/\\",\\"referrer\\":\\"https://google.com/\\"},\\"ip\\":\\"0.0.0.0\\",\\"user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57\\"},\\"properties\\":{\\"contents\\":[{\\"price\\":100,\\"quantity\\":2,\\"content_type\\":\\"Air Force One (Size S)\\",\\"content_id\\":\\"abc123\\"}],\\"currency\\":\\"USD\\",\\"value\\":100,\\"query\\":\\"shoes\\"}}"`
+        `"{\\"pixel_code\\":\\"test\\",\\"event\\":\\"AddToCart\\",\\"event_id\\":\\"corey123_seg\\",\\"timestamp\\":\\"2021-09-2T15:21:15.449Z\\",\\"test_event_code\\":\\"TEST04030\\",\\"context\\":{\\"user\\":{\\"external_id\\":\\"481f202262e9c5ccc48d24e60798fadaa5f6ff1f8369f7ab927c04c3aa682a7f\\",\\"phone_number\\":\\"910a625c4ba147b544e6bd2f267e130ae14c591b6ba9c25cb8573322dedbebd0\\",\\"email\\":\\"eb9869a32b532840dd6aa714f7a872d21d6f650fc5aa933d9feefc64708969c7\\"},\\"ad\\":{\\"callback\\":\\"12345\\"},\\"page\\":{\\"url\\":\\"https://segment.com/\\",\\"referrer\\":\\"https://google.com/\\"},\\"ip\\":\\"0.0.0.0\\",\\"user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57\\"},\\"properties\\":{\\"contents\\":[{\\"price\\":100,\\"quantity\\":2,\\"content_type\\":\\"Air Force One (Size S)\\",\\"content_id\\":\\"abc123\\"}],\\"currency\\":\\"USD\\",\\"value\\":100,\\"query\\":\\"shoes\\"},\\"partner_name\\":\\"Segment\\"}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/tiktok-conversions/reportWebEvent/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/reportWebEvent/index.ts
@@ -192,6 +192,17 @@ const action: ActionDefinition<Settings, Payload> = {
       hashedPhoneNumber: formatPhone(payload.phone_number)
     }
 
+    let payloadUrl, urlTtclid
+    if (payload.url) {
+      try {
+        payloadUrl = new URL(payload.url)
+      } catch (error) {
+        //  invalid url
+      }
+    }
+
+    if (payloadUrl) urlTtclid = payloadUrl.searchParams.get('ttclid')
+
     // Request to tiktok Events Web API
     return request('https://business-api.tiktok.com/open_api/v1.2/pixel/track/', {
       method: 'post',
@@ -208,7 +219,7 @@ const action: ActionDefinition<Settings, Payload> = {
             email: userData.hashedEmail
           },
           ad: {
-            callback: payload.ttclid
+            callback: payload.ttclid ? payload.ttclid : urlTtclid ? urlTtclid : undefined
           },
           page: {
             url: payload.url,
@@ -223,7 +234,8 @@ const action: ActionDefinition<Settings, Payload> = {
           value: payload.value,
           description: payload.description,
           query: payload.query
-        }
+        },
+        partner_name: 'Segment'
       }
     })
   }


### PR DESCRIPTION
This PR updates the TikTok conversions destination:
1. Adds partner_name in the event payload with a default value "Segment"
2. Parse ttclid from context.page.url when ttclid is not available

## Testing

1. local server testing
<img width="1892" alt="Screen Shot 2022-05-03 at 5 36 27 PM" src="https://user-images.githubusercontent.com/104358284/166608660-1b64c1e6-79d7-4a2a-b493-5959f4e080f4.png">
2. add 1 unit test to test ttclid parse from page.url when ttclid is not available

![Screen Shot 2022-05-03 at 5 34 04 PM](https://user-images.githubusercontent.com/104358284/166608758-6ad6e348-9514-444d-b4b7-0e2ccec4679d.png)



- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
