### PR TITLE
BE-857 Add status to TimeoutError to avoid being flagged as internal

### DIFF
--- a/packages/core/src/request-client.ts
+++ b/packages/core/src/request-client.ts
@@ -179,15 +179,20 @@ export class HTTPError extends CustomError {
   }
 }
 
-/** Error thrown when a request is aborted because of a client timeout. */
+/**
+ * Error thrown when a request is aborted because of a client timeout.
+ * We add a code so that the error is not treated as an "internal" error
+ */
 export class TimeoutError extends CustomError {
   request: Request
   options: NormalizedOptions
+  code: string
 
   constructor(request: Request, options: NormalizedOptions) {
     super(`Request timed out`)
     this.request = request
     this.options = options
+    this.code = 'ETIMEDOUT'
   }
 }
 


### PR DESCRIPTION
## Summary

Taking a look at the “[Internal Errors](https://segment.datadoghq.com/dashboard/s5c-zmu-hnj/integrations-fka-integrations-monoservice?fullscreen_end_ts=1656104246451&fullscreen_paused=true&fullscreen_section=overview&fullscreen_start_ts=1656100646451&fullscreen_widget=8902786990389380&tile_focus=8902786990389380&from_ts=1656100646451&to_ts=1656104246451&live=false)” DataDog graph, we can see that some `etimedout` action-destination errors are being flagged as "internal" ([s3 logs](https://s3logs.segment.com/?service=integrations&since=20220624T2001Z&until=20220624T2101Z&filter=actions-amplitude)) 

Cause: inside the `integrations` repo, [if an incoming error doesn't have a status or code, it is treated as an "internal" error](https://github.com/segmentio/integrations/blob/master/Service/cloudevents.js#L785-L798).

One easy solution is to then add a `status` to the `TimeoutError`'s that we're passing.

## Testing

1. I added a [timeout option to actions-webhook](https://github.com/segmentio/action-destinations/pull/667)
2. Without my fix, I used actions-webhook to hit a 100% timeout URL
3. "Internal" errors were showing on DataDog 👍

4. I published my fix to staging (which was a hairy process of publishing actions-core changes that took a day and a half 😭 )
5. Hit the URL again
6. `etimedout` errors are now showing up
7. Profit 💰
<img width="1282" alt="Screen Shot 2022-07-08 at 4 18 32 PM" src="https://user-images.githubusercontent.com/1487616/178081764-b2f736dc-cb73-4155-83cf-dd41bb1b66aa.png">

https://s3logs.segment.build/?service=integrations&since=20220708T2325Z&until=20220708T2330Z&filter=actions-webhook

<img width="1286" alt="Screen Shot 2022-07-08 at 4 30 47 PM" src="https://user-images.githubusercontent.com/1487616/178081907-4ff002aa-41d7-4258-a4ce-7dcc7b3791b9.png">



- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
