### PR TITLE
GA4 updates

### DIFF
--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Payment Info Entered',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -36,6 +37,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -70,7 +72,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"add_payment_info\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"add_payment_info\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -242,6 +244,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Payment Info Entered',
         userId: '1234abc',
+        timestamp: '2022-06-22T22:20:58.905Z',
         type: 'track',
         properties: {
           currency: 'USD',
@@ -263,6 +266,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           currency: {
             '@path': '$.properties.currency'
@@ -304,7 +308,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"1234abc\\",\\"events\\":[{\\"name\\":\\"add_payment_info\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"value\\":10,\\"coupon\\":\\"SUMMER_FUN\\",\\"payment_type\\":\\"Credit Card\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"12345\\"}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"1234abc\\",\\"events\\":[{\\"name\\":\\"add_payment_info\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"value\\":10,\\"coupon\\":\\"SUMMER_FUN\\",\\"payment_type\\":\\"Credit Card\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"12345\\"}],\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
@@ -571,5 +571,129 @@ describe('GA4', () => {
         `"{\\"client_id\\":\\"anon-2134\\",\\"user_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"add_payment_info\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"Test_key\\":\\"test_value\\"}}]}"`
       )
     })
+
+    it('should throw an error when param value is null', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Payment Info Entered',
+        userId: 'abc123',
+        type: 'track',
+        properties: {
+          products: [
+            {
+              product_id: '123456',
+              currency: 'USD'
+            }
+          ]
+        }
+      })
+      try {
+        await testDestination.testAction('addPaymentInfo', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.userId'
+            },
+            params: {
+              test_key: null
+            },
+            items: [
+              {
+                item_id: {
+                  '@path': '$.properties.products.0.product_id'
+                },
+                currency: {
+                  '@path': `$.properties.products.0.currency`
+                }
+              }
+            ]
+          },
+          useDefaultMappings: false
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+        )
+      }
+    })
+
+    it('should throw an error when user_properties value is an array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Payment Info Entered',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          products: [
+            {
+              product_id: '12345abcde',
+              name: 'Quadruple Stack Oreos, 52 ct',
+              currency: 'USD',
+              price: 12.99,
+              quantity: 1
+            }
+          ]
+        }
+      })
+      try {
+        await testDestination.testAction('addPaymentInfo', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            user_properties: {
+              hello: ['World', 'world'],
+              a: '1',
+              b: '2',
+              c: '3'
+            },
+            items: [
+              {
+                item_name: {
+                  '@path': `$.properties.products.0.name`
+                },
+                item_id: {
+                  '@path': `$.properties.products.0.product_id`
+                },
+                currency: {
+                  '@path': `$.properties.products.0.currency`
+                },
+                price: {
+                  '@path': `$.properties.products.0.price`
+                },
+                quantity: {
+                  '@path': `$.properties.products.0.quantity`
+                }
+              }
+            ]
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+        )
+      }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Added',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -32,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -47,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -58,6 +60,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Added',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -82,6 +85,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -142,7 +146,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -153,6 +157,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Added',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -178,6 +183,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -241,7 +247,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"currency\\":\\"usd\\"}],\\"value\\":18.99,\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"currency\\":\\"usd\\"}],\\"value\\":18.99,\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -329,6 +335,7 @@ describe('GA4', () => {
         event: 'Product Added',
         userId: '3456fff',
         anonymousId: 'anon-567890',
+        timestamp: '2022-06-22T22:20:58.905Z',
         type: 'track',
         properties: {
           cart_id: 'skdjsidjsdkdj29j',
@@ -352,6 +359,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -372,7 +380,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
@@ -375,5 +375,135 @@ describe('GA4', () => {
         `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"add_to_cart\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}]}"`
       )
     })
+
+    it('should throw an error when param value is not a string or number', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+      const event = createTestEvent({
+        event: 'Product Added',
+        userId: '3456fff',
+        anonymousId: 'anon-567890',
+        type: 'track',
+        properties: {
+          name: 'Game Board',
+          category: 'Games',
+          brand: 'Hasbro',
+          variant: '200 pieces',
+          price: 18.99,
+          quantity: 1,
+          coupon: 'MAYDEALS',
+          position: 3,
+          url: 'https://www.example.com/product/path',
+          image_url: 'https://www.example.com/product/path.jpg'
+        }
+      })
+
+      try {
+        await testDestination.testAction('addToCart', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            coupon: {
+              '@path': '$.properties.coupon'
+            },
+            value: {
+              '@path': '$.properties.price'
+            },
+            items: [
+              {
+                item_name: {
+                  '@path': `$.properties.name`
+                },
+                item_id: {
+                  '@path': `$.properties.product_id`
+                },
+                quantity: {
+                  '@path': `$.properties.quantity`
+                },
+                coupon: {
+                  '@path': `$.properties.coupon`
+                },
+                item_brand: {
+                  '@path': `$.properties..brand`
+                },
+                item_category: {
+                  '@path': `$.properties.category`
+                },
+                item_variant: {
+                  '@path': `$.properties.variant`
+                },
+                price: {
+                  '@path': `$.properties.price`
+                }
+              }
+            ],
+            params: {
+              test_key: null
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+        )
+      }
+    })
+
+    it('should throw an error when user_properties value is an array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Product Added',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('addToCart', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            user_properties: {
+              hello: ['World', 'world'],
+              a: '1',
+              b: '2',
+              c: '3'
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+        )
+      }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Added to Wishlist',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -32,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -47,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"add_to_wishlist\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"add_to_wishlist\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -59,6 +61,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Added to Wishlist',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -79,9 +82,13 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
+          },
+          timestamp_micros: {
+            '@path': '$.timestamp'
           },
           engagement_time_msec: 2,
           items: [
@@ -124,7 +131,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"add_to_wishlist\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"add_to_wishlist\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
@@ -344,5 +344,106 @@ describe('GA4', () => {
         expect(e.message).toBe('One of item-level currency or top-level currency is required.')
       }
     })
+
+    it('should throw an error when param value is null', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Product Added to Wishlist',
+        userId: 'abc123',
+        type: 'track',
+        properties: {
+          products: [
+            {
+              product_id: '123456',
+              currency: 'USD'
+            }
+          ]
+        }
+      })
+      try {
+        await testDestination.testAction('addToWishlist', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.userId'
+            },
+            items: [
+              {
+                item_id: {
+                  '@path': '$.properties.products.0.product_id'
+                },
+                currency: {
+                  '@path': '$.properties.products.0.currency'
+                }
+              }
+            ],
+            params: {
+              test_key: null
+            }
+          },
+          useDefaultMappings: false
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+        )
+      }
+    })
+
+    it('should throw an error when user_properties value is an array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Added to Wishlist',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('addToWishlist', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            user_properties: {
+              hello: ['World', 'world'],
+              a: '1',
+              b: '2',
+              c: '3'
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+        )
+      }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
@@ -414,5 +414,141 @@ describe('GA4', () => {
         `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"begin_checkout\\",\\"params\\":{\\"coupon\\":\\"hasbros\\",\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"price\\":19,\\"quantity\\":1}],\\"value\\":30,\\"engagement_time_msec\\":1}}]}"`
       )
     })
+
+    it('should throw an error when param value is null', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+      const event = createTestEvent({
+        event: 'Checkout Started',
+        userId: '3456fff',
+        type: 'track',
+        properties: {
+          order_id: '5678dd9087-78',
+          coupon: 'SUMMER_FEST',
+          currency: 'USD',
+          products: [
+            {
+              name: 'test',
+              quantity: 2,
+              coupon: 'MOUNTAIN',
+              brand: 'Canvas',
+              category: 'T-Shirt',
+              variant: 'Black',
+              price: 19.98
+            }
+          ]
+        }
+      })
+      try {
+        await testDestination.testAction('beginCheckout', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            currency: {
+              '@path': '$.properties.currency'
+            },
+            value: {
+              '@path': '$.properties.value'
+            },
+            items: [
+              {
+                item_brand: {
+                  '@path': `$.properties.brand`
+                },
+                item_name: {
+                  '@path': '$.properties.products.0.name'
+                }
+              }
+            ],
+            params: {
+              test_key: null
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+        )
+      }
+    })
+
+    it('should throw an error when user_properties value is array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Checkout Started',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1,
+          products: [
+            {
+              product_id: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'Monopoly: 3rd Edition',
+              price: 19,
+              quantity: 1,
+              category: 'Games',
+              url: 'https://www.example.com/product/path',
+              image_url: 'https://www.example.com/product/path.jpg'
+            }
+          ]
+        }
+      })
+      try {
+        await testDestination.testAction('beginCheckout', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            user_properties: {
+              hello: ['World', 'world'],
+              a: '1',
+              b: '2',
+              c: '3'
+            },
+            items: [
+              {
+                item_name: {
+                  '@path': `$.properties.products.0.name`
+                },
+                item_category: {
+                  '@path': `$.properties.products.0.category`
+                }
+              }
+            ]
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+        )
+      }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Checkout Started',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -44,6 +45,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -69,7 +71,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"begin_checkout\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\"}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"begin_checkout\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\"}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -359,6 +361,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Checkout Started',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -391,6 +394,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -411,7 +415,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"begin_checkout\\",\\"params\\":{\\"coupon\\":\\"hasbros\\",\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"price\\":19,\\"quantity\\":1}],\\"value\\":30,\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"begin_checkout\\",\\"params\\":{\\"coupon\\":\\"hasbros\\",\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"price\\":19,\\"quantity\\":1}],\\"value\\":30,\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Some Event Here',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -32,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -47,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"Some_Event_Here\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"Some_Event_Here\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -58,6 +60,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Order Completed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -86,6 +89,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           name: 'this_is_a_test'
         },
