### PR TITLE
webhook: Add optional request signing

### DIFF
--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -89,12 +89,12 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
   readonly destinationName: string
   readonly schema?: JSONSchema4
   readonly hasBatchSupport: boolean
-  private extendRequest: RequestExtension<Settings> | undefined
+  private extendRequest: RequestExtension<Settings, any> | undefined
 
   constructor(
     destinationName: string,
     definition: ActionDefinition<Settings, Payload>,
-    extendRequest?: RequestExtension<Settings>
+    extendRequest?: RequestExtension<Settings, any>
   ) {
     super()
     this.definition = definition

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -70,7 +70,7 @@ export interface DestinationDefinition<Settings = unknown> extends BaseDefinitio
   actions: Record<string, ActionDefinition<Settings>>
 
   /** An optional function to extend requests sent from the destination (including all actions) */
-  extendRequest?: RequestExtension<Settings>
+  extendRequest?: RequestExtension<Settings, any>
 
   /** Optional authentication configuration */
   authentication?: AuthenticationScheme<Settings>
@@ -204,7 +204,7 @@ export class Destination<Settings = JSONObject> {
   readonly definition: DestinationDefinition<Settings>
   readonly name: string
   readonly authentication?: AuthenticationScheme<Settings>
-  readonly extendRequest?: RequestExtension<Settings>
+  readonly extendRequest?: RequestExtension<Settings, any>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly actions: PartnerActions<Settings, any>
   readonly responses: DecoratedResponse[]
@@ -253,7 +253,7 @@ export class Destination<Settings = JSONObject> {
     const auth = getAuthData(settings as unknown as JSONObject)
     const data = { settings: destinationSettings, auth }
 
-    const context: ExecuteInput<Settings, undefined> = { settings: destinationSettings, payload: undefined, auth }
+    const context: ExecuteInput<Settings, any> = { settings: destinationSettings, payload: undefined, auth }
 
     // Validate settings according to the destination's `authentication.fields` schema
     this.validateSettings(destinationSettings)
@@ -286,7 +286,7 @@ export class Destination<Settings = JSONObject> {
     }
 
     // TODO: clean up context/extendRequest so we don't have to send information that is not needed (payload & cachedFields)
-    const context: ExecuteInput<Settings, undefined> = {
+    const context: ExecuteInput<Settings, any> = {
       settings,
       payload: undefined,
       auth: getAuthData(settings as unknown as JSONObject)
@@ -445,7 +445,7 @@ export class Destination<Settings = JSONObject> {
     this.validateSettings(destinationSettings)
     const auth = getAuthData(settings as unknown as JSONObject)
     const data: ExecuteInput<Settings, DeletionPayload> = { payload, settings: destinationSettings, auth }
-    const context: ExecuteInput<Settings, undefined> = { settings: destinationSettings, payload: undefined, auth }
+    const context: ExecuteInput<Settings, any> = { settings: destinationSettings, payload, auth }
 
     const opts = this.extendRequest?.(context) ?? {}
     const requestClient = createRequestClient(opts)

--- a/packages/destination-actions/src/destinations/webhook/__test__/webhook.test.ts
+++ b/packages/destination-actions/src/destinations/webhook/__test__/webhook.test.ts
@@ -1,18 +1,15 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Webhook from '../index'
+import { createHmac } from 'crypto'
 
 const testDestination = createTestIntegration(Webhook)
-const timestamp = new Date().toISOString()
 
 describe('Webhook', () => {
   describe('send', () => {
     it('should work with default mapping', async () => {
       const url = 'https://example.com'
-      const event = createTestEvent({
-        timestamp,
-        event: 'Test Event'
-      })
+      const event = createTestEvent()
 
       nock(url)
         .post('/', event as any)
@@ -32,10 +29,7 @@ describe('Webhook', () => {
 
     it('supports customizations', async () => {
       const url = 'https://example.build'
-      const event = createTestEvent({
-        timestamp,
-        event: 'Test Event'
-      })
+      const event = createTestEvent()
       const headerField = 'Custom-Header'
       const headerValue = 'Custom-Value'
       const data = { cool: true }
@@ -50,6 +44,35 @@ describe('Webhook', () => {
           headers: { [headerField]: headerValue },
           data
         }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+    })
+
+    it('supports request signing', async () => {
+      const url = 'https://example.com'
+      const event = createTestEvent({
+        properties: { cool: true }
+      })
+      const payload = event.properties
+      const sharedSecret = 'abc123'
+
+      const digest = createHmac('sha1', sharedSecret).update(JSON.stringify(payload), 'utf8').digest('hex')
+
+      nock(url)
+        .matchHeader('x-signature', digest)
+        .post('/', payload as any)
+        .reply(200)
+
+      const responses = await testDestination.testAction('send', {
+        event,
+        mapping: {
+          url,
+          data: { '@path': '$.properties' }
+        },
+        settings: { sharedSecret },
+        useDefaultMappings: true
       })
 
       expect(responses.length).toBe(1)

--- a/packages/destination-actions/src/destinations/webhook/generated-types.ts
+++ b/packages/destination-actions/src/destinations/webhook/generated-types.ts
@@ -1,3 +1,8 @@
 // Generated file. DO NOT MODIFY IT BY HAND.
 
-export interface Settings {}
+export interface Settings {
+  /**
+   * If set, Segment will sign requests with an HMAC in the "X-Signature" request header. The HMAC is a hex-encoded SHA1 hash generated using this shared secret and the request body.
+   */
+  sharedSecret?: string
+}

--- a/packages/destination-actions/src/destinations/webhook/index.ts
+++ b/packages/destination-actions/src/destinations/webhook/index.ts
@@ -1,5 +1,6 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
+import { createHmac } from 'crypto'
 
 import send from './send'
 
@@ -7,6 +8,26 @@ const destination: DestinationDefinition<Settings> = {
   name: 'Webhook',
   slug: 'actions-webhook',
   mode: 'cloud',
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      sharedSecret: {
+        type: 'string',
+        label: 'Shared Secret',
+        description:
+          'If set, Segment will sign requests with an HMAC in the "X-Signature" request header. The HMAC is a hex-encoded SHA1 hash generated using this shared secret and the request body.'
+      }
+    }
+  },
+  extendRequest: ({ settings, payload }) => {
+    if (settings.sharedSecret && Object.prototype.hasOwnProperty.call(payload as object, 'data')) {
+      const digest = createHmac('sha1', settings.sharedSecret)
+        .update(JSON.stringify(payload.data), 'utf8')
+        .digest('hex')
+      return { headers: { 'X-Signature': digest } }
+    }
+    return {}
+  },
   actions: {
     send
   }


### PR DESCRIPTION
This PR adds the ability to sign requests sent by the Webhook destination. The method used here is compatible with the existing Segment webhook destination, as documented here: https://segment.com/docs/connections/destinations/catalog/webhooks/#authentication

## Testing

Testing completed successfully locally:



- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
