### PR TITLE
[STRATCONN-1509] add new field pcc_games to GEC

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/google-enhanced-conversions.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/google-enhanced-conversions.test.ts
@@ -105,6 +105,55 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
     })
+    it('should send pcc_game:1 when PCC Game is set to true', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        properties: {
+          email: 'janedoe@gmail.com',
+          orderId: '123',
+          firstName: 'Bob John',
+          lastName: 'Smith',
+          phone: '14150000000',
+          address: {
+            street: '123 Market Street',
+            city: 'San Francisco',
+            state: 'CA',
+            postalCode: '94000',
+            country: 'USA'
+          }
+        }
+      })
+
+      nock('https://www.google.com/ads/event/api/v1')
+        .post(`?conversion_tracking_id=${conversionTrackingId}`)
+        .reply(201, {})
+
+      const responses = await testDestination.testAction('postConversion', {
+        event,
+        mapping: {
+          conversion_label: conversionLabel,
+          pcc_game: true
+        },
+        useDefaultMappings: true,
+        settings: {
+          conversionTrackingId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"pii_data\\":{\\"hashed_email\\":\\"1hFzBkhe0OUK-rOshx6Y-BaZFR8wKBUn1j_18jNlbGk=\\",\\"hashed_phone_number\\":[\\"5pAiami9y4LWCmP12H9fXJpoqrnOFRL7u9q1pkqlMmI=\\"],\\"address\\":[{\\"hashed_first_name\\":\\"IGT0sXMskUo9vWuqGeOhA-RylOG2Oj_IcIX2Zr5f7GU=\\",\\"hashed_last_name\\":\\"ZieDX5iOLF5QUz1JEWMHLT9PQfXIsEYwFQ3rs3Isot0=\\",\\"hashed_street_address\\":\\"tHP71r8-GY59XKpmdb6ssI3fd7TIBB6E6aCWN06RGBw=\\",\\"city\\":\\"sanfrancisco\\",\\"region\\":\\"ca\\",\\"postcode\\":\\"94000\\",\\"country\\":\\"USA\\"}]},\\"oid\\":\\"123\\",\\"user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"conversion_time\\":1623348484000000,\\"label\\":\\"_conversion_\\",\\"pcc_game\\":1}"`
+      )
+
+      expect(responses[0].options.searchParams).toMatchInlineSnapshot(`
+        Object {
+          "conversion_tracking_id": "_conversion_id_",
+        }
+      `)
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
     it('should send is_app_incrementality:1 when App conversion for Incrementality Study is set to true', async () => {
       const event = createTestEvent({
         timestamp,

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/generated-types.ts
@@ -34,6 +34,10 @@ export interface Payload {
    */
   is_app_incrementality?: boolean
   /**
+   * Description
+   */
+  pcc_game?: boolean
+  /**
    * Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000.
    */
   phone_number?: string

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/generated-types.ts
@@ -34,7 +34,7 @@ export interface Payload {
    */
   is_app_incrementality?: boolean
   /**
-   * Description
+   * Alpha feature offered by Google for gaming industry. When set to true, Segment will send pcc_game = 1 to Google.
    */
   pcc_game?: boolean
   /**

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
@@ -220,8 +220,6 @@ const action: ActionDefinition<Settings, Payload> = {
       pcc_game: payload.pcc_game ? 1 : 0
     })
 
-    console.log('Data', conversionData)
-
     const address = cleanData({
       hashed_first_name: formatFirstName(payload.first_name),
       hashed_last_name: formatLastName(payload.last_name),

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
@@ -102,6 +102,12 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'boolean',
       default: false
     },
+    pcc_game: {
+      label: 'Name',
+      description: 'Description',
+      type: 'boolean',
+      default: false
+    },
     // PII Fields - These fields must be hashed using SHA 256 and encoded as websafe-base64.
     phone_number: {
       label: 'Phone Number',
@@ -210,8 +216,11 @@ const action: ActionDefinition<Settings, Payload> = {
       label: payload.conversion_label,
       value: payload.value,
       currency_code: payload.currency_code,
-      is_app_incrementality: payload.is_app_incrementality ? 1 : 0
+      is_app_incrementality: payload.is_app_incrementality ? 1 : 0,
+      pcc_game: payload.pcc_game ? 1 : 0
     })
+
+    console.log('Data', conversionData)
 
     const address = cleanData({
       hashed_first_name: formatFirstName(payload.first_name),

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
@@ -103,8 +103,9 @@ const action: ActionDefinition<Settings, Payload> = {
       default: false
     },
     pcc_game: {
-      label: 'Name',
-      description: 'Description',
+      label: 'PCC Game Flag',
+      description:
+        'Alpha feature offered by Google for gaming industry. When set to true, Segment will send pcc_game = 1 to Google.',
       type: 'boolean',
       default: false
     },


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_This PR adds a new field in the `Post Conversion` action for Google Enhanced Conversions, called `PCC Game Flag`. This is not a required field however when set to true will include `pcc_game: 1` parameter in the request from Segment._ 

We are planning to only expose this setting to one customer with a [flagon](https://flagon.segment.com/families/destination-actions/gates/gec-pcc-games-field). 

Here is the app PR with the flagon code: https://github.com/segmentio/app/pull/13664

Note: The app PR will be merged first to ensure only workspaces added to the flagon will see this new field in the mappings. 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

Tested in stage via deploying to stage. [Testing Doc](https://paper.dropbox.com/doc/GEC-pcc_games-field-Testing--BlvHf5SCZFyu0dK6Rvj8tv8vAg-Sct7lxT58TYtujIkJWgLb)

- [ x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ x] [Segmenters] Tested in the staging environment
