### PR TITLE
[Salesforce] Bulk Update

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
@@ -453,7 +453,7 @@ describe('Salesforce', () => {
         })
         .reply(201, {})
 
-      await sf.bulkUpsert(bulkUpsertPayloads, 'Account')
+      await sf.bulkHandler(bulkUpsertPayloads, 'Account')
     })
 
     it('should correctly parse the customFields object', async () => {
@@ -488,7 +488,7 @@ describe('Salesforce', () => {
         })
         .reply(201, {})
 
-      await sf.bulkUpsert(customPayloads, 'Account')
+      await sf.bulkHandler(customPayloads, 'Account')
     })
 
     it('should correctly update a batch of records', async () => {
@@ -523,7 +523,7 @@ describe('Salesforce', () => {
         })
         .reply(201, {})
 
-      await sf.bulkUpdate(bulkUpdatePayloads, 'Account')
+      await sf.bulkHandler(bulkUpdatePayloads, 'Account')
     })
   })
 })

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
@@ -404,6 +404,23 @@ describe('Salesforce', () => {
       }
     ]
 
+    const bulkUpdatePayloads: GenericPayload[] = [
+      {
+        operation: 'bulkUpdate',
+        bulkUpdateRecordId: 'ab',
+        name: 'SpongeBob Squarepants',
+        phone: '1234567890',
+        description: 'Krusty Krab'
+      },
+      {
+        operation: 'bulkUpdate',
+        bulkUpdateRecordId: 'cd',
+        name: 'Squidward Tentacles',
+        phone: '1234567891',
+        description: 'Krusty Krab'
+      }
+    ]
+
     it('should correctly upsert a batch of records', async () => {
       //create bulk job
       nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest`)
@@ -472,6 +489,41 @@ describe('Salesforce', () => {
         .reply(201, {})
 
       await sf.bulkUpsert(customPayloads, 'Account')
+    })
+
+    it('should correctly update a batch of records', async () => {
+      //create bulk job
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest`)
+        .post('', {
+          object: 'Account',
+          externalIdFieldName: 'Id',
+          operation: 'update',
+          contentType: 'CSV'
+        })
+        .reply(201, {
+          id: 'abc123'
+        })
+
+      const CSV = `Name,Phone,Description,Id\n"SpongeBob Squarepants","1234567890","Krusty Krab","ab"\n"Squidward Tentacles","1234567891","Krusty Krab","cd"\n`
+
+      //upload csv
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest/abc123/batches`, {
+        reqheaders: {
+          'Content-Type': 'text/csv',
+          Accept: 'application/json'
+        }
+      })
+        .put('', CSV)
+        .reply(201, {})
+
+      //close bulk job
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest/abc123`)
+        .patch('', {
+          state: 'UploadComplete'
+        })
+        .reply(201, {})
+
+      await sf.bulkUpdate(bulkUpdatePayloads, 'Account')
     })
   })
 })

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
@@ -106,5 +106,51 @@ describe('Salesforce Utils', () => {
         buildCSVData(invalidCustomFieldPayloads, 'test__c')
       }).toThrowError(`Invalid character in field name: a,weird,field`)
     })
