### PR TITLE
Update parseFQL function to correctly handle name exists/not_exists c…

### DIFF
--- a/packages/destination-subscriptions/src/__tests__/fql.test.ts
+++ b/packages/destination-subscriptions/src/__tests__/fql.test.ts
@@ -194,6 +194,32 @@ test('name = "Home"', () => {
   })
 })
 
+test.only('name != null', () => {
+  testFql('name != null', {
+    type: 'group',
+    operator: 'and',
+    children: [
+      {
+        type: 'name',
+        operator: 'exists'
+      }
+    ]
+  })
+})
+
+test.only('name = null', () => {
+  testFql('name = null', {
+    type: 'group',
+    operator: 'and',
+    children: [
+      {
+        type: 'name',
+        operator: 'not_exists'
+      }
+    ]
+  })
+})
+
 test('event = "Product Added" or event = "Order Completed"', () => {
   testFql('event = "Product Added" or event = "Order Completed"', {
     type: 'group',

--- a/packages/destination-subscriptions/src/__tests__/fql.test.ts
+++ b/packages/destination-subscriptions/src/__tests__/fql.test.ts
@@ -194,7 +194,7 @@ test('name = "Home"', () => {
   })
 })
 
-test.only('name != null', () => {
+test('name != null', () => {
   testFql('name != null', {
     type: 'group',
     operator: 'and',
@@ -207,7 +207,7 @@ test.only('name != null', () => {
   })
 })
 
-test.only('name = null', () => {
+test('name = null', () => {
   testFql('name = null', {
     type: 'group',
     operator: 'and',

--- a/packages/destination-subscriptions/src/parse-fql.ts
+++ b/packages/destination-subscriptions/src/parse-fql.ts
@@ -206,11 +206,23 @@ const parse = (tokens: Token[]): Condition => {
             value: String(getTokenValue(valueToken))
           })
         } else if (conditionType === 'name') {
-          nodes.push({
-            type: 'name',
-            operator: operatorToken.value as Operator,
-            value: String(getTokenValue(valueToken))
-          })
+          if (isExists) {
+            nodes.push({
+              type: 'name',
+              operator: 'exists'
+            })
+          } else if (isNotExists) {
+            nodes.push({
+              type: 'name',
+              operator: 'not_exists'
+            })
+          } else {
+            nodes.push({
+              type: 'name',
+              operator: operatorToken.value as Operator,
+              value: String(getTokenValue(valueToken))
+            })
+          }
         } else if (conditionType === 'userId') {
           if (isExists) {
             nodes.push({


### PR DESCRIPTION
This PR addresses [JIRA ACT-214](https://segment.atlassian.net/browse/ACT-214)

In it, we add support for the `Page/Sreen name` `exists`/`does not exist` operators to the `parseFql` function. 


| Previously | Now |
| ---------- | ----- |
| the event trigger `name != null` would be parsed into `name` `is not` `null` | the event trigger `name != null` is parsed into `name` `exists` |
| the event trigger `name = null` would be parsed into `name` `is` `null` | the event trigger `name = null` is parsed into `name` `does not exist` |

While this does fix the issue with the UI incorrectly displaying the mapping. I am curious to see if this was the cause for `event tester` to not be correctly sending the events.

## Testing


https://user-images.githubusercontent.com/98849774/190272417-d45f9249-cbdb-4646-9f1e-5ce9d3e85ab9.mov


_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
