### PR TITLE
Update validate.ts to include is_true and is_false operators and add unit tests ensuring functionality

### DIFF
--- a/packages/destination-subscriptions/src/__tests__/validate.test.ts
+++ b/packages/destination-subscriptions/src/__tests__/validate.test.ts
@@ -77,6 +77,7 @@ test('operators - equals (boolean true)', () => {
 
   expect(validate(ast, { properties: { value: true } })).toEqual(true)
   expect(validate(ast, { properties: { value: false } })).toEqual(false)
+  expect(validate(ast, { properties: { value: 'true' } })).toEqual(false)
 })
 
 test('operators - equals (boolean false)', () => {
@@ -94,6 +95,7 @@ test('operators - equals (boolean false)', () => {
 
   expect(validate(ast, { properties: { value: false } })).toEqual(true)
   expect(validate(ast, { properties: { value: true } })).toEqual(false)
+  expect(validate(ast, { properties: { value: 'false' } })).toEqual(false)
 })
 
 test('operators - equals (strings)', () => {

--- a/packages/destination-subscriptions/src/__tests__/validate.test.ts
+++ b/packages/destination-subscriptions/src/__tests__/validate.test.ts
@@ -62,6 +62,40 @@ test('should handle empty event', () => {
   expect(validate(ast, {})).toEqual(false)
 })
 
+test('operators - equals (boolean true)', () => {
+  const ast = {
+    type: 'group',
+    operator: 'and',
+    children: [
+      {
+        type: 'event-property',
+        name: 'value',
+        operator: 'is_true'
+      }
+    ]
+  }
+
+  expect(validate(ast, { properties: { value: true } })).toEqual(true)
+  expect(validate(ast, { properties: { value: false } })).toEqual(false)
+})
+
+test('operators - equals (boolean false)', () => {
+  const ast = {
+    type: 'group',
+    operator: 'and',
+    children: [
+      {
+        type: 'event-property',
+        name: 'value',
+        operator: 'is_false'
+      }
+    ]
+  }
+
+  expect(validate(ast, { properties: { value: false } })).toEqual(true)
+  expect(validate(ast, { properties: { value: true } })).toEqual(false)
+})
+
 test('operators - equals (strings)', () => {
   const ast = {
     type: 'group',

--- a/packages/destination-subscriptions/src/validate.ts
+++ b/packages/destination-subscriptions/src/validate.ts
@@ -99,6 +99,10 @@ const validateValue = (actual: unknown, operator: Operator, expected?: string | 
       return actual !== undefined && actual !== null
     case 'not_exists':
       return actual === undefined || actual === null
+    case 'is_true':
+      return typeof actual === 'boolean' && actual === true
+    case 'is_false':
+      return typeof actual === 'boolean' && actual === false
     default:
       return false
   }


### PR DESCRIPTION
This PR updates the validate.ts file with the inclusion of two new operators `is_true` and `is_false`. 

Previously there was no support for these operators which would lead to the validate function indefinitely returning false and thus the event and action subscriptions would not be correctly matched.

Context of previous changes where this update was missed:
- [app](https://github.com/segmentio/app/commit/78e721e2d47cccd7a5c346a0ca7294bd1c63d4ff)
- [action-destinations](https://github.com/segmentio/action-destinations/commit/6c117e93a78396e166145939d9edbc3b8d04f55e)
## Testing

Included two new unit tests in validate.test.ts that use the new operators and passed as expected.

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
