### PR TITLE
STRATCONN-1350: Salesforce Action - Bug fix for Account upserts - allow numeric values

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
@@ -62,7 +62,7 @@ describe('Salesforce', () => {
     })
 
     it('should fail when a record is not found', async () => {
-      const query = encodeURIComponent(`SELECT Id FROM Lead WHERE email = 'sponge@seamail.com'`)
+      const query = encodeURIComponent(`SELECT Id FROM Lead WHERE account_number = '123456789'`)
       nock(`${settings.instanceUrl}services/data/${API_VERSION}/query`).get(`/?q=${query}`).reply(201, {
         totalSize: 0
       })
@@ -71,7 +71,7 @@ describe('Salesforce', () => {
         sf.updateRecord(
           {
             traits: {
-              email: 'sponge@seamail.com'
+              account_number: 123456789
             }
           },
           'Lead'
@@ -100,7 +100,7 @@ describe('Salesforce', () => {
     describe('upsert', () => {
       it('should create a new record when no records are found', async () => {
         const query = encodeURIComponent(
-          `SELECT Id FROM Lead WHERE email = 'sponge@seamail.com' OR company = 'Krusty Krab'`
+          `SELECT Id FROM Lead WHERE email = 'sponge@seamail.com' OR account_number = '123456789'`
         )
         nock(`${settings.instanceUrl}services/data/${API_VERSION}/query`).get(`/?q=${query}`).reply(201, {
           totalSize: 0
@@ -112,7 +112,7 @@ describe('Salesforce', () => {
           {
             traits: {
               email: 'sponge@seamail.com',
-              company: 'Krusty Krab'
+              account_number: 123456789
             },
             company: 'Krusty Krab LLC',
             last_name: 'Krabs'
@@ -201,7 +201,7 @@ describe('Salesforce', () => {
 
       it('should properly escape quotes in a record matcher', async () => {
         const query = encodeURIComponent(
-          `SELECT Id FROM Lead WHERE email = 'sponge@seamail.com' OR company = 'Krusty\\'s Krab'`
+          `SELECT Id FROM Lead WHERE email = 'sponge@seamail.com' OR company = 'Krusty\\'s Krab' OR account_number = '12345678'`
         )
         nock(`${settings.instanceUrl}services/data/${API_VERSION}/query`)
           .get(`/?q=${query}`)
@@ -217,7 +217,8 @@ describe('Salesforce', () => {
           {
             traits: {
               email: 'sponge@seamail.com',
-              company: "Krusty's Krab"
+              company: "Krusty's Krab",
+              account_number: 12345678
             },
             company: 'Krusty Krab LLC',
             last_name: 'Krabs'

--- a/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
@@ -93,7 +93,7 @@ export default class Salesforce {
   }
 
   // Salesforce SOQL spec requires any single quotes to be escaped.
-  private escapeQuotes = (value: string) => value.replace(/'/g, "\\'")
+  private escapeQuotes = (value: string) => value.toString().replace(/'/g, "\\'")
 
   // Salesforce field names should have only characters in {a-z, A-Z, 0-9, _}.
   private removeInvalidChars = (value: string) => value.replace(/[^a-zA-Z0-9_]/g, '')


### PR DESCRIPTION
This PR fixes a bug in Salesforce(Actions) Destination while upserting Account records. User cannot associate numeric field to send to SF APIs for Account ids(and other) fields. Root-cause was around a code snippet where we were assuming the fields will be String and running a String manipulation function on it.  

https://segment.atlassian.net/browse/STRATCONN-1350

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment

BEFORE the fix : 
<img width="1153" alt="Screen Shot 2022-05-11 at 3 00 45 PM" src="https://user-images.githubusercontent.com/101593714/169150559-1580087a-5931-47b5-9623-eca14b5d4820.png">


AFTER the fix : 
<img width="1467" alt="Screen Shot 2022-05-11 at 4 49 40 PM" src="https://user-images.githubusercontent.com/101593714/169150708-e9f40239-49b6-4b07-b002-0a46b2b56188.png">


Additional testing with other data types: 

<img width="1466" alt="Screen Shot 2022-05-11 at 4 50 42 PM" src="https://user-images.githubusercontent.com/101593714/169150851-9ef46a42-1be1-4dde-8a9e-bda2cf95465f.png">
<img width="1462" alt="Screen Shot 2022-05-11 at 4 51 33 PM" src="https://user-images.githubusercontent.com/101593714/169150866-5585f980-d647-414f-952d-019f9a469231.png">

