### PR TITLE
Add slugs to cloud actions

### DIFF
--- a/packages/destination-actions/src/destinations/1plusx/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx/index.ts
@@ -6,6 +6,7 @@ import sendUserData from './sendUserData'
 
 const destination: DestinationDefinition<Settings> = {
   name: '1plusX',
+  slug: 'actions-1plusx',
   mode: 'cloud',
   //No authentication required for 1plusX Data Collection API
   authentication: {

--- a/packages/destination-actions/src/destinations/amplitude/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/index.ts
@@ -53,6 +53,7 @@ const presets: DestinationDefinition['presets'] = [
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Actions Amplitude',
+  slug: 'actions-amplitude',
   mode: 'cloud',
   authentication: {
     scheme: 'custom',

--- a/packages/destination-actions/src/destinations/customerio/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/index.ts
@@ -11,6 +11,7 @@ import { AccountRegion, trackApiEndpoint } from './utils'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Actions Customerio',
+  slug: 'actions-customerio',
   mode: 'cloud',
   authentication: {
     scheme: 'basic',

--- a/packages/destination-actions/src/destinations/google-analytics-4/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/index.ts
@@ -24,6 +24,7 @@ const destination: DestinationDefinition<Settings> = {
   // NOTE: We need to match the name with the creation name in DB.
   // This is not the value used in the UI.
   name: 'Actions Google Analytic 4',
+  slug: 'actions-google-analytics-4',
   mode: 'cloud',
   authentication: {
     scheme: 'custom',

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -19,6 +19,7 @@ const destination: DestinationDefinition<Settings> = {
   // NOTE: We need to match the name with the creation name in DB.
   // This is not the value used in the UI.
   name: 'Google Enhanced Conversions',
+  slug: 'actions-google-enhanced-conversions',
   mode: 'cloud',
   authentication: {
     scheme: 'oauth2',

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/index.ts
@@ -4,6 +4,7 @@ import sendEmail from './sendEmail'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Actions Personas Messaging Sendgrid',
+  slug: 'actions-personas-messaging-sendgrid',
   mode: 'cloud',
   description: 'This is a personas specific action to send an email',
   authentication: {

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/index.ts
@@ -80,6 +80,7 @@ const destination: DestinationDefinition<Settings> = {
   //The name below is creation name however in partner portal this is Actions Personas Messaging Twilio
   //This is due to integrations-consumer fetches the creation name instead of current name
   name: 'Personas Messaging Twilio (Actions)',
+  slug: 'actions-personas-messaging-twilio',
   mode: 'cloud',
   authentication: {
     scheme: 'custom',

--- a/packages/destination-actions/src/destinations/pipedrive/index.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/index.ts
@@ -13,6 +13,7 @@ import createUpdateNote from './createUpdateNote'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Actions Pipedrive',
+  slug: 'actions-pipedrive',
   mode: 'cloud',
   authentication: {
     scheme: 'custom',

--- a/packages/destination-actions/src/destinations/slack/index.ts
+++ b/packages/destination-actions/src/destinations/slack/index.ts
@@ -4,6 +4,7 @@ import postToChannel from './postToChannel'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Slack',
+  slug: 'actions-slack',
   mode: 'cloud',
   actions: {
     postToChannel

--- a/packages/destination-actions/src/destinations/twilio/index.ts
+++ b/packages/destination-actions/src/destinations/twilio/index.ts
@@ -4,6 +4,7 @@ import sendSMS from './sendSms'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Twilio',
+  slug: 'actions-twilio',
   mode: 'cloud',
   authentication: {
     scheme: 'basic',


### PR DESCRIPTION
- This PR adds `slug`s to cloud action destinations that are missing this field.
- These `slug`s are used as a `tag` in integrations-related metrics, hence should be defined directly on each destination's `definition`:  https://github.com/segmentio/integrations/blob/8ac2432cdcfab3cbb1b3ef477bd16667808bb2fe/createActionDestination/index.js#L89
- This also ensures that metrics are tagged with the same slug that's used to filter metrics on the `integrations` dashboard in [DataDog here.](https://segment.datadoghq.com/dashboard/s5c-zmu-hnj/integrations-fka-integrations-monoservice?tpl_var_integration=actions-google-analytics-4&from_ts=1657129556872&to_ts=1657133156872&live=true)

## Testing

### Quasar Testing

```
treb start -e production -b 8ac2432 integrations-qa-control-prod-2
treb start -e production -b b73fe4e integrations-qa-candidate-prod-2

❯ quasar create -e production -i all -s 2
2022/07/06 11:24:40 SAML: Sending DUO push notification...
Success! New experiment created with id: 2Ba6XakqLpIYypdLA2Mt2OZGCs1
View experiment results here: https://segment.datadoghq.com/dashboard/kpu-nnr-kn2/quasar-destinations-qa?live=true&tpl_var_candidate_service_name=integrations-qa-candidate-2&tpl_var_control_service_name=integrations-qa-control-2&tpl_var_experiment_id=2ba6xakqlpiyypdla2mt2ozgcs1&tpl_var_env=production
To view any differences, run: quasar get-diffs -e production -x 2Ba6XakqLpIYypdLA2Mt2OZGCs1
To stop experiment early, run: quasar cancel -e production -x 2Ba6XakqLpIYypdLA2Mt2OZGCs1
```

See DataDog experiment [here](https://segment.datadoghq.com/dashboard/kpu-nnr-kn2/quasar-destinations-qa?tpl_var_candidate_service_name=integrations-qa-candidate-2&tpl_var_control_service_name=integrations-qa-control-2&tpl_var_env=production&tpl_var_experiment_id=2ba6xakqlpiyypdla2mt2ozgcs1&from_ts=1657131814054&to_ts=1657132902000&live=false):

<img width="1579" alt="Screen Shot 2022-07-06 at 11 42 01 AM" src="https://user-images.githubusercontent.com/11224497/177621751-36538753-29c1-40f2-82ec-06509215a512.png">

Testing looks ok. These destinations frequently report diffs, even when the destinations themselves aren't updated. The `actions-amplitude` diff is because properties are in a different order in the control vs. the candidate. This is also a frequent occurrence and doesn't pose a risk.

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
