### PR TITLE
Fix execution halting for Google Sheets when processing a large Spreadsheet

### DIFF
--- a/packages/core/src/middleware/after-response/prepare-response.ts
+++ b/packages/core/src/middleware/after-response/prepare-response.ts
@@ -4,10 +4,17 @@ import type { ModifiedResponse } from '../../types'
 const prepareResponse: AfterResponseHook = async (_request, _options, response) => {
   const modifiedResponse = response as ModifiedResponse
 
-  // Clone the response before reading the body to avoid
-  // `TypeError: body used already` elsewhere
-  const clone = response.clone()
-  const content = await clone.text()
+  let content: string
+  if (_options.skipResponseCloning) {
+    // Skip cloning the response to avoid a Node crash in case the response payload is larger than 16KB
+    // TODO STRATCONN-1396: Move all action-destinations to follow this code path instead of cloning the response
+    content = await response.text()
+  } else {
+    // Clone the response before reading the body to avoid
+    // `TypeError: body used already` elsewhere
+    const clone = response.clone()
+    content = await clone.text()
+  }
   let data: unknown
 
   try {

--- a/packages/core/src/request-client.ts
+++ b/packages/core/src/request-client.ts
@@ -46,6 +46,10 @@ export interface RequestOptions extends Omit<RequestInit, 'headers'> {
    * When provided, will automatically apply basic authentication
    */
   username?: string
+  /**
+   * If enabled, will not clone the response as part of post-request processing
+   */
+  skipResponseCloning?: boolean
 }
 
 /**

--- a/packages/destination-actions/src/destinations/google-sheets/googleapis/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/googleapis/index.ts
@@ -19,7 +19,8 @@ export class GoogleSheets {
     return this.request(
       `https://sheets.googleapis.com/${API_VERSION}/spreadsheets/${mappingSettings.spreadsheetId}/values/${mappingSettings.spreadsheetName}!${range}`,
       {
-        method: 'get'
+        method: 'get',
+        skipResponseCloning: true
       }
     )
   }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Stop cloning the response object for Google Sheets to unblock STRATCONN-1260 release. I've filed tech debt ticket https://segment.atlassian.net/browse/STRATCONN-1396 to address underlying issue for all other action-destinations.

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment

Full test suite pending as part of STRATCONN-1260 merge into main.
