### PR TITLE
Changing ope_alt_user_ids from array to string type for 1PlusX

### DIFF
--- a/packages/destination-actions/src/destinations/1plusx/__tests__/oneplusx.test.ts
+++ b/packages/destination-actions/src/destinations/1plusx/__tests__/oneplusx.test.ts
@@ -217,7 +217,7 @@ describe('1plusX', () => {
         gdpr: 1,
         gdpr_consent: 'Functional',
         ope_usp_string: 'Functional',
-        ope_alt_user_ids: 'assetId:12345,title:The Simpsons,genre:Comedy'
+        ope_alt_user_ids: '12345'
       })
     })
   })

--- a/packages/destination-actions/src/destinations/1plusx/__tests__/oneplusx.test.ts
+++ b/packages/destination-actions/src/destinations/1plusx/__tests__/oneplusx.test.ts
@@ -198,7 +198,7 @@ describe('1plusX', () => {
             '@path': '$.properties.consents'
           },
           ope_alt_user_ids: {
-            '@path': `assetId:{$.properties.assetId},title:{$.properties.title},genre:{$.properties.genre}`
+            '@path': `assetId:{$properties.assetId},title:{$properties.title},genre:{$properties.genre}`
           }
         },
         useDefaultMappings: true

--- a/packages/destination-actions/src/destinations/1plusx/__tests__/oneplusx.test.ts
+++ b/packages/destination-actions/src/destinations/1plusx/__tests__/oneplusx.test.ts
@@ -198,7 +198,7 @@ describe('1plusX', () => {
             '@path': '$.properties.consents'
           },
           ope_alt_user_ids: {
-            '@path': `assetId:{$properties.assetId},title:{$properties.title},genre:{$properties.genre}`
+            '@path': '$.properties.assetId'
           }
         },
         useDefaultMappings: true

--- a/packages/destination-actions/src/destinations/1plusx/__tests__/oneplusx.test.ts
+++ b/packages/destination-actions/src/destinations/1plusx/__tests__/oneplusx.test.ts
@@ -158,6 +158,68 @@ describe('1plusX', () => {
         ope_usp_string: 'Functional'
       })
     })