+
+    it('should correctly build an update CSV', async () => {
+      const updatePayloads: GenericPayload[] = [
+        {
+          operation: 'bulkUpdate',
+          bulkUpdateRecordId: '00',
+          name: 'SpongeBob Squarepants',
+          phone: '1234567890',
+          description: 'Krusty Krab'
+        },
+        {
+          operation: 'bulkUpdate',
+          bulkUpdateRecordId: '01',
+          name: 'Squidward Tentacles',
+          phone: '1234567891',
+          description: 'Krusty Krab'
+        }
+      ]
+
+      const csv = buildCSVData(updatePayloads, 'Id')
+      const expected = `Name,Phone,Description,Id\n"SpongeBob Squarepants","1234567890","Krusty Krab","00"\n"Squidward Tentacles","1234567891","Krusty Krab","01"\n`
+
+      expect(csv).toEqual(expected)
+    })
+
+    it('should correctly build an update CSV with incomplete data', async () => {
+      const incompleteUpdatePayloads: GenericPayload[] = [
+        {
+          operation: 'bulkUpdate',
+          bulkUpdateRecordId: '00',
+          name: 'SpongeBob Squarepants',
+          phone: '1234567890'
+        },
+        {
+          operation: 'bulkUpdate',
+          bulkUpdateRecordId: '01',
+          name: 'Squidward Tentacles',
+          description: 'Krusty Krab'
+        }
+      ]
+
+      const csv = buildCSVData(incompleteUpdatePayloads, 'Id')
+      const expected = `Name,Description,Phone,Id\n"SpongeBob Squarepants",#N/A,"1234567890","00"\n"Squidward Tentacles","Krusty Krab",#N/A,"01"\n`
+
+      expect(csv).toEqual(expected)
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
@@ -33,6 +33,10 @@ export interface Payload {
     externalIdValue?: string
   }
   /**
+   * The record id value to use for bulk update.
+   */
+  bulkUpdateRecordId?: string
+  /**
    * Name of the account. **This is required to create an account.**
    */
   name?: string

--- a/packages/destination-actions/src/destinations/salesforce/account/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account/index.ts
@@ -1,7 +1,14 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import Salesforce from '../sf-operations'
-import { bulkUpsertExternalId, customFields, operation, traits, validateLookup } from '../sf-properties'
+import {
+  bulkUpsertExternalId,
+  customFields,
+  operation,
+  traits,
+  validateLookup,
+  thowBulkMismatchError
+} from '../sf-properties'
 import type { Payload } from './generated-types'
 
 const OBJECT_NAME = 'Account'
@@ -198,9 +205,10 @@ const action: ActionDefinition<Settings, Payload> = {
       }
 
       return await sf.bulkUpsert(payload, OBJECT_NAME)
+    } else if (payload[0].operation === 'bulkUpdate') {
+      return await sf.bulkUpdate(payload, OBJECT_NAME)
     } else {
-      const errorMsg = 'Bulk Upsert action must be used with batching'
-      throw new IntegrationError(errorMsg, errorMsg, 400)
+      thowBulkMismatchError()
     }
   }
 }

