### PR TITLE
[STRATCONN-1353] Add engagement_time_msec to GA4 customEvent action

### DIFF
--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
@@ -47,7 +47,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"Some_Event_Here\\",\\"engagement_time_msec\\":1}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"Some_Event_Here\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 
@@ -109,7 +109,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"engagement_time_msec\\":1}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
       )
     })
 
@@ -152,7 +152,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"engagement_time_msec\\":1}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
       )
     })
 
@@ -212,7 +212,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"engagement_time_msec\\":2,\\"params\\":{\\"order_id\\":\\"5678dd9087-78\\",\\"coupon\\":\\"SUMMER_FEST\\",\\"currency\\":\\"USD\\",\\"revenue\\":11.99,\\"total\\":15.99}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"params\\":{\\"engagement_time_msec\\":2,\\"order_id\\":\\"5678dd9087-78\\",\\"coupon\\":\\"SUMMER_FEST\\",\\"currency\\":\\"USD\\",\\"revenue\\":11.99,\\"total\\":15.99}}]}"`
       )
     })
 
@@ -253,7 +253,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"Order_Completed\\",\\"engagement_time_msec\\":1}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"Order_Completed\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
       )
     })
 
@@ -297,7 +297,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"order_completed\\",\\"engagement_time_msec\\":1}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"order_completed\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
@@ -47,7 +47,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"Some_Event_Here\\"}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"Some_Event_Here\\",\\"engagement_time_msec\\":1}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 
@@ -109,7 +109,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\"}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"engagement_time_msec\\":1}]}"`
       )
     })
 
@@ -152,7 +152,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\"}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"engagement_time_msec\\":1}]}"`
       )
     })
 
@@ -212,7 +212,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"params\\":{\\"order_id\\":\\"5678dd9087-78\\",\\"coupon\\":\\"SUMMER_FEST\\",\\"currency\\":\\"USD\\",\\"revenue\\":11.99,\\"total\\":15.99}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"engagement_time_msec\\":2,\\"params\\":{\\"order_id\\":\\"5678dd9087-78\\",\\"coupon\\":\\"SUMMER_FEST\\",\\"currency\\":\\"USD\\",\\"revenue\\":11.99,\\"total\\":15.99}}]}"`
       )
     })
 
@@ -253,7 +253,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"Order_Completed\\"}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"Order_Completed\\",\\"engagement_time_msec\\":1}]}"`
       )
     })
 
@@ -297,7 +297,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"order_completed\\"}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"order_completed\\",\\"engagement_time_msec\\":1}]}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
@@ -58,7 +58,10 @@ const action: ActionDefinition<Settings, Payload> = {
         events: [
           {
             name: event_name,
-            params: payload.params
+            params: {
+              engagement_time_msec: payload.engagement_time_msec,
+              ...payload.params
+            }
           }
         ],
         ...formatUserProperties(payload.user_properties)


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_This PR adds `engagement_time_msec` to GA4's `customEvent` action in the event params. This new field will allow user data to appear in GA4 custom events._


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

Testing completed successfully through stage deploy with event tester and sending dispatch events end to end. 

Event Tester with no other data in params: 

<img width="552" alt="image" src="https://user-images.githubusercontent.com/89420099/167676766-5c6e7aea-9177-46dd-9709-d29fab23171b.png">

Event Tester with other data params: 

<img width="619" alt="image" src="https://user-images.githubusercontent.com/89420099/167676604-4eaec515-d7da-4396-86c6-92d56730582a.png">


Action Tester: 

Custom Event: 

<img width="1430" alt="image" src="https://user-images.githubusercontent.com/89420099/167502745-73113550-a0bc-4733-b0d1-29592c0c5386.png">


Page View: (Just to make sure other actions are still working correctly) 

<img width="1608" alt="image" src="https://user-images.githubusercontent.com/89420099/167502713-ffe59df1-643c-4936-82d6-2b209c987234.png">

GA4 Dashboard: 

<img width="1104" alt="image" src="https://user-images.githubusercontent.com/89420099/167502815-cd1429a8-be34-49cc-9aeb-e96813a776f2.png">

Confirm with GA4 `/debug` endpoint: 

<img width="1789" alt="image" src="https://user-images.githubusercontent.com/89420099/167557557-70fac5ff-e458-4123-90aa-e3b757b70552.png">

<img width="1762" alt="image" src="https://user-images.githubusercontent.com/89420099/167557709-27a30a62-48fe-474f-9148-6181dc3e2bfc.png">


- [ x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x ] [Segmenters] Tested in the staging environment
