### PR TITLE
Regional data hosting for intercom web

### DIFF
--- a/packages/browser-destinations/src/destinations/intercom/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/intercom/generated-types.ts
@@ -13,4 +13,8 @@ export interface Settings {
    * A list of rich link property keys.
    */
   richLinkProperties?: string[]
+  /**
+   * The regional API to use for processing the data
+   */
+  apiBase?: string
 }

--- a/packages/browser-destinations/src/destinations/intercom/index.ts
+++ b/packages/browser-destinations/src/destinations/intercom/index.ts
@@ -40,6 +40,27 @@ export const destination: BrowserDestinationDefinition<Settings, Intercom> = {
       type: 'string',
       multiple: true,
       required: false
+    },
+    apiBase: {
+      description: 'The regional API to use for processing the data',
+      label: 'Regional Data Hosting',
+      type: 'string',
+      choices: [
+        {
+          label: 'US',
+          value: 'https://api-iam.intercom.io'
+        },
+        {
+          label: 'EU',
+          value: 'https://api-iam.eu.intercom.io'
+        },
+        {
+          label: 'Australia',
+          value: 'https://api-iam.au.intercom.io'
+        }
+      ],
+      default: 'https://api-iam.intercom.io',
+      required: false
     }
   },
 
@@ -47,7 +68,7 @@ export const destination: BrowserDestinationDefinition<Settings, Intercom> = {
     //initialize Intercom
     initScript({ appId: settings.appId })
     const preloadedIntercom = window.Intercom
-    initialBoot(settings.appId)
+    initialBoot(settings.appId, { api_base: settings.apiBase })
 
     await deps.resolveWhen(() => window.Intercom !== preloadedIntercom, 100)
 


### PR DESCRIPTION
This PR adds support for regional endpoints for Intercom Web destination. More context: 
https://segment.atlassian.net/browse/LIBWEB-1195

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
