### PR TITLE
CONMAN-167: updating engage-messaging-sendgrid to respect subscription group status if present

### DIFF
--- a/packages/core/src/segment-event.ts
+++ b/packages/core/src/segment-event.ts
@@ -155,4 +155,16 @@ export interface SegmentEvent {
   }
 
   timestamp?: Date | string
+
+  external_ids?: {
+    id: string
+    type: 'email' | 'phone'
+    isSubscribed: boolean | null
+    collection: 'users'
+    encoding: 'none'
+    groups?: {
+      id: string
+      isSubscribed: boolean | null
+    }[]
+  }[]
 }

--- a/packages/core/src/segment-event.ts
+++ b/packages/core/src/segment-event.ts
@@ -155,16 +155,4 @@ export interface SegmentEvent {
   }
 
   timestamp?: Date | string
-
-  external_ids?: {
-    id: string
-    type: 'email' | 'phone'
-    isSubscribed: boolean | null
-    collection: 'users'
-    encoding: 'none'
-    groups?: {
-      id: string
-      isSubscribed: boolean | null
-    }[]
-  }[]
 }

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/__tests__/send-email.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { createTestIntegration, omit } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration, omit } from '@segment/actions-core'
 import { createMessagingTestEvent } from '../../../lib/engage-test-data/create-messaging-test-event'
 import Sendgrid from '..'
 
@@ -93,10 +93,35 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       send: true,
       traitEnrichment: true,
       toEmail: '',
