### PR TITLE
[BE-787] Prevent actual value coercion to string for '=' and '!=' operators

### DIFF
--- a/packages/destination-subscriptions/src/__tests__/validate.test.ts
+++ b/packages/destination-subscriptions/src/__tests__/validate.test.ts
@@ -131,7 +131,9 @@ test('operators - equals (numbers)', () => {
       ]
     }
 
-    expect(validate(ast, { properties: { value: 123 } })).toEqual(true)
+    // Since action tester UI only supports string type input, we assume the value in the ast is a string for now (i.e. 123 !== "123")
+    expect(validate(ast, { properties: { value: 123 } })).toEqual(false)
+
     expect(validate(ast, { properties: { value: '123' } })).toEqual(true)
     expect(validate(ast, { properties: { value: 0 } })).toEqual(false)
   }
@@ -170,7 +172,9 @@ test('operators - not equals (numbers)', () => {
       ]
     }
 
-    expect(validate(ast, { properties: { value: 123 } })).toEqual(false)
+    // Since action tester UI only supports string type input, we assume the value in the ast is a string for now (i.e. 123 !== "123")
+    expect(validate(ast, { properties: { value: 123 } })).toEqual(true)
+
     expect(validate(ast, { properties: { value: '123' } })).toEqual(false)
     expect(validate(ast, { properties: { value: 456 } })).toEqual(true)
     expect(validate(ast, { properties: { value: '456' } })).toEqual(true)

--- a/packages/destination-subscriptions/src/validate.ts
+++ b/packages/destination-subscriptions/src/validate.ts
@@ -72,9 +72,9 @@ const validateCondition = (condition: Condition, data: any): boolean => {
 const validateValue = (actual: unknown, operator: Operator, expected?: string | boolean | number): boolean => {
   switch (operator) {
     case '=':
-      return String(actual) === String(expected)
+      return actual === String(expected)
     case '!=':
-      return String(actual) !== String(expected)
+      return actual !== String(expected)
     case '<':
       return Number(actual) < Number(expected)
     case '<=':


### PR DESCRIPTION
Our current trigger UI only supports input for string values when using the `is` and `is not` operator

For instance below:
![image](https://user-images.githubusercontent.com/3202990/174354699-0bcee094-e07b-4367-98a0-64e7e419ea4b.png)

The value for `clv` above is actually interpreted and persisted as a string (`"5"`) instead of number (`5`) which is not at all obvious looking at the UI above. 

Unfortunately, our tester then also lets you pass in `{'clv': 5}` or `{'clv': "5"}` as valid matching event payload input. In reality, when you actually send events through our data pipeline, we will filter out events with `{'clv': 5}` because we're actually _just_ looking for `{clv: "5"}`.

This PR is a short term fix to prevent any user confusion but our long term fix will be to add more granular control over data type interpretations.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- ~Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)~ N/A 
- [X] [Segmenters] Tested in the staging environment

Trying to match on a number `5` will fail (whereas previously this would succeed)
![Screen Shot 2022-06-17 at 12 08 31 PM](https://user-images.githubusercontent.com/3202990/174387783-4a5b9d9a-1a99-48c3-b6bb-bd44dbda6e01.png)

Trying to match on string `"5"` will pass:
![Screen Shot 2022-06-17 at 12 07 56 PM](https://user-images.githubusercontent.com/3202990/174387788-7afae02e-b965-4d12-ba03-7ec85479c984.png)
