### PR TITLE
Run a ./bin/run generate:types

### DIFF
--- a/packages/destination-actions/src/destinations/mixpanel/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackEvent/generated-types.ts
@@ -152,7 +152,7 @@ export interface Payload {
    */
   userAgent?: string
   /**
-   * Set as true to ensure Segment sends data to Mixpanel in batches. Please do not set to false.
+   * Set as true to ensure Segment sends data to Mixpanel in batches.
    */
   enable_batching?: boolean
 }


### PR DESCRIPTION
Runs a `./bin/run generate:types` to correctly update the mixpanel types.

## Testing

No testing needed.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
