### PR TITLE
add console warning if payload is invalid

### DIFF
--- a/packages/browser-destinations/src/destinations/sprig-web/identifyUser/index.ts
+++ b/packages/browser-destinations/src/destinations/sprig-web/identifyUser/index.ts
@@ -39,7 +39,13 @@ const action: BrowserActionDefinition<Settings, Sprig, Payload> = {
   },
   perform: (Sprig, event) => {
     const payload = event.payload
-    if (!payload || typeof payload !== 'object' || !(payload.userId || payload.anonymousId || payload.traits)) return
+    if (!payload || typeof payload !== 'object' || !(payload.userId || payload.anonymousId || payload.traits)) {
+      console.warn(
+        '[Sprig] received invalid payload (expected userId, anonymousId, or traits to be present); skipping identifyUser',
+        payload
+      )
+      return
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sprigIdentifyAndSetAttributesPayload: {

--- a/packages/browser-destinations/src/destinations/sprig-web/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/sprig-web/trackEvent/index.ts
@@ -39,7 +39,10 @@ const action: BrowserActionDefinition<Settings, Sprig, Payload> = {
   },
   perform: (Sprig, event) => {
     const payload = event.payload
-    if (!payload || typeof payload !== 'object' || !payload.name) return
+    if (!payload || typeof payload !== 'object' || !payload.name) {
+      console.warn('[Sprig] received invalid payload (expected name to be present); skipping trackEvent', payload)
+      return
+    }
 
     const sprigIdentifyAndTrackPayload: { eventName: string; userId?: string; anonymousId?: string } = {
       eventName: payload.name

--- a/packages/browser-destinations/src/destinations/sprig-web/updateUserId/index.ts
+++ b/packages/browser-destinations/src/destinations/sprig-web/updateUserId/index.ts
@@ -30,7 +30,13 @@ const action: BrowserActionDefinition<Settings, Sprig, Payload> = {
   },
   perform: (Sprig, event) => {
     const payload = event.payload
-    if (!payload || typeof payload !== 'object' || !(payload.userId || payload.anonymousId)) return
+    if (!payload || typeof payload !== 'object' || !(payload.userId || payload.anonymousId)) {
+      console.warn(
+        '[Sprig] received invalid payload (expected userId or anonymousId to be present); skipping updateUserId',
+        payload
+      )
+      return
+    }
 
     const sprigIdentifyAndSetAttributesPayload: { userId?: string; anonymousId?: string } = {}
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._
* small PR to add console warnings if mappings are such that Sprig SDK is not invoked as a result of an action. For example, a customer tried to track an event but manually mapped the event name to `eventName` instead of `event`, so the action short-circuited -- now this would log a console warning to aid in debugging in the future

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [existing unit tests pass] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [n/a for browser destinations] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
