### PR TITLE
PEREX-1329 fix: update SMS action to use api key

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/generated-types.ts
@@ -2,13 +2,17 @@
 
 export interface Settings {
   /**
-   * Twilio Account ID
+   * Twilio Account SID
    */
-  twilioAccountId: string
+  twilioAccountSID: string
   /**
-   * Twilio Auth Token
+   * Twilio API Key SID
    */
-  twilioAuthToken: string
+  twilioApiKeySID: string
+  /**
+   * Twilio API Key Secret
+   */
+  twilioApiKeySecret: string
   /**
    * Profile API Environment
    */

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
@@ -84,15 +84,21 @@ const destination: DestinationDefinition<Settings> = {
   authentication: {
     scheme: 'custom',
     fields: {
-      twilioAccountId: {
-        label: 'Twilio Account ID',
-        description: 'Twilio Account ID',
+      twilioAccountSID: {
+        label: 'Twilio Account SID',
+        description: 'Twilio Account SID',
         type: 'string',
         required: true
       },
-      twilioAuthToken: {
-        label: 'Twilio Auth Token',
-        description: 'Twilio Auth Token',
+      twilioApiKeySID: {
+        label: 'Twilio API Key SID',
+        description: 'Twilio API Key SID',
+        type: 'string',
+        required: true
+      },
+      twilioApiKeySecret: {
+        label: 'Twilio API Key Secret',
+        description: 'Twilio API Key Secret',
         type: 'password',
         required: true
       },

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
@@ -150,7 +150,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
       // TODO: GROW-259 remove this when we can extend the request
       // and we no longer need to call the profiles API first
-      const token = Buffer.from(`${settings.twilioAccountId}:${settings.twilioAuthToken}`).toString('base64')
+      const token = Buffer.from(`${settings.twilioApiKeySID}:${settings.twilioApiKeySecret}`).toString('base64')
       const parsedBody = await Liquid.parseAndRender(payload.body, { profile })
 
       const body = new URLSearchParams({
@@ -181,7 +181,7 @@ const action: ActionDefinition<Settings, Payload> = {
         body.append('StatusCallback', webhookUrlWithParams.toString())
       }
 
-      return request(`https://api.twilio.com/2010-04-01/Accounts/${settings.twilioAccountId}/Messages.json`, {
+      return request(`https://api.twilio.com/2010-04-01/Accounts/${settings.twilioAccountSID}/Messages.json`, {
         method: 'POST',
         headers: {
           authorization: `Basic ${token}`


### PR DESCRIPTION
Update personas sms action to use correct setting names and values

https://segment.atlassian.net/browse/PEREX-1329

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
