### PR TITLE
fix google sheets font

### DIFF
--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
@@ -56,13 +56,15 @@ const action: ActionDefinition<Settings, Payload> = {
     fields: {
       label: 'Fields',
       description: `
-      The fields to write to the spreadsheet. 
-      On the left-hand side, input the name of the field as it will appear in the Google Sheet. 
-      On the right-hand side, select the field from your data model that maps to the given field in your sheet.
+  The fields to write to the spreadsheet. 
+
+  On the left-hand side, input the name of the field as it will appear in the Google Sheet. 
+  
+  On the right-hand side, select the field from your data model that maps to the given field in your sheet.
+     
+  ---
       
-      ---
-      
-      `,
+  `,
       type: 'object',
       required: true,
       defaultObjectUI: 'keyvalue:only'


### PR DESCRIPTION
Manually add carriage returns to prevent Google Sheets font from reverting to code formatting. See thread for context:  https://segment.slack.com/archives/C03ADA99G7R/p1658436350987959

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the local server by checking that fonts render correctly
- [ ] [Segmenters] Tested in the staging environment

Before:
![image](https://user-images.githubusercontent.com/103517471/180501167-a5f491ca-c300-40c5-882d-e3e154dd189f.png)


After: 
![image](https://user-images.githubusercontent.com/103517471/180501012-8a6e527d-0546-4de5-b20b-85e31ad4c308.png)
