### PR TITLE
[STRATCONN] Expose DataDog stats client and tags in perform and performBatch handlers

### DIFF
--- a/packages/core/src/__tests__/destination-kit.test.ts
+++ b/packages/core/src/__tests__/destination-kit.test.ts
@@ -1,5 +1,4 @@
-import { StatsClient } from 'src/destination-kit/types'
-import { Destination, DestinationDefinition } from '../destination-kit'
+import { Destination, DestinationDefinition, StatsClient } from '../destination-kit'
 import { JSONObject } from '../json-object'
 import { SegmentEvent } from '../segment-event'
 
@@ -97,8 +96,8 @@ const destinationWithOptions: DestinationDefinition<JSONObject> = {
       description: 'Send events to a custom event in API',
       defaultSubscription: 'type = "track"',
       fields: {},
-      perform: (_request, { features, stats }) => {
-        return { features, stats }
+      perform: (_request, { features, statsContext }) => {
+        return { features, statsContext }
       }
     }
   }

--- a/packages/core/src/__tests__/destination-kit.test.ts
+++ b/packages/core/src/__tests__/destination-kit.test.ts
@@ -1,4 +1,4 @@
-import { Destination, DestinationDefinition, StatsClient } from '../destination-kit'
+import { Destination, DestinationDefinition, StatsClient, StatsContext } from '../destination-kit'
 import { JSONObject } from '../json-object'
 import { SegmentEvent } from '../segment-event'
 
