### PR TITLE
PEREX-1295 feat: add better logging to personas SMS action

### DIFF
--- a/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-sendgrid/sendEmail/index.ts
@@ -51,7 +51,7 @@ const fetchProfileTraits = async (
     const body = await response.json()
     return body.traits
   } catch (error) {
-    throw new IntegrationError('Unable to get profile traits', 'Trait fetch failure', 500)
+    throw new IntegrationError('Unable to get profile traits for email message', 'Email trait fetch failure', 500)
   }
 }
 

--- a/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/personas-messaging-twilio/sendSms/index.ts
@@ -32,7 +32,7 @@ const fetchProfileTraits = async (
 
     const body = await response.json()
     return body.traits
-  } catch (error) {
+  } catch (error: unknown) {
     throw new IntegrationError('Unable to get profile traits for SMS message', 'SMS trait fetch failure', 500)
   }
 }
@@ -159,7 +159,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
       try {
         parsedBody = await Liquid.parseAndRender(payload.body, { profile })
-      } catch (error) {
+      } catch (error: unknown) {
         throw new IntegrationError(`Unable to parse templating in SMS`, `SMS templating parse failure`, 400)
       }
 


### PR DESCRIPTION
Adds better logging to personas SMS action to match the logging in the personas email action
[PEREX-1295](https://segment.atlassian.net/browse/PEREX-1295)

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
