### PR TITLE
[Customer.io] Use email if userId doesn't exist for createUpdatePerson

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/createUpdatePerson/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/createUpdatePerson/index.ts
@@ -15,7 +15,11 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: true,
       default: {
-        '@path': '$.userId'
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@template': '{{traits.email}}' }
+        }
       }
     },
     anonymous_id: {

--- a/packages/destination-actions/src/destinations/customerio/createUpdatePerson/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/createUpdatePerson/index.ts
@@ -18,7 +18,7 @@ const action: ActionDefinition<Settings, Payload> = {
         '@if': {
           exists: { '@path': '$.userId' },
           then: { '@path': '$.userId' },
-          else: { '@template': '{{traits.email}}' }
+          else: { '@path': '$.traits.email' }
         }
       }
     },


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

We allow email addresses to be used as an identifier within our systems. We've gotten complaints from some users that they can't use the customer.io destination action if `userId` isn't present, but email is. This adds a small if/else block to `createUpdatePerson` that will use the email address trait if `userId` isn't present. If both aren't present, it should still fail on our end.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
