### PR TITLE
rename Pardot Actions

### DIFF
--- a/packages/destination-actions/src/destinations/actions-pardot/index.ts
+++ b/packages/destination-actions/src/destinations/actions-pardot/index.ts
@@ -7,7 +7,7 @@ interface RefreshTokenResponse {
 }
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Pardot Actions',
+  name: 'Pardot (Actions)',
   slug: 'actions-pardot',
   mode: 'cloud',
 


### PR DESCRIPTION
The destination name cannot be changed to a previous name, so renaming Pardot Actions to Pardot (Actions). This is also consistent to what the name is in Partner Portal.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