-      externalIds: [
-        { id: userData.email, type: 'email', subscriptionStatus: 'subscribed' },
-        { id: userData.phone, type: 'phone', subscriptionStatus: 'subscribed' }
-      ],
+      externalIds: {
+        '@arrayPath': [
+          '$.external_ids',
+          {
+            id: {
+              '@path': '$.id'
+            },
+            type: {
+              '@path': '$.type'
+            },
+            subscriptionStatus: {
+              '@path': '$.isSubscribed'
+            },
+            groups: {
+              '@arrayPath': [
+                '$.groups',
+                {
+                  id: {
+                    '@path': '$.id'
+                  },
+                  subscriptionStatus: {
+                    '@path': '$.isSubscribed'
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
       traits: { '@path': '$.properties' },
       ...overrides
     }
@@ -125,7 +150,16 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         event: createMessagingTestEvent({
           timestamp,
           event: 'Audience Entered',
-          userId: userData.userId
+          userId: userData.userId,
+          external_ids: [
+            {
+              collection: 'users',
+              encoding: 'none',
+              id: userData.email,
+              isSubscribed: true,
+              type: 'email'
+            }
+          ]
         }),
         settings,
         mapping: getDefaultMapping()
@@ -345,7 +379,16 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         event: createMessagingTestEvent({
           timestamp,
           event: 'Audience Entered',
-          userId: userData.userId
+          userId: userData.userId,
+          external_ids: [
+            {
+              collection: 'users',
+              encoding: 'none',
+              id: userData.email,
+              isSubscribed: true,
+              type: 'email'
+            }
+          ]
         }),
         settings,
         mapping: getDefaultMapping({
@@ -430,7 +473,16 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         event: createMessagingTestEvent({
           timestamp,
           event: 'Audience Entered',
-          userId: userData.userId
+          userId: userData.userId,
+          external_ids: [
+            {
+              collection: 'users',
+              encoding: 'none',
+              id: userData.email,
+              isSubscribed: true,
+              type: 'email'
+            }
+          ]
         }),
         settings,
         mapping: getDefaultMapping({
@@ -531,7 +583,16 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         event: createMessagingTestEvent({
           timestamp,
           event: 'Audience Entered',
-          userId: userData.userId
+          userId: userData.userId,
+          external_ids: [
+            {
+              collection: 'users',
+              encoding: 'none',
+              id: userData.email,
+              isSubscribed: true,
+              type: 'email'
+            }
+          ]
         }),
         settings,
         mapping: getDefaultMapping({
@@ -558,7 +619,16 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         event: createMessagingTestEvent({
           timestamp,
           event: 'Audience Entered',
-          userId: userData.userId
+          userId: userData.userId,
+          external_ids: [
+            {
+              collection: 'users',
+              encoding: 'none',
+              id: userData.email,
+              isSubscribed: true,
+              type: 'email'
+            }
+          ]
         }),
         settings,
         mapping: getDefaultMapping({
@@ -587,7 +657,16 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         event: createMessagingTestEvent({
           timestamp,
           event: 'Audience Entered',
-          userId: userData.userId
+          userId: userData.userId,
+          external_ids: [
+            {
+              collection: 'users',
+              encoding: 'none',
+              id: userData.email,
+              isSubscribed: true,
+              type: 'email'
+            }
+          ]
         }),
         settings,
         mapping: getDefaultMapping({
@@ -616,44 +695,124 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       nock.cleanAll()
     })
 
-    it.each(['subscribed', true])('sends the email when subscriptionStatus = "%s"', async (subscriptionStatus) => {
+    it('sends the email when subscriptionStatus is true', async () => {
       const sendGridRequest = nock('https://api.sendgrid.com').post('/v3/mail/send').reply(200, {})
 
+      const isSubscribed = true
       const responses = await sendgrid.testAction('sendEmail', {
         event: createMessagingTestEvent({
           timestamp,
           event: 'Audience Entered',
-          userId: userData.userId
+          userId: userData.userId,
+          external_ids: [
+            { id: userData.email, type: 'email', isSubscribed, collection: 'users', encoding: 'none' },
+            { id: userData.phone, type: 'phone', isSubscribed: true, collection: 'users', encoding: 'none' }
+          ]
         }),
         settings,
-        mapping: getDefaultMapping({
-          externalIds: [
-            { id: userData.email, type: 'email', subscriptionStatus },
-            { id: userData.phone, type: 'phone', subscriptionStatus: 'subscribed' }
-          ]
-        })
+        mapping: getDefaultMapping()
       })
 
       expect(responses.length).toBeGreaterThan(0)
       expect(sendGridRequest.isDone()).toEqual(true)
     })
 
-    it.each(['unsubscribed', 'did not subscribed', '', null, false])(
+    it.each([null, false])(
       'does NOT send the email when subscriptionStatus = "%s"',
-      async (subscriptionStatus) => {
+      async (isSubscribed: boolean | null) => {
         await sendgrid.testAction('sendEmail', {
           event: createMessagingTestEvent({
             timestamp,
             event: 'Audience Entered',
-            userId: userData.userId
+            userId: userData.userId,
+            external_ids: [
+              { id: userData.email, type: 'email', isSubscribed, collection: 'users', encoding: 'none' },
+              { id: userData.phone, type: 'phone', isSubscribed: true, collection: 'users', encoding: 'none' }
+            ]
           }),
           settings,
-          mapping: getDefaultMapping({
-            externalIds: [
-              { id: userData.email, type: 'email', subscriptionStatus },
-              { id: userData.phone, type: 'phone', subscriptionStatus: 'subscribed' }
+          mapping: getDefaultMapping()
+        })
+        const sendGridRequest = nock('https://api.sendgrid.com')
+          .post('/v3/mail/send', sendgridRequestBody)
+          .reply(200, {})
+
+        expect(sendGridRequest.isDone()).toBe(false)
+      }
+    )
+  })
+
+  describe('subscription groups', () => {
+    beforeEach(() => {
+      nock(`${endpoint}/v1/spaces/spaceId/collections/users/profiles/user_id:${userData.userId}`)
+        .get('/traits?limit=200')
+        .reply(200, {
+          traits: {
+            firstName: userData.firstName,
+            lastName: userData.lastName
+          }
+        })
+    })
+
+    afterEach(() => {
+      nock.cleanAll()
+    })
+
+    it('should send email to group', async () => {
+      const sendGridRequest = nock('https://api.sendgrid.com').post('/v3/mail/send').reply(200, {})
+
+      const responses = await sendgrid.testAction('sendEmail', {
+        event: createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          userId: userData.userId,
+          external_ids: [
+            {
+              id: userData.email,
+              type: 'email',
+              isSubscribed: true,
+              collection: 'users',
+              encoding: 'none',
+              groups: [{ id: 'grp_1', isSubscribed: true }]
+            }
+          ]
+        }),
+        settings: {
+          ...settings,
+          groupId: 'grp_1'
+        },
+        mapping: getDefaultMapping()
+      })
+
+      expect(responses.length).toBeGreaterThan(0)
+      expect(sendGridRequest.isDone()).toEqual(true)
+    })
+
+    it.each([null, false])(
+      'does NOT send the email to group when group\'s subscriptionStatus = "%s"',
+      async (isSubscribed: boolean | null) => {
+        await sendgrid.testAction('sendEmail', {
+          event: createTestEvent({
+            timestamp,
+            event: 'Audience Entered',
+            userId: userData.userId,
+            external_ids: [
+              {
+                id: userData.email,
+                type: 'email',
+                isSubscribed: true,
+                collection: 'users',
+                encoding: 'none',
+                groups: [{ id: 'grp_1', isSubscribed }]
+              },
+              { id: userData.phone, type: 'phone', isSubscribed: true, collection: 'users', encoding: 'none' }
             ]
-          })
+          }),
+          settings: {
+            groupId: 'grp_1',
+            ...settings
+          },
+          mapping: getDefaultMapping()
         })
         const sendGridRequest = nock('https://api.sendgrid.com')
           .post('/v3/mail/send', sendgridRequestBody)
@@ -663,24 +822,58 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       }
     )
 
-    it('throws an error when subscriptionStatus is unrecognizable"', async () => {
-      const subscriptionStatus = 'random-string'
-      const response = sendgrid.testAction('sendEmail', {
-        event: createMessagingTestEvent({
+    it('does NOT send email to group when groupId is not in groups', async () => {
+      await sendgrid.testAction('sendEmail', {
+        event: createTestEvent({
           timestamp,
           event: 'Audience Entered',
-          userId: userData.userId
-        }),
-        settings,
-        mapping: getDefaultMapping({
-          externalIds: [
-            { id: userData.email, type: 'email', subscriptionStatus },
-            { id: userData.phone, type: 'phone', subscriptionStatus: 'subscribed' }
+          userId: userData.userId,
+          external_ids: [
+            {
+              collection: 'users',
+              encoding: 'none',
+              id: userData.email,
+              isSubscribed: true,
+              type: 'email',
+              groups: [
+                {
+                  id: 'grp_1',
+                  isSubscribed: true
+                }
+              ]
+            }
           ]
-        })
+        }),
+        settings: {
+          groupId: 'grp_2',
+          ...settings
+        },
+        mapping: getDefaultMapping()
       })
 
-      await expect(response).rejects.toThrowError(`Failed to process the subscription state: "${subscriptionStatus}"`)
+      const sendGridRequest = nock('https://api.sendgrid.com').post('/v3/mail/send', sendgridRequestBody).reply(200, {})
+
+      expect(sendGridRequest.isDone()).toBe(false)
+    })
+
+    it('does NOT send email to group when external ids are not present', async () => {
+      await sendgrid.testAction('sendEmail', {
+        event: createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          userId: userData.userId,
+          external_ids: undefined
+        }),
+        settings: {
+          groupId: 'grp_2',
+          ...settings
+        },
+        mapping: getDefaultMapping()
+      })
+
+      const sendGridRequest = nock('https://api.sendgrid.com').post('/v3/mail/send', sendgridRequestBody).reply(200, {})
+
+      expect(sendGridRequest.isDone()).toBe(false)
     })
   })
 })

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/generated-types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/generated-types.ts
@@ -25,4 +25,8 @@ export interface Settings {
    * Source ID
    */
   sourceId: string
+  /**
+   * Subscription group ID
+   */
+  groupId?: string
 }

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/index.ts
@@ -44,6 +44,11 @@ const destination: DestinationDefinition<Settings> = {
         description: 'Source ID',
         type: 'string',
         required: true
+      },
+      groupId: {
+        label: 'Group ID',
+        description: 'Subscription group ID',
+        type: 'string'
       }
     },
     testAuthentication: (request) => {

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/generated-types.ts
@@ -85,6 +85,16 @@ export interface Payload {
      * The subscription status for the identity.
      */
     subscriptionStatus?: string
+    /**
+     * Subscription groups and their statuses for this id.
+     */
+    groups?: {
+      id?: string
+      /**
+       * Group subscription status true is subscribed, false is unsubscribed or did-not-subscribe
+       */
+      subscriptionStatus?: boolean
+    }[]
   }[]
   /**
    * Additional custom args that we be passed back opaquely on webhook events

--- a/packages/destination-actions/src/lib/engage-test-data/create-messaging-test-event.ts
+++ b/packages/destination-actions/src/lib/engage-test-data/create-messaging-test-event.ts
@@ -1,7 +1,23 @@
 import { v4 as uuidv4 } from '@lukeed/uuid'
 import type { SegmentEvent } from '@segment/actions-core'
 
-export function createMessagingTestEvent(event: Partial<SegmentEvent> = {}): SegmentEvent {
+type SegmentEventWithExternalIds = SegmentEvent & {
+  external_ids?: {
+    id: string
+    type: 'email' | 'phone'
+    isSubscribed: boolean | null
+    collection: 'users'
+    encoding: 'none'
+    groups?: {
+      id: string
+      isSubscribed: boolean | null
+    }[]
+  }[]
+}
+
+export function createMessagingTestEvent(
+  event: Partial<SegmentEventWithExternalIds> = {}
+): SegmentEventWithExternalIds {
   return {
     anonymousId: uuidv4(),
     context: {

--- a/packages/destination-actions/src/lib/engage-test-data/create-messaging-test-event.ts
+++ b/packages/destination-actions/src/lib/engage-test-data/create-messaging-test-event.ts
@@ -41,6 +41,22 @@ export function createMessagingTestEvent(event: Partial<SegmentEvent> = {}): Seg
     traits: {},
     type: 'track',
     userId: 'user1234',
+    external_ids: [
+      {
+        collection: 'users',
+        encoding: 'none',
+        groups:
+          [
+            {
+              id: uuidv4(),
+              isSubscribed: true
+            }
+          ] || undefined,
+        id: uuidv4() + '@unittest.com',
+        isSubscribed: true,
+        type: 'email'
+      }
+    ],
     ...event
   }
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Adds subscription group support to engage-messaging-sendgrid. Now we can associate a particular destination with a subscription group. If the email is globally subscribed it'll check to see if it's subscribed for the group associated with the destination. If yes, send. If not, don't.

I also needed to refactor a couple of tests which were incorrect. There was some confusion between mappings and settings.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
