### PR TITLE
Imlement a script to bump alpha version

### DIFF
--- a/packages/cli/bin/publish-alpha.sh
+++ b/packages/cli/bin/publish-alpha.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Description:
+#   - A handy utility that takes care of releasing alpha package in staging.
+#   - Automatically bump to correct next alpha version.
+#Run:
+#   - Give execute permission to publish-alpha and run:
+#   - ~ chmod +x ./bin/publish-alpha.sh
+#   - ~ ./bin/publish-alpha.sh
+true
+brew install coreutils
+MODULE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PACKAGE_DIR="$MODULE_DIR/../../"
+IGNORE_DIR=("cli" "cli-internal" "..")
+export NVM_DIR=$HOME/.nvm;
+source $NVM_DIR/nvm.sh;
+
+# Process and prepare
+git checkout staging
+nvm use
+yarn install
+
+# Try to publish alpha version
+{
+    yarn alpha
+}||{
+    echo "❌Failed to publish alpha, updating version to next tag"
+    for d in $(find $PACKAGE_DIR -maxdepth 1 -type d)
+    do
+        pkg_path="$(basename "$d")"
+        if [[ " ${IGNORE_DIR[*]} " =~ " ${pkg_path} " ]]; 
+        then
+            continue
+        else
+            FILE="$d/package.json"
+            if [ -f "$FILE" ]; then
+                # Get the package name in JSON file
+                pkg_name=$( sed -n 's/.*"name":.*"\(.*\)"\(,\)\{0,1\}/\1/p' "$FILE" )
+                # Get the next tag from npm
+                ver=$(npm view  ${pkg_name}@next version)
+                echo "✅Bumping ${pkg_name} into next tag version ${ver}"
+                cd ${d}
+                # Bump to next tag, update package file
+                npm version --no-git-tag-version ${ver} 
+            fi
+        fi
+    done
+    cd "${PACKAGE_DIR}/.."
+    yarn alpha
+}


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->
Description:
   - A handy utility that takes care of releasing alpha package in staging.
   - Automatically bump to correct next alpha version.
   
<img width="675" alt="image" src="https://user-images.githubusercontent.com/107439031/182212570-bb4393b1-0dfe-4c5a-8e8e-de1bddaa2830.png">

 
Run:
   - Give execute permission to publish-alpha and run:
   - ~ `chmod +x ./bin/publish-alpha.sh`
   - ~ `./bin/publish-alpha.sh`
<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->
