### PR TITLE
GRAMA-829: allow for a custom hostname

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/generated-types.ts
@@ -34,6 +34,10 @@ export interface Settings {
    */
   webhookUrl?: string
   /**
+   * Overrides the default Twilio host name used mainly for testing without having to send real messages.
+   */
+  twilioHostname?: string
+  /**
    * Connection overrides are configuration supported by twilio webhook services. Must be passed as fragments on the callback url
    */
   connectionOverrides?: string

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
@@ -133,6 +133,14 @@ const destination: DestinationDefinition<Settings> = {
         format: 'uri',
         required: false
       },
+      twilioHostname: {
+        label: 'Twilio host name',
+        description:
+          'Overrides the default Twilio host name used mainly for testing without having to send real messages.',
+        type: 'string',
+        default: 'api.twilio.com',
+        required: false
+      },
       connectionOverrides: {
         label: 'Connection Overrides',
         description:
@@ -143,8 +151,9 @@ const destination: DestinationDefinition<Settings> = {
         properties: ConnectionOverridesProperties
       }
     },
-    testAuthentication: (request) => {
-      return request('https://api.twilio.com/2010-04-01')
+    testAuthentication: (request, options) => {
+      const hostName = options.settings.twilioHostname ?? 'api.twilio.com'
+      return request(`https://${hostName}/2010-04-01`)
     }
   },
   // TODO: GROW-259 we'll uncomment this once we remove the calls to the profiles API,

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
@@ -34,6 +34,7 @@ const fetchProfileTraits = async (
 }
 
 const EXTERNAL_ID_KEY = 'phone'
+const DEFAULT_HOSTNAME = 'api.twilio.com'
 
 const DEFAULT_CONNECTION_OVERRIDES = 'rp=all&rc=5'
 const action: ActionDefinition<Settings, Payload> = {
@@ -137,7 +138,6 @@ const action: ActionDefinition<Settings, Payload> = {
       return
     } else if (['subscribed', 'true'].includes(externalId.subscriptionStatus)) {
       const traits = await fetchProfileTraits(request, settings, payload.userId)
-
       const phone = payload.toNumber || externalId.id
       if (!phone) {
         return
@@ -181,7 +181,8 @@ const action: ActionDefinition<Settings, Payload> = {
         body.append('StatusCallback', webhookUrlWithParams.toString())
       }
 
-      return request(`https://api.twilio.com/2010-04-01/Accounts/${settings.twilioAccountSID}/Messages.json`, {
+      const hostname = settings.twilioHostname ?? DEFAULT_HOSTNAME
+      return request(`https://${hostname}/2010-04-01/Accounts/${settings.twilioAccountSID}/Messages.json`, {
         method: 'POST',
         headers: {
           authorization: `Basic ${token}`


### PR DESCRIPTION
Testing Twilio directly can be fairly expensive. Twilio has a way to do mock tests, but it's not great. It simply mocks the response without giving you information on what it would have sent. This may be fine in certain scenarios, but there's probably plenty where this is a problem. Adding this custom hostname field allows you to point the destination action at a mock endpoint to enable testing.

[GRAMA-829](https://segment.atlassian.net/browse/GRAMA-829)

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
