### PR TITLE
STRATCONN-1413: New event parameters check 

### DIFF
--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
@@ -2,7 +2,7 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams } from '../ga4-functions'
 import {
   user_id,
   formatUserProperties,
@@ -104,7 +104,7 @@ const action: ActionDefinition<Settings, Payload> = {
               payment_type: payload.payment_type,
               items: googleItems,
               engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
+              ...verifyParams(payload.params)
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
@@ -2,7 +2,7 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { ProductItem } from '../ga4-types'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -70,7 +70,7 @@ const action: ActionDefinition<Settings, Payload> = {
               items: googleItems,
               value: payload.value,
               engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
+              ...verifyParams(payload.params)
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
@@ -2,7 +2,7 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -87,7 +87,7 @@ const action: ActionDefinition<Settings, Payload> = {
               value: payload.value,
               items: googleItems,
               engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
+              ...verifyParams(payload.params)
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -75,7 +75,7 @@ const action: ActionDefinition<Settings, Payload> = {
               items: googleItems,
               value: payload.value,
               engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
+              ...verifyParams(payload.params)
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
@@ -1,6 +1,8 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+import { verifyParams } from '../ga4-functions'
+
 import {
   formatUserProperties,
   user_properties,
@@ -60,7 +62,7 @@ const action: ActionDefinition<Settings, Payload> = {
             name: event_name,
             params: {
               engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
+              ...verifyParams(payload.params)
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
@@ -7,3 +7,22 @@ export function verifyCurrency(currency: string): void {
     throw new IntegrationError(`${currency} is not a valid currency code.`, 'Incorrect value format', 400)
   }
 }
+
+// Ensure the values in params match Googles expectations
+export function verifyParams(params: object | undefined): object | undefined {
+  if (!params) {
+    return undefined
+  }
+
+  Object.entries(params).forEach(([_, value]) => {
+    if (typeof value !== 'string' && typeof value != 'number') {
+      throw new IntegrationError(
+        'GA4 only accepts string or number values for event parameters, item parameters, and user properties. Please ensure you are not including null, array, or nested values.',
+        'Invalid value',
+        400
+      )
+    }
+  })
+
+  return params
+}

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-properties.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-properties.ts
@@ -1,4 +1,5 @@
 import { InputField } from '@segment/actions-core/src/destination-kit/types'
+import { IntegrationError } from '@segment/actions-core'
 
 export const formatUserProperties = (userProperties: object | undefined): object | undefined => {
   if (!userProperties) {
@@ -8,6 +9,13 @@ export const formatUserProperties = (userProperties: object | undefined): object
   let properties = {}
 
   Object.entries(userProperties).forEach(([key, value]) => {
+    if (typeof value !== 'string' && typeof value != 'number') {
+      throw new IntegrationError(
+        'GA4 only accepts string or number values for event parameters, item parameters, and user properties. Please ensure you are not including null, array, or nested values.',
+        'Invalid value',
+        400
+      )
+    }
     properties = { ...properties, ...{ [key]: { value: value } } }
   })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams } from '../ga4-functions'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import {
@@ -48,7 +48,7 @@ const action: ActionDefinition<Settings, Payload> = {
               currency: payload.currency,
               value: payload.value,
               engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
+              ...verifyParams(payload.params)
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
@@ -1,6 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+import { verifyParams } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -39,7 +40,7 @@ const action: ActionDefinition<Settings, Payload> = {
             params: {
               method: payload.method,
               engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
+              ...verifyParams(payload.params)
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
@@ -1,6 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+import { verifyParams } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -59,7 +60,7 @@ const action: ActionDefinition<Settings, Payload> = {
               page_referrer: payload.page_referrer,
               page_title: payload.page_title,
               engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
+              ...verifyParams(payload.params)
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
@@ -1,7 +1,7 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams } from '../ga4-functions'
 import { ProductItem } from '../ga4-types'
 import {
   coupon,
@@ -87,7 +87,7 @@ const action: ActionDefinition<Settings, Payload> = {
               value: payload.value,
               tax: payload.tax,
               engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
+              ...verifyParams(payload.params)
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams } from '../ga4-functions'
 import {
   coupon,
   transaction_id,
@@ -105,7 +105,7 @@ const action: ActionDefinition<Settings, Payload> = {
               tax: payload.tax,
               items: googleItems,
               engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
+              ...verifyParams(payload.params)
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -88,7 +88,7 @@ const action: ActionDefinition<Settings, Payload> = {
               value: payload.value,
               items: googleItems,
               engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
+              ...verifyParams(payload.params)
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
@@ -1,6 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+import { verifyParams } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -42,7 +43,7 @@ const action: ActionDefinition<Settings, Payload> = {
             params: {
               search_term: payload.search_term,
               engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
+              ...verifyParams(payload.params)
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams } from '../ga4-functions'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -72,7 +72,7 @@ const action: ActionDefinition<Settings, Payload> = {
               item_list_name: payload.item_list_name,
               item_list_id: payload.item_list_id,
               engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
+              ...verifyParams(payload.params)
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams } from '../ga4-functions'
 import {
   creative_name,
   client_id,
@@ -101,7 +101,7 @@ const action: ActionDefinition<Settings, Payload> = {
               promotion_name: payload.promotion_name,
               items: googleItems,
               engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
+              ...verifyParams(payload.params)
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
@@ -1,6 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+import { verifyParams } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -41,7 +42,7 @@ const action: ActionDefinition<Settings, Payload> = {
             params: {
               method: payload.method,
               engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
+              ...verifyParams(payload.params)
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -83,7 +83,7 @@ const action: ActionDefinition<Settings, Payload> = {
               value: payload.value,
               items: googleItems,
               engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
+              ...verifyParams(payload.params)
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -82,7 +82,7 @@ const action: ActionDefinition<Settings, Payload> = {
               items: googleItems,
               value: payload.value,
               engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
+              ...verifyParams(payload.params)
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -82,7 +82,7 @@ const action: ActionDefinition<Settings, Payload> = {
               item_list_name: payload.item_list_name,
               items: googleItems,
               engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
+              ...verifyParams(payload.params)
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams } from '../ga4-functions'
 import {
   creative_name,
   creative_slot,
@@ -98,7 +98,7 @@ const action: ActionDefinition<Settings, Payload> = {
               promotion_name: payload.promotion_name,
               items: googleItems,
               engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
+              ...verifyParams(payload.params)
             }
           }
         ],


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR addresses [STRATCONN-1413](https://segment.atlassian.net/browse/STRATCONN-1413?focusedCommentId=281578). Google only allows parameters to be sent in as string or number and currently if events are sent with different variables like `null` GA4 silently drops these events. 

This PR adds a check to the params and user_properties and throws an error if the variables are not the right type. 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
