### PR TITLE
[Mixpanel] Converted basic Error to IntegrationError

### DIFF
--- a/packages/destination-actions/src/destinations/mixpanel/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackEvent/index.ts
@@ -1,4 +1,4 @@
-import { ActionDefinition } from '@segment/actions-core'
+import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { MixpanelEvent } from './types'
@@ -387,7 +387,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (!settings.apiSecret) {
-      throw new Error('Missing api secret')
+      throw new IntegrationError('Missing api secret')
     }
     return request('https://api.mixpanel.com/import?strict=1', {
       method: 'post',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR converts an Error to the correct IntegrationError type. 

## Testing

No testing required as the `IntegrationError` type is a wrapper around `Error` which provides some more information. This is not a functional change.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
