### PR TITLE
[ACT-163] Pass internal-only logging context into perform block

### DIFF
--- a/packages/core/src/create-test-integration.ts
+++ b/packages/core/src/create-test-integration.ts
@@ -1,7 +1,7 @@
 import { createTestEvent } from './create-test-event'
 import { Destination } from './destination-kit'
 import { mapValues } from './map-values'
-import type { DestinationDefinition, StatsContext } from './destination-kit'
+import type { DestinationDefinition, StatsContext, LoggerContext } from './destination-kit'
 import type { JSONObject } from './json-object'
 import type { SegmentEvent } from './segment-event'
 import { AuthTokens } from './destination-kit/parse-settings'
@@ -34,10 +34,11 @@ interface InputData<Settings> {
   auth?: AuthTokens
   /**
    * The features available in the request based on the customer's sourceID;
-   * Both `features` and `stats` are for internal Twilio/Segment use only.
+   * `features`, `stats` and `logs` are for internal Segment/Twilio use only.
    */
   features?: Features
   statsContext?: StatsContext
+  loggerContext?: LoggerContext
 }
 
 class TestDestination<T> extends Destination<T> {
@@ -59,7 +60,7 @@ class TestDestination<T> extends Destination<T> {
   /** Testing method that runs an action e2e while allowing slightly more flexible inputs */
   async testAction(
     action: string,
-    { event, mapping, settings, useDefaultMappings, auth, features, statsContext }: InputData<T>
+    { event, mapping, settings, useDefaultMappings, auth, features, statsContext, loggerContext }: InputData<T>
   ): Promise<Destination['responses']> {
     mapping = mapping ?? {}
 
@@ -75,7 +76,8 @@ class TestDestination<T> extends Destination<T> {
       settings: settings ?? ({} as T),
       auth,
       features: features ?? {},
-      statsContext: statsContext ?? ({} as StatsContext)
+      statsContext: statsContext ?? ({} as StatsContext),
+      loggerContext: loggerContext ?? ({} as LoggerContext)
     })
 
     const responses = this.responses
@@ -93,7 +95,8 @@ class TestDestination<T> extends Destination<T> {
       useDefaultMappings,
       auth,
       features,
-      statsContext
+      statsContext,
+      loggerContext
     }: Omit<InputData<T>, 'event'> & { events?: SegmentEvent[] }
   ): Promise<Destination['responses']> {
     mapping = mapping ?? {}
@@ -114,7 +117,8 @@ class TestDestination<T> extends Destination<T> {
       settings: settings ?? ({} as T),
       auth,
       features: features ?? {},
-      statsContext: statsContext ?? ({} as StatsContext)
+      statsContext: statsContext ?? ({} as StatsContext),
+      loggerContext: loggerContext ?? ({} as LoggerContext)
     })
 
     const responses = this.responses

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -12,7 +12,7 @@ import { validateSchema } from '../schema-validation'
 import { AuthTokens } from './parse-settings'
 import { IntegrationError } from '../errors'
 import { removeEmptyValues } from '../remove-empty-values'
-import { StatsContext } from './index'
+import { StatsContext, LoggerContext } from './index'
 
 type MaybePromise<T> = T | Promise<T>
 type RequestClient = ReturnType<typeof createRequestClient>
@@ -81,6 +81,7 @@ interface ExecuteBundle<T = unknown, Data = unknown> {
   /** For internal Segment/Twilio use only. */
   features?: Features | undefined
   statsContext?: StatsContext | undefined
+  loggerContext?: LoggerContext | undefined
 }
 
 /**
@@ -141,7 +142,8 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
       payload,
       auth: bundle.auth,
       features: bundle.features,
-      statsContext: bundle.statsContext
+      statsContext: bundle.statsContext,
+      loggerContext: bundle.loggerContext
     }
 
     // Construct the request client and perform the action
@@ -185,7 +187,8 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
         payload: payloads,
         auth: bundle.auth,
         features: bundle.features,
-        statsContext: bundle.statsContext
+        statsContext: bundle.statsContext,
+        loggerContext: bundle.loggerContext
       }
       await this.performRequest(this.definition.performBatch, data)
     }

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -1,4 +1,4 @@
-import { StatsContext } from './index'
+import { StatsContext, LoggerContext } from './index'
 import type { RequestOptions } from '../request-client'
 import type { JSONObject } from '../json-object'
 import { AuthTokens } from './parse-settings'
@@ -27,10 +27,11 @@ export interface ExecuteInput<Settings, Payload> {
   readonly auth?: AuthTokens
   /**
    * The features available in the request based on the customer's sourceID;
-   * Both `features` and `stats` are for internal Twilio/Segment use only.
+   * `features`, `stats` and `logs` are for internal Segment/Twilio use only.
    */
   readonly features?: Features
   readonly statsContext?: StatsContext
+  readonly loggerContext?: LoggerContext
 }
 
 export interface DynamicFieldResponse {


### PR DESCRIPTION
We'd like to expose logging for some of our internal action destinations. This change enables that.


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
