### PR TITLE
Add Support for Canary API Version in FB CAPI

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../index'
+import { API_VERSION } from '../constants'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -11,7 +12,7 @@ const settings = {
 describe('FacebookConversionsApi', () => {
   describe('AddToCart', () => {
     it('should handle a basic event', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Added',
@@ -66,7 +67,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error for invalid currency values', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Added',
@@ -108,7 +109,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should handle default mappings', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Added',
@@ -140,7 +141,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error if no id parameter is included in contents array objects', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Added',
@@ -194,7 +195,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error if contents.delivery_category is not supported', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Added',
@@ -252,7 +253,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error if no user_data keys are included', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Added',

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/custom.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/custom.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../index'
+import { API_VERSION } from '../constants'
 
 const testDestination = createTestIntegration(Destination)
 const settings = {
@@ -11,7 +12,7 @@ const settings = {
 describe('FacebookConversionsApi', () => {
   describe('Custom', () => {
     it('should fail if no event_name is passed', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         userId: 'abc123',
@@ -39,7 +40,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should fail if an empty event_name is passed', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: '',
@@ -68,7 +69,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error for an invalid action_source', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'custom',
@@ -102,7 +103,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should map a standard identify event to a custom event', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         anonymousId: '507f191e810c19729de860ea',

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/initiateCheckout.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/initiateCheckout.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../index'
+import { API_VERSION } from '../constants'
 
 const testDestination = createTestIntegration(Destination)
 const settings = {
@@ -10,7 +11,7 @@ const settings = {
 describe('FacebookConversionsApi', () => {
   describe('InitiateCheckout', () => {
     it('should handle basic mapping overrides', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Checkout Started',
@@ -57,7 +58,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error for invalid currency values', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}0/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Checkout Started',
@@ -99,7 +100,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should handle default mappings', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Checkout Started',
@@ -133,7 +134,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error if no user_data keys are included', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Checkout Started',

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/pageView.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../index'
+import { API_VERSION } from '../constants'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -11,7 +12,7 @@ const settings = {
 describe('FacebookConversionsApi', () => {
   describe('PageView', () => {
     it('should handle a basic event', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         type: 'page',
@@ -41,7 +42,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error when action_source is website and no client_user_agent', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         type: 'page',
@@ -75,7 +76,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should handle default mappings', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Added',
@@ -103,7 +104,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error if no user_data keys are included', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Added',

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/purchase.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/purchase.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../index'
+import { API_VERSION } from '../constants'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -11,7 +12,7 @@ const settings = {
 
 describe('purchase', () => {
   it('should handle a basic event', async () => {
-    nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+    nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
     const event = createTestEvent({
       event: 'Order Completed',
@@ -81,7 +82,7 @@ describe('purchase', () => {
   })
 
   it('should handle default mappings', async () => {
-    nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+    nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
     const event = createTestEvent({
       event: 'Order Completed',
@@ -115,7 +116,7 @@ describe('purchase', () => {
   })
 
   it('should throw an error when currency and value are missing', async () => {
-    nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+    nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
     const event = createTestEvent({
       event: 'Order Completed',
@@ -156,7 +157,7 @@ describe('purchase', () => {
   })
 
   it('should throw an error if no user_data keys are included', async () => {
-    nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+    nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
     const event = createTestEvent({
       event: 'Order Completed',

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/search.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/search.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../index'
+import { API_VERSION } from '../constants'
 
 const testDestination = createTestIntegration(Destination)
 const settings = {
@@ -10,7 +11,7 @@ const settings = {
 describe('FacebookConversionsApi', () => {
   describe('Search', () => {
     it('should handle a basic event', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Products Searched',
@@ -76,7 +77,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should handle default mappings', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Products Searched',
@@ -109,7 +110,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error if no user_data keys are included', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Products Searched',

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/utils.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/utils.test.ts
@@ -1,0 +1,21 @@
+import { get_api_version } from '../utils'
+import { API_VERSION, CANARY_API_VERSION } from '../constants'
+import { StatsContext } from '@segment/actions-core/src/destination-kit'
+
+describe('FacebookConversionsApi', () => {
+  describe('get_api_version', () => {
+    it('should return the canary API version', async () => {
+      const features = {
+        'facebook-capi-actions-canary-version': true
+      }
+      const version = get_api_version(features, {} as StatsContext)
+      expect(version).toEqual(CANARY_API_VERSION)
+    })
+
+    it('should return the regular API version', async () => {
+      const features = {}
+      const version = get_api_version(features, {} as StatsContext)
+      expect(version).toEqual(API_VERSION)
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/viewContent.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/viewContent.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../index'
+import { API_VERSION } from '../constants'
 
 const testDestination = createTestIntegration(Destination)
 const settings = {
@@ -10,7 +11,7 @@ const settings = {
 describe('FacebookConversionsApi', () => {
   describe('ViewContent', () => {
     it('should handle a basic event', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Viewed',
@@ -83,7 +84,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should handle default mappings', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Viewed',
@@ -116,7 +117,7 @@ describe('FacebookConversionsApi', () => {
     })
 
     it('should throw an error if no user_data keys are included', async () => {
-      nock(`https://graph.facebook.com/v12.0/${settings.pixelId}`).post(`/events`).reply(201, {})
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
         event: 'Product Viewed',

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
@@ -15,8 +15,9 @@ import {
   event_id,
   custom_data
 } from '../fb-capi-properties'
-import { CURRENCY_ISO_CODES, API_VERSION } from '../constants'
+import { CURRENCY_ISO_CODES } from '../constants'
 import { hash_user_data, user_data_field } from '../fb-capi-user-data'
+import { get_api_version } from '../utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Add to Cart',
@@ -55,7 +56,7 @@ const action: ActionDefinition<Settings, Payload> = {
     value: { ...value, default: { '@path': '$.properties.price' } },
     custom_data: custom_data
   },
-  perform: (request, { payload, settings }) => {
+  perform: (request, { payload, settings, features, statsContext }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.has(payload.currency)) {
       throw new IntegrationError(
         `${payload.currency} is not a valid currency code.`,
@@ -81,30 +82,33 @@ const action: ActionDefinition<Settings, Payload> = {
       if (err) throw err
     }
 
-    return request(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}/events`, {
-      method: 'POST',
-      json: {
-        data: [
-          {
-            event_name: 'AddToCart',
-            event_time: payload.event_time,
-            event_source_url: payload.event_source_url,
-            event_id: payload.event_id,
-            action_source: payload.action_source,
-            user_data: hash_user_data({ user_data: payload.user_data }),
-            custom_data: {
-              ...payload.custom_data,
-              currency: payload.currency,
-              value: payload.value,
-              content_ids: payload.content_ids,
-              content_name: payload.content_name,
-              contents: payload.contents,
-              content_type: payload.content_type
+    return request(
+      `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
+      {
+        method: 'POST',
+        json: {
+          data: [
+            {
+              event_name: 'AddToCart',
+              event_time: payload.event_time,
+              event_source_url: payload.event_source_url,
+              event_id: payload.event_id,
+              action_source: payload.action_source,
+              user_data: hash_user_data({ user_data: payload.user_data }),
+              custom_data: {
+                ...payload.custom_data,
+                currency: payload.currency,
+                value: payload.value,
+                content_ids: payload.content_ids,
+                content_name: payload.content_name,
+                contents: payload.contents,
+                content_type: payload.content_type
+              }
             }
-          }
-        ]
+          ]
+        }
       }
-    })
+    )
   }
 }
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/constants.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/constants.ts
@@ -1,4 +1,5 @@
 export const API_VERSION = '12.0'
+export const CANARY_API_VERSION = '12.0'
 export const CURRENCY_ISO_CODES = new Set([
   'AED',
   'AFN',

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
@@ -3,7 +3,8 @@ import { action_source, custom_data, event_id, event_source_url, event_time } fr
 import { hash_user_data, user_data_field } from '../fb-capi-user-data'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { API_VERSION } from '../constants'
+import { get_api_version } from '../utils'
+
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Custom Event',
   description: 'Send a custom event',
@@ -11,7 +12,8 @@ const action: ActionDefinition<Settings, Payload> = {
     action_source: { ...action_source, required: true },
     event_name: {
       label: 'Event Name',
-      description: 'A Facebook [standard event](https://developers.facebook.com/docs/meta-pixel/implementation/conversion-tracking#standard-events) or [custom event](https://developers.facebook.com/docs/meta-pixel/implementation/conversion-tracking#custom-events) name.',
+      description:
+        'A Facebook [standard event](https://developers.facebook.com/docs/meta-pixel/implementation/conversion-tracking#standard-events) or [custom event](https://developers.facebook.com/docs/meta-pixel/implementation/conversion-tracking#custom-events) name.',
       type: 'string',
       required: true,
       default: {
@@ -24,7 +26,7 @@ const action: ActionDefinition<Settings, Payload> = {
     event_id: event_id,
     event_source_url: event_source_url
   },
-  perform: (request, { payload, settings }) => {
+  perform: (request, { payload, settings, features, statsContext }) => {
     if (!payload.user_data) {
       throw new IntegrationError('Must include at least one user data property', 'Misconfigured required field', 400)
     }
@@ -41,22 +43,25 @@ const action: ActionDefinition<Settings, Payload> = {
       )
     }
 
-    return request(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}/events`, {
-      method: 'POST',
-      json: {
-        data: [
-          {
-            event_name: payload.event_name,
-            event_time: payload.event_time,
-            action_source: payload.action_source,
-            event_id: payload.event_id,
-            event_source_url: payload.event_source_url,
-            user_data: hash_user_data({ user_data: payload.user_data }),
-            custom_data: payload.custom_data
-          }
-        ]
+    return request(
+      `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
+      {
+        method: 'POST',
+        json: {
+          data: [
+            {
+              event_name: payload.event_name,
+              event_time: payload.event_time,
+              action_source: payload.action_source,
+              event_id: payload.event_id,
+              event_source_url: payload.event_source_url,
+              user_data: hash_user_data({ user_data: payload.user_data }),
+              custom_data: payload.custom_data
+            }
+          ]
+        }
       }
-    })
+    )
   }
 }
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
@@ -1,7 +1,7 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { CURRENCY_ISO_CODES, API_VERSION } from '../constants'
+import { CURRENCY_ISO_CODES } from '../constants'
 import {
   currency,
   value,
@@ -17,6 +17,7 @@ import {
   event_id
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
+import { get_api_version } from '../utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Initiate Checkout',
@@ -58,7 +59,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     custom_data: custom_data
   },
-  perform: (request, { payload, settings }) => {
+  perform: (request, { payload, settings, features, statsContext }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.has(payload.currency)) {
       throw new IntegrationError(
         `${payload.currency} is not a valid currency code.`,
@@ -84,30 +85,33 @@ const action: ActionDefinition<Settings, Payload> = {
       if (err) throw err
     }
 
-    return request(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}/events`, {
-      method: 'POST',
-      json: {
-        data: [
-          {
-            event_name: 'InitiateCheckout',
-            event_time: payload.event_time,
-            action_source: payload.action_source,
-            event_source_url: payload.event_source_url,
-            event_id: payload.event_id,
-            user_data: hash_user_data({ user_data: payload.user_data }),
-            custom_data: {
-              ...payload.custom_data,
-              currency: payload.currency,
-              value: payload.value,
-              content_ids: payload.content_ids,
-              contents: payload.contents,
-              num_items: payload.num_items,
-              content_category: payload.content_category
+    return request(
+      `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
+      {
+        method: 'POST',
+        json: {
+          data: [
+            {
+              event_name: 'InitiateCheckout',
+              event_time: payload.event_time,
+              action_source: payload.action_source,
+              event_source_url: payload.event_source_url,
+              event_id: payload.event_id,
+              user_data: hash_user_data({ user_data: payload.user_data }),
+              custom_data: {
+                ...payload.custom_data,
+                currency: payload.currency,
+                value: payload.value,
+                content_ids: payload.content_ids,
+                contents: payload.contents,
+                num_items: payload.num_items,
+                content_category: payload.content_category
+              }
             }
-          }
-        ]
+          ]
+        }
       }
-    })
+    )
   }
 }
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
@@ -1,7 +1,8 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { CURRENCY_ISO_CODES, API_VERSION } from '../constants'
+import { CURRENCY_ISO_CODES } from '../constants'
+import { get_api_version } from '../utils'
 import {
   currency,
   value,
@@ -61,7 +62,7 @@ const action: ActionDefinition<Settings, Payload> = {
     num_items: num_items,
     custom_data: custom_data
   },
-  perform: (request, { payload, settings }) => {
+  perform: (request, { payload, settings, features, statsContext }) => {
     if (!CURRENCY_ISO_CODES.has(payload.currency)) {
       throw new IntegrationError(
         `${payload.currency} is not a valid currency code.`,
@@ -87,31 +88,34 @@ const action: ActionDefinition<Settings, Payload> = {
       if (err) throw err
     }
 
-    return request(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}/events`, {
-      method: 'POST',
-      json: {
-        data: [
-          {
-            event_name: 'Purchase',
-            event_time: payload.event_time,
-            action_source: payload.action_source,
-            event_source_url: payload.event_source_url,
-            event_id: payload.event_id,
-            user_data: hash_user_data({ user_data: payload.user_data }),
-            custom_data: {
-              ...payload.custom_data,
-              currency: payload.currency,
-              value: payload.value,
-              content_ids: payload.content_ids,
-              content_name: payload.content_name,
-              content_type: payload.content_type,
-              contents: payload.contents,
-              num_items: payload.num_items
+    return request(
+      `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
+      {
+        method: 'POST',
+        json: {
+          data: [
+            {
+              event_name: 'Purchase',
+              event_time: payload.event_time,
+              action_source: payload.action_source,
+              event_source_url: payload.event_source_url,
+              event_id: payload.event_id,
+              user_data: hash_user_data({ user_data: payload.user_data }),
+              custom_data: {
+                ...payload.custom_data,
+                currency: payload.currency,
+                value: payload.value,
+                content_ids: payload.content_ids,
+                content_name: payload.content_name,
+                content_type: payload.content_type,
+                contents: payload.contents,
+                num_items: payload.num_items
+              }
             }
-          }
-        ]
+          ]
+        }
       }
-    })
+    )
   }
 }
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
@@ -1,7 +1,8 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { CURRENCY_ISO_CODES, API_VERSION } from '../constants'
+import { CURRENCY_ISO_CODES } from '../constants'
+import { get_api_version } from '../utils'
 import {
   currency,
   value,
@@ -61,7 +62,7 @@ const action: ActionDefinition<Settings, Payload> = {
     value: value,
     custom_data: custom_data
   },
-  perform: (request, { payload, settings }) => {
+  perform: (request, { payload, settings, features, statsContext }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.has(payload.currency)) {
       throw new IntegrationError(
         `${payload.currency} is not a valid currency code.`,
@@ -87,30 +88,33 @@ const action: ActionDefinition<Settings, Payload> = {
       if (err) throw err
     }
 
-    return request(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}/events`, {
-      method: 'POST',
-      json: {
-        data: [
-          {
-            event_name: 'Search',
-            event_time: payload.event_time,
-            action_source: payload.action_source,
-            event_id: payload.event_id,
-            event_source_url: payload.event_source_url,
-            user_data: hash_user_data({ user_data: payload.user_data }),
-            custom_data: {
-              ...payload.custom_data,
-              currency: payload.currency,
-              content_ids: payload.content_ids,
-              contents: payload.contents,
-              content_category: payload.content_category,
-              value: payload.value,
-              search_string: payload.search_string
+    return request(
+      `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
+      {
+        method: 'POST',
+        json: {
+          data: [
+            {
+              event_name: 'Search',
+              event_time: payload.event_time,
+              action_source: payload.action_source,
+              event_id: payload.event_id,
+              event_source_url: payload.event_source_url,
+              user_data: hash_user_data({ user_data: payload.user_data }),
+              custom_data: {
+                ...payload.custom_data,
+                currency: payload.currency,
+                content_ids: payload.content_ids,
+                contents: payload.contents,
+                content_category: payload.content_category,
+                value: payload.value,
+                search_string: payload.search_string
+              }
             }
-          }
-        ]
+          ]
+        }
       }
-    })
+    )
   }
 }
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/utils.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/utils.ts
@@ -1,0 +1,20 @@
+import { StatsContext } from '@segment/actions-core/src/destination-kit'
+import { Features } from '@segment/actions-core/src/mapping-kit'
+import { API_VERSION, CANARY_API_VERSION } from './constants'
+
+const FLAGON_NAME = 'facebook-capi-actions-canary-version'
+
+export const get_api_version = (features: Features | undefined, statsContext: StatsContext | undefined): string => {
+  const statsClient = statsContext?.statsClient
+  const tags = statsContext?.tags
+
+  if (features && features[FLAGON_NAME]) {
+    tags?.push(`version:${CANARY_API_VERSION}`)
+    statsClient?.incr(`fb_api_version`, 1, tags)
+    return CANARY_API_VERSION
+  }
+
+  tags?.push(`version:${API_VERSION}`)
+  statsClient?.incr(`fb_api_version`, 1, tags)
+  return API_VERSION
+}

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
@@ -17,7 +17,8 @@ import {
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { CURRENCY_ISO_CODES, API_VERSION } from '../constants'
+import { CURRENCY_ISO_CODES } from '../constants'
+import { get_api_version } from '../utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'View Content',
@@ -57,7 +58,7 @@ const action: ActionDefinition<Settings, Payload> = {
     value: { ...value, default: { '@path': '$.properties.price' } },
     custom_data: custom_data
   },
-  perform: (request, { payload, settings }) => {
+  perform: (request, { payload, settings, features, statsContext }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.has(payload.currency)) {
       throw new IntegrationError(
         `${payload.currency} is not a valid currency code.`,
@@ -83,30 +84,33 @@ const action: ActionDefinition<Settings, Payload> = {
       if (err) throw err
     }
 
-    return request(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}/events`, {
-      method: 'POST',
-      json: {
-        data: [
-          {
-            event_name: 'ViewContent',
-            event_time: payload.event_time,
-            action_source: payload.action_source,
-            event_id: payload.event_id,
-            event_source_url: payload.event_source_url,
-            user_data: hash_user_data({ user_data: payload.user_data }),
-            custom_data: {
-              ...payload.custom_data,
-              currency: payload.currency,
-              value: payload.value,
-              content_ids: payload.content_ids,
-              content_name: payload.content_name,
-              content_type: payload.content_type,
-              contents: payload.contents
+    return request(
+      `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
+      {
+        method: 'POST',
+        json: {
+          data: [
+            {
+              event_name: 'ViewContent',
+              event_time: payload.event_time,
+              action_source: payload.action_source,
+              event_id: payload.event_id,
+              event_source_url: payload.event_source_url,
+              user_data: hash_user_data({ user_data: payload.user_data }),
+              custom_data: {
+                ...payload.custom_data,
+                currency: payload.currency,
+                value: payload.value,
+                content_ids: payload.content_ids,
+                content_name: payload.content_name,
+                content_type: payload.content_type,
+                contents: payload.contents
+              }
             }
-          }
-        ]
+          ]
+        }
       }
-    })
+    )
   }
 }
 


### PR DESCRIPTION
# Summary

We are looking to update our FB Marketing API version from V12.0 to V14.0. This PR adds an intermediate (and safer) step towards that migration. By adding canary support we will be able to granularly control the levels of traffic received by X version of the API.

## Testing

![Screen Shot 2022-07-22 at 3 09 01 PM](https://user-images.githubusercontent.com/316711/180574983-cb648e80-4fe4-4675-aa4f-3aa359a38682.png)

```
➜  quasar git:(master) treb deploy -e production -b 32696a5 integrations-qa-control-prod-2

To see the changes you will deploy, navigate to:
https://github.com/segmentio/integrations/compare/8ac2432cdcfab3cbb1b3ef477bd16667808bb2fe...32696a5

Deploy to Production? [Yn]: y
Deploying integrations-qa-control-prod-2@32696a5 to production...
Cloudformation stack 'arn:aws:cloudformation:us-west-2:752180062774:stack/production--integrations-qa-control-prod-2/b7d4fbd0-54d4-11ea-a0c6-06e1bfa6e222' updating
Updated TaskDefinition 'arn:aws:ecs:us-west-2:752180062774:task-definition/productionintegrations-qa-control-prod-2:63'
Updated Service 'arn:aws:ecs:us-west-2:752180062774:service/outbound/production-integrations-qa-control-prod-2-Service-KLN9ZN0UTXJ4'
Cloudformation stack 'arn:aws:cloudformation:us-west-2:752180062774:stack/production--integrations-qa-control-prod-2/b7d4fbd0-54d4-11ea-a0c6-06e1bfa6e222' updated

Success!
➜  quasar git:(master) treb deploy -e production -b 32696a5 integrations-qa-candidate-prod-2

To see the changes you will deploy, navigate to:
https://github.com/segmentio/integrations/compare/b73fe4e84d3a7c4d36d31dcb2f55555305f65366...32696a5

Deploy to Production? [Yn]: y
Deploying integrations-qa-candidate-prod-2@32696a5 to production...
Cloudformation stack 'arn:aws:cloudformation:us-west-2:752180062774:stack/production--integrations-qa-candidate-prod-2/740f53b0-4452-11ea-8948-02e1301110e6' updating
Updated TaskDefinition 'arn:aws:ecs:us-west-2:752180062774:task-definition/productionintegrations-qa-candidate-prod-2:92'
Updated Service 'arn:aws:ecs:us-west-2:752180062774:service/outbound/production-integrations-qa-candidate-prod-2-Service-1JTR5VATE90TW'
Cloudformation stack 'arn:aws:cloudformation:us-west-2:752180062774:stack/production--integrations-qa-candidate-prod-2/740f53b0-4452-11ea-8948-02e1301110e6' updated

Success!
➜  quasar git:(master) quasar create -e production -s 2 -i actions-facebook-conversions-api
Success! New experiment created with id: 2CJLql7Wq0ZJib2lDOvfYQBXFy9
View experiment results here: https://segment.datadoghq.com/dashboard/kpu-nnr-kn2/quasar-destinations-qa?live=true&tpl_var_candidate_service_name=integrations-qa-candidate-2&tpl_var_control_service_name=integrations-qa-control-2&tpl_var_experiment_id=2cjlql7wq0zjib2ldovfyqbxfy9&tpl_var_env=production
To view any differences, run: quasar get-diffs -e production -x 2CJLql7Wq0ZJib2lDOvfYQBXFy9
To stop experiment early, run: quasar cancel -e production -x 2CJLql7Wq0ZJib2lDOvfYQBXFy9
➜  quasar git:(master) quasar get-diffs -e production -x 2CJLql7Wq0ZJib2lDOvfYQBXFy9
Fetching diffs, this could take a minute or more for diffs over 1000
➜  quasar git:(master) quasar get-diffs -e production -x 2CJLql7Wq0ZJib2lDOvfYQBXFy9
➜  quasar git:(master) quasar create -e production -s 2 -t 120m -i actions-facebook-conversions-api
Success! New experiment created with id: 2CJVQxrfncmQvuUjTLs36msUgO6
View experiment results here: https://segment.datadoghq.com/dashboard/kpu-nnr-kn2/quasar-destinations-qa?live=true&tpl_var_candidate_service_name=integrations-qa-candidate-2&tpl_var_control_service_name=integrations-qa-control-2&tpl_var_experiment_id=2cjvqxrfncmqvuujtls36msugo6&tpl_var_env=production
To view any differences, run: quasar get-diffs -e production -x 2CJVQxrfncmQvuUjTLs36msUgO6
To stop experiment early, run: quasar cancel -e production -x 2CJVQxrfncmQvuUjTLs36msUgO6
```

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
