### PR TITLE
Fork @flighter/a1-notation into @segment/a1-notation

### DIFF
--- a/packages/destination-actions/package.json
+++ b/packages/destination-actions/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@amplitude/ua-parser-js": "^0.7.25",
-    "@flighter/a1-notation": "^2.1.2",
+    "@segment/a1-notation": "^2.1.2",
     "@segment/actions-core": "^3.23.1",
     "@segment/actions-shared": "^1.6.0",
     "cheerio": "^1.0.0-rc.10",

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/operations.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/operations.ts
@@ -2,8 +2,7 @@ import type { Payload } from './generated-types'
 import { RequestClient } from '@segment/actions-core'
 import { GoogleSheets, GetResponse } from '../googleapis/index'
 
-// TODO (STRATCONN-1379): Fork @flighter/a1-notation into @segment/a1-notation and add test cases
-import A1 from '@flighter/a1-notation'
+import A1 from '@segment/a1-notation'
 
 type Fields = {
   [k: string]: string


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

We're forking an external package used for a1-notation data manipulation into @segment's workspace so we have better control of future changes and additions.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment

Full test suite will follow as part of STRATCONN-1260 merge into main.