### PR TITLE
core: Add 'mappingRoot' option to support mapping against a nested field

### DIFF
--- a/packages/core/src/create-test-integration.ts
+++ b/packages/core/src/create-test-integration.ts
@@ -20,6 +20,10 @@ interface InputData<Settings> {
    */
   mapping?: JSONObject
   /**
+   * Optional path that mappings should be evaluated against.
+   */
+  mappingRoot?: string
+  /**
    * The settings for a destination instance. Includes things like
    * `apiKey` or `subdomain`. Any fields that are used across all actions
    * in a destination.
@@ -59,7 +63,7 @@ class TestDestination<T> extends Destination<T> {
   /** Testing method that runs an action e2e while allowing slightly more flexible inputs */
   async testAction(
     action: string,
-    { event, mapping, settings, useDefaultMappings, auth, features, statsContext }: InputData<T>
+    { event, mapping, mappingRoot = '', settings, useDefaultMappings, auth, features, statsContext }: InputData<T>
   ): Promise<Destination['responses']> {
     mapping = mapping ?? {}
 
@@ -72,6 +76,7 @@ class TestDestination<T> extends Destination<T> {
     await super.executeAction(action, {
       event: createTestEvent(event),
       mapping,
+      mappingRoot,
       settings: settings ?? ({} as T),
       auth,
       features: features ?? {},
@@ -89,6 +94,7 @@ class TestDestination<T> extends Destination<T> {
     {
       events,
       mapping,
+      mappingRoot = '',
       settings,
       useDefaultMappings,
       auth,
@@ -111,6 +117,7 @@ class TestDestination<T> extends Destination<T> {
     await super.executeBatch(action, {
       events: events.map((event) => createTestEvent(event)),
       mapping,
+      mappingRoot,
       settings: settings ?? ({} as T),
       auth,
       features: features ?? {},

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -160,7 +160,7 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
       throw new IntegrationError('This action does not support batched requests.', 'NotImplemented', 501)
     }
 
-    const transformData = bundle.data.map((data) => {
+    const transformData: InputData[] = bundle.data.map((data) => {
       if (bundle.mappingRoot) return get(data, bundle.mappingRoot) || {}
       return data
     })

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -163,6 +163,7 @@ export type AuthenticationScheme<Settings = any> =
 interface EventInput<Settings> {
   readonly event: SegmentEvent
   readonly mapping: JSONObject
+  readonly mappingRoot: string
   readonly settings: Settings
   /** Authentication-related data based on the destination's authentication.fields definition and authentication scheme */
   readonly auth?: AuthTokens
@@ -174,6 +175,7 @@ interface EventInput<Settings> {
 interface BatchEventInput<Settings> {
   readonly events: SegmentEvent[]
   readonly mapping: JSONObject
+  readonly mappingRoot: string
   readonly settings: Settings
   /** Authentication-related data based on the destination's authentication.fields definition and authentication scheme */
   readonly auth?: AuthTokens
@@ -192,6 +194,7 @@ interface OnEventOptions {
   onComplete?: (stats: SubscriptionStats) => void
   features?: Features
   statsContext?: StatsContext
+  mappingRoot?: string
 }
 
 export interface StatsClient {
@@ -331,7 +334,7 @@ export class Destination<Settings = JSONObject> {
 
   protected async executeAction(
     actionSlug: string,
-    { event, mapping, settings, auth, features, statsContext }: EventInput<Settings>
+    { event, mapping, mappingRoot, settings, auth, features, statsContext }: EventInput<Settings>
   ): Promise<Result[]> {
     const action = this.actions[actionSlug]
     if (!action) {
@@ -341,6 +344,7 @@ export class Destination<Settings = JSONObject> {
     return action.execute({
       mapping,
       data: event as unknown as InputData,
+      mappingRoot,
       settings,
       auth,
       features,
@@ -350,7 +354,7 @@ export class Destination<Settings = JSONObject> {
 
   public async executeBatch(
     actionSlug: string,
-    { events, mapping, settings, auth, features, statsContext }: BatchEventInput<Settings>
+    { events, mapping, mappingRoot, settings, auth, features, statsContext }: BatchEventInput<Settings>
   ) {
     const action = this.actions[actionSlug]
     if (!action) {
@@ -359,6 +363,7 @@ export class Destination<Settings = JSONObject> {
 
     await action.executeBatch({
       mapping,
+      mappingRoot,
       data: events as unknown as InputData[],
       settings,
       auth,
@@ -393,6 +398,7 @@ export class Destination<Settings = JSONObject> {
     const actionSlug = subscription.partnerAction
     const input = {
       mapping: subscription.mapping || {},
+      mappingRoot: options?.mappingRoot || '',
       settings,
       auth,
       features: options?.features || {},


### PR DESCRIPTION
This PR is a WIP proposal for allowing custom mapping roots. This option would allow callers to specify that mappings should be done against a sub-object of the event, like `properties`. This supports use cases that use Segment events as a wrapper and in which we'd like to hide the event format implementation detail from people configuring mappings.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
