### PR TITLE
STRATCONN-1356: Add timestamp_micros to GA4

### DIFF
--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Payment Info Entered',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -70,7 +71,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"add_payment_info\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"add_payment_info\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 
@@ -242,6 +243,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Payment Info Entered',
         userId: '1234abc',
+        timestamp: '2022-06-22T22:20:58.905Z',
         type: 'track',
         properties: {
           currency: 'USD',
@@ -304,7 +306,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"1234abc\\",\\"events\\":[{\\"name\\":\\"add_payment_info\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"value\\":10,\\"coupon\\":\\"SUMMER_FUN\\",\\"payment_type\\":\\"Credit Card\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"12345\\"}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"1234abc\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"add_payment_info\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"value\\":10,\\"coupon\\":\\"SUMMER_FUN\\",\\"payment_type\\":\\"Credit Card\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"12345\\"}],\\"engagement_time_msec\\":1}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
@@ -72,7 +72,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"add_payment_info\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"add_payment_info\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -308,7 +308,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"1234abc\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"add_payment_info\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"value\\":10,\\"coupon\\":\\"SUMMER_FUN\\",\\"payment_type\\":\\"Credit Card\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"12345\\"}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"1234abc\\",\\"events\\":[{\\"name\\":\\"add_payment_info\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"value\\":10,\\"coupon\\":\\"SUMMER_FUN\\",\\"payment_type\\":\\"Credit Card\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"12345\\"}],\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
@@ -37,6 +37,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -265,6 +266,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           currency: {
             '@path': '$.properties.currency'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
@@ -49,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -146,7 +146,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -247,7 +247,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"currency\\":\\"usd\\"}],\\"value\\":18.99,\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"currency\\":\\"usd\\"}],\\"value\\":18.99,\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -380,7 +380,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Added',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -47,7 +48,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 
@@ -58,6 +59,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Added',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -142,7 +144,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":2}}]}"`
       )
     })
 
@@ -153,6 +155,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Added',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -241,7 +244,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"currency\\":\\"usd\\"}],\\"value\\":18.99,\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"currency\\":\\"usd\\"}],\\"value\\":18.99,\\"engagement_time_msec\\":2}}]}"`
       )
     })
 
@@ -329,6 +332,7 @@ describe('GA4', () => {
         event: 'Product Added',
         userId: '3456fff',
         anonymousId: 'anon-567890',
+        timestamp: '2022-06-22T22:20:58.905Z',
         type: 'track',
         properties: {
           cart_id: 'skdjsidjsdkdj29j',
@@ -372,7 +376,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}]}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
@@ -33,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -84,6 +85,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -181,6 +183,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -356,6 +359,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
@@ -49,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"add_to_wishlist\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"add_to_wishlist\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -131,7 +131,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"add_to_wishlist\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"add_to_wishlist\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Added to Wishlist',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -47,7 +48,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"add_to_wishlist\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"add_to_wishlist\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 
@@ -59,6 +60,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Added to Wishlist',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -82,6 +84,9 @@ describe('GA4', () => {
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
+          },
+          timestamp_micros: {
+            '@path': '$.timestamp'
           },
           engagement_time_msec: 2,
           items: [
@@ -124,7 +129,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"add_to_wishlist\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"add_to_wishlist\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":2}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
@@ -33,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -81,6 +82,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
@@ -45,6 +45,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -393,6 +394,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Checkout Started',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -69,7 +70,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"begin_checkout\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\"}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"begin_checkout\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\"}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 
@@ -359,6 +360,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Checkout Started',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -411,7 +413,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"begin_checkout\\",\\"params\\":{\\"coupon\\":\\"hasbros\\",\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"price\\":19,\\"quantity\\":1}],\\"value\\":30,\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"begin_checkout\\",\\"params\\":{\\"coupon\\":\\"hasbros\\",\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"price\\":19,\\"quantity\\":1}],\\"value\\":30,\\"engagement_time_msec\\":1}}]}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
@@ -71,7 +71,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"begin_checkout\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\"}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"begin_checkout\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\"}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -415,7 +415,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"begin_checkout\\",\\"params\\":{\\"coupon\\":\\"hasbros\\",\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"price\\":19,\\"quantity\\":1}],\\"value\\":30,\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"begin_checkout\\",\\"params\\":{\\"coupon\\":\\"hasbros\\",\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"price\\":19,\\"quantity\\":1}],\\"value\\":30,\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Some Event Here',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -47,7 +48,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"Some_Event_Here\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"abc123\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"Some_Event_Here\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 
@@ -58,6 +59,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Order Completed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -109,7 +111,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
       )
     })
 
@@ -120,6 +122,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Order Completed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track'
       })
@@ -152,7 +155,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
       )
     })
 
@@ -224,6 +227,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Order Completed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track'
       })
@@ -253,7 +257,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"Order_Completed\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"Order_Completed\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
       )
     })
 
@@ -265,6 +269,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: '         Order Completed ',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track'
       })
@@ -297,7 +302,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"order_completed\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"order_completed\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
@@ -49,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"abc123\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"Some_Event_Here\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"Some_Event_Here\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -113,7 +113,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -158,7 +158,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -261,7 +261,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"Order_Completed\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"Order_Completed\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -307,7 +307,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"order_completed\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"order_completed\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
@@ -33,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -88,6 +89,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           name: 'this_is_a_test'
         },
@@ -132,6 +134,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           name: 'this_is_a_test'
         },
