### PR TITLE
[Salesforce] - Simplify batching configuration

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
@@ -354,7 +354,8 @@ describe('Salesforce', () => {
 
     const bulkUpsertPayloads: GenericPayload[] = [
       {
-        operation: 'bulkUpsert',
+        operation: 'upsert',
+        enable_batching: true,
         bulkUpsertExternalId: {
           externalIdName: 'test__c',
           externalIdValue: 'ab'
@@ -364,7 +365,8 @@ describe('Salesforce', () => {
         description: 'Krusty Krab'
       },
       {
-        operation: 'bulkUpsert',
+        operation: 'upsert',
+        enable_batching: true,
         bulkUpsertExternalId: {
           externalIdName: 'test__c',
           externalIdValue: 'cd'
@@ -377,7 +379,8 @@ describe('Salesforce', () => {
 
     const customPayloads: GenericPayload[] = [
       {
-        operation: 'bulkUpsert',
+        operation: 'upsert',
+        enable_batching: true,
         bulkUpsertExternalId: {
           externalIdName: 'test__c',
           externalIdValue: 'ab'
@@ -390,7 +393,8 @@ describe('Salesforce', () => {
         }
       },
       {
-        operation: 'bulkUpsert',
+        operation: 'upsert',
+        enable_batching: true,
         bulkUpsertExternalId: {
           externalIdName: 'test__c',
           externalIdValue: 'cd'
@@ -406,14 +410,16 @@ describe('Salesforce', () => {
 
     const bulkUpdatePayloads: GenericPayload[] = [
       {
-        operation: 'bulkUpdate',
+        operation: 'update',
+        enable_batching: true,
         bulkUpdateRecordId: 'ab',
         name: 'SpongeBob Squarepants',
         phone: '1234567890',
         description: 'Krusty Krab'
       },
       {
-        operation: 'bulkUpdate',
+        operation: 'update',
+        enable_batching: true,
         bulkUpdateRecordId: 'cd',
         name: 'Squidward Tentacles',
         phone: '1234567891',

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
@@ -531,5 +531,28 @@ describe('Salesforce', () => {
 
       await sf.bulkHandler(bulkUpdatePayloads, 'Account')
     })
+
+    it('should fail if the bulkHandler is triggered but enable_batching is not true', async () => {
+      const payloads: GenericPayload[] = [
+        {
+          operation: 'upsert',
+          enable_batching: false,
+          name: 'SpongeBob Squarepants',
+          phone: '1234567890',
+          description: 'Krusty Krab'
+        },
+        {
+          operation: 'upsert',
+          enable_batching: false,
+          name: 'Squidward Tentacles',
+          phone: '1234567891',
+          description: 'Krusty Krab'
+        }
+      ]
+
+      await expect(sf.bulkHandler(payloads, 'Account')).rejects.toThrow(
+        'Bulk operation triggered where enable_batching is false.'
+      )
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
@@ -6,7 +6,8 @@ describe('Salesforce Utils', () => {
     it('should correctly build a CSV from payloads with complete data', async () => {
       const completePayloads: GenericPayload[] = [
         {
-          operation: 'bulkUpsert',
+          operation: 'upsert',
+          enable_batching: true,
           bulkUpsertExternalId: {
             externalIdName: 'test__c',
             externalIdValue: '00'
@@ -16,7 +17,8 @@ describe('Salesforce Utils', () => {
           phone: '555-555-5555'
         },
         {
-          operation: 'bulkUpsert',
+          operation: 'upsert',
+          enable_batching: true,
           bulkUpsertExternalId: {
             externalIdName: 'test__c',
             externalIdValue: '01'
@@ -35,7 +37,8 @@ describe('Salesforce Utils', () => {
     it('should correctly build a CSV from payloads with incomplete data', async () => {
       const incompletePayloads: GenericPayload[] = [
         {
-          operation: 'bulkUpsert',
+          operation: 'upsert',
+          enable_batching: true,
           bulkUpsertExternalId: {
             externalIdName: 'test__c',
             externalIdValue: '00'
@@ -47,7 +50,8 @@ describe('Salesforce Utils', () => {
           }
         },
         {
-          operation: 'bulkUpsert',
+          operation: 'upsert',
+          enable_batching: true,
           bulkUpsertExternalId: {
             externalIdName: 'test__c',
             externalIdValue: '01'
@@ -56,7 +60,8 @@ describe('Salesforce Utils', () => {
           phone: '123-456-7890'
         },
         {
-          operation: 'bulkUpsert',
+          operation: 'upsert',
+          enable_batching: true,
           bulkUpsertExternalId: {
             externalIdName: 'test__c',
             externalIdValue: '11'
@@ -75,7 +80,8 @@ describe('Salesforce Utils', () => {
     it('should throw an error for invalid customFields', async () => {
       const invalidCustomFieldPayloads: GenericPayload[] = [
         {
-          operation: 'bulkUpsert',
+          operation: 'upsert',
+          enable_batching: true,
           traits: {
             externalIdFieldName: 'test__c',
             externalIdFieldValue: 'ab'
@@ -88,7 +94,8 @@ describe('Salesforce Utils', () => {
           }
         },
         {
-          operation: 'bulkUpsert',
+          operation: 'upsert',
+          enable_batching: true,
           traits: {
             externalIdFieldName: 'test__c',
             externalIdFieldValue: 'cd'
@@ -110,14 +117,16 @@ describe('Salesforce Utils', () => {
     it('should correctly build an update CSV', async () => {
       const updatePayloads: GenericPayload[] = [
         {
-          operation: 'bulkUpdate',
+          operation: 'update',
+          enable_batching: true,
           bulkUpdateRecordId: '00',
           name: 'SpongeBob Squarepants',
           phone: '1234567890',
           description: 'Krusty Krab'
         },
         {
-          operation: 'bulkUpdate',
+          operation: 'update',
+          enable_batching: true,
           bulkUpdateRecordId: '01',
           name: 'Squidward Tentacles',
           phone: '1234567891',
@@ -134,13 +143,15 @@ describe('Salesforce Utils', () => {
     it('should correctly build an update CSV with incomplete data', async () => {
       const incompleteUpdatePayloads: GenericPayload[] = [
         {
-          operation: 'bulkUpdate',
+          operation: 'update',
+          enable_batching: true,
           bulkUpdateRecordId: '00',
           name: 'SpongeBob Squarepants',
           phone: '1234567890'
         },
         {
-          operation: 'bulkUpdate',
+          operation: 'update',
+          enable_batching: true,
           bulkUpdateRecordId: '01',
           name: 'Squidward Tentacles',
           description: 'Krusty Krab'

--- a/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   operation: string
   /**
-   * Use the Salesforce Bulk API to perform bulk operations. Not compatible with the create operation.
+   * Use the Salesforce Bulk API to perform bulk operations. *Not compatible with the create operation*. This will collect events into a batch of 1000 before delivery to Salesforce.
    */
   enable_batching: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   operation: string
   /**
-   * Use the Salesforce Bulk API to perform bulk operations. *Not compatible with the create operation*. This will collect events into a batch of 1000 before delivery to Salesforce.
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
   enable_batching: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
@@ -8,7 +8,7 @@ export interface Payload {
   /**
    * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
-  enable_batching: boolean
+  enable_batching?: boolean
   /**
    * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
    *

--- a/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   operation: string
   /**
+   * Use the Salesforce Bulk API to perform bulk operations. Not compatible with the create operation.
+   */
+  enable_batching: boolean
+  /**
    * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
    *
    *   Any field can function as a matcher, including Record ID, External IDs, standard fields and custom fields. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.

--- a/packages/destination-actions/src/destinations/salesforce/account/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account/index.ts
@@ -7,7 +7,8 @@ import {
   customFields,
   operation,
   traits,
-  validateLookup
+  validateLookup,
+  enable_batching
 } from '../sf-properties'
 import type { Payload } from './generated-types'
 
@@ -19,6 +20,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "group"',
   fields: {
     operation: operation,
+    enable_batching: enable_batching,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,
     bulkUpdateRecordId: bulkUpdateRecordId,

--- a/packages/destination-actions/src/destinations/salesforce/account/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account/index.ts
@@ -202,7 +202,7 @@ const action: ActionDefinition<Settings, Payload> = {
   performBatch: async (request, { settings, payload }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)
 
-    if (payload[0].operation === 'bulkUpsert') {
+    if (payload[0].operation === 'upsert') {
       if (!payload[0].name) {
         throw new IntegrationError('Missing name value', 'Misconfigured required field', 400)
       }

--- a/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   operation: string
   /**
-   * Use the Salesforce Bulk API to perform bulk operations. Not compatible with the create operation.
+   * Use the Salesforce Bulk API to perform bulk operations. *Not compatible with the create operation*. This will collect events into a batch of 1000 before delivery to Salesforce.
    */
   enable_batching: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   operation: string
   /**
-   * Use the Salesforce Bulk API to perform bulk operations. *Not compatible with the create operation*. This will collect events into a batch of 1000 before delivery to Salesforce.
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
   enable_batching: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
@@ -8,7 +8,7 @@ export interface Payload {
   /**
    * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
-  enable_batching: boolean
+  enable_batching?: boolean
   /**
    * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
    *

--- a/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   operation: string
   /**
+   * Use the Salesforce Bulk API to perform bulk operations. Not compatible with the create operation.
+   */
+  enable_batching: boolean
+  /**
    * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
    *
    *   Any field can function as a matcher, including Record ID, External IDs, standard fields and custom fields. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.

--- a/packages/destination-actions/src/destinations/salesforce/cases/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases/index.ts
@@ -7,7 +7,8 @@ import {
   customFields,
   operation,
   traits,
-  validateLookup
+  validateLookup,
+  enable_batching
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
 
@@ -18,6 +19,7 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Represents a case, which is a customer issue or problem.',
   fields: {
     operation: operation,
+    enable_batching: enable_batching,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,
     bulkUpdateRecordId: bulkUpdateRecordId,

--- a/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   operation: string
   /**
-   * Use the Salesforce Bulk API to perform bulk operations. Not compatible with the create operation.
+   * Use the Salesforce Bulk API to perform bulk operations. *Not compatible with the create operation*. This will collect events into a batch of 1000 before delivery to Salesforce.
    */
   enable_batching: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   operation: string
   /**
-   * Use the Salesforce Bulk API to perform bulk operations. *Not compatible with the create operation*. This will collect events into a batch of 1000 before delivery to Salesforce.
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
   enable_batching: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
@@ -8,7 +8,7 @@ export interface Payload {
   /**
    * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
-  enable_batching: boolean
+  enable_batching?: boolean
   /**
    * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
    *

--- a/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   operation: string
   /**
+   * Use the Salesforce Bulk API to perform bulk operations. Not compatible with the create operation.
+   */
+  enable_batching: boolean
+  /**
    * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
    *
    *   Any field can function as a matcher, including Record ID, External IDs, standard fields and custom fields. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.

--- a/packages/destination-actions/src/destinations/salesforce/contact/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact/index.ts
@@ -153,7 +153,7 @@ const action: ActionDefinition<Settings, Payload> = {
   performBatch: async (request, { settings, payload }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)
 
-    if (payload[0].operation === 'bulkUpsert') {
+    if (payload[0].operation === 'upsert') {
       if (!payload[0].last_name) {
         throw new IntegrationError('Missing last_name value', 'Misconfigured required field', 400)
       }

--- a/packages/destination-actions/src/destinations/salesforce/contact/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact/index.ts
@@ -7,7 +7,8 @@ import {
   customFields,
   operation,
   traits,
-  validateLookup
+  validateLookup,
+  enable_batching
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
 
@@ -18,6 +19,7 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Represents a contact, which is a person associated with an account.',
   fields: {
     operation: operation,
+    enable_batching: enable_batching,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,
     bulkUpdateRecordId: bulkUpdateRecordId,

--- a/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   operation: string
   /**
-   * Use the Salesforce Bulk API to perform bulk operations. Not compatible with the create operation.
+   * Use the Salesforce Bulk API to perform bulk operations. *Not compatible with the create operation*. This will collect events into a batch of 1000 before delivery to Salesforce.
    */
   enable_batching: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   operation: string
   /**
-   * Use the Salesforce Bulk API to perform bulk operations. *Not compatible with the create operation*. This will collect events into a batch of 1000 before delivery to Salesforce.
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
   enable_batching: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
@@ -8,7 +8,7 @@ export interface Payload {
   /**
    * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
-  enable_batching: boolean
+  enable_batching?: boolean
   /**
    * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
    *

--- a/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   operation: string
   /**
+   * Use the Salesforce Bulk API to perform bulk operations. Not compatible with the create operation.
+   */
+  enable_batching: boolean
+  /**
    * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
    *
    *   Any field can function as a matcher, including Record ID, External IDs, standard fields and custom fields. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.

--- a/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
@@ -7,7 +7,8 @@ import {
   operation,
   traits,
   customFields,
-  validateLookup
+  validateLookup,
+  enable_batching
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
 
@@ -17,6 +18,7 @@ const action: ActionDefinition<Settings, Payload> = {
     "Represents a custom object, which you create to store information that's specific to your company or industry, or a standard object.",
   fields: {
     operation: operation,
+    enable_batching: enable_batching,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,
     bulkUpdateRecordId: bulkUpdateRecordId,

--- a/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   operation: string
   /**
-   * Use the Salesforce Bulk API to perform bulk operations. Not compatible with the create operation.
+   * Use the Salesforce Bulk API to perform bulk operations. *Not compatible with the create operation*. This will collect events into a batch of 1000 before delivery to Salesforce.
    */
   enable_batching: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   operation: string
   /**
-   * Use the Salesforce Bulk API to perform bulk operations. *Not compatible with the create operation*. This will collect events into a batch of 1000 before delivery to Salesforce.
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
   enable_batching: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
@@ -8,7 +8,7 @@ export interface Payload {
   /**
    * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
-  enable_batching: boolean
+  enable_batching?: boolean
   /**
    * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
    *

--- a/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   operation: string
   /**
+   * Use the Salesforce Bulk API to perform bulk operations. Not compatible with the create operation.
+   */
+  enable_batching: boolean
+  /**
    * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
    *
    *   Any field can function as a matcher, including Record ID, External IDs, standard fields and custom fields. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.

--- a/packages/destination-actions/src/destinations/salesforce/lead/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/index.ts
@@ -7,7 +7,8 @@ import {
   customFields,
   operation,
   traits,
-  validateLookup
+  validateLookup,
+  enable_batching
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
 
@@ -19,6 +20,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "identify"',
   fields: {
     operation: operation,
+    enable_batching: enable_batching,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,
     bulkUpdateRecordId: bulkUpdateRecordId,

--- a/packages/destination-actions/src/destinations/salesforce/lead/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/index.ts
@@ -160,7 +160,7 @@ const action: ActionDefinition<Settings, Payload> = {
   performBatch: async (request, { settings, payload }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)
 
-    if (payload[0].operation === 'bulkUpsert') {
+    if (payload[0].operation === 'upsert') {
       if (!payload[0].company || !payload[0].last_name) {
         throw new IntegrationError('Missing company or last_name value', 'Misconfigured required field', 400)
       }

--- a/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   operation: string
   /**
-   * Use the Salesforce Bulk API to perform bulk operations. Not compatible with the create operation.
+   * Use the Salesforce Bulk API to perform bulk operations. *Not compatible with the create operation*. This will collect events into a batch of 1000 before delivery to Salesforce.
    */
   enable_batching: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   operation: string
   /**
-   * Use the Salesforce Bulk API to perform bulk operations. *Not compatible with the create operation*. This will collect events into a batch of 1000 before delivery to Salesforce.
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
   enable_batching: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
@@ -8,7 +8,7 @@ export interface Payload {
   /**
    * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
-  enable_batching: boolean
+  enable_batching?: boolean
   /**
    * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
    *

--- a/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   operation: string
   /**
+   * Use the Salesforce Bulk API to perform bulk operations. Not compatible with the create operation.
+   */
+  enable_batching: boolean
+  /**
    * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
    *
    *   Any field can function as a matcher, including Record ID, External IDs, standard fields and custom fields. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.

--- a/packages/destination-actions/src/destinations/salesforce/opportunity/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity/index.ts
@@ -7,7 +7,8 @@ import {
   customFields,
   operation,
   traits,
-  validateLookup
+  validateLookup,
+  enable_batching
 } from '../sf-properties'
 import type { Payload } from './generated-types'
 
@@ -18,6 +19,7 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Represents an opportunity, which is a sale or pending deal.',
   fields: {
     operation: operation,
+    enable_batching: enable_batching,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,
     bulkUpdateRecordId: bulkUpdateRecordId,

--- a/packages/destination-actions/src/destinations/salesforce/opportunity/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity/index.ts
@@ -77,7 +77,7 @@ const action: ActionDefinition<Settings, Payload> = {
   performBatch: async (request, { settings, payload }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)
 
-    if (payload[0].operation === 'bulkUpsert') {
+    if (payload[0].operation === 'upsert') {
       if (!payload[0].close_date || !payload[0].name || !payload[0].stage_name) {
         throw new IntegrationError('Missing close_date, name or stage_name value', 'Misconfigured required field', 400)
       }

--- a/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
@@ -5,18 +5,6 @@ import { buildCSVData } from './sf-utils'
 
 export const API_VERSION = 'v53.0'
 
-/**
- * This error is triggered if a batch of payloads arrives inside the performBatch handler
- * where the operation is not either bulkUpsert or bulkUpdate. This would occur if a user ever disables
- * the `enable_batching` setting on their action.
- * TODO: Automatically enable `enable_batching` for any action with a bulk operation.
- * https://segment.atlassian.net/browse/STRATCONN-1369
- */
-const throwBulkMismatchError = () => {
-  const errorMsg = 'Standard operation used with batching enabled.'
-  throw new IntegrationError(errorMsg, errorMsg, 400)
-}
-
 interface Records {
   Id?: string
 }
@@ -86,13 +74,17 @@ export default class Salesforce {
   }
 
   bulkHandler = async (payloads: GenericPayload[], sobject: string) => {
-    if (payloads[0].operation === 'bulkUpsert') {
+    if (payloads[0].operation === 'upsert') {
       return await this.bulkUpsert(payloads, sobject)
-    } else if (payloads[0].operation === 'bulkUpdate') {
+    } else if (payloads[0].operation === 'update') {
       return await this.bulkUpdate(payloads, sobject)
-    } else {
-      throwBulkMismatchError()
     }
+
+    throw new IntegrationError(
+      `Unsupported operation: Bulk API does not support the create operation`,
+      'Unsupported operation',
+      400
+    )
   }
 
   private bulkUpsert = async (payloads: GenericPayload[], sobject: string) => {

--- a/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
@@ -5,6 +5,14 @@ import { buildCSVData } from './sf-utils'
 
 export const API_VERSION = 'v53.0'
 
+/**
+ * This error is triggered if the bulkHandler is ever triggered when the enable_batching setting is false.
+ */
+const throwBulkMismatchError = () => {
+  const errorMsg = 'Bulk operation triggered where enable_batching is false.'
+  throw new IntegrationError(errorMsg, errorMsg, 400)
+}
+
 interface Records {
   Id?: string
 }
@@ -74,6 +82,10 @@ export default class Salesforce {
   }
 
   bulkHandler = async (payloads: GenericPayload[], sobject: string) => {
+    if (!payloads[0].enable_batching) {
+      throwBulkMismatchError()
+    }
+
     if (payloads[0].operation === 'upsert') {
       return await this.bulkUpsert(payloads, sobject)
     } else if (payloads[0].operation === 'update') {

--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -17,8 +17,9 @@ export const operation: InputField = {
 }
 
 export const enable_batching: InputField = {
-  label: 'Use Salesforce Bulk API',
-  description: 'Use the Salesforce Bulk API to perform bulk operations. Not compatible with the create operation.',
+  label: 'Use Salesforce Bulk API to batch events.',
+  description:
+    'Use the Salesforce Bulk API to perform bulk operations. *Not compatible with the create operation*. This will collect events into a batch of 1000 before delivery to Salesforce.',
   type: 'boolean',
   default: false,
   required: true

--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -10,16 +10,14 @@ export const operation: InputField = {
   choices: [
     { label: 'Create new record', value: 'create' },
     { label: 'Update existing record', value: 'update' },
-    { label: `Update or create a record if one doesn't exist`, value: 'upsert' },
-    { label: 'Bulk Upsert', value: 'bulkUpsert' },
-    { label: 'Bulk Update', value: 'bulkUpdate' }
+    { label: `Update or create a record if one doesn't exist`, value: 'upsert' }
   ]
 }
 
 export const enable_batching: InputField = {
-  label: 'Use Salesforce Bulk API to batch events.',
+  label: 'Use Salesforce Bulk API',
   description:
-    'Use the Salesforce Bulk API to perform bulk operations. *Not compatible with the create operation*. This will collect events into a batch of 1000 before delivery to Salesforce.',
+    'If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.',
   type: 'boolean',
   default: false,
   required: true

--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -19,8 +19,7 @@ export const enable_batching: InputField = {
   description:
     'If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.',
   type: 'boolean',
-  default: false,
-  required: true
+  default: false
 }
 
 export const bulkUpsertExternalId: InputField = {

--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -16,6 +16,14 @@ export const operation: InputField = {
   ]
 }
 
+export const enable_batching: InputField = {
+  label: 'Use Salesforce Bulk API',
+  description: 'Use the Salesforce Bulk API to perform bulk operations. Not compatible with the create operation.',
+  type: 'boolean',
+  default: false,
+  required: true
+}
+
 export const bulkUpsertExternalId: InputField = {
   label: 'Bulk Upsert External Id',
   description: 'The external id field name and mapping to use for bulk upsert.',

--- a/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
@@ -5,6 +5,7 @@ import camelCase from 'lodash/camelCase'
 const isSettingsKey = new Set<string>([
   'operation',
   'traits',
+  'enable_batching',
   'customFields',
   'bulkUpsertExternalId',
   'bulkUpdateRecordId'
@@ -125,20 +126,21 @@ const buildCSVFromHeaderMap = (
 
 const getUniqueIdValue = (payload: GenericPayload): string => {
   if (
-    payload.operation === 'bulkUpsert' &&
+    payload.enable_batching &&
+    payload.operation === 'upsert' &&
     payload.bulkUpsertExternalId &&
     payload.bulkUpsertExternalId.externalIdValue
   ) {
     return payload.bulkUpsertExternalId.externalIdValue
   }
 
-  if (payload.operation === 'bulkUpdate' && payload.bulkUpdateRecordId) {
+  if (payload.enable_batching && payload.operation === 'update' && payload.bulkUpdateRecordId) {
     return payload.bulkUpdateRecordId
   }
 
   throw new IntegrationError(
-    `${payload.operation} is missing the required bulk ID`,
-    `${payload.operation} is missing the required bulk ID`,
+    `bulk ${payload.operation} is missing the required bulk ID`,
+    `bulk ${payload.operation} is missing the required bulk ID`,
     400
   )
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR implements a custom `enable_batching` field that provides unique info for users of the Salesforce Bulk API. It also removes the now redundant "Bulk Update" and "Bulk Upsert" operations. Instead users will be able to select `Operation: Upsert`, and `Enable Bulk API: true` to get the same configuration.

The flagon configuration in `app` that hides this from users during internal beta will not need any changes due to this PR.

## Testing

Tested successfully in stage. Event delivery still works and users will only have to flip the enable batching switch to use the bulk API.

Tested with the following configuration and python script:
<img width="1080" alt="Screen Shot 2022-07-08 at 10 19 23 AM" src="https://user-images.githubusercontent.com/27820201/178040314-a7a98c8a-af0e-4ae7-afe3-cb30b8d95d4e.png">

```python3
import analytics
import csv
import time

analytics.write_key = '<write-key>'
analytics.host = 'https://api.segment.build'

with open('./lead_id.csv') as file:
    reader = csv.reader(file)
    i = 0
    for row in reader:
        lead_id = row[0]
        print(i, lead_id)
        time.sleep(.01)
        analytics.track(str(i), 'Lead', {
            'recordId': lead_id,
            'company': 'Bulk Update 7.7 ' + str(i),
            'last_name': 'Stage 7.7 ' + str(i),
            'email': 'stage@test.7.7' + str(i)
        })

        i += 1

    print('flushing...')
    analytics.flush()
    print('done')

```
`lead_id.csv` is a list of 3000 record IDs for lead records in my testing Salesforce account.

Pics below show records updated today via stage test.
<img width="1625" alt="Screen Shot 2022-07-07 at 4 28 27 PM" src="https://user-images.githubusercontent.com/27820201/177887972-e6044aba-8327-41b5-9c8b-24abc20ddb75.png">
<img width="1496" alt="Screen Shot 2022-07-07 at 4 28 14 PM" src="https://user-images.githubusercontent.com/27820201/177887981-cb9f2c67-c320-49e5-84ba-69fafe1175e3.png">


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
