### PR TITLE
Add Mixpanel EU Data Residency Setting

### DIFF
--- a/packages/destination-actions/src/destinations/mixpanel/alias/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/alias/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
+import { ApiRegions } from '../../utils'
 
 const testDestination = createTestIntegration(Destination)
 const MIXPANEL_API_SECRET = 'test-api-key'
@@ -17,7 +18,8 @@ describe('Mixpanel.alias', () => {
       useDefaultMappings: true,
       settings: {
         projectToken: MIXPANEL_PROJECT_TOKEN,
-        apiSecret: MIXPANEL_API_SECRET
+        apiSecret: MIXPANEL_API_SECRET,
+        apiRegion: ApiRegions.US
       }
     })
     expect(responses.length).toBe(1)
@@ -48,7 +50,7 @@ describe('Mixpanel.alias', () => {
       settings: {
         projectToken: MIXPANEL_PROJECT_TOKEN,
         apiSecret: MIXPANEL_API_SECRET,
-        eu: true
+        apiRegion: ApiRegions.EU
       }
     })
     expect(responses.length).toBe(1)
@@ -61,8 +63,7 @@ describe('Mixpanel.alias', () => {
           properties: {
             distinct_id: 'test-prev-id',
             alias: 'user1234',
-            token: MIXPANEL_PROJECT_TOKEN,
-            $mp_api_endpoint: 'api-eu.mixpanel.com'
+            token: MIXPANEL_PROJECT_TOKEN
           }
         })
       })

--- a/packages/destination-actions/src/destinations/mixpanel/alias/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/alias/__tests__/index.test.ts
@@ -36,4 +36,36 @@ describe('Mixpanel.alias', () => {
       })
     )
   })
+
+  it('should use EU server URL', async () => {
+    const event = createTestEvent({ previousId: 'test-prev-id' })
+
+    nock('https://api-eu.mixpanel.com').post('/track').reply(200, {})
+
+    const responses = await testDestination.testAction('alias', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        projectToken: MIXPANEL_PROJECT_TOKEN,
+        apiSecret: MIXPANEL_API_SECRET,
+        eu: true
+      }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.body).toMatchObject(
+      new URLSearchParams({
+        data: JSON.stringify({
+          event: '$create_alias',
+          properties: {
+            distinct_id: 'test-prev-id',
+            alias: 'user1234',
+            token: MIXPANEL_PROJECT_TOKEN,
+            $mp_api_endpoint: 'api-eu.mixpanel.com'
+          }
+        })
+      })
+    )
+  })
 })

--- a/packages/destination-actions/src/destinations/mixpanel/alias/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/alias/index.ts
@@ -2,6 +2,8 @@ import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
+import { getApiServerUrl } from '../utils'
+
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Alias',
   description:
@@ -40,7 +42,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
 
