### PR TITLE
Update FS creation name

### DIFF
--- a/packages/browser-destinations/src/destinations/fullstory/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/index.ts
@@ -17,7 +17,7 @@ declare global {
 export const segmentEventSource = 'segment-browser-actions'
 
 export const destination: BrowserDestinationDefinition<Settings, FS> = {
-  name: 'Fullstory (Actions)',
+  name: 'Fullstory',
   slug: 'actions-fullstory',
   mode: 'device',
   presets: [


### PR DESCRIPTION
Looks like the creation name for FS is `Fullstory` rather than `Fullstory (Actions)` ... updating the definition to reflect that. 