### PR TITLE
webhook: Add support for headers

### DIFF
--- a/packages/destination-actions/src/destinations/webhook/__test__/webhook.test.ts
+++ b/packages/destination-actions/src/destinations/webhook/__test__/webhook.test.ts
@@ -32,44 +32,23 @@ describe('Webhook', () => {
 
     it('supports customizations', async () => {
       const url = 'https://example.build'
-
       const event = createTestEvent({
         timestamp,
         event: 'Test Event'
       })
+      const headerField = 'Custom-Header'
+      const headerValue = 'Custom-Value'
       const data = { cool: true }
 
-      nock(url).put('/', data).reply(200)
+      nock(url).put('/', data).matchHeader(headerField, headerValue).reply(200)
 
       const responses = await testDestination.testAction('send', {
         event,
         mapping: {
           url,
           method: 'PUT',
-          data: { cool: true }
-        }
-      })
-
-      expect(responses.length).toBe(1)
-      expect(responses[0].status).toBe(200)
-    })
-
-    it('supports customizations', async () => {
-      const url = 'https://example.build'
-      const event = createTestEvent({
-        timestamp,
-        event: 'Test Event'
-      })
-      const data = { cool: true }
-
-      nock(url).put('/', data).reply(200)
-
-      const responses = await testDestination.testAction('send', {
-        event,
-        mapping: {
-          url,
-          method: 'PUT',
-          data: { cool: true }
+          headers: { [headerField]: headerValue },
+          data
         }
       })
 

--- a/packages/destination-actions/src/destinations/webhook/send/generated-types.ts
+++ b/packages/destination-actions/src/destinations/webhook/send/generated-types.ts
@@ -10,6 +10,12 @@ export interface Payload {
    */
   method: string
   /**
+   * HTTP headers to send with each request.
+   */
+  headers?: {
+    [k: string]: unknown
+  }
+  /**
    * Payload to deliver to webhook URL (JSON-encoded).
    */
   data?: {

--- a/packages/destination-actions/src/destinations/webhook/send/index.ts
+++ b/packages/destination-actions/src/destinations/webhook/send/index.ts
@@ -29,6 +29,12 @@ const action: ActionDefinition<Settings, Payload> = {
       default: 'POST',
       required: true
     },
+    headers: {
+      label: 'Headers',
+      description: 'HTTP headers to send with each request.',
+      type: 'object',
+      defaultObjectUI: 'keyvalue:only'
+    },
     data: {
       label: 'Data',
       description: 'Payload to deliver to webhook URL (JSON-encoded).',
@@ -39,15 +45,17 @@ const action: ActionDefinition<Settings, Payload> = {
   perform: (request, { payload }) => {
     return request(payload.url, {
       method: payload.method as RequestMethod,
+      headers: payload.headers as Record<string, string>,
       json: payload.data
     })
   },
   performBatch: (request, { payload }) => {
     // Expect these to be the same across the payloads
-    const { url, method } = payload[0]
+    const { url, method, headers } = payload[0]
 
     return request(url, {
       method: method as RequestMethod,
+      headers: headers as Record<string, string>,
       json: payload.map(({ data }) => data)
     })
   }


### PR DESCRIPTION
This PR adds support for headers to the webhook action.

## Testing

I verified the change using the local test server by sending a request with a custom header to a webhook:

<img width="433" alt="image" src="https://user-images.githubusercontent.com/111501/175999032-ad26305f-fa96-4580-9bc1-a17efb1ffd1d.png">

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