-    return request(`https://${settings.apiRegion}.mixpanel.com/track`, {
+    return request(`${getApiServerUrl(settings.apiRegion)}/track`, {
       method: 'post',
       body: new URLSearchParams({ data: JSON.stringify(data) })
     })

--- a/packages/destination-actions/src/destinations/mixpanel/alias/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/alias/index.ts
@@ -40,7 +40,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
 
-    return request(`https://${settings.eu ? 'api-eu' : 'api'}.mixpanel.com/track`, {
+    return request(`https://${settings.apiRegion}.mixpanel.com/track`, {
       method: 'post',
       body: new URLSearchParams({ data: JSON.stringify(data) })
     })

--- a/packages/destination-actions/src/destinations/mixpanel/alias/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/alias/index.ts
@@ -40,7 +40,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
 
-    return request('https://api.mixpanel.com/track', {
+    return request(`https://${settings.eu ? 'api-eu' : 'api'}.mixpanel.com/track`, {
       method: 'post',
       body: new URLSearchParams({ data: JSON.stringify(data) })
     })

--- a/packages/destination-actions/src/destinations/mixpanel/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/generated-types.ts
@@ -9,4 +9,8 @@ export interface Settings {
    * Mixpanel project secret.
    */
   apiSecret: string
+  /**
+   * Mixpanel project EU data residency
+   */
+  eu: boolean
 }

--- a/packages/destination-actions/src/destinations/mixpanel/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/generated-types.ts
@@ -10,7 +10,7 @@ export interface Settings {
    */
   apiSecret: string
   /**
-   * Mixpanel project EU data residency
+   * Learn about [EU data residency](https://help.mixpanel.com/hc/en-us/articles/360039135652-Data-Residency-in-EU)
    */
-  eu: boolean
+  apiRegion: string
 }

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
+import { ApiRegions } from '../../utils'
 
 const testDestination = createTestIntegration(Destination)
 const MIXPANEL_API_SECRET = 'test-api-key'
@@ -23,7 +24,8 @@ describe('Mixpanel.groupIdentifyUser', () => {
       useDefaultMappings: true,
       settings: {
         projectToken: MIXPANEL_PROJECT_TOKEN,
-        apiSecret: MIXPANEL_API_SECRET
+        apiSecret: MIXPANEL_API_SECRET,
+        apiRegion: ApiRegions.US
       }
     })
     expect(responses.length).toBe(1)
@@ -58,7 +60,8 @@ describe('Mixpanel.groupIdentifyUser', () => {
       useDefaultMappings: true,
       settings: {
         projectToken: MIXPANEL_PROJECT_TOKEN,
-        apiSecret: MIXPANEL_API_SECRET
+        apiSecret: MIXPANEL_API_SECRET,
+        apiRegion: ApiRegions.US
       }
     })
     expect(responses.length).toBe(1)
@@ -94,7 +97,7 @@ describe('Mixpanel.groupIdentifyUser', () => {
       settings: {
         projectToken: MIXPANEL_PROJECT_TOKEN,
         apiSecret: MIXPANEL_API_SECRET,
-        eu: true
+        apiRegion: ApiRegions.EU
       }
     })
     expect(responses.length).toBe(1)

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/index.test.ts
@@ -78,4 +78,40 @@ describe('Mixpanel.groupIdentifyUser', () => {
       })
     )
   })
+
+  it('should use EU server URL', async () => {
+    const event = createTestEvent({
+      timestamp,
+      groupId: 'test-group-id',
+      traits: { hello: 'world', company: 'Mixpanel' }
+    })
+
+    nock('https://api-eu.mixpanel.com').post('/groups').reply(200, {})
+
+    const responses = await testDestination.testAction('groupIdentifyUser', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        projectToken: MIXPANEL_PROJECT_TOKEN,
+        apiSecret: MIXPANEL_API_SECRET,
+        eu: true
+      }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.body).toMatchObject(
+      new URLSearchParams({
+        data: JSON.stringify({
+          $token: MIXPANEL_PROJECT_TOKEN,
+          $group_key: '$group_id',
+          $group_id: 'test-group-id',
+          $set: {
+            hello: 'world',
+            company: 'Mixpanel'
+          }
+        })
+      })
+    )
+  })
 })

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/snapshot.test.ts
@@ -30,8 +30,6 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       auth: undefined
     })
 
-    console.log(responses[0].request)
-
     const request = responses[0].request
     const rawBody = await request.text()
 

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/snapshot.test.ts
@@ -30,6 +30,8 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       auth: undefined
     })
 
+    console.log(responses[0].request)
+
     const request = responses[0].request
     const rawBody = await request.text()
 

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
@@ -1,5 +1,6 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
+import { getApiServerUrl } from '../utils'
 import type { Payload } from './generated-types'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -52,7 +53,7 @@ const action: ActionDefinition<Settings, Payload> = {
       $set: payload.traits
     }
 