@@ -109,7 +113,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -120,6 +124,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Order Completed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track'
       })
@@ -129,6 +134,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           name: 'this_is_a_test'
         },
@@ -152,7 +158,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"this_is_a_test\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -224,6 +230,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Order Completed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track'
       })
@@ -233,6 +240,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -253,7 +261,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"Order_Completed\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"Order_Completed\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -265,6 +273,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: '         Order Completed ',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track'
       })
@@ -274,6 +283,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           lowercase: true
         },
@@ -297,7 +307,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"order_completed\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"order_completed\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
@@ -300,5 +300,96 @@ describe('GA4', () => {
         `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"order_completed\\",\\"params\\":{\\"engagement_time_msec\\":1}}]}"`
       )
     })
+
+    it('should throw an error when param value is null', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Some Event Here',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('customEvent', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            params: {
+              test_key: null
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+        )
+      }
+    })
+
+    it('should throw an error when user_properties value is array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Some Event Here',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('customEvent', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            user_properties: {
+              hello: ['World', 'world'],
+              a: '1',
+              b: '2',
+              c: '3'
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+        )
+      }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
@@ -240,5 +240,93 @@ describe('GA4', () => {
         `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"generate_lead\\",\\"params\\":{}}]}"`
       )
     })
+
+    it('should throw an error when param value is null', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Generate Lead',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('generateLead', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            params: {
+              test_key: null
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+        )
+      }
+    })
+
+    it('should throw an error when user_properties value is array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Generate Lead',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('generateLead', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            user_properties: {
+              hello: ['World', 'world']
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+        )
+      }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Generate Lead',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -32,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -47,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"generate_lead\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"generate_lead\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -59,6 +61,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Lead Generated',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         type: 'track',
         properties: {
           currency: 'USD',
@@ -71,9 +74,13 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.userId'
+          },
+          timestamp_micros: {
+            '@path': '$.timestamp'
           },
           engagement_time_msec: 2,
           currency: {
@@ -102,7 +109,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"generate_lead\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"value\\":300,\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"generate_lead\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"value\\":300,\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Login',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -32,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -47,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"login\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"login\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -60,6 +62,7 @@ describe('GA4', () => {
         event: 'Signed In',
         userId: 'abc123',
         type: 'track',
+        timestamp: '2022-06-22T22:20:58.905Z',
         properties: {
           login_method: 'Okta SSO'
         }
@@ -70,9 +73,13 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.userId'
+          },
+          timestamp_micros: {
+            '@path': '$.timestamp'
           },
           engagement_time_msec: 2,
           method: {
@@ -98,7 +105,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"login\\",\\"params\\":{\\"method\\":\\"Okta SSO\\",\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"login\\",\\"params\\":{\\"method\\":\\"Okta SSO\\",\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
@@ -101,5 +101,96 @@ describe('GA4', () => {
         `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"login\\",\\"params\\":{\\"method\\":\\"Okta SSO\\",\\"engagement_time_msec\\":2}}]}"`
       )
     })
+
+    it('should throw an error when param value is null', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Login',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('login', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            params: {
+              test_key: null
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+        )
+      }
+    })
+
+    it('should throw an error when user_properties value is array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Login',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('login', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            user_properties: {
+              hello: ['World', 'world'],
+              a: '1',
+              b: '2',
+              c: '3'
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+        )
+      }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
@@ -170,5 +170,93 @@ describe('GA4', () => {
         `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"http://www.example.com/home\\",\\"page_referrer\\":\\"https://segment.com/academy/\\",\\"page_title\\":\\"Analytics Academy\\",\\"engagement_time_msec\\":1}}]}"`
       )
     })
+
+    it('should throw an error when param value is null', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Page',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('pageView', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            params: {
+              test_input: null
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+        )
+      }
+    })
+
+    it('should throw an error when user_properties value is array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Page',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('pageView', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            user_properties: {
+              hello: ['World', 'world']
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+        )
+      }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Page',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -32,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -47,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"https://segment.com/academy/\\",\\"page_title\\":\\"Analytics Academy\\",\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"https://segment.com/academy/\\",\\"page_title\\":\\"Analytics Academy\\",\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -58,6 +60,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Page View',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -81,6 +84,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -113,7 +117,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"http://www.example.com/pageOne\\",\\"page_referrer\\":\\"https://segment.com/academy/\\",\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"http://www.example.com/pageOne\\",\\"page_referrer\\":\\"https://segment.com/academy/\\",\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -124,6 +128,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Page View',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -147,6 +152,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -167,7 +173,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"http://www.example.com/home\\",\\"page_referrer\\":\\"https://segment.com/academy/\\",\\"page_title\\":\\"Analytics Academy\\",\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"page_view\\",\\"params\\":{\\"page_location\\":\\"http://www.example.com/home\\",\\"page_referrer\\":\\"https://segment.com/academy/\\",\\"page_title\\":\\"Analytics Academy\\",\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Order Completed',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -48,6 +49,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           transaction_id: {
             '@path': '$.properties.order_number'
@@ -94,7 +96,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"purchase\\",\\"params\\":{\\"affiliation\\":\\"TI Online Store\\",\\"coupon\\":\\"SUMMER_FEST\\",\\"currency\\":\\"EUR\\",\\"items\\":[{\\"item_name\\":\\"Tour t-shirt\\",\\"item_id\\":\\"pid-123456\\",\\"quantity\\":2,\\"coupon\\":\\"MOUNTAIN\\",\\"item_brand\\":\\"Canvas\\",\\"item_category\\":\\"T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"price\\":19.98}],\\"transaction_id\\":\\"5678dd9087-78\\",\\"shipping\\":1.5,\\"value\\":24.48,\\"tax\\":3,\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"purchase\\",\\"params\\":{\\"affiliation\\":\\"TI Online Store\\",\\"coupon\\":\\"SUMMER_FEST\\",\\"currency\\":\\"EUR\\",\\"items\\":[{\\"item_name\\":\\"Tour t-shirt\\",\\"item_id\\":\\"pid-123456\\",\\"quantity\\":2,\\"coupon\\":\\"MOUNTAIN\\",\\"item_brand\\":\\"Canvas\\",\\"item_category\\":\\"T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"price\\":19.98}],\\"transaction_id\\":\\"5678dd9087-78\\",\\"shipping\\":1.5,\\"value\\":24.48,\\"tax\\":3,\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -463,6 +465,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Order Completed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -495,6 +498,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -515,7 +519,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"purchase\\",\\"params\\":{\\"affiliation\\":\\"TI Online Store\\",\\"coupon\\":\\"SUMMER_FEST\\",\\"currency\\":\\"EUR\\",\\"items\\":[{\\"item_id\\":\\"pid-123456\\",\\"item_name\\":\\"Tour t-shirt\\",\\"coupon\\":\\"MOUNTAIN\\",\\"item_brand\\":\\"Canvas\\",\\"item_category\\":\\"T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"price\\":19.98,\\"quantity\\":2}],\\"transaction_id\\":\\"5678dd9087-78\\",\\"shipping\\":1.5,\\"value\\":24.48,\\"tax\\":3,\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"purchase\\",\\"params\\":{\\"affiliation\\":\\"TI Online Store\\",\\"coupon\\":\\"SUMMER_FEST\\",\\"currency\\":\\"EUR\\",\\"items\\":[{\\"item_id\\":\\"pid-123456\\",\\"item_name\\":\\"Tour t-shirt\\",\\"coupon\\":\\"MOUNTAIN\\",\\"item_brand\\":\\"Canvas\\",\\"item_category\\":\\"T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"price\\":19.98,\\"quantity\\":2}],\\"transaction_id\\":\\"5678dd9087-78\\",\\"shipping\\":1.5,\\"value\\":24.48,\\"tax\\":3,\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
@@ -518,5 +518,190 @@ describe('GA4', () => {
         `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"purchase\\",\\"params\\":{\\"affiliation\\":\\"TI Online Store\\",\\"coupon\\":\\"SUMMER_FEST\\",\\"currency\\":\\"EUR\\",\\"items\\":[{\\"item_id\\":\\"pid-123456\\",\\"item_name\\":\\"Tour t-shirt\\",\\"coupon\\":\\"MOUNTAIN\\",\\"item_brand\\":\\"Canvas\\",\\"item_category\\":\\"T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"price\\":19.98,\\"quantity\\":2}],\\"transaction_id\\":\\"5678dd9087-78\\",\\"shipping\\":1.5,\\"value\\":24.48,\\"tax\\":3,\\"engagement_time_msec\\":1}}]}"`
       )
     })
+
+    it('should throw an error when param value is null', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Order Completed',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          affiliation: 'TI Online Store',
+          order_number: '5678dd9087-78',
+          coupon: 'SUMMER_FEST',
+          currency: 'EUR',
+          products: [
+            {
+              product_id: 'pid-123456',
+              sku: 'SKU-123456',
+              name: 'Tour t-shirt',
+              quantity: 2,
+              coupon: 'MOUNTAIN',
+              brand: 'Canvas',
+              category: 'T-Shirt',
+              variant: 'Black',
+              price: 19.98
+            }
+          ],
+          revenue: 5.99,
+          shipping: 1.5,
+          tax: 3.0,
+          total: 24.48
+        }
+      })
+      try {
+        await testDestination.testAction('purchase', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            transaction_id: {
+              '@path': '$.properties.order_number'
+            },
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            params: {
+              test_value: null
+            },
+            items: [
+              {
+                item_name: {
+                  '@path': `$.properties.products.0.name`
+                },
+                item_id: {
+                  '@path': `$.properties.products.0.product_id`
+                },
+                quantity: {
+                  '@path': `$.properties.products.0.quantity`
+                },
+                coupon: {
+                  '@path': `$.properties.products.0.coupon`
+                },
+                item_brand: {
+                  '@path': `$.properties.products.0.brand`
+                },
+                item_category: {
+                  '@path': `$.properties.products.0.category`
+                },
+                item_variant: {
+                  '@path': `$.properties.products.0.variant`
+                },
+                price: {
+                  '@path': `$.properties.products.0.price`
+                }
+              }
+            ]
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+        )
+      }
+    })
+
+    it('should throw an error when user_properties value is array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Order Completed',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          affiliation: 'TI Online Store',
+          order_number: '5678dd9087-78',
+          coupon: 'SUMMER_FEST',
+          currency: 'EUR',
+          products: [
+            {
+              product_id: 'pid-123456',
+              sku: 'SKU-123456',
+              name: 'Tour t-shirt',
+              quantity: 2,
+              coupon: 'MOUNTAIN',
+              brand: 'Canvas',
+              category: 'T-Shirt',
+              variant: 'Black',
+              price: 19.98
+            }
+          ],
+          revenue: 5.99,
+          shipping: 1.5,
+          tax: 3.0,
+          total: 24.48
+        }
+      })
+      try {
+        await testDestination.testAction('purchase', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            transaction_id: {
+              '@path': '$.properties.order_number'
+            },
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            user_properties: {
+              hello: ['World', 'world'],
+              a: '1',
+              b: '2',
+              c: '3'
+            },
+            items: [
+              {
+                item_name: {
+                  '@path': `$.properties.products.0.name`
+                },
+                item_id: {
+                  '@path': `$.properties.products.0.product_id`
+                },
+                quantity: {
+                  '@path': `$.properties.products.0.quantity`
+                },
+                coupon: {
+                  '@path': `$.properties.products.0.coupon`
+                },
+                item_brand: {
+                  '@path': `$.properties.products.0.brand`
+                },
+                item_category: {
+                  '@path': `$.properties.products.0.category`
+                },
+                item_variant: {
+                  '@path': `$.properties.products.0.variant`
+                },
+                price: {
+                  '@path': `$.properties.products.0.price`
+                }
+              }
+            ]
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+        )
+      }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Order Refunded',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -32,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           transaction_id: {
             '@path': '$.properties.order_number'