@@ -237,6 +240,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -279,6 +283,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           lowercase: true
         },

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
@@ -49,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"generate_lead\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"generate_lead\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -109,7 +109,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"abc123\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"generate_lead\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"value\\":300,\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"generate_lead\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"value\\":300,\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
@@ -33,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -73,6 +74,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.userId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Generate Lead',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -47,7 +48,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"generate_lead\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"generate_lead\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 
@@ -59,6 +60,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Lead Generated',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         type: 'track',
         properties: {
           currency: 'USD',
@@ -74,6 +76,9 @@ describe('GA4', () => {
         mapping: {
           client_id: {
             '@path': '$.userId'
+          },
+          timestamp_micros: {
+            '@path': '$.timestamp'
           },
           engagement_time_msec: 2,
           currency: {
@@ -102,7 +107,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"generate_lead\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"value\\":300,\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"abc123\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"generate_lead\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"value\\":300,\\"engagement_time_msec\\":2}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Login',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -47,7 +48,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"login\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"login\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 
@@ -60,6 +61,7 @@ describe('GA4', () => {
         event: 'Signed In',
         userId: 'abc123',
         type: 'track',
+        timestamp: '2022-06-22T22:20:58.905Z',
         properties: {
           login_method: 'Okta SSO'
         }
@@ -73,6 +75,9 @@ describe('GA4', () => {
         mapping: {
           client_id: {
             '@path': '$.userId'
+          },
+          timestamp_micros: {
+            '@path': '$.timestamp'
           },
           engagement_time_msec: 2,
           method: {
@@ -98,7 +103,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"login\\",\\"params\\":{\\"method\\":\\"Okta SSO\\",\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"abc123\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"login\\",\\"params\\":{\\"method\\":\\"Okta SSO\\",\\"engagement_time_msec\\":2}}]}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
@@ -33,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -72,6 +73,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.userId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
@@ -49,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"login\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"login\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -105,7 +105,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"abc123\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"login\\",\\"params\\":{\\"method\\":\\"Okta SSO\\",\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"login\\",\\"params\\":{\\"method\\":\\"Okta SSO\\",\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
@@ -33,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -83,6 +84,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -150,6 +152,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Page',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -47,7 +48,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"https://segment.com/academy/\\",\\"page_title\\":\\"Analytics Academy\\",\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"abc123\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"https://segment.com/academy/\\",\\"page_title\\":\\"Analytics Academy\\",\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 
@@ -58,6 +59,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Page View',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -113,7 +115,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"http://www.example.com/pageOne\\",\\"page_referrer\\":\\"https://segment.com/academy/\\",\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"http://www.example.com/pageOne\\",\\"page_referrer\\":\\"https://segment.com/academy/\\",\\"engagement_time_msec\\":2}}]}"`
       )
     })
 
@@ -124,6 +126,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Page View',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -167,7 +170,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"http://www.example.com/home\\",\\"page_referrer\\":\\"https://segment.com/academy/\\",\\"page_title\\":\\"Analytics Academy\\",\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"http://www.example.com/home\\",\\"page_referrer\\":\\"https://segment.com/academy/\\",\\"page_title\\":\\"Analytics Academy\\",\\"engagement_time_msec\\":1}}]}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
@@ -49,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"abc123\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"https://segment.com/academy/\\",\\"page_title\\":\\"Analytics Academy\\",\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"https://segment.com/academy/\\",\\"page_title\\":\\"Analytics Academy\\",\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -117,7 +117,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"http://www.example.com/pageOne\\",\\"page_referrer\\":\\"https://segment.com/academy/\\",\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"http://www.example.com/pageOne\\",\\"page_referrer\\":\\"https://segment.com/academy/\\",\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -173,7 +173,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"http://www.example.com/home\\",\\"page_referrer\\":\\"https://segment.com/academy/\\",\\"page_title\\":\\"Analytics Academy\\",\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"http://www.example.com/home\\",\\"page_referrer\\":\\"https://segment.com/academy/\\",\\"page_title\\":\\"Analytics Academy\\",\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
@@ -96,7 +96,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"purchase\\",\\"params\\":{\\"affiliation\\":\\"TI Online Store\\",\\"coupon\\":\\"SUMMER_FEST\\",\\"currency\\":\\"EUR\\",\\"items\\":[{\\"item_name\\":\\"Tour t-shirt\\",\\"item_id\\":\\"pid-123456\\",\\"quantity\\":2,\\"coupon\\":\\"MOUNTAIN\\",\\"item_brand\\":\\"Canvas\\",\\"item_category\\":\\"T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"price\\":19.98}],\\"transaction_id\\":\\"5678dd9087-78\\",\\"shipping\\":1.5,\\"value\\":24.48,\\"tax\\":3,\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"purchase\\",\\"params\\":{\\"affiliation\\":\\"TI Online Store\\",\\"coupon\\":\\"SUMMER_FEST\\",\\"currency\\":\\"EUR\\",\\"items\\":[{\\"item_name\\":\\"Tour t-shirt\\",\\"item_id\\":\\"pid-123456\\",\\"quantity\\":2,\\"coupon\\":\\"MOUNTAIN\\",\\"item_brand\\":\\"Canvas\\",\\"item_category\\":\\"T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"price\\":19.98}],\\"transaction_id\\":\\"5678dd9087-78\\",\\"shipping\\":1.5,\\"value\\":24.48,\\"tax\\":3,\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -519,7 +519,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"purchase\\",\\"params\\":{\\"affiliation\\":\\"TI Online Store\\",\\"coupon\\":\\"SUMMER_FEST\\",\\"currency\\":\\"EUR\\",\\"items\\":[{\\"item_id\\":\\"pid-123456\\",\\"item_name\\":\\"Tour t-shirt\\",\\"coupon\\":\\"MOUNTAIN\\",\\"item_brand\\":\\"Canvas\\",\\"item_category\\":\\"T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"price\\":19.98,\\"quantity\\":2}],\\"transaction_id\\":\\"5678dd9087-78\\",\\"shipping\\":1.5,\\"value\\":24.48,\\"tax\\":3,\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"purchase\\",\\"params\\":{\\"affiliation\\":\\"TI Online Store\\",\\"coupon\\":\\"SUMMER_FEST\\",\\"currency\\":\\"EUR\\",\\"items\\":[{\\"item_id\\":\\"pid-123456\\",\\"item_name\\":\\"Tour t-shirt\\",\\"coupon\\":\\"MOUNTAIN\\",\\"item_brand\\":\\"Canvas\\",\\"item_category\\":\\"T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"price\\":19.98,\\"quantity\\":2}],\\"transaction_id\\":\\"5678dd9087-78\\",\\"shipping\\":1.5,\\"value\\":24.48,\\"tax\\":3,\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
@@ -49,6 +49,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           transaction_id: {
             '@path': '$.properties.order_number'
@@ -497,6 +498,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Order Completed',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -94,7 +95,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"purchase\\",\\"params\\":{\\"affiliation\\":\\"TI Online Store\\",\\"coupon\\":\\"SUMMER_FEST\\",\\"currency\\":\\"EUR\\",\\"items\\":[{\\"item_name\\":\\"Tour t-shirt\\",\\"item_id\\":\\"pid-123456\\",\\"quantity\\":2,\\"coupon\\":\\"MOUNTAIN\\",\\"item_brand\\":\\"Canvas\\",\\"item_category\\":\\"T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"price\\":19.98}],\\"transaction_id\\":\\"5678dd9087-78\\",\\"shipping\\":1.5,\\"value\\":24.48,\\"tax\\":3,\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"purchase\\",\\"params\\":{\\"affiliation\\":\\"TI Online Store\\",\\"coupon\\":\\"SUMMER_FEST\\",\\"currency\\":\\"EUR\\",\\"items\\":[{\\"item_name\\":\\"Tour t-shirt\\",\\"item_id\\":\\"pid-123456\\",\\"quantity\\":2,\\"coupon\\":\\"MOUNTAIN\\",\\"item_brand\\":\\"Canvas\\",\\"item_category\\":\\"T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"price\\":19.98}],\\"transaction_id\\":\\"5678dd9087-78\\",\\"shipping\\":1.5,\\"value\\":24.48,\\"tax\\":3,\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 
@@ -463,6 +464,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Order Completed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -515,7 +517,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"purchase\\",\\"params\\":{\\"affiliation\\":\\"TI Online Store\\",\\"coupon\\":\\"SUMMER_FEST\\",\\"currency\\":\\"EUR\\",\\"items\\":[{\\"item_id\\":\\"pid-123456\\",\\"item_name\\":\\"Tour t-shirt\\",\\"coupon\\":\\"MOUNTAIN\\",\\"item_brand\\":\\"Canvas\\",\\"item_category\\":\\"T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"price\\":19.98,\\"quantity\\":2}],\\"transaction_id\\":\\"5678dd9087-78\\",\\"shipping\\":1.5,\\"value\\":24.48,\\"tax\\":3,\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"purchase\\",\\"params\\":{\\"affiliation\\":\\"TI Online Store\\",\\"coupon\\":\\"SUMMER_FEST\\",\\"currency\\":\\"EUR\\",\\"items\\":[{\\"item_id\\":\\"pid-123456\\",\\"item_name\\":\\"Tour t-shirt\\",\\"coupon\\":\\"MOUNTAIN\\",\\"item_brand\\":\\"Canvas\\",\\"item_category\\":\\"T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"price\\":19.98,\\"quantity\\":2}],\\"transaction_id\\":\\"5678dd9087-78\\",\\"shipping\\":1.5,\\"value\\":24.48,\\"tax\\":3,\\"engagement_time_msec\\":1}}]}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
@@ -51,7 +51,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"transaction_id\\":\\"12345abcde\\",\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"transaction_id\\":\\"12345abcde\\",\\"items\\":[],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
@@ -33,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           transaction_id: {
             '@path': '$.properties.order_number'
@@ -166,6 +167,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           currency: {
             '@path': '$.properties.currency'
@@ -241,6 +243,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           currency: {
             '@path': '$.properties.currency'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
@@ -52,7 +52,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"transaction_id\\":\\"12345abcde\\",\\"items\\":[],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"transaction_id\\":\\"12345abcde\\",\\"items\\":[],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -209,7 +209,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"1234abc\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"transaction_id\\":\\"c1209123\\",\\"value\\":10,\\"coupon\\":\\"SUMMER_FUN\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"12345\\"}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"1234abc\\",\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"transaction_id\\":\\"c1209123\\",\\"value\\":10,\\"coupon\\":\\"SUMMER_FUN\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"12345\\"}],\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -285,7 +285,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"1234abc\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"transaction_id\\":\\"c1209123\\",\\"value\\":10,\\"coupon\\":\\"SUMMER_FUN\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"12345\\"}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"1234abc\\",\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"transaction_id\\":\\"c1209123\\",\\"value\\":10,\\"coupon\\":\\"SUMMER_FUN\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"12345\\"}],\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Order Refunded',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -50,7 +51,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"transaction_id\\":\\"12345abcde\\",\\"items\\":[],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"transaction_id\\":\\"12345abcde\\",\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 
@@ -143,6 +144,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Order Refunded',
         userId: '1234abc',
+        timestamp: '2022-06-22T22:20:58.905Z',
         type: 'track',
         properties: {
           currency: 'USD',
@@ -205,7 +207,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"1234abc\\",\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"transaction_id\\":\\"c1209123\\",\\"value\\":10,\\"coupon\\":\\"SUMMER_FUN\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"12345\\"}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"1234abc\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"transaction_id\\":\\"c1209123\\",\\"value\\":10,\\"coupon\\":\\"SUMMER_FUN\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"12345\\"}],\\"engagement_time_msec\\":1}}]}"`
       )
     })
 
@@ -217,6 +219,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Order Refunded',
         userId: '1234abc',
+        timestamp: '2022-06-22T22:20:58.905Z',
         type: 'track',
         properties: {
           currency: 'usd',
@@ -279,7 +282,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"1234abc\\",\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"transaction_id\\":\\"c1209123\\",\\"value\\":10,\\"coupon\\":\\"SUMMER_FUN\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"12345\\"}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"1234abc\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"transaction_id\\":\\"c1209123\\",\\"value\\":10,\\"coupon\\":\\"SUMMER_FUN\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"12345\\"}],\\"engagement_time_msec\\":1}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
@@ -49,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"remove_from_cart\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"remove_from_cart\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Removed',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -47,7 +48,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"remove_from_cart\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"remove_from_cart\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
@@ -33,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
@@ -50,7 +50,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"search\\",\\"params\\":{\\"search_term\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"engagement_time_msec\\":2}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"search\\",\\"params\\":{\\"search_term\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"engagement_time_msec\\":2}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -82,7 +82,7 @@ describe('GA4', () => {
       expect(responses[0].status).toBe(201)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"search\\",\\"params\\":{\\"search_term\\":\\"milk and cookies\\",\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"search\\",\\"params\\":{\\"search_term\\":\\"milk and cookies\\",\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
@@ -33,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -73,6 +74,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Search',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -48,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"search\\",\\"params\\":{\\"search_term\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"engagement_time_msec\\":2}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"search\\",\\"params\\":{\\"search_term\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"engagement_time_msec\\":2}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 
@@ -60,6 +61,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Products Searched',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         type: 'track',
         properties: {
           query: 'milk and cookies'
@@ -76,6 +78,10 @@ describe('GA4', () => {
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"search\\",\\"params\\":{\\"search_term\\":\\"milk and cookies\\",\\"engagement_time_msec\\":1}}]}"`
+      )
     })
 
     //event without query term event

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
@@ -33,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -83,6 +84,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -176,6 +178,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -271,6 +274,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Select Item',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -47,7 +48,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 
@@ -58,6 +59,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Clicked',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -138,7 +140,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"index\\":3,\\"item_brand\\":\\"Hasbro\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"index\\":3,\\"item_brand\\":\\"Hasbro\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"engagement_time_msec\\":2}}]}"`
       )
     })
 
@@ -149,6 +151,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Clicked',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -233,7 +236,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"index\\":3,\\"item_brand\\":\\"Hasbro\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"currency\\":\\"usd\\"}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"index\\":3,\\"item_brand\\":\\"Hasbro\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"currency\\":\\"usd\\"}],\\"engagement_time_msec\\":2}}]}"`
       )
     })
 
@@ -244,6 +247,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Clicked',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -287,7 +291,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"5678fkj9087\\",\\"item_name\\":\\"Limited Edition T\\",\\"coupon\\":\\"SummerFest\\",\\"item_brand\\":\\"yeezy\\",\\"item_category\\":\\"Clothing\\",\\"item_variant\\":\\"Black\\",\\"price\\":8.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"5678fkj9087\\",\\"item_name\\":\\"Limited Edition T\\",\\"coupon\\":\\"SummerFest\\",\\"item_brand\\":\\"yeezy\\",\\"item_category\\":\\"Clothing\\",\\"item_variant\\":\\"Black\\",\\"price\\":8.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
@@ -49,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -142,7 +142,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"index\\":3,\\"item_brand\\":\\"Hasbro\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"index\\":3,\\"item_brand\\":\\"Hasbro\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -239,7 +239,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"index\\":3,\\"item_brand\\":\\"Hasbro\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"currency\\":\\"usd\\"}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"index\\":3,\\"item_brand\\":\\"Hasbro\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"currency\\":\\"usd\\"}],\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -295,7 +295,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"5678fkj9087\\",\\"item_name\\":\\"Limited Edition T\\",\\"coupon\\":\\"SummerFest\\",\\"item_brand\\":\\"yeezy\\",\\"item_category\\":\\"Clothing\\",\\"item_variant\\":\\"Black\\",\\"price\\":8.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"5678fkj9087\\",\\"item_name\\":\\"Limited Edition T\\",\\"coupon\\":\\"SummerFest\\",\\"item_brand\\":\\"yeezy\\",\\"item_category\\":\\"Clothing\\",\\"item_variant\\":\\"Black\\",\\"price\\":8.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Select Promotion',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -55,7 +56,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"promotion_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"promotion_name\\":\\"Quadruple Stack Oreos, 52 ct\\"}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"promotion_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"promotion_name\\":\\"Quadruple Stack Oreos, 52 ct\\"}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 
@@ -66,6 +67,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Promotion Clicked',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -119,7 +121,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_id\\":\\"abc\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\"}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_id\\":\\"abc\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\"}],\\"engagement_time_msec\\":2}}]}"`
       )
     })
 
@@ -130,6 +132,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Promotion Clicked',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -208,7 +211,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"creative_name\\":\\"top_banner_2\\",\\"creative_slot\\":\\"2\\",\\"location_id\\":\\"home\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_id\\":\\"SKU_12345\\",\\"item_name\\":\\"jeggings\\",\\"coupon\\":\\"SUMMER_FUN\\",\\"discount\\":2.22,\\"promotion_id\\":\\"P_12345\\",\\"promotion_name\\":\\"Summer Sale\\",\\"creative_slot\\":\\"featured_app_1\\",\\"location_id\\":\\"L_12345\\",\\"affiliation\\":\\"Google Store\\",\\"item_brand\\":\\"Gucci\\",\\"item_category\\":\\"pants\\",\\"item_variant\\":\\"Black\\",\\"price\\":9.99,\\"currency\\":\\"USD\\"}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"creative_name\\":\\"top_banner_2\\",\\"creative_slot\\":\\"2\\",\\"location_id\\":\\"home\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_id\\":\\"SKU_12345\\",\\"item_name\\":\\"jeggings\\",\\"coupon\\":\\"SUMMER_FUN\\",\\"discount\\":2.22,\\"promotion_id\\":\\"P_12345\\",\\"promotion_name\\":\\"Summer Sale\\",\\"creative_slot\\":\\"featured_app_1\\",\\"location_id\\":\\"L_12345\\",\\"affiliation\\":\\"Google Store\\",\\"item_brand\\":\\"Gucci\\",\\"item_category\\":\\"pants\\",\\"item_variant\\":\\"Black\\",\\"price\\":9.99,\\"currency\\":\\"USD\\"}],\\"engagement_time_msec\\":1}}]}"`
       )
     })
 
