### PR TITLE
[STRATCONN 1413] change check to use blocklist

### DIFF
--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
@@ -625,7 +625,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -695,7 +695,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
@@ -625,7 +625,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -695,7 +695,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
+          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
@@ -576,6 +576,58 @@ describe('GA4', () => {
       )
     })
 
+    it('should allow boolean value and user_property', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Payment Info Entered',
+        userId: 'abc123',
+        type: 'track',
+        properties: {
+          products: [
+            {
+              product_id: '123456',
+              currency: 'USD'
+            }
+          ]
+        }
+      })
+      const responses = await testDestination.testAction('addPaymentInfo', {
+        event,
+        settings: {
+          apiSecret,
+          measurementId
+        },
+        features: { 'actions-google-analytics-4-verify-params-feature': true },
+        mapping: {
+          client_id: {
+            '@path': '$.userId'
+          },
+          user_properties: {
+            hello: true
+          },
+          params: {
+            test_key: true
+          },
+          items: [
+            {
+              item_id: {
+                '@path': '$.properties.products.0.product_id'
+              },
+              currency: {
+                '@path': `$.properties.products.0.currency`
+              }
+            }
+          ]
+        },
+        useDefaultMappings: false
+      })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
     it('should throw an error when param value is null', async () => {
       nock('https://www.google-analytics.com/mp/collect')
         .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
@@ -625,7 +677,115 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'Param [test_key] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+        )
+      }
+    })
+
+    it('should throw an error when param value is array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Payment Info Entered',
+        userId: 'abc123',
+        type: 'track',
+        properties: {
+          products: [
+            {
+              product_id: '123456',
+              currency: 'USD'
+            }
+          ]
+        }
+      })
+      try {
+        await testDestination.testAction('addPaymentInfo', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.userId'
+            },
+            params: {
+              test_key: ['one', 'two']
+            },
+            items: [
+              {
+                item_id: {
+                  '@path': '$.properties.products.0.product_id'
+                },
+                currency: {
+                  '@path': `$.properties.products.0.currency`
+                }
+              }
+            ]
+          },
+          useDefaultMappings: false
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'Param [test_key] has unsupported value. GA4 does not accept array values for event parameters and item parameters.'
+        )
+      }
+    })
+
+    it('should throw an error when param value is object', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Payment Info Entered',
+        userId: 'abc123',
+        type: 'track',
+        properties: {
+          products: [
+            {
+              product_id: '123456',
+              currency: 'USD'
+            }
+          ]
+        }
+      })
+      try {
+        await testDestination.testAction('addPaymentInfo', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.userId'
+            },
+            params: {
+              test_key: { key: 'value' }
+            },
+            items: [
+              {
+                item_id: {
+                  '@path': '$.properties.products.0.product_id'
+                },
+                currency: {
+                  '@path': `$.properties.products.0.currency`
+                }
+              }
+            ]
+          },
+          useDefaultMappings: false
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'Param [test_key] has unsupported value. GA4 does not accept object values for event parameters and item parameters.'
         )
       }
     })