@@ -50,7 +52,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"transaction_id\\":\\"12345abcde\\",\\"items\\":[],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"transaction_id\\":\\"12345abcde\\",\\"items\\":[],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -143,6 +145,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Order Refunded',
         userId: '1234abc',
+        timestamp: '2022-06-22T22:20:58.905Z',
         type: 'track',
         properties: {
           currency: 'USD',
@@ -164,6 +167,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           currency: {
             '@path': '$.properties.currency'
@@ -205,7 +209,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"1234abc\\",\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"transaction_id\\":\\"c1209123\\",\\"value\\":10,\\"coupon\\":\\"SUMMER_FUN\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"12345\\"}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"1234abc\\",\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"transaction_id\\":\\"c1209123\\",\\"value\\":10,\\"coupon\\":\\"SUMMER_FUN\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"12345\\"}],\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -217,6 +221,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Order Refunded',
         userId: '1234abc',
+        timestamp: '2022-06-22T22:20:58.905Z',
         type: 'track',
         properties: {
           currency: 'usd',
@@ -238,6 +243,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           currency: {
             '@path': '$.properties.currency'
@@ -279,7 +285,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"1234abc\\",\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"transaction_id\\":\\"c1209123\\",\\"value\\":10,\\"coupon\\":\\"SUMMER_FUN\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"12345\\"}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"1234abc\\",\\"events\\":[{\\"name\\":\\"refund\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"transaction_id\\":\\"c1209123\\",\\"value\\":10,\\"coupon\\":\\"SUMMER_FUN\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"12345\\"}],\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
@@ -429,5 +429,102 @@ describe('GA4', () => {
         expect(e.message).toBe('One of item-level currency or top-level currency is required.')
       }
     })
+
+    it('should throw an error when params value is null', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Order Refunded',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          order_number: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('refund', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            transaction_id: {
+              '@path': '$.properties.order_number'
+            },
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            params: {
+              test_value: null
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+        )
+      }
+    })
+
+    it('should throw an error when user_properties value is array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Order Refunded',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          order_number: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('refund', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            transaction_id: {
+              '@path': '$.properties.order_number'
+            },
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            user_properties: {
+              hello: ['World', 'world'],
+              a: '1',
+              b: '2',
+              c: '3'
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+        )
+      }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
@@ -344,5 +344,96 @@ describe('GA4', () => {
         expect(e.message).toBe('One of item-level currency or top-level currency is required.')
       }
     })
+
+    it('should throw an error when params value is null', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Product Removed',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('removeFromCart', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            params: {
+              test_value: null
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+        )
+      }
+    })
+
+    it('should throw an error when user_properties value is array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Product Removed',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('removeFromCart', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            user_properties: {
+              hello: ['World', 'world'],
+              a: '1',
+              b: '2',
+              c: '3'
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+        )
+      }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Removed',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -32,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -47,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"remove_from_cart\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"remove_from_cart\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
@@ -102,5 +102,98 @@ describe('GA4', () => {
         expect(e.message).toBe("The root value is missing the required field 'search_term'.")
       }
     })
+
+    it('should throw an error when param value is null', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Search',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          query: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('search', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            engagement_time_msec: 2,
+            params: {
+              test_value: null
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+        )
+      }
+    })
+
+    it('should throw an error when user_properties value is array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Search',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          query: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('search', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            engagement_time_msec: 2,
+            user_properties: {
+              hello: ['World', 'world'],
+              a: '1',
+              b: '2',
+              c: '3'
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+        )
+      }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Search',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -32,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -48,7 +50,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"search\\",\\"params\\":{\\"search_term\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"engagement_time_msec\\":2}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"search\\",\\"params\\":{\\"search_term\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"engagement_time_msec\\":2}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -60,6 +62,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Products Searched',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         type: 'track',
         properties: {
           query: 'milk and cookies'
@@ -71,11 +74,16 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"search\\",\\"params\\":{\\"search_term\\":\\"milk and cookies\\",\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
+      )
     })
 
     //event without query term event

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Select Item',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -32,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -47,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -58,6 +60,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Clicked',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -81,6 +84,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -138,7 +142,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"index\\":3,\\"item_brand\\":\\"Hasbro\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"index\\":3,\\"item_brand\\":\\"Hasbro\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -149,6 +153,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Clicked',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -173,6 +178,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -233,7 +239,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"index\\":3,\\"item_brand\\":\\"Hasbro\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"currency\\":\\"usd\\"}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"index\\":3,\\"item_brand\\":\\"Hasbro\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"currency\\":\\"usd\\"}],\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -244,6 +250,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Clicked',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -267,6 +274,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -287,7 +295,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"5678fkj9087\\",\\"item_name\\":\\"Limited Edition T\\",\\"coupon\\":\\"SummerFest\\",\\"item_brand\\":\\"yeezy\\",\\"item_category\\":\\"Clothing\\",\\"item_variant\\":\\"Black\\",\\"price\\":8.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"select_item\\",\\"params\\":{\\"items\\":[{\\"item_id\\":\\"5678fkj9087\\",\\"item_name\\":\\"Limited Edition T\\",\\"coupon\\":\\"SummerFest\\",\\"item_brand\\":\\"yeezy\\",\\"item_category\\":\\"Clothing\\",\\"item_variant\\":\\"Black\\",\\"price\\":8.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
@@ -341,5 +341,96 @@ describe('GA4', () => {
         expect(e.message).toBe('One of product name or product id is required for product or impression data.')
       }
     })
+
+    it('should throw an error when params value is null', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Select Item',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('selectItem', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            params: {
+              test_value: null
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+        )
+      }
+    })
+
+    it('should throw an error when user_properties value is array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Select Item',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('selectItem', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            user_properties: {
+              hello: ['World', 'world'],
+              a: '1',
+              b: '2',
+              c: '3'
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+        )
+      }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Select Promotion',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -32,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -55,7 +57,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"promotion_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"promotion_name\\":\\"Quadruple Stack Oreos, 52 ct\\"}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"promotion_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"promotion_name\\":\\"Quadruple Stack Oreos, 52 ct\\"}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -66,6 +68,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Promotion Clicked',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -82,6 +85,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -119,7 +123,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_id\\":\\"abc\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\"}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_id\\":\\"abc\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\"}],\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -130,6 +134,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Promotion Clicked',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -165,6 +170,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -208,7 +214,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"creative_name\\":\\"top_banner_2\\",\\"creative_slot\\":\\"2\\",\\"location_id\\":\\"home\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_id\\":\\"SKU_12345\\",\\"item_name\\":\\"jeggings\\",\\"coupon\\":\\"SUMMER_FUN\\",\\"discount\\":2.22,\\"promotion_id\\":\\"P_12345\\",\\"promotion_name\\":\\"Summer Sale\\",\\"creative_slot\\":\\"featured_app_1\\",\\"location_id\\":\\"L_12345\\",\\"affiliation\\":\\"Google Store\\",\\"item_brand\\":\\"Gucci\\",\\"item_category\\":\\"pants\\",\\"item_variant\\":\\"Black\\",\\"price\\":9.99,\\"currency\\":\\"USD\\"}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"creative_name\\":\\"top_banner_2\\",\\"creative_slot\\":\\"2\\",\\"location_id\\":\\"home\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_id\\":\\"SKU_12345\\",\\"item_name\\":\\"jeggings\\",\\"coupon\\":\\"SUMMER_FUN\\",\\"discount\\":2.22,\\"promotion_id\\":\\"P_12345\\",\\"promotion_name\\":\\"Summer Sale\\",\\"creative_slot\\":\\"featured_app_1\\",\\"location_id\\":\\"L_12345\\",\\"affiliation\\":\\"Google Store\\",\\"item_brand\\":\\"Gucci\\",\\"item_category\\":\\"pants\\",\\"item_variant\\":\\"Black\\",\\"price\\":9.99,\\"currency\\":\\"USD\\"}],\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -219,6 +225,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Promotion Clicked',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -254,6 +261,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -297,7 +305,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"creative_name\\":\\"top_banner_2\\",\\"creative_slot\\":\\"2\\",\\"location_id\\":\\"home\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_id\\":\\"SKU_12345\\",\\"item_name\\":\\"jeggings\\",\\"coupon\\":\\"SUMMER_FUN\\",\\"discount\\":2.22,\\"promotion_id\\":\\"P_12345\\",\\"promotion_name\\":\\"Summer Sale\\",\\"creative_slot\\":\\"featured_app_1\\",\\"location_id\\":\\"L_12345\\",\\"affiliation\\":\\"Google Store\\",\\"item_brand\\":\\"Gucci\\",\\"item_category\\":\\"pants\\",\\"item_variant\\":\\"Black\\",\\"price\\":9.99,\\"currency\\":\\"usd\\"}],\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"select_promotion\\",\\"params\\":{\\"creative_name\\":\\"top_banner_2\\",\\"creative_slot\\":\\"2\\",\\"location_id\\":\\"home\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_id\\":\\"SKU_12345\\",\\"item_name\\":\\"jeggings\\",\\"coupon\\":\\"SUMMER_FUN\\",\\"discount\\":2.22,\\"promotion_id\\":\\"P_12345\\",\\"promotion_name\\":\\"Summer Sale\\",\\"creative_slot\\":\\"featured_app_1\\",\\"location_id\\":\\"L_12345\\",\\"affiliation\\":\\"Google Store\\",\\"item_brand\\":\\"Gucci\\",\\"item_category\\":\\"pants\\",\\"item_variant\\":\\"Black\\",\\"price\\":9.99,\\"currency\\":\\"usd\\"}],\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
@@ -479,5 +479,112 @@ describe('GA4', () => {
         expect(e.message).toBe('US4D is not a valid currency code.')
       }
     })
