### PR TITLE
FB Marketing API Version Update - Canary

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-conversions-api/constants.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/constants.ts
@@ -1,5 +1,5 @@
 export const API_VERSION = '12.0'
-export const CANARY_API_VERSION = '12.0'
+export const CANARY_API_VERSION = '14.0'
 export const CURRENCY_ISO_CODES = new Set([
   'AED',
   'AFN',


### PR DESCRIPTION
Upgrading FB Marketing API Version for Facebook CAPI Actions.

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
