### PR TITLE
Initialize UTM properties changes

### DIFF
--- a/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
@@ -645,7 +645,7 @@ describe('Amplitude', () => {
       })
     })
 
-    it('should override values of the setOnce and setAlways with the values in utm_properties and referrer', async () => {
+    it.only('should override values of the setOnce and setAlways with the values in utm_properties and referrer', async () => {
       nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
 
       const event = createTestEvent({
@@ -672,7 +672,15 @@ describe('Amplitude', () => {
         utm_properties: {
           utm_source: 'Override source'
         },
-        referrer: 'Override referrer'
+        referrer: 'Override referrer',
+        setOnce: {
+          initial_utm_source: 'Second source',
+          initial_utm_campaign: 'TPS Innovation Newsletter',
+          initial_utm_content: 'image link',
+          initial_utm_medium: 'email',
+          initial_utm_term: 'tps reports',
+          test: true
+        }
       }
 
       const responses = await testDestination.testAction('logEvent', { event, mapping, useDefaultMappings: true })
@@ -697,7 +705,8 @@ describe('Amplitude', () => {
                 initial_utm_content: 'image link',
                 initial_utm_medium: 'email',
                 initial_utm_source: 'Override source',
-                initial_utm_term: 'tps reports'
+                initial_utm_term: 'tps reports',
+                test: true
               }
             })
           })

--- a/packages/destination-actions/src/destinations/amplitude/emptyObject.ts
+++ b/packages/destination-actions/src/destinations/amplitude/emptyObject.ts
@@ -1,0 +1,14 @@
+import { Payload as LogPayload } from './logEvent/generated-types'
+
+/**
+ * takes a object and removes all keys with a falsey value. Then checks if the object is empty or not
+ *
+ * @param object the setAlways, setOnce, or add object from the LogEvent payload
+ * @returns a boolean signifying whether the resulting object is empty or not
+ */
+
+export default function removeEmptyKeysAndCheckIfEmpty(
+  object: LogPayload['setOnce'] | LogPayload['setAlways'] | LogPayload['add']
+): boolean {
+  return Object.keys(Object.fromEntries(Object.entries(object ?? {}).filter(([_, v]) => v))).length > 0
+}

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/generated-types.ts
@@ -217,7 +217,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * The following fields will be set only once per session when using AJS2 as the source
+   * Increment a user property by a number with add. If the user property doesn't have a value set yet, it's initialized to 0.
    */
   add?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/generated-types.ts
@@ -190,6 +190,39 @@ export interface Payload {
    */
   userAgentParsing?: boolean
   /**
+   * The following fields will be set only once per session when using AJS2 as the source
+   */
+  setOnce?: {
+    /**
+     * The referrer of the web request
+     */
+    initial_referrer?: string
+    initial_utm_source?: string
+    initial_utm_medium?: string
+    initial_utm_campaign?: string
+    initial_utm_term?: string
+    initial_utm_content?: string
+    [k: string]: unknown
+  }
+  /**
+   * The following fields will be set every session when using AJS2 as the source
+   */
+  setAlways?: {
+    referrer?: string
+    utm_source?: string
+    utm_medium?: string
+    utm_campaign?: string
+    utm_term?: string
+    utm_content?: string
+    [k: string]: unknown
+  }
+  /**
+   * The following fields will be set only once per session when using AJS2 as the source
+   */
+  add?: {
+    [k: string]: unknown
+  }
+  /**
    * UTM Tracking Properties
    */
   utm_properties?: {

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/generated-types.ts
@@ -237,7 +237,7 @@ export interface Payload {
    */
   referrer?: string
   /**
-   * Amplitude has a default minimum id lenght of 5 characters for user_id and device_id fields. This field allows the minimum to be overridden to allow shorter id lengths.
+   * Amplitude has a default minimum id length of 5 characters for user_id and device_id fields. This field allows the minimum to be overridden to allow shorter id lengths.
    */
   min_id_length?: number | null
 }

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
@@ -9,6 +9,7 @@ import { convertReferrerProperty } from '../referrer'
 import { mergeUserProperties } from '../merge-user-properties'
 import { parseUserAgentProperties } from '../user-agent'
 import { getEndpointByRegion } from '../regional-endpoints'
+import removeEmptyKeysAndCheckIfEmpty from '../emptyObject'
 
 export interface AmplitudeEvent extends Omit<Payload, 'products' | 'time' | 'session_id'> {
   library?: string
@@ -191,9 +192,11 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     add: {
       label: 'Add',
-      description: 'The following fields will be set only once per session when using AJS2 as the source',
+      description:
+        "Increment a user property by a number with add. If the user property doesn't have a value set yet, it's initialized to 0.",
       type: 'object',
-      additionalProperties: true
+      additionalProperties: true,
+      defaultObjectUI: 'keyvalue'
     },
     utm_properties: {
       label: 'UTM Properties',
@@ -272,13 +275,13 @@ const action: ActionDefinition<Settings, Payload> = {
       properties.session_id = dayjs.utc(session_id).valueOf()
     }
 
-    if (Object.keys(Object.fromEntries(Object.entries(setOnce ?? {}).filter(([_, v]) => v))).length) {
+    if (removeEmptyKeysAndCheckIfEmpty(setOnce)) {
       properties.user_properties = { ...properties.user_properties, $setOnce: setOnce }
     }
-    if (Object.keys(Object.fromEntries(Object.entries(setAlways ?? {}).filter(([_, v]) => v))).length) {
+    if (removeEmptyKeysAndCheckIfEmpty(setAlways)) {
       properties.user_properties = { ...properties.user_properties, $set: setAlways }
     }
-    if (Object.keys(Object.fromEntries(Object.entries(add ?? {}).filter(([_, v]) => v))).length) {
+    if (removeEmptyKeysAndCheckIfEmpty(add)) {
       properties.user_properties = { ...properties.user_properties, $add: add }
     }
 

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
@@ -114,7 +114,6 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'object',
       additionalProperties: true,
       properties: {
-        //should the types of these properties be string? Is there anything else they could be?
         initial_referrer: {
           label: 'Initial Referrer',
           type: 'string',
@@ -156,7 +155,6 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'object',
       additionalProperties: true,
       properties: {
-        //should the types of these properties be string? Is there anything else they could be?
         referrer: {
           label: 'Referrer',
           type: 'string'
@@ -191,7 +189,6 @@ const action: ActionDefinition<Settings, Payload> = {
         utm_content: { '@path': '$.context.campaign.content' }
       }
     },
-    //Looking at the amplitude docs, do we expect this to be an object containing types of number?
     add: {
       label: 'Add',
       description: 'The following fields will be set only once per session when using AJS2 as the source',

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
@@ -223,23 +223,13 @@ const action: ActionDefinition<Settings, Payload> = {
           label: 'UTM Content',
           type: 'string'
         }
-      },
-      default: {
-        utm_source: { '@path': '$.context.campaign.source' },
-        utm_medium: { '@path': '$.context.campaign.medium' },
-        utm_campaign: { '@path': '$.context.campaign.name' },
-        utm_term: { '@path': '$.context.campaign.term' },
-        utm_content: { '@path': '$.context.campaign.content' }
       }
     },
     referrer: {
       label: 'Referrer',
       type: 'string',
       description:
-        'The referrer of the web request. Sent to Amplitude as both last touch “referrer” and first touch “initial_referrer”',
-      default: {
-        '@path': '$.context.page.referrer'
-      }
+        'The referrer of the web request. Sent to Amplitude as both last touch “referrer” and first touch “initial_referrer”'
     },
     min_id_length: {
       label: 'Minimum ID Length',


### PR DESCRIPTION
This PR addresses [JIRA ACT-146](https://segment.atlassian.net/browse/ACT-146) & [Design Doc](https://paper.dropbox.com/doc/Amplitude-Transparency-and-control-over-setsetOnce--BocP0wAMd7029sN0gSA2eaSoAg-7PxGzLWcZJFtaA5pbAT7C)

In it we create three new object fields for the Amplitude `logEvent` action - `setAlways`, `setOnce` and `add`. The goal of these new fields is to replace the previous fields of `UTM_properties` and `referrer` since the values for these old fields undergo some hidden things in the background of the `perform` block that aren't clear to users. This change should make it much clearer to the user what is happening to their data, as well as allow for greater customizability as to what fields get passed to Amplitude in their respective `$set`, `$setOnce`, and `$add` fields.

To allow for backwards compatibility we decided to leave in the logic that handles what happens when the fields for `referrer` and `UTM_properties` are set. In the instance both the new fields _AND_ old field have values passed in, whatever values are in the older fields will win out. For example, say in the payload passed to the `perform` block the fields `setOnce`, `setAlways` and `UTM_properties` look like this respectively:
```
setOnce: {
  "initial_utm_source": "google"
}
setAlways: {
  "utm_source": "bing"
}
UTM_properties: {
  "utm_source": "yahoo"
}
```

The resulting payload sent to amplitude will look like
```
$set: {
  "utm_source": "yahoo"
}
$setAlways: {
  "utm_source": "yahoo"
}
```

(This override will only happen for the `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`, and `referrer` fields)

## Testing

Testing completed successfully via a stage deploy to Actions Amplitude and sending test events through `dispatch` + `event-tester`

### Test One
This test was to ensure the "overriding" was occurring correctly. Events sent with values for the `utm_properties` and `referrer` fields would override any matching fields sent in the `setOnce` and `setAlways` fields.

| Mapping  | Amplitude Result |
| ------------- | ------------- |
| ![Screen Shot 2022-09-12 at 11 39 19 AM](https://user-images.githubusercontent.com/98849774/189734850-e788a3c1-fb47-4aee-9a65-6eb92d65b885.png) | ![Screen Shot 2022-09-12 at 11 39 40 AM](https://user-images.githubusercontent.com/98849774/189734901-aec040dc-287a-4bc5-a742-675981bd667e.png) |

As seen, the values set in the `utm_properties` and `referrer` objects "win out" over those same fields set in the `setAlways` and `setOnce` objects.

### Test Two
This test was to ensure when there were no values in the `utm_properties` and `referrer` fields, the `setAlways` and `setOnce` fields worked correctly.

| Mapping  | Amplitude Result |
| ------------- | ------------- |
| ![Screen Shot 2022-09-12 at 11 41 44 AM](https://user-images.githubusercontent.com/98849774/189735405-8b16c4e2-4c5a-4371-8b3f-880b04b2d8df.png) | ![Screen Shot 2022-09-12 at 11 41 58 AM](https://user-images.githubusercontent.com/98849774/189735438-32133dd6-4212-4e8f-9409-b78f35812cfe.png) |

As seen, the corresponding fields are correctly set in Amplitude.

### Test Three
This test was to ensure that any fields in the `setOnce` object are truly only set on the first event, and ignored for any future events. In addition, it ensures that any fields in the `setAlways` object are updated on each new event.

| Mapping  | Amplitude Result |
| ------------- | ------------- |
| ![Screen Shot 2022-09-12 at 11 44 03 AM](https://user-images.githubusercontent.com/98849774/189736107-f52858b9-0881-4ce4-ab0d-4770fb782839.png) | ![Screen Shot 2022-09-12 at 11 44 35 AM](https://user-images.githubusercontent.com/98849774/189736135-ec551994-39af-4798-966c-ab0d6b149462.png) |

As seen, only the fields in the `setAlways` object are updated on new events.

### Test Four
This test was to ensure functionality of the `add` object.

| Mapping  | Amplitude Result |
| ------------- | ------------- |
| ![Screen Shot 2022-09-12 at 11 48 23 AM](https://user-images.githubusercontent.com/98849774/189736615-cabc400b-c7b3-4fcf-b68f-8bde11dea891.png) | ![Screen Shot 2022-09-12 at 11 48 31 AM](https://user-images.githubusercontent.com/98849774/189736643-424d74f4-a6bc-41d8-b3b8-d80ea1595534.png) |

As seen, we set a variable `test` to 10 in the `setOnce` object, and then attempted to add 5 to it using the `add` object. The resulting field in amplitude is 15 showing it works as expected.

### Test Five
This test was to ensure all previous instances of the `LogEvent` action would still work correctly after the changes.
- The new fields do show up in the old action but there are no `defaults` set for them as seen in the image below.
- Events through dispatch were correctly delivered both when the new fields did and didn't have values for them.

![Screen Shot 2022-09-12 at 11 45 58 AM](https://user-images.githubusercontent.com/98849774/189737315-8df3932d-15d9-4e29-ae9e-8758f62641f2.png)


_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
