### PR TITLE
[STRATCONN] Unit testing supports features and statsContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ The `perform` method accepts two arguments, (1) the request client instance (ext
 - `settings` - The global destination settings.
 - `auth` - The data needed in OAuth requests. This is useful if fetching an updated OAuth `access_token` using a `refresh_token`. The `refresh_token` is available in `auth.refreshToken`.
 - `features` - The features available in the request based on either customer workspaceID or sourceID. Features can only be enabled and/or used by internal Twilio/Segment employees. Features cannot be used for Partner builds.
+- `statsContext` - An object, containing a `statsClient` and `tags`. Stats can only be used by internal Twilio/Segment employees. Stats cannot be used for Partner builds.
 
 A basic example:
 
@@ -352,7 +353,7 @@ const destination = {
       // `perform` takes two arguments:
       // 1. the request client instance (extended with your destination's `extendRequest`
       // 2. the data bundle (destructured below)
-      perform: (request, { payload, settings, auth, features }) => {
+      perform: (request, { payload, settings, auth, features, statsContext }) => {
         return request('https://example.com', {
           headers: { Authorization: `Bearer ${data.settings.api_key}` },
           json: data.payload

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -102,7 +102,7 @@ import nock from 'nock'
 import { createTestIntegration, StatsClient } from '@segment/actions-core'
 import SendGrid from '../index'
 
-const statsClient = ({} as StatsClient)
+const statsClient = {} as StatsClient
 const tags = ['integration:actions-sendgrid']
 
 const testDestination = createTestDestination(SendGrid)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -32,7 +32,7 @@ To test a specific destination action, you can send a Postman or cURL request wi
 
 ### Example
 
-The following is an example of a cURL command for `google-analytics-4`'s `search` action. Note that `payload`, `settings`, and `auth` values are all optional in the request body. However, you must still pass in all required fields for the specific destination action under `payload`.
+The following is an example of a cURL command for `google-analytics-4`'s `search` action. Note that `payload`, `settings`, `auth`, and `features` values are all optional in the request body. However, you must still pass in all required fields for the specific destination action under `payload`. `features` is for internal Twilio/Segment use only.
 
 ```sh
 curl --location --request POST 'http://localhost:3000/search' \
@@ -49,6 +49,9 @@ curl --location --request POST 'http://localhost:3000/search' \
     "auth": {
         "accessToken": "<ACCESS_TOKEN>",
         "refreshToken": "<REFRESH_TOKEN>"
+    }
+    "features": {
+        "test_feature": true,
     }
 }'
 ```
@@ -69,7 +72,8 @@ curl --location --request POST 'http://localhost:3000/send' \
         }
     }],
     "settings": {},
-    "auth": {}
+    "auth": {},
+    "features": {}
 }'
 ```
 
@@ -95,8 +99,11 @@ While testing, we want to avoid hitting external APIs. We use `nock` to intercep
 
 ```sh
 import nock from 'nock'
-import { createTestIntegration } from '@segment/actions-core'
+import { createTestIntegration, StatsClient } from '@segment/actions-core'
 import SendGrid from '../index'
+
+const statsClient = ({} as StatsClient)
+const tags = ['integration:actions-sendgrid']
 
 const testDestination = createTestDestination(SendGrid)
 
@@ -122,7 +129,9 @@ describe('SendGrid', () => {
 
       await testDestination.testAction('createList', {
         mapping: { name: 'Some Name' },
-        settings: { apiKey: SENDGRID_API_KEY }
+        settings: { apiKey: SENDGRID_API_KEY },
+        features: { my_feature: true },
+        statsContext: { statsClient, tags }
       })
     })
   })

--- a/packages/core/src/create-test-integration.ts
+++ b/packages/core/src/create-test-integration.ts
@@ -1,7 +1,7 @@
 import { createTestEvent } from './create-test-event'
 import { Destination } from './destination-kit'
 import { mapValues } from './map-values'
-import type { DestinationDefinition } from './destination-kit'
+import type { DestinationDefinition, StatsContext } from './destination-kit'
 import type { JSONObject } from './json-object'
 import type { SegmentEvent } from './segment-event'
 import { AuthTokens } from './destination-kit/parse-settings'
@@ -30,6 +30,12 @@ interface InputData<Settings> {
    */
   useDefaultMappings?: boolean
   auth?: AuthTokens
+  /**
+   * The features available in the request based on either customer workspaceID or sourceID;
+   * Both `features` and `stats` are for internal Twilio/Segment use only.
+   */
+  features?: { [key: string]: boolean }
+  statsContext?: StatsContext
 }
 
 class TestDestination<T> extends Destination<T> {
@@ -42,7 +48,7 @@ class TestDestination<T> extends Destination<T> {
   /** Testing method that runs an action e2e while allowing slightly more flexible inputs */
   async testAction(
     action: string,
-    { event, mapping, settings, useDefaultMappings, auth }: InputData<T>
+    { event, mapping, settings, useDefaultMappings, auth, features, statsContext }: InputData<T>
   ): Promise<Destination['responses']> {
     mapping = mapping ?? {}
 
@@ -56,7 +62,9 @@ class TestDestination<T> extends Destination<T> {
       event: createTestEvent(event),
       mapping,
       settings: settings ?? ({} as T),
-      auth
+      auth,
+      features: features ?? {},
+      statsContext: statsContext ?? ({} as StatsContext)
     })
 
     const responses = this.responses
@@ -67,7 +75,15 @@ class TestDestination<T> extends Destination<T> {
 
   async testBatchAction(
     action: string,
-    { events, mapping, settings, useDefaultMappings, auth }: Omit<InputData<T>, 'event'> & { events?: SegmentEvent[] }
+    {
+      events,
+      mapping,
+      settings,
+      useDefaultMappings,
+      auth,
+      features,
+      statsContext
+    }: Omit<InputData<T>, 'event'> & { events?: SegmentEvent[] }
   ): Promise<Destination['responses']> {
     mapping = mapping ?? {}
 
@@ -85,7 +101,9 @@ class TestDestination<T> extends Destination<T> {
       events: events.map((event) => createTestEvent(event)),
       mapping,
       settings: settings ?? ({} as T),
-      auth
+      auth,
+      features: features ?? {},
+      statsContext: statsContext ?? ({} as StatsContext)
     })
 
     const responses = this.responses


### PR DESCRIPTION
- This PR adds support for testing `features` and `statsContext` in unit tests.
- Updates READMEs with examples of how to use `features` and `statsContext`.

## Testing
- Existing unit tests continue to pass.

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