+
+    it('should send ope_alt_user_ids as string type with custom mappings', async () => {
+      nock('https://tagger-test.opecloud.com').post(`/${client_id}/v2/native/event`).reply(204)
+      const event = createTestEvent({
+        anonymousId: 'anon-user123',
+        userId: 'user123',
+        timestamp: '2021-07-12T23:02:40.563Z',
+        event: 'Test Event',
+        type: 'track',
+        properties: {
+          assetId: '12345',
+          title: 'The Simpsons',
+          genre: 'Comedy',
+          full_episode: true,
+          platform: 'web',
+          opt_out: 1,
+          consents: 'Functional'
+        }
+      })
+
+      const responses = await testDestination.testAction('sendEvent', {
+        event,
+        settings: {
+          client_id,
+          use_test_endpoint
+        },
+        mapping: {
+          platform: {
+            '@path': '$.properties.platform'
+          },
+          gdpr: {
+            '@path': '$.properties.opt_out'
+          },
+          gdpr_consent: {
+            '@path': '$.properties.consents'
+          },
+          ope_usp_string: {
+            '@path': '$.properties.consents'
+          },
+          ope_alt_user_ids: {
+            '@path': `assetId:{$.properties.assetId},title:{$.properties.title},genre:{$.properties.genre}`
+          }
+        },
+        useDefaultMappings: true
+      })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(204)
+      expect(responses[0].options.json).toMatchObject({
+        ope_user_id: 'ANONYMOUSID:anon-user123',
+        ope_event_type: 'Test Event',
+        ope_event_time_ms: '2021-07-12T23:02:40.563Z',
+        assetId: '12345',
+        title: 'The Simpsons',
+        genre: 'Comedy',
+        full_episode: 'true',
+        platform: 'web',
+        gdpr: 1,
+        gdpr_consent: 'Functional',
+        ope_usp_string: 'Functional',
+        ope_alt_user_ids: 'assetId:12345,title:The Simpsons,genre:Comedy'
+      })
+    })
   })
 
   describe('sendPageview', () => {

--- a/packages/destination-actions/src/destinations/1plusx/sendEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/1plusx/sendEvent/generated-types.ts
@@ -12,7 +12,7 @@ export interface Payload {
   /**
    * Alternative user ids if there is more than one identifier available, each prefixed with the identifier type and separated by commas
    */
-  ope_alt_user_ids?: string[]
+  ope_alt_user_ids?: string
   /**
    * The website URL of the page
    */

--- a/packages/destination-actions/src/destinations/1plusx/sendEvent/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx/sendEvent/index.ts
@@ -33,7 +33,6 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'Alternative user ids if there is more than one identifier available, each prefixed with the identifier type and separated by commas',
       type: 'string'
-      //multiple: true --commenting this since Fox wants ope_alt_user_ids to be a string value
     },
     //Highly recommended to include
     ope_item_uri: {

--- a/packages/destination-actions/src/destinations/1plusx/sendEvent/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx/sendEvent/index.ts
@@ -32,8 +32,8 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Alternative User IDs',
       description:
         'Alternative user ids if there is more than one identifier available, each prefixed with the identifier type and separated by commas',
-      type: 'string',
-      multiple: true
+      type: 'string'
+      //multiple: true --commenting this since Fox wants ope_alt_user_ids to be a string value
     },
     //Highly recommended to include
     ope_item_uri: {

--- a/packages/destination-actions/src/destinations/1plusx/sendPageview/generated-types.ts
+++ b/packages/destination-actions/src/destinations/1plusx/sendPageview/generated-types.ts
@@ -12,7 +12,7 @@ export interface Payload {
   /**
    * Alternative user ids if there is more than one identifier available, each prefixed with the identifier type and separated by commas
    */
-  ope_alt_user_ids?: string[]
+  ope_alt_user_ids?: string
   /**
    * The website URL of the page
    */

--- a/packages/destination-actions/src/destinations/1plusx/sendPageview/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx/sendPageview/index.ts
@@ -30,8 +30,8 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Alternative User IDs',
       description:
         'Alternative user ids if there is more than one identifier available, each prefixed with the identifier type and separated by commas',
-      type: 'string',
-      multiple: true
+      type: 'string'
+      //multiple: true  --commenting this since Fox wants ope_alt_user_ids to be a string value
     },
     //Highly recommended to include
     ope_item_uri: {

--- a/packages/destination-actions/src/destinations/1plusx/sendPageview/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx/sendPageview/index.ts
@@ -31,7 +31,6 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'Alternative user ids if there is more than one identifier available, each prefixed with the identifier type and separated by commas',
       type: 'string'
-      //multiple: true  --commenting this since Fox wants ope_alt_user_ids to be a string value
     },
     //Highly recommended to include
     ope_item_uri: {

--- a/packages/destination-actions/src/destinations/1plusx/sendUserData/generated-types.ts
+++ b/packages/destination-actions/src/destinations/1plusx/sendUserData/generated-types.ts
@@ -12,7 +12,7 @@ export interface Payload {
   /**
    * Alternative user ids if there is more than one identifier available, each prefixed with the identifier type and separated by commas
    */
-  ope_alt_user_ids?: string[]
+  ope_alt_user_ids?: string
   /**
    * The website URL of the page
    */

--- a/packages/destination-actions/src/destinations/1plusx/sendUserData/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx/sendUserData/index.ts
@@ -32,7 +32,6 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'Alternative user ids if there is more than one identifier available, each prefixed with the identifier type and separated by commas',
       type: 'string'
-      //multiple: true --commenting this since Fox wants ope_alt_user_ids to be a string value
     },
     //Highly recommended to include
     ope_item_uri: {

--- a/packages/destination-actions/src/destinations/1plusx/sendUserData/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx/sendUserData/index.ts
@@ -31,8 +31,8 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Alternative User IDs',
       description:
         'Alternative user ids if there is more than one identifier available, each prefixed with the identifier type and separated by commas',
-      type: 'string',
-      multiple: true
+      type: 'string'
+      //multiple: true --commenting this since Fox wants ope_alt_user_ids to be a string value
     },
     //Highly recommended to include
     ope_item_uri: {

--- a/packages/destination-actions/src/destinations/intercom/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/intercom/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-intercom destination: groupIdentifyContact action - all fields 1`] = `
+Object {
+  "query": Object {
+    "field": "external_id",
+    "operator": "=",
+    "value": "&c*y@t",
+  },
+}
+`;
+
+exports[`Testing snapshot for actions-intercom destination: groupIdentifyContact action - required fields 1`] = `
+Object {
+  "query": Object {
+    "field": "external_id",
+    "operator": "=",
+    "value": "&c*y@t",
+  },
+}
+`;
+
+exports[`Testing snapshot for actions-intercom destination: identifyContact action - all fields 1`] = `
+Object {
+  "query": Object {
+    "field": "external_id",
+    "operator": "=",
+    "value": "w4Cd)ds3Aa1uN",
+  },
+}
+`;
+
+exports[`Testing snapshot for actions-intercom destination: identifyContact action - required fields 1`] = `
+Object {
+  "query": Object {
+    "field": "external_id",
+    "operator": "=",
+    "value": "w4Cd)ds3Aa1uN",
+  },
+}
+`;
+
+exports[`Testing snapshot for actions-intercom destination: trackEvent action - all fields 1`] = `
+Object {
+  "created_at": 1612137600,
+  "email": "wuveska@faoh.jm",
+  "event_name": "LTimWPMaHwGcz)",
+  "id": "LTimWPMaHwGcz)",
+  "metadata": Object {
+    "price": Object {
+      "amount": 1670923425939456,
+      "currency": "SYP",
+    },
+    "testType": "LTimWPMaHwGcz)",
+  },
+  "user_id": "LTimWPMaHwGcz)",
+}
+`;
+
+exports[`Testing snapshot for actions-intercom destination: trackEvent action - required fields 1`] = `
+Object {
+  "created_at": 1612137600,
+  "event_name": "LTimWPMaHwGcz)",
+  "id": "LTimWPMaHwGcz)",
+  "user_id": "LTimWPMaHwGcz)",
+}
+`;


### PR DESCRIPTION
 Changing the `ope_alt_user_ids` field from data type `array` to `string`. 1plusx was not able to process it as an `array`.

## Testing

I finished local end-to-end testing and unit testing on my end 
- [ ] Added 'should send ope_alt_user_ids as string type with custom mappings' unit test under the sendEvent test cases for 1plusx
- [ ] Tested end-to-end using the 3000 port (https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] I did not test it in the staging environment yet as these changes have not been pushed to staging

Please feel free to reach out to me with any questions.
Thanks,
Shraddha
