### PR TITLE
[webhooks] Update destination definition name

### DIFF
--- a/packages/destination-actions/src/destinations/webhook/index.ts
+++ b/packages/destination-actions/src/destinations/webhook/index.ts
@@ -4,7 +4,7 @@ import type { Settings } from './generated-types'
 import send from './send'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Webhook',
+  name: 'Webhooks (Actions)',
   slug: 'actions-webhook',
   mode: 'cloud',
   actions: {


### PR DESCRIPTION
Update the Destination Definition name for Webhooks to include Actions in the name to disambiguate from classic Webhooks.

https://segment.atlassian.net/browse/ACT-81

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
  - n/a
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
  - n/a
- [ ] [Segmenters] Tested in the staging environment
  - TODO!