### PR TITLE
Remove dependency on rawData

### DIFF
--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -126,8 +126,6 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
 
     // Construct the data bundle to send to an action
     const dataBundle = {
-      rawData: bundle.data,
-      rawMapping: bundle.mapping,
       settings: bundle.settings,
       payload,
       auth: bundle.auth
@@ -168,8 +166,6 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
 
     if (this.definition.performBatch) {
       const data = {
-        rawData: bundle.data,
-        rawMapping: bundle.mapping,
         settings: bundle.settings,
         payload: payloads,
         auth: bundle.auth

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -3,7 +3,6 @@ import type { JSONObject } from '../json-object'
 import { AuthTokens } from './parse-settings'
 import type { RequestClient } from '../create-request-client'
 import type { ID } from '../segment-event'
-import { InputData } from '../mapping-kit'
 
 export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>
 export type MaybePromise<T> = T | Promise<T>
@@ -24,8 +23,6 @@ export interface ExecuteInput<Settings, Payload> {
   page?: string
   /** The data needed in OAuth requests */
   readonly auth?: AuthTokens
-  /** The input data in its raw form without any transformations */
-  readonly rawData?: InputData | InputData[]
 }
 
 export interface DynamicFieldResponse {

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/generated-types.ts
@@ -2,6 +2,14 @@
 
 export interface Payload {
   /**
+   * Property which uniquely identifies each row in the spreadsheet.
+   */
+  record_identifier: string
+  /**
+   * Describes the nature of the operation being performed. Only supported values are 'new', 'updated', and 'deleted'.
+   */
+  operation_type: string
+  /**
    * The identifier of the spreadsheet. You can find this value in the URL of the spreadsheet. e.g. https://docs.google.com/spreadsheets/d/{SPREADSHEET_ID}/edit
    */
   spreadsheet_id: string

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/operations.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/operations.ts
@@ -10,15 +10,6 @@ type Fields = {
 }
 
 /**
- * Union of mapping data (payload) and dependencies taken on the source type
- */
-type PayloadEvent = {
-  identifier: string
-  operation: string
-  payload: Payload
-}
-
-/**
  * Invariant settings that are common to all events in the payload.
  */
 export type MappingSettings = {
@@ -62,14 +53,14 @@ const generateColumnValuesFromFields = (identifier: string, fields: Fields, colu
  * @param events data to be written to the spreadsheet
  * @returns
  */
-function processGetSpreadsheetResponse(response: any, events: PayloadEvent[]) {
+function processGetSpreadsheetResponse(response: any, events: Payload[]) {
   // TODO (STRATCONN-1375): Fail request if above row limit
 
   const updateBatch: { identifier: string; event: Fields; targetIndex: number }[] = []
   const appendBatch: { identifier: string; event: Fields }[] = []
 
   // Use a hashmap to efficiently find if the event already exists in the spreadsheet (update) or not (append).
-  const eventMap = new Map(events.map((e) => [e.identifier, e.payload.fields as Fields]))
+  const eventMap = new Map(events.map((e) => [e.record_identifier, e.fields]))
 
   if (response.data.values && response.data.values.length > 0) {
     for (let i = 1; i < response.data.values.length; i++) {
@@ -88,7 +79,7 @@ function processGetSpreadsheetResponse(response: any, events: PayloadEvent[]) {
   eventMap.forEach((value, key) => {
     appendBatch.push({
       identifier: key,
-      event: value
+      event: value as Fields
     })
   })
 
@@ -106,6 +97,7 @@ function processUpdateBatch(
   updateBatch: { identifier: string; event: { [k: string]: string }; targetIndex: number }[],
   gs: GoogleSheets
 ) {
+  // Utility function used to calculate which range an event should be written to
   const getRange = (targetIndex: number, columnCount: number, startRow = 1, startColumn = 1) => {
     const targetRange = new A1(startColumn, targetIndex + startRow)
     targetRange.addX(columnCount)
@@ -121,7 +113,7 @@ function processUpdateBatch(
     }
   })
 
-  // Always write columns names on first row
+  // Always add to the payload a write to the first row (containing column names) in case that columns have been updated
   const headerRowRange = new A1(1, 1, 1, mappingSettings.columns.length + 1)
   batchPayload.push({
     range: `${mappingSettings.spreadsheetName}!${headerRowRange.toString()}`,
@@ -173,13 +165,13 @@ function processAppendBatch(
  * @param request request object used to perform HTTP calls
  * @param events array of events to commit to the spreadsheet
  */
-function processData(request: RequestClient, events: PayloadEvent[]) {
+function processData(request: RequestClient, events: Payload[]) {
   // These are assumed to be constant across all events
   const mappingSettings = {
-    spreadsheetId: events[0].payload.spreadsheet_id,
-    spreadsheetName: events[0].payload.spreadsheet_name,
-    dataFormat: events[0].payload.data_format,
-    columns: Object.getOwnPropertyNames(events[0].payload.fields)
+    spreadsheetId: events[0].spreadsheet_id,
+    spreadsheetName: events[0].spreadsheet_name,
+    dataFormat: events[0].data_format,
+    columns: Object.getOwnPropertyNames(events[0].fields)
   }
 
   const gs: GoogleSheets = new GoogleSheets(request)


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

We needed to take a dependency on `__segment_id` and `event` from the RETL sources and were leveraging rawData to do that. Instead, we will make them actual mappings and leverage the functionality from BE-797 to hide them and prevent users from changing them.

In addition, I have removed rawData and rawMapping from being passed to the perform* functions to prevent anyone from taking a dependency on it.

## Testing

Performed manual testing with Insomnia but full testing suite blocks STRATCONN-1260 from being merged to main until complete.

cURL command:
```
curl --request POST \
  --url http://localhost:3000/postSheet \
  --header 'Content-Type: application/json' \
  --data '{
	"payload": [
		{
			"type": "track",
			"event": "updated",
			"receivedAt": "2022-04-12T23:17:41.192501242Z",
			"channel": "server",
			"properties": {
				"CLOSE_DATE": "2022-07-08T00:00:00Z",
				"CLOSE_DATE_EOQ": "2022-07-08",
				"ENTRY_POINT": "Website Demo Request",
				"E_ARR_POST_LAUNCH_C": "100001.0",
				"FINANCE_ENTRY_POINT": "Inbound High CHANGE"
			},
			"__segment_id": "0063q0000126KchAAE-Robert16"
		},
		{
			"type": "track",
			"event": "updated",
			"receivedAt": "2022-04-12T23:17:41.192501242Z",
			"channel": "server",
			"properties": {
				"CLOSE_DATE": "2022-07-10T00:00:00Z",
				"CLOSE_DATE_EOQ": "2022-07-10",
				"ENTRY_POINT": "Website Demo Response",
				"E_ARR_POST_LAUNCH_C": "100000.0",
				"FINANCE_ENTRY_POINT": "Inbound Low Change"
			},
			"__segment_id": "0063q0000126KchAAE-Robert13"
		}
	],
	"mapping": {
		"record_identifier": {
			"@path": "$.__segment_id"
		},
		"operation_type": {
			"@path": "$.event"
		},
		"spreadsheet_id": "1ORcFZ73VJXzj7rruKTrbUCgtRjqvKS4qW1uwDGP8tiY",
		"spreadsheet_name": "Sheet1",
		"data_format": "RAW",
		"fields": {
			"@path": "$.properties"
		}
	},
	"settings": {
	},
	"auth": {
		"clientId": "",
		"clientSecret": "",
		"accessToken": "<ADD ME>",
		"refreshToken": ""
	}
}'
```