@@ -695,7 +855,77 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
+          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+        )
+      }
+    })
+
+    it('should throw an error when user_properties value is an object', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Payment Info Entered',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          products: [
+            {
+              product_id: '12345abcde',
+              name: 'Quadruple Stack Oreos, 52 ct',
+              currency: 'USD',
+              price: 12.99,
+              quantity: 1
+            }
+          ]
+        }
+      })
+      try {
+        await testDestination.testAction('addPaymentInfo', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            user_properties: {
+              hello: { World: 'world' },
+              a: '1',
+              b: '2',
+              c: '3'
+            },
+            items: [
+              {
+                item_name: {
+                  '@path': `$.properties.products.0.name`
+                },
+                item_id: {
+                  '@path': `$.properties.products.0.product_id`
+                },
+                currency: {
+                  '@path': `$.properties.products.0.currency`
+                },
+                price: {
+                  '@path': `$.properties.products.0.price`
+                },
+                quantity: {
+                  '@path': `$.properties.products.0.quantity`
+                }
+              }
+            ]
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'Param [hello] has unsupported value. GA4 does not accept object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
@@ -576,7 +576,7 @@ describe('GA4', () => {
       )
     })
 
-    it('should allow boolean value and user_property', async () => {
+    it('should allow boolean and null values for user_property', async () => {
       nock('https://www.google-analytics.com/mp/collect')
         .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
         .reply(201, {})
@@ -606,7 +606,8 @@ describe('GA4', () => {
             '@path': '$.userId'
           },
           user_properties: {
-            hello: true
+            hello: true,
+            goodbye: null
           },
           params: {
             test_key: true
@@ -677,7 +678,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_key] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+          'Param [test_key] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -731,7 +732,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_key] has unsupported value. GA4 does not accept array values for event parameters and item parameters.'
+          'Param [test_key] has unsupported value of type [Array]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -785,7 +786,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_key] has unsupported value. GA4 does not accept object values for event parameters and item parameters.'
+          'Param [test_key] has unsupported value of type [object]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -855,7 +856,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+          'Param [hello] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.'
         )
       }
     })
@@ -925,7 +926,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept object values for user properties.'
+          'Param [hello] has unsupported value of type [object]. GA4 does not accept array or object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
@@ -462,7 +462,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -509,7 +509,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
@@ -384,7 +384,89 @@ describe('GA4', () => {
       )
     })
 
-    it('should throw an error when param value is not a string or number', async () => {
+    it('should allow boolean user_properties', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+      const event = createTestEvent({
+        event: 'Product Added',
+        userId: '3456fff',
+        anonymousId: 'anon-567890',
+        type: 'track',
+        properties: {
+          name: 'Game Board',
+          category: 'Games',
+          brand: 'Hasbro',
+          variant: '200 pieces',
+          price: 18.99,
+          quantity: 1,
+          coupon: 'MAYDEALS',
+          position: 3,
+          url: 'https://www.example.com/product/path',
+          image_url: 'https://www.example.com/product/path.jpg'
+        }
+      })
+
+      const responses = await testDestination.testAction('addToCart', {
+        event,
+        settings: {
+          apiSecret,
+          measurementId
+        },
+        features: { 'actions-google-analytics-4-verify-params-feature': true },
+        mapping: {
+          client_id: {
+            '@path': '$.anonymousId'
+          },
+          coupon: {
+            '@path': '$.properties.coupon'
+          },
+          value: {
+            '@path': '$.properties.price'
+          },
+          items: [
+            {
+              item_name: {
+                '@path': `$.properties.name`
+              },
+              item_id: {
+                '@path': `$.properties.product_id`
+              },
+              quantity: {
+                '@path': `$.properties.quantity`
+              },
+              coupon: {
+                '@path': `$.properties.coupon`
+              },
+              item_brand: {
+                '@path': `$.properties..brand`
+              },
+              item_category: {
+                '@path': `$.properties.category`
+              },
+              item_variant: {
+                '@path': `$.properties.variant`
+              },
+              price: {
+                '@path': `$.properties.price`
+              }
+            }
+          ],
+          user_properties: {
+            hello: true
+          },
+          params: {
+            test_key: true
+          }
+        },
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('should throw an error when param value is null', async () => {
       nock('https://www.google-analytics.com/mp/collect')
         .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
         .reply(201, {})
@@ -462,7 +544,173 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'Param [test_key] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+        )
+      }
+    })
+
+    it('should throw an error when param value is array', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+      const event = createTestEvent({
+        event: 'Product Added',
+        userId: '3456fff',
+        anonymousId: 'anon-567890',
+        type: 'track',
+        properties: {
+          name: 'Game Board',
+          category: 'Games',
+          brand: 'Hasbro',
+          variant: '200 pieces',
+          price: 18.99,
+          quantity: 1,
+          coupon: 'MAYDEALS',
+          position: 3,
+          url: 'https://www.example.com/product/path',
+          image_url: 'https://www.example.com/product/path.jpg'
+        }
+      })
+
+      try {
+        await testDestination.testAction('addToCart', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            coupon: {
+              '@path': '$.properties.coupon'
+            },
+            value: {
+              '@path': '$.properties.price'
+            },
+            items: [
+              {
+                item_name: {
+                  '@path': `$.properties.name`
+                },
+                item_id: {
+                  '@path': `$.properties.product_id`
+                },
+                quantity: {
+                  '@path': `$.properties.quantity`
+                },
+                coupon: {
+                  '@path': `$.properties.coupon`
+                },
+                item_brand: {
+                  '@path': `$.properties..brand`
+                },
+                item_category: {
+                  '@path': `$.properties.category`
+                },
+                item_variant: {
+                  '@path': `$.properties.variant`
+                },
+                price: {
+                  '@path': `$.properties.price`
+                }
+              }
+            ],
+            params: {
+              test_key: ['one', 'two']
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'Param [test_key] has unsupported value. GA4 does not accept array values for event parameters and item parameters.'
+        )
+      }
+    })
+
+    it('should throw an error when param value is object', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+      const event = createTestEvent({
+        event: 'Product Added',
+        userId: '3456fff',
+        anonymousId: 'anon-567890',
+        type: 'track',
+        properties: {
+          name: 'Game Board',
+          category: 'Games',
+          brand: 'Hasbro',
+          variant: '200 pieces',
+          price: 18.99,
+          quantity: 1,
+          coupon: 'MAYDEALS',
+          position: 3,
+          url: 'https://www.example.com/product/path',
+          image_url: 'https://www.example.com/product/path.jpg'
+        }
+      })
+
+      try {
+        await testDestination.testAction('addToCart', {
+          event,
+          settings: {
+            apiSecret,
+            measurementId
+          },
+          features: { 'actions-google-analytics-4-verify-params-feature': true },
+          mapping: {
+            client_id: {
+              '@path': '$.anonymousId'
+            },
+            coupon: {
+              '@path': '$.properties.coupon'
+            },
+            value: {
+              '@path': '$.properties.price'
+            },
+            items: [
+              {
+                item_name: {
+                  '@path': `$.properties.name`
+                },
+                item_id: {
+                  '@path': `$.properties.product_id`
+                },
+                quantity: {
+                  '@path': `$.properties.quantity`
+                },
+                coupon: {
+                  '@path': `$.properties.coupon`
+                },
+                item_brand: {
+                  '@path': `$.properties..brand`
+                },
+                item_category: {
+                  '@path': `$.properties.category`
+                },
+                item_variant: {
+                  '@path': `$.properties.variant`
+                },
+                price: {
+                  '@path': `$.properties.price`
+                }
+              }
+            ],
+            params: {
+              test_key: { one: 'two' }
+            }
+          },
+          useDefaultMappings: true
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect(e.message).toBe(
+          'Param [test_key] has unsupported value. GA4 does not accept object values for event parameters and item parameters.'
         )
       }
     })
@@ -509,7 +757,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
+          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
@@ -462,7 +462,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -509,7 +509,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
+          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
@@ -544,7 +544,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_key] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+          'Param [test_key] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -627,7 +627,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_key] has unsupported value. GA4 does not accept array values for event parameters and item parameters.'
+          'Param [test_key] has unsupported value of type [Array]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -710,7 +710,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_key] has unsupported value. GA4 does not accept object values for event parameters and item parameters.'
+          'Param [test_key] has unsupported value of type [object]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -757,7 +757,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+          'Param [hello] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
@@ -401,7 +401,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -448,7 +448,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
@@ -401,7 +401,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_key] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+          'Param [test_key] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -448,7 +448,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+          'Param [hello] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
@@ -401,7 +401,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -448,7 +448,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
+          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
@@ -401,7 +401,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'Param [test_key] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
         )
       }
     })
