### PR TITLE
[MAI-10] Update sendEmail destination action to check for the group subscription state before sending the message

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -91,7 +91,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       bodyHtml: 'Hi {{profile.traits.firstName}}, Welcome to segment',
       send: true,
       toEmail: '',
-      externalIds: [
+      externalIds: JSON.stringify([
         {
           id: userData.email,
           type: 'email',
@@ -99,7 +99,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           groups: [{ id: 'grp_1', subscriptionStatus: 'subscribed' }]
         },
         { id: userData.phone, type: 'phone', subscriptionStatus: 'subscribed' }
-      ],
+      ]),
       ...overrides
     }
   }
@@ -719,7 +719,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
                 id: userData.email,
                 type: 'email',
                 subscriptionStatus: 'subscribed',
-                groups: [{ id: 'grp_1', subscriptionStatus: subscriptionStatus }]
+                groups: JSON.stringify([{ id: 'grp_1', subscriptionStatus: subscriptionStatus }])
               },
               { id: userData.phone, type: 'phone', subscriptionStatus: 'subscribed' }
             ],

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -92,7 +92,12 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       send: true,
       toEmail: '',
       externalIds: [
-        { id: userData.email, type: 'email', subscriptionStatus: 'subscribed' },
+        {
+          id: userData.email,
+          type: 'email',
+          subscriptionStatus: 'subscribed',
+          groups: [{ id: 'grp_1', subscriptionStatus: 'subscribed' }]
+        },
         { id: userData.phone, type: 'phone', subscriptionStatus: 'subscribed' }
       ],
       ...overrides
@@ -679,6 +684,70 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       })
 
       await expect(response).rejects.toThrowError(`Failed to process the subscription state: "${subscriptionStatus}"`)
+    })
+
+    it('should send Email to group', async () => {
+      const sendGridRequest = nock('https://api.sendgrid.com').post('/v3/mail/send', sendgridRequestBody).reply(200, {})
+
+      const responses = await sendgrid.testAction('sendEmail', {
+        event: createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          userId: userData.userId
+        }),
+        settings,
+        mapping: getDefaultMapping({ groupId: 'grp_1' })
+      })
+
+      expect(responses.length).toBeGreaterThan(0)
+      expect(sendGridRequest.isDone()).toEqual(true)
+    })
+
+    it.each(['unsubscribed', 'did not subscribed', '', null, false])(
+      'does NOT send the email to group when group\'s subscriptionStatus = "%s"',
+      async (subscriptionStatus) => {
+        await sendgrid.testAction('sendEmail', {
+          event: createTestEvent({
+            timestamp,
+            event: 'Audience Entered',
+            userId: userData.userId
+          }),
+          settings,
+          mapping: getDefaultMapping({
+            externalIds: [
+              {
+                id: userData.email,
+                type: 'email',
+                subscriptionStatus: 'subscribed',
+                groups: [{ id: 'grp_1', subscriptionStatus: subscriptionStatus }]
+              },
+              { id: userData.phone, type: 'phone', subscriptionStatus: 'subscribed' }
+            ],
+            groupId: 'grp_1'
+          })
+        })
+        const sendGridRequest = nock('https://api.sendgrid.com')
+          .post('/v3/mail/send', sendgridRequestBody)
+          .reply(200, {})
+
+        expect(sendGridRequest.isDone()).toBe(false)
+      }
+    )
+
+    it('does NOT send Email to group when groupId is not in groups', async () => {
+      await sendgrid.testAction('sendEmail', {
+        event: createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          userId: userData.userId
+        }),
+        settings,
+        mapping: getDefaultMapping({ groupId: 'grp_2' })
+      })
+
+      const sendGridRequest = nock('https://api.sendgrid.com').post('/v3/mail/send', sendgridRequestBody).reply(200, {})
+
+      expect(sendGridRequest.isDone()).toBe(false)
     })
   })
 })

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -91,15 +91,15 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       bodyHtml: 'Hi {{profile.traits.firstName}}, Welcome to segment',
       send: true,
       toEmail: '',
