### PR TITLE
Fix Mixpanel EU Data Residency Setting

### DIFF
--- a/packages/destination-actions/src/destinations/mixpanel/alias/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/alias/__tests__/index.test.ts
@@ -69,4 +69,34 @@ describe('Mixpanel.alias', () => {
       })
     )
   })
+
+  it('should default to US endpoint if apiRegion setting is undefined', async () => {
+    const event = createTestEvent({ previousId: 'test-prev-id' })
+
+    nock('https://api.mixpanel.com').post('/track').reply(200, {})
+
+    const responses = await testDestination.testAction('alias', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        projectToken: MIXPANEL_PROJECT_TOKEN,
+        apiSecret: MIXPANEL_API_SECRET
+      }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.body).toMatchObject(
+      new URLSearchParams({
+        data: JSON.stringify({
+          event: '$create_alias',
+          properties: {
+            distinct_id: 'test-prev-id',
+            alias: 'user1234',
+            token: MIXPANEL_PROJECT_TOKEN
+          }
+        })
+      })
+    )
+  })
 })

--- a/packages/destination-actions/src/destinations/mixpanel/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/generated-types.ts
@@ -12,5 +12,5 @@ export interface Settings {
   /**
    * Learn about [EU data residency](https://help.mixpanel.com/hc/en-us/articles/360039135652-Data-Residency-in-EU)
    */
-  apiRegion: string
+  apiRegion?: string
 }

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/index.test.ts
@@ -117,4 +117,75 @@ describe('Mixpanel.groupIdentifyUser', () => {
       })
     )
   })
+
+  it('should use EU server URL', async () => {
+    const event = createTestEvent({
+      timestamp,
+      groupId: 'test-group-id',
+      traits: { hello: 'world', company: 'Mixpanel' }
+    })
+
+    nock('https://api-eu.mixpanel.com').post('/groups').reply(200, {})
+
+    const responses = await testDestination.testAction('groupIdentifyUser', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        projectToken: MIXPANEL_PROJECT_TOKEN,
+        apiSecret: MIXPANEL_API_SECRET,
+        apiRegion: ApiRegions.EU
+      }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.body).toMatchObject(
+      new URLSearchParams({
+        data: JSON.stringify({
+          $token: MIXPANEL_PROJECT_TOKEN,
+          $group_key: '$group_id',
+          $group_id: 'test-group-id',
+          $set: {
+            hello: 'world',
+            company: 'Mixpanel'
+          }
+        })
+      })
+    )
+  })
+
+  it('should default to US endpoint if apiRegion setting is undefined', async () => {
+    const event = createTestEvent({
+      timestamp,
+      groupId: 'test-group-id',
+      traits: { hello: 'world', company: 'Mixpanel' }
+    })
+
+    nock('https://api.mixpanel.com').post('/groups').reply(200, {})
+
+    const responses = await testDestination.testAction('groupIdentifyUser', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        projectToken: MIXPANEL_PROJECT_TOKEN,
+        apiSecret: MIXPANEL_API_SECRET
+      }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.body).toMatchObject(
+      new URLSearchParams({
+        data: JSON.stringify({
+          $token: MIXPANEL_PROJECT_TOKEN,
+          $group_key: '$group_id',
+          $group_id: 'test-group-id',
+          $set: {
+            hello: 'world',
+            company: 'Mixpanel'
+          }
+        })
+      })
+    )
+  })
 })

--- a/packages/destination-actions/src/destinations/mixpanel/identifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/identifyUser/__tests__/index.test.ts
@@ -98,4 +98,48 @@ describe('Mixpanel.identifyUser', () => {
       })
     )
   })
+
+  it('should default to US endpoint if apiRegion setting is undefined', async () => {
+    const event = createTestEvent({ timestamp, traits: { abc: '123' } })
+
+    nock('https://api.mixpanel.com').post('/engage').reply(200, {})
+    nock('https://api.mixpanel.com').post('/track').reply(200, {})
+
+    const responses = await testDestination.testAction('identifyUser', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        projectToken: MIXPANEL_PROJECT_TOKEN,
+        apiSecret: MIXPANEL_API_SECRET
+      }
+    })
+    expect(responses.length).toBe(2)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.body).toMatchObject(
+      new URLSearchParams({
+        data: JSON.stringify({
+          event: '$identify',
+          properties: {
+            $identified_id: 'user1234',
+            $anon_id: event.anonymousId,
+            token: MIXPANEL_PROJECT_TOKEN
+          }
+        })
+      })
+    )
+    expect(responses[1].status).toBe(200)
+    expect(responses[1].data).toMatchObject({})
+    expect(responses[1].options.body).toMatchObject(
+      new URLSearchParams({
+        data: JSON.stringify({
+          $token: MIXPANEL_PROJECT_TOKEN,
+          $distinct_id: 'user1234',
+          $set: {
+            abc: '123'
+          }
+        })
+      })
+    )
+  })
 })

