### PR TITLE
BE-849 Add Track action + tests

### DIFF
--- a/packages/destination-actions/src/destinations/intercom/index.ts
+++ b/packages/destination-actions/src/destinations/intercom/index.ts
@@ -2,6 +2,7 @@ import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import identifyContact from './identifyContact'
 import groupIdentifyContact from './groupIdentifyContact'
+import trackEvent from './trackEvent'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Intercom (Actions)',
@@ -33,7 +34,8 @@ const destination: DestinationDefinition<Settings> = {
 
   actions: {
     identifyContact,
-    groupIdentifyContact
+    groupIdentifyContact,
+    trackEvent
   }
 }
 

--- a/packages/destination-actions/src/destinations/intercom/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/intercom/trackEvent/__tests__/index.test.ts
@@ -1,0 +1,27 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+const endpoint = 'https://api.intercom.io'
+
+describe('Intercom.trackEvent', () => {
+  it('should create an event with epoch seconds', async () => {
+    const event = createTestEvent({ event: 'Segment Test Event Name 3' })
+
+    nock(`${endpoint}`).post(`/events`).reply(200, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      useDefaultMappings: true
+    })
+
+    const epochDate = Math.floor(new Date(event.timestamp as string).valueOf() / 1000)
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.body).toBe(
+      `{"event_name":"Segment Test Event Name 3","created_at":${epochDate},"user_id":"user1234","metadata":{}}`
+    )
+  })
+})

--- a/packages/destination-actions/src/destinations/intercom/trackEvent/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/intercom/trackEvent/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'trackEvent'
+const destinationSlug = 'Intercom'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/intercom/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/intercom/trackEvent/generated-types.ts
@@ -1,0 +1,26 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The name of the event. Names are treated as case insensitive. Periods (.) and dollars ($) in event names are replaced with hyphens.
+   */
+  event_name: string
+  /**
+   * A datetime in Unix timestamp format (seconds since Epoch).
+   */
+  created_at: string | number
+  /**
+   * The user's ID; required if no email provided.
+   */
+  user_id?: string
+  /**
+   * The user's email; required if no User ID provided.
+   */
+  email?: string
+  /**
+   * Metadata object describing the event. There is a limit to 10 keys. Intercom does not currently support nested JSON structures.
+   */
+  metadata?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/intercom/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/intercom/trackEvent/index.ts
@@ -1,0 +1,83 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import dayjs from '../../../lib/dayjs'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Track Event',
+  description: 'Submit a data event to Intercom.',
+  fields: {
+    event_name: {
+      type: 'string',
+      required: true,
+      description:
+        'The name of the event. Names are treated as case insensitive. Periods (.) and dollars ($) in event names are replaced with hyphens.',
+      label: 'Event Name',
+      default: {
+        '@path': '$.event'
+      }
+    },
+    created_at: {
+      type: 'datetime',
+      required: true,
+      description: 'A datetime in Unix timestamp format (seconds since Epoch).',
+      label: 'Created At',
+      default: {
+        '@path': '$.timestamp'
+      }
+    },
+    user_id: {
+      type: 'string',
+      description: "The user's ID; required if no email provided.",
+      label: 'User ID',
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    email: {
+      type: 'string',
+      description: "The user's email; required if no User ID provided.",
+      label: 'Email',
+      format: 'email',
+      default: {
+        '@path': '$.email'
+      }
+    },
+    metadata: {
+      type: 'object',
+      description:
+        'Metadata object describing the event. There is a limit to 10 keys. Intercom does not currently support nested JSON structures.',
+      label: 'Metadata',
+      default: {
+        '@path': '$.properties'
+      }
+    }
+  },
+  perform: (request, { payload }) => {
+    payload.created_at = convertValidTimestamp(payload.created_at)
+    return request('https://api.intercom.io/events', {
+      method: 'POST',
+      json: payload
+    })
+  }
+}
+
+function convertValidTimestamp(value: string | number): string | number {
+  // Timestamps may be on a `string` field, so check if the string is only
+  // numbers. If it is, ignore it since it's probably already a unix timestamp.
+  // DayJS doesn't parse unix timestamps correctly outside of the `.unix()`
+  // initializer.
+  if (typeof value !== 'string' || /^\d+$/.test(value)) {
+    return value
+  }
+
+  const maybeDate = dayjs.utc(value)
+
+  if (maybeDate.isValid()) {
+    return maybeDate.unix()
+  }
+
+  return value
+}
+
+export default action


### PR DESCRIPTION
## Description
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Adding the Track action!

Track Event API Docs - https://developers.intercom.com/intercom-api-reference/reference/submitting-events

This `track event` action is fairly straightforward, as we're passing in all attributes into Intercom's API. Unclear behavior is noted in the attribute descriptions, such as:

- Event names are case insensitive (they are automatically lowercased by intercom)
- There is a limit to 10 keys on metadata events

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment

<img width="1182" alt="Screen Shot 2022-06-15 at 1 22 39 PM" src="https://user-images.githubusercontent.com/1487616/174854749-ccae9f3c-8f15-45e1-939e-fd18a768c3df.png">

