### PR TITLE
Action Tester for Web

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -79,6 +79,13 @@
         // skip annoying `async_hooks` file for promises
         "<node_internals>/**"
       ]
+    },
+    {
+      "name": "Launch Action Tester Web",
+      "type": "chrome",
+      "request": "launch",
+      "url": "https://app.segment.com/dev-center/actions-tester",
+      "webRoot": "${workspaceFolder}/packages/browser-destinations"
     }
   ]
 }

--- a/packages/browser-destinations/package.json
+++ b/packages/browser-destinations/package.json
@@ -28,7 +28,7 @@
     "prepublishOnly": "yarn build",
     "test": "jest",
     "typecheck": "tsc -p tsconfig.build.json --noEmit",
-    "dev": "NODE_ENV=development concurrently \"webpack serve --open\" \"webpack -c webpack.config.js --watch\""
+    "dev": "NODE_ENV=development concurrently \"webpack serve\" \"webpack -c webpack.config.js --watch\""
   },
   "dependencies": {
     "@braze/web-sdk": "npm:@braze/web-sdk@^4.1.0",

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,5 +1,5 @@
 import { Command, flags } from '@oclif/command'
-import { ChildProcess, fork } from 'child_process'
+import { ChildProcess, fork, exec } from 'child_process'
 import { autoPrompt } from '../lib/prompt'
 import chalk from 'chalk'
 import chokidar from 'chokidar'
@@ -36,6 +36,10 @@ export default class Serve extends Command {
     noUI: flags.boolean({
       char: 'n',
       description: 'do not open actions tester UI in browser'
+    }),
+    browser: flags.boolean({
+      char: 'r',
+      description: 'serve browser destinations'
     })
   }
 
@@ -122,6 +126,10 @@ export default class Serve extends Command {
         child?.removeAllListeners()
         child = undefined
       })
+
+      if (flags.browser) {
+        exec('yarn --cwd packages/browser-destinations dev')
+      }
     }
 
     watcher.on('change', (file) => {

--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -152,7 +152,7 @@ function setupRoutes(def: DestinationDefinition | null): void {
   router.get(
     '/manifest',
     asyncHandler(async (_, res: express.Response) => {
-      res.json(destination.definition)
+      res.json({ ...destination.definition, directoryName: process.env.DESTINATION })
     })
   )
 


### PR DESCRIPTION
Adding support for Action Tester for web destinations. Changes are rather minor: 
- passing `directoryName` property for each destination in the server.ts ( we need that name instead of the real slug for browser destinations ) 
- updating the `serve` command to accept a browser flag 
- update the launch.json to allow debugging with VS code. 

Note that the PR for the app portion is here: https://github.com/segmentio/app/pull/13980

## Testing
Tested locally with action tester. 

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
