### PR TITLE
[GA4] Throw correct class of error in purchase action

### DIFF
--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
@@ -48,7 +48,11 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: (request, { payload }) => {
     if (!CURRENCY_ISO_CODES.includes(payload.currency)) {
-      throw new IntegrationError(`${payload.currency} is not a valid currency code.`, 400)
+      throw new IntegrationError(
+        `${payload.currency} is not a valid currency code.`,
+        'Misconfigured required field',
+        400
+      )
     }
 
     let googleItems: ProductItem[] = []

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
@@ -48,7 +48,7 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: (request, { payload }) => {
     if (!CURRENCY_ISO_CODES.includes(payload.currency)) {
-      throw new Error(`${payload.currency} is not a valid currency code.`)
+      throw new IntegrationError(`${payload.currency} is not a valid currency code.`, 400)
     }
 
     let googleItems: ProductItem[] = []


### PR DESCRIPTION
- This PR throws an error of class `IntegrationError`, rather than `Error`, when the customer has passed an invalid `currency` value to a `purchase` action.
- This change is necessary to prevent the `throw new Error(${payload.currency} is not a valid currency code.)` error from being written to Sentry. Example of the error in [Sentry here](https://sentry.io/organizations/segment/issues/3039383961/?project=1110287&query=is%3Aunresolved).
- We should only be writing `internal` errors to Sentry (defined as errors without an error `code` and `status`). See [definition of `internal` error here in the monoservice](https://github.com/segmentio/integrations/blob/a64f6bc3cace4ea7d9b919bdbf004d81562fca07/Service/cloudevents.js#L794-L798).
- Because this particular error is Segment-defined and intentional, we should not be writing this error to Sentry.

## Testing
- Testing completed successfully locally using local server (see below).
- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment

Sent a test event via local server to trigger this error. `IntegrationError` was thrown as expected:

```
{
  "statusCode": 400,
  "message": "US is not a valid currency code.",
  "stack": [
    "IntegrationError: US is not a valid currency code.",
    "    at perform (/Users/brennan.gamwell/dev/src/github.com/segmentio/action-destinations/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts:51:13)",
    "    at Action.performRequest (/Users/brennan.gamwell/dev/src/github.com/segmentio/action-destinations/packages/core/src/destination-kit/action.ts:203:28)",
    "    at Action.execute (/Users/brennan.gamwell/dev/src/github.com/segmentio/action-destinations/packages/core/src/destination-kit/action.ts:137:31)",
    "    at /Users/brennan.gamwell/dev/src/github.com/segmentio/action-destinations/packages/cli/src/lib/server.ts:230:26",
    "    at /Users/brennan.gamwell/dev/src/github.com/segmentio/action-destinations/packages/cli/src/lib/async-handler.ts:7:12",
    "    at Layer.handle [as handle_request] (/Users/brennan.gamwell/dev/src/github.com/segmentio/action-destinations/node_modules/express/lib/router/layer.js:95:5)",
    "    at next (/Users/brennan.gamwell/dev/src/github.com/segmentio/action-destinations/node_modules/express/lib/router/route.js:137:13)",
    "    at Route.dispatch (/Users/brennan.gamwell/dev/src/github.com/segmentio/action-destinations/node_modules/express/lib/router/route.js:112:3)",
    "    at Layer.handle [as handle_request] (/Users/brennan.gamwell/dev/src/github.com/segmentio/action-destinations/node_modules/express/lib/router/layer.js:95:5)",
    "    at /Users/brennan.gamwell/dev/src/github.com/segmentio/action-destinations/node_modules/express/lib/router/index.js:281:22"
  ],
  "requestError": true
}
```

<img width="1410" alt="Screen Shot 2022-05-06 at 9 38 40 AM" src="https://user-images.githubusercontent.com/11224497/167175385-7ce7f816-e0fe-441a-857b-bb8088861b56.png">
