### PR TITLE
Add integration source to FullStory API calls

### DIFF
--- a/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
@@ -10,6 +10,7 @@ export const email = 'fake+email@example.com'
 export const displayName = 'fake-display-name'
 export const baseUrl = 'https://api.fullstory.com'
 export const settings = { apiKey }
+export const integrationSourceQueryParam = `integration=segment`
 
 const testDestination = createTestIntegration(Definition)
 
@@ -23,7 +24,9 @@ describe('FullStory', () => {
 
   describe('trackEvent', () => {
     it('makes expected request with default mappings', async () => {
-      nock(baseUrl).post(`/users/v1/individual/${urlEncodedUserId}/customevent`).reply(200)
+      nock(baseUrl)
+        .post(`/users/v1/individual/${urlEncodedUserId}/customevent?${integrationSourceQueryParam}`)
+        .reply(200)
       const eventName = 'test-event'
 
       const properties = {
@@ -78,7 +81,9 @@ describe('FullStory', () => {
     })
 
     it('handles undefined event values', async () => {
-      nock(baseUrl).post(`/users/v1/individual/${urlEncodedUserId}/customevent`).reply(200)
+      nock(baseUrl)
+        .post(`/users/v1/individual/${urlEncodedUserId}/customevent?${integrationSourceQueryParam}`)
+        .reply(200)
       const eventName = 'test-event'
 
       const event = createTestEvent({
@@ -106,7 +111,9 @@ describe('FullStory', () => {
 
   describe('identifyUser', () => {
     it('makes expected request with default mappings', async () => {
-      nock(baseUrl).post(`/users/v1/individual/${urlEncodedUserId}/customvars`).reply(200)
+      nock(baseUrl)
+        .post(`/users/v1/individual/${urlEncodedUserId}/customvars?${integrationSourceQueryParam}`)
+        .reply(200)
       const event = createTestEvent({
         type: 'identify',
         userId,

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
@@ -4,7 +4,16 @@ import {
   setUserPropertiesRequestParams,
   deleteUserRequestParams
 } from '../request-params'
-import { anonymousId, displayName, email, userId, urlEncodedUserId, baseUrl, settings } from './fullstory.test'
+import {
+  anonymousId,
+  displayName,
+  email,
+  userId,
+  urlEncodedUserId,
+  baseUrl,
+  settings,
+  integrationSourceQueryParam
+} from './fullstory.test'
 
 describe('requestParams', () => {
   describe('listOperations', () => {
@@ -35,7 +44,7 @@ describe('requestParams', () => {
       expect(options.method).toBe('post')
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
-      expect(url).toBe(`${baseUrl}/users/v1/individual/${urlEncodedUserId}/customevent`)
+      expect(url).toBe(`${baseUrl}/users/v1/individual/${urlEncodedUserId}/customevent?${integrationSourceQueryParam}`)
       expect(options.json).toEqual({
         event: {
           event_name: requestValues.eventName,
@@ -57,7 +66,7 @@ describe('requestParams', () => {
       expect(options.method).toBe('post')
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
-      expect(url).toBe(`${baseUrl}/users/v1/individual/${urlEncodedUserId}/customevent`)
+      expect(url).toBe(`${baseUrl}/users/v1/individual/${urlEncodedUserId}/customevent?${integrationSourceQueryParam}`)
       expect(options.json).toEqual({
         event: {
           event_name: requestValues.eventName,
@@ -77,7 +86,7 @@ describe('requestParams', () => {
       expect(options.method).toBe('post')
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
-      expect(url).toBe(`${baseUrl}/users/v1/individual/${urlEncodedUserId}/customevent`)
+      expect(url).toBe(`${baseUrl}/users/v1/individual/${urlEncodedUserId}/customevent?${integrationSourceQueryParam}`)
       expect(options.json).toEqual({
         event: {
           event_name: requestValues.eventName,
@@ -100,7 +109,7 @@ describe('requestParams', () => {
       expect(options.method).toBe('post')
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
-      expect(url).toBe(`${baseUrl}/users/v1/individual/${urlEncodedUserId}/customvars`)
+      expect(url).toBe(`${baseUrl}/users/v1/individual/${urlEncodedUserId}/customvars?${integrationSourceQueryParam}`)
       expect(options.json).toEqual(requestBody)
     })
   })

--- a/packages/destination-actions/src/destinations/fullstory/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/identifyUser/index.ts
@@ -64,7 +64,6 @@ const action: ActionDefinition<Settings> = {
       normalizedTraits.segmentAnonymousId_str = anonymousId
     }
 
-    // TODO(nate): Include a source value once the HTTP API is updated to support it
     const requestBody = {
       ...normalizedTraits,
       ...(email !== undefined && { email }),

--- a/packages/destination-actions/src/destinations/fullstory/request-params.ts
+++ b/packages/destination-actions/src/destinations/fullstory/request-params.ts
@@ -10,6 +10,8 @@ interface RequestParams {
 }
 
 const apiBaseUrl = 'https://api.fullstory.com'
+const segmentIntegrationSource = 'segment'
+const integrationSourceQueryParam = `integration=${segmentIntegrationSource}`
 
 /**
  * Returns default {@link RequestParams} suitable for most FullStory HTTP API requests.
@@ -56,7 +58,10 @@ export const customEventRequestParams = (
   }
 ): RequestParams => {
   const { userId, eventName, eventData, timestamp, useRecentSession, sessionUrl } = requestValues
-  const defaultParams = defaultRequestParams(settings, `users/v1/individual/${encodeURIComponent(userId)}/customevent`)
+  const defaultParams = defaultRequestParams(
+    settings,
+    `users/v1/individual/${encodeURIComponent(userId)}/customevent?${integrationSourceQueryParam}`
+  )
 
   const requestBody: Record<string, any> = {
     event: {
@@ -102,7 +107,10 @@ export const setUserPropertiesRequestParams = (
   userId: string,
   requestBody: Object
 ): RequestParams => {
-  const defaultParams = defaultRequestParams(settings, `users/v1/individual/${encodeURIComponent(userId)}/customvars`)
+  const defaultParams = defaultRequestParams(
+    settings,
+    `users/v1/individual/${encodeURIComponent(userId)}/customvars?${integrationSourceQueryParam}`
+  )
 
   return {
     ...defaultParams,

--- a/packages/destination-actions/src/destinations/fullstory/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/trackEvent/index.ts
@@ -67,7 +67,6 @@ const action: ActionDefinition<Settings, Payload> = {
     const { userId, name, properties, timestamp, useRecentSession, sessionUrl } = payload
     const utcTimestamp = timestamp ? dayjs.utc(timestamp) : undefined
 
-    // TODO(nate): Include a source value once the HTTP API is updated to support it
     const { url, options } = customEventRequestParams(settings, {
       userId,
       eventName: name,


### PR DESCRIPTION
Adds an integration source to FullStory API calls from the FullStory Segment cloud mode destination to assist with analytics and service health monitoring.

## Testing

Changes tested against a FullStory production environment organization.

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
