### PR TITLE
[Actions-Server] Pass in mappings object for batching & noActionsTester flag

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -35,7 +35,7 @@ export default class Serve extends Command {
     }),
     noUI: flags.boolean({
       char: 'n',
-      description: 'do not open actions tester'
+      description: 'do not open actions tester UI in browser'
     })
   }
 

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -33,7 +33,7 @@ export default class Serve extends Command {
       description: 'destination actions directory',
       default: './packages/destination-actions/src/destinations'
     }),
-    noActionsTester: flags.boolean({
+    noUI: flags.boolean({
       char: 'n',
       description: 'do not open actions tester'
     })
@@ -86,7 +86,7 @@ export default class Serve extends Command {
     const DEFAULT_PORT = 3000
     const port = parseInt(process.env.PORT ?? '', 10) || DEFAULT_PORT
 
-    if (!flags.noActionsTester) {
+    if (!flags.noUI) {
       const wss = new WebSocketServer({ port: port + 1 })
 
       wss.on('connection', function connection(ws) {
@@ -144,7 +144,7 @@ export default class Serve extends Command {
     watcher.once('ready', () => {
       this.log(chalk.greenBright`Watching required files for changes .. `)
 
-      if (!flags.noActionsTester) {
+      if (!flags.noUI) {
         this.log(
           chalk.greenBright`Visit https://app.segment.com/dev-center/actions-tester to preview your integration.`
         )

--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -222,9 +222,10 @@ function setupRoutes(def: DestinationDefinition | null): void {
           }
 
           if (Array.isArray(eventParams.data)) {
-            // We assume that the the first payload in the data array
-            // provided for testing contains all actions mappings
-            if (Array.isArray(eventParams.mapping)) {
+            // If no mapping is provided default to using the first payload across all events.
+            if (!req.body.mapping) {
+              // We assume that the the first payload in the data array
+              // provided for testing contains all actions mappings
               eventParams.mapping = eventParams.data[0] || {}
             }
 

--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -223,12 +223,9 @@ function setupRoutes(def: DestinationDefinition | null): void {
 
           if (Array.isArray(eventParams.data)) {
             // If no mapping is provided default to using the first payload across all events.
-            if (!req.body.mapping) {
-              // We assume that the the first payload in the data array
-              // provided for testing contains all actions mappings
-              eventParams.mapping = eventParams.data[0] || {}
-            }
-
+            // We assume that the the first payload in the data array
+            // provided for testing contains all actions mappings
+            eventParams.mapping = req.body.mapping ?? eventParams.data[0] ?? {}
             await action.executeBatch(eventParams)
           } else {
             await action.execute(eventParams)

--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -223,8 +223,6 @@ function setupRoutes(def: DestinationDefinition | null): void {
 
           if (Array.isArray(eventParams.data)) {
             // If no mapping is provided default to using the first payload across all events.
-            // We assume that the the first payload in the data array
-            // provided for testing contains all actions mappings
             eventParams.mapping = req.body.mapping ?? eventParams.data[0] ?? {}
             await action.executeBatch(eventParams)
           } else {

--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -224,7 +224,10 @@ function setupRoutes(def: DestinationDefinition | null): void {
           if (Array.isArray(eventParams.data)) {
             // We assume that the the first payload in the data array
             // provided for testing contains all actions mappings
-            eventParams.mapping = eventParams.data[0] || {}
+            if (Array.isArray(eventParams.mapping)) {
+              eventParams.mapping = eventParams.data[0] || {}
+            }
+
             await action.executeBatch(eventParams)
           } else {
             await action.execute(eventParams)


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

To enable testing batching enabled destinations locally this PR adds:
* Option to pass in a `mapping` object that applies to all payloads in a request. Previously we would use only the first payload as a mapping, resulting in that payload being cloned to every event in the batch. We will fallback to this if no `mapping` object is provided.
* A new `-n` `--noActionsTester` flag which turns off the actions tester. Useful for testing batching locally with Insomnia, and avoiding having to close the actions-tester popup every time.

## Testing
Tested the new flag with `./bin/run serve -n`. The actions-tester does not open but the server accepts local insomnia requests as expected.

Tested locally by successfully sending through this request shape. All mappings apply as expected.
<img width="608" alt="Screen Shot 2022-05-06 at 10 13 46 AM" src="https://user-images.githubusercontent.com/27820201/167180516-bb6db336-ac66-4392-8cb7-6daa78ef4e1b.png">


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