-    return request(`https://${settings.apiRegion}.mixpanel.com/groups`, {
+    return request(`${getApiServerUrl(settings.apiRegion)}/groups`, {
       method: 'post',
       body: new URLSearchParams({ data: JSON.stringify(data) })
     })

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
@@ -52,7 +52,7 @@ const action: ActionDefinition<Settings, Payload> = {
       $set: payload.traits
     }
 
-    return request('https://api.mixpanel.com/groups', {
+    return request(`https://${settings.eu ? 'api-eu' : 'api'}.mixpanel.com/groups`, {
       method: 'post',
       body: new URLSearchParams({ data: JSON.stringify(data) })
     })

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
@@ -52,7 +52,7 @@ const action: ActionDefinition<Settings, Payload> = {
       $set: payload.traits
     }
 
-    return request(`https://${settings.eu ? 'api-eu' : 'api'}.mixpanel.com/groups`, {
+    return request(`https://${settings.apiRegion}.mixpanel.com/groups`, {
       method: 'post',
       body: new URLSearchParams({ data: JSON.stringify(data) })
     })

--- a/packages/destination-actions/src/destinations/mixpanel/identifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/identifyUser/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
+import { ApiRegions } from '../../utils'
 
 const testDestination = createTestIntegration(Destination)
 const MIXPANEL_API_SECRET = 'test-api-key'
@@ -19,7 +20,8 @@ describe('Mixpanel.identifyUser', () => {
       useDefaultMappings: true,
       settings: {
         projectToken: MIXPANEL_PROJECT_TOKEN,
-        apiSecret: MIXPANEL_API_SECRET
+        apiSecret: MIXPANEL_API_SECRET,
+        apiRegion: ApiRegions.US
       }
     })
     expect(responses.length).toBe(2)
@@ -64,7 +66,7 @@ describe('Mixpanel.identifyUser', () => {
       settings: {
         projectToken: MIXPANEL_PROJECT_TOKEN,
         apiSecret: MIXPANEL_API_SECRET,
-        eu: true
+        apiRegion: ApiRegions.EU
       }
     })
     expect(responses.length).toBe(2)
@@ -77,8 +79,7 @@ describe('Mixpanel.identifyUser', () => {
           properties: {
             $identified_id: 'user1234',
             $anon_id: event.anonymousId,
-            token: MIXPANEL_PROJECT_TOKEN,
-            $mp_api_endpoint: 'api-eu.mixpanel.com'
+            token: MIXPANEL_PROJECT_TOKEN
           }
         })
       })

--- a/packages/destination-actions/src/destinations/mixpanel/identifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/identifyUser/__tests__/index.test.ts
@@ -51,4 +51,50 @@ describe('Mixpanel.identifyUser', () => {
       })
     )
   })
+
+  it('should use EU server URL', async () => {
+    const event = createTestEvent({ timestamp, traits: { abc: '123' } })
+
+    nock('https://api-eu.mixpanel.com').post('/engage').reply(200, {})
+    nock('https://api-eu.mixpanel.com').post('/track').reply(200, {})
+
+    const responses = await testDestination.testAction('identifyUser', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        projectToken: MIXPANEL_PROJECT_TOKEN,
+        apiSecret: MIXPANEL_API_SECRET,
+        eu: true
+      }
+    })
+    expect(responses.length).toBe(2)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.body).toMatchObject(
+      new URLSearchParams({
+        data: JSON.stringify({
+          event: '$identify',
+          properties: {
+            $identified_id: 'user1234',
+            $anon_id: event.anonymousId,
+            token: MIXPANEL_PROJECT_TOKEN,
+            $mp_api_endpoint: 'api-eu.mixpanel.com'
+          }
+        })
+      })
+    )
+    expect(responses[1].status).toBe(200)
+    expect(responses[1].data).toMatchObject({})
+    expect(responses[1].options.body).toMatchObject(
+      new URLSearchParams({
+        data: JSON.stringify({
+          $token: MIXPANEL_PROJECT_TOKEN,
+          $distinct_id: 'user1234',
+          $set: {
+            abc: '123'
+          }
+        })
+      })
+    )
+  })
 })

--- a/packages/destination-actions/src/destinations/mixpanel/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/identifyUser/index.ts
@@ -2,6 +2,8 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
+import { getApiServerUrl } from '../utils'
+
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Identify User',
   description:
@@ -40,6 +42,9 @@ const action: ActionDefinition<Settings, Payload> = {
     if (!settings.projectToken) {
       throw new IntegrationError('Missing project token', 'Missing required field', 400)
     }
+
+    const apiServerUrl = getApiServerUrl(settings.apiRegion)
+
     const responses = []
     if (payload.anonymous_id) {
       const identifyEvent = {
@@ -51,7 +56,7 @@ const action: ActionDefinition<Settings, Payload> = {
         }
       }
 
-      const identifyResponse = await request(`https://${settings.apiRegion}.mixpanel.com/track`, {
+      const identifyResponse = await request(`${apiServerUrl}/track`, {
         method: 'post',
         body: new URLSearchParams({ data: JSON.stringify(identifyEvent) })
       })
@@ -65,7 +70,7 @@ const action: ActionDefinition<Settings, Payload> = {
         $set: payload.traits
       }
 
-      const engageResponse = request(`https://${settings.apiRegion}.mixpanel.com/engage`, {
+      const engageResponse = request(`${apiServerUrl}/engage`, {
         method: 'post',
         body: new URLSearchParams({ data: JSON.stringify(data) })
       })

--- a/packages/destination-actions/src/destinations/mixpanel/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/identifyUser/index.ts
@@ -51,7 +51,7 @@ const action: ActionDefinition<Settings, Payload> = {
         }
       }
 
-      const identifyResponse = await request(`https://${settings.eu ? 'api-eu' : 'api'}.mixpanel.com/track`, {
+      const identifyResponse = await request(`https://${settings.apiRegion}.mixpanel.com/track`, {
         method: 'post',
         body: new URLSearchParams({ data: JSON.stringify(identifyEvent) })
       })
@@ -65,7 +65,7 @@ const action: ActionDefinition<Settings, Payload> = {
         $set: payload.traits
       }
 
-      const engageResponse = request(`https://${settings.eu ? 'api-eu' : 'api'}.mixpanel.com/engage`, {
+      const engageResponse = request(`https://${settings.apiRegion}.mixpanel.com/engage`, {
         method: 'post',
         body: new URLSearchParams({ data: JSON.stringify(data) })
       })

--- a/packages/destination-actions/src/destinations/mixpanel/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/identifyUser/index.ts
@@ -51,7 +51,7 @@ const action: ActionDefinition<Settings, Payload> = {
         }
       }
 
-      const identifyResponse = await request('https://api.mixpanel.com/track', {
+      const identifyResponse = await request(`https://${settings.eu ? 'api-eu' : 'api'}.mixpanel.com/track`, {
         method: 'post',
         body: new URLSearchParams({ data: JSON.stringify(identifyEvent) })
       })
@@ -65,7 +65,7 @@ const action: ActionDefinition<Settings, Payload> = {
         $set: payload.traits
       }
 
-      const engageResponse = request('https://api.mixpanel.com/engage', {
+      const engageResponse = request(`https://${settings.eu ? 'api-eu' : 'api'}.mixpanel.com/engage`, {
         method: 'post',
         body: new URLSearchParams({ data: JSON.stringify(data) })
       })

--- a/packages/destination-actions/src/destinations/mixpanel/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/index.ts
@@ -7,6 +7,7 @@ import identifyUser from './identifyUser'
 import groupIdentifyUser from './groupIdentifyUser'
 
 import alias from './alias'
+import { ApiRegions } from './utils'
 
 /** used in the quick setup */
 const presets: DestinationDefinition['presets'] = [
@@ -72,12 +73,17 @@ const destination: DestinationDefinition<Settings> = {
         type: 'string',
         required: true
       },
-      eu: {
-        label: 'EU Data Residency',
-        description: 'Mixpanel project EU data residency',
-        type: 'boolean',
-        required: true,
-        default: false
+      apiRegion: {
+        label: 'Data Residency',
+        description:
+          'Learn about [EU data residency](https://help.mixpanel.com/hc/en-us/articles/360039135652-Data-Residency-in-EU)',
+        type: 'string',
+        choices: [
+          { label: 'US 🇺🇸', value: ApiRegions.US },
+          { label: 'EU 🇪🇺', value: ApiRegions.EU }
+        ],
+        default: ApiRegions.US,
+        required: true
       }
     },
     testAuthentication: (request, { settings }) => {

--- a/packages/destination-actions/src/destinations/mixpanel/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/index.ts
@@ -78,10 +78,7 @@ const destination: DestinationDefinition<Settings> = {
         description:
           'Learn about [EU data residency](https://help.mixpanel.com/hc/en-us/articles/360039135652-Data-Residency-in-EU)',
         type: 'string',
-        choices: [
-          { label: 'US 🇺🇸', value: ApiRegions.US },
-          { label: 'EU 🇪🇺', value: ApiRegions.EU }
-        ],
+        choices: Object.values(ApiRegions).map((apiRegion) => ({ label: apiRegion, value: apiRegion })),
         default: ApiRegions.US,
         required: true
       }

--- a/packages/destination-actions/src/destinations/mixpanel/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/index.ts
@@ -71,6 +71,13 @@ const destination: DestinationDefinition<Settings> = {
         description: 'Mixpanel project secret.',
         type: 'string',
         required: true
+      },
+      eu: {
+        label: 'EU Data Residency',
+        description: 'Mixpanel project EU data residency',
+        type: 'boolean',
+        required: true,
+        default: false
       }
     },
     testAuthentication: (request, { settings }) => {

--- a/packages/destination-actions/src/destinations/mixpanel/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackEvent/__tests__/index.test.ts
@@ -39,6 +39,39 @@ describe('Mixpanel.trackEvent', () => {
     ])
   })
 
+  it('should use EU server URL', async () => {
+    const event = createTestEvent({ timestamp, event: 'Test Event' })
+
+    nock('https://api-eu.mixpanel.com').post('/import?strict=1').reply(200, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        projectToken: MIXPANEL_PROJECT_TOKEN,
+        apiSecret: MIXPANEL_API_SECRET,
+        eu: true
+      }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.json).toMatchObject([
+      {
+        event: 'Test Event',
+        properties: expect.objectContaining({
+          ip: '8.8.8.8',
+          distinct_id: 'user1234',
+          $current_url: 'https://segment.com/academy/',
+          $locale: 'en-US',
+          mp_country_code: 'United States',
+          mp_lib: 'Segment: analytics.js',
+          $mp_api_endpoint: 'api-eu.mixpanel.com'
+        })
+      }
+    ])
+  })
+
   it('should require event field', async () => {
     const event = createTestEvent({ timestamp })
     event.event = undefined

--- a/packages/destination-actions/src/destinations/mixpanel/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackEvent/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
+import { ApiRegions } from '../../utils'
 
 const testDestination = createTestIntegration(Destination)
 const MIXPANEL_API_SECRET = 'test-api-key'
@@ -18,7 +19,8 @@ describe('Mixpanel.trackEvent', () => {
       useDefaultMappings: true,
       settings: {
         projectToken: MIXPANEL_PROJECT_TOKEN,
-        apiSecret: MIXPANEL_API_SECRET
+        apiSecret: MIXPANEL_API_SECRET,
+        apiRegion: ApiRegions.US
       }
     })
     expect(responses.length).toBe(1)
@@ -50,7 +52,7 @@ describe('Mixpanel.trackEvent', () => {
       settings: {
         projectToken: MIXPANEL_PROJECT_TOKEN,
         apiSecret: MIXPANEL_API_SECRET,
-        eu: true
+        apiRegion: ApiRegions.EU
       }
     })
     expect(responses.length).toBe(1)
@@ -65,8 +67,7 @@ describe('Mixpanel.trackEvent', () => {
           $current_url: 'https://segment.com/academy/',
           $locale: 'en-US',
           mp_country_code: 'United States',
-          mp_lib: 'Segment: analytics.js',
-          $mp_api_endpoint: 'api-eu.mixpanel.com'
+          mp_lib: 'Segment: analytics.js'
         })
       }
     ])

--- a/packages/destination-actions/src/destinations/mixpanel/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackEvent/index.ts
@@ -389,7 +389,7 @@ const action: ActionDefinition<Settings, Payload> = {
     if (!settings.apiSecret) {
       throw new InvalidAuthenticationError('Missing api secret')
     }
-    return request(`https://${settings.eu ? 'api-eu' : 'api'}.mixpanel.com/import?strict=1`, {
+    return request(`https://${settings.apiRegion}.mixpanel.com/import?strict=1`, {
       method: 'post',
       json: [event],
       headers: {

--- a/packages/destination-actions/src/destinations/mixpanel/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackEvent/index.ts
@@ -2,7 +2,7 @@ import { ActionDefinition, InvalidAuthenticationError } from '@segment/actions-c
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { MixpanelEvent } from './types'
-import { getBrowser, getBrowserVersion, cheapGuid } from '../utils'
+import { getApiServerUrl, getBrowser, getBrowserVersion, cheapGuid } from '../utils'
 import dayjs from '../../../lib/dayjs'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -389,7 +389,7 @@ const action: ActionDefinition<Settings, Payload> = {
     if (!settings.apiSecret) {
       throw new InvalidAuthenticationError('Missing api secret')
     }
-    return request(`https://${settings.apiRegion}.mixpanel.com/import?strict=1`, {
+    return request(`${getApiServerUrl(settings.apiRegion)}/import?strict=1`, {
       method: 'post',
       json: [event],
       headers: {

--- a/packages/destination-actions/src/destinations/mixpanel/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackEvent/index.ts
@@ -389,7 +389,7 @@ const action: ActionDefinition<Settings, Payload> = {
     if (!settings.apiSecret) {
       throw new InvalidAuthenticationError('Missing api secret')
     }
-    return request('https://api.mixpanel.com/import?strict=1', {
+    return request(`https://${settings.eu ? 'api-eu' : 'api'}.mixpanel.com/import?strict=1`, {
       method: 'post',
       json: [event],
       headers: {

--- a/packages/destination-actions/src/destinations/mixpanel/utils.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/utils.ts
@@ -1,6 +1,6 @@
 export enum ApiRegions {
-  US = 'api',
-  EU = 'api-eu'
+  US = 'US 🇺🇸',
+  EU = 'EU 🇪🇺'
 }
 
 export function getApiServerUrl(apiRegion: string) {

--- a/packages/destination-actions/src/destinations/mixpanel/utils.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/utils.ts
@@ -3,6 +3,13 @@ export enum ApiRegions {
   EU = 'api-eu'
 }
 
+export function getApiServerUrl(apiRegion: string) {
+  if (apiRegion == ApiRegions.EU) {
+    return 'https://api-eu.mixpanel.com'
+  }
+  return 'https://api.mixpanel.com'
+}
+
 export function getBrowser(userAgent: string, vendor: string | undefined): string {
   vendor = vendor || '' // vendor is undefined for at least IE9
   if (userAgent.includes(' OPR/')) {

--- a/packages/destination-actions/src/destinations/mixpanel/utils.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/utils.ts
@@ -1,3 +1,8 @@
+export enum ApiRegions {
+  US = 'api',
+  EU = 'api-eu'
+}
+
 export function getBrowser(userAgent: string, vendor: string | undefined): string {
   vendor = vendor || '' // vendor is undefined for at least IE9
   if (userAgent.includes(' OPR/')) {


### PR DESCRIPTION
This PR adds a setting for [Mixpanel's EU Data Residency feature](https://help.mixpanel.com/hc/en-us/articles/360039135652-Data-Residency-in-EU). When the setting is set to `EU` data will be sent to `api-eu.mixpanel.com`, the default is `US` which sends to `api.mixpanel.com`.

![image](https://user-images.githubusercontent.com/10504508/185476161-f061c849-85b5-4728-a80f-8c292b106f42.png)

## Testing

- [ X ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ X ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
