### PR TITLE
remove cli check for creation name for cloud destinations

### DIFF
--- a/packages/cli-internal/src/commands/push.ts
+++ b/packages/cli-internal/src/commands/push.ts
@@ -84,23 +84,6 @@ export default class Push extends Command {
       throw new Error('Number of metadatas must match number of schemas')
     }
 
-    // Guardrails to ensure action-destination definition don't
-    // deviate from stable idenfitiers in the control-plane definition.
-    // We check this to fail fast and early, before parsing actions and
-    // building request payloads.
-    for (const metadata of metadatas) {
-      const entry = manifest[metadata.id]
-      const definition = entry.definition
-
-      // Creation Name check
-      if (metadata.creationName !== definition.name) {
-        this.spinner.fail()
-        throw new Error(
-          `The definition name '${definition.name}' should always match the control plane creation name '${metadata.creationName}'.`
-        )
-      }
-    }
-
     this.spinner.stop()
 
     for (const metadata of metadatas) {


### PR DESCRIPTION
This PR removes the CLI check for cloud destination names to match the creation name as a result of this [PR](https://github.com/segmentio/integrations/pull/2330).

Will merge only after the above PR is deployed.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
