### PR TITLE
Rename Gainsight to original creation name in control-plane

### DIFF
--- a/packages/destination-actions/src/destinations/gainsight-px-cloud-action/index.ts
+++ b/packages/destination-actions/src/destinations/gainsight-px-cloud-action/index.ts
@@ -9,7 +9,7 @@ import sendEvent from './sendEvent'
 const defaultVals = { ...defaultValues(sendEvent.fields) }
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Gainsight PX Cloud (Actions)',
+  name: 'Gainsight Px Cloud (Actions)',
   slug: 'actions-gainsight-px-cloud',
   mode: 'cloud',
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

This PR addresses a change Gainsight made to their action destination name in a previous PR. Changing it from `Gainsight Px Cloud (Actions)` => `Gainsight PX Cloud (Actions)`. This resulted in the following error

```
logan.luque@workbench-platform-production-usw2-0d1aaa4249b67ffc0:~/action-destinations$ ./bin/run push
✔ Pick the definitions you would like to push to Segment: › Gainsight PX Cloud (Actions), Talon.One (Actions)
✖ Fetching existing definitions for Gainsight PX Cloud (Actions), Talon.One (Actions)...
    Error: The definition name 'Gainsight PX Cloud (Actions)' should always match the control plane creation name 'Gainsight Px Cloud
    (Actions)'.
```

The changes found in this PR should appease this error and allow the `./bin/run push` command to successfully complete.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
