### PR TITLE
CONMAN-167: updating engage-messaging-sendgrid to respect subscription group status if present

### DIFF
--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/__tests__/send-email.test.ts
@@ -107,17 +107,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
               '@path': '$.isSubscribed'
             },
             groups: {
-              '@arrayPath': [
-                '$.groups',
-                {
-                  id: {
-                    '@path': '$.id'
-                  },
-                  subscriptionStatus: {
-                    '@path': '$.isSubscribed'
-                  }
-                }
-              ]
+              '@path': '$.groups'
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/generated-types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/generated-types.ts
@@ -25,4 +25,8 @@ export interface Settings {
    * Source ID
    */
   sourceId: string
+  /**
+   * Subscription group ID
+   */
+  groupId?: string
 }

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/index.ts
@@ -44,6 +44,11 @@ const destination: DestinationDefinition<Settings> = {
         description: 'Source ID',
         type: 'string',
         required: true
+      },
+      groupId: {
+        label: 'Group ID',
+        description: 'Subscription group ID',
+        type: 'string'
       }
     },
     testAuthentication: (request) => {

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/generated-types.ts
@@ -85,6 +85,16 @@ export interface Payload {
      * The subscription status for the identity.
      */
     subscriptionStatus?: string
+    /**
+     * Subscription groups and their statuses for this id.
+     */
+    groups?: {
+      id?: string
+      /**
+       * Group subscription status true is subscribed, false is unsubscribed or did-not-subscribe
+       */
+      subscriptionStatus?: boolean
+    }[]
   }[]
   /**
    * Additional custom args that we be passed back opaquely on webhook events

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/generated-types.ts
@@ -93,7 +93,7 @@ export interface Payload {
       /**
        * Group subscription status true is subscribed, false is unsubscribed or did-not-subscribe
        */
-      subscriptionStatus?: boolean
+      subscriptionStatus?: string
     }[]
   }[]
   /**

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/generated-types.ts
@@ -93,7 +93,7 @@ export interface Payload {
       /**
        * Group subscription status true is subscribed, false is unsubscribed or did-not-subscribe
        */
