### PR TITLE
do not escape forward slash for string directives

### DIFF
--- a/packages/core/src/create-test-integration.ts
+++ b/packages/core/src/create-test-integration.ts
@@ -5,6 +5,7 @@ import type { DestinationDefinition, StatsContext } from './destination-kit'
 import type { JSONObject } from './json-object'
 import type { SegmentEvent } from './segment-event'
 import { AuthTokens } from './destination-kit/parse-settings'
+import { Features } from './mapping-kit'
 
 interface InputData<Settings> {
   /**
@@ -34,7 +35,7 @@ interface InputData<Settings> {
    * The features available in the request based on either customer workspaceID or sourceID;
    * Both `features` and `stats` are for internal Twilio/Segment use only.
    */
-  features?: { [key: string]: boolean }
+  features?: Features
   statsContext?: StatsContext
 }
 

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events'
 import createRequestClient from '../create-request-client'
 import { JSONLikeObject, JSONObject } from '../json-object'
-import { InputData, transform, transformBatch } from '../mapping-kit'
+import { InputData, Features, transform, transformBatch } from '../mapping-kit'
 import { fieldsToJsonSchema } from './fields-to-jsonschema'
 import { Response } from '../fetch'
 import type { ModifiedResponse } from '../types'
@@ -77,7 +77,7 @@ interface ExecuteBundle<T = unknown, Data = unknown> {
   mapping: JSONObject
   auth: AuthTokens | undefined
   /** For internal Segment/Twilio use only. */
-  features?: { [key: string]: boolean }
+  features?: Features
 }
 
 /**

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -117,7 +117,7 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
     const results: Result[] = []
 
     // Resolve/transform the mapping with the input data
-    let payload = transform(bundle.mapping, bundle.data) as Payload
+    let payload = transform(bundle.mapping, bundle.data, bundle.features) as Payload
     results.push({ output: 'Mappings resolved' })
 
     // Remove empty values (`null`, `undefined`, `''`) when not explicitly accepted

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -12,7 +12,7 @@ import type { GlobalSetting, RequestExtension, ExecuteInput, Result, Deletion, D
 import type { AllRequestOptions } from '../request-client'
 import { IntegrationError, InvalidAuthenticationError } from '../errors'
 import { AuthTokens, getAuthData, getOAuth2Data, updateOAuthSettings } from './parse-settings'
-import { InputData } from '../mapping-kit'
+import { InputData, Features } from '../mapping-kit'
 import { retry } from '../retry'
 import { HTTPError } from '..'
 
@@ -167,7 +167,7 @@ interface EventInput<Settings> {
   /** Authentication-related data based on the destination's authentication.fields definition and authentication scheme */
   readonly auth?: AuthTokens
   /** For internal Segment/Twilio use only. */