@@ -330,7 +330,8 @@ describe('destination kit', () => {
       const eventOptions = {
         features: {
           test_feature: true
-        }
+        },
+        statsContext: {} as StatsContext
       }
 
       const res = await destinationTest.onEvent(testEvent, testSettings, eventOptions)
@@ -340,7 +341,7 @@ describe('destination kit', () => {
         {
           output: {
             features: eventOptions.features,
-            stats: {}
+            statsContext: {}
           }
         }
       ])
@@ -381,7 +382,7 @@ describe('destination kit', () => {
         {
           output: {
             features: {},
-            stats: eventOptions.statsContext
+            statsContext: eventOptions.statsContext
           }
         }
       ])

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -12,6 +12,7 @@ import { validateSchema } from '../schema-validation'
 import { AuthTokens } from './parse-settings'
 import { IntegrationError } from '../errors'
 import { removeEmptyValues } from '../remove-empty-values'
+import { StatsContext } from './index'
 
 type MaybePromise<T> = T | Promise<T>
 type RequestClient = ReturnType<typeof createRequestClient>

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -77,7 +77,8 @@ interface ExecuteBundle<T = unknown, Data = unknown> {
   mapping: JSONObject
   auth: AuthTokens | undefined
   /** For internal Segment/Twilio use only. */
-  features?: { [key: string]: boolean }
+  features?: { [key: string]: boolean } | undefined
+  stats?: StatsContext | undefined
 }
 
 /**
@@ -133,7 +134,8 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
       settings: bundle.settings,
       payload,
       auth: bundle.auth,
-      features: bundle.features
+      features: bundle.features,
+      stats: bundle.stats
     }
 
     // Construct the request client and perform the action
@@ -176,7 +178,8 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
         settings: bundle.settings,
         payload: payloads,
         auth: bundle.auth,
-        features: bundle.features
+        features: bundle.features,
+        stats: bundle.stats
       }
       await this.performRequest(this.definition.performBatch, data)
     }

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -79,7 +79,7 @@ interface ExecuteBundle<T = unknown, Data = unknown> {
   auth: AuthTokens | undefined
   /** For internal Segment/Twilio use only. */
   features?: { [key: string]: boolean } | undefined
-  stats?: StatsContext | undefined
+  statsContext?: StatsContext | undefined
 }
 
 /**
@@ -136,7 +136,7 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
       payload,
       auth: bundle.auth,
       features: bundle.features,
-      stats: bundle.stats
+      statsContext: bundle.statsContext
     }
 
     // Construct the request client and perform the action
@@ -180,7 +180,7 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
         payload: payloads,
         auth: bundle.auth,
         features: bundle.features,
-        stats: bundle.stats
+        statsContext: bundle.statsContext
       }
       await this.performRequest(this.definition.performBatch, data)
     }

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -374,7 +374,7 @@ export class Destination<Settings = JSONObject> {
       settings,
       auth,
       features: options?.features || {},
-      statsContext: options?.statsContext
+      statsContext: options?.statsContext || ({} as StatsContext)
     }
 
     let results: Result[] | null = null

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -8,15 +8,7 @@ import { fieldsToJsonSchema, MinimalInputField } from './fields-to-jsonschema'
 import createRequestClient, { RequestClient, ResponseError } from '../create-request-client'
 import { validateSchema } from '../schema-validation'
 import type { ModifiedResponse } from '../types'
-import type {
-  GlobalSetting,
-  RequestExtension,
-  ExecuteInput,
-  Result,
-  Deletion,
-  DeletionPayload,
-  StatsContext
-} from './types'
+import type { GlobalSetting, RequestExtension, ExecuteInput, Result, Deletion, DeletionPayload } from './types'
 import type { AllRequestOptions } from '../request-client'
 import { IntegrationError, InvalidAuthenticationError } from '../errors'
 import { AuthTokens, getAuthData, getOAuth2Data, updateOAuthSettings } from './parse-settings'

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -374,7 +374,7 @@ export class Destination<Settings = JSONObject> {
       settings,
       auth,
       features: options?.features || {},
-      stats: options?.statsContext || {}
+      stats: options?.statsContext
     }
 
     let results: Result[] | null = null

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -198,7 +198,8 @@ export interface StatsClient {
 }
 
 /** DataDog stats client and tags passed from the `CreateActionDestination`
- * in the monoservice.
+ * in the monoservice as `options`.
+ * See: https://github.com/segmentio/integrations/blob/cbd8f80024eceb2f1229f2bd0c9eb5b204f66c58/createActionDestination/index.js#L205-L208
  */
 export interface StatsContext {
   statsClient: StatsClient

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -162,7 +162,7 @@ interface EventInput<Settings> {
   readonly auth?: AuthTokens
   /** `features` and `stats` are for internal Segment/Twilio use only. */
   readonly features?: { [key: string]: boolean }
-  readonly stats?: StatsContext
+  readonly statsContext?: StatsContext
 }
 
 interface BatchEventInput<Settings> {
@@ -173,7 +173,7 @@ interface BatchEventInput<Settings> {
   readonly auth?: AuthTokens
   /** `features` and `stats` are for internal Segment/Twilio use only. */
   readonly features?: { [key: string]: boolean }
-  readonly stats?: StatsContext
+  readonly statsContext?: StatsContext
 }
 
 export interface DecoratedResponse extends ModifiedResponse {
@@ -322,7 +322,7 @@ export class Destination<Settings = JSONObject> {
 
   protected async executeAction(
     actionSlug: string,
-    { event, mapping, settings, auth, features, stats }: EventInput<Settings>
+    { event, mapping, settings, auth, features, statsContext }: EventInput<Settings>
   ): Promise<Result[]> {
     const action = this.actions[actionSlug]
     if (!action) {
@@ -335,13 +335,13 @@ export class Destination<Settings = JSONObject> {
       settings,
       auth,
       features,
-      stats
+      statsContext
     })
   }
 
   public async executeBatch(
     actionSlug: string,
-    { events, mapping, settings, auth, features, stats }: BatchEventInput<Settings>
+    { events, mapping, settings, auth, features, statsContext }: BatchEventInput<Settings>
   ) {
     const action = this.actions[actionSlug]
     if (!action) {
@@ -354,7 +354,7 @@ export class Destination<Settings = JSONObject> {
       settings,
       auth,
       features,
-      stats
+      statsContext
     })
 
     return [{ output: 'successfully processed batch of events' }]
@@ -374,7 +374,7 @@ export class Destination<Settings = JSONObject> {
       settings,
       auth,
       features: options?.features || {},
-      stats: options?.statsContext
+      statsContext: options?.statsContext
     }
 
     let results: Result[] | null = null

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -1,9 +1,9 @@
+import { StatsContext } from './index'
 import type { RequestOptions } from '../request-client'
 import type { JSONObject } from '../json-object'
 import { AuthTokens } from './parse-settings'
 import type { RequestClient } from '../create-request-client'
 import type { ID } from '../segment-event'
-import { StatsContext } from './index'
 
 export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>
 export type MaybePromise<T> = T | Promise<T>
@@ -29,7 +29,7 @@ export interface ExecuteInput<Settings, Payload> {
    * Both `features` and `stats` are for internal Twilio/Segment use only.
    */
   readonly features?: { [key: string]: boolean }
-  readonly stats?: StatsContext
+  readonly statsContext?: StatsContext
 }
 
 export interface DynamicFieldResponse {

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -3,6 +3,7 @@ import type { JSONObject } from '../json-object'
 import { AuthTokens } from './parse-settings'
 import type { RequestClient } from '../create-request-client'
 import type { ID } from '../segment-event'
+import { StatsContext } from './index'
 
 export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>
 export type MaybePromise<T> = T | Promise<T>
@@ -25,9 +26,10 @@ export interface ExecuteInput<Settings, Payload> {
   readonly auth?: AuthTokens
   /**
    * The features available in the request based on either customer workspaceID or sourceID;
-   * For internal Twilio/Segment use only.
+   * Both `features` and `stats` are for internal Twilio/Segment use only.
    */
   readonly features?: { [key: string]: boolean }
+  readonly stats?: StatsContext
 }
 
 export interface DynamicFieldResponse {

--- a/packages/destination-actions/src/destinations/snap-conversions-api/generated-types.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/generated-types.ts
@@ -10,7 +10,7 @@ export interface Settings {
    */
   snap_app_id?: string
   /**
-   * The unique ID assigned for a given application. It should be numeric for iOS, and the human interpretable string for Android. Required for app events.
+   * The unique ID assigned for a given application. It should be numeric for iOS, and the human interpretable string for Android. **Required for app events**.
    */
   app_id?: string
 }


### PR DESCRIPTION
- This PR passes the DataDog stats client and DataDog tags to the `perform` and `performBatch` handler.
- The DataDog stats client and tags were passed to Actions in this prior `integrations` PR: https://github.com/segmentio/integrations/commit/cb50c4585e10eb8cbab5265b3a5a3e901ca9f471#diff-6db3e5ddc729acbbb968d5dd771dfa6d542245e980e9b9d12bdb2417d2e05163R205-R208

## Testing
- Testing completed successfully in stage. I deployed this branch/code to the staging environment and sent test events to validate that the desired metrics were collected: https://github.com/segmentio/action-destinations/blob/35c82a50874b8384a7a5504aa7b3c556178b4159/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts#L49-L50

<img width="1089" alt="Screen Shot 2022-07-05 at 11 39 02 AM" src="https://user-images.githubusercontent.com/11224497/177393837-c739065d-c184-42e0-b961-33f89d353706.png">

https://segment.datadoghq.com/notebook/2808803/-testing-datadog-in-actions?live=false&start=1657045801741&range=467259

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment