### PR TITLE
[Actions-Salesforce] Update operation choice labels

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -8,9 +8,9 @@ export const operation: InputField = {
   type: 'string',
   required: true,
   choices: [
-    { label: 'Create', value: 'create' },
-    { label: 'Update', value: 'update' },
-    { label: 'Upsert', value: 'upsert' },
+    { label: 'Create new record', value: 'create' },
+    { label: 'Update existing record', value: 'update' },
+    { label: `Update or create a record if one doesn't exist`, value: 'upsert' },
     { label: 'Bulk Upsert', value: 'bulkUpsert' },
     { label: 'Bulk Update', value: 'bulkUpdate' }
   ]


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This is a purely cosmetic change which updates the labels for the Salesforce `operation` choices.


## Testing

![Screen Shot 2022-06-14 at 1 01 06 PM](https://user-images.githubusercontent.com/27820201/173678262-f0692123-1038-4815-9166-95971ec836cd.png)

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