--- a/packages/destination-actions/src/destinations/salesforce/account/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account/index.ts
@@ -3,6 +3,7 @@ import type { Settings } from '../generated-types'
 import Salesforce from '../sf-operations'
 import {
   bulkUpsertExternalId,
+  bulkUpdateRecordId,
   customFields,
   operation,
   traits,
@@ -21,6 +22,7 @@ const action: ActionDefinition<Settings, Payload> = {
     operation: operation,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,
+    bulkUpdateRecordId: bulkUpdateRecordId,
     name: {
       label: 'Name',
       description: 'Name of the account. **This is required to create an account.**',

--- a/packages/destination-actions/src/destinations/salesforce/account/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account/index.ts
@@ -7,8 +7,7 @@ import {
   customFields,
   operation,
   traits,
-  validateLookup,
-  thowBulkMismatchError
+  validateLookup
 } from '../sf-properties'
 import type { Payload } from './generated-types'
 
@@ -205,13 +204,9 @@ const action: ActionDefinition<Settings, Payload> = {
       if (!payload[0].name) {
         throw new IntegrationError('Missing name value', 'Misconfigured required field', 400)
       }
-
-      return await sf.bulkUpsert(payload, OBJECT_NAME)
-    } else if (payload[0].operation === 'bulkUpdate') {
-      return await sf.bulkUpdate(payload, OBJECT_NAME)
-    } else {
-      thowBulkMismatchError()
     }
+
+    return sf.bulkHandler(payload, OBJECT_NAME)
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
@@ -33,6 +33,10 @@ export interface Payload {
     externalIdValue?: string
   }
   /**
+   * The record id value to use for bulk update.
+   */
+  bulkUpdateRecordId?: string
+  /**
    * A text description of the case.
    */
   description?: string

--- a/packages/destination-actions/src/destinations/salesforce/cases/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases/index.ts
@@ -3,6 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import {
   bulkUpsertExternalId,
+  bulkUpdateRecordId,
   customFields,
   operation,
   traits,
@@ -20,6 +21,7 @@ const action: ActionDefinition<Settings, Payload> = {
     operation: operation,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,
+    bulkUpdateRecordId: bulkUpdateRecordId,
     description: {
       label: 'Description',
       description: 'A text description of the case.',

--- a/packages/destination-actions/src/destinations/salesforce/cases/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases/index.ts
@@ -1,9 +1,15 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { bulkUpsertExternalId, customFields, operation, traits, validateLookup } from '../sf-properties'
+import {
+  bulkUpsertExternalId,
+  customFields,
+  operation,
+  traits,
+  validateLookup,
+  thowBulkMismatchError
+} from '../sf-properties'
 import Salesforce from '../sf-operations'
-import { IntegrationError } from '@segment/actions-core'
 
 const OBJECT_NAME = 'Case'
 
@@ -43,9 +49,10 @@ const action: ActionDefinition<Settings, Payload> = {
 
     if (payload[0].operation === 'bulkUpsert') {
       return await sf.bulkUpsert(payload, OBJECT_NAME)
+    } else if (payload[0].operation === 'bulkUpdate') {
+      return await sf.bulkUpdate(payload, OBJECT_NAME)
     } else {
-      const errorMsg = 'Bulk Upsert action must be used with batching'
-      throw new IntegrationError(errorMsg, errorMsg, 400)
+      thowBulkMismatchError()
     }
   }
 }

--- a/packages/destination-actions/src/destinations/salesforce/cases/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases/index.ts
@@ -7,8 +7,7 @@ import {
   customFields,
   operation,
   traits,
-  validateLookup,
-  thowBulkMismatchError
+  validateLookup
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
 
@@ -49,13 +48,7 @@ const action: ActionDefinition<Settings, Payload> = {
   performBatch: async (request, { settings, payload }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)
 
-    if (payload[0].operation === 'bulkUpsert') {
-      return await sf.bulkUpsert(payload, OBJECT_NAME)
-    } else if (payload[0].operation === 'bulkUpdate') {
-      return await sf.bulkUpdate(payload, OBJECT_NAME)
-    } else {
-      thowBulkMismatchError()
-    }
+    return sf.bulkHandler(payload, OBJECT_NAME)
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
@@ -33,6 +33,10 @@ export interface Payload {
     externalIdValue?: string
   }
   /**
+   * The record id value to use for bulk update.
+   */
+  bulkUpdateRecordId?: string
+  /**
    * The contact's last name up to 80 characters. **This is required to create a contact.**
    */
   last_name?: string

--- a/packages/destination-actions/src/destinations/salesforce/contact/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact/index.ts
@@ -7,8 +7,7 @@ import {
   customFields,
   operation,
   traits,
-  validateLookup,
-  thowBulkMismatchError
+  validateLookup
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
 
@@ -156,12 +155,9 @@ const action: ActionDefinition<Settings, Payload> = {
       if (!payload[0].last_name) {
         throw new IntegrationError('Missing last_name value', 'Misconfigured required field', 400)
       }
-      return await sf.bulkUpsert(payload, OBJECT_NAME)
-    } else if (payload[0].operation === 'bulkUpdate') {
-      return await sf.bulkUpdate(payload, OBJECT_NAME)
-    } else {
-      thowBulkMismatchError()
     }
+
+    return sf.bulkHandler(payload, OBJECT_NAME)
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/contact/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact/index.ts
@@ -3,6 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import {
   bulkUpsertExternalId,
+  bulkUpdateRecordId,
   customFields,
   operation,
   traits,
@@ -20,6 +21,7 @@ const action: ActionDefinition<Settings, Payload> = {
     operation: operation,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,
+    bulkUpdateRecordId: bulkUpdateRecordId,
     last_name: {
       label: 'Last Name',
       description: "The contact's last name up to 80 characters. **This is required to create a contact.**",

--- a/packages/destination-actions/src/destinations/salesforce/contact/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact/index.ts
@@ -1,7 +1,14 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { bulkUpsertExternalId, customFields, operation, traits, validateLookup } from '../sf-properties'
+import {
+  bulkUpsertExternalId,
+  customFields,
+  operation,
+  traits,
+  validateLookup,
+  thowBulkMismatchError
+} from '../sf-properties'
 import Salesforce from '../sf-operations'
 
 const OBJECT_NAME = 'Contact'
@@ -148,9 +155,10 @@ const action: ActionDefinition<Settings, Payload> = {
         throw new IntegrationError('Missing last_name value', 'Misconfigured required field', 400)
       }
       return await sf.bulkUpsert(payload, OBJECT_NAME)
+    } else if (payload[0].operation === 'bulkUpdate') {
+      return await sf.bulkUpdate(payload, OBJECT_NAME)
     } else {
-      const errorMsg = 'Bulk Upsert action must be used with batching'
-      throw new IntegrationError(errorMsg, errorMsg, 400)
+      thowBulkMismatchError()
     }
   }
 }

--- a/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
@@ -33,6 +33,10 @@ export interface Payload {
     externalIdValue?: string
   }
   /**
+   * The record id value to use for bulk update.
+   */
+  bulkUpdateRecordId?: string
+  /**
    * The API name of the Salesforce object that records will be added or updated within. This can be a standard or custom object. Custom objects must be predefined in your Salesforce account and should end with "__c".
    */
   customObjectName: string

--- a/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
@@ -1,7 +1,14 @@
-import { ActionDefinition, IntegrationError } from '@segment/actions-core'
+import { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { bulkUpsertExternalId, operation, traits, customFields, validateLookup } from '../sf-properties'
+import {
+  bulkUpsertExternalId,
+  operation,
+  traits,
+  customFields,
+  validateLookup,
+  thowBulkMismatchError
+} from '../sf-properties'
 import Salesforce from '../sf-operations'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -43,9 +50,10 @@ const action: ActionDefinition<Settings, Payload> = {
 
     if (payload[0].operation === 'bulkUpsert') {
       return await sf.bulkUpsert(payload, payload[0].customObjectName)
+    } else if (payload[0].operation === 'bulkUpdate') {
+      return await sf.bulkUpdate(payload, payload[0].customObjectName)
     } else {
-      const errorMsg = 'Bulk Upsert action must be used with batching'
-      throw new IntegrationError(errorMsg, errorMsg, 400)
+      thowBulkMismatchError()
     }
   }
 }

--- a/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
@@ -3,6 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import {
   bulkUpsertExternalId,
+  bulkUpdateRecordId,
   operation,
   traits,
   customFields,
@@ -19,6 +20,7 @@ const action: ActionDefinition<Settings, Payload> = {
     operation: operation,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,
+    bulkUpdateRecordId: bulkUpdateRecordId,
     customObjectName: {
       label: 'Salesforce Object',
       description:

--- a/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
@@ -7,8 +7,7 @@ import {
   operation,
   traits,
   customFields,
-  validateLookup,
-  thowBulkMismatchError
+  validateLookup
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
 
@@ -50,13 +49,7 @@ const action: ActionDefinition<Settings, Payload> = {
   performBatch: async (request, { settings, payload }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)
 
-    if (payload[0].operation === 'bulkUpsert') {
-      return await sf.bulkUpsert(payload, payload[0].customObjectName)
-    } else if (payload[0].operation === 'bulkUpdate') {
-      return await sf.bulkUpdate(payload, payload[0].customObjectName)
-    } else {
-      thowBulkMismatchError()
-    }
+    return sf.bulkHandler(payload, payload[0].customObjectName)
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
@@ -33,6 +33,10 @@ export interface Payload {
     externalIdValue?: string
   }
   /**
+   * The record id value to use for bulk update.
+   */
+  bulkUpdateRecordId?: string
+  /**
    * The lead's company. **This is required to create a lead.**
    */
   company?: string

--- a/packages/destination-actions/src/destinations/salesforce/lead/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/index.ts
@@ -7,7 +7,8 @@ import {
   customFields,
   operation,
   traits,
-  validateLookup
+  validateLookup,
+  thowBulkMismatchError
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
 
@@ -166,8 +167,7 @@ const action: ActionDefinition<Settings, Payload> = {
     } else if (payload[0].operation === 'bulkUpdate') {
       return await sf.bulkUpdate(payload, OBJECT_NAME)
     } else {
-      const errorMsg = 'Bulk Upsert action must be used with batching'
-      throw new IntegrationError(errorMsg, errorMsg, 400)
+      thowBulkMismatchError()
     }
   }
 }

--- a/packages/destination-actions/src/destinations/salesforce/lead/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/index.ts
@@ -1,7 +1,14 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { bulkUpsertExternalId, customFields, operation, traits, validateLookup } from '../sf-properties'
+import {
+  bulkUpdateRecordId,
+  bulkUpsertExternalId,
+  customFields,
+  operation,
+  traits,
+  validateLookup
+} from '../sf-properties'
 import Salesforce from '../sf-operations'
 
 const OBJECT_NAME = 'Lead'
@@ -14,6 +21,7 @@ const action: ActionDefinition<Settings, Payload> = {
     operation: operation,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,
+    bulkUpdateRecordId: bulkUpdateRecordId,
     company: {
       label: 'Company',
       description: "The lead's company. **This is required to create a lead.**",
@@ -155,6 +163,8 @@ const action: ActionDefinition<Settings, Payload> = {
         throw new IntegrationError('Missing company or last_name value', 'Misconfigured required field', 400)
       }
       return await sf.bulkUpsert(payload, OBJECT_NAME)
+    } else if (payload[0].operation === 'bulkUpdate') {
+      return await sf.bulkUpdate(payload, OBJECT_NAME)
     } else {
       const errorMsg = 'Bulk Upsert action must be used with batching'
       throw new IntegrationError(errorMsg, errorMsg, 400)

--- a/packages/destination-actions/src/destinations/salesforce/lead/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/index.ts
@@ -7,8 +7,7 @@ import {
   customFields,
   operation,
   traits,
-  validateLookup,
-  thowBulkMismatchError
+  validateLookup
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
 
@@ -163,12 +162,9 @@ const action: ActionDefinition<Settings, Payload> = {
       if (!payload[0].company || !payload[0].last_name) {
         throw new IntegrationError('Missing company or last_name value', 'Misconfigured required field', 400)
       }
-      return await sf.bulkUpsert(payload, OBJECT_NAME)
-    } else if (payload[0].operation === 'bulkUpdate') {
-      return await sf.bulkUpdate(payload, OBJECT_NAME)
-    } else {
-      thowBulkMismatchError()
     }
+
+    return sf.bulkHandler(payload, OBJECT_NAME)
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
@@ -33,6 +33,10 @@ export interface Payload {
     externalIdValue?: string
   }
   /**
+   * The record id value to use for bulk update.
+   */
+  bulkUpdateRecordId?: string
+  /**
    * Date when the opportunity is expected to close. Use yyyy-MM-dd format. **This is required to create an opportunity.**
    */
   close_date?: string

--- a/packages/destination-actions/src/destinations/salesforce/opportunity/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity/index.ts
@@ -3,6 +3,7 @@ import type { Settings } from '../generated-types'
 import Salesforce from '../sf-operations'
 import {
   bulkUpsertExternalId,
+  bulkUpdateRecordId,
   customFields,
   operation,
   traits,
@@ -20,6 +21,7 @@ const action: ActionDefinition<Settings, Payload> = {
     operation: operation,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,
+    bulkUpdateRecordId: bulkUpdateRecordId,
     close_date: {
       label: 'Close Date',
       description:

--- a/packages/destination-actions/src/destinations/salesforce/opportunity/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity/index.ts
@@ -7,8 +7,7 @@ import {
   customFields,
   operation,
   traits,
-  validateLookup,
-  thowBulkMismatchError
+  validateLookup
 } from '../sf-properties'
 import type { Payload } from './generated-types'
 
@@ -80,13 +79,9 @@ const action: ActionDefinition<Settings, Payload> = {
       if (!payload[0].close_date || !payload[0].name || !payload[0].stage_name) {
         throw new IntegrationError('Missing close_date, name or stage_name value', 'Misconfigured required field', 400)
       }
-
-      return await sf.bulkUpsert(payload, OBJECT_NAME)
-    } else if (payload[0].operation === 'bulkUpdate') {
-      return await sf.bulkUpdate(payload, OBJECT_NAME)
-    } else {
-      thowBulkMismatchError()
     }
+
+    return sf.bulkHandler(payload, OBJECT_NAME)
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/opportunity/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity/index.ts
@@ -1,7 +1,14 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import Salesforce from '../sf-operations'
-import { bulkUpsertExternalId, customFields, operation, traits, validateLookup } from '../sf-properties'
+import {
+  bulkUpsertExternalId,
+  customFields,
+  operation,
+  traits,
+  validateLookup,
+  thowBulkMismatchError
+} from '../sf-properties'
 import type { Payload } from './generated-types'
 
 const OBJECT_NAME = 'Opportunity'
@@ -73,9 +80,10 @@ const action: ActionDefinition<Settings, Payload> = {
       }
 
       return await sf.bulkUpsert(payload, OBJECT_NAME)
+    } else if (payload[0].operation === 'bulkUpdate') {
+      return await sf.bulkUpdate(payload, OBJECT_NAME)
     } else {
-      const errorMsg = 'Bulk Upsert action must be used with batching'
-      throw new IntegrationError(errorMsg, errorMsg, 400)
+      thowBulkMismatchError()
     }
   }
 }

--- a/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
@@ -2,9 +2,20 @@ import { IntegrationError, RequestClient } from '@segment/actions-core'
 import type { GenericPayload } from './sf-types'
 import { mapObjectToShape } from './sf-object-to-shape'
 import { buildCSVData } from './sf-utils'
-import { throwBulkMismatchError } from './sf-properties'
 
 export const API_VERSION = 'v53.0'
+
+/**
+ * This error is triggered if a batch of payloads arrives inside the performBatch handler
+ * where the operation is not either bulkUpsert or bulkUpdate. This would occur if a user ever disables
+ * the `enable_batching` setting on their action.
+ * TODO: Automatically enable `enable_batching` for any action with a bulk operation.
+ * https://segment.atlassian.net/browse/STRATCONN-1369
+ */
+const throwBulkMismatchError = () => {
+  const errorMsg = 'Standard operation used with batching enabled.'
+  throw new IntegrationError(errorMsg, errorMsg, 400)
+}
 
 interface Records {
   Id?: string

--- a/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
@@ -87,7 +87,7 @@ export default class Salesforce {
     }
     const externalIdFieldName = payloads[0].bulkUpsertExternalId.externalIdName
 
-    const jobId = await this.createBulkJob(sobject, externalIdFieldName)
+    const jobId = await this.createBulkJob(sobject, externalIdFieldName, 'upsert')
 
     const csv = buildCSVData(payloads, externalIdFieldName)
 
@@ -95,7 +95,16 @@ export default class Salesforce {
     return await this.closeBulkJob(jobId)
   }
 
-  private createBulkJob = async (sobject: string, externalIdFieldName: string) => {
+  bulkUpdate = async (payloads: GenericPayload[], sobject: string) => {
+    const jobId = await this.createBulkJob(sobject, 'Id', 'update')
+
+    const csv = buildCSVData(payloads, 'Id')
+
+    await this.uploadBulkCSV(jobId, csv)
+    return await this.closeBulkJob(jobId)
+  }
+
+  private createBulkJob = async (sobject: string, externalIdFieldName: string, operation: string) => {
     const res = await this.request<CreateJobResponseData>(
       `${this.instanceUrl}services/data/${API_VERSION}/jobs/ingest`,
       {
@@ -104,7 +113,7 @@ export default class Salesforce {
           object: sobject,
           externalIdFieldName: externalIdFieldName,
           contentType: 'CSV',
-          operation: 'upsert'
+          operation: operation
         }
       }
     )

--- a/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
@@ -96,8 +96,15 @@ export default class Salesforce {
   }
 
   bulkUpdate = async (payloads: GenericPayload[], sobject: string) => {
-    const jobId = await this.createBulkJob(sobject, 'Id', 'update')
+    if (!payloads[0].bulkUpdateRecordId) {
+      throw new IntegrationError(
+        'Undefined bulkUpdateRecordId when using bulkUpdate operation',
+        'Undefined bulkUpdateRecordId',
+        400
+      )
+    }
 
+    const jobId = await this.createBulkJob(sobject, 'Id', 'update')
     const csv = buildCSVData(payloads, 'Id')
 
     await this.uploadBulkCSV(jobId, csv)

--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -11,7 +11,8 @@ export const operation: InputField = {
     { label: 'Create', value: 'create' },
     { label: 'Update', value: 'update' },
     { label: 'Upsert', value: 'upsert' },
-    { label: 'Bulk Upsert', value: 'bulkUpsert' }
+    { label: 'Bulk Upsert', value: 'bulkUpsert' },
+    { label: 'Bulk Update', value: 'bulkUpdate' }
   ]
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -87,15 +87,3 @@ export const validateLookup = (payload: Payload) => {
     }
   }
 }
-
-/**
- * This error is triggered if a batch of payloads arrives inside the performBatch handler
- * where the operation is not either bulkUpsert or bulkUpdate. This would occur if a user ever disables
- * the `enable_batching` setting on their action.
- * TODO: Automatically enable `enable_batching` for any action with a bulk operation.
- * https://segment.atlassian.net/browse/STRATCONN-1369
- */
-export const throwBulkMismatchError = () => {
-  const errorMsg = 'Standard operation used with batching enabled.'
-  throw new IntegrationError(errorMsg, errorMsg, 400)
-}

--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -87,3 +87,9 @@ export const validateLookup = (payload: Payload) => {
     }
   }
 }
+
+// This error is only thrown if an array of payloads arrives to performBatch.
+export const thowBulkMismatchError = () => {
+  const errorMsg = 'Standard operation used with batching enabled.'
+  throw new IntegrationError(errorMsg, errorMsg, 400)
+}

--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -88,7 +88,13 @@ export const validateLookup = (payload: Payload) => {
   }
 }
 
-// This error is only thrown if an array of payloads arrives to performBatch.
+/**
+ * This error is triggered if a batch of payloads arrives inside the performBatch handler
+ * where the operation is not either bulkUpsert or bulkUpdate. This would occur if a user ever disables
+ * the `enable_batching` setting on their action.
+ * TODO: Automatically enable `enable_batching` for any action with a bulk operation.
+ * https://segment.atlassian.net/browse/STRATCONN-1369
+ */
 export const throwBulkMismatchError = () => {
   const errorMsg = 'Standard operation used with batching enabled.'
   throw new IntegrationError(errorMsg, errorMsg, 400)

--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -89,7 +89,7 @@ export const validateLookup = (payload: Payload) => {
 }
 
 // This error is only thrown if an array of payloads arrives to performBatch.
-export const thowBulkMismatchError = () => {
+export const throwBulkMismatchError = () => {
   const errorMsg = 'Standard operation used with batching enabled.'
   throw new IntegrationError(errorMsg, errorMsg, 400)
 }

--- a/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
@@ -124,15 +124,23 @@ const buildCSVFromHeaderMap = (
 }
 
 const getUniqueIdValue = (payload: GenericPayload): string => {
-  if (payload.operation === 'bulkUpsert') {
-    return payload.bulkUpsertExternalId?.externalIdValue as string
+  if (
+    payload.operation === 'bulkUpsert' &&
+    payload.bulkUpsertExternalId &&
+    payload.bulkUpsertExternalId.externalIdValue
+  ) {
+    return payload.bulkUpsertExternalId.externalIdValue
   }
 
-  if (payload.operation === 'bulkUpdate') {
-    return payload.bulkUpdateRecordId as string
+  if (payload.operation === 'bulkUpdate' && payload.bulkUpdateRecordId) {
+    return payload.bulkUpdateRecordId
   }
 
-  return NO_VALUE
+  throw new IntegrationError(
+    `${payload.operation} is missing the required bulk ID`,
+    `${payload.operation} is missing the required bulk ID`,
+    400
+  )
 }
 
 /**


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR adds support for the Salesforce Bulk API Update operation. This is an initial build that will only be useable by Segment Internal users. More details on that can be found in the [(Segment Internal) Bulk API Mini-SDD](https://paper.dropbox.com/doc/Mini-SDD-Salesforce-Bulk-API--BhoQssc8VEjaaGVvnkxwnG0EAg-OW8Dn2fzQRDPlCa8trLLG).

## Testing
Testing completed successfully via stage deploy. Batches of events arrive in the `bulkUpdate` handler and are correctly delivered downstream to Salesforce.

Tested with the following Python script:
```python
import analytics
import csv
import time

analytics.write_key = '<write key>'
analytics.host = 'https://api.segment.build'

with open('./lead_id.csv') as file:
    reader = csv.reader(file)
    i = 0
    for row in reader:
        lead_id = row[0]
        print(i, lead_id)
        time.sleep(.05)
        analytics.track(str(i), 'Lead', {
            'recordId': lead_id,
            'company': 'Bulk Update Test Stage 6.9.' + str(i),
            'last_name': 'Stage 6.9.' + str(i),
            'email': 'stage@test.' + str(i)
        })

        i += 1

    print('flushing...')
    analytics.flush()
    print('done')
``` 
`lead_id.csv` is a list of all Lead object Ids in my SF workspace.

Batch handler triggering in DataDog:
![Screen Shot 2022-06-09 at 10 21 34 AM](https://user-images.githubusercontent.com/27820201/172916353-474a738c-02ac-48a6-abe8-136775b2d1e3.png)

Salesforce Bulk Jobs being triggered and processed:
![Screen Shot 2022-06-09 at 10 21 11 AM](https://user-images.githubusercontent.com/27820201/172916356-48c5f8e6-fb63-4832-b9b3-930b4109a5f7.png)

Event Delivery in stage:
![Screen Shot 2022-06-09 at 10 20 55 AM](https://user-images.githubusercontent.com/27820201/172916361-0406910b-4931-4d32-a068-c9c03556cb08.png)


_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
