### PR TITLE
Update heap.track calls

### DIFF
--- a/packages/browser-destinations/src/destinations/heap/constants.ts
+++ b/packages/browser-destinations/src/destinations/heap/constants.ts
@@ -1,1 +1,1 @@
-export const HEAP_LIBRARY_NAME = 'segment'
+export const HEAP_SEGMENT_LIBRARY_NAME = 'destinations-actions'

--- a/packages/browser-destinations/src/destinations/heap/trackEvent/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/heap/trackEvent/__tests__/index.test.ts
@@ -27,12 +27,8 @@ describe('#trackEvent', () => {
       })
     )
 
-    expect(heapTrackSpy).toHaveBeenCalledWith(
-      'hello!',
-      {
-        banana: '📞'
-      },
-      'segment'
-    )
+    expect(heapTrackSpy).toHaveBeenCalledWith('hello!', {
+      banana: '📞'
+    })
   })
 })

--- a/packages/browser-destinations/src/destinations/heap/trackEvent/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/heap/trackEvent/__tests__/index.test.ts
@@ -6,7 +6,7 @@ import {
   mockHeapJsHttpRequest,
   trackEventSubscription
 } from '../../test-utilities'
-import { HEAP_SEGMENT_LIBRARY_NAME } from '../index'
+import { HEAP_SEGMENT_LIBRARY_NAME } from '../../constants'
 
 describe('#trackEvent', () => {
   const createHeapDestinationAndSpy = async (): Promise<[Plugin, jest.SpyInstance]> => {

--- a/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
@@ -3,6 +3,8 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { HeapApi } from '../types'
 
+export const HEAP_SEGMENT_LIBRARY_NAME = 'destinations-actions'
+
 const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
   title: 'Track Event',
   description: 'Track events',
@@ -29,7 +31,9 @@ const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
     }
   },
   perform: (heap, event) => {
-    heap.track(event.payload.name, event.payload.properties ?? {})
+    const defaultEventProperties = { segment_library: HEAP_SEGMENT_LIBRARY_NAME }
+    const eventProperties = Object.assign(defaultEventProperties, event.payload.properties ?? {})
+    heap.track(event.payload.name, eventProperties)
   }
 }
 

--- a/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
@@ -2,7 +2,6 @@ import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { HeapApi } from '../types'
-import { HEAP_LIBRARY_NAME } from '../constants'
 
 const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
   title: 'Track Event',
@@ -30,7 +29,7 @@ const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
     }
   },
   perform: (heap, event) => {
-    heap.track(event.payload.name, event.payload.properties ?? {}, HEAP_LIBRARY_NAME)
+    heap.track(event.payload.name, event.payload.properties ?? {})
   }
 }
 

--- a/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
@@ -2,8 +2,7 @@ import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { HeapApi } from '../types'
-
-export const HEAP_SEGMENT_LIBRARY_NAME = 'destinations-actions'
+import { HEAP_SEGMENT_LIBRARY_NAME } from '../constants'
 
 const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
   title: 'Track Event',

--- a/packages/browser-destinations/src/destinations/heap/types.ts
+++ b/packages/browser-destinations/src/destinations/heap/types.ts
@@ -13,7 +13,7 @@ type EventProperties = {
 
 export type HeapApi = {
   appid: string
-  track: (eventName: string, eventProperties: EventProperties, library: string) => void
+  track: (eventName: string, eventProperties: EventProperties, library?: string) => void
   load: () => void
   config: UserConfig
   identify: (identity: string) => void


### PR DESCRIPTION
After some internal debates, we decided to update how we ingest events coming from this Segment integration.

Instead of passing `segment` as the third `heap.track` parameter, we decided to merge this value into the events property object. This change will make it easier to process events in our preferred way on our end.

In addition to unit tests, I verified that the events appear in Heap correctly using the local server.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
