### PR TITLE
[STRATCONN-1146] Expose Flagon and DataDog stats client

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,14 +302,14 @@ const destination = {
       fields: {
         name: {
           label: 'Name',
-          description: 'The person\'s name',
+          description: "The person's name",
           type: 'string',
           default: { '@path': '$.traits.name' },
           required: true
         },
         email: {
           label: 'Email',
-          description: 'The person\'s email address',
+          description: "The person's email address",
           type: 'string',
           default: { '@path': '$.properties.email_address' }
         }
@@ -325,7 +325,14 @@ In addition to default values for input fields, you can also specify the default
 
 The `perform` function defines what the action actually does. All logic and request handling happens here. Every action MUST have a `perform` function defined.
 
-By the time the actions runtime invokes your action’s perform, payloads have already been resolved based on the customer’s configuration, validated against the schema, and can be expected to match the types provided in your `perform` function. You’ll get compile-time type-safety for how you access anything in the `data.payload` (the 2nd argument of the perform).
+By the time the actions runtime invokes your action’s perform, payloads have already been resolved based on the customer’s configuration, validated against the schema, and can be expected to match the types provided in your `perform` function.
+
+The `perform` method accepts two arguments, (1) the request client instance (extended with your destination's `extendRequest`, and (2) the data bundle. The data bundle includes the following fields:
+
+- `payload` - The transformed input data, based on `mapping` + `event` (or `events` if batched). You’ll get compile-time type-safety for how you access anything in the `data.payload`.
+- `settings` - The global destination settings.
+- `auth` - The data needed in OAuth requests. This is useful if fetching an updated OAuth `access_token` using a `refresh_token`. The `refresh_token` is available in `auth.refreshToken`.
+- `features` - The features available in the request based on either customer workspaceID or sourceID. Features can only be enabled and/or used by internal Twilio/Segment employees. Features cannot be used for Partner builds.
 
 A basic example:
 
@@ -344,8 +351,8 @@ const destination = {
       },
       // `perform` takes two arguments:
       // 1. the request client instance (extended with your destination's `extendRequest`
-      // 2. the data bundle which includes `settings` for top-level authentication fields and the `payload` which contains all the validated, resolved fields expected by the action
-      perform: (request, data) => {
+      // 2. the data bundle (destructed below)
+      perform: (request, { payload, settings, auth, features }) => {
         return request('https://example.com', {
           headers: { Authorization: `Bearer ${data.settings.api_key}` },
           json: data.payload

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ const destination = {
       },
       // `perform` takes two arguments:
       // 1. the request client instance (extended with your destination's `extendRequest`
-      // 2. the data bundle (destructed below)
+      // 2. the data bundle (destructured below)
       perform: (request, { payload, settings, auth, features }) => {
         return request('https://example.com', {
           headers: { Authorization: `Bearer ${data.settings.api_key}` },

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -76,6 +76,7 @@ interface ExecuteBundle<T = unknown, Data = unknown> {
   settings: T
   mapping: JSONObject
   auth: AuthTokens | undefined
+  features?: { [key: string]: boolean }
 }
 
 /**
@@ -130,7 +131,8 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
       rawMapping: bundle.mapping,
       settings: bundle.settings,
       payload,
-      auth: bundle.auth
+      auth: bundle.auth,
+      features: bundle.features
     }
 
     // Construct the request client and perform the action
@@ -172,7 +174,8 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
         rawMapping: bundle.mapping,
         settings: bundle.settings,
         payload: payloads,
-        auth: bundle.auth
+        auth: bundle.auth,
+        features: bundle.features
       }
       await this.performRequest(this.definition.performBatch, data)
     }

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -76,6 +76,7 @@ interface ExecuteBundle<T = unknown, Data = unknown> {
   settings: T
   mapping: JSONObject
   auth: AuthTokens | undefined
+  /** For internal Segment/Twilio use only. */
   features?: { [key: string]: boolean }
 }
 

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -177,11 +177,27 @@ export interface DecoratedResponse extends ModifiedResponse {
   options: AllRequestOptions
 }
 
+interface StatsClient {
+  observe: (metric: any) => any
+  _name(name: string): string
+  _tags(tags?: string[]): string[]
+  incr(name: string, value?: number, tags?: string[]): void
+  set(name: string, value: number, tags?: string[]): void
+  histogram(name: string, value?: number, tags?: string[]): void
+}
+
+interface StatsContext {
+  stats: StatsClient
+  tags: string[]
+}
+
 interface OnEventOptions {
   onTokenRefresh?: (tokens: RefreshAccessTokenResult) => void
   onComplete?: (stats: SubscriptionStats) => void
   features?: { [key: string]: boolean }
+  statsContext?: StatsContext
 }
+
 export class Destination<Settings = JSONObject> {
   readonly definition: DestinationDefinition<Settings>
   readonly name: string

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -160,6 +160,7 @@ interface EventInput<Settings> {
   readonly settings: Settings
   /** Authentication-related data based on the destination's authentication.fields definition and authentication scheme */
   readonly auth?: AuthTokens
+  /** For internal Segment/Twilio use only. */
   readonly features?: { [key: string]: boolean }
 }
 
@@ -169,6 +170,7 @@ interface BatchEventInput<Settings> {
   readonly settings: Settings
   /** Authentication-related data based on the destination's authentication.fields definition and authentication scheme */
   readonly auth?: AuthTokens
+  /** For internal Segment/Twilio use only. */
   readonly features?: { [key: string]: boolean }
 }
 

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -340,8 +340,7 @@ export class Destination<Settings = JSONObject> {
     events: SegmentEvent | SegmentEvent[],
     settings: Settings,
     auth: AuthTokens,
-    features: OnEventOptions['features'],
-    onComplete?: OnEventOptions['onComplete']
+    options?: OnEventOptions
   ): Promise<Result[]> {
     const subscriptionStartedAt = time()
     const actionSlug = subscription.partnerAction
@@ -349,7 +348,7 @@ export class Destination<Settings = JSONObject> {
       mapping: subscription.mapping || {},
       settings,
       auth,
-      features
+      features: options?.features || {}
     }
 
     let results: Result[] | null = null
@@ -393,7 +392,7 @@ export class Destination<Settings = JSONObject> {
       const subscriptionEndedAt = time()
       const subscriptionDuration = duration(subscriptionStartedAt, subscriptionEndedAt)
 
-      onComplete?.({
+      options?.onComplete?.({
         duration: subscriptionDuration,
         destination: this.name,
         action: actionSlug,
@@ -476,7 +475,7 @@ export class Destination<Settings = JSONObject> {
     const run = async () => {
       const authData = getAuthData(settings)
       const promises = subscriptions.map((subscription) =>
-        this.onSubscription(subscription, data, destinationSettings, authData, options?.onComplete)
+        this.onSubscription(subscription, data, destinationSettings, authData, options)
       )
       const results = await Promise.all(promises)
       return ([] as Result[]).concat(...results)

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -23,7 +23,10 @@ export interface ExecuteInput<Settings, Payload> {
   page?: string
   /** The data needed in OAuth requests */
   readonly auth?: AuthTokens
-  /** The features available in the request based on either customer workspaceID or sourceID */
+  /**
+   * The features available in the request based on either customer workspaceID or sourceID;
+   * For internal Twilio/Segment use only.
+   */
   readonly features?: { [key: string]: boolean }
 }
 

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -23,7 +23,7 @@ export interface ExecuteInput<Settings, Payload> {
   page?: string
   /** The data needed in OAuth requests */
   readonly auth?: AuthTokens
-  /** The Flagon features available in the request */
+  /** The features available in the request based on either customer workspaceID or sourceID */
   readonly features?: { [key: string]: boolean }
 }
 

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -23,6 +23,8 @@ export interface ExecuteInput<Settings, Payload> {
   page?: string
   /** The data needed in OAuth requests */
   readonly auth?: AuthTokens
+  /** The Flagon features available in the request */
+  readonly features?: { [key: string]: boolean }
 }
 
 export interface DynamicFieldResponse {


### PR DESCRIPTION
- Jira: https://segment.atlassian.net/browse/STRATCONN-1146
- This PR updates actions `destination-kit` to accept an instance of the Stats client and Flagon features, both passed from the monoservice in this PR: https://github.com/segmentio/integrations/pull/2297
- Testing completed successfully locally: https://paper.dropbox.com/doc/Test-Doc-Flagon-and-DataDog-in-Action-Destinations--BkDeVPbZOGa7NX4DJV2WZ99MAg-r57m6xS4UpBZkBnCwx8FT

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
