### PR TITLE
Adding instruction link to Qualtrics workflow action

### DIFF
--- a/packages/destination-actions/src/destinations/qualtrics/triggerXflowWorkflow/generated-types.ts
+++ b/packages/destination-actions/src/destinations/qualtrics/triggerXflowWorkflow/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * Enter the full URL as you see in your Xflow trigger. See more details on setting up an xflow trigger and getting the URL here.
+   * Enter the full URL as you see in your Xflow trigger. [See more details on setting up an xflow trigger and getting the URL.](https://static-assets.qualtrics.com/static/integrations-external/twilio_segment_event_webhook_setup_instructions.pdf)
    */
   workflowUrl: string
   /**

--- a/packages/destination-actions/src/destinations/qualtrics/triggerXflowWorkflow/index.ts
+++ b/packages/destination-actions/src/destinations/qualtrics/triggerXflowWorkflow/index.ts
@@ -11,7 +11,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       format: 'uri',
       description:
-        'Enter the full URL as you see in your Xflow trigger. See more details on setting up an xflow trigger and getting the URL here.',
+        'Enter the full URL as you see in your Xflow trigger. [See more details on setting up an xflow trigger and getting the URL.](https://static-assets.qualtrics.com/static/integrations-external/twilio_segment_event_webhook_setup_instructions.pdf)',
       required: true
     },
     eventPayload: {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Added a documentation link for obtaining the correct URl for the trigger xflow workflow action type.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
