### PR TITLE
Google Sheets: hide operation type

### DIFF
--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
@@ -21,7 +21,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Operation Type',
       description:
         "Describes the nature of the operation being performed. Only supported values are 'new' and 'updated'.",
-      type: 'string',
+      type: 'hidden',
       required: true,
       default: { '@path': '$.event' }
     },


### PR DESCRIPTION
This change hides the `operation type` field in Google Sheets to satisfy https://segment.atlassian.net/browse/STRATCONN-1426

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