-      subscriptionStatus?: string
+      isSubscribed?: boolean
     }[]
   }[]
   /**

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
@@ -333,7 +333,8 @@ const action: ActionDefinition<Settings, Payload> = {
     } else if (['subscribed', 'true'].includes(emailProfile?.subscriptionStatus)) {
       statsClient?.incr('actions-personas-messaging-sendgrid.subscribed', 1, tags)
       if (settings.groupId) {
-        if (typeof logger?.info === 'function') {
+        if (Object.keys(logger ?? {}).length > 0) {
+          statsClient?.incr('actions-personas-messaging-sendgrid.logged_msg', 1, tags)
           logger?.info(`groups ${JSON.stringify(payload.externalIds)}`)
         }
         const group = (payload.externalIds ?? [])

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
@@ -315,7 +315,7 @@ const action: ActionDefinition<Settings, Payload> = {
       default: { '@path': '$.properties' }
     }
   },
-  perform: async (request, { settings, payload, statsContext }) => {
+  perform: async (request, { settings, payload, statsContext, logger }) => {
     const statsClient = statsContext?.statsClient
     const tags = statsContext?.tags
     tags?.push(`space_id:${settings.spaceId}`, `projectid:${settings.sourceId}`)
@@ -333,6 +333,9 @@ const action: ActionDefinition<Settings, Payload> = {
     } else if (['subscribed', 'true'].includes(emailProfile?.subscriptionStatus)) {
       statsClient?.incr('actions-personas-messaging-sendgrid.subscribed', 1, tags)
       if (settings.groupId) {
+        if (typeof logger?.info === 'function') {
+          logger?.info(`groups ${JSON.stringify(payload.externalIds)}`)
+        }
         const group = (payload.externalIds ?? [])
           .flatMap((externalId) => externalId.groups)
           .find((group) => group?.id === settings.groupId)

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
@@ -263,11 +263,11 @@ const action: ActionDefinition<Settings, Payload> = {
               label: 'Subscription group id',
               type: 'string'
             },
-            subscriptionStatus: {
+            isSubscribed: {
               label: 'status',
               description: 'Group subscription status true is subscribed, false is unsubscribed or did-not-subscribe',
               // for some reason this still gets deserialized as a string.
-              type: 'string'
+              type: 'boolean'
             }
           }
         }
@@ -286,17 +286,7 @@ const action: ActionDefinition<Settings, Payload> = {
               '@path': '$.isSubscribed'
             },
             groups: {
-              '@arrayPath': [
-                '$.groups',
-                {
-                  id: {
-                    '@path': '$.id'
-                  },
-                  subscriptionStatus: {
-                    '@path': '$.isSubscribed'
-                  }
-                }
-              ]
+              '@path': '$.groups'
             }
           }
         ]
@@ -343,7 +333,7 @@ const action: ActionDefinition<Settings, Payload> = {
         if (!group) {
           statsClient?.incr('actions-personas-messaging-sendgrid.group_notfound', 1, tags)
           return
-        } else if (group.subscriptionStatus !== 'true') {
+        } else if (!group.isSubscribed) {
           statsClient?.incr('actions-personas-messaging-sendgrid.group_notsubscribed', 1, tags)
           return
         }

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
@@ -335,7 +335,7 @@ const action: ActionDefinition<Settings, Payload> = {
       statsClient?.incr('actions-personas-messaging-sendgrid.subscribed', 1, tags)
       if (settings.groupId) {
         if (Object.keys(logger ?? {}).length > 0) {
-          logger?.info(`groups ${JSON.stringify(payload.externalIds)}`)
+          logger?.info(`groups ${JSON.stringify(payload.externalIds)} payload ${JSON.stringify(payload)}`)
         }
         const group = (payload.externalIds ?? [])
           .flatMap((externalId) => externalId.groups)

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
@@ -266,7 +266,8 @@ const action: ActionDefinition<Settings, Payload> = {
             subscriptionStatus: {
               label: 'status',
               description: 'Group subscription status true is subscribed, false is unsubscribed or did-not-subscribe',
-              type: 'boolean'
+              // for some reason this still gets deserialized as a string.
+              type: 'string'
             }
           }
         }
@@ -334,7 +335,6 @@ const action: ActionDefinition<Settings, Payload> = {
       statsClient?.incr('actions-personas-messaging-sendgrid.subscribed', 1, tags)
       if (settings.groupId) {
         if (Object.keys(logger ?? {}).length > 0) {
-          statsClient?.incr('actions-personas-messaging-sendgrid.logged_msg', 1, tags)
           logger?.info(`groups ${JSON.stringify(payload.externalIds)}`)
         }
         const group = (payload.externalIds ?? [])
@@ -343,7 +343,7 @@ const action: ActionDefinition<Settings, Payload> = {
         if (!group) {
           statsClient?.incr('actions-personas-messaging-sendgrid.group_notfound', 1, tags)
           return
-        } else if (!group.subscriptionStatus) {
+        } else if (group.subscriptionStatus !== 'true') {
           statsClient?.incr('actions-personas-messaging-sendgrid.group_notsubscribed', 1, tags)
           return
         }

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
@@ -335,7 +335,7 @@ const action: ActionDefinition<Settings, Payload> = {
       if (settings.groupId) {
         const group = (payload.externalIds ?? [])
           .flatMap((externalId) => externalId.groups)
-          .find((group) => group?.id == settings.groupId)
+          .find((group) => group?.id === settings.groupId)
         if (!group) {
           statsClient?.incr('actions-personas-messaging-sendgrid.group_notfound', 1, tags)
           return

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
@@ -306,7 +306,7 @@ const action: ActionDefinition<Settings, Payload> = {
       default: { '@path': '$.properties' }
     }
   },
-  perform: async (request, { settings, payload, statsContext, logger }) => {
+  perform: async (request, { settings, payload, statsContext }) => {
     const statsClient = statsContext?.statsClient
     const tags = statsContext?.tags
     tags?.push(`space_id:${settings.spaceId}`, `projectid:${settings.sourceId}`)
@@ -324,9 +324,6 @@ const action: ActionDefinition<Settings, Payload> = {
     } else if (['subscribed', 'true'].includes(emailProfile?.subscriptionStatus)) {
       statsClient?.incr('actions-personas-messaging-sendgrid.subscribed', 1, tags)
       if (settings.groupId) {
-        if (Object.keys(logger ?? {}).length > 0) {
-          logger?.info(`groups ${JSON.stringify(payload.externalIds)} payload ${JSON.stringify(payload)}`)
-        }
         const group = (payload.externalIds ?? [])
           .flatMap((externalId) => externalId.groups)
           .find((group) => group?.id === settings.groupId)

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
@@ -336,7 +336,10 @@ const action: ActionDefinition<Settings, Payload> = {
         const group = (payload.externalIds ?? [])
           .flatMap((externalId) => externalId.groups)
           .find((group) => group?.id == settings.groupId)
-        if (!group || !group.subscriptionStatus) {
+        if (!group) {
+          statsClient?.incr('actions-personas-messaging-sendgrid.group_notfound', 1, tags)
+          return
+        } else if (!group.subscriptionStatus) {
           statsClient?.incr('actions-personas-messaging-sendgrid.group_notsubscribed', 1, tags)
           return
         }

--- a/packages/destination-actions/src/lib/engage-test-data/create-messaging-test-event.ts
+++ b/packages/destination-actions/src/lib/engage-test-data/create-messaging-test-event.ts
@@ -1,7 +1,23 @@
 import { v4 as uuidv4 } from '@lukeed/uuid'
 import type { SegmentEvent } from '@segment/actions-core'
 
-export function createMessagingTestEvent(event: Partial<SegmentEvent> = {}): SegmentEvent {
+type SegmentEventWithExternalIds = SegmentEvent & {
+  external_ids?: {
+    id: string
+    type: 'email' | 'phone'
+    isSubscribed: boolean | null
+    collection: 'users'
+    encoding: 'none'
+    groups?: {
+      id: string
+      isSubscribed: boolean | null
+    }[]
+  }[]
+}
+
+export function createMessagingTestEvent(
+  event: Partial<SegmentEventWithExternalIds> = {}
+): SegmentEventWithExternalIds {
   return {
     anonymousId: uuidv4(),
     context: {
@@ -41,6 +57,22 @@ export function createMessagingTestEvent(event: Partial<SegmentEvent> = {}): Seg
     traits: {},
     type: 'track',
     userId: 'user1234',
+    external_ids: [
+      {
+        collection: 'users',
+        encoding: 'none',
+        groups:
+          [
+            {
+              id: uuidv4(),
+              isSubscribed: true
+            }
+          ] || undefined,
+        id: uuidv4() + '@unittest.com',
+        isSubscribed: true,
+        type: 'email'
+      }
+    ],
     ...event
   }
 }


### PR DESCRIPTION
Adds subscription group support to engage-messaging-sendgrid. Now we can associate a particular destination with a subscription group. If the email is globally subscribed it'll check to see if it's subscribed for the group associated with the destination. If yes, send. If not, don't.

I also needed to refactor a couple of tests which were incorrect. There was some confusion between mappings and settings.

CONMAN-167

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