@@ -448,7 +448,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
+          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
@@ -481,7 +481,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -550,7 +550,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
@@ -481,7 +481,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'Param [test_key] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
         )
       }
     })
@@ -550,7 +550,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
+          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
@@ -481,7 +481,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_key] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+          'Param [test_key] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -550,7 +550,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+          'Param [hello] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
@@ -481,7 +481,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -550,7 +550,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
+          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
@@ -350,7 +350,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -397,7 +397,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
+          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
@@ -350,7 +350,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'Param [test_key] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
         )
       }
     })
@@ -397,7 +397,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
+          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
@@ -350,7 +350,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -397,7 +397,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
@@ -350,7 +350,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_key] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+          'Param [test_key] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -397,7 +397,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+          'Param [hello] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
@@ -287,7 +287,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'Param [test_key] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
         )
       }
     })
@@ -331,7 +331,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
+          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
@@ -287,7 +287,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_key] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+          'Param [test_key] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -331,7 +331,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+          'Param [hello] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
@@ -287,7 +287,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -331,7 +331,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
+          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
@@ -287,7 +287,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -331,7 +331,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
@@ -148,7 +148,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'Param [test_key] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
         )
       }
     })
@@ -195,7 +195,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
+          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
@@ -148,7 +148,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_key] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+          'Param [test_key] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -195,7 +195,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+          'Param [hello] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
@@ -148,7 +148,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -195,7 +195,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
@@ -148,7 +148,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -195,7 +195,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
+          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
@@ -216,7 +216,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_input] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+          'Param [test_input] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -260,7 +260,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+          'Param [hello] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
@@ -216,7 +216,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -260,7 +260,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
+          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
@@ -216,7 +216,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'Param [test_input] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
         )
       }
     })
