### PR TITLE
Rename new Heap destination

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackEvent/generated-types.ts
@@ -14,7 +14,7 @@ export interface Payload {
    */
   name: string
   /**
-   * An optional identifier used to deduplicate events. This value must be a valid ULID otherwise one will be generated. [Learn more](https://customer.io/docs/api/#operation/track)
+   * An optional identifier used to deduplicate events. [Learn more](https://customer.io/docs/api/#operation/track).
    */
   event_id?: string
   /**

--- a/packages/destination-actions/src/destinations/heap/index.ts
+++ b/packages/destination-actions/src/destinations/heap/index.ts
@@ -22,7 +22,7 @@ const presets: DestinationDefinition['presets'] = [
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Heap Cloud (Actions)',
-  slug: 'actions-heap',
+  slug: 'actions-heap-cloud',
   mode: 'cloud',
   authentication: {
     scheme: 'custom',

--- a/packages/destination-actions/src/destinations/heap/index.ts
+++ b/packages/destination-actions/src/destinations/heap/index.ts
@@ -21,7 +21,7 @@ const presets: DestinationDefinition['presets'] = [
 ]
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Heap',
+  name: 'Heap Cloud (Actions)',
   slug: 'actions-heap',
   mode: 'cloud',
   authentication: {

--- a/packages/destination-actions/src/destinations/qualtrics/generated-types.ts
+++ b/packages/destination-actions/src/destinations/qualtrics/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Settings {
   /**
-   * Qualtrics API token found in your Qualtrics account under "Account settings" -> "Qualtrics IDs"
+   * Qualtrics API token found in your Qualtrics account under "Account settings" -> "Qualtrics IDs."
    */
   apiToken: string
   /**
-   * Qualtrics datacenter id that identifies where your qualtrics instance is located. Found under "Account settings" -> "Qualtrics IDs"
+   * Qualtrics datacenter id that identifies where your qualtrics instance is located. Found under "Account settings" -> "Qualtrics IDs".
    */
   datacenter: string
 }

--- a/packages/destination-actions/src/destinations/qualtrics/triggerXflowWorkflow/generated-types.ts
+++ b/packages/destination-actions/src/destinations/qualtrics/triggerXflowWorkflow/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Payload {
   /**
-   * Enter the full URL as you see in your Xflow trigger. See more details on setting up an xflow trigger and getting the URL here
+   * Enter the full URL as you see in your Xflow trigger. See more details on setting up an xflow trigger and getting the URL here.
    */
   workflowUrl: string
   /**
-   * A mapping of key values to send to Qualtrics xflow
+   * A mapping of key values to send to Qualtrics xflow.
    */
   eventPayload?: {
     [k: string]: unknown


### PR DESCRIPTION
I'm renaming the new Heap destination from `Heap` to `Heap Cloud (Actions)` because there's an existing destination with that name. `Heap Cloud (Actions)` matches the current naming convention we and Heap have for `Heap Web (Actions)`.

Additionally, the linter detected that some type files from the new Qualtrics destination weren't regenerated so I'm adding them here. They only contain updates in comments.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
