### PR TITLE
[STRATCONN-1649] - Adobe Target Cloud - Do not run getNestedObjects for null values

### DIFF
--- a/packages/destination-actions/src/destinations/adobe-target/adobeTarget_operations.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/adobeTarget_operations.ts
@@ -1,15 +1,19 @@
 import { RequestClient, IntegrationError } from '@segment/actions-core'
 
 function getNestedObjects(obj: { [x: string]: any }, objectPath = '', attributes: { [x: string]: string } = {}) {
-  Object.keys(obj).forEach((key) => {
-    const currObjectPath = objectPath ? `${objectPath}.${key}` : key
-    if (typeof obj[key] !== 'object') {
-      attributes[currObjectPath] = obj[key].toString()
-    } else {
-      getNestedObjects(obj[key], currObjectPath, attributes)
-    }
-  })
-  return attributes
+  // Do not run on null or undefined
+  if (obj != null || obj != undefined) {
+    Object.keys(obj).forEach((key) => {
+      const currObjectPath = objectPath ? `${objectPath}.${key}` : key
+
+      if (typeof obj[key] !== 'object') {
+        attributes[currObjectPath] = obj[key].toString()
+      } else {
+        getNestedObjects(obj[key], currObjectPath, attributes)
+      }
+    })
+    return attributes
+  }
 }
 const objectToQueryString = (object: { [x: string]: { toString: () => string } }) =>
   Object.keys(object)

--- a/packages/destination-actions/src/destinations/adobe-target/adobeTarget_operations.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/adobeTarget_operations.ts
@@ -39,13 +39,15 @@ export default class AdobeTarget {
       throw err
     } else {
       const traits = getNestedObjects(this.traits)
-      const requestUrl = `https://${this.clientCode}.tt.omtrdc.net/m2/${
-        this.clientCode
-      }/profile/update?mbox3rdPartyId=${this.userId}&${objectToQueryString(traits)}`
+      if (traits) {
+        const requestUrl = `https://${this.clientCode}.tt.omtrdc.net/m2/${
+          this.clientCode
+        }/profile/update?mbox3rdPartyId=${this.userId}&${objectToQueryString(traits)}`
 
-      return this.request(requestUrl, {
-        method: 'POST'
-      })
+        return this.request(requestUrl, {
+          method: 'POST'
+        })
+      }
     }
   }
 

--- a/packages/destination-actions/src/destinations/adobe-target/updateProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/updateProfile/__tests__/index.test.ts
@@ -206,6 +206,71 @@ describe('AdobeTarget', () => {
         })
       ).rejects.toThrowError("The root value is missing the required field 'traits'.")
     })
+
+    it('removes null values from nested event', async () => {
+      nock(
+        `https://${settings.client_code}.tt.omtrdc.net/rest/v1/profiles/thirdPartyId/${settings.client_id}?client=${settings.client_code}`
+      )
+        .get(/.*/)
+        .reply(200, {})
+      nock(
+        `https://${settings.client_code}.tt.omtrdc.net/m2/${settings.client_code}/profile/update?mbox3rdPartyId=${settings.client_id}`
+      )
+        .post(/.*/)
+        .reply(200, {})
+
+      const event = createTestEvent({
+        type: 'identify',
+        userId: '123-test',
+        traits: {
+          name: 'Rajul',
+          age: null,
+          address: {
+            city: 'New York City',
+            zipCode: null
+          },
+          param1: 'value1',
+          param2: 'value2'
+        }
+      })
+      const responses = await testDestination.testAction('updateProfile', {
+        event,
+        settings,
+        mapping: {
+          traits: {
+            address: {
+              city: {
+                '@path': '$.traits.address.city'
+              },
+              zipCode: {
+                '@path': '$.traits.address.zipCode'
+              }
+            },
+            name: {
+              '@path': '$.traits.name'
+            },
+            age: {
+              '@path': '$.traits.age'
+            },
+            param1: {
+              '@path': '$.traits.param1'
+            },
+            param2: {
+              '@path': '$.traits.param2'
+            }
+          },
+          user_id: {
+            '@path': '$.userId'
+          }
+        }
+      })
+      expect(responses.length).toBe(2)
+      expect(responses[0].status).toBe(200)
+      expect(responses[1].status).toBe(200)
+      expect(responses[1].url).toBe(
+        'https://segmentexchangepartn.tt.omtrdc.net/m2/segmentexchangepartn/profile/update?mbox3rdPartyId=123-test&profile.address.city=New%20York%20City&profile.name=Rajul&profile.param1=value1&profile.param2=value2'
+      )
+    })
   })
   it('should handle default mappings', async () => {
     nock(


### PR DESCRIPTION
Errors surfaced showing that `getNestedObjects` was being called with `null` values. That makes sense because this is a recursive function that doesn't check if it runs on top of a `null` value. With this check we guarantee a safe execution of the code.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
