### PR TITLE
Allow builders to define their own enable_batching fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,27 @@ function performBatch(request, { settings, payload }) {
 }
 ```
 
+All actions where a `performBatch` method is defined will automatically include an `enable_batching` input field for users. This field is a boolean switch which allows users to toggle batching functionality. Builders can override the automatically included field by explicitly defining a field named `enable_batching` with type boolean in the `fields` section of the `ActionDefinition`. This may be useful if the builder wants to specify custom labels or descriptions or set a default value.
+
+```js
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Account',
+  description: 'Represents an individual account, which is an organization or person involved with your business.',
+  defaultSubscription: 'type = "group"',
+  fields: {
+    enable_batching: {
+      type: 'boolean',
+      label: 'Use Salesforce Bulk API',
+      description:
+        'When enabled, the action will use the Salesforce Bulk API to perform the operation. Not compatible with the insert operation.',
+      required: true,
+      default: false
+    }
+  },
+  performBatch: async (request, { settings, payload }) => { ... }
+}
+```
+
 This will give customers the ability to opt-in to batching (there may be trade-offs they need to consider before opting in). Each customer subscription will be given the ability to Enable Batching.
 
 Keep in mind a few important things about how batching works:

--- a/packages/cli-internal/src/commands/push.ts
+++ b/packages/cli-internal/src/commands/push.ts
@@ -191,18 +191,6 @@ export default class Push extends Command {
               `The builder defined batching field is not a boolean. Please update the field type to "boolean".`
             )
           }
-
-          fields.push({
-            fieldKey: 'enable_batching',
-            type: 'boolean',
-            label: builderDefinedBatchingField.label,
-            description: builderDefinedBatchingField.description,
-            defaultValue: builderDefinedBatchingField.defaultValue,
-            required: builderDefinedBatchingField.required,
-            multiple: false,
-            dynamic: false,
-            allowNull: false
-          })
         }
 
         const base: BaseActionInput = {

--- a/packages/cli-internal/src/commands/push.ts
+++ b/packages/cli-internal/src/commands/push.ts
@@ -168,8 +168,11 @@ export default class Push extends Command {
           }
         })
 
+        const hasBuilderDefinedBatchingField = fields.filter((f) => f.fieldKey === 'enable_batching').length === 1
+        const isBatchingDestination = typeof action.performBatch === 'function'
+
         // Automatically include a field for customers to control batching behavior, when supported
-        if (typeof action.performBatch === 'function') {
+        if (isBatchingDestination && !hasBuilderDefinedBatchingField) {
           fields.push({
             fieldKey: 'enable_batching',
             type: 'boolean',
@@ -177,6 +180,25 @@ export default class Push extends Command {
             description: 'When enabled, Segment will send events in batches.',
             defaultValue: false,
             required: false,
+            multiple: false,
+            dynamic: false,
+            allowNull: false
+          })
+        } else if (isBatchingDestination && hasBuilderDefinedBatchingField) {
+          const builderDefinedBatchingField = fields.filter((f) => f.fieldKey === 'enable_batching')[0]
+          if (builderDefinedBatchingField.type !== 'boolean') {
+            this.error(
+              `The builder defined batching field is not a boolean. Please update the field type to "boolean".`
+            )
+          }
+
+          fields.push({
+            fieldKey: 'enable_batching',
+            type: 'boolean',
+            label: builderDefinedBatchingField.label,
+            description: builderDefinedBatchingField.description,
+            defaultValue: builderDefinedBatchingField.defaultValue,
+            required: builderDefinedBatchingField.required,
             multiple: false,
             dynamic: false,
             allowNull: false

--- a/packages/cli-internal/src/commands/push.ts
+++ b/packages/cli-internal/src/commands/push.ts
@@ -168,7 +168,7 @@ export default class Push extends Command {
           }
         })
 
-        const hasBuilderDefinedBatchingField = fields.filter((f) => f.fieldKey === 'enable_batching').length === 1
+        const hasBuilderDefinedBatchingField = fields.some((f) => f.fieldKey === 'enable_batching')
         const isBatchingDestination = typeof action.performBatch === 'function'
 
         // Automatically include a field for customers to control batching behavior, when supported

--- a/packages/cli-internal/src/commands/push.ts
+++ b/packages/cli-internal/src/commands/push.ts
@@ -185,17 +185,7 @@ export default class Push extends Command {
             allowNull: false
           })
         } else if (isBatchingDestination && builderDefinedBatchingField.length > 0) {
-          if (builderDefinedBatchingField[0].type !== 'boolean') {
-            this.error(
-              `The builder defined batching field is not a boolean. Please update the field type to "boolean".`
-            )
-          }
-
-          if (builderDefinedBatchingField[0].multiple) {
-            this.error(
-              `The builder defined batching field should not be a multiple field. Please update the field to not be a multiple field.`
-            )
-          }
+          this.validateBatching(builderDefinedBatchingField)
         }
 
         const base: BaseActionInput = {
@@ -323,6 +313,18 @@ export default class Push extends Command {
 
       // We have to wait to do this until after the associated actions are created (otherwise it may fail)
       await setSubscriptionPresets(metadata.id, presets)
+    }
+  }
+
+  validateBatching = (builderDefinedBatchingField: DestinationMetadataActionFieldCreateInput[]) => {
+    if (builderDefinedBatchingField[0].type !== 'boolean') {
+      this.error(`The builder defined batching field is not a boolean. Please update the field type to "boolean".`)
+    }
+
+    if (builderDefinedBatchingField[0].multiple) {
+      this.error(
+        `The builder defined batching field should not be a multiple field. Please update the field to not be a multiple field.`
+      )
     }
   }
 }

--- a/packages/cli-internal/src/commands/push.ts
+++ b/packages/cli-internal/src/commands/push.ts
@@ -168,11 +168,11 @@ export default class Push extends Command {
           }
         })
 
-        const builderDefinedBatchingField = fields.filter((f) => f.fieldKey === 'enable_batching')
+        const builderDefinedBatchingField = fields.find((f) => f.fieldKey === 'enable_batching')
         const isBatchingDestination = typeof action.performBatch === 'function'
 
         // Automatically include a field for customers to control batching behavior, when supported
-        if (isBatchingDestination && builderDefinedBatchingField.length === 0) {
+        if (isBatchingDestination && !builderDefinedBatchingField) {
           fields.push({
             fieldKey: 'enable_batching',
             type: 'boolean',
@@ -184,7 +184,7 @@ export default class Push extends Command {
             dynamic: false,
             allowNull: false
           })
-        } else if (isBatchingDestination && builderDefinedBatchingField.length > 0) {
+        } else if (isBatchingDestination && builderDefinedBatchingField) {
           this.validateBatching(builderDefinedBatchingField)
         }
 
@@ -316,12 +316,12 @@ export default class Push extends Command {
     }
   }
 
-  validateBatching = (builderDefinedBatchingField: DestinationMetadataActionFieldCreateInput[]) => {
-    if (builderDefinedBatchingField[0].type !== 'boolean') {
+  validateBatching = (builderDefinedBatchingField: DestinationMetadataActionFieldCreateInput) => {
+    if (builderDefinedBatchingField.type !== 'boolean') {
       this.error(`The builder defined batching field is not a boolean. Please update the field type to "boolean".`)
     }
 
-    if (builderDefinedBatchingField[0].multiple) {
+    if (builderDefinedBatchingField.multiple) {
       this.error(
         `The builder defined batching field should not be a multiple field. Please update the field to not be a multiple field.`
       )

--- a/packages/cli-internal/src/commands/push.ts
+++ b/packages/cli-internal/src/commands/push.ts
@@ -168,11 +168,11 @@ export default class Push extends Command {
           }
         })
 
-        const hasBuilderDefinedBatchingField = fields.some((f) => f.fieldKey === 'enable_batching')
+        const builderDefinedBatchingField = fields.filter((f) => f.fieldKey === 'enable_batching')
         const isBatchingDestination = typeof action.performBatch === 'function'
 
         // Automatically include a field for customers to control batching behavior, when supported
-        if (isBatchingDestination && !hasBuilderDefinedBatchingField) {
+        if (isBatchingDestination && builderDefinedBatchingField.length === 0) {
           fields.push({
             fieldKey: 'enable_batching',
             type: 'boolean',
@@ -184,11 +184,16 @@ export default class Push extends Command {
             dynamic: false,
             allowNull: false
           })
-        } else if (isBatchingDestination && hasBuilderDefinedBatchingField) {
-          const builderDefinedBatchingField = fields.filter((f) => f.fieldKey === 'enable_batching')[0]
-          if (builderDefinedBatchingField.type !== 'boolean') {
+        } else if (isBatchingDestination && builderDefinedBatchingField.length > 0) {
+          if (builderDefinedBatchingField[0].type !== 'boolean') {
             this.error(
               `The builder defined batching field is not a boolean. Please update the field type to "boolean".`
+            )
+          }
+
+          if (builderDefinedBatchingField[0].multiple) {
+            this.error(
+              `The builder defined batching field should not be a multiple field. Please update the field to not be a multiple field.`
             )
           }
         }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR allows builders of batching destinations to override the automatically created `enable_batching` input field with their own. This will allow builders to customize the description, label, and default values of the field. This will be used in Salesforce to write new descriptions and labels, and make the field required.

## Testing
Tested by manually creating an `enable_batching` field in Salesforce, and pushing it to stage. The field is correctly added to the stage DB.

<img width="1085" alt="Screen Shot 2022-06-29 at 12 54 09 PM" src="https://user-images.githubusercontent.com/27820201/176532884-1f28e344-7637-48d4-9679-f60137c955bf.png">

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