-      externalIds: JSON.stringify([
+      externalIds: [
         {
           id: userData.email,
           type: 'email',
           subscriptionStatus: 'subscribed',
-          groups: [{ id: 'grp_1', subscriptionStatus: 'subscribed' }]
+          groups: JSON.stringify([{ id: 'grp_1', subscriptionStatus: 'subscribed' }])
         },
         { id: userData.phone, type: 'phone', subscriptionStatus: 'subscribed' }
-      ]),
+      ],
       ...overrides
     }
   }

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -703,7 +703,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       expect(sendGridRequest.isDone()).toEqual(true)
     })
 
-    it.each(['unsubscribed', 'did not subscribed', '', null, false])(
+    it.each([null, false])(
       'does NOT send the email to group when group\'s subscriptionStatus = "%s"',
       async (subscriptionStatus) => {
         await sendgrid.testAction('sendEmail', {

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/__tests__/send-email.test.ts
@@ -96,7 +96,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           id: userData.email,
           type: 'email',
           subscriptionStatus: 'subscribed',
-          groups: JSON.stringify([{ id: 'grp_1', subscriptionStatus: 'subscribed' }])
+          groups: JSON.stringify([{ id: 'grp_1', isSubscribed: true }])
         },
         { id: userData.phone, type: 'phone', subscriptionStatus: 'subscribed' }
       ],
@@ -719,7 +719,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
                 id: userData.email,
                 type: 'email',
                 subscriptionStatus: 'subscribed',
-                groups: JSON.stringify([{ id: 'grp_1', subscriptionStatus: subscriptionStatus }])
+                groups: JSON.stringify([{ id: 'grp_1', isSubscribed: subscriptionStatus }])
               },
               { id: userData.phone, type: 'phone', subscriptionStatus: 'subscribed' }
             ],

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
@@ -82,18 +82,9 @@ export interface Payload {
      */
     subscriptionStatus?: string
     /**
-     * An array of subscription groups status
+     * An json stringify array of subscription groups status
      */
-    groups?: {
-      /**
-       * A unique identifier for the subsription group.
-       */
-      id?: string
-      /**
-       * The subscription group status for the identity.
-       */
-      subscriptionStatus?: string
-    }[]
+    groups?: string
   }[]
   /**
    * The subscription group to send the email

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/generated-types.ts
@@ -81,7 +81,24 @@ export interface Payload {
      * The subscription status for the identity.
      */
     subscriptionStatus?: string
+    /**
+     * An array of subscription groups status
+     */
+    groups?: {
+      /**
+       * A unique identifier for the subsription group.
+       */
+      id?: string
+      /**
+       * The subscription group status for the identity.
+       */
+      subscriptionStatus?: string
+    }[]
   }[]
+  /**
+   * The subscription group to send the email
+   */
+  groupId?: string
   /**
    * Additional custom args that we be passed back opaquely on webhook events
    */

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -245,6 +245,24 @@ const action: ActionDefinition<Settings, Payload> = {
           label: 'ID',
           description: 'The subscription status for the identity.',
           type: 'string'
+        },
+        groups: {
+          label: 'Groups',
+          description: 'An array of subscription groups status',
+          type: 'object',
+          multiple: true,
+          properties: {
+            id: {
+              label: 'ID',
+              description: 'A unique identifier for the subsription group.',
+              type: 'string'
+            },
+            subscriptionStatus: {
+              label: 'Subscription Group Status',
+              description: 'The subscription group status for the identity.',
+              type: 'string'
+            }
+          }
         }
       },
       default: {
@@ -263,6 +281,11 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         ]
       }
