### PR TITLE
remove use_user_id

### DIFF
--- a/packages/destination-actions/src/destinations/heap/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/heap/trackEvent/__tests__/index.test.ts
@@ -19,7 +19,6 @@ describe('Heap.trackEvent', () => {
     }
     timestamp: string
     identity?: string
-    use_user_id?: boolean
     user_id?: number
   }
   beforeEach(() => {
@@ -76,7 +75,6 @@ describe('Heap.trackEvent', () => {
       messageId: '123'
     })
 
-    body.use_user_id = true
     body.user_id = 8325872782136936
 
     nock('https://heapanalytics.com').post('/api/track', body).reply(200, {})
@@ -107,7 +105,6 @@ describe('Heap.trackEvent', () => {
       properties
     })
 
-    body.use_user_id = true
     body.user_id = 8325872782136936
     body.properties = {
       segment_library: 'analytics.js',

--- a/packages/destination-actions/src/destinations/heap/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/heap/trackEvent/index.ts
@@ -10,7 +10,6 @@ import { IntegrationError } from '@segment/actions-core'
 type HeapEvent = {
   app_id: string
   identity?: string
-  use_user_id?: boolean
   user_id?: number
   event: string
   properties: {
@@ -106,20 +105,19 @@ const action: ActionDefinition<Settings, Payload> = {
       properties: eventProperties,
       idempotency_key: payload.message_id
     }
-    
+
     if (payload.anonymous_id && !payload.identity) {
-      event.use_user_id = true
       event.user_id = getHeapUserId(payload.anonymous_id)
     }
-    
+
     if (payload.identity) {
       event.identity = payload.identity
     }
-    
+
     if (payload.timestamp && dayjs.utc(payload.timestamp).isValid()) {
       event.timestamp = dayjs.utc(payload.timestamp).toISOString()
     }
-    
+
     return request('https://heapanalytics.com/api/track', {
       method: 'post',
       json: event


### PR DESCRIPTION
We've removed this field from our endpoint. It will now check for the existence of a user_id. 

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
