### PR TITLE
updates FullStory browser destination recordOnlyThisIFrame label

### DIFF
--- a/packages/browser-destinations/src/destinations/fullstory/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/index.ts
@@ -50,7 +50,7 @@ export const destination: BrowserDestinationDefinition<Settings, FS> = {
     },
     recordOnlyThisIFrame: {
       description: 'Enables FullStory inside an iframe.',
-      label: 'Record only this iframe',
+      label: 'Capture only this iFrame',
       type: 'boolean',
       required: false,
       default: false


### PR DESCRIPTION
This PR updates the label for the FullStory browser destination.

## Testing

Unnecessary as this is just changing the label of a setting.