+    },
+    groupId: {
+      label: 'Subscription Group ID',
+      description: 'The subscription group to send the email',
+      type: 'string'
     },
     customArgs: {
       label: 'Custom Args',
@@ -288,6 +311,22 @@ const action: ActionDefinition<Settings, Payload> = {
       return
     } else if (['subscribed', 'true'].includes(emailProfile?.subscriptionStatus)) {
       statsClient?.incr('actions-personas-messaging-sendgrid.subscribed', 1, tags)
+      if (payload?.groupId) {
+        let subscribed = false
+        emailProfile?.groups?.forEach((group) => {
+          if (
+            group.id == payload?.groupId &&
+            group.subscriptionStatus &&
+            ['subscribed', 'true'].includes(group.subscriptionStatus)
+          ) {
+            subscribed = true
+          }
+        })
+        if (!subscribed) {
+          return
+        }
+      }
+
       const traits = await fetchProfileTraits(request, settings, payload.userId, statsClient, tags)
 
       const profile: Profile = {

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -304,12 +304,8 @@ const action: ActionDefinition<Settings, Payload> = {
       if (payload?.groupId) {
         let subscribed = false
         const groups = JSON.parse(emailProfile.groups ?? '')
-        groups.forEach((group: { id: string | undefined; subscriptionStatus: string | undefined }) => {
-          if (
-            group.id == payload.groupId &&
-            group.subscriptionStatus &&
-            ['subscribed', 'true'].includes(group.subscriptionStatus)
-          ) {
+        groups.forEach((group: { id: string; isSubscribed: boolean }) => {
+          if (group.id == payload.groupId && group.isSubscribed) {
             subscribed = true
           }
         })

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -277,6 +277,19 @@ const action: ActionDefinition<Settings, Payload> = {
             },
             subscriptionStatus: {
               '@path': '$.isSubscribed'
+            },
+            groups: {
+              '@arrayPath': [
+                '$.external_ids.groups',
+                {
+                  id: {
+                    '@path': '$.id'
+                  },
+                  subscriptionStatus: {
+                    '@path': '$.isSubscribed'
+                  }
+                }
+              ]
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -248,21 +248,8 @@ const action: ActionDefinition<Settings, Payload> = {
         },
         groups: {
           label: 'Groups',
-          description: 'An array of subscription groups status',
-          type: 'object',
-          multiple: true,
-          properties: {
-            id: {
-              label: 'ID',
-              description: 'A unique identifier for the subsription group.',
-              type: 'string'
-            },
-            subscriptionStatus: {
-              label: 'Subscription Group Status',
-              description: 'The subscription group status for the identity.',
-              type: 'string'
-            }
-          }
+          description: 'An json stringify array of subscription groups status',
+          type: 'string'
         }
       },
       default: {
@@ -279,17 +266,7 @@ const action: ActionDefinition<Settings, Payload> = {
               '@path': '$.isSubscribed'
             },
             groups: {
-              '@arrayPath': [
-                '$.external_ids.groups',
-                {
-                  id: {
-                    '@path': '$.id'
-                  },
-                  subscriptionStatus: {
-                    '@path': '$.isSubscribed'
-                  }
-                }
-              ]
+              '@path': '$.groups'
             }
           }
         ]
@@ -326,9 +303,10 @@ const action: ActionDefinition<Settings, Payload> = {
       statsClient?.incr('actions-personas-messaging-sendgrid.subscribed', 1, tags)
       if (payload?.groupId) {
         let subscribed = false
-        emailProfile?.groups?.forEach((group) => {
+        const groups = JSON.parse(emailProfile.groups ?? '')
+        groups.forEach((group: { id: string | undefined; subscriptionStatus: string | undefined }) => {
           if (
-            group.id == payload?.groupId &&
+            group.id == payload.groupId &&
             group.subscriptionStatus &&
             ['subscribed', 'true'].includes(group.subscriptionStatus)
           ) {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

JIRA: [MAI-10](https://segment.atlassian.net/browse/MAI-10?atlOrigin=eyJpIjoiOTZiZDkwZDk5NGYzNGY5Njk5ZmVjOTZhZjQwZDY1ODQiLCJwIjoiaiJ9)

Check group's subscription state before sending out email with `personas-messaing-sendgrid` sendEmail destination action.
This addition would allow the users to control which groups Twilio Engage messages are sent to.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