+
+    it('should throw an error when params value is null', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Select Promotion',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('selectPromotion', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            params: {
+              test_value: null
+            },
+            items: {
+              item_id: {
+                '@path': '$.properties.id'
+              },
+              promotion_name: {
+                '@path': '$.properties.name'
+              }
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+        )
+      }
+    })
+
+    it('should throw an error when user_properties value is array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Select Promotion',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('selectPromotion', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            user_properties: {
+              hello: ['World', 'world'],
+              a: '1',
+              b: '2',
+              c: '3'
+            },
+            items: {
+              item_id: {
+                '@path': '$.properties.id'
+              },
+              promotion_name: {
+                '@path': '$.properties.name'
+              }
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+        )
+      }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
@@ -144,5 +144,96 @@ describe('GA4', () => {
         `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"sign_up\\",\\"params\\":{\\"method\\":\\"Google\\",\\"engagement_time_msec\\":2}}]}"`
       )
     })
+
+    it('should throw an error when params value is null', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Signup',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('signUp', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            params: {
+              test_value: null
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+        )
+      }
+    })
+
+    it('should throw an error when user_properties value is array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Signup',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('signUp', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            user_properties: {
+              hello: ['World', 'world'],
+              a: '1',
+              b: '2',
+              c: '3'
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+        )
+      }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Signup',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -32,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -47,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"sign_up\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"sign_up\\",\\"params\\":{\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -59,6 +61,7 @@ describe('GA4', () => {
         event: 'Signed Up',
         type: 'track',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         properties: {
           type: 'Google'
         }
@@ -70,6 +73,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -90,7 +94,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"sign_up\\",\\"params\\":{\\"method\\":\\"Google\\",\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"sign_up\\",\\"params\\":{\\"method\\":\\"Google\\",\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
@@ -359,5 +359,126 @@ describe('GA4', () => {
         expect(e.message).toBe('One of item-level currency or top-level currency is required.')
       }
     })
+
+    it('should throw an error when params value is null', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Cart Viewed',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          currency: 'USD',
+          promotion_id: 'promo_1',
+          creative: 'top_banner_2',
+          name: '75% store-wide shoe sale',
+          position: 'home_banner_top',
+          products: [
+            {
+              product_id: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'Monopoly: 3rd Edition',
+              price: 19,
+              quantity: 1,
+              currency: 'USD',
+              category: 'Games',
+              promotion: 'SUPER SUMMER SALE; 3% off',
+              slot: '2',
+              promo_id: '12345',
+              creative_name: 'Sale'
+            }
+          ]
+        }
+      })
+      try {
+        await testDestination.testAction('viewCart', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            params: {
+              test_value: null
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+        )
+      }
+    })
+
+    it('should throw an error when user_properties value is array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Cart Viewed',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          currency: 'USD',
+          promotion_id: 'promo_1',
+          creative: 'top_banner_2',
+          name: '75% store-wide shoe sale',
+          position: 'home_banner_top',
+          products: [
+            {
+              product_id: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'Monopoly: 3rd Edition',
+              price: 19,
+              quantity: 1,
+              currency: 'USD',
+              category: 'Games',
+              promotion: 'SUPER SUMMER SALE; 3% off',
+              slot: '2',
+              promo_id: '12345',
+              creative_name: 'Sale'
+            }
+          ]
+        }
+      })
+      try {
+        await testDestination.testAction('viewCart', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            user_properties: {
+              hello: ['World', 'world'],
+              a: '1',
+              b: '2',
+              c: '3'
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+        )
+      }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Cart Viewed',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -47,6 +48,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -62,7 +64,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"view_cart\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"price\\":19,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"view_cart\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_category\\":\\"Games\\",\\"price\\":19,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -74,6 +76,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Cart Viewed',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -94,9 +97,13 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
+          },
+          timestamp_micros: {
+            '@path': '$.timestamp'
           },
           engagement_time_msec: 2,
           items: [
@@ -139,7 +146,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"view_cart\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"view_cart\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Item Viewed',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -32,6 +33,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -47,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"quantity\\":1,\\"price\\":12.99}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"quantity\\":1,\\"price\\":12.99}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -58,6 +60,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Viewed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -83,6 +86,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -122,7 +126,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"Monopoly: 3rd Edition\\"}],\\"value\\":18.99,\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"anon-567890\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"Monopoly: 3rd Edition\\"}],\\"value\\":18.99,\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -133,6 +137,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Viewed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -158,6 +163,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -178,7 +184,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -189,6 +195,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product Viewed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -214,6 +221,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -234,7 +242,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
@@ -278,5 +278,96 @@ describe('GA4', () => {
         expect(e.message).toBe('1234 is not a valid currency code.')
       }
     })