@@ -219,6 +222,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Promotion Clicked',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -297,7 +301,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"creative_name\\":\\"top_banner_2\\",\\"creative_slot\\":\\"2\\",\\"location_id\\":\\"home\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_id\\":\\"SKU_12345\\",\\"item_name\\":\\"jeggings\\",\\"coupon\\":\\"SUMMER_FUN\\",\\"discount\\":2.22,\\"promotion_id\\":\\"P_12345\\",\\"promotion_name\\":\\"Summer Sale\\",\\"creative_slot\\":\\"featured_app_1\\",\\"location_id\\":\\"L_12345\\",\\"affiliation\\":\\"Google Store\\",\\"item_brand\\":\\"Gucci\\",\\"item_category\\":\\"pants\\",\\"item_variant\\":\\"Black\\",\\"price\\":9.99,\\"currency\\":\\"usd\\"}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"creative_name\\":\\"top_banner_2\\",\\"creative_slot\\":\\"2\\",\\"location_id\\":\\"home\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_id\\":\\"SKU_12345\\",\\"item_name\\":\\"jeggings\\",\\"coupon\\":\\"SUMMER_FUN\\",\\"discount\\":2.22,\\"promotion_id\\":\\"P_12345\\",\\"promotion_name\\":\\"Summer Sale\\",\\"creative_slot\\":\\"featured_app_1\\",\\"location_id\\":\\"L_12345\\",\\"affiliation\\":\\"Google Store\\",\\"item_brand\\":\\"Gucci\\",\\"item_category\\":\\"pants\\",\\"item_variant\\":\\"Black\\",\\"price\\":9.99,\\"currency\\":\\"usd\\"}],\\"engagement_time_msec\\":1}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
@@ -57,7 +57,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"promotion_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"promotion_name\\":\\"Quadruple Stack Oreos, 52 ct\\"}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"promotion_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"promotion_name\\":\\"Quadruple Stack Oreos, 52 ct\\"}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -123,7 +123,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_id\\":\\"abc\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\"}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_id\\":\\"abc\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\"}],\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -214,7 +214,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"creative_name\\":\\"top_banner_2\\",\\"creative_slot\\":\\"2\\",\\"location_id\\":\\"home\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_id\\":\\"SKU_12345\\",\\"item_name\\":\\"jeggings\\",\\"coupon\\":\\"SUMMER_FUN\\",\\"discount\\":2.22,\\"promotion_id\\":\\"P_12345\\",\\"promotion_name\\":\\"Summer Sale\\",\\"creative_slot\\":\\"featured_app_1\\",\\"location_id\\":\\"L_12345\\",\\"affiliation\\":\\"Google Store\\",\\"item_brand\\":\\"Gucci\\",\\"item_category\\":\\"pants\\",\\"item_variant\\":\\"Black\\",\\"price\\":9.99,\\"currency\\":\\"USD\\"}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"creative_name\\":\\"top_banner_2\\",\\"creative_slot\\":\\"2\\",\\"location_id\\":\\"home\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_id\\":\\"SKU_12345\\",\\"item_name\\":\\"jeggings\\",\\"coupon\\":\\"SUMMER_FUN\\",\\"discount\\":2.22,\\"promotion_id\\":\\"P_12345\\",\\"promotion_name\\":\\"Summer Sale\\",\\"creative_slot\\":\\"featured_app_1\\",\\"location_id\\":\\"L_12345\\",\\"affiliation\\":\\"Google Store\\",\\"item_brand\\":\\"Gucci\\",\\"item_category\\":\\"pants\\",\\"item_variant\\":\\"Black\\",\\"price\\":9.99,\\"currency\\":\\"USD\\"}],\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -305,7 +305,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"creative_name\\":\\"top_banner_2\\",\\"creative_slot\\":\\"2\\",\\"location_id\\":\\"home\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_id\\":\\"SKU_12345\\",\\"item_name\\":\\"jeggings\\",\\"coupon\\":\\"SUMMER_FUN\\",\\"discount\\":2.22,\\"promotion_id\\":\\"P_12345\\",\\"promotion_name\\":\\"Summer Sale\\",\\"creative_slot\\":\\"featured_app_1\\",\\"location_id\\":\\"L_12345\\",\\"affiliation\\":\\"Google Store\\",\\"item_brand\\":\\"Gucci\\",\\"item_category\\":\\"pants\\",\\"item_variant\\":\\"Black\\",\\"price\\":9.99,\\"currency\\":\\"usd\\"}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"creative_name\\":\\"top_banner_2\\",\\"creative_slot\\":\\"2\\",\\"location_id\\":\\"home\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_id\\":\\"SKU_12345\\",\\"item_name\\":\\"jeggings\\",\\"coupon\\":\\"SUMMER_FUN\\",\\"discount\\":2.22,\\"promotion_id\\":\\"P_12345\\",\\"promotion_name\\":\\"Summer Sale\\",\\"creative_slot\\":\\"featured_app_1\\",\\"location_id\\":\\"L_12345\\",\\"affiliation\\":\\"Google Store\\",\\"item_brand\\":\\"Gucci\\",\\"item_category\\":\\"pants\\",\\"item_variant\\":\\"Black\\",\\"price\\":9.99,\\"currency\\":\\"usd\\"}],\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
@@ -33,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -84,6 +85,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -168,6 +170,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -258,6 +261,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Signup',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -47,7 +48,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"sign_up\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"sign_up\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 
@@ -59,6 +60,7 @@ describe('GA4', () => {
         event: 'Signed Up',
         type: 'track',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         properties: {
           type: 'Google'
         }
@@ -90,7 +92,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"sign_up\\",\\"params\\":{\\"method\\":\\"Google\\",\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"sign_up\\",\\"params\\":{\\"method\\":\\"Google\\",\\"engagement_time_msec\\":1}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
@@ -33,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -72,6 +73,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
@@ -49,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"sign_up\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"sign_up\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -94,7 +94,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"sign_up\\",\\"params\\":{\\"method\\":\\"Google\\",\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"sign_up\\",\\"params\\":{\\"method\\":\\"Google\\",\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
@@ -64,7 +64,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_cart\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"price\\":19,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"view_cart\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"price\\":19,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -146,7 +146,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_cart\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"view_cart\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
@@ -48,6 +48,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -96,6 +97,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Cart Viewed',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -62,7 +63,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"view_cart\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"price\\":19,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_cart\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"price\\":19,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 
@@ -74,6 +75,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Cart Viewed',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -97,6 +99,9 @@ describe('GA4', () => {
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
+          },
+          timestamp_micros: {
+            '@path': '$.timestamp'
           },
           engagement_time_msec: 2,
           items: [
@@ -139,7 +144,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"view_cart\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_cart\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":2}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Item Viewed',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -47,7 +48,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"quantity\\":1,\\"price\\":12.99}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 
@@ -58,6 +59,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Viewed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -122,7 +124,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"Monopoly: 3rd Edition\\"}],\\"value\\":18.99,\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"Monopoly: 3rd Edition\\"}],\\"value\\":18.99,\\"engagement_time_msec\\":2}}]}"`
       )
     })
 
@@ -133,6 +135,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Viewed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -178,7 +181,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"quantity\\":1}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}]}"`
       )
     })
 
@@ -189,6 +192,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Viewed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -234,7 +238,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"quantity\\":1}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
@@ -33,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -85,6 +86,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -161,6 +163,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -218,6 +221,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
@@ -49,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"quantity\\":1,\\"price\\":12.99}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"quantity\\":1,\\"price\\":12.99}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -126,7 +126,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"Monopoly: 3rd Edition\\"}],\\"value\\":18.99,\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"Monopoly: 3rd Edition\\"}],\\"value\\":18.99,\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -184,7 +184,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -242,7 +242,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
@@ -48,7 +48,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"quantity\\":1,\\"price\\":12.99}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 
@@ -181,7 +181,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"quantity\\":1}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}]}"`
       )
     })
 
@@ -238,7 +238,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"quantity\\":1}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
@@ -78,7 +78,7 @@ describe('GA4', () => {
       expect(responses[0].status).toBe(201)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_item_list\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":2}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"view_item_list\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":2}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product List Viewed',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -39,6 +40,9 @@ describe('GA4', () => {
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
+          },
+          timestamp_micros: {
+            '@path': '$.timestamp'
           },
           engagement_time_msec: 2,
           user_properties: {
@@ -73,7 +77,7 @@ describe('GA4', () => {
       expect(responses[0].status).toBe(201)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"view_item_list\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":2}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_item_list\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":2}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
@@ -37,6 +37,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
@@ -15,6 +15,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Promotion Viewed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -47,6 +48,9 @@ describe('GA4', () => {
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
+          },
+          timestamp_micros: {
+            '@path': '$.timestamp'
           },
           engagement_time_msec: 2,
           location_id: {
@@ -95,7 +99,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"promotion_name\\":\\"SUPER SUMMER SALE; 3% off\\",\\"creative_slot\\":\\"2\\",\\"promotion_id\\":\\"12345\\",\\"creative_name\\":\\"Sale\\"}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"promotion_name\\":\\"SUPER SUMMER SALE; 3% off\\",\\"creative_slot\\":\\"2\\",\\"promotion_id\\":\\"12345\\",\\"creative_name\\":\\"Sale\\"}],\\"engagement_time_msec\\":2}}]}"`
       )
     })
 
@@ -106,6 +110,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Promotion Viewed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -190,7 +195,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"promotion_name\\":\\"SUPER SUMMER SALE; 3% off\\",\\"creative_slot\\":\\"2\\",\\"promotion_id\\":\\"12345\\",\\"creative_name\\":\\"Sale\\",\\"currency\\":\\"usd\\"}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"promotion_name\\":\\"SUPER SUMMER SALE; 3% off\\",\\"creative_slot\\":\\"2\\",\\"promotion_id\\":\\"12345\\",\\"creative_name\\":\\"Sale\\",\\"currency\\":\\"usd\\"}],\\"engagement_time_msec\\":2}}]}"`
       )
     })
 
@@ -303,7 +308,7 @@ describe('GA4', () => {
         })
         fail('the test should have thrown an error')
       } catch (e) {
-        expect(e.message).toBe('One of item id or item name is required.')
+        expect(e.message).toBe('One of product name or product id is required for product or impression data.')
       }
     })
 
