### PR TITLE
Update FB Marketing API Version for all

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-conversions-api/constants.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/constants.ts
@@ -1,4 +1,4 @@
-export const API_VERSION = '12.0'
+export const API_VERSION = '14.0'
 export const CANARY_API_VERSION = '14.0'
 export const CURRENCY_ISO_CODES = new Set([
   'AED',


### PR DESCRIPTION
# Summary
Now that we are fully rolled out there's no need to keep a difference between canary and regular API versions for these integrations. This PR takes care of that.

# Test Results

Changes are currently live. Testing completed successfully in prod thanks to a slow rollout. 