### PR TITLE
Add timeout option to webhook action

### DIFF
--- a/packages/destination-actions/src/destinations/webhook/send/generated-types.ts
+++ b/packages/destination-actions/src/destinations/webhook/send/generated-types.ts
@@ -16,6 +16,10 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
+   * Time in milliseconds when a request should be aborted. Default is 10000
+   */
+  timeout?: number
+  /**
    * Payload to deliver to webhook URL (JSON-encoded).
    */
   data?: {

--- a/packages/destination-actions/src/destinations/webhook/send/index.ts
+++ b/packages/destination-actions/src/destinations/webhook/send/index.ts
@@ -35,6 +35,12 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'object',
       defaultObjectUI: 'keyvalue:only'
     },
+    timeout: {
+      label: 'Timeout',
+      description: 'Time in milliseconds when a request should be aborted. Default is 10000',
+      type: 'number',
+      default: 10000
+    },
     data: {
       label: 'Data',
       description: 'Payload to deliver to webhook URL (JSON-encoded).',
@@ -46,17 +52,19 @@ const action: ActionDefinition<Settings, Payload> = {
     return request(payload.url, {
       method: payload.method as RequestMethod,
       headers: payload.headers as Record<string, string>,
-      json: payload.data
+      json: payload.data,
+      timeout: payload.timeout
     })
   },
   performBatch: (request, { payload }) => {
     // Expect these to be the same across the payloads
-    const { url, method, headers } = payload[0]
+    const { url, method, headers, timeout } = payload[0]
 
     return request(url, {
       method: method as RequestMethod,
       headers: headers as Record<string, string>,
-      json: payload.map(({ data }) => data)
+      json: payload.map(({ data }) => data),
+      timeout
     })
   }
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

<img width="1280" alt="Screen Shot 2022-07-07 at 1 43 21 PM" src="https://user-images.githubusercontent.com/1487616/177868249-03df2229-3e48-457f-aaea-8507db76a801.png">

Tested using actions-tester; putting in different Timeout numbers + url = `http://www.google.com:81/` led to differing amounts of time inbetween `etimedout` errors :) 

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
