### PR TITLE
Add hidden type

### DIFF
--- a/packages/core/src/__tests__/schema-validation.test.ts
+++ b/packages/core/src/__tests__/schema-validation.test.ts
@@ -111,6 +111,20 @@ describe('validateSchema', () => {
     expect(payload).toMatchInlineSnapshot(`Object {}`)
   })
 
+  it('should not throw when type = hidden', () => {
+    const hiddenSchema = fieldsToJsonSchema({
+      h: {
+        label: 'h',
+        type: 'hidden'
+      }
+    })
+
+    const payload = {}
+
+    const isValid = validateSchema(payload, hiddenSchema, { schemaKey: `testSchema` })
+    expect(isValid).toBe(true)
+  })
+
   // For now we always remove unknown keys, until builders have a way to specify the behavior
   it.todo('should not remove nested keys for valid properties')
 

--- a/packages/core/src/destination-kit/fields-to-jsonschema.ts
+++ b/packages/core/src/destination-kit/fields-to-jsonschema.ts
@@ -6,6 +6,7 @@ function toJsonSchemaType(type: FieldTypeName): JSONSchema4TypeName | JSONSchema
     case 'string':
     case 'text':
     case 'password':
+    case 'hidden':
       return 'string'
     case 'datetime':
       return ['string', 'number']
@@ -14,7 +15,9 @@ function toJsonSchemaType(type: FieldTypeName): JSONSchema4TypeName | JSONSchema
   }
 }
 
-export type MinimalInputField = Optional<InputField, 'description'> | Optional<GlobalSetting, 'description'> & { additionalProperties?: boolean }
+export type MinimalInputField =
+  | Optional<InputField, 'description'>
+  | (Optional<GlobalSetting, 'description'> & { additionalProperties?: boolean })
 
 export type MinimalFields = Record<string, MinimalInputField>
 
@@ -87,9 +90,14 @@ export function fieldsToJsonSchema(fields: MinimalFields = {}, options?: SchemaO
 
     if (schemaType === 'object' && field.properties) {
       if (isMulti) {
-        schema.items = fieldsToJsonSchema(field.properties, { additionalProperties: field?.additionalProperties || false })
+        schema.items = fieldsToJsonSchema(field.properties, {
+          additionalProperties: field?.additionalProperties || false
+        })
       } else {
-        schema = { ...schema, ...fieldsToJsonSchema(field.properties, { additionalProperties: field?.additionalProperties || false }) }
+        schema = {
+          ...schema,
+          ...fieldsToJsonSchema(field.properties, { additionalProperties: field?.additionalProperties || false })
+        }
       }
     }
 

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -66,7 +66,16 @@ export interface GlobalSetting {
 }
 
 /** The supported field type names */
-export type FieldTypeName = 'string' | 'text' | 'number' | 'integer' | 'datetime' | 'boolean' | 'password' | 'object'
+export type FieldTypeName =
+  | 'string'
+  | 'text'
+  | 'number'
+  | 'integer'
+  | 'datetime'
+  | 'boolean'
+  | 'password'
+  | 'object'
+  | 'hidden'
 
 /** The shape of an input field definition */
 export interface InputField {


### PR DESCRIPTION
This PR adds a `hidden` type, which is overridden as type `string` for AJV validation. This change is so that we can hide certain fields from the UI. 

## Testing

Verified that the perform block works and build is successful.
![Screen Shot 2022-05-20 at 11 10 48 AM](https://user-images.githubusercontent.com/87985289/169561318-2b67b200-3584-465e-a670-20c80ea35275.png)



_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
