### PR TITLE
add separate cjs build step for browser, removes publish block

### DIFF
--- a/packages/browser-destinations/package.json
+++ b/packages/browser-destinations/package.json
@@ -3,19 +3,22 @@
   "version": "3.44.1",
   "description": "Action based browser destinations",
   "author": "Netto Farah",
-  "private": true,
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",
     "directory": "packages/browser-destinations"
   },
-  "main": "dist/index.js",
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "dist/index.d.ts",
   "scripts": {
     "analyze": "NODE_ENV=production webpack --profile --json > stats.json && webpack-bundle-analyzer --port 4200 stats.json",
-    "build": "yarn clean && yarn build-ts && yarn build-web",
+    "build": "yarn clean && yarn build-ts && yarn build-cjs && yarn build-web",
     "build-ts": "yarn tsc -b tsconfig.build.json",
+    "build-cjs": "yarn tsc -p ./tsconfig.build.json -m commonjs --outDir ./dist/cjs/",
     "build-web": "NODE_ENV=production ASSET_ENV=production yarn webpack -c webpack.config.js",
     "build-web-stage": "NODE_ENV=production ASSET_ENV=stage yarn webpack -c webpack.config.js",
     "deploy-prod": "yarn build-web && aws s3 sync ./dist/web/ s3://segment-ajs-next-destinations-production/next-integrations/actions --grants read=id=$npm_config_prod_cdn_oai,id=$npm_config_prod_custom_domain_oai",


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

publishing browser destinations -- now without exploding the bundle size in webpack. This is part of a broader effort to remove the cps dependency from the actions install to make it easier for partners to get started.

## Testing

installed and built locally using yalc

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
