### PR TITLE
Update Description for FB CAPI Event Time

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
@@ -122,7 +122,7 @@ export const num_items: InputField = {
 
 export const event_time: InputField = {
   label: 'Event Time',
-  description: 'A Unix timestamp in seconds indicating when the actual event occurred.',
+  description: 'A Unix timestamp in seconds indicating when the actual event occurred. Facebook will automatically convert ISO 8601 timestamps to Unix.',
   type: 'string',
   default: {
     '@path': '$.timestamp'


### PR DESCRIPTION
_A summary of your pull request, including the what change you're making and why._

Updating field description for Event Time as Facebook confirmed that they are automatically converting our ISO 8601 timestamp to Unix. Support has gotten a few questions/confusion from customers about this since our description says it should be Unix but `timestamp` is not Unix. Ngan at Facebook and I ran a test and confirmed Facebook is handling an conversion to Unix so this clarifies to customers.

Slack thread: https://segment.slack.com/archives/CQ1F92KUG/p1650410774517389

## Testing
_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

**No testing required as this is only a description change.**

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
