### PR TITLE
[STRATCONN-1660] Add Limited Data Usage Mapping for FB CAPI Actions

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
@@ -20,6 +20,9 @@ describe('FacebookConversionsApi', () => {
         timestamp: '1631210000',
         properties: {
           action_source: 'email',
+          enable_limited_data_use: false,
+          data_processing_state: 1,
+          data_processing_country: 1000,
           currency: 'USD',
           value: 12.12,
           email: 'nicholas.aguilar@segment.com',
@@ -54,6 +57,15 @@ describe('FacebookConversionsApi', () => {
           },
           custom_data: {
             '@path': '$.properties.traits'
+          },
+          enable_limited_data_use: {
+            '@path': '$.properties.enable_limited_data_use'
+          },
+          data_processing_state: {
+            '@path': '$.properties.data_processing_state'
+          },
+          data_processing_country: {
+            '@path': '$.properties.data_processing_country'
           }
         }
       })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
@@ -141,4 +141,16 @@ export interface Payload {
   custom_data?: {
     [k: string]: unknown
   }
+  /**
+   * The Data Processing Options to send to Facebook. If set to true, Segment will send an array to Facebook indicating events should be processed with Limited Data Use (LDU) restrictions. More information can be found in [Facebook’s documentation](https://developers.facebook.com/docs/marketing-apis/data-processing-options).
+   */
+  enable_limited_data_use?: boolean
+  /**
+   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   */
+  data_processing_country?: number
+  /**
+   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   */
+  data_processing_state?: number
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
@@ -144,13 +144,13 @@ export interface Payload {
   /**
    * The Data Processing Options to send to Facebook. If set to true, Segment will send an array to Facebook indicating events should be processed with Limited Data Use (LDU) restrictions. More information can be found in [Facebook’s documentation](https://developers.facebook.com/docs/marketing-apis/data-processing-options).
    */
-  enable_limited_data_use?: boolean
+  data_processing_options?: boolean
   /**
-   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
-  data_processing_country?: number
+  data_processing_options_country?: number
   /**
-   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
-  data_processing_state?: number
+  data_processing_options_state?: number
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
@@ -90,13 +90,11 @@ const action: ActionDefinition<Settings, Payload> = {
       if (err) throw err
     }
 
-    let data_options, country_code, state_code
-    if (payload.data_processing_options) {
-      [data_options, country_code, state_code] = dataProcessingOptions(
-        payload.data_processing_options_country,
-        payload.data_processing_options_state
-      )
-    }
+    const [data_options, country_code, state_code] = dataProcessingOptions(
+      payload.data_processing_options,
+      payload.data_processing_options_country,
+      payload.data_processing_options_state
+    )
 
     return request(
       `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
@@ -16,7 +16,8 @@ import {
   custom_data,
   data_processing_options,
   data_processing_options_country,
-  data_processing_options_state
+  data_processing_options_state,
+  dataProcessingOptions
 } from '../fb-capi-properties'
 import { CURRENCY_ISO_CODES } from '../constants'
 import { hash_user_data, user_data_field } from '../fb-capi-user-data'
@@ -91,9 +92,10 @@ const action: ActionDefinition<Settings, Payload> = {
 
     let data_options, country_code, state_code
     if (payload.data_processing_options) {
-      data_options = ['LDU']
-      country_code = payload.data_processing_options_country ? payload.data_processing_options_country : 0
-      state_code = payload.data_processing_options_state ? payload.data_processing_options_state : 0
+      ;[data_options, country_code, state_code] = dataProcessingOptions(
+        payload.data_processing_options_country,
+        payload.data_processing_options_state
+      )
     }
 
     return request(

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
@@ -92,7 +92,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
     let data_options, country_code, state_code
     if (payload.data_processing_options) {
-      ;[data_options, country_code, state_code] = dataProcessingOptions(
+      [data_options, country_code, state_code] = dataProcessingOptions(
         payload.data_processing_options_country,
         payload.data_processing_options_state
       )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
@@ -14,9 +14,9 @@ import {
   event_source_url,
   event_id,
   custom_data,
-  enable_limited_data_use,
-  data_processing_country,
-  data_processing_state
+  data_processing_options,
+  data_processing_options_country,
+  data_processing_options_state
 } from '../fb-capi-properties'
 import { CURRENCY_ISO_CODES } from '../constants'
 import { hash_user_data, user_data_field } from '../fb-capi-user-data'
@@ -58,9 +58,9 @@ const action: ActionDefinition<Settings, Payload> = {
     event_source_url: event_source_url,
     value: { ...value, default: { '@path': '$.properties.price' } },
     custom_data: custom_data,
-    enable_limited_data_use: enable_limited_data_use,
-    data_processing_country: data_processing_country,
-    data_processing_state: data_processing_state
+    data_processing_options: data_processing_options,
+    data_processing_options_country: data_processing_options_country,
+    data_processing_options_state: data_processing_options_state
   },
 
   perform: (request, { payload, settings, features, statsContext }) => {
@@ -89,12 +89,11 @@ const action: ActionDefinition<Settings, Payload> = {
       if (err) throw err
     }
 
-    let data_options
-    if (payload.enable_limited_data_use) {
+    let data_options, country_code, state_code
+    if (payload.data_processing_options) {
       data_options = ['LDU']
-    } else {
-      delete payload?.data_processing_country
-      delete payload?.data_processing_state
+      country_code = payload.data_processing_options_country ? payload.data_processing_options_country : 0
+      state_code = payload.data_processing_options_state ? payload.data_processing_options_state : 0
     }
 
     return request(
@@ -120,8 +119,8 @@ const action: ActionDefinition<Settings, Payload> = {
                 content_type: payload.content_type
               },
               data_processing_options: data_options,
-              data_processing_state: payload?.data_processing_state,
-              data_processing_country: payload?.data_processing_country
+              data_processing_options_country: country_code,
+              data_processing_options_state: state_code
             }
           ]
         }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom/generated-types.ts
@@ -107,13 +107,13 @@ export interface Payload {
   /**
    * The Data Processing Options to send to Facebook. If set to true, Segment will send an array to Facebook indicating events should be processed with Limited Data Use (LDU) restrictions. More information can be found in [Facebook’s documentation](https://developers.facebook.com/docs/marketing-apis/data-processing-options).
    */
-  enable_limited_data_use?: boolean
+  data_processing_options?: boolean
   /**
-   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
-  data_processing_country?: number
+  data_processing_options_country?: number
   /**
-   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
-  data_processing_state?: number
+  data_processing_options_state?: number
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom/generated-types.ts
@@ -104,4 +104,16 @@ export interface Payload {
    * The browser URL where the event happened. The URL must begin with http:// or https:// and should match the verified domain. This is required if the action source is "website."
    */
   event_source_url?: string
+  /**
+   * The Data Processing Options to send to Facebook. If set to true, Segment will send an array to Facebook indicating events should be processed with Limited Data Use (LDU) restrictions. More information can be found in [Facebook’s documentation](https://developers.facebook.com/docs/marketing-apis/data-processing-options).
+   */
+  enable_limited_data_use?: boolean
+  /**
+   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   */
+  data_processing_country?: number
+  /**
+   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   */
+  data_processing_state?: number
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
@@ -7,7 +7,8 @@ import {
   event_time,
   data_processing_options,
   data_processing_options_country,
-  data_processing_options_state
+  data_processing_options_state,
+  dataProcessingOptions
 } from '../fb-capi-properties'
 import { hash_user_data, user_data_field } from '../fb-capi-user-data'
 import type { Settings } from '../generated-types'
@@ -45,9 +46,10 @@ const action: ActionDefinition<Settings, Payload> = {
 
     let data_options, country_code, state_code
     if (payload.data_processing_options) {
-      data_options = ['LDU']
-      country_code = payload.data_processing_options_country ? payload.data_processing_options_country : 0
-      state_code = payload.data_processing_options_state ? payload.data_processing_options_state : 0
+      ;[data_options, country_code, state_code] = dataProcessingOptions(
+        payload.data_processing_options_country,
+        payload.data_processing_options_state
+      )
     }
 
     return request(

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
@@ -44,13 +44,11 @@ const action: ActionDefinition<Settings, Payload> = {
       throw new IntegrationError('Must include at least one user data property', 'Misconfigured required field', 400)
     }
 
-    let data_options, country_code, state_code
-    if (payload.data_processing_options) {
-      ;[data_options, country_code, state_code] = dataProcessingOptions(
-        payload.data_processing_options_country,
-        payload.data_processing_options_state
-      )
-    }
+    const [data_options, country_code, state_code] = dataProcessingOptions(
+      payload.data_processing_options,
+      payload.data_processing_options_country,
+      payload.data_processing_options_state
+    )
 
     return request(
       `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
@@ -5,9 +5,9 @@ import {
   event_id,
   event_source_url,
   event_time,
-  enable_limited_data_use,
-  data_processing_country,
-  data_processing_state
+  data_processing_options,
+  data_processing_options_country,
+  data_processing_options_state
 } from '../fb-capi-properties'
 import { hash_user_data, user_data_field } from '../fb-capi-user-data'
 import type { Settings } from '../generated-types'
@@ -34,20 +34,20 @@ const action: ActionDefinition<Settings, Payload> = {
     custom_data: custom_data,
     event_id: event_id,
     event_source_url: event_source_url,
-    enable_limited_data_use: enable_limited_data_use,
-    data_processing_country: data_processing_country,
-    data_processing_state: data_processing_state
+    data_processing_options: data_processing_options,
+    data_processing_options_country: data_processing_options_country,
+    data_processing_options_state: data_processing_options_state
   },
   perform: (request, { payload, settings, features, statsContext }) => {
     if (!payload.user_data) {
       throw new IntegrationError('Must include at least one user data property', 'Misconfigured required field', 400)
     }
-    let data_options
-    if (payload.enable_limited_data_use) {
+
+    let data_options, country_code, state_code
+    if (payload.data_processing_options) {
       data_options = ['LDU']
-    } else {
-      delete payload?.data_processing_country
-      delete payload?.data_processing_state
+      country_code = payload.data_processing_options_country ? payload.data_processing_options_country : 0
+      state_code = payload.data_processing_options_state ? payload.data_processing_options_state : 0
     }
 
     return request(
@@ -65,8 +65,8 @@ const action: ActionDefinition<Settings, Payload> = {
               user_data: hash_user_data({ user_data: payload.user_data }),
               custom_data: payload.custom_data,
               data_processing_options: data_options,
-              data_processing_state: payload?.data_processing_state,
-              data_processing_country: payload?.data_processing_country
+              data_processing_options_country: country_code,
+              data_processing_options_state: state_code
             }
           ]
         }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
@@ -141,6 +141,17 @@ export const validateContents = (contents: Content[]): IntegrationError | false 
   return false
 }
 
+export const dataProcessingOptions = (
+  countryOption: number | undefined,
+  stateOption: number | undefined
+): Array<Array<String> | number> => {
+  const data_options = ['LDU']
+  const country_code = countryOption ? countryOption : 0
+  const state_code = stateOption ? stateOption : 0
+  const DPO: (Array<String> | number)[] = [data_options, country_code, state_code]
+  return DPO
+}
+
 export const num_items: InputField = {
   label: 'Number of Items',
   description: 'The number of items when checkout was initiated.',

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
@@ -141,15 +141,20 @@ export const validateContents = (contents: Content[]): IntegrationError | false 
   return false
 }
 
+type DPOption = string[] | number
+
 export const dataProcessingOptions = (
+  data_processing_options: boolean | undefined,
   countryOption: number | undefined,
   stateOption: number | undefined
-): Array<Array<String> | number> => {
-  const data_options = ['LDU']
-  const country_code = countryOption ? countryOption : 0
-  const state_code = stateOption ? stateOption : 0
-  const DPO: (Array<String> | number)[] = [data_options, country_code, state_code]
-  return DPO
+): DPOption[] => {
+  if (data_processing_options) {
+    const data_options = ['LDU']
+    const country_code = countryOption ? countryOption : 0
+    const state_code = stateOption ? stateOption : 0
+    return [data_options, country_code, state_code]
+  }
+  return []
 }
 
 export const num_items: InputField = {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
@@ -91,16 +91,16 @@ export const contents: InputField = {
   }
 }
 
-export const enable_limited_data_use: InputField = {
-  label: 'Enable Limited Data Use',
+export const data_processing_options: InputField = {
+  label: 'Data Processing Options',
   description: `The Data Processing Options to send to Facebook. If set to true, Segment will send an array to Facebook indicating events should be processed with Limited Data Use (LDU) restrictions. More information can be found in [Facebook’s documentation](https://developers.facebook.com/docs/marketing-apis/data-processing-options).`,
   type: 'boolean'
 }
 
-export const data_processing_country: InputField = {
+export const data_processing_options_country: InputField = {
   label: 'Data Processing Country',
   description:
-    'A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.',
+    'A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.',
   type: 'number',
   choices: [
     { label: '0', value: 0 },
@@ -108,10 +108,10 @@ export const data_processing_country: InputField = {
   ]
 }
 
-export const data_processing_state: InputField = {
+export const data_processing_options_state: InputField = {
   label: 'Data Processing State',
   description:
-    'A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.',
+    'A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.',
   type: 'number',
   choices: [
     { label: '0', value: 0 },

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
@@ -103,8 +103,8 @@ export const data_processing_options_country: InputField = {
     'A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.',
   type: 'number',
   choices: [
-    { label: '0', value: 0 },
-    { label: '1', value: 1 }
+    { label: 'Use Facebook’s Geolocation Logic', value: 0 },
+    { label: 'United States of America', value: 1 }
   ]
 }
 
@@ -114,8 +114,8 @@ export const data_processing_options_state: InputField = {
     'A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.',
   type: 'number',
   choices: [
-    { label: '0', value: 0 },
-    { label: '1000', value: 1000 }
+    { label: 'Use Facebook’s Geolocation Logic', value: 0 },
+    { label: 'California', value: 1000 }
   ]
 }
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
@@ -29,7 +29,8 @@ export const currency: InputField = {
 
 export const value: InputField = {
   label: 'Value',
-  description: 'A numeric value associated with this event. This could be a monetary value or a value in some other metric.',
+  description:
+    'A numeric value associated with this event. This could be a monetary value or a value in some other metric.',
   type: 'number'
 }
 
@@ -54,7 +55,8 @@ export const content_name: InputField = {
 
 export const content_type: InputField = {
   label: 'Content Type',
-  description: 'The content type should be set to product or product_group. See [Facebook documentation](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/custom-data) for more information.',
+  description:
+    'The content type should be set to product or product_group. See [Facebook documentation](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/custom-data) for more information.',
   type: 'string'
 }
 
@@ -87,6 +89,34 @@ export const contents: InputField = {
       type: 'string'
     }
   }
+}
+
+export const enable_limited_data_use: InputField = {
+  label: 'Enable Limited Data Use',
+  description: `The Data Processing Options to send to Facebook. If set to true, Segment will send an array to Facebook indicating events should be processed with Limited Data Use (LDU) restrictions. More information can be found in [Facebook’s documentation](https://developers.facebook.com/docs/marketing-apis/data-processing-options).`,
+  type: 'boolean'
+}
+
+export const data_processing_country: InputField = {
+  label: 'Data Processing Country',
+  description:
+    'A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.',
+  type: 'number',
+  choices: [
+    { label: '0', value: 0 },
+    { label: '1', value: 1 }
+  ]
+}
+
+export const data_processing_state: InputField = {
+  label: 'Data Processing State',
+  description:
+    'A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.',
+  type: 'number',
+  choices: [
+    { label: '0', value: 0 },
+    { label: '1000', value: 1000 }
+  ]
 }
 
 export const validateContents = (contents: Content[]): IntegrationError | false => {
@@ -122,7 +152,8 @@ export const num_items: InputField = {
 
 export const event_time: InputField = {
   label: 'Event Time',
-  description: 'A Unix timestamp in seconds indicating when the actual event occurred. Facebook will automatically convert ISO 8601 timestamps to Unix.',
+  description:
+    'A Unix timestamp in seconds indicating when the actual event occurred. Facebook will automatically convert ISO 8601 timestamps to Unix.',
   type: 'string',
   default: {
     '@path': '$.timestamp'
@@ -131,7 +162,8 @@ export const event_time: InputField = {
 
 export const action_source: InputField = {
   label: 'Action Source',
-  description: 'This field allows you to specify where your conversions occurred. See [Facebook documentation](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/server-event) for supported values.',
+  description:
+    'This field allows you to specify where your conversions occurred. See [Facebook documentation](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/server-event) for supported values.',
   type: 'string'
 }
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
@@ -141,4 +141,16 @@ export interface Payload {
   custom_data?: {
     [k: string]: unknown
   }
+  /**
+   * The Data Processing Options to send to Facebook. If set to true, Segment will send an array to Facebook indicating events should be processed with Limited Data Use (LDU) restrictions. More information can be found in [Facebook’s documentation](https://developers.facebook.com/docs/marketing-apis/data-processing-options).
+   */
+  enable_limited_data_use?: boolean
+  /**
+   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   */
+  data_processing_country?: number
+  /**
+   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   */
+  data_processing_state?: number
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
@@ -144,13 +144,13 @@ export interface Payload {
   /**
    * The Data Processing Options to send to Facebook. If set to true, Segment will send an array to Facebook indicating events should be processed with Limited Data Use (LDU) restrictions. More information can be found in [Facebook’s documentation](https://developers.facebook.com/docs/marketing-apis/data-processing-options).
    */
-  enable_limited_data_use?: boolean
+  data_processing_options?: boolean
   /**
-   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
-  data_processing_country?: number
+  data_processing_options_country?: number
   /**
-   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
-  data_processing_state?: number
+  data_processing_options_state?: number
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
@@ -15,9 +15,9 @@ import {
   content_category,
   event_source_url,
   event_id,
-  enable_limited_data_use,
-  data_processing_country,
-  data_processing_state
+  data_processing_options,
+  data_processing_options_country,
+  data_processing_options_state
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import { get_api_version } from '../utils'
@@ -61,9 +61,9 @@ const action: ActionDefinition<Settings, Payload> = {
       default: { '@path': '$.properties.revenue' }
     },
     custom_data: custom_data,
-    enable_limited_data_use: enable_limited_data_use,
-    data_processing_country: data_processing_country,
-    data_processing_state: data_processing_state
+    data_processing_options: data_processing_options,
+    data_processing_options_country: data_processing_options_country,
+    data_processing_options_state: data_processing_options_state
   },
   perform: (request, { payload, settings, features, statsContext }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.has(payload.currency)) {
@@ -91,12 +91,11 @@ const action: ActionDefinition<Settings, Payload> = {
       if (err) throw err
     }
 
-    let data_options
-    if (payload.enable_limited_data_use) {
+    let data_options, country_code, state_code
+    if (payload.data_processing_options) {
       data_options = ['LDU']
-    } else {
-      delete payload?.data_processing_country
-      delete payload?.data_processing_state
+      country_code = payload.data_processing_options_country ? payload.data_processing_options_country : 0
+      state_code = payload.data_processing_options_state ? payload.data_processing_options_state : 0
     }
 
     return request(
@@ -122,8 +121,8 @@ const action: ActionDefinition<Settings, Payload> = {
                 content_category: payload.content_category
               },
               data_processing_options: data_options,
-              data_processing_state: payload?.data_processing_state,
-              data_processing_country: payload?.data_processing_country
+              data_processing_options_country: country_code,
+              data_processing_options_state: state_code
             }
           ]
         }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
@@ -14,7 +14,10 @@ import {
   custom_data,
   content_category,
   event_source_url,
-  event_id
+  event_id,
+  enable_limited_data_use,
+  data_processing_country,
+  data_processing_state
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import { get_api_version } from '../utils'
@@ -57,7 +60,10 @@ const action: ActionDefinition<Settings, Payload> = {
       ...value,
       default: { '@path': '$.properties.revenue' }
     },
-    custom_data: custom_data
+    custom_data: custom_data,
+    enable_limited_data_use: enable_limited_data_use,
+    data_processing_country: data_processing_country,
+    data_processing_state: data_processing_state
   },
   perform: (request, { payload, settings, features, statsContext }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.has(payload.currency)) {
@@ -85,6 +91,14 @@ const action: ActionDefinition<Settings, Payload> = {
       if (err) throw err
     }
 
+    let data_options
+    if (payload.enable_limited_data_use) {
+      data_options = ['LDU']
+    } else {
+      delete payload?.data_processing_country
+      delete payload?.data_processing_state
+    }
+
     return request(
       `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
       {
@@ -106,7 +120,10 @@ const action: ActionDefinition<Settings, Payload> = {
                 contents: payload.contents,
                 num_items: payload.num_items,
                 content_category: payload.content_category
-              }
+              },
+              data_processing_options: data_options,
+              data_processing_state: payload?.data_processing_state,
+              data_processing_country: payload?.data_processing_country
             }
           ]
         }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
@@ -92,13 +92,11 @@ const action: ActionDefinition<Settings, Payload> = {
       if (err) throw err
     }
 
-    let data_options, country_code, state_code
-    if (payload.data_processing_options) {
-      ;[data_options, country_code, state_code] = dataProcessingOptions(
-        payload.data_processing_options_country,
-        payload.data_processing_options_state
-      )
-    }
+    const [data_options, country_code, state_code] = dataProcessingOptions(
+      payload.data_processing_options,
+      payload.data_processing_options_country,
+      payload.data_processing_options_state
+    )
     return request(
       `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
       {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
@@ -17,7 +17,8 @@ import {
   event_id,
   data_processing_options,
   data_processing_options_country,
-  data_processing_options_state
+  data_processing_options_state,
+  dataProcessingOptions
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import { get_api_version } from '../utils'
@@ -93,11 +94,11 @@ const action: ActionDefinition<Settings, Payload> = {
 
     let data_options, country_code, state_code
     if (payload.data_processing_options) {
-      data_options = ['LDU']
-      country_code = payload.data_processing_options_country ? payload.data_processing_options_country : 0
-      state_code = payload.data_processing_options_state ? payload.data_processing_options_state : 0
+      ;[data_options, country_code, state_code] = dataProcessingOptions(
+        payload.data_processing_options_country,
+        payload.data_processing_options_state
+      )
     }
-
     return request(
       `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
       {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
@@ -100,4 +100,16 @@ export interface Payload {
   custom_data?: {
     [k: string]: unknown
   }
+  /**
+   * The Data Processing Options to send to Facebook. If set to true, Segment will send an array to Facebook indicating events should be processed with Limited Data Use (LDU) restrictions. More information can be found in [Facebook’s documentation](https://developers.facebook.com/docs/marketing-apis/data-processing-options).
+   */
+  enable_limited_data_use?: boolean
+  /**
+   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   */
+  data_processing_country?: number
+  /**
+   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   */
+  data_processing_state?: number
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
@@ -103,13 +103,13 @@ export interface Payload {
   /**
    * The Data Processing Options to send to Facebook. If set to true, Segment will send an array to Facebook indicating events should be processed with Limited Data Use (LDU) restrictions. More information can be found in [Facebook’s documentation](https://developers.facebook.com/docs/marketing-apis/data-processing-options).
    */
-  enable_limited_data_use?: boolean
+  data_processing_options?: boolean
   /**
-   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
-  data_processing_country?: number
+  data_processing_options_country?: number
   /**
-   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
-  data_processing_state?: number
+  data_processing_options_state?: number
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/index.ts
@@ -42,13 +42,11 @@ const action: ActionDefinition<Settings, Payload> = {
       )
     }
 
-    let data_options, country_code, state_code
-    if (payload.data_processing_options) {
-      ;[data_options, country_code, state_code] = dataProcessingOptions(
-        payload.data_processing_options_country,
-        payload.data_processing_options_state
-      )
-    }
+    const [data_options, country_code, state_code] = dataProcessingOptions(
+      payload.data_processing_options,
+      payload.data_processing_options_country,
+      payload.data_processing_options_state
+    )
 
     return request(
       `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/index.ts
@@ -5,9 +5,9 @@ import {
   event_time,
   event_id,
   event_source_url,
-  enable_limited_data_use,
-  data_processing_country,
-  data_processing_state
+  data_processing_options,
+  data_processing_options_country,
+  data_processing_options_state
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import type { Settings } from '../generated-types'
@@ -24,9 +24,9 @@ const action: ActionDefinition<Settings, Payload> = {
     event_id: event_id,
     event_source_url: event_source_url,
     custom_data: custom_data,
-    enable_limited_data_use: enable_limited_data_use,
-    data_processing_country: data_processing_country,
-    data_processing_state: data_processing_state
+    data_processing_options: data_processing_options,
+    data_processing_options_country: data_processing_options_country,
+    data_processing_options_state: data_processing_options_state
   },
   perform: (request, { payload, settings, features, statsContext }) => {
     if (!payload.user_data) {
@@ -41,12 +41,11 @@ const action: ActionDefinition<Settings, Payload> = {
       )
     }
 
-    let data_options
-    if (payload.enable_limited_data_use) {
+    let data_options, country_code, state_code
+    if (payload.data_processing_options) {
       data_options = ['LDU']
-    } else {
-      delete payload?.data_processing_country
-      delete payload?.data_processing_state
+      country_code = payload.data_processing_options_country ? payload.data_processing_options_country : 0
+      state_code = payload.data_processing_options_state ? payload.data_processing_options_state : 0
     }
 
     return request(
@@ -63,8 +62,8 @@ const action: ActionDefinition<Settings, Payload> = {
               event_id: payload.event_id,
               user_data: hash_user_data({ user_data: payload.user_data }),
               data_processing_options: data_options,
-              data_processing_state: payload?.data_processing_state,
-              data_processing_country: payload?.data_processing_country
+              data_processing_options_country: country_code,
+              data_processing_options_state: state_code
             }
           ]
         }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/index.ts
@@ -7,7 +7,8 @@ import {
   event_source_url,
   data_processing_options,
   data_processing_options_country,
-  data_processing_options_state
+  data_processing_options_state,
+  dataProcessingOptions
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import type { Settings } from '../generated-types'
@@ -43,9 +44,10 @@ const action: ActionDefinition<Settings, Payload> = {
 
     let data_options, country_code, state_code
     if (payload.data_processing_options) {
-      data_options = ['LDU']
-      country_code = payload.data_processing_options_country ? payload.data_processing_options_country : 0
-      state_code = payload.data_processing_options_state ? payload.data_processing_options_state : 0
+      ;[data_options, country_code, state_code] = dataProcessingOptions(
+        payload.data_processing_options_country,
+        payload.data_processing_options_state
+      )
     }
 
     return request(

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
@@ -145,4 +145,16 @@ export interface Payload {
   custom_data?: {
     [k: string]: unknown
   }
+  /**
+   * The Data Processing Options to send to Facebook. If set to true, Segment will send an array to Facebook indicating events should be processed with Limited Data Use (LDU) restrictions. More information can be found in [Facebook’s documentation](https://developers.facebook.com/docs/marketing-apis/data-processing-options).
+   */
+  enable_limited_data_use?: boolean
+  /**
+   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   */
+  data_processing_country?: number
+  /**
+   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   */
+  data_processing_state?: number
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
@@ -148,13 +148,13 @@ export interface Payload {
   /**
    * The Data Processing Options to send to Facebook. If set to true, Segment will send an array to Facebook indicating events should be processed with Limited Data Use (LDU) restrictions. More information can be found in [Facebook’s documentation](https://developers.facebook.com/docs/marketing-apis/data-processing-options).
    */
-  enable_limited_data_use?: boolean
+  data_processing_options?: boolean
   /**
-   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
-  data_processing_country?: number
+  data_processing_options_country?: number
   /**
-   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
-  data_processing_state?: number
+  data_processing_options_state?: number
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
@@ -19,7 +19,8 @@ import {
   event_id,
   data_processing_options,
   data_processing_options_country,
-  data_processing_options_state
+  data_processing_options_state,
+  dataProcessingOptions
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 
@@ -96,9 +97,10 @@ const action: ActionDefinition<Settings, Payload> = {
 
     let data_options, country_code, state_code
     if (payload.data_processing_options) {
-      data_options = ['LDU']
-      country_code = payload.data_processing_options_country ? payload.data_processing_options_country : 0
-      state_code = payload.data_processing_options_state ? payload.data_processing_options_state : 0
+      ;[data_options, country_code, state_code] = dataProcessingOptions(
+        payload.data_processing_options_country,
+        payload.data_processing_options_state
+      )
     }
 
     return request(

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
@@ -17,9 +17,9 @@ import {
   action_source,
   event_source_url,
   event_id,
-  enable_limited_data_use,
-  data_processing_country,
-  data_processing_state
+  data_processing_options,
+  data_processing_options_country,
+  data_processing_options_state
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 
@@ -64,9 +64,9 @@ const action: ActionDefinition<Settings, Payload> = {
     event_source_url: event_source_url,
     num_items: num_items,
     custom_data: custom_data,
-    enable_limited_data_use: enable_limited_data_use,
-    data_processing_country: data_processing_country,
-    data_processing_state: data_processing_state
+    data_processing_options: data_processing_options,
+    data_processing_options_country: data_processing_options_country,
+    data_processing_options_state: data_processing_options_state
   },
   perform: (request, { payload, settings, features, statsContext }) => {
     if (!CURRENCY_ISO_CODES.has(payload.currency)) {
@@ -94,12 +94,11 @@ const action: ActionDefinition<Settings, Payload> = {
       if (err) throw err
     }
 
-    let data_options
-    if (payload.enable_limited_data_use) {
+    let data_options, country_code, state_code
+    if (payload.data_processing_options) {
       data_options = ['LDU']
-    } else {
-      delete payload?.data_processing_country
-      delete payload?.data_processing_state
+      country_code = payload.data_processing_options_country ? payload.data_processing_options_country : 0
+      state_code = payload.data_processing_options_state ? payload.data_processing_options_state : 0
     }
 
     return request(
@@ -126,8 +125,8 @@ const action: ActionDefinition<Settings, Payload> = {
                 num_items: payload.num_items
               },
               data_processing_options: data_options,
-              data_processing_state: payload?.data_processing_state,
-              data_processing_country: payload?.data_processing_country
+              data_processing_options_country: country_code,
+              data_processing_options_state: state_code
             }
           ]
         }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
@@ -95,13 +95,11 @@ const action: ActionDefinition<Settings, Payload> = {
       if (err) throw err
     }
 
-    let data_options, country_code, state_code
-    if (payload.data_processing_options) {
-      ;[data_options, country_code, state_code] = dataProcessingOptions(
-        payload.data_processing_options_country,
-        payload.data_processing_options_state
-      )
-    }
+    const [data_options, country_code, state_code] = dataProcessingOptions(
+      payload.data_processing_options,
+      payload.data_processing_options_country,
+      payload.data_processing_options_state
+    )
 
     return request(
       `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
@@ -16,7 +16,10 @@ import {
   event_time,
   action_source,
   event_source_url,
-  event_id
+  event_id,
+  enable_limited_data_use,
+  data_processing_country,
+  data_processing_state
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 
@@ -60,7 +63,10 @@ const action: ActionDefinition<Settings, Payload> = {
     event_id: event_id,
     event_source_url: event_source_url,
     num_items: num_items,
-    custom_data: custom_data
+    custom_data: custom_data,
+    enable_limited_data_use: enable_limited_data_use,
+    data_processing_country: data_processing_country,
+    data_processing_state: data_processing_state
   },
   perform: (request, { payload, settings, features, statsContext }) => {
     if (!CURRENCY_ISO_CODES.has(payload.currency)) {
@@ -88,6 +94,14 @@ const action: ActionDefinition<Settings, Payload> = {
       if (err) throw err
     }
 
+    let data_options
+    if (payload.enable_limited_data_use) {
+      data_options = ['LDU']
+    } else {
+      delete payload?.data_processing_country
+      delete payload?.data_processing_state
+    }
+
     return request(
       `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
       {
@@ -110,7 +124,10 @@ const action: ActionDefinition<Settings, Payload> = {
                 content_type: payload.content_type,
                 contents: payload.contents,
                 num_items: payload.num_items
-              }
+              },
+              data_processing_options: data_options,
+              data_processing_state: payload?.data_processing_state,
+              data_processing_country: payload?.data_processing_country
             }
           ]
         }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
@@ -141,4 +141,16 @@ export interface Payload {
   custom_data?: {
     [k: string]: unknown
   }
+  /**
+   * The Data Processing Options to send to Facebook. If set to true, Segment will send an array to Facebook indicating events should be processed with Limited Data Use (LDU) restrictions. More information can be found in [Facebook’s documentation](https://developers.facebook.com/docs/marketing-apis/data-processing-options).
+   */
+  enable_limited_data_use?: boolean
+  /**
+   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   */
+  data_processing_country?: number
+  /**
+   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   */
+  data_processing_state?: number
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
@@ -144,13 +144,13 @@ export interface Payload {
   /**
    * The Data Processing Options to send to Facebook. If set to true, Segment will send an array to Facebook indicating events should be processed with Limited Data Use (LDU) restrictions. More information can be found in [Facebook’s documentation](https://developers.facebook.com/docs/marketing-apis/data-processing-options).
    */
-  enable_limited_data_use?: boolean
+  data_processing_options?: boolean
   /**
-   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
-  data_processing_country?: number
+  data_processing_options_country?: number
   /**
-   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
-  data_processing_state?: number
+  data_processing_options_state?: number
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
@@ -15,9 +15,9 @@ import {
   content_category,
   event_id,
   event_source_url,
-  enable_limited_data_use,
-  data_processing_country,
-  data_processing_state
+  data_processing_options,
+  data_processing_options_country,
+  data_processing_options_state
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 
@@ -64,9 +64,9 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     value: value,
     custom_data: custom_data,
-    enable_limited_data_use: enable_limited_data_use,
-    data_processing_country: data_processing_country,
-    data_processing_state: data_processing_state
+    data_processing_options: data_processing_options,
+    data_processing_options_country: data_processing_options_country,
+    data_processing_options_state: data_processing_options_state
   },
   perform: (request, { payload, settings, features, statsContext }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.has(payload.currency)) {
@@ -94,12 +94,11 @@ const action: ActionDefinition<Settings, Payload> = {
       if (err) throw err
     }
 
-    let data_options
-    if (payload.enable_limited_data_use) {
+    let data_options, country_code, state_code
+    if (payload.data_processing_options) {
       data_options = ['LDU']
-    } else {
-      delete payload?.data_processing_country
-      delete payload?.data_processing_state
+      country_code = payload.data_processing_options_country ? payload.data_processing_options_country : 0
+      state_code = payload.data_processing_options_state ? payload.data_processing_options_state : 0
     }
 
     return request(
@@ -125,8 +124,8 @@ const action: ActionDefinition<Settings, Payload> = {
                 search_string: payload.search_string
               },
               data_processing_options: data_options,
-              data_processing_state: payload?.data_processing_state,
-              data_processing_country: payload?.data_processing_country
+              data_processing_options_country: country_code,
+              data_processing_options_state: state_code
             }
           ]
         }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
@@ -17,7 +17,8 @@ import {
   event_source_url,
   data_processing_options,
   data_processing_options_country,
-  data_processing_options_state
+  data_processing_options_state,
+  dataProcessingOptions
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 
@@ -96,9 +97,10 @@ const action: ActionDefinition<Settings, Payload> = {
 
     let data_options, country_code, state_code
     if (payload.data_processing_options) {
-      data_options = ['LDU']
-      country_code = payload.data_processing_options_country ? payload.data_processing_options_country : 0
-      state_code = payload.data_processing_options_state ? payload.data_processing_options_state : 0
+      ;[data_options, country_code, state_code] = dataProcessingOptions(
+        payload.data_processing_options_country,
+        payload.data_processing_options_state
+      )
     }
 
     return request(

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
@@ -14,7 +14,10 @@ import {
   action_source,
   content_category,
   event_id,
-  event_source_url
+  event_source_url,
+  enable_limited_data_use,
+  data_processing_country,
+  data_processing_state
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 
@@ -60,7 +63,10 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     value: value,
-    custom_data: custom_data
+    custom_data: custom_data,
+    enable_limited_data_use: enable_limited_data_use,
+    data_processing_country: data_processing_country,
+    data_processing_state: data_processing_state
   },
   perform: (request, { payload, settings, features, statsContext }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.has(payload.currency)) {
@@ -88,6 +94,14 @@ const action: ActionDefinition<Settings, Payload> = {
       if (err) throw err
     }
 
+    let data_options
+    if (payload.enable_limited_data_use) {
+      data_options = ['LDU']
+    } else {
+      delete payload?.data_processing_country
+      delete payload?.data_processing_state
+    }
+
     return request(
       `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
       {
@@ -109,7 +123,10 @@ const action: ActionDefinition<Settings, Payload> = {
                 content_category: payload.content_category,
                 value: payload.value,
                 search_string: payload.search_string
-              }
+              },
+              data_processing_options: data_options,
+              data_processing_state: payload?.data_processing_state,
+              data_processing_country: payload?.data_processing_country
             }
           ]
         }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
@@ -95,13 +95,11 @@ const action: ActionDefinition<Settings, Payload> = {
       if (err) throw err
     }
 
-    let data_options, country_code, state_code
-    if (payload.data_processing_options) {
-      ;[data_options, country_code, state_code] = dataProcessingOptions(
-        payload.data_processing_options_country,
-        payload.data_processing_options_state
-      )
-    }
+    const [data_options, country_code, state_code] = dataProcessingOptions(
+      payload.data_processing_options,
+      payload.data_processing_options_country,
+      payload.data_processing_options_state
+    )
 
     return request(
       `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
@@ -145,4 +145,16 @@ export interface Payload {
   custom_data?: {
     [k: string]: unknown
   }
+  /**
+   * The Data Processing Options to send to Facebook. If set to true, Segment will send an array to Facebook indicating events should be processed with Limited Data Use (LDU) restrictions. More information can be found in [Facebook’s documentation](https://developers.facebook.com/docs/marketing-apis/data-processing-options).
+   */
+  enable_limited_data_use?: boolean
+  /**
+   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   */
+  data_processing_country?: number
+  /**
+   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   */
+  data_processing_state?: number
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
@@ -148,13 +148,13 @@ export interface Payload {
   /**
    * The Data Processing Options to send to Facebook. If set to true, Segment will send an array to Facebook indicating events should be processed with Limited Data Use (LDU) restrictions. More information can be found in [Facebook’s documentation](https://developers.facebook.com/docs/marketing-apis/data-processing-options).
    */
-  enable_limited_data_use?: boolean
+  data_processing_options?: boolean
   /**
-   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   * A country that you want to associate to the Data Processing Options. Accepted values are 1, for the United States of America, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
-  data_processing_country?: number
+  data_processing_options_country?: number
   /**
-   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true.
+   * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
-  data_processing_state?: number
+  data_processing_options_state?: number
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
@@ -15,7 +15,8 @@ import {
   value,
   data_processing_options,
   data_processing_options_country,
-  data_processing_options_state
+  data_processing_options_state,
+  dataProcessingOptions
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import type { Settings } from '../generated-types'
@@ -92,9 +93,10 @@ const action: ActionDefinition<Settings, Payload> = {
 
     let data_options, country_code, state_code
     if (payload.data_processing_options) {
-      data_options = ['LDU']
-      country_code = payload.data_processing_options_country ? payload.data_processing_options_country : 0
-      state_code = payload.data_processing_options_state ? payload.data_processing_options_state : 0
+      ;[data_options, country_code, state_code] = dataProcessingOptions(
+        payload.data_processing_options_country,
+        payload.data_processing_options_state
+      )
     }
 
     return request(

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
@@ -91,13 +91,11 @@ const action: ActionDefinition<Settings, Payload> = {
       if (err) throw err
     }
 
-    let data_options, country_code, state_code
-    if (payload.data_processing_options) {
-      ;[data_options, country_code, state_code] = dataProcessingOptions(
-        payload.data_processing_options_country,
-        payload.data_processing_options_state
-      )
-    }
+    const [data_options, country_code, state_code] = dataProcessingOptions(
+      payload.data_processing_options,
+      payload.data_processing_options_country,
+      payload.data_processing_options_state
+    )
 
     return request(
       `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
@@ -13,9 +13,9 @@ import {
   event_source_url,
   event_time,
   value,
-  enable_limited_data_use,
-  data_processing_country,
-  data_processing_state
+  data_processing_options,
+  data_processing_options_country,
+  data_processing_options_state
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import type { Settings } from '../generated-types'
@@ -60,9 +60,9 @@ const action: ActionDefinition<Settings, Payload> = {
     event_source_url: event_source_url,
     value: { ...value, default: { '@path': '$.properties.price' } },
     custom_data: custom_data,
-    enable_limited_data_use: enable_limited_data_use,
-    data_processing_country: data_processing_country,
-    data_processing_state: data_processing_state
+    data_processing_options: data_processing_options,
+    data_processing_options_country: data_processing_options_country,
+    data_processing_options_state: data_processing_options_state
   },
   perform: (request, { payload, settings, features, statsContext }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.has(payload.currency)) {
@@ -90,12 +90,11 @@ const action: ActionDefinition<Settings, Payload> = {
       if (err) throw err
     }
 
-    let data_options
-    if (payload.enable_limited_data_use) {
+    let data_options, country_code, state_code
+    if (payload.data_processing_options) {
       data_options = ['LDU']
-    } else {
-      delete payload?.data_processing_country
-      delete payload?.data_processing_state
+      country_code = payload.data_processing_options_country ? payload.data_processing_options_country : 0
+      state_code = payload.data_processing_options_state ? payload.data_processing_options_state : 0
     }
 
     return request(
@@ -121,8 +120,8 @@ const action: ActionDefinition<Settings, Payload> = {
                 contents: payload.contents
               },
               data_processing_options: data_options,
-              data_processing_state: payload?.data_processing_state,
-              data_processing_country: payload?.data_processing_country
+              data_processing_options_country: country_code,
+              data_processing_options_state: state_code
             }
           ]
         }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR adds three new fields {`Data Processing Options`, `Data Processing Country`, `Data Processing State`} to all `Facebook Conversions API` Actions . More information attached to the testing doc below. 

## Testing

_Tested in stage via deploying to stage.[Testing Doc](https://paper.dropbox.com/doc/FB-Conversions-API-Actions-LDU-Testing--BptaTXPyxYpNSCXud4Da0q0PAg-NEfw3v0hD8aALT0BBKCzr)._

- [ x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ x] [Segmenters] Tested in the staging environment
