### PR TITLE
Update Friendbuy Creation Name 

### DIFF
--- a/packages/browser-destinations/src/destinations/friendbuy/index.ts
+++ b/packages/browser-destinations/src/destinations/friendbuy/index.ts
@@ -48,7 +48,7 @@ const presets: DestinationDefinition['presets'] = [
 ]
 
 export const destination: BrowserDestinationDefinition<Settings, FriendbuyAPI> = {
-  name: 'Friendbuy (Web Destination)',
+  name: 'Friendbuy (Actions)',
   slug: 'actions-friendbuy',
   mode: 'device',
 


### PR DESCRIPTION
This field should reflect the creation name of the destination. Changing it so that it matches the creation name in control plane so I don't hit this error: 
https://github.com/segmentio/action-destinations/blob/main/packages/cli-internal/src/commands/push.ts#L96

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
