### PR TITLE
[STRATCONN-1541, ACT-163] Pass logger to perform and performBatch handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ The `perform` method accepts two arguments, (1) the request client instance (ext
 - `auth` - The data needed in OAuth requests. This is useful if fetching an updated OAuth `access_token` using a `refresh_token`. The `refresh_token` is available in `auth.refreshToken`.
 - `features` - The features available in the request based on the customer's sourceID. Features can only be enabled and/or used by internal Twilio/Segment employees. Features cannot be used for Partner builds.
 - `statsContext` - An object, containing a `statsClient` and `tags`. Stats can only be used by internal Twilio/Segment employees. Stats cannot be used for Partner builds.
+- `logger` - Logger can only be used by internal Twilio/Segment employees. Logger cannot be used for Partner builds.
 
 A basic example:
 

--- a/packages/core/src/create-test-integration.ts
+++ b/packages/core/src/create-test-integration.ts
@@ -1,7 +1,7 @@
 import { createTestEvent } from './create-test-event'
 import { Destination } from './destination-kit'
 import { mapValues } from './map-values'
-import type { DestinationDefinition, StatsContext } from './destination-kit'
+import type { DestinationDefinition, StatsContext, Logger } from './destination-kit'
 import type { JSONObject } from './json-object'
 import type { SegmentEvent } from './segment-event'
 import { AuthTokens } from './destination-kit/parse-settings'
@@ -34,10 +34,11 @@ interface InputData<Settings> {
   auth?: AuthTokens
   /**
    * The features available in the request based on the customer's sourceID;
-   * Both `features` and `stats` are for internal Twilio/Segment use only.
+   * `features`, `stats` and `logger` are for internal Twilio/Segment use only.
    */
   features?: Features
   statsContext?: StatsContext
+  logger?: Logger
 }
 
 class TestDestination<T> extends Destination<T> {
@@ -59,7 +60,7 @@ class TestDestination<T> extends Destination<T> {
   /** Testing method that runs an action e2e while allowing slightly more flexible inputs */
   async testAction(
     action: string,
-    { event, mapping, settings, useDefaultMappings, auth, features, statsContext }: InputData<T>
+    { event, mapping, settings, useDefaultMappings, auth, features, statsContext, logger }: InputData<T>
   ): Promise<Destination['responses']> {
     mapping = mapping ?? {}
 
@@ -75,7 +76,8 @@ class TestDestination<T> extends Destination<T> {
       settings: settings ?? ({} as T),
       auth,
       features: features ?? {},
-      statsContext: statsContext ?? ({} as StatsContext)
+      statsContext: statsContext ?? ({} as StatsContext),
+      logger: logger ?? ({} as Logger)
     })
 
     const responses = this.responses
@@ -93,7 +95,8 @@ class TestDestination<T> extends Destination<T> {
       useDefaultMappings,
       auth,
       features,
-      statsContext
+      statsContext,
+      logger
     }: Omit<InputData<T>, 'event'> & { events?: SegmentEvent[] }
   ): Promise<Destination['responses']> {
     mapping = mapping ?? {}
@@ -114,7 +117,8 @@ class TestDestination<T> extends Destination<T> {
       settings: settings ?? ({} as T),
       auth,
       features: features ?? {},
-      statsContext: statsContext ?? ({} as StatsContext)
+      statsContext: statsContext ?? ({} as StatsContext),
+      logger: logger ?? ({} as Logger)
     })
 
     const responses = this.responses

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -12,7 +12,7 @@ import { validateSchema } from '../schema-validation'
 import { AuthTokens } from './parse-settings'
 import { IntegrationError } from '../errors'
 import { removeEmptyValues } from '../remove-empty-values'
-import { StatsContext } from './index'
+import { Logger, StatsContext } from './index'
 
 type MaybePromise<T> = T | Promise<T>
 type RequestClient = ReturnType<typeof createRequestClient>
@@ -81,6 +81,7 @@ interface ExecuteBundle<T = unknown, Data = unknown> {
   /** For internal Segment/Twilio use only. */
   features?: Features | undefined
   statsContext?: StatsContext | undefined
+  logger?: Logger | undefined
 }
 
 /**
@@ -141,7 +142,8 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
       payload,
       auth: bundle.auth,
       features: bundle.features,
-      statsContext: bundle.statsContext
+      statsContext: bundle.statsContext,
+      logger: bundle.logger
     }
 
     // Construct the request client and perform the action
@@ -185,7 +187,8 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
         payload: payloads,
         auth: bundle.auth,
         features: bundle.features,
-        statsContext: bundle.statsContext
+        statsContext: bundle.statsContext,
+        logger: bundle.logger
       }
       await this.performRequest(this.definition.performBatch, data)
     }

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -1,4 +1,4 @@
-import { StatsContext } from './index'
+import { Logger, StatsContext } from './index'
 import type { RequestOptions } from '../request-client'
 import type { JSONObject } from '../json-object'
 import { AuthTokens } from './parse-settings'
@@ -27,10 +27,11 @@ export interface ExecuteInput<Settings, Payload> {
   readonly auth?: AuthTokens
   /**
    * The features available in the request based on the customer's sourceID;
-   * Both `features` and `stats` are for internal Twilio/Segment use only.
+   * `features`,`stats` and `logger` are for internal Twilio/Segment use only.
    */
   readonly features?: Features
   readonly statsContext?: StatsContext
+  readonly logger?: Logger
 }
 
 export interface DynamicFieldResponse {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This change passes logger instance to perform and performBatch action hooks to help in debugging. The control to enable/disable logging for a destination and set the log level is in integrations service.

Associated Integrations PR - https://github.com/segmentio/integrations/pull/2361

## Testing
Testing completed successfully in stage. I deployed this branch/code to the staging environment and sent test events to validate that the log statements are collected from `perform` and `performBatch`

Documented both local and staging test here: https://docs.google.com/document/d/1aBWX35QQ_9H0azUBZXChAuR1owmV163BDd8c3jcGWBI/edit#

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