--- a/packages/destination-actions/src/destinations/mixpanel/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/index.ts
@@ -79,8 +79,7 @@ const destination: DestinationDefinition<Settings> = {
           'Learn about [EU data residency](https://help.mixpanel.com/hc/en-us/articles/360039135652-Data-Residency-in-EU)',
         type: 'string',
         choices: Object.values(ApiRegions).map((apiRegion) => ({ label: apiRegion, value: apiRegion })),
-        default: ApiRegions.US,
-        required: true
+        default: ApiRegions.US
       }
     },
     testAuthentication: (request, { settings }) => {

--- a/packages/destination-actions/src/destinations/mixpanel/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackEvent/__tests__/index.test.ts
@@ -73,6 +73,37 @@ describe('Mixpanel.trackEvent', () => {
     ])
   })
 
+  it('should default to US endpoint if apiRegion setting is undefined', async () => {
+    const event = createTestEvent({ timestamp, event: 'Test Event' })
+
+    nock('https://api.mixpanel.com').post('/import?strict=1').reply(200, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        projectToken: MIXPANEL_PROJECT_TOKEN,
+        apiSecret: MIXPANEL_API_SECRET
+      }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.json).toMatchObject([
+      {
+        event: 'Test Event',
+        properties: expect.objectContaining({
+          ip: '8.8.8.8',
+          distinct_id: 'user1234',
+          $current_url: 'https://segment.com/academy/',
+          $locale: 'en-US',
+          mp_country_code: 'United States',
+          mp_lib: 'Segment: analytics.js'
+        })
+      }
+    ])
+  })
+
   it('should require event field', async () => {
     const event = createTestEvent({ timestamp })
     event.event = undefined

--- a/packages/destination-actions/src/destinations/mixpanel/utils.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/utils.ts
@@ -3,7 +3,7 @@ export enum ApiRegions {
   EU = 'EU 🇪🇺'
 }
 
-export function getApiServerUrl(apiRegion: string) {
+export function getApiServerUrl(apiRegion: string | undefined) {
   if (apiRegion == ApiRegions.EU) {
     return 'https://api-eu.mixpanel.com'
   }

--- a/packages/destination-actions/src/destinations/mixpanel/utils.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/utils.ts
@@ -1,6 +1,6 @@
 export enum ApiRegions {
-  US = 'US 🇺🇸',
-  EU = 'EU 🇪🇺'
+  US = 'US',
+  EU = 'EU'
 }
 
 export function getApiServerUrl(apiRegion: string | undefined) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2300,21 +2300,6 @@
   resolved "https://registry.yarnpkg.com/@segment/a1-notation/-/a1-notation-2.1.4.tgz#35a48a0688019c3ffff23b1ba890e864c891a11f"
   integrity sha512-SId7GOdDFmm/B9ajIQpXELHW4OTbVvmJbOsoJkQOcUEtoZIiX2UWfk1v4BpKql8wJW9oAhzhIIru2Pv2Yxcg+w==
 
-"@segment/action-destinations@^3.82.0":
-  version "3.82.0"
-  resolved "https://registry.yarnpkg.com/@segment/action-destinations/-/action-destinations-3.82.0.tgz#aa225756c9d4a87b58d7683518462ceaa0802319"
-  integrity sha512-q7cqpgPdiPsvfWTTVg7wtrjWEEqUb2T85FGPWk09f66zVEVqinFTWqSIozK4VZFSPa4iEgwfKM/5vUuvi24ecA==
-  dependencies:
-    "@amplitude/ua-parser-js" "^0.7.25"
-    "@segment/a1-notation" "^2.1.4"
-    "@segment/actions-core" "^3.29.0"
-    "@segment/actions-shared" "^1.12.0"
-    cheerio "^1.0.0-rc.10"
-    dayjs "^1.10.7"
-    escape-goat "^3"
-    liquidjs "^9.37.0"
-    lodash "^4.17.21"
-
 "@segment/analytics-next@^1.29.3":
   version "1.29.3"
   resolved "https://registry.yarnpkg.com/@segment/analytics-next/-/analytics-next-1.29.3.tgz#51ea4d7e487e95c2862ec5d52fd34a113c20161e"


### PR DESCRIPTION
- See original PR here: https://github.com/segmentio/action-destinations/pull/727
- Prevents internal errors, as identified in #sev-3-wide-possum

## Testing
Additional manual testing [documented here](https://paper.dropbox.com/doc/Actions-Mixpanel-Local-Manual-Testing--BnhpJxBYCdIgqUM3pgifPBMRAg-TzdeMDUsnPlzA5cExBFxN). Existing and new unit tests all pass. Will also run Quasar - which [now supports this destination](https://github.com/segmentio/quasar/pull/146) - before deploying.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