@@ -260,7 +260,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
+          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
@@ -216,7 +216,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -260,7 +260,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
@@ -609,7 +609,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
         )
       }
     })
@@ -703,7 +703,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
+          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
@@ -609,7 +609,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+          'Param [test_value] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -703,7 +703,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+          'Param [hello] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
@@ -609,7 +609,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -703,7 +703,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
+          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
@@ -609,7 +609,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -703,7 +703,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
@@ -478,7 +478,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -528,7 +528,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
@@ -478,7 +478,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
         )
       }
     })
@@ -528,7 +528,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
+          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
@@ -478,7 +478,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+          'Param [test_value] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -528,7 +528,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+          'Param [hello] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
@@ -478,7 +478,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -528,7 +528,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
+          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
@@ -386,7 +386,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
         )
       }
     })
@@ -433,7 +433,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
+          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
@@ -386,7 +386,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -433,7 +433,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
@@ -386,7 +386,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -433,7 +433,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
+          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
@@ -386,7 +386,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+          'Param [test_value] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -433,7 +433,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+          'Param [hello] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
@@ -151,7 +151,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+          'Param [test_value] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -199,7 +199,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+          'Param [hello] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
@@ -151,7 +151,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -199,7 +199,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
@@ -151,7 +151,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
         )
       }
     })
@@ -199,7 +199,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
+          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
@@ -151,7 +151,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -199,7 +199,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
+          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
@@ -389,7 +389,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -436,7 +436,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
+          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
@@ -389,7 +389,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
         )
       }
     })
@@ -436,7 +436,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
+          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
@@ -389,7 +389,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -436,7 +436,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
@@ -389,7 +389,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+          'Param [test_value] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -436,7 +436,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+          'Param [hello] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
@@ -535,7 +535,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -590,7 +590,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
+          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
@@ -535,7 +535,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -590,7 +590,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
@@ -535,7 +535,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
         )
       }
     })
@@ -590,7 +590,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
+          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
@@ -535,7 +535,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+          'Param [test_value] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -590,7 +590,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+          'Param [hello] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
@@ -188,7 +188,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -235,7 +235,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
+          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
@@ -188,7 +188,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+          'Param [test_value] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -235,7 +235,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+          'Param [hello] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
@@ -188,7 +188,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -235,7 +235,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
@@ -188,7 +188,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
         )
       }
     })
@@ -235,7 +235,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
+          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
@@ -421,7 +421,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+          'Param [test_value] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -483,7 +483,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+          'Param [hello] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
@@ -421,7 +421,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -483,7 +483,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
@@ -421,7 +421,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -483,7 +483,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
+          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
@@ -421,7 +421,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
         )
       }
     })
@@ -483,7 +483,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
+          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
@@ -326,7 +326,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
         )
       }
     })