-  readonly features?: { [key: string]: boolean }
+  readonly features?: Features
 }
 
 interface BatchEventInput<Settings> {
@@ -177,7 +177,7 @@ interface BatchEventInput<Settings> {
   /** Authentication-related data based on the destination's authentication.fields definition and authentication scheme */
   readonly auth?: AuthTokens
   /** For internal Segment/Twilio use only. */
-  readonly features?: { [key: string]: boolean }
+  readonly features?: Features
 }
 
 export interface DecoratedResponse extends ModifiedResponse {
@@ -202,7 +202,7 @@ interface StatsContext {
 interface OnEventOptions {
   onTokenRefresh?: (tokens: RefreshAccessTokenResult) => void
   onComplete?: (stats: SubscriptionStats) => void
-  features?: { [key: string]: boolean }
+  features?: Features
   statsContext?: StatsContext
 }
 

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -3,6 +3,7 @@ import type { JSONObject } from '../json-object'
 import { AuthTokens } from './parse-settings'
 import type { RequestClient } from '../create-request-client'
 import type { ID } from '../segment-event'
+import { Features } from 'src/mapping-kit'
 
 export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>
 export type MaybePromise<T> = T | Promise<T>
@@ -27,7 +28,7 @@ export interface ExecuteInput<Settings, Payload> {
    * The features available in the request based on either customer workspaceID or sourceID;
    * For internal Twilio/Segment use only.
    */
-  readonly features?: { [key: string]: boolean }
+  readonly features?: Features
 }
 
 export interface DynamicFieldResponse {

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -4,7 +4,7 @@ import type { JSONObject } from '../json-object'
 import { AuthTokens } from './parse-settings'
 import type { RequestClient } from '../create-request-client'
 import type { ID } from '../segment-event'
-import { Features } from 'src/mapping-kit'
+import { Features } from '../mapping-kit'
 
 export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>
 export type MaybePromise<T> = T | Promise<T>

--- a/packages/core/src/mapping-kit/__tests__/index.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.test.ts
@@ -335,7 +335,7 @@ describe('@template', () => {
 
   test('no escaping', () => {
     const output = transform({ '@template': '<blink>{{a}} {{{a}}}</blink>' }, { a: '<b>Hi</b>' })
-    expect(output).toStrictEqual('<blink>&lt;b&gt;Hi&lt;&#x2F;b&gt; <b>Hi</b></blink>')
+    expect(output).toStrictEqual('<blink>&lt;b&gt;Hi&lt;/b&gt; <b>Hi</b></blink>')
   })
 
   test('missing fields', () => {

--- a/packages/core/src/mapping-kit/__tests__/index.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.test.ts
@@ -333,9 +333,18 @@ describe('@template', () => {
     expect(output).toStrictEqual('Hello, World!')
   })
 
-  test('no escaping', () => {
+  test('escaping', () => {
     const output = transform({ '@template': '<blink>{{a}} {{{a}}}</blink>' }, { a: '<b>Hi</b>' })
-    expect(output).toStrictEqual('<blink>&lt;b&gt;Hi&lt;/b&gt; <b>Hi</b></blink>')
+    expect(output).toStrictEqual('<blink>&lt;b&gt;Hi&lt;&#x2F;b&gt; <b>Hi</b></blink>')
+  })
+
+  test('no escaping if flag is on', () => {
+    const output = transform(
+      { '@template': '<blink>{{a}} {{{a}}}</blink>' },
+      { a: '<b>Hi</b>' },
+      { actionsEscapeOff: true }
+    )
+    expect(output).toStrictEqual('<blink><b>Hi</b> <b>Hi</b></blink>')
   })
 
   test('missing fields', () => {

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -7,8 +7,8 @@ import { removeUndefined } from '../remove-undefined'
 import validate from './validate'
 import { arrify } from '../arrify'
 
-type Directive = (options: JSONValue, payload: JSONObject) => JSONLike
-type StringDirective = (value: string, payload: JSONObject) => JSONLike
+type Directive = (options: JSONValue, payload: JSONObject, features?: { [key: string]: boolean }) => JSONLike
+type StringDirective = (value: string, payload: JSONObject, features?: { [key: string]: boolean }) => JSONLike
 
 interface Directives {
   [directive: string]: Directive | undefined
@@ -26,17 +26,17 @@ function registerDirective(name: string, fn: Directive): void {
 }
 
 function registerStringDirective(name: string, fn: StringDirective): void {
-  registerDirective(name, (value, payload) => {
+  registerDirective(name, (value, payload, features) => {
     const str = resolve(value, payload)
     if (typeof str !== 'string') {
       throw new Error(`${name}: expected string, got ${realTypeOf(str)}`)
     }
 
-    return fn(str, payload)
+    return fn(str, payload, features)
   })
 }
 
-function runDirective(obj: JSONObject, payload: JSONObject): JSONLike {
+function runDirective(obj: JSONObject, payload: JSONObject, features?: { [key: string]: boolean }): JSONLike {
   const name = Object.keys(obj).find((key) => key.startsWith('@')) as string
   const directiveFn = directives[name]
   const value = obj[name]
@@ -45,7 +45,7 @@ function runDirective(obj: JSONObject, payload: JSONObject): JSONLike {
     throw new Error(`${name} is not a valid directive, got ${realTypeOf(directiveFn)}`)
   }
 
-  return directiveFn(value, payload)
+  return directiveFn(value, payload, features)
 }
 
 registerDirective('@if', (opts, payload) => {
@@ -93,8 +93,8 @@ registerStringDirective('@path', (path, payload) => {
   return get(payload, path.replace('$.', ''))
 })
 
-registerStringDirective('@template', (template: string, payload) => {
-  return render(template, payload)
+registerStringDirective('@template', (template: string, payload, features) => {
+  return render(template, payload, features)
 })
 
 // Literal should be used in place of 'empty' template strings as they will not resolve correctly
@@ -106,25 +106,26 @@ registerDirective('@literal', (value, payload) => {
  * Resolves a mapping value/object by applying the input payload based on directives
  * @param mapping - the mapping directives or raw values to resolve
  * @param payload - the input data to apply to the mapping directives
+ * @param features - the object of feature flags (optional)
  * @todo support arrays or array directives?
  */
-function resolve(mapping: JSONLike, payload: JSONObject): JSONLike {
+function resolve(mapping: JSONLike, payload: JSONObject, features?: { [key: string]: boolean }): JSONLike {
   if (!isObject(mapping) && !isArray(mapping)) {
     return mapping
   }
 
   if (isDirective(mapping)) {
-    return runDirective(mapping, payload)
+    return runDirective(mapping, payload, features)
   }
 
   if (Array.isArray(mapping)) {
-    return mapping.map((value) => resolve(value, payload))
+    return mapping.map((value) => resolve(value, payload, features))
   }
 
   const resolved: JSONLikeObject = {}
 
   for (const key of Object.keys(mapping)) {
-    resolved[key] = resolve(mapping[key], payload)
+    resolved[key] = resolve(mapping[key], payload, features)
   }
 
   return resolved
@@ -137,8 +138,13 @@ export type InputData = { [key: string]: unknown }
  * based on the directives and raw values defined in the mapping object
  * @param mapping - the directives and raw values
  * @param data - the input data to apply to directives
+ * @param features - the object of feature flags (optional)
  */
-export function transform(mapping: JSONLikeObject, data: InputData | undefined = {}): JSONObject {
+export function transform(
+  mapping: JSONLikeObject,
+  data: InputData | undefined = {},
+  features?: { [key: string]: boolean }
+): JSONObject {
   const realType = realTypeOf(data)
   if (realType !== 'object') {
     throw new Error(`data must be an object, got ${realType}`)
@@ -147,7 +153,7 @@ export function transform(mapping: JSONLikeObject, data: InputData | undefined =
   // throws if the mapping config is invalid
   validate(mapping)
 
-  const resolved = resolve(mapping, data as JSONObject)
+  const resolved = resolve(mapping, data as JSONObject, features)
   const cleaned = removeUndefined(resolved)
 
   // Cast because we know there are no `undefined` values anymore

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -7,8 +7,10 @@ import { removeUndefined } from '../remove-undefined'
 import validate from './validate'
 import { arrify } from '../arrify'
 
-type Directive = (options: JSONValue, payload: JSONObject, features?: { [key: string]: boolean }) => JSONLike
-type StringDirective = (value: string, payload: JSONObject, features?: { [key: string]: boolean }) => JSONLike
+export type InputData = { [key: string]: unknown }
+export type Features = { [key: string]: boolean }
+type Directive = (options: JSONValue, payload: JSONObject, features?: Features) => JSONLike
+type StringDirective = (value: string, payload: JSONObject, features?: Features) => JSONLike
 
 interface Directives {
   [directive: string]: Directive | undefined
@@ -36,7 +38,7 @@ function registerStringDirective(name: string, fn: StringDirective): void {
   })
 }
 
-function runDirective(obj: JSONObject, payload: JSONObject, features?: { [key: string]: boolean }): JSONLike {
+function runDirective(obj: JSONObject, payload: JSONObject, features?: Features): JSONLike {
   const name = Object.keys(obj).find((key) => key.startsWith('@')) as string
   const directiveFn = directives[name]
   const value = obj[name]
@@ -109,7 +111,7 @@ registerDirective('@literal', (value, payload) => {
  * @param features - the object of feature flags (optional)
  * @todo support arrays or array directives?
  */
-function resolve(mapping: JSONLike, payload: JSONObject, features?: { [key: string]: boolean }): JSONLike {
+function resolve(mapping: JSONLike, payload: JSONObject, features?: Features): JSONLike {
   if (!isObject(mapping) && !isArray(mapping)) {
     return mapping
   }
@@ -131,8 +133,6 @@ function resolve(mapping: JSONLike, payload: JSONObject, features?: { [key: stri
   return resolved
 }
 
-export type InputData = { [key: string]: unknown }
-
 /**
  * Validates and transforms a mapping by applying the input payload
  * based on the directives and raw values defined in the mapping object
@@ -140,11 +140,7 @@ export type InputData = { [key: string]: unknown }
  * @param data - the input data to apply to directives
  * @param features - the object of feature flags (optional)
  */
-export function transform(
-  mapping: JSONLikeObject,
-  data: InputData | undefined = {},
-  features?: { [key: string]: boolean }
-): JSONObject {
+export function transform(mapping: JSONLikeObject, data: InputData | undefined = {}, features?: Features): JSONObject {
   const realType = realTypeOf(data)
   if (realType !== 'object') {
     throw new Error(`data must be an object, got ${realType}`)

--- a/packages/core/src/mapping-kit/placeholders.ts
+++ b/packages/core/src/mapping-kit/placeholders.ts
@@ -14,7 +14,7 @@ const entityMap: Record<string, string> = {
 function escapeHtml(value: unknown): string | unknown {
   if (typeof value !== 'string') return value
 
-  return value.replace(/[&<>"'`=/]/g, (match) => {
+  return value.replace(/[&<>"'`=]/g, (match) => {
     return entityMap[match]
   })
 }

--- a/packages/core/src/mapping-kit/placeholders.ts
+++ b/packages/core/src/mapping-kit/placeholders.ts
@@ -7,6 +7,7 @@ const entityMap: Record<string, string> = {
   '>': '&gt;',
   '"': '&quot;',
   "'": '&#39;',
+  '/': '&#x2F;',
   '`': '&#x60;',
   '=': '&#x3D;'
 }
@@ -14,7 +15,7 @@ const entityMap: Record<string, string> = {
 function escapeHtml(value: unknown): string | unknown {
   if (typeof value !== 'string') return value
 
-  return value.replace(/[&<>"'`=]/g, (match) => {
+  return value.replace(/[&<>"'`=/]/g, (match) => {
     return entityMap[match]
   })
 }
@@ -22,7 +23,7 @@ function escapeHtml(value: unknown): string | unknown {
 /**
  * Replaces curly brace placeholders in a template with real content
  */
-export function render(template: string, data: unknown = {}): string {
+export function render(template: string, data: unknown = {}, features?: { [key: string]: boolean }): string {
   if (typeof template !== 'string') {
     throw new TypeError(`Invalid template! Template should be a "string" but ${realTypeOf(template)} was given.`)
   }
@@ -35,8 +36,9 @@ export function render(template: string, data: unknown = {}): string {
       // Grab the value from data, if it exists
       const value = get(data, match)
 
-      // Replace with the value (or empty string)
-      if (escape) {
+      // Replace with the value (or empty string) only if flag isn't set
+      const actionsEscapeOff = features && features.actionsEscapeOff
+      if (escape && !actionsEscapeOff) {
         return String(escapeHtml(value) ?? '')
       }
 

--- a/packages/core/src/mapping-kit/placeholders.ts
+++ b/packages/core/src/mapping-kit/placeholders.ts
@@ -7,7 +7,6 @@ const entityMap: Record<string, string> = {
   '>': '&gt;',
   '"': '&quot;',
   "'": '&#39;',
-  '/': '&#x2F;',
   '`': '&#x60;',
   '=': '&#x3D;'
 }

--- a/packages/core/src/mapping-kit/placeholders.ts
+++ b/packages/core/src/mapping-kit/placeholders.ts
@@ -1,5 +1,6 @@
 import { get } from '../get'
 import { realTypeOf } from '../real-type-of'
+import { Features } from './index'
 
 const entityMap: Record<string, string> = {
   '&': '&amp;',
@@ -23,7 +24,7 @@ function escapeHtml(value: unknown): string | unknown {
 /**
  * Replaces curly brace placeholders in a template with real content
  */
-export function render(template: string, data: unknown = {}, features?: { [key: string]: boolean }): string {
+export function render(template: string, data: unknown = {}, features?: Features): string {
   if (typeof template !== 'string') {
     throw new TypeError(`Invalid template! Template should be a "string" but ${realTypeOf(template)} was given.`)
   }


### PR DESCRIPTION
This PR puts the logic to escape html characters for template string values behind a flag.

Further discussion here:
https://paper.dropbox.com/doc/Escape-Forward-Slash--BkYjgmWE22SsnHQMAJdt7CRJAg-17kgY9Ua5bQ7ZH7AfuxRD

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
