### PR TITLE
[STRATCONN-1572] Remove Custom Events Verification 

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
@@ -31,18 +31,6 @@ const action: ActionDefinition<Settings, Payload> = {
       throw new IntegrationError('Must include at least one user data property', 'Misconfigured required field', 400)
     }
 
-    if (
-      !['email', 'website', 'phone_call', 'chat', 'physical_store', 'system_generated', 'other'].includes(
-        payload.action_source
-      )
-    ) {
-      throw new IntegrationError(
-        'Provide a valid value for the action source parameter, such as "website"',
-        'Misconfigured required field',
-        400
-      )
-    }
-
     return request(
       `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
       {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_Currently the value `app` is not an accepted value for the Custom Event Action for Facebook CAPI. This PR removes the extra verification step. We are completely removing the verification to unblock customers, and make sure any new future accepted values for `action_source` are not throwing verification errors. We will let the FB api handle the errors if an action_source is not accepted. We also do not have this verification for other actions, only for Custom Events._

For more details, please look at the [ticket](https://segment.atlassian.net/jira/software/c/projects/STRATCONN/boards/310?modal=detail&selectedIssue=STRATCONN-1572). 

## Testing

Testing was completed succesfully by deploying to staging. 

1. `action_source`: `app`

<img width="925" alt="image" src="https://user-images.githubusercontent.com/89420099/187355312-ec30b470-e2a3-431b-8fdf-34e79b65311f.png">
<img width="915" alt="image" src="https://user-images.githubusercontent.com/89420099/187355646-b8e335ee-02bf-4cb5-a809-0e256e1b2353.png">




2. `action_source`: `website`

<img width="921" alt="image" src="https://user-images.githubusercontent.com/89420099/187355494-b68683dc-aa68-4dd1-96ee-9645027e906c.png">
<img width="915" alt="image" src="https://user-images.githubusercontent.com/89420099/187355638-ab9a9990-e8a7-490e-9328-68ab5eff71a0.png">


3. `action_source`: `fake`

<img width="1018" alt="image" src="https://user-images.githubusercontent.com/89420099/187355842-bf220462-1008-4edc-a71d-f58af274733d.png">
<img width="887" alt="image" src="https://user-images.githubusercontent.com/89420099/187356063-f35be0d7-0d5d-4da0-b4df-1843c90f1581.png">



- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
