### PR TITLE
Update docs for disablePushTokenMaintenance setting

### DIFF
--- a/packages/browser-destinations/src/destinations/braze/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/braze/generated-types.ts
@@ -34,7 +34,7 @@ export interface Settings {
    */
   devicePropertyAllowlist?: string[]
   /**
-   * By default, users who have already granted web push permission will sync their push token with the Braze backend automatically on new session to ensure deliverability. To disable this behavior, set this option to false
+   * By default, users who have already granted web push permission will sync their push token with the Braze backend automatically on new session to ensure deliverability. To disable this behavior, set this option to true
    */
   disablePushTokenMaintenance?: boolean
   /**

--- a/packages/browser-destinations/src/destinations/braze/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/index.ts
@@ -149,7 +149,7 @@ export const destination: BrowserDestinationDefinition<Settings, BrazeType> = {
       default: false,
       required: false,
       description:
-        'By default, users who have already granted web push permission will sync their push token with the Braze backend automatically on new session to ensure deliverability. To disable this behavior, set this option to false'
+        'By default, users who have already granted web push permission will sync their push token with the Braze backend automatically on new session to ensure deliverability. To disable this behavior, set this option to true'
     },
     doNotLoadFontAwesome: {
       label: 'Do Not Load Font Awesome',


### PR DESCRIPTION
Our docs are misleading for the `disablePushTokenMaintenance` setting for Braze Web actions. 
Going to quote our current docs below:
```
Required.
By default, users who have already granted web push permission will sync their push token with the Braze backend automatically on new session to ensure deliverability. To disable this behavior, set this option to false
```
It’s really not clear if we’re disabling the Segment setting, or disabling the push token maintenance setting for Braze when we toggle that setting.
Braze’s docs also seem to suggest this should be set to true to disable it, which seems to contradict our docs:
https://js.appboycdn.com/web-sdk/latest/doc/modules/braze.html#disablePushTokenMaintenance
```
By default, users who have already granted web push permission (e.g. through requestPushPermission or from a prior push provider) will sync their push token with the Braze backend automatically on new session to ensure deliverability. To disable this behavior, set this option to true.
```
Changing our docs to match the braze behavior, with setting needing to be true to disable.

## Testing
Docs change so no unit testing required
