### PR TITLE
STRATCONN-1350 : Bugfix - Support other datatypes as trait values in SF Actions

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
@@ -166,13 +166,31 @@ export default class Salesforce {
   // Salesforce field names should have only characters in {a-z, A-Z, 0-9, _}.
   private removeInvalidChars = (value: string) => value.replace(/[^a-zA-Z0-9_]/g, '')
 
+  // Pre-formats trait values based on datatypes for correct SOQL syntax
+  private typecast = (value: any) => {
+    switch (typeof value) {
+      case 'boolean':
+        return value
+      case 'number':
+        return value
+      case 'string':
+        return `'${this.escapeQuotes(value)}'`
+      default:
+        throw new IntegrationError(
+          'Unsupported datatype for record matcher traits - ' + typeof value,
+          'Unsupported Type',
+          400
+        )
+    }
+  }
+
   private buildQuery = (traits: object, sobject: string) => {
     let soql = `SELECT Id FROM ${sobject} WHERE `
 
     const entries = Object.entries(traits)
     let i = 0
     for (const [key, value] of entries) {
-      let token = `${this.removeInvalidChars(key)} = '${this.escapeQuotes(value)}'`
+      let token = `${this.removeInvalidChars(key)} = ${this.typecast(value)}`
 
       if (i < entries.length - 1) {
         token += ' OR '


### PR DESCRIPTION
We only supported String types for trait values so far which breaks some formatting related code in SOQL query generation code. This PR adds code to handle numeric and boolean data types along with String. We don't support object types yet. 

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment

### Staging testing : 


#### Configured mappings for trait: 

<img width="1102" alt="Screen Shot 2022-06-01 at 5 10 17 PM" src="https://user-images.githubusercontent.com/101593714/171659288-bcf8aae6-a333-4eb3-9075-50afb34bdb6d.png">

#### Issue reproduced in staging: 
Note the last two fields, values for No of Employees and Account Number fields. 
<img width="1466" alt="Screen Shot 2022-06-01 at 4 59 28 PM" src="https://user-images.githubusercontent.com/101593714/171659774-8eebcb55-2912-4041-a006-f1787ad8d731.png">

#### After the fix: 
All String doesn't work after fixing the error. SF doesn't support String values in numeric fields. 
<img width="1489" alt="Screen Shot 2022-06-01 at 5 08 30 PM" src="https://user-images.githubusercontent.com/101593714/171659759-fe0c82cc-949b-4935-87b6-d1d623c063a3.png">

SF doesn't support numeric data in String fields. 
<img width="1492" alt="Screen Shot 2022-06-01 at 5 09 51 PM" src="https://user-images.githubusercontent.com/101593714/171659292-cfe4f431-7ada-43d0-acd0-bcfb89162675.png">

Values of correct types:
<img width="1462" alt="Screen Shot 2022-06-01 at 5 09 30 PM" src="https://user-images.githubusercontent.com/101593714/171659297-6a2b4109-b5dc-4ad6-85c1-70099f519e40.png">

