### PR TITLE
[STRATCONN-1578] sends conversion tracking id in postConversion action

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Settings {
   /**
-   * You will find this information in the event snippet for your conversion action, for example `send_to: AW-CONVERSION_ID/AW-CONVERSION_LABEL`. In the sample snippet, AW-CONVERSION_ID stands for the conversion ID unique to your account. Enter the conversion Id, without the AW- prefix. This is required if you are using the Upload Enhanced Conversion (Legacy) Action which uses the Enhanced Conversions API.
+   * You will find this information in the event snippet for your conversion action, for example `send_to: AW-CONVERSION_ID/AW-CONVERSION_LABEL`. In the sample snippet, AW-CONVERSION_ID stands for the conversion ID unique to your account. Enter the conversion Id, without the AW- prefix. **Required if you are using an Action that sends data to the legacy Google Enhanced Conversions API.**
    */
   conversionTrackingId?: string
 }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Settings {
   /**
-   * You will find this information in the event snippet for your conversion action, for example `send_to: AW-CONVERSION_ID/AW-CONVERSION_LABEL`. In the sample snippet, AW-CONVERSION_ID stands for the conversion ID unique to your account. Enter the conversion Id, without the AW- prefix.
+   * You will find this information in the event snippet for your conversion action, for example `send_to: AW-CONVERSION_ID/AW-CONVERSION_LABEL`. In the sample snippet, AW-CONVERSION_ID stands for the conversion ID unique to your account. Enter the conversion Id, without the AW- prefix. This is required if you are using the Upload Enhanced Conversion (Legacy) Action which uses the Enhanced Conversions API.
    */
-  conversionTrackingId: string
+  conversionTrackingId?: string
 }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -27,7 +27,7 @@ const destination: DestinationDefinition<Settings> = {
       conversionTrackingId: {
         label: 'Conversion ID',
         description:
-          'You will find this information in the event snippet for your conversion action, for example `send_to: AW-CONVERSION_ID/AW-CONVERSION_LABEL`. In the sample snippet, AW-CONVERSION_ID stands for the conversion ID unique to your account. Enter the conversion Id, without the AW- prefix. This is required if you are using the Upload Enhanced Conversion (Legacy) Action which uses the Enhanced Conversions API. ',
+          'You will find this information in the event snippet for your conversion action, for example `send_to: AW-CONVERSION_ID/AW-CONVERSION_LABEL`. In the sample snippet, AW-CONVERSION_ID stands for the conversion ID unique to your account. Enter the conversion Id, without the AW- prefix. **Required if you are using an Action that sends data to the legacy Google Enhanced Conversions API.**',
         type: 'string'
       }
     },

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -27,9 +27,8 @@ const destination: DestinationDefinition<Settings> = {
       conversionTrackingId: {
         label: 'Conversion ID',
         description:
-          'You will find this information in the event snippet for your conversion action, for example `send_to: AW-CONVERSION_ID/AW-CONVERSION_LABEL`. In the sample snippet, AW-CONVERSION_ID stands for the conversion ID unique to your account. Enter the conversion Id, without the AW- prefix.',
-        type: 'string',
-        required: true
+          'You will find this information in the event snippet for your conversion action, for example `send_to: AW-CONVERSION_ID/AW-CONVERSION_LABEL`. In the sample snippet, AW-CONVERSION_ID stands for the conversion ID unique to your account. Enter the conversion Id, without the AW- prefix. This is required if you are using the Upload Enhanced Conversion (Legacy) Action which uses the Enhanced Conversions API. ',
+        type: 'string'
       }
     },
     testAuthentication: async (_request) => {
@@ -56,13 +55,10 @@ const destination: DestinationDefinition<Settings> = {
       return { accessToken: res.data.access_token }
     }
   },
-  extendRequest({ settings, auth }) {
+  extendRequest({ auth }) {
     return {
       headers: {
         authorization: `Bearer ${auth?.accessToken}`
-      },
-      searchParams: {
-        conversion_tracking_id: settings.conversionTrackingId
       }
     }
   },

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
@@ -209,7 +209,15 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
 
-  perform: async (request, { payload }) => {
+  perform: async (request, { payload, settings }) => {
+    if (!settings.conversionTrackingId) {
+      throw new IntegrationError(
+        'Conversion tracking id is required for this action. Please set it in destination settings.',
+        'Missing required fields.',
+        400
+      )
+    }
+
     const conversionData = cleanData({
       oid: payload.transaction_id,
       user_agent: payload.user_agent,
@@ -247,6 +255,9 @@ const action: ActionDefinition<Settings, Payload> = {
     try {
       return await request('https://www.google.com/ads/event/api/v1', {
         method: 'post',
+        searchParams: {
+          conversion_tracking_id: settings.conversionTrackingId
+        },
         json: {
           pii_data: { ...pii_data, address: [address] },
           ...conversionData


### PR DESCRIPTION
This PR is to address [STRATCONN-1578](https://segment.atlassian.net/browse/STRATCONN-1578) to send conversion tracking id within the postConversion Action since we will be adding new actions that don't require this field.

## Testing
Successfully tested in staging and conversion_tracking_id still sent correctly.

![Screen Shot 2022-08-26 at 5 27 20 PM](https://user-images.githubusercontent.com/99763167/187006914-486df5e8-f771-4f52-ac89-0884be0e7139.png)

If conversion_tracking_id is not set the following error is shown:
![Screen Shot 2022-08-26 at 5 30 34 PM](https://user-images.githubusercontent.com/99763167/187007024-d8292b6b-1dec-487a-8252-cc8ef1ec1557.png)

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
