### PR TITLE
Cordial: added anonymousId and userId as hidden fields

### DIFF
--- a/packages/destination-actions/src/destinations/cordial/cordial-client.ts
+++ b/packages/destination-actions/src/destinations/cordial/cordial-client.ts
@@ -17,26 +17,16 @@ class CordialClient {
   addContactActivity(payload: CreateContactactivityPayload) {
     return this.request(`${this.apiUrl}/createContactactivity`, {
       method: 'post',
-      json: {
-        userIdentities: payload.userIdentities,
-        action: payload.action,
-        time: payload.time,
-        properties: payload.properties,
-        context: payload.context
-      }
+      json: payload
     })
   }
 
   async upsertContact(payload: UpsertContactPayload) {
     return this.request(`${this.apiUrl}/upsertContact`, {
       method: 'post',
-      json: {
-        userIdentities: payload.userIdentities,
-        attributes: payload.attributes
-      }
+      json: payload
     })
   }
-
 
   async addContactToList(payload: AddContactToListPayload) {
     return this.request(`${this.apiUrl}/addContactToList`, {

--- a/packages/destination-actions/src/destinations/cordial/createContactactivity/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/cordial/createContactactivity/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Testing snapshot for Cordial's createContactactivity destination action: all fields 1`] = `
 Object {
   "action": "Test Event",
+  "anonymousId": "a922ab56-80b7-40c5-be4d-e089026593cd",
   "context": Object {
     "ip": "8.8.8.8",
     "library": Object {
@@ -28,19 +29,10 @@ Object {
     "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
   },
   "properties": Object {
-    "action": "%!C)I@n7Uu54P",
-    "context": Object {
-      "testType": "%!C)I@n7Uu54P",
-    },
-    "properties": Object {
-      "testType": "%!C)I@n7Uu54P",
-    },
-    "time": "2021-02-01T00:00:00.000Z",
-    "userIdentities": Object {
-      "testType": "%!C)I@n7Uu54P",
-    },
+    "testType": "%!C)I@n7Uu54P",
   },
   "time": "2022-04-04T13:08:53.205Z",
+  "userId": "user1234",
   "userIdentities": Object {
     "channels.email.address": "contact@example.com",
   },

--- a/packages/destination-actions/src/destinations/cordial/createContactactivity/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/cordial/createContactactivity/__tests__/snapshot.test.ts
@@ -19,13 +19,11 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       .post(/\/.*\/createContactactivity/)
       .reply(200)
 
-    const event = createTestEvent({
-      properties: eventData
-    })
+    const event = createTestEvent(eventData)
 
     const responses = await testDestination.testAction(actionSlug, {
       event: event,
-      mapping: event.properties,
+      mapping: eventData,
       settings: settingsData,
       auth: undefined
     })
@@ -54,30 +52,21 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       .reply(200)
 
     const event = createTestEvent({
-      properties: eventData,
-      sentAt: '2022-04-04T13:08:53.205Z'
+      anonymousId: 'a922ab56-80b7-40c5-be4d-e089026593cd',
+      properties: eventData.properties,
+      sentAt: '2022-04-04T13:08:53.205Z',
+      timestamp: '2022-04-04T13:08:53.205Z'
     })
 
     const mapping = {
-      userIdentities: { 'channels.email.address': 'contact@example.com' },
-      action: {
-        '@path': '$.event'
-      },
-      time: {
-        '@path': '$.sentAt'
-      },
-      properties: {
-        '@path': '$.properties'
-      },
-      context: {
-        '@path': '$.context'
-      }
+      userIdentities: { 'channels.email.address': 'contact@example.com' }
     }
 
     const responses = await testDestination.testAction(actionSlug, {
       event: event,
       mapping: mapping,
       settings: settingsData,
+      useDefaultMappings: true,
       auth: undefined
     })
 

--- a/packages/destination-actions/src/destinations/cordial/createContactactivity/generated-types.ts
+++ b/packages/destination-actions/src/destinations/cordial/createContactactivity/generated-types.ts
@@ -27,4 +27,6 @@ export interface Payload {
   context?: {
     [k: string]: unknown
   }
+  userId?: string
+  anonymousId?: string
 }

--- a/packages/destination-actions/src/destinations/cordial/createContactactivity/index.ts
+++ b/packages/destination-actions/src/destinations/cordial/createContactactivity/index.ts
@@ -54,6 +54,22 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.context'
       }
+    },
+    userId: {
+      label: 'Segment userId',
+      description: '',
+      type: 'hidden',
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    anonymousId: {
+      label: 'Segment anonymousId',
+      description: '',
+      type: 'hidden',
+      default: {
+        '@path': '$.anonymousId'
+      }
     }
   },
   perform: (request, { settings, payload }) => {

--- a/packages/destination-actions/src/destinations/cordial/upsertContact/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/cordial/upsertContact/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -2,9 +2,11 @@
 
 exports[`Testing snapshot for Cordial's upsertContact destination action: all fields 1`] = `
 Object {
+  "anonymousId": "2AUBtz6WjM5lHBm",
   "attributes": Object {
     "testType": "2AUBtz6WjM5lHBm",
   },
+  "userId": "2AUBtz6WjM5lHBm",
   "userIdentities": Object {
     "testType": "2AUBtz6WjM5lHBm",
   },

--- a/packages/destination-actions/src/destinations/cordial/upsertContact/generated-types.ts
+++ b/packages/destination-actions/src/destinations/cordial/upsertContact/generated-types.ts
@@ -13,4 +13,6 @@ export interface Payload {
   attributes?: {
     [k: string]: unknown
   }
+  userId?: string
+  anonymousId?: string
 }

--- a/packages/destination-actions/src/destinations/cordial/upsertContact/index.ts
+++ b/packages/destination-actions/src/destinations/cordial/upsertContact/index.ts
@@ -23,6 +23,22 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'object',
       required: false,
       defaultObjectUI: 'keyvalue:only'
+    },
+    userId: {
+      label: 'Segment userId',
+      description: '',
+      type: 'hidden',
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    anonymousId: {
+      label: 'Segment anonymousId',
+      description: '',
+      type: 'hidden',
+      default: {
+        '@path': '$.anonymousId'
+      }
     }
   },
   perform: async (request, { settings, payload }) => {


### PR DESCRIPTION
Added anonymousId and userId as hidden fields for upsertContact and createContactactivity

<!-- Hello and thank you for contributing to Segment action-destinations! -->

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