@@ -353,6 +358,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Promotion Viewed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -423,7 +429,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"promotion_name\\":\\"SUPER SUMMER SALE; 3% off\\",\\"creative_slot\\":\\"2\\",\\"promotion_id\\":\\"12345\\",\\"creative_name\\":\\"Sale\\"}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"promotion_name\\":\\"SUPER SUMMER SALE; 3% off\\",\\"creative_slot\\":\\"2\\",\\"promotion_id\\":\\"12345\\",\\"creative_name\\":\\"Sale\\"}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
@@ -100,7 +100,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"promotion_name\\":\\"SUPER SUMMER SALE; 3% off\\",\\"creative_slot\\":\\"2\\",\\"promotion_id\\":\\"12345\\",\\"creative_name\\":\\"Sale\\"}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"promotion_name\\":\\"SUPER SUMMER SALE; 3% off\\",\\"creative_slot\\":\\"2\\",\\"promotion_id\\":\\"12345\\",\\"creative_name\\":\\"Sale\\"}],\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -197,7 +197,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"promotion_name\\":\\"SUPER SUMMER SALE; 3% off\\",\\"creative_slot\\":\\"2\\",\\"promotion_id\\":\\"12345\\",\\"creative_name\\":\\"Sale\\",\\"currency\\":\\"usd\\"}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"promotion_name\\":\\"SUPER SUMMER SALE; 3% off\\",\\"creative_slot\\":\\"2\\",\\"promotion_id\\":\\"12345\\",\\"creative_name\\":\\"Sale\\",\\"currency\\":\\"usd\\"}],\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -432,7 +432,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"timestamp_micros\\":1655936458905000,\\"events\\":[{\\"name\\":\\"view_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"promotion_name\\":\\"SUPER SUMMER SALE; 3% off\\",\\"creative_slot\\":\\"2\\",\\"promotion_id\\":\\"12345\\",\\"creative_name\\":\\"Sale\\"}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"promotion_name\\":\\"SUPER SUMMER SALE; 3% off\\",\\"creative_slot\\":\\"2\\",\\"promotion_id\\":\\"12345\\",\\"creative_name\\":\\"Sale\\"}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
@@ -45,6 +45,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -141,6 +142,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -389,6 +391,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           user_properties: {
             hello: 'world',

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
@@ -308,7 +308,7 @@ describe('GA4', () => {
         })
         fail('the test should have thrown an error')
       } catch (e) {
-        expect(e.message).toBe('One of product name or product id is required for product or impression data.')
+        expect(e.message).toBe('One of item id or item name is required.')
       }
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
@@ -2,7 +2,7 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   user_id,
   formatUserProperties,
@@ -14,6 +14,7 @@ import {
   payment_type,
   items_multi_products,
   engagement_time_msec,
+  timestamp_micros,
   params
 } from '../ga4-properties'
 
@@ -24,6 +25,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     currency: { ...currency },
     value: { ...value },
     coupon: { ...coupon },
@@ -94,6 +96,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         client_id: payload.client_id,
         user_id: payload.user_id,
+        timestamp_micros: convertTimestamp(payload.timestamp_micros),
         events: [
           {
             name: 'add_payment_info',

--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
@@ -1,8 +1,7 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyCurrency, convertTimestamp } from '../ga4-functions'
+import { verifyCurrency, convertTimestamp, formatItems, checkCurrencyDefinition } from '../ga4-functions'
 import {
   user_id,
   formatUserProperties,
@@ -53,43 +52,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyCurrency(payload.currency)
     }
 
-    // Google requires that currency be included at the event level if value is included.
-    if (payload.value && payload.currency === undefined) {
-      throw new IntegrationError('Currency is required if value is set.', 'Misconfigured required field', 400)
-    }
-
-    /**
-     * Google requires a currency be specified either at the event level or the item level.
-     * If set at the event level, item-level currency is ignored. If event-level currency is not set then
-     * currency from the first item in items is used.
-     */
-    if (payload.currency === undefined && payload.items[0].currency === undefined) {
-      throw new IntegrationError(
-        'One of item-level currency or top-level currency is required.',
-        'Misconfigured required field',
-        400
-      )
-    }
-
-    let googleItems: ProductItem[] = []
-
-    if (payload.items) {
-      googleItems = payload.items.map((product) => {
-        if (product.item_name === undefined && product.item_id === undefined) {
-          throw new IntegrationError(
-            'One of product name or product id is required for product or impression data.',
-            'Misconfigured required field',
-            400
-          )
-        }
-
-        if (product.currency) {
-          verifyCurrency(product.currency)
-        }
-
-        return product as ProductItem
-      })
-    }
+    checkCurrencyDefinition(payload.value, payload.currency, payload.items)
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
@@ -105,7 +68,7 @@ const action: ActionDefinition<Settings, Payload> = {
               value: payload.value,
               coupon: payload.coupon,
               payment_type: payload.payment_type,
-              items: googleItems,
+              items: formatItems(payload.items),
               engagement_time_msec: payload.engagement_time_msec,
               ...payload.params
             }

--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
@@ -38,7 +38,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     // Google requires that `add_payment_info` events include an array of products: https://developers.google.com/analytics/devguides/collection/ga4/reference/events
     // This differs from the Segment spec, which doesn't require a products array: https://segment.com/docs/connections/spec/ecommerce/v2/#payment-info-entered
     if (payload.items && !payload.items.length) {
@@ -91,28 +91,33 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'add_payment_info',
+          params: {
+            currency: payload.currency,
+            value: payload.value,
+            coupon: payload.coupon,
+            payment_type: payload.payment_type,
+            items: googleItems,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        timestamp_micros: convertTimestamp(payload.timestamp_micros),
-        events: [
-          {
-            name: 'add_payment_info',
-            params: {
-              currency: payload.currency,
-              value: payload.value,
-              coupon: payload.coupon,
-              payment_type: payload.payment_type,
-              items: googleItems,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
@@ -1,7 +1,8 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
+import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyCurrency, convertTimestamp, formatItems, checkCurrencyDefinition } from '../ga4-functions'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   user_id,
   formatUserProperties,
@@ -52,7 +53,43 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyCurrency(payload.currency)
     }
 
-    checkCurrencyDefinition(payload.value, payload.currency, payload.items)
+    // Google requires that currency be included at the event level if value is included.
+    if (payload.value && payload.currency === undefined) {
+      throw new IntegrationError('Currency is required if value is set.', 'Misconfigured required field', 400)
+    }
+
+    /**
+     * Google requires a currency be specified either at the event level or the item level.
+     * If set at the event level, item-level currency is ignored. If event-level currency is not set then
+     * currency from the first item in items is used.
+     */
+    if (payload.currency === undefined && payload.items[0].currency === undefined) {
+      throw new IntegrationError(
+        'One of item-level currency or top-level currency is required.',
+        'Misconfigured required field',
+        400
+      )
+    }
+
+    let googleItems: ProductItem[] = []
+
+    if (payload.items) {
+      googleItems = payload.items.map((product) => {
+        if (product.item_name === undefined && product.item_id === undefined) {
+          throw new IntegrationError(
+            'One of product name or product id is required for product or impression data.',
+            'Misconfigured required field',
+            400
+          )
+        }
+
+        if (product.currency) {
+          verifyCurrency(product.currency)
+        }
+
+        return product as ProductItem
+      })
+    }
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
@@ -68,7 +105,7 @@ const action: ActionDefinition<Settings, Payload> = {
               value: payload.value,
               coupon: payload.coupon,
               payment_type: payload.payment_type,
-              items: formatItems(payload.items),
+              items: googleItems,
               engagement_time_msec: payload.engagement_time_msec,
               ...payload.params
             }

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
@@ -2,7 +2,7 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { ProductItem } from '../ga4-types'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -12,7 +12,8 @@ import {
   client_id,
   items_single_products,
   user_id,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -22,6 +23,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     currency: { ...currency },
     items: {
       ...items_single_products,
@@ -62,6 +64,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         client_id: payload.client_id,
         user_id: payload.user_id,
+        timestamp_micros: convertTimestamp(payload.timestamp_micros),
         events: [
           {
             name: 'add_to_cart',

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
@@ -34,7 +34,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     let googleItems: ProductItem[] = []
 
     if (payload.currency) {
@@ -59,26 +59,31 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'add_to_cart',
+          params: {
+            currency: payload.currency,
+            items: googleItems,
+            value: payload.value,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        timestamp_micros: convertTimestamp(payload.timestamp_micros),
-        events: [
-          {
-            name: 'add_to_cart',
-            params: {
-              currency: payload.currency,
-              items: googleItems,
-              value: payload.value,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
@@ -1,7 +1,8 @@
-import { ActionDefinition } from '@segment/actions-core'
+import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyCurrency, convertTimestamp, formatItems } from '../ga4-functions'
+import { ProductItem } from '../ga4-types'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -34,8 +35,28 @@ const action: ActionDefinition<Settings, Payload> = {
     params: params
   },
   perform: (request, { payload }) => {
+    let googleItems: ProductItem[] = []
+
     if (payload.currency) {
       verifyCurrency(payload.currency)
+    }
+
+    if (payload.items) {
+      googleItems = payload.items.map((product) => {
+        if (product.item_name === undefined && product.item_id === undefined) {
+          throw new IntegrationError(
+            'One of product name or product id is required for product or impression data.',
+            'Misconfigured required field',
+            400
+          )
+        }
+
+        if (product.currency) {
+          verifyCurrency(product.currency)
+        }
+
+        return product as ProductItem
+      })
     }
 
     return request('https://www.google-analytics.com/mp/collect', {
@@ -49,7 +70,7 @@ const action: ActionDefinition<Settings, Payload> = {
             name: 'add_to_cart',
             params: {
               currency: payload.currency,
-              items: formatItems(payload.items),
+              items: googleItems,
               value: payload.value,
               engagement_time_msec: payload.engagement_time_msec,
               ...payload.params

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
@@ -1,7 +1,8 @@
-import { ActionDefinition } from '@segment/actions-core'
+import { ActionDefinition, IntegrationError } from '@segment/actions-core'
+import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyCurrency, convertTimestamp, formatItems, checkCurrencyDefinition } from '../ga4-functions'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -38,7 +39,42 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyCurrency(payload.currency)
     }
 
-    checkCurrencyDefinition(payload.value, payload.currency, payload.items)
+    // Google requires that currency be included at the event level if value is included.
+    if (payload.value && payload.currency === undefined) {
+      throw new IntegrationError('Currency is required if value is set.', 'Misconfigured required field', 400)
+    }
+
+    /**
+     * Google requires a currency be specified either at the event level or the item level.
+     * If set at the event level, item-level currency is ignored. If event-level currency is not set then
+     * currency from the first item in items is used.
+     */
+    if (payload.currency === undefined && (!payload.items || !payload.items[0] || !payload.items[0].currency)) {
+      throw new IntegrationError(
+        'One of item-level currency or top-level currency is required.',
+        'Misconfigured required field',
+        400
+      )
+    }
+
+    let googleItems: ProductItem[] = []
+
+    if (payload.items) {
+      googleItems = payload.items.map((product) => {
+        if (product.item_name === undefined && product.item_id === undefined) {
+          throw new IntegrationError(
+            'One of product name or product id is required for product or impression data.',
+            'Misconfigured required field',
+            400
+          )
+        }
+        if (product.currency) {
+          verifyCurrency(product.currency)
+        }
+
+        return product as ProductItem
+      })
+    }
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
@@ -52,7 +88,7 @@ const action: ActionDefinition<Settings, Payload> = {
             params: {
               currency: payload.currency,
               value: payload.value,
-              items: formatItems(payload.items),
+              items: googleItems,
               engagement_time_msec: payload.engagement_time_msec,
               ...payload.params
             }

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
@@ -2,7 +2,7 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -12,7 +12,8 @@ import {
   client_id,
   items_single_products,
   user_id,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -22,6 +23,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     currency: { ...currency },
     value: { ...value },
     items: {
@@ -79,6 +81,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         client_id: payload.client_id,
         user_id: payload.user_id,
+        timestamp_micros: convertTimestamp(payload.timestamp_micros),
         events: [
           {
             name: 'add_to_wishlist',

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
@@ -34,7 +34,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     if (payload.currency) {
       verifyCurrency(payload.currency)
     }
@@ -76,26 +76,31 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'add_to_wishlist',
+          params: {
+            currency: payload.currency,
+            value: payload.value,
+            items: googleItems,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        timestamp_micros: convertTimestamp(payload.timestamp_micros),
-        events: [
-          {
-            name: 'add_to_wishlist',
-            params: {
-              currency: payload.currency,
-              value: payload.value,
-              items: googleItems,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Coupon code used for a purchase.
    */
   coupon?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
@@ -1,5 +1,5 @@
-import { ActionDefinition } from '@segment/actions-core'
-import { verifyCurrency, convertTimestamp, formatItems } from '../ga4-functions'
+import { ActionDefinition, IntegrationError } from '@segment/actions-core'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -13,6 +13,7 @@ import {
   timestamp_micros,
   engagement_time_msec
 } from '../ga4-properties'
+import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
@@ -42,6 +43,26 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyCurrency(payload.currency)
     }
 
+    let googleItems: ProductItem[] = []
+
+    if (payload.items) {
+      googleItems = payload.items.map((product) => {
+        if (product.item_name === undefined && product.item_id === undefined) {
+          throw new IntegrationError(
+            'One of product name or product id is required for product or impression data.',
+            'Misconfigured required field',
+            400
+          )
+        }
+
+        if (product.currency) {
+          verifyCurrency(product.currency)
+        }
+
+        return product as ProductItem
+      })
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {
@@ -54,7 +75,7 @@ const action: ActionDefinition<Settings, Payload> = {
             params: {
               coupon: payload.coupon,
               currency: payload.currency,
-              items: formatItems(payload.items),
+              items: googleItems,
               value: payload.value,
               engagement_time_msec: payload.engagement_time_msec,
               ...payload.params

--- a/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -10,6 +10,7 @@ import {
   value,
   items_multi_products,
   user_id,
+  timestamp_micros,
   engagement_time_msec
 } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
@@ -23,6 +24,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     coupon: { ...coupon, default: { '@path': '$.properties.coupon' } },
     currency: { ...currency },
     // Google does not have anything to map position, url and image url fields (Segment spec) to
@@ -66,6 +68,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         client_id: payload.client_id,
         user_id: payload.user_id,
+        timestamp_micros: convertTimestamp(payload.timestamp_micros),
         events: [
           {
             name: 'begin_checkout',

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * The unique name of the custom event created in GA4. GA4 does not accept spaces in event names so Segment will replace any spaces with underscores. More information about GA4 event name rules is available in [their docs](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article).
    */
   name: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
@@ -51,25 +51,31 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: { ...params }
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     const event_name = normalizeEventName(payload.name, payload.lowercase)
+
+    let request_object = {
+      client_id: payload.clientId,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: event_name,
+          params: {
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.clientId,
-        user_id: payload.user_id,
-        timestamp_micros: convertTimestamp(payload.timestamp_micros),
-        events: [
-          {
-            name: event_name,
-            params: {
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
@@ -1,13 +1,15 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+import { convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
   params,
   client_id,
   user_id,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 
 const normalizeEventName = (name: string, lowercase: boolean | undefined): string => {
@@ -27,6 +29,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     clientId: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     name: {
       label: 'Event Name',
       description:
@@ -55,6 +58,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         client_id: payload.clientId,
         user_id: payload.user_id,
+        timestamp_micros: convertTimestamp(payload.timestamp_micros),
         events: [
           {
             name: event_name,

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
@@ -1,35 +1,10 @@
 import { IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from './constants'
-import { ProductItem, PromotionProductItem } from './ga4-types'
 
 // Google expects currency to be a 3-letter ISO 4217 format
 export function verifyCurrency(currency: string): void {
   if (!CURRENCY_ISO_CODES.includes(currency.toUpperCase())) {
     throw new IntegrationError(`${currency} is not a valid currency code.`, 'Incorrect value format', 400)
-  }
-}
-
-export function checkCurrencyDefinition(
-  value: number | undefined,
-  eventCurrency: string | undefined,
-  items: ProductItem[] | undefined
-): void {
-  // Google requires that currency be included at the event level if value is included.
-  if (value && eventCurrency === undefined) {
-    throw new IntegrationError('Currency is required if value is set.', 'Misconfigured required field', 400)
-  }
-
-  /**
-   * Google requires a currency be specified either at the event level or the item level.
-   * If set at the event level, item-level currency is ignored. If event-level currency is not set then
-   * currency from the first item in items is used.
-   */
-  if (eventCurrency === undefined && (!items || !items[0] || !items[0].currency)) {
-    throw new IntegrationError(
-      'One of item-level currency or top-level currency is required.',
-      'Misconfigured required field',
-      400
-    )
   }
 }
 
@@ -46,58 +21,4 @@ export function convertTimestamp(timestamp: string | undefined): number | undefi
 
   // converts non-unix timestamp to unix microseconds
   return Date.parse(timestamp) * 1000
-}
-
-export function formatItems(
-  items: ProductItem[] | PromotionProductItem[] | undefined
-): ProductItem[] | PromotionProductItem[] | undefined {
-  if (!items) {
-    return undefined
-  }
-  // let googleItems: ProductItem[] = []
-  const googleItems = items.map((product) => {
-    if (product.item_name === undefined && product.item_id === undefined) {
-      throw new IntegrationError(
-        'One of product name or product id is required for product or impression data.',
-        'Misconfigured required field',
-        400
-      )
-    }
-    if (product.currency) {
-      verifyCurrency(product.currency)
-    }
-    return product
-  })
-
-  return googleItems
-}
-
-export function formatPromotionItems(items: PromotionProductItem[] | undefined): PromotionProductItem[] | undefined {
-  if (!items) {
-    return undefined
-  }
-  let googleItems: PromotionProductItem[] = []
-  googleItems = items.map((product) => {
-    if (product.item_name === undefined && product.item_id === undefined) {
-      throw new IntegrationError(
-        'One of product name or product id is required for product or impression data.',
-        'Misconfigured required field',
-        400
-      )
-    }
-    if (product.promotion_id === undefined && product.promotion_name === undefined) {
-      throw new IntegrationError(
-        'One of promotion name or promotion id is required.',
-        'Misconfigured required field',
-        400
-      )
-    }
-    if (product.currency) {
-      verifyCurrency(product.currency)
-    }
-
-    return product
-  })
-
-  return googleItems
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
@@ -7,3 +7,18 @@ export function verifyCurrency(currency: string): void {
     throw new IntegrationError(`${currency} is not a valid currency code.`, 'Incorrect value format', 400)
   }
 }
+
+// Google expects timestamps to be in Unix microseconds
+export function convertTimestamp(timestamp: string | undefined): number | undefined {
+  if (!timestamp) {
+    return undefined
+  }
+
+  // verify that timestamp is not already in unix
+  if (!isNaN(+timestamp)) {
+    return +timestamp
+  }
+
+  // converts non-unix timestamp to unix microseconds
+  return Date.parse(timestamp) * 1000
+}

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
@@ -1,10 +1,35 @@
 import { IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from './constants'
+import { ProductItem, PromotionProductItem } from './ga4-types'
 
 // Google expects currency to be a 3-letter ISO 4217 format
 export function verifyCurrency(currency: string): void {
   if (!CURRENCY_ISO_CODES.includes(currency.toUpperCase())) {
     throw new IntegrationError(`${currency} is not a valid currency code.`, 'Incorrect value format', 400)
+  }
+}
+
+export function checkCurrencyDefinition(
+  value: number | undefined,
+  eventCurrency: string | undefined,
+  items: ProductItem[] | undefined
+): void {
+  // Google requires that currency be included at the event level if value is included.
+  if (value && eventCurrency === undefined) {
+    throw new IntegrationError('Currency is required if value is set.', 'Misconfigured required field', 400)
+  }
+
+  /**
+   * Google requires a currency be specified either at the event level or the item level.
+   * If set at the event level, item-level currency is ignored. If event-level currency is not set then
+   * currency from the first item in items is used.
+   */
+  if (eventCurrency === undefined && (!items || !items[0] || !items[0].currency)) {
+    throw new IntegrationError(
+      'One of item-level currency or top-level currency is required.',
+      'Misconfigured required field',
+      400
+    )
   }
 }
 
@@ -21,4 +46,58 @@ export function convertTimestamp(timestamp: string | undefined): number | undefi
 
   // converts non-unix timestamp to unix microseconds
   return Date.parse(timestamp) * 1000
+}
+
+export function formatItems(
+  items: ProductItem[] | PromotionProductItem[] | undefined
+): ProductItem[] | PromotionProductItem[] | undefined {
+  if (!items) {
+    return undefined
+  }
+  // let googleItems: ProductItem[] = []
+  const googleItems = items.map((product) => {
+    if (product.item_name === undefined && product.item_id === undefined) {
+      throw new IntegrationError(
+        'One of product name or product id is required for product or impression data.',
+        'Misconfigured required field',
+        400
+      )
+    }
+    if (product.currency) {
+      verifyCurrency(product.currency)
+    }
+    return product
+  })
+
+  return googleItems
+}
+
+export function formatPromotionItems(items: PromotionProductItem[] | undefined): PromotionProductItem[] | undefined {
+  if (!items) {
+    return undefined
+  }
+  let googleItems: PromotionProductItem[] = []
+  googleItems = items.map((product) => {
+    if (product.item_name === undefined && product.item_id === undefined) {
+      throw new IntegrationError(
+        'One of product name or product id is required for product or impression data.',
+        'Misconfigured required field',
+        400
+      )
+    }
+    if (product.promotion_id === undefined && product.promotion_name === undefined) {
+      throw new IntegrationError(
+        'One of promotion name or promotion id is required.',
+        'Misconfigured required field',
+        400
+      )
+    }
+    if (product.currency) {
+      verifyCurrency(product.currency)
+    }
+
+    return product
+  })
+
+  return googleItems
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-properties.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-properties.ts
@@ -331,3 +331,13 @@ export const engagement_time_msec: InputField = {
     'The amount of time a user interacted with your site, in milliseconds. Google only counts users who interact with your site for a non-zero amount of time. By default, Segment sets engagement time to 1 so users are counted.',
   default: 1
 }
+
+export const timestamp_micros: InputField = {
+  label: 'Event Timestamp',
+  type: 'string',
+  description:
+    'A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.',
+  default: {
+    '@path': '$.timestamp'
+  }
+}

--- a/packages/destination-actions/src/destinations/google-analytics-4/generateLead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/generateLead/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import {
@@ -10,7 +10,8 @@ import {
   user_id,
   currency,
   value,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -20,6 +21,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     currency: { ...currency },
     value: { ...value },
     user_properties: user_properties,
@@ -41,6 +43,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         client_id: payload.client_id,
         user_id: payload.user_id,
+        timestamp_micros: convertTimestamp(payload.timestamp_micros),
         events: [
           {
             name: 'generate_lead',

--- a/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
@@ -28,7 +28,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     if (payload.currency) {
       verifyCurrency(payload.currency)
     }
@@ -38,25 +38,30 @@ const action: ActionDefinition<Settings, Payload> = {
       throw new IntegrationError('Currency is required if value is set.', 'Misconfigured required field', 400)
     }
 
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'generate_lead',
+          params: {
+            currency: payload.currency,
+            value: payload.value,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        timestamp_micros: convertTimestamp(payload.timestamp_micros),
-        events: [
-          {
-            name: 'generate_lead',
-            params: {
-              currency: payload.currency,
-              value: payload.value,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/login/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/login/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * The method used to login.
    */
   method?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
@@ -1,13 +1,15 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+import { convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
   params,
   user_id,
   client_id,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -17,6 +19,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     method: {
       label: 'Method',
       type: 'string',
@@ -33,6 +36,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         client_id: payload.client_id,
         user_id: payload.user_id,
+        timestamp_micros: convertTimestamp(payload.timestamp_micros),
         events: [
           {
             name: 'login',

--- a/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
@@ -30,25 +30,30 @@ const action: ActionDefinition<Settings, Payload> = {
     params: params
   },
 
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'login',
+          params: {
+            method: payload.method,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        timestamp_micros: convertTimestamp(payload.timestamp_micros),
-        events: [
-          {
-            name: 'login',
-            params: {
-              method: payload.method,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * The current page URL
    */
   page_location?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
@@ -1,13 +1,15 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+import { convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
   params,
   user_id,
   client_id,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -17,6 +19,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     clientId: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     page_location: {
       label: 'Page Location',
       type: 'string',
@@ -51,6 +54,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         client_id: payload.clientId,
         user_id: payload.user_id,
+        timestamp_micros: convertTimestamp(payload.timestamp_micros),
         events: [
           {
             name: 'page_view',

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
@@ -48,27 +48,31 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
+    let request_object = {
+      client_id: payload.clientId,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'page_view',
+          params: {
+            page_location: payload.page_location,
+            page_referrer: payload.page_referrer,
+            page_title: payload.page_title,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.clientId,
-        user_id: payload.user_id,
-        timestamp_micros: convertTimestamp(payload.timestamp_micros),
-        events: [
-          {
-            name: 'page_view',
-            params: {
-              page_location: payload.page_location,
-              page_referrer: payload.page_referrer,
-              page_title: payload.page_title,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Store or affiliation from which this transaction occurred (e.g. Google Store).
    */
   affiliation?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
@@ -1,7 +1,7 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import { ProductItem } from '../ga4-types'
 import {
   coupon,
@@ -17,7 +17,8 @@ import {
   params,
   formatUserProperties,
   user_properties,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 
 // https://segment.com/docs/connections/spec/ecommerce/v2/#order-completed
@@ -29,6 +30,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     affiliation: { ...affiliation },
     coupon: { ...coupon, default: { '@path': '$.properties.coupon' } },
     currency: { ...currency, required: true },
@@ -74,6 +76,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         client_id: payload.client_id,
         user_id: payload.user_id,
+        timestamp_micros: convertTimestamp(payload.timestamp_micros),
         events: [
           {
             name: 'purchase',

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
@@ -1,8 +1,7 @@
-import { ActionDefinition, IntegrationError } from '@segment/actions-core'
+import { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyCurrency, convertTimestamp } from '../ga4-functions'
-import { ProductItem } from '../ga4-types'
+import { verifyCurrency, convertTimestamp, formatItems } from '../ga4-functions'
 import {
   coupon,
   currency,
@@ -51,26 +50,6 @@ const action: ActionDefinition<Settings, Payload> = {
   perform: (request, { payload }) => {
     verifyCurrency(payload.currency)
 
-    let googleItems: ProductItem[] = []
-
-    if (payload.items) {
-      googleItems = payload.items.map((product) => {
-        if (product.item_name === undefined && product.item_id === undefined) {
-          throw new IntegrationError(
-            'One of product name or product id is required for product or impression data.',
-            'Misconfigured required field',
-            400
-          )
-        }
-
-        if (product.currency) {
-          verifyCurrency(product.currency)
-        }
-
-        return product as ProductItem
-      })
-    }
-
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {
@@ -84,7 +63,7 @@ const action: ActionDefinition<Settings, Payload> = {
               affiliation: payload.affiliation,
               coupon: payload.coupon,
               currency: payload.currency,
-              items: googleItems,
+              items: formatItems(payload.items),
               transaction_id: payload.transaction_id,
               shipping: payload.shipping,
               value: payload.value,

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
@@ -1,5 +1,5 @@
-import { ActionDefinition } from '@segment/actions-core'
-import { verifyCurrency, convertTimestamp, formatItems, checkCurrencyDefinition } from '../ga4-functions'
+import { ActionDefinition, IntegrationError } from '@segment/actions-core'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   coupon,
   transaction_id,
@@ -16,6 +16,7 @@ import {
   engagement_time_msec,
   timestamp_micros
 } from '../ga4-properties'
+import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
@@ -50,7 +51,43 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyCurrency(payload.currency)
     }
 
-    checkCurrencyDefinition(payload.value, payload.currency, payload.items)
+    // Google requires that currency be included at the event level if value is included.
+    if (payload.value && payload.currency === undefined) {
+      throw new IntegrationError('Currency is required if value is set.', 'Misconfigured required field', 400)
+    }
+
+    /**
+     * Google requires a currency be specified either at the event level or the item level.
+     * If set at the event level, item-level currency is ignored. If event-level currency is not set then
+     * currency from the first item in items is used.
+     */
+    if (payload.currency === undefined && (!payload.items || !payload.items[0] || !payload.items[0].currency)) {
+      throw new IntegrationError(
+        'One of item-level currency or top-level currency is required.',
+        'Misconfigured required field',
+        400
+      )
+    }
+
+    let googleItems: ProductItem[] = []
+
+    if (payload.items) {
+      googleItems = payload.items.map((product) => {
+        if (product.item_name === undefined && product.item_id === undefined) {
+          throw new IntegrationError(
+            'One of product name or product id is required for product or impression data.',
+            'Misconfigured required field',
+            400
+          )
+        }
+
+        if (product.currency) {
+          verifyCurrency(product.currency)
+        }
+
+        return product as ProductItem
+      })
+    }
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
@@ -69,7 +106,7 @@ const action: ActionDefinition<Settings, Payload> = {
               coupon: payload.coupon,
               shipping: payload.shipping,
               tax: payload.tax,
-              items: formatItems(payload.items),
+              items: googleItems,
               engagement_time_msec: payload.engagement_time_msec,
               ...payload.params
             }

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
@@ -1,5 +1,5 @@
-import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency, convertTimestamp } from '../ga4-functions'
+import { ActionDefinition } from '@segment/actions-core'
+import { verifyCurrency, convertTimestamp, formatItems, checkCurrencyDefinition } from '../ga4-functions'
 import {
   coupon,
   transaction_id,
@@ -16,7 +16,6 @@ import {
   engagement_time_msec,
   timestamp_micros
 } from '../ga4-properties'
-import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
@@ -51,43 +50,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyCurrency(payload.currency)
     }
 
-    // Google requires that currency be included at the event level if value is included.
-    if (payload.value && payload.currency === undefined) {
-      throw new IntegrationError('Currency is required if value is set.', 'Misconfigured required field', 400)
-    }
-
-    /**
-     * Google requires a currency be specified either at the event level or the item level.
-     * If set at the event level, item-level currency is ignored. If event-level currency is not set then
-     * currency from the first item in items is used.
-     */
-    if (payload.currency === undefined && (!payload.items || !payload.items[0] || !payload.items[0].currency)) {
-      throw new IntegrationError(
-        'One of item-level currency or top-level currency is required.',
-        'Misconfigured required field',
-        400
-      )
-    }
-
-    let googleItems: ProductItem[] = []
-
-    if (payload.items) {
-      googleItems = payload.items.map((product) => {
-        if (product.item_name === undefined && product.item_id === undefined) {
-          throw new IntegrationError(
-            'One of product name or product id is required for product or impression data.',
-            'Misconfigured required field',
-            400
-          )
-        }
-
-        if (product.currency) {
-          verifyCurrency(product.currency)
-        }
-
-        return product as ProductItem
-      })
-    }
+    checkCurrencyDefinition(payload.value, payload.currency, payload.items)
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
@@ -106,7 +69,7 @@ const action: ActionDefinition<Settings, Payload> = {
               coupon: payload.coupon,
               shipping: payload.shipping,
               tax: payload.tax,
-              items: googleItems,
+              items: formatItems(payload.items),
               engagement_time_msec: payload.engagement_time_msec,
               ...payload.params
             }

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   coupon,
   transaction_id,
@@ -13,7 +13,8 @@ import {
   params,
   formatUserProperties,
   user_properties,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -26,6 +27,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     currency: { ...currency },
     transaction_id: { ...transaction_id, required: true },
     value: { ...value, default: { '@path': '$.properties.total' } },
@@ -92,6 +94,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         client_id: payload.client_id,
         user_id: payload.user_id,
+        timestamp_micros: convertTimestamp(payload.timestamp_micros),
         events: [
           {
             name: 'refund',

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
@@ -1,5 +1,5 @@
-import { ActionDefinition } from '@segment/actions-core'
-import { verifyCurrency, convertTimestamp, formatItems, checkCurrencyDefinition } from '../ga4-functions'
+import { ActionDefinition, IntegrationError } from '@segment/actions-core'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -12,6 +12,7 @@ import {
   engagement_time_msec,
   timestamp_micros
 } from '../ga4-properties'
+import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
@@ -38,7 +39,43 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyCurrency(payload.currency)
     }
 
-    checkCurrencyDefinition(payload.value, payload.currency, payload.items)
+    // Google requires that currency be included at the event level if value is included.
+    if (payload.value && payload.currency === undefined) {
+      throw new IntegrationError('Currency is required if value is set.', 'Misconfigured required field', 400)
+    }
+
+    /**
+     * Google requires a currency be specified either at the event level or the item level.
+     * If set at the event level, item-level currency is ignored. If event-level currency is not set then
+     * currency from the first item in items is used.
+     */
+    if (payload.currency === undefined && (!payload.items || !payload.items[0] || !payload.items[0].currency)) {
+      throw new IntegrationError(
+        'One of item-level currency or top-level currency is required.',
+        'Misconfigured required field',
+        400
+      )
+    }
+
+    let googleItems: ProductItem[] = []
+
+    if (payload.items) {
+      googleItems = payload.items.map((product) => {
+        if (product.item_name === undefined && product.item_id === undefined) {
+          throw new IntegrationError(
+            'One of product name or product id is required for product or impression data.',
+            'Misconfigured required field',
+            400
+          )
+        }
+
+        if (product.currency) {
+          verifyCurrency(product.currency)
+        }
+
+        return product as ProductItem
+      })
+    }
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
@@ -52,7 +89,7 @@ const action: ActionDefinition<Settings, Payload> = {
             params: {
               currency: payload.currency,
               value: payload.value,
-              items: formatItems(payload.items),
+              items: googleItems,
               engagement_time_msec: payload.engagement_time_msec,
               ...payload.params
             }

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
@@ -34,7 +34,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     if (payload.currency) {
       verifyCurrency(payload.currency)
     }
@@ -77,26 +77,31 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'remove_from_cart',
+          params: {
+            currency: payload.currency,
+            value: payload.value,
+            items: googleItems,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        timestamp_micros: convertTimestamp(payload.timestamp_micros),
-        events: [
-          {
-            name: 'remove_from_cart',
-            params: {
-              currency: payload.currency,
-              value: payload.value,
-              items: googleItems,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
@@ -1,5 +1,5 @@
-import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency, convertTimestamp } from '../ga4-functions'
+import { ActionDefinition } from '@segment/actions-core'
+import { verifyCurrency, convertTimestamp, formatItems, checkCurrencyDefinition } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -12,7 +12,6 @@ import {
   engagement_time_msec,
   timestamp_micros
 } from '../ga4-properties'
-import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
@@ -39,43 +38,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyCurrency(payload.currency)
     }
 
-    // Google requires that currency be included at the event level if value is included.
-    if (payload.value && payload.currency === undefined) {
-      throw new IntegrationError('Currency is required if value is set.', 'Misconfigured required field', 400)
-    }
-
-    /**
-     * Google requires a currency be specified either at the event level or the item level.
-     * If set at the event level, item-level currency is ignored. If event-level currency is not set then
-     * currency from the first item in items is used.
-     */
-    if (payload.currency === undefined && (!payload.items || !payload.items[0] || !payload.items[0].currency)) {
-      throw new IntegrationError(
-        'One of item-level currency or top-level currency is required.',
-        'Misconfigured required field',
-        400
-      )
-    }
-
-    let googleItems: ProductItem[] = []
-
-    if (payload.items) {
-      googleItems = payload.items.map((product) => {
-        if (product.item_name === undefined && product.item_id === undefined) {
-          throw new IntegrationError(
-            'One of product name or product id is required for product or impression data.',
-            'Misconfigured required field',
-            400
-          )
-        }
-
-        if (product.currency) {
-          verifyCurrency(product.currency)
-        }
-
-        return product as ProductItem
-      })
-    }
+    checkCurrencyDefinition(payload.value, payload.currency, payload.items)
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
@@ -89,7 +52,7 @@ const action: ActionDefinition<Settings, Payload> = {
             params: {
               currency: payload.currency,
               value: payload.value,
-              items: googleItems,
+              items: formatItems(payload.items),
               engagement_time_msec: payload.engagement_time_msec,
               ...payload.params
             }

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -9,7 +9,8 @@ import {
   client_id,
   currency,
   items_single_products,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -22,6 +23,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     currency: { ...currency },
     value: { ...value },
     items: {
@@ -80,6 +82,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         client_id: payload.client_id,
         user_id: payload.user_id,
+        timestamp_micros: convertTimestamp(payload.timestamp_micros),
         events: [
           {
             name: 'remove_from_cart',

--- a/packages/destination-actions/src/destinations/google-analytics-4/search/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/search/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * The term that was searched for.
    */
   search_term: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
@@ -33,25 +33,30 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'search',
+          params: {
+            search_term: payload.search_term,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        timestamp_micros: convertTimestamp(payload.timestamp_micros),
-        events: [
-          {
-            name: 'search',
-            params: {
-              search_term: payload.search_term,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
@@ -1,13 +1,15 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+import { convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
   params,
   user_id,
   client_id,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -17,6 +19,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     search_term: {
       label: 'Search Term',
       type: 'string',
@@ -36,6 +39,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         client_id: payload.client_id,
         user_id: payload.user_id,
+        timestamp_micros: convertTimestamp(payload.timestamp_micros),
         events: [
           {
             name: 'search',

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * The name of the list in which the item was presented to the user.
    */
   item_list_name?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
@@ -1,6 +1,5 @@
-import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency, convertTimestamp } from '../ga4-functions'
-import { ProductItem } from '../ga4-types'
+import { ActionDefinition } from '@segment/actions-core'
+import { convertTimestamp, formatItems } from '../ga4-functions'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import {
@@ -41,26 +40,6 @@ const action: ActionDefinition<Settings, Payload> = {
     params: params
   },
   perform: (request, { payload }) => {
-    let googleItems: ProductItem[] = []
-
-    if (payload.items) {
-      googleItems = payload.items.map((product) => {
-        if (product.item_name === undefined && product.item_id === undefined) {
-          throw new IntegrationError(
-            'One of product name or product id is required for product or impression data.',
-            'Misconfigured required field',
-            400
-          )
-        }
-
-        if (product.currency) {
-          verifyCurrency(product.currency)
-        }
-
-        return product as ProductItem
-      })
-    }
-
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {
@@ -71,7 +50,7 @@ const action: ActionDefinition<Settings, Payload> = {
           {
             name: 'select_item',
             params: {
-              items: googleItems,
+              items: formatItems(payload.items),
               item_list_name: payload.item_list_name,
               item_list_id: payload.item_list_id,
               engagement_time_msec: payload.engagement_time_msec,

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -10,7 +10,8 @@ import {
   user_id,
   client_id,
   items_single_products,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -20,6 +21,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     item_list_name: {
       label: 'Item List Name',
       description: 'The name of the list in which the item was presented to the user.',
@@ -64,6 +66,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         client_id: payload.client_id,
         user_id: payload.user_id,
+        timestamp_micros: convertTimestamp(payload.timestamp_micros),
         events: [
           {
             name: 'select_item',

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
@@ -1,5 +1,6 @@
-import { ActionDefinition } from '@segment/actions-core'
-import { convertTimestamp, formatItems } from '../ga4-functions'
+import { ActionDefinition, IntegrationError } from '@segment/actions-core'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
+import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import {
@@ -40,6 +41,26 @@ const action: ActionDefinition<Settings, Payload> = {
     params: params
   },
   perform: (request, { payload }) => {
+    let googleItems: ProductItem[] = []
+
+    if (payload.items) {
+      googleItems = payload.items.map((product) => {
+        if (product.item_name === undefined && product.item_id === undefined) {
+          throw new IntegrationError(
+            'One of product name or product id is required for product or impression data.',
+            'Misconfigured required field',
+            400
+          )
+        }
+
+        if (product.currency) {
+          verifyCurrency(product.currency)
+        }
+
+        return product as ProductItem
+      })
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {
@@ -50,7 +71,7 @@ const action: ActionDefinition<Settings, Payload> = {
           {
             name: 'select_item',
             params: {
-              items: formatItems(payload.items),
+              items: googleItems,
               item_list_name: payload.item_list_name,
               item_list_id: payload.item_list_id,
               engagement_time_msec: payload.engagement_time_msec,

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
@@ -40,7 +40,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     let googleItems: ProductItem[] = []
 
     if (payload.items) {
@@ -61,26 +61,31 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'select_item',
+          params: {
+            items: googleItems,
+            item_list_name: payload.item_list_name,
+            item_list_id: payload.item_list_id,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        timestamp_micros: convertTimestamp(payload.timestamp_micros),
-        events: [
-          {
-            name: 'select_item',
-            params: {
-              items: googleItems,
-              item_list_name: payload.item_list_name,
-              item_list_id: payload.item_list_id,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * The name of the promotional creative.
    */
   creative_name?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
@@ -1,5 +1,5 @@
-import { ActionDefinition } from '@segment/actions-core'
-import { convertTimestamp, formatPromotionItems } from '../ga4-functions'
+import { ActionDefinition, IntegrationError } from '@segment/actions-core'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   creative_name,
   client_id,
@@ -15,6 +15,7 @@ import {
   engagement_time_msec,
   timestamp_micros
 } from '../ga4-properties'
+import { PromotionProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
@@ -58,6 +59,34 @@ const action: ActionDefinition<Settings, Payload> = {
     params: params
   },
   perform: (request, { payload }) => {
+    let googleItems: PromotionProductItem[] = []
+
+    if (payload.items) {
+      googleItems = payload.items.map((product) => {
+        if (product.item_name === undefined && product.item_id === undefined) {
+          throw new IntegrationError(
+            'One of product name or product id is required for product or impression data.',
+            'Misconfigured required field',
+            400
+          )
+        }
+
+        if (product.currency) {
+          verifyCurrency(product.currency)
+        }
+
+        if (product.promotion_id === undefined && product.promotion_name === undefined) {
+          throw new IntegrationError(
+            'One of promotion name or promotion id is required.',
+            'Misconfigured required field',
+            400
+          )
+        }
+
+        return product as PromotionProductItem
+      })
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {
@@ -73,7 +102,7 @@ const action: ActionDefinition<Settings, Payload> = {
               location_id: payload.location_id,
               promotion_id: payload.promotion_id,
               promotion_name: payload.promotion_name,
-              items: formatPromotionItems(payload.items),
+              items: googleItems,
               engagement_time_msec: payload.engagement_time_msec,
               ...payload.params
             }

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
@@ -1,5 +1,5 @@
-import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency, convertTimestamp } from '../ga4-functions'
+import { ActionDefinition } from '@segment/actions-core'
+import { convertTimestamp, formatPromotionItems } from '../ga4-functions'
 import {
   creative_name,
   client_id,
@@ -15,7 +15,6 @@ import {
   engagement_time_msec,
   timestamp_micros
 } from '../ga4-properties'
-import { PromotionProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
@@ -59,34 +58,6 @@ const action: ActionDefinition<Settings, Payload> = {
     params: params
   },
   perform: (request, { payload }) => {
-    let googleItems: PromotionProductItem[] = []
-
-    if (payload.items) {
-      googleItems = payload.items.map((product) => {
-        if (product.item_name === undefined && product.item_id === undefined) {
-          throw new IntegrationError(
-            'One of product name or product id is required for product or impression data.',
-            'Misconfigured required field',
-            400
-          )
-        }
-
-        if (product.currency) {
-          verifyCurrency(product.currency)
-        }
-
-        if (product.promotion_id === undefined && product.promotion_name === undefined) {
-          throw new IntegrationError(
-            'One of promotion name or promotion id is required.',
-            'Misconfigured required field',
-            400
-          )
-        }
-
-        return product as PromotionProductItem
-      })
-    }
-
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {
@@ -102,7 +73,7 @@ const action: ActionDefinition<Settings, Payload> = {
               location_id: payload.location_id,
               promotion_id: payload.promotion_id,
               promotion_name: payload.promotion_name,
-              items: googleItems,
+              items: formatPromotionItems(payload.items),
               engagement_time_msec: payload.engagement_time_msec,
               ...payload.params
             }

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   creative_name,
   client_id,
@@ -12,7 +12,8 @@ import {
   params,
   formatUserProperties,
   user_properties,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 import { PromotionProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -25,6 +26,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     creative_name: { ...creative_name },
     creative_slot: { ...creative_slot, default: { '@path': '$.properties.creative' } },
     location_id: {
@@ -90,6 +92,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         client_id: payload.client_id,
         user_id: payload.user_id,
+        timestamp_micros: convertTimestamp(payload.timestamp_micros),
         events: [
           {
             name: 'select_promotion',

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
@@ -58,7 +58,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     let googleItems: PromotionProductItem[] = []
 
     if (payload.items) {
@@ -87,29 +87,34 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'select_promotion',
+          params: {
+            creative_name: payload.creative_name,
+            creative_slot: payload.creative_slot,
+            location_id: payload.location_id,
+            promotion_id: payload.promotion_id,
+            promotion_name: payload.promotion_name,
+            items: googleItems,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        timestamp_micros: convertTimestamp(payload.timestamp_micros),
-        events: [
-          {
-            name: 'select_promotion',
-            params: {
-              creative_name: payload.creative_name,
-              creative_slot: payload.creative_slot,
-              location_id: payload.location_id,
-              promotion_id: payload.promotion_id,
-              promotion_name: payload.promotion_name,
-              items: googleItems,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/signUp/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/signUp/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * The method used for sign up.
    */
   method?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
@@ -32,25 +32,30 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'sign_up',
+          params: {
+            method: payload.method,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        timestamp_micros: convertTimestamp(payload.timestamp_micros),
-        events: [
-          {
-            name: 'sign_up',
-            params: {
-              method: payload.method,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
@@ -1,13 +1,15 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+import { convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
   params,
   user_id,
   client_id,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -17,6 +19,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     method: {
       label: 'Method',
       description: 'The method used for sign up.',
@@ -35,6 +38,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         client_id: payload.client_id,
         user_id: payload.user_id,
+        timestamp_micros: convertTimestamp(payload.timestamp_micros),
         events: [
           {
             name: 'sign_up',

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
@@ -34,7 +34,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     if (payload.currency) {
       verifyCurrency(payload.currency)
     }
@@ -72,26 +72,31 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'view_cart',
+          params: {
+            currency: payload.currency,
+            value: payload.value,
+            items: googleItems,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        timestamp_micros: convertTimestamp(payload.timestamp_micros),
-        events: [
-          {
-            name: 'view_cart',
-            params: {
-              currency: payload.currency,
-              value: payload.value,
-              items: googleItems,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
@@ -1,5 +1,5 @@
-import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency, convertTimestamp } from '../ga4-functions'
+import { ActionDefinition } from '@segment/actions-core'
+import { verifyCurrency, convertTimestamp, formatItems, checkCurrencyDefinition } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -12,7 +12,6 @@ import {
   engagement_time_msec,
   timestamp_micros
 } from '../ga4-properties'
-import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
@@ -39,38 +38,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyCurrency(payload.currency)
     }
 
-    if (payload.value && payload.currency === undefined) {
-      throw new IntegrationError('Currency is required if value is set.', 'Misconfigured required field', 400)
-    }
-
-    //Currency must exist either as a param or in the first item in items.
-    if (payload.currency === undefined && (!payload.items || !payload.items[0] || !payload.items[0].currency)) {
-      throw new IntegrationError(
-        'One of item-level currency or top-level currency is required.',
-        'Misconfigured required field',
-        400
-      )
-    }
-
-    let googleItems: ProductItem[] = []
-
-    if (payload.items) {
-      googleItems = payload.items.map((product) => {
-        if (product.item_name === undefined && product.item_id === undefined) {
-          throw new IntegrationError(
-            'One of product name or product id is required for product or impression data.',
-            'Misconfigured required field',
-            400
-          )
-        }
-
-        if (product.currency) {
-          verifyCurrency(product.currency)
-        }
-
-        return product as ProductItem
-      })
-    }
+    checkCurrencyDefinition(payload.value, payload.currency, payload.items)
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
@@ -84,7 +52,7 @@ const action: ActionDefinition<Settings, Payload> = {
             params: {
               currency: payload.currency,
               value: payload.value,
-              items: googleItems,
+              items: formatItems(payload.items),
               engagement_time_msec: payload.engagement_time_msec,
               ...payload.params
             }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
@@ -1,5 +1,5 @@
-import { ActionDefinition } from '@segment/actions-core'
-import { verifyCurrency, convertTimestamp, formatItems, checkCurrencyDefinition } from '../ga4-functions'
+import { ActionDefinition, IntegrationError } from '@segment/actions-core'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -12,6 +12,7 @@ import {
   engagement_time_msec,
   timestamp_micros
 } from '../ga4-properties'
+import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
@@ -38,7 +39,38 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyCurrency(payload.currency)
     }
 
-    checkCurrencyDefinition(payload.value, payload.currency, payload.items)
+    if (payload.value && payload.currency === undefined) {
+      throw new IntegrationError('Currency is required if value is set.', 'Misconfigured required field', 400)
+    }
+
+    //Currency must exist either as a param or in the first item in items.
+    if (payload.currency === undefined && (!payload.items || !payload.items[0] || !payload.items[0].currency)) {
+      throw new IntegrationError(
+        'One of item-level currency or top-level currency is required.',
+        'Misconfigured required field',
+        400
+      )
+    }
+
+    let googleItems: ProductItem[] = []
+
+    if (payload.items) {
+      googleItems = payload.items.map((product) => {
+        if (product.item_name === undefined && product.item_id === undefined) {
+          throw new IntegrationError(
+            'One of product name or product id is required for product or impression data.',
+            'Misconfigured required field',
+            400
+          )
+        }
+
+        if (product.currency) {
+          verifyCurrency(product.currency)
+        }
+
+        return product as ProductItem
+      })
+    }
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
@@ -52,7 +84,7 @@ const action: ActionDefinition<Settings, Payload> = {
             params: {
               currency: payload.currency,
               value: payload.value,
-              items: formatItems(payload.items),
+              items: googleItems,
               engagement_time_msec: payload.engagement_time_msec,
               ...payload.params
             }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -9,7 +9,8 @@ import {
   user_id,
   client_id,
   items_multi_products,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -22,6 +23,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     currency: { ...currency },
     value: { ...value },
     items: {
@@ -75,6 +77,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         client_id: payload.client_id,
         user_id: payload.user_id,
+        timestamp_micros: convertTimestamp(payload.timestamp_micros),
         events: [
           {
             name: 'view_cart',

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -9,7 +9,8 @@ import {
   client_id,
   value,
   items_single_products,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -22,6 +23,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     currency: { ...currency },
     value: { ...value },
     items: {
@@ -74,6 +76,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         client_id: payload.client_id,
         user_id: payload.user_id,
+        timestamp_micros: convertTimestamp(payload.timestamp_micros),
         events: [
           {
             name: 'view_item',

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
@@ -34,7 +34,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     if (payload.currency) {
       verifyCurrency(payload.currency)
     }
@@ -71,26 +71,31 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'view_item',
+          params: {
+            currency: payload.currency,
+            items: googleItems,
+            value: payload.value,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        timestamp_micros: convertTimestamp(payload.timestamp_micros),
-        events: [
-          {
-            name: 'view_item',
-            params: {
-              currency: payload.currency,
-              items: googleItems,
-              value: payload.value,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
@@ -1,5 +1,5 @@
-import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency, convertTimestamp } from '../ga4-functions'
+import { ActionDefinition } from '@segment/actions-core'
+import { verifyCurrency, convertTimestamp, formatItems } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -12,7 +12,6 @@ import {
   engagement_time_msec,
   timestamp_micros
 } from '../ga4-properties'
-import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
@@ -39,38 +38,6 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyCurrency(payload.currency)
     }
 
-    let googleItems: ProductItem[] = []
-
-    if (payload.items) {
-      googleItems = payload.items.map((product) => {
-        if (product.item_name === undefined && product.item_id === undefined) {
-          throw new IntegrationError(
-            'One of product name or product id is required for product or impression data.',
-            'Misconfigured required field',
-            400
-          )
-        }
-
-        if (product.currency) {
-          verifyCurrency(product.currency)
-        }
-
-        return {
-          item_id: product.item_id,
-          item_name: product.item_name,
-          quantity: product.quantity,
-          affiliation: product.affiliation,
-          coupon: product.coupon,
-          discount: product.discount,
-          item_brand: product.item_brand,
-          item_category: product.item_category,
-          item_variant: product.item_variant,
-          price: product.price,
-          currency: product.currency
-        } as ProductItem
-      })
-    }
-
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {
@@ -82,7 +49,7 @@ const action: ActionDefinition<Settings, Payload> = {
             name: 'view_item',
             params: {
               currency: payload.currency,
-              items: googleItems,
+              items: formatItems(payload.items),
               value: payload.value,
               engagement_time_msec: payload.engagement_time_msec,
               ...payload.params

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * The ID of the list in which the item was presented to the user.
    */
   item_list_id?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
@@ -50,7 +50,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     let googleItems: ProductItem[] = []
 
     if (payload.items) {
@@ -71,26 +71,31 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'view_item_list',
+          params: {
+            item_list_id: payload.item_list_id,
+            item_list_name: payload.item_list_name,
+            items: googleItems,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        timestamp_micros: convertTimestamp(payload.timestamp_micros),
-        events: [
-          {
-            name: 'view_item_list',
-            params: {
-              item_list_id: payload.item_list_id,
-              item_list_name: payload.item_list_name,
-              items: googleItems,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
@@ -1,5 +1,5 @@
-import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency, convertTimestamp } from '../ga4-functions'
+import { ActionDefinition } from '@segment/actions-core'
+import { convertTimestamp, formatItems } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -10,7 +10,6 @@ import {
   engagement_time_msec,
   timestamp_micros
 } from '../ga4-properties'
-import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
@@ -51,26 +50,6 @@ const action: ActionDefinition<Settings, Payload> = {
     params: params
   },
   perform: (request, { payload }) => {
-    let googleItems: ProductItem[] = []
-
-    if (payload.items) {
-      googleItems = payload.items.map((product) => {
-        if (product.item_name === undefined && product.item_id === undefined) {
-          throw new IntegrationError(
-            'One of product name or product id is required for product or impression data.',
-            'Misconfigured required field',
-            400
-          )
-        }
-
-        if (product.currency) {
-          verifyCurrency(product.currency)
-        }
-
-        return product as ProductItem
-      })
-    }
-
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {
@@ -83,7 +62,7 @@ const action: ActionDefinition<Settings, Payload> = {
             params: {
               item_list_id: payload.item_list_id,
               item_list_name: payload.item_list_name,
-              items: googleItems,
+              items: formatItems(payload.items),
               engagement_time_msec: payload.engagement_time_msec,
               ...payload.params
             }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -7,7 +7,8 @@ import {
   user_id,
   client_id,
   items_multi_products,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -24,6 +25,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     item_list_id: {
       label: 'Item List ID',
       type: 'string',
@@ -74,6 +76,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         client_id: payload.client_id,
         user_id: payload.user_id,
+        timestamp_micros: convertTimestamp(payload.timestamp_micros),
         events: [
           {
             name: 'view_item_list',

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * The name of the promotional creative.
    */
   creative_name?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   creative_name,
   creative_slot,
@@ -12,7 +12,8 @@ import {
   params,
   formatUserProperties,
   user_properties,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 import { PromotionProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -29,6 +30,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     creative_name: { ...creative_name },
     creative_slot: { ...creative_slot, default: { '@path': '$.properties.creative' } },
     location_id: {
@@ -87,6 +89,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         client_id: payload.client_id,
         user_id: payload.user_id,
+        timestamp_micros: convertTimestamp(payload.timestamp_micros),
         events: [
           {
             name: 'view_promotion',

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
@@ -67,7 +67,7 @@ const action: ActionDefinition<Settings, Payload> = {
     params: params
   },
 
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     let googleItems: PromotionProductItem[] = []
 
     if (payload.items) {
@@ -84,29 +84,34 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'view_promotion',
+          params: {
+            creative_name: payload.creative_name,
+            creative_slot: payload.creative_slot,
+            location_id: payload.location_id,
+            promotion_id: payload.promotion_id,
+            promotion_name: payload.promotion_name,
+            items: googleItems,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        timestamp_micros: convertTimestamp(payload.timestamp_micros),
-        events: [
-          {
-            name: 'view_promotion',
-            params: {
-              creative_name: payload.creative_name,
-              creative_slot: payload.creative_slot,
-              location_id: payload.location_id,
-              promotion_id: payload.promotion_id,
-              promotion_name: payload.promotion_name,
-              items: googleItems,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
@@ -1,5 +1,5 @@
-import { ActionDefinition } from '@segment/actions-core'
-import { convertTimestamp, formatItems } from '../ga4-functions'
+import { ActionDefinition, IntegrationError } from '@segment/actions-core'
+import { verifyCurrency, convertTimestamp } from '../ga4-functions'
 import {
   creative_name,
   creative_slot,
@@ -15,6 +15,7 @@ import {
   engagement_time_msec,
   timestamp_micros
 } from '../ga4-properties'
+import { PromotionProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
@@ -67,6 +68,22 @@ const action: ActionDefinition<Settings, Payload> = {
   },
 
   perform: (request, { payload }) => {
+    let googleItems: PromotionProductItem[] = []
+
+    if (payload.items) {
+      googleItems = payload.items.map((product) => {
+        if (product.item_name === undefined && product.item_id === undefined) {
+          throw new IntegrationError('One of item id or item name is required.', 'Misconfigured required field', 400)
+        }
+
+        if (product.currency) {
+          verifyCurrency(product.currency)
+        }
+
+        return product as PromotionProductItem
+      })
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {
@@ -82,7 +99,7 @@ const action: ActionDefinition<Settings, Payload> = {
               location_id: payload.location_id,
               promotion_id: payload.promotion_id,
               promotion_name: payload.promotion_name,
-              items: formatItems(payload.items),
+              items: googleItems,
               engagement_time_msec: payload.engagement_time_msec,
               ...payload.params
             }

--- a/packages/destination-actions/src/destinations/snap-conversions-api/generated-types.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/generated-types.ts
@@ -10,7 +10,7 @@ export interface Settings {
    */
   snap_app_id?: string
   /**
-   * The unique ID assigned for a given application. It should be numeric for iOS, and the human interpretable string for Android. Required for app events.
+   * The unique ID assigned for a given application. It should be numeric for iOS, and the human interpretable string for Android. **Required for app events**.
    */
   app_id?: string
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

In our GA4 destination, we do not currently send a timestamp. The GA4 Measurement Protocol API supports sending a field called timestamp_micros and this PR adds that field to be sent to GA4.

## Testing

Deployed to stage and tested end to end. 
![Screen Shot 2022-06-28 at 10 29 53 AM](https://user-images.githubusercontent.com/99763167/176245840-91b67ef5-b91f-454a-aa7c-8649bca981b3.png)

Verified event showed up with given timestamp.
![Screen Shot 2022-06-28 at 10 11 03 AM](https://user-images.githubusercontent.com/99763167/176245895-c52dc500-6818-40f0-846f-84c1e5a3f7a6.png)


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
