### PR TITLE
adds name and description to metadata updates for CPS

### DIFF
--- a/packages/cli-internal/src/commands/push.ts
+++ b/packages/cli-internal/src/commands/push.ts
@@ -202,6 +202,8 @@ export default class Push extends Command {
       const basicOptions = getBasicOptions(options)
       const diff = diffString(
         asJson({
+          name: metadata.name,
+          description: metadata.description,
           basicOptions: filterOAuth(metadata.basicOptions),
           options: pick(metadata.options, filterOAuth(Object.keys(options))),
           platforms: metadata.platforms,
@@ -217,6 +219,8 @@ export default class Push extends Command {
           presets: sortBy(existingPresets, 'name')
         }),
         asJson({
+          name: definition.name,
+          description: definition.description,
           basicOptions: filterOAuth(basicOptions),
           options: pick(options, filterOAuth(Object.keys(options))),
           platforms,
@@ -259,9 +263,12 @@ export default class Push extends Command {
         continue
       }
 
+      //blah
       try {
         await Promise.all([
           updateDestinationMetadata(metadata.id, {
+            name,
+            description,
             advancedOptions: [], // make sure this gets cleared out since we don't use advancedOptions in Actions
             basicOptions,
             options,

--- a/packages/cli-internal/src/commands/push.ts
+++ b/packages/cli-internal/src/commands/push.ts
@@ -263,7 +263,6 @@ export default class Push extends Command {
         continue
       }
 
-      //blah
       try {
         await Promise.all([
           updateDestinationMetadata(metadata.id, {


### PR DESCRIPTION
Adding support that was seemingly removed in 2021 for updating name/description from the actions manifest index

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