+
+    it('should throw an error when params value is null', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Item Viewed',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('viewItem', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            params: {
+              test_value: null
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+        )
+      }
+    })
+
+    it('should throw an error when user_properties value is array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Item Viewed',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          product_id: '12345abcde',
+          name: 'Quadruple Stack Oreos, 52 ct',
+          currency: 'USD',
+          price: 12.99,
+          quantity: 1
+        }
+      })
+      try {
+        await testDestination.testAction('viewItem', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            user_properties: {
+              hello: ['World', 'world'],
+              a: '1',
+              b: '2',
+              c: '3'
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+        )
+      }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
@@ -16,6 +16,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Product List Viewed',
         userId: 'abc123',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-2134',
         type: 'track',
         properties: {
@@ -36,9 +37,13 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
+          },
+          timestamp_micros: {
+            '@path': '$.timestamp'
           },
           engagement_time_msec: 2,
           user_properties: {
@@ -73,7 +78,7 @@ describe('GA4', () => {
       expect(responses[0].status).toBe(201)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"view_item_list\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":2}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"view_item_list\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":2}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
@@ -15,6 +15,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Promotion Viewed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -44,9 +45,13 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
+          },
+          timestamp_micros: {
+            '@path': '$.timestamp'
           },
           engagement_time_msec: 2,
           location_id: {
@@ -95,7 +100,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"promotion_name\\":\\"SUPER SUMMER SALE; 3% off\\",\\"creative_slot\\":\\"2\\",\\"promotion_id\\":\\"12345\\",\\"creative_name\\":\\"Sale\\"}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"promotion_name\\":\\"SUPER SUMMER SALE; 3% off\\",\\"creative_slot\\":\\"2\\",\\"promotion_id\\":\\"12345\\",\\"creative_name\\":\\"Sale\\"}],\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -106,6 +111,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Promotion Viewed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -136,6 +142,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -190,7 +197,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"promotion_name\\":\\"SUPER SUMMER SALE; 3% off\\",\\"creative_slot\\":\\"2\\",\\"promotion_id\\":\\"12345\\",\\"creative_name\\":\\"Sale\\",\\"currency\\":\\"usd\\"}],\\"engagement_time_msec\\":2}}]}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"promotion_name\\":\\"SUPER SUMMER SALE; 3% off\\",\\"creative_slot\\":\\"2\\",\\"promotion_id\\":\\"12345\\",\\"creative_name\\":\\"Sale\\",\\"currency\\":\\"usd\\"}],\\"engagement_time_msec\\":2}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -353,6 +360,7 @@ describe('GA4', () => {
       const event = createTestEvent({
         event: 'Promotion Viewed',
         userId: '3456fff',
+        timestamp: '2022-06-22T22:20:58.905Z',
         anonymousId: 'anon-567890',
         type: 'track',
         properties: {
@@ -383,6 +391,7 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
+        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           user_properties: {
             hello: 'world',
@@ -423,7 +432,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"promotion_name\\":\\"SUPER SUMMER SALE; 3% off\\",\\"creative_slot\\":\\"2\\",\\"promotion_id\\":\\"12345\\",\\"creative_name\\":\\"Sale\\"}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"promotion_name\\":\\"SUPER SUMMER SALE; 3% off\\",\\"creative_slot\\":\\"2\\",\\"promotion_id\\":\\"12345\\",\\"creative_name\\":\\"Sale\\"}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
@@ -426,5 +426,172 @@ describe('GA4', () => {
         `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_promotion\\",\\"params\\":{\\"creative_slot\\":\\"top_banner_2\\",\\"location_id\\":\\"promo_1\\",\\"promotion_id\\":\\"promo_1\\",\\"promotion_name\\":\\"75% store-wide shoe sale\\",\\"items\\":[{\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"promotion_name\\":\\"SUPER SUMMER SALE; 3% off\\",\\"creative_slot\\":\\"2\\",\\"promotion_id\\":\\"12345\\",\\"creative_name\\":\\"Sale\\"}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}}}"`
       )
     })
+
+    it('should throw an error when params value is null', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+      const event = createTestEvent({
+        event: 'Promotion Viewed',
+        userId: '3456fff',
+        anonymousId: 'anon-567890',
+        type: 'track',
+        properties: {
+          promotion_id: 'promo_1',
+          creative: 'top_banner_2',
+          name: '75% store-wide shoe sale',
+          position: 'home_banner_top',
+          products: [
+            {
+              product_id: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'Monopoly: 3rd Edition',
+              price: 19,
+              quantity: 1,
+              category: 'Games',
+              promotion: 'SUPER SUMMER SALE; 3% off',
+              slot: '2',
+              promo_id: '12345',
+              creative_name: 'Sale'
+            }
+          ]
+        }
+      })
+
+      try {
+        await testDestination.testAction('viewPromotion', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            params: {
+              test_value: null
+            },
+            clientId: {
+              '@path': '$.anonymousId'
+            },
+            location_id: {
+              '@path': '$.properties.promotion_id'
+            },
+            items: [
+              {
+                item_name: {
+                  '@path': `$.properties.products.0.name`
+                },
+                item_id: {
+                  '@path': `$.properties.products.0.product_id`
+                },
+                promotion_name: {
+                  '@path': `$.properties.products.0.promotion`
+                },
+                creative_slot: {
+                  '@path': `$.properties.products.0.slot`
+                },
+                promotion_id: {
+                  '@path': `$.properties.products.0.promo_id`
+                },
+                creative_name: {
+                  '@path': `$.properties.products.0.creative_name`
+                }
+              }
+            ]
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+        )
+      }
+    })
+
+    it('should throw an error when user_properties value is array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+      const event = createTestEvent({
+        event: 'Promotion Viewed',
+        userId: '3456fff',
+        anonymousId: 'anon-567890',
+        type: 'track',
+        properties: {
+          promotion_id: 'promo_1',
+          creative: 'top_banner_2',
+          name: '75% store-wide shoe sale',
+          position: 'home_banner_top',
+          products: [
+            {
+              product_id: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'Monopoly: 3rd Edition',
+              price: 19,
+              quantity: 1,
+              category: 'Games',
+              promotion: 'SUPER SUMMER SALE; 3% off',
+              slot: '2',
+              promo_id: '12345',
+              creative_name: 'Sale'
+            }
+          ]
+        }
+      })
+
+      try {
+        await testDestination.testAction('viewPromotion', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            user_properties: {
+              hello: ['World', 'world'],
+              a: '1',
+              b: '2',
+              c: '3'
+            },
+            clientId: {
+              '@path': '$.anonymousId'
+            },
+            location_id: {
+              '@path': '$.properties.promotion_id'
+            },
+            items: [
+              {
+                item_name: {
+                  '@path': `$.properties.products.0.name`
+                },
+                item_id: {
+                  '@path': `$.properties.products.0.product_id`
+                },
+                promotion_name: {
+                  '@path': `$.properties.products.0.promotion`
+                },
+                creative_slot: {
+                  '@path': `$.properties.products.0.slot`
+                },
+                promotion_id: {
+                  '@path': `$.properties.products.0.promo_id`
+                },
+                creative_name: {
+                  '@path': `$.properties.products.0.creative_name`
+                }
+              }
+            ]
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+        )
+      }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.
    */
   timestamp_micros?: string
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
@@ -96,7 +96,8 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyUserProps(payload.user_properties)
     }
 
-    let request_object = {
+    let request_object: { [key: string]: any } = {}
+    request_object = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [
@@ -117,7 +118,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
@@ -96,8 +96,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyUserProps(payload.user_properties)
     }
 
-    let request_object: { [key: string]: any } = {}
-    request_object = {
+    const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [

--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
@@ -2,7 +2,7 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps, convertTimestamp } from '../ga4-functions'
 import {
   user_id,
   formatUserProperties,
@@ -14,6 +14,7 @@ import {
   payment_type,
   items_multi_products,
   engagement_time_msec,
+  timestamp_micros,
   params
 } from '../ga4-properties'
 
@@ -24,6 +25,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     currency: { ...currency },
     value: { ...value },
     coupon: { ...coupon },
@@ -94,27 +96,33 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyUserProps(payload.user_properties)
     }
 
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'add_payment_info',
+          params: {
+            currency: payload.currency,
+            value: payload.value,
+            coupon: payload.coupon,
+            payment_type: payload.payment_type,
+            items: googleItems,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        events: [
-          {
-            name: 'add_payment_info',
-            params: {
-              currency: payload.currency,
-              value: payload.value,
-              coupon: payload.coupon,
-              payment_type: payload.payment_type,
-              items: googleItems,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.
    */
   timestamp_micros?: string
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
@@ -64,8 +64,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyUserProps(payload.user_properties)
     }
 
-    let request_object: { [key: string]: any } = {}
-    request_object = {
+    const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
@@ -2,7 +2,7 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { ProductItem } from '../ga4-types'
-import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -12,7 +12,8 @@ import {
   client_id,
   items_single_products,
   user_id,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -22,6 +23,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     currency: { ...currency },
     items: {
       ...items_single_products,
@@ -62,25 +64,31 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyUserProps(payload.user_properties)
     }
 
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'add_to_cart',
+          params: {
+            currency: payload.currency,
+            items: googleItems,
+            value: payload.value,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        events: [
-          {
-            name: 'add_to_cart',
-            params: {
-              currency: payload.currency,
-              items: googleItems,
-              value: payload.value,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
@@ -2,7 +2,7 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { ProductItem } from '../ga4-types'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -32,7 +32,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     let googleItems: ProductItem[] = []
 
     if (payload.currency) {
@@ -55,6 +55,11 @@ const action: ActionDefinition<Settings, Payload> = {
 
         return product as ProductItem
       })
+    }
+
+    if (features && features['actions-google-analytics-4-verify-params-feature']) {
+      verifyParams(payload.params)
+      verifyUserProps(payload.user_properties)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
@@ -64,7 +64,8 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyUserProps(payload.user_properties)
     }
 
-    let request_object = {
+    let request_object: { [key: string]: any } = {}
+    request_object = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [
@@ -83,7 +84,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.
    */
   timestamp_micros?: string
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
@@ -80,7 +80,8 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object = {
+    let request_object: { [key: string]: any } = {}
+    request_object = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [
@@ -99,7 +100,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
@@ -2,7 +2,7 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -32,7 +32,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     if (payload.currency) {
       verifyCurrency(payload.currency)
     }
@@ -72,6 +72,11 @@ const action: ActionDefinition<Settings, Payload> = {
 
         return product as ProductItem
       })
+    }
+
+    if (features && features['actions-google-analytics-4-verify-params-feature']) {
+      verifyParams(payload.params)
+      verifyUserProps(payload.user_properties)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
@@ -80,8 +80,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object: { [key: string]: any } = {}
-    request_object = {
+    const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
@@ -2,7 +2,7 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -12,7 +12,8 @@ import {
   client_id,
   items_single_products,
   user_id,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -22,6 +23,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     currency: { ...currency },
     value: { ...value },
     items: {
@@ -78,26 +80,31 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'add_to_wishlist',
+          params: {
+            currency: payload.currency,
+            value: payload.value,
+            items: googleItems,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        events: [
-          {
-            name: 'add_to_wishlist',
-            params: {
-              currency: payload.currency,
-              value: payload.value,
-              items: googleItems,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.
    */
   timestamp_micros?: string
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Coupon code used for a purchase.
    */
   coupon?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
@@ -68,8 +68,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyUserProps(payload.user_properties)
     }
 
-    let request_object: { [key: string]: any } = {}
-    request_object = {
+    const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [

--- a/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -36,7 +36,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     if (payload.currency) {
       verifyCurrency(payload.currency)
     }
@@ -59,6 +59,11 @@ const action: ActionDefinition<Settings, Payload> = {
 
         return product as ProductItem
       })
+    }
+
+    if (features && features['actions-google-analytics-4-verify-params-feature']) {
+      verifyParams(payload.params)
+      verifyUserProps(payload.user_properties)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
@@ -68,7 +68,8 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyUserProps(payload.user_properties)
     }
 
-    let request_object = {
+    let request_object: { [key: string]: any } = {}
+    request_object = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [
@@ -88,7 +89,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * The unique name of the custom event created in GA4. GA4 does not accept spaces in event names so Segment will replace any spaces with underscores. More information about GA4 event name rules is available in [their docs](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article).
    */
   name: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.
    */
   timestamp_micros?: string
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
@@ -60,7 +60,8 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyUserProps(payload.user_properties)
     }
 
-    let request_object = {
+    let request_object: { [key: string]: any } = {}
+    request_object = {
       client_id: payload.clientId,
       user_id: payload.user_id,
       events: [
@@ -76,7 +77,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
@@ -1,6 +1,8 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+import { verifyParams, verifyUserProps } from '../ga4-functions'
+
 import {
   formatUserProperties,
   user_properties,
@@ -48,8 +50,14 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: { ...params }
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     const event_name = normalizeEventName(payload.name, payload.lowercase)
+
+    if (features && features['actions-google-analytics-4-verify-params-feature']) {
+      verifyParams(payload.params)
+      verifyUserProps(payload.user_properties)
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
@@ -60,8 +60,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyUserProps(payload.user_properties)
     }
 
-    let request_object: { [key: string]: any } = {}
-    request_object = {
+    const request_object: { [key: string]: any } = {
       client_id: payload.clientId,
       user_id: payload.user_id,
       events: [

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyParams, verifyUserProps } from '../ga4-functions'
+import { verifyParams, verifyUserProps, convertTimestamp } from '../ga4-functions'
 
 import {
   formatUserProperties,
@@ -9,7 +9,8 @@ import {
   params,
   client_id,
   user_id,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 
 const normalizeEventName = (name: string, lowercase: boolean | undefined): string => {
@@ -29,6 +30,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     clientId: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     name: {
       label: 'Event Name',
       description:
@@ -58,22 +60,28 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyUserProps(payload.user_properties)
     }
 
+    let request_object = {
+      client_id: payload.clientId,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: event_name,
+          params: {
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.clientId,
-        user_id: payload.user_id,
-        events: [
-          {
-            name: event_name,
-            params: {
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
@@ -14,7 +14,7 @@ export function verifyParams(params: object | undefined): void {
     return
   }
 
-  Object.entries(params).forEach(([_, value]) => {
+  Object.values(params).forEach((value) => {
     if (typeof value != 'string' && typeof value != 'number') {
       throw new IntegrationError(
         'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.',
@@ -30,7 +30,7 @@ export function verifyUserProps(userProperties: object | undefined): void {
     return
   }
 
-  Object.entries(userProperties).forEach(([_, value]) => {
+  Object.values(userProperties).forEach((value) => {
     if (typeof value != 'string' && typeof value != 'number' && value != null) {
       throw new IntegrationError(
         'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.',

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
@@ -7,3 +7,36 @@ export function verifyCurrency(currency: string): void {
     throw new IntegrationError(`${currency} is not a valid currency code.`, 'Incorrect value format', 400)
   }
 }
+
+// Ensure the values in params match Googles expectations
+export function verifyParams(params: object | undefined): void {
+  if (!params) {
+    return
+  }
+
+  Object.entries(params).forEach(([_, value]) => {
+    if (typeof value != 'string' && typeof value != 'number') {
+      throw new IntegrationError(
+        'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.',
+        'Invalid value',
+        400
+      )
+    }
+  })
+}
+
+export function verifyUserProps(userProperties: object | undefined): void {
+  if (!userProperties) {
+    return
+  }
+
+  Object.entries(userProperties).forEach(([_, value]) => {
+    if (typeof value != 'string' && typeof value != 'number' && value != null) {
+      throw new IntegrationError(
+        'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.',
+        'Invalid value',
+        400
+      )
+    }
+  })
+}

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
@@ -40,3 +40,18 @@ export function verifyUserProps(userProperties: object | undefined): void {
     }
   })
 }
+
+// Google expects timestamps to be in Unix microseconds
+export function convertTimestamp(timestamp: string | undefined): number | undefined {
+  if (!timestamp) {
+    return undefined
+  }
+
+  // verify that timestamp is not already in unix
+  if (!isNaN(+timestamp)) {
+    return +timestamp
+  }
+
+  // converts non-unix timestamp to unix microseconds
+  return Date.parse(timestamp) * 1000
+}

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-properties.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-properties.ts
@@ -336,7 +336,7 @@ export const timestamp_micros: InputField = {
   label: 'Event Timestamp',
   type: 'string',
   description:
-    'A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.',
+    "A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.",
   default: {
     '@path': '$.timestamp'
   }

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-properties.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-properties.ts
@@ -331,3 +331,13 @@ export const engagement_time_msec: InputField = {
     'The amount of time a user interacted with your site, in milliseconds. Google only counts users who interact with your site for a non-zero amount of time. By default, Segment sets engagement time to 1 so users are counted.',
   default: 1
 }
+
+export const timestamp_micros: InputField = {
+  label: 'Event Timestamp',
+  type: 'string',
+  description:
+    'A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.',
+  default: {
+    '@path': '$.timestamp'
+  }
+}

--- a/packages/destination-actions/src/destinations/google-analytics-4/generateLead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/generateLead/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/generateLead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/generateLead/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.
    */
   timestamp_micros?: string
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
@@ -43,7 +43,8 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyUserProps(payload.user_properties)
     }
 
-    let request_object = {
+    let request_object: { [key: string]: any } = {}
+    request_object = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [
@@ -61,7 +62,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
@@ -43,8 +43,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyUserProps(payload.user_properties)
     }
 
-    let request_object: { [key: string]: any } = {}
-    request_object = {
+    const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [

--- a/packages/destination-actions/src/destinations/google-analytics-4/login/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/login/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.
    */
   timestamp_micros?: string
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/login/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/login/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * The method used to login.
    */
   method?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
@@ -1,6 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+import { verifyParams, verifyUserProps } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -27,7 +28,12 @@ const action: ActionDefinition<Settings, Payload> = {
     params: params
   },
 
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
+    if (features && features['actions-google-analytics-4-verify-params-feature']) {
+      verifyParams(payload.params)
+      verifyUserProps(payload.user_properties)
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {

--- a/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
@@ -1,14 +1,15 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyParams, verifyUserProps } from '../ga4-functions'
+import { verifyParams, verifyUserProps, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
   params,
   user_id,
   client_id,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -18,6 +19,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     method: {
       label: 'Method',
       type: 'string',
@@ -34,23 +36,29 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyUserProps(payload.user_properties)
     }
 
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'login',
+          params: {
+            method: payload.method,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        events: [
-          {
-            name: 'login',
-            params: {
-              method: payload.method,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
@@ -36,7 +36,8 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyUserProps(payload.user_properties)
     }
 
-    let request_object = {
+    let request_object: { [key: string]: any } = {}
+    request_object = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [
@@ -53,7 +54,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
@@ -36,8 +36,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyUserProps(payload.user_properties)
     }
 
-    let request_object: { [key: string]: any } = {}
-    request_object = {
+    const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * The current page URL
    */
   page_location?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.
    */
   timestamp_micros?: string
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
@@ -53,7 +53,8 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object = {
+    let request_object: { [key: string]: any } = {}
+    request_object = {
       client_id: payload.clientId,
       user_id: payload.user_id,
       events: [
@@ -72,7 +73,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
     }
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
@@ -53,8 +53,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object: { [key: string]: any } = {}
-    request_object = {
+    const request_object: { [key: string]: any } = {
       client_id: payload.clientId,
       user_id: payload.user_id,
       events: [

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
@@ -1,6 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+import { verifyParams, verifyUserProps } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -45,7 +46,11 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
+    if (features && features['actions-google-analytics-4-verify-params-feature']) {
+      verifyParams(payload.params)
+      verifyUserProps(payload.user_properties)
+    }
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
@@ -1,14 +1,15 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyParams, verifyUserProps } from '../ga4-functions'
+import { verifyParams, verifyUserProps, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
   params,
   user_id,
   client_id,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -18,6 +19,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     clientId: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     page_location: {
       label: 'Page Location',
       type: 'string',
@@ -51,25 +53,30 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
+    let request_object = {
+      client_id: payload.clientId,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'page_view',
+          params: {
+            page_location: payload.page_location,
+            page_referrer: payload.page_referrer,
+            page_title: payload.page_title,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.clientId,
-        user_id: payload.user_id,
-        events: [
-          {
-            name: 'page_view',
-            params: {
-              page_location: payload.page_location,
-              page_referrer: payload.page_referrer,
-              page_title: payload.page_title,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.
    */
   timestamp_micros?: string
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Store or affiliation from which this transaction occurred (e.g. Google Store).
    */
   affiliation?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
@@ -75,8 +75,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object: { [key: string]: any } = {}
-    request_object = {
+    const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
@@ -1,7 +1,7 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps, convertTimestamp } from '../ga4-functions'
 import { ProductItem } from '../ga4-types'
 import {
   coupon,
@@ -17,7 +17,8 @@ import {
   params,
   formatUserProperties,
   user_properties,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 
 // https://segment.com/docs/connections/spec/ecommerce/v2/#order-completed
@@ -29,6 +30,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     affiliation: { ...affiliation },
     coupon: { ...coupon, default: { '@path': '$.properties.coupon' } },
     currency: { ...currency, required: true },
@@ -73,31 +75,36 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'purchase',
+          params: {
+            affiliation: payload.affiliation,
+            coupon: payload.coupon,
+            currency: payload.currency,
+            items: googleItems,
+            transaction_id: payload.transaction_id,
+            shipping: payload.shipping,
+            value: payload.value,
+            tax: payload.tax,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        events: [
-          {
-            name: 'purchase',
-            params: {
-              affiliation: payload.affiliation,
-              coupon: payload.coupon,
-              currency: payload.currency,
-              items: googleItems,
-              transaction_id: payload.transaction_id,
-              shipping: payload.shipping,
-              value: payload.value,
-              tax: payload.tax,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
@@ -1,7 +1,7 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
 import { ProductItem } from '../ga4-types'
 import {
   coupon,
@@ -46,7 +46,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     verifyCurrency(payload.currency)
 
     let googleItems: ProductItem[] = []
@@ -67,6 +67,11 @@ const action: ActionDefinition<Settings, Payload> = {
 
         return product as ProductItem
       })
+    }
+
+    if (features && features['actions-google-analytics-4-verify-params-feature']) {
+      verifyParams(payload.params)
+      verifyUserProps(payload.user_properties)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
@@ -75,7 +75,8 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object = {
+    let request_object: { [key: string]: any } = {}
+    request_object = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [
@@ -99,7 +100,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.
    */
   timestamp_micros?: string
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
@@ -93,7 +93,8 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object = {
+    let request_object: { [key: string]: any } = {}
+    request_object = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [
@@ -117,7 +118,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
@@ -93,8 +93,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object: { [key: string]: any } = {}
-    request_object = {
+    const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps, convertTimestamp } from '../ga4-functions'
 import {
   coupon,
   transaction_id,
@@ -13,7 +13,8 @@ import {
   params,
   formatUserProperties,
   user_properties,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -26,6 +27,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     currency: { ...currency },
     transaction_id: { ...transaction_id, required: true },
     value: { ...value, default: { '@path': '$.properties.total' } },
@@ -91,31 +93,36 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'refund',
+          params: {
+            currency: payload.currency,
+            transaction_id: payload.transaction_id,
+            value: payload.value,
+            affiliation: payload.affiliation,
+            coupon: payload.coupon,
+            shipping: payload.shipping,
+            tax: payload.tax,
+            items: googleItems,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        events: [
-          {
-            name: 'refund',
-            params: {
-              currency: payload.currency,
-              transaction_id: payload.transaction_id,
-              value: payload.value,
-              affiliation: payload.affiliation,
-              coupon: payload.coupon,
-              shipping: payload.shipping,
-              tax: payload.tax,
-              items: googleItems,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
 import {
   coupon,
   transaction_id,
@@ -44,7 +44,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     if (payload.currency) {
       verifyCurrency(payload.currency)
     }
@@ -85,6 +85,11 @@ const action: ActionDefinition<Settings, Payload> = {
 
         return product as ProductItem
       })
+    }
+
+    if (features && features['actions-google-analytics-4-verify-params-feature']) {
+      verifyParams(payload.params)
+      verifyUserProps(payload.user_properties)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.
    */
   timestamp_micros?: string
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -32,7 +32,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     if (payload.currency) {
       verifyCurrency(payload.currency)
     }
@@ -73,6 +73,11 @@ const action: ActionDefinition<Settings, Payload> = {
 
         return product as ProductItem
       })
+    }
+
+    if (features && features['actions-google-analytics-4-verify-params-feature']) {
+      verifyParams(payload.params)
+      verifyUserProps(payload.user_properties)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
@@ -81,7 +81,8 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object = {
+    let request_object: { [key: string]: any } = {}
+    request_object = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [
@@ -100,7 +101,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -9,7 +9,8 @@ import {
   client_id,
   currency,
   items_single_products,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -22,6 +23,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     currency: { ...currency },
     value: { ...value },
     items: {
@@ -79,26 +81,31 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'remove_from_cart',
+          params: {
+            currency: payload.currency,
+            value: payload.value,
+            items: googleItems,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        events: [
-          {
-            name: 'remove_from_cart',
-            params: {
-              currency: payload.currency,
-              value: payload.value,
-              items: googleItems,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
@@ -81,8 +81,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object: { [key: string]: any } = {}
-    request_object = {
+    const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [

--- a/packages/destination-actions/src/destinations/google-analytics-4/search/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/search/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.
    */
   timestamp_micros?: string
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/search/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/search/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * The term that was searched for.
    */
   search_term: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
@@ -38,7 +38,8 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object = {
+    let request_object: { [key: string]: any } = {}
+    request_object = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [
@@ -55,7 +56,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
@@ -38,8 +38,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object: { [key: string]: any } = {}
-    request_object = {
+    const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [

--- a/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
@@ -1,14 +1,15 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { verifyParams, verifyUserProps } from '../ga4-functions'
+import { verifyParams, verifyUserProps, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
   params,
   user_id,
   client_id,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -18,6 +19,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     search_term: {
       label: 'Search Term',
       type: 'string',
@@ -36,24 +38,29 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'search',
+          params: {
+            search_term: payload.search_term,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        events: [
-          {
-            name: 'search',
-            params: {
-              search_term: payload.search_term,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
@@ -1,6 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+import { verifyParams, verifyUserProps } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -30,7 +31,12 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
+    if (features && features['actions-google-analytics-4-verify-params-feature']) {
+      verifyParams(payload.params)
+      verifyUserProps(payload.user_properties)
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.
    */
   timestamp_micros?: string
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * The name of the list in which the item was presented to the user.
    */
   item_list_name?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
@@ -65,7 +65,8 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object = {
+    let request_object: { [key: string]: any } = {}
+    request_object = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [
@@ -84,7 +85,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
@@ -65,8 +65,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object: { [key: string]: any } = {}
-    request_object = {
+    const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps, convertTimestamp } from '../ga4-functions'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -10,7 +10,8 @@ import {
   user_id,
   client_id,
   items_single_products,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -20,6 +21,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     item_list_name: {
       label: 'Item List Name',
       description: 'The name of the list in which the item was presented to the user.',
@@ -63,26 +65,31 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'select_item',
+          params: {
+            items: googleItems,
+            item_list_name: payload.item_list_name,
+            item_list_id: payload.item_list_id,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        events: [
-          {
-            name: 'select_item',
-            params: {
-              items: googleItems,
-              item_list_name: payload.item_list_name,
-              item_list_id: payload.item_list_id,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -38,7 +38,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     let googleItems: ProductItem[] = []
 
     if (payload.items) {
@@ -57,6 +57,11 @@ const action: ActionDefinition<Settings, Payload> = {
 
         return product as ProductItem
       })
+    }
+
+    if (features && features['actions-google-analytics-4-verify-params-feature']) {
+      verifyParams(payload.params)
+      verifyUserProps(payload.user_properties)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * The name of the promotional creative.
    */
   creative_name?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.
    */
   timestamp_micros?: string
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
@@ -91,7 +91,8 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object = {
+    let request_object: { [key: string]: any } = {}
+    request_object = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [
@@ -113,7 +114,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
 import {
   creative_name,
   client_id,
@@ -56,7 +56,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     let googleItems: PromotionProductItem[] = []
 
     if (payload.items) {
@@ -83,6 +83,11 @@ const action: ActionDefinition<Settings, Payload> = {
 
         return product as PromotionProductItem
       })
+    }
+
+    if (features && features['actions-google-analytics-4-verify-params-feature']) {
+      verifyParams(payload.params)
+      verifyUserProps(payload.user_properties)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
@@ -91,8 +91,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object: { [key: string]: any } = {}
-    request_object = {
+    const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps, convertTimestamp } from '../ga4-functions'
 import {
   creative_name,
   client_id,
@@ -12,7 +12,8 @@ import {
   params,
   formatUserProperties,
   user_properties,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 import { PromotionProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -25,6 +26,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     creative_name: { ...creative_name },
     creative_slot: { ...creative_slot, default: { '@path': '$.properties.creative' } },
     location_id: {
@@ -89,29 +91,34 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'select_promotion',
+          params: {
+            creative_name: payload.creative_name,
+            creative_slot: payload.creative_slot,
+            location_id: payload.location_id,
+            promotion_id: payload.promotion_id,
+            promotion_name: payload.promotion_name,
+            items: googleItems,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        events: [
-          {
-            name: 'select_promotion',
-            params: {
-              creative_name: payload.creative_name,
-              creative_slot: payload.creative_slot,
-              location_id: payload.location_id,
-              promotion_id: payload.promotion_id,
-              promotion_name: payload.promotion_name,
-              items: googleItems,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/signUp/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/signUp/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * The method used for sign up.
    */
   method?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/signUp/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/signUp/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.
    */
   timestamp_micros?: string
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
@@ -1,6 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+import { verifyParams, verifyUserProps } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -29,7 +30,12 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
+    if (features && features['actions-google-analytics-4-verify-params-feature']) {
+      verifyParams(payload.params)
+      verifyUserProps(payload.user_properties)
+    }
+
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {

--- a/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
@@ -37,7 +37,8 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object = {
+    let request_object: { [key: string]: any } = {}
+    request_object = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [
@@ -54,7 +55,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
@@ -37,8 +37,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object: { [key: string]: any } = {}
-    request_object = {
+    const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.
    */
   timestamp_micros?: string
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -9,7 +9,8 @@ import {
   user_id,
   client_id,
   items_multi_products,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -22,6 +23,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     currency: { ...currency },
     value: { ...value },
     items: {
@@ -74,26 +76,31 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'view_cart',
+          params: {
+            currency: payload.currency,
+            value: payload.value,
+            items: googleItems,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        events: [
-          {
-            name: 'view_cart',
-            params: {
-              currency: payload.currency,
-              value: payload.value,
-              items: googleItems,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
@@ -76,8 +76,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object: { [key: string]: any } = {}
-    request_object = {
+    const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -32,7 +32,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     if (payload.currency) {
       verifyCurrency(payload.currency)
     }
@@ -68,6 +68,11 @@ const action: ActionDefinition<Settings, Payload> = {
 
         return product as ProductItem
       })
+    }
+
+    if (features && features['actions-google-analytics-4-verify-params-feature']) {
+      verifyParams(payload.params)
+      verifyUserProps(payload.user_properties)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
@@ -76,7 +76,8 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object = {
+    let request_object: { [key: string]: any } = {}
+    request_object = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [
@@ -95,7 +96,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.
    */
   timestamp_micros?: string
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
@@ -75,8 +75,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object: { [key: string]: any } = {}
-    request_object = {
+    const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
@@ -75,7 +75,8 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object = {
+    let request_object: { [key: string]: any } = {}
+    request_object = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [
@@ -94,7 +95,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -32,7 +32,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     if (payload.currency) {
       verifyCurrency(payload.currency)
     }
@@ -67,6 +67,11 @@ const action: ActionDefinition<Settings, Payload> = {
           currency: product.currency
         } as ProductItem
       })
+    }
+
+    if (features && features['actions-google-analytics-4-verify-params-feature']) {
+      verifyParams(payload.params)
+      verifyUserProps(payload.user_properties)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -9,7 +9,8 @@ import {
   client_id,
   value,
   items_single_products,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -22,6 +23,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     currency: { ...currency },
     value: { ...value },
     items: {
@@ -73,26 +75,31 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'view_item',
+          params: {
+            currency: payload.currency,
+            items: googleItems,
+            value: payload.value,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        events: [
-          {
-            name: 'view_item',
-            params: {
-              currency: payload.currency,
-              items: googleItems,
-              value: payload.value,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.
    */
   timestamp_micros?: string
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * The ID of the list in which the item was presented to the user.
    */
   item_list_id?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
@@ -75,8 +75,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object: { [key: string]: any } = {}
-    request_object = {
+    const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -48,7 +48,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     let googleItems: ProductItem[] = []
 
     if (payload.items) {
@@ -67,6 +67,11 @@ const action: ActionDefinition<Settings, Payload> = {
 
         return product as ProductItem
       })
+    }
+
+    if (features && features['actions-google-analytics-4-verify-params-feature']) {
+      verifyParams(payload.params)
+      verifyUserProps(payload.user_properties)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
@@ -75,7 +75,8 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object = {
+    let request_object: { [key: string]: any } = {}
+    request_object = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [
@@ -94,7 +95,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps, convertTimestamp } from '../ga4-functions'
 import {
   formatUserProperties,
   user_properties,
@@ -7,7 +7,8 @@ import {
   user_id,
   client_id,
   items_multi_products,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -24,6 +25,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     item_list_id: {
       label: 'Item List ID',
       type: 'string',
@@ -73,26 +75,31 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'view_item_list',
+          params: {
+            item_list_id: payload.item_list_id,
+            item_list_name: payload.item_list_name,
+            items: googleItems,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        events: [
-          {
-            name: 'view_item_list',
-            params: {
-              item_list_id: payload.item_list_id,
-              item_list_name: payload.item_list_name,
-              items: googleItems,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   */
+  timestamp_micros?: string
+  /**
    * The name of the promotional creative.
    */
   creative_name?: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the propertys timezone.
+   * A Unix timestamp (in microseconds) for the time to associate with the event. Events can be backdated up to 3 calendar days based on the property's timezone.
    */
   timestamp_micros?: string
   /**

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps, convertTimestamp } from '../ga4-functions'
 import {
   creative_name,
   creative_slot,
@@ -12,7 +12,8 @@ import {
   params,
   formatUserProperties,
   user_properties,
-  engagement_time_msec
+  engagement_time_msec,
+  timestamp_micros
 } from '../ga4-properties'
 import { PromotionProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -29,6 +30,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     client_id: { ...client_id },
     user_id: { ...user_id },
+    timestamp_micros: { ...timestamp_micros },
     creative_name: { ...creative_name },
     creative_slot: { ...creative_slot, default: { '@path': '$.properties.creative' } },
     location_id: {
@@ -86,29 +88,34 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
+    let request_object = {
+      client_id: payload.client_id,
+      user_id: payload.user_id,
+      events: [
+        {
+          name: 'view_promotion',
+          params: {
+            creative_name: payload.creative_name,
+            creative_slot: payload.creative_slot,
+            location_id: payload.location_id,
+            promotion_id: payload.promotion_id,
+            promotion_name: payload.promotion_name,
+            items: googleItems,
+            engagement_time_msec: payload.engagement_time_msec,
+            ...payload.params
+          }
+        }
+      ],
+      ...formatUserProperties(payload.user_properties)
+    }
+
+    if (features && features['actions-google-analytics-4-add-timestamp']) {
+      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+    }
 
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
-      json: {
-        client_id: payload.client_id,
-        user_id: payload.user_id,
-        events: [
-          {
-            name: 'view_promotion',
-            params: {
-              creative_name: payload.creative_name,
-              creative_slot: payload.creative_slot,
-              location_id: payload.location_id,
-              promotion_id: payload.promotion_id,
-              promotion_name: payload.promotion_name,
-              items: googleItems,
-              engagement_time_msec: payload.engagement_time_msec,
-              ...payload.params
-            }
-          }
-        ],
-        ...formatUserProperties(payload.user_properties)
-      }
+      json: request_object
     })
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
@@ -88,8 +88,7 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object: { [key: string]: any } = {}
-    request_object = {
+    const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
@@ -88,7 +88,8 @@ const action: ActionDefinition<Settings, Payload> = {
       verifyParams(payload.params)
       verifyUserProps(payload.user_properties)
     }
-    let request_object = {
+    let request_object: { [key: string]: any } = {}
+    request_object = {
       client_id: payload.client_id,
       user_id: payload.user_id,
       events: [
@@ -110,7 +111,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object = { ...request_object, ...{ ['timestamp_micros']: convertTimestamp(payload.timestamp_micros) } }
+      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { verifyCurrency } from '../ga4-functions'
+import { verifyCurrency, verifyParams, verifyUserProps } from '../ga4-functions'
 import {
   creative_name,
   creative_slot,
@@ -65,7 +65,7 @@ const action: ActionDefinition<Settings, Payload> = {
     params: params
   },
 
-  perform: (request, { payload }) => {
+  perform: (request, { payload, features }) => {
     let googleItems: PromotionProductItem[] = []
 
     if (payload.items) {
@@ -80,6 +80,11 @@ const action: ActionDefinition<Settings, Payload> = {
 
         return product as PromotionProductItem
       })
+    }
+
+    if (features && features['actions-google-analytics-4-verify-params-feature']) {
+      verifyParams(payload.params)
+      verifyUserProps(payload.user_properties)
     }
 
     return request('https://www.google-analytics.com/mp/collect', {


### PR DESCRIPTION
This PR combines https://github.com/segmentio/action-destinations/pull/634 and https://github.com/segmentio/action-destinations/pull/644 since they both are making changes to the same files to address both [STRATCONN-1413](https://segment.atlassian.net/browse/STRATCONN-1413) and [STRATCONN-1356](https://segment.atlassian.net/browse/STRATCONN-1356). 

This PR adds a new check that verifies the types of event parameters and user_properties to make sure we are sending valid payloads to the GA4 endpoint. It also adds a new field ` timestamp_micros` to be sent with the payload.

Testing Doc: https://paper.dropbox.com/doc/Maryam-GA4-Testing--BlMwm5hqvFSQ9FzSU6ll0R8gAg-oEvVvYlc2u1ildRMlIGPt

## Testing
_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