@@ -373,7 +373,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
+          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
@@ -326,7 +326,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -373,7 +373,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
@@ -326,7 +326,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+          'Param [test_value] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -373,7 +373,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+          'Param [hello] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
@@ -326,7 +326,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -373,7 +373,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
+          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
@@ -359,7 +359,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+          'Param [test_value] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -429,7 +429,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+          'Param [hello] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
@@ -359,7 +359,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
         )
       }
     })
@@ -429,7 +429,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
+          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
@@ -359,7 +359,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -429,7 +429,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
+          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
@@ -359,7 +359,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -429,7 +429,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
@@ -513,7 +513,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
         )
       }
     })
@@ -598,7 +598,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
+          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
@@ -513,7 +513,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
+          'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -598,7 +598,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
+          'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
@@ -513,7 +513,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [test_value] has unsupported value. GA4 does not accept null values for event parameters and item parameters.'
+          'Param [test_value] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.'
         )
       }
     })
@@ -598,7 +598,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'Param [hello] has unsupported value. GA4 does not accept array values for user properties.'
+          'Param [hello] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
@@ -513,7 +513,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.'
+          'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.'
         )
       }
     })
@@ -598,7 +598,7 @@ describe('GA4', () => {
         fail('the test should have thrown an error')
       } catch (e) {
         expect(e.message).toBe(
-          'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.'
+          'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.'
         )
       }
     })

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
@@ -15,9 +15,10 @@ export function verifyParams(params: object | undefined): void {
   }
 
   Object.values(params).forEach((value) => {
-    if (typeof value == 'object' || value instanceof Array) {
+    const invalidEventType = typeof value == 'object' || value instanceof Array
+    if (invalidEventType) {
       throw new IntegrationError(
-        'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.',
+        'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.',
         'Invalid value',
         400
       )
@@ -31,10 +32,10 @@ export function verifyUserProps(userProperties: object | undefined): void {
   }
 
   Object.values(userProperties).forEach((value) => {
-    // typeof null == 'object' and GA4 accepts nulls for user_properties
+    // Extra check to ensure null values are not filtered out since GA4 accepts nulls for user_properties
     if ((value != null && typeof value == 'object') || value instanceof Array) {
       throw new IntegrationError(
-        'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.',
+        'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.',
         'Invalid value',
         400
       )

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
@@ -15,9 +15,9 @@ export function verifyParams(params: object | undefined): void {
   }
 
   Object.values(params).forEach((value) => {
-    if (typeof value != 'string' && typeof value != 'number') {
+    if (typeof value == 'object' || value instanceof Array) {
       throw new IntegrationError(
-        'GA4 only accepts string or number values for event parameters and item parameters. Please ensure you are not including null, array, or nested values.',
+        'GA4 does not accept null, array, or nested values for event parameters and item parameters. Please ensure you are using allowed data types.',
         'Invalid value',
         400
       )
@@ -31,9 +31,10 @@ export function verifyUserProps(userProperties: object | undefined): void {
   }
 
   Object.values(userProperties).forEach((value) => {
-    if (typeof value != 'string' && typeof value != 'number' && value != null) {
+    // typeof null == 'object' and GA4 accepts nulls for user_properties
+    if ((value != null && typeof value == 'object') || value instanceof Array) {
       throw new IntegrationError(
-        'GA4 only accepts string, number or null values for user properties. Please ensure you are not including array or nested values.',
+        'GA4 does not accept array or nested values for user properties. Please ensure you are using allowed data types.',
         'Invalid value',
         400
       )

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
@@ -14,11 +14,22 @@ export function verifyParams(params: object | undefined): void {
     return
   }
 
-  Object.values(params).forEach((value) => {
-    const invalidEventType = typeof value == 'object' || value instanceof Array
-    if (invalidEventType) {
+  Object.entries(params).forEach(([key, value]) => {
+    if (value instanceof Array) {
       throw new IntegrationError(
-        'GA4 does not accept null, array, or object values for event parameters and item parameters. Please ensure you are using allowed data types.',
+        `Param [${key}] has unsupported value. GA4 does not accept array values for event parameters and item parameters.`,
+        'Invalid value',
+        400
+      )
+    } else if (value == null) {
+      throw new IntegrationError(
+        `Param [${key}] has unsupported value. GA4 does not accept null values for event parameters and item parameters.`,
+        'Invalid value',
+        400
+      )
+    } else if (typeof value == 'object') {
+      throw new IntegrationError(
+        `Param [${key}] has unsupported value. GA4 does not accept object values for event parameters and item parameters.`,
         'Invalid value',
         400
       )
@@ -31,11 +42,16 @@ export function verifyUserProps(userProperties: object | undefined): void {
     return
   }
 
-  Object.values(userProperties).forEach((value) => {
-    // Extra check to ensure null values are not filtered out since GA4 accepts nulls for user_properties
-    if ((value != null && typeof value == 'object') || value instanceof Array) {
+  Object.entries(userProperties).forEach(([key, value]) => {
+    if (value instanceof Array) {
       throw new IntegrationError(
-        'GA4 does not accept array or object values for user properties. Please ensure you are using allowed data types.',
+        `Param [${key}] has unsupported value. GA4 does not accept array values for user properties.`,
+        'Invalid value',
+        400
+      )
+    } else if (value != null && typeof value == 'object') {
+      throw new IntegrationError(
+        `Param [${key}] has unsupported value. GA4 does not accept object values for user properties.`,
         'Invalid value',
         400
       )

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
@@ -17,19 +17,19 @@ export function verifyParams(params: object | undefined): void {
   Object.entries(params).forEach(([key, value]) => {
     if (value instanceof Array) {
       throw new IntegrationError(
-        `Param [${key}] has unsupported value. GA4 does not accept array values for event parameters and item parameters.`,
+        `Param [${key}] has unsupported value of type [Array]. GA4 does not accept null, array, or object values for event parameters and item parameters.`,
         'Invalid value',
         400
       )
     } else if (value == null) {
       throw new IntegrationError(
-        `Param [${key}] has unsupported value. GA4 does not accept null values for event parameters and item parameters.`,
+        `Param [${key}] has unsupported value of type [NULL]. GA4 does not accept null, array, or object values for event parameters and item parameters.`,
         'Invalid value',
         400
       )
     } else if (typeof value == 'object') {
       throw new IntegrationError(
-        `Param [${key}] has unsupported value. GA4 does not accept object values for event parameters and item parameters.`,
+        `Param [${key}] has unsupported value of type [${typeof value}]. GA4 does not accept null, array, or object values for event parameters and item parameters.`,
         'Invalid value',
         400
       )
@@ -45,13 +45,13 @@ export function verifyUserProps(userProperties: object | undefined): void {
   Object.entries(userProperties).forEach(([key, value]) => {
     if (value instanceof Array) {
       throw new IntegrationError(
-        `Param [${key}] has unsupported value. GA4 does not accept array values for user properties.`,
+        `Param [${key}] has unsupported value of type [Array]. GA4 does not accept array or object values for user properties.`,
         'Invalid value',
         400
       )
     } else if (value != null && typeof value == 'object') {
       throw new IntegrationError(
-        `Param [${key}] has unsupported value. GA4 does not accept object values for user properties.`,
+        `Param [${key}] has unsupported value of type [${typeof value}]. GA4 does not accept array or object values for user properties.`,
         'Invalid value',
         400
       )


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR edits the original changes made for [STRATCONN-1413](https://segment.atlassian.net/browse/STRATCONN-1413) and implements a blocklist instead of an allowlist to make sure the filter is not too narrow and we are only blocking data types that we are sure GA4 does not accept. 

## Testing

We used Google's debug endpoint to verify that GA4 does not allow null, array, or objects as params but does allow nulls for user_properties. We also verified that GA4 does accept boolean variables for both params and user_properties.

[Testing Doc](https://paper.dropbox.com/doc/GA4-Parameters-Testing--BncVWRzcIaMUuSoFLrZ6K1FRAg-FMVqXKylO9KdoPkgtDtth).

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
