### PR TITLE
[Customer.io] Add support to send an event id for track event calls

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/__tests__/trackEvent.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/trackEvent.test.ts
@@ -270,23 +270,23 @@ describe('CustomerIO', () => {
       })
     })
 
-    it('should extract properties.id when supplied and map to id in the payload', async () => {
+    it('should map messageId to id in the payload', async () => {
       const settings: Settings = {
         siteId: '12345',
         apiKey: 'abcde',
       }
-      const eventId = '000RZ3NDEKTSV4RRFFQ69G5BBB'
+      const messageId = 'message123'
       const userId = 'abc123'
       const name = 'testEvent'
       const data = {
-        id: eventId,
         property1: 'this is a test'
       }
       trackEventService.post(`/customers/${userId}/events`).reply(200, {}, { 'x-customerio-region': 'US-fallback' })
       const event = createTestEvent({
         event: name,
         userId,
-        properties: data
+        properties: data,
+        messageId
       })
       const responses = await testDestination.testAction('trackEvent', { event, settings, useDefaultMappings: true })
 
@@ -298,7 +298,7 @@ describe('CustomerIO', () => {
       })
       expect(responses[0].data).toMatchObject({})
       expect(responses[0].options.json).toMatchObject({
-        id: eventId,
+        id: messageId,
         name,
         data
       })

--- a/packages/destination-actions/src/destinations/customerio/__tests__/trackEvent.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/trackEvent.test.ts
@@ -16,6 +16,7 @@ describe('CustomerIO', () => {
         apiKey: 'abcde',
         accountRegion: AccountRegion.US
       }
+      const eventId = '000RZ3NDEKTSV4RRFFQ69G5BBB'
       const userId = 'abc123'
       const name = 'testEvent'
       const timestamp = dayjs.utc().toISOString()
@@ -33,7 +34,8 @@ describe('CustomerIO', () => {
         event: name,
         userId,
         properties: data,
-        timestamp
+        timestamp,
+        eventId
       })
       const responses = await testDestination.testAction('trackEvent', { event, settings, useDefaultMappings: true })
 
@@ -46,6 +48,7 @@ describe('CustomerIO', () => {
       expect(responses[0].data).toMatchObject({})
       expect(responses[0].options.json).toMatchObject({
         name,
+        event_id: eventId,
         timestamp: dayjs.utc(timestamp).unix(),
         data: {
           ...data,

--- a/packages/destination-actions/src/destinations/customerio/__tests__/trackEvent.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/trackEvent.test.ts
@@ -22,6 +22,7 @@ describe('CustomerIO', () => {
       const timestamp = dayjs.utc().toISOString()
       const birthdate = dayjs.utc('1990-01-01T00:00:00Z').toISOString()
       const data = {
+        id: eventId,
         property1: 'this is a test',
         person: {
           over18: true,
@@ -34,8 +35,7 @@ describe('CustomerIO', () => {
         event: name,
         userId,
         properties: data,
-        timestamp,
-        eventId
+        timestamp
       })
       const responses = await testDestination.testAction('trackEvent', { event, settings, useDefaultMappings: true })
 

--- a/packages/destination-actions/src/destinations/customerio/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackEvent/generated-types.ts
@@ -14,6 +14,10 @@ export interface Payload {
    */
   name: string
   /**
+   * An optional identifier used to deduplicate events. This value must be a valid ULID otherwise one will be generated. [Learn more](https://customer.io/docs/api/#operation/track)
+   */
+  event_id?: string
+  /**
    * A timestamp of when the event took place. Default is current date and time.
    */
   timestamp?: string

--- a/packages/destination-actions/src/destinations/customerio/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackEvent/index.ts
@@ -47,7 +47,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     event_id: {
       label: 'Event ID',
-      description: 'An optional identifier used to deduplicate events. [Learn more](https://customer.io/docs/api/#operation/track)',
+      description: 'An optional identifier used to deduplicate events. [Learn more](https://customer.io/docs/api/#operation/track).',
       type: 'string',
       default: {
         '@path': '$.messageId'

--- a/packages/destination-actions/src/destinations/customerio/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackEvent/index.ts
@@ -47,10 +47,10 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     event_id: {
       label: 'Event ID',
-      description: 'An optional identifier used to dedulpicate events. This value must be a valid ULID otherwise one will be generated.',
+      description: 'An optional identifier used to deduplicate events. This value must be a valid ULID otherwise one will be generated. [Learn more](https://customer.io/docs/api/#operation/track)',
       type: 'string',
       default: {
-        '@path': '$.eventId'
+        '@path': '$.properties.id'
       }
     },
     timestamp: {

--- a/packages/destination-actions/src/destinations/customerio/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackEvent/index.ts
@@ -8,6 +8,7 @@ interface TrackEventPayload {
   type?: string
   timestamp?: string | number
   data?: Record<string, unknown>
+  event_id?: string
   // Required for anonymous events
   anonymous_id?: string
 }
@@ -42,6 +43,14 @@ const action: ActionDefinition<Settings, Payload> = {
       required: true,
       default: {
         '@path': '$.event'
+      }
+    },
+    event_id: {
+      label: 'Event ID',
+      description: 'An optional identifier used to dedulpicate events. This value must be a valid ULID otherwise one will be generated.',
+      type: 'string',
+      default: {
+        '@path': '$.eventId'
       }
     },
     timestamp: {
@@ -86,6 +95,10 @@ const action: ActionDefinition<Settings, Payload> = {
       name: payload.name,
       data,
       timestamp
+    }
+
+    if (payload.event_id) {
+      body.event_id = payload.event_id
     }
 
     let url: string

--- a/packages/destination-actions/src/destinations/customerio/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackEvent/index.ts
@@ -8,7 +8,7 @@ interface TrackEventPayload {
   type?: string
   timestamp?: string | number
   data?: Record<string, unknown>
-  event_id?: string
+  id?: string
   // Required for anonymous events
   anonymous_id?: string
 }
@@ -98,7 +98,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (payload.event_id) {
-      body.event_id = payload.event_id
+      body.id = payload.event_id
     }
 
     let url: string

--- a/packages/destination-actions/src/destinations/customerio/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackEvent/index.ts
@@ -47,10 +47,10 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     event_id: {
       label: 'Event ID',
-      description: 'An optional identifier used to deduplicate events. This value must be a valid ULID otherwise one will be generated. [Learn more](https://customer.io/docs/api/#operation/track)',
+      description: 'An optional identifier used to deduplicate events. [Learn more](https://customer.io/docs/api/#operation/track)',
       type: 'string',
       default: {
-        '@path': '$.properties.id'
+        '@path': '$.messageId'
       }
     },
     timestamp: {


### PR DESCRIPTION
The [customer.io track event api call](https://customer.io/docs/api/#operation/track) has support to pass an event id that may be used to deduplicate events.
This change makes that field available to the customer.io destination.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
