### PR TITLE
Initialize new logEventV2 action

### DIFF
--- a/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
@@ -921,8 +921,8 @@ describe('Amplitude', () => {
     })
   })
 
-  describe.only('logEvent V2', () => {
-    it('should work with default mappings', async () => {
+  describe('logEvent V2', () => {
+    it('works with default mappings', async () => {
       const event = createTestEvent({ timestamp, event: 'Test Event' })
 
       nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
@@ -943,7 +943,7 @@ describe('Amplitude', () => {
       })
     })
 
-    it('should change casing for device type when value is ios', async () => {
+    it('changes casing for device type when value is ios', async () => {
       const event = createTestEvent({
         event: 'Test Event',
         context: {
@@ -968,7 +968,7 @@ describe('Amplitude', () => {
       })
     })
 
-    it('should change casing for device type when value is android', async () => {
+    it('changes casing for device type when value is android', async () => {
       const event = createTestEvent({
         event: 'Test Event',
         context: {
@@ -993,7 +993,7 @@ describe('Amplitude', () => {
       })
     })
 
-    it('should accept null for user_id', async () => {
+    it('accepts null for user_id', async () => {
       const event = createTestEvent({ timestamp, userId: null, event: 'Null User' })
 
       nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
@@ -1013,7 +1013,7 @@ describe('Amplitude', () => {
       })
     })
 
-    it('should work with default mappings without generating additional events from products array', async () => {
+    it('works with default mappings without generating additional events from products array', async () => {
       const event = createTestEvent({
         event: 'Order Completed',
         timestamp,
@@ -1046,7 +1046,7 @@ describe('Amplitude', () => {
       })
     })
 
-    it('should allow alternate revenue names at the root level', async () => {
+    it('allows alternate revenue names at the root level', async () => {
       //understand that this is basically just testing mapping kit which is already tested
       nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
 
@@ -1079,7 +1079,7 @@ describe('Amplitude', () => {
       })
     })
 
-    it('should not inject userData if the default mapping is not satisfied and utm / referrer are not provided', async () => {
+    it('does not inject userData if the default mapping is not satisfied and utm / referrer are not provided', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -1110,7 +1110,7 @@ describe('Amplitude', () => {
       })
     })
 
-    it('should support referrer and utm properties in logEvent call to amplitude', async () => {
+    it('supports referrer and utm properties in logEvent call to amplitude', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -1164,7 +1164,7 @@ describe('Amplitude', () => {
       })
     })
 
-    it('should support parsing userAgent when the setting is true', async () => {
+    it('supports parsing userAgent when the setting is true', async () => {
       const event = createTestEvent({
         anonymousId: '6fd32a7e-3c56-44c2-bd32-62bbec44c53d',
         timestamp,
@@ -1206,7 +1206,7 @@ describe('Amplitude', () => {
       `)
     })
 
-    it('should support session_id from `integrations.Actions Amplitude.session_id`', async () => {
+    it('supports session_id from `integrations.Actions Amplitude.session_id`', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -1259,7 +1259,7 @@ describe('Amplitude', () => {
       `)
     })
 
-    it('should send data to the EU endpoint', async () => {
+    it('sends data to the EU endpoint', async () => {
       const event = createTestEvent({ timestamp, event: 'Test Event' })
 
       nock('https://api.eu.amplitude.com/2').post('/httpapi').reply(200, {})
@@ -1287,7 +1287,7 @@ describe('Amplitude', () => {
       })
     })
 
-    it('should send data to the batch EU endpoint when specified in settings', async () => {
+    it('sends data to the batch EU endpoint when specified in settings', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event'
@@ -1321,7 +1321,7 @@ describe('Amplitude', () => {
       })
     })
 
-    it.only('should correctly handle the default mappings for setOnce, setAlways, and add', async () => {
+    it('correctly handles the default mappings for setOnce, setAlways, and add', async () => {
       nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
 
       const event = createTestEvent({
@@ -1374,7 +1374,7 @@ describe('Amplitude', () => {
       })
     })
 
-    it('should work when setOnce, setAlways, and add are empty', async () => {
+    it('works when setOnce, setAlways, and add are empty', async () => {
       nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
 
       const event = createTestEvent({
@@ -1419,7 +1419,7 @@ describe('Amplitude', () => {
     })
   })
 
-  it('should not send parsed user agent properties when setting is false', async () => {
+  it('does not send parsed user agent properties when setting is false', async () => {
     const event = createTestEvent({
       timestamp: '2021-04-12T16:32:37.710Z',
       event: 'Test Event',

--- a/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
@@ -921,6 +921,504 @@ describe('Amplitude', () => {
     })
   })
 
+  describe.only('logEvent V2', () => {
+    it('should work with default mappings', async () => {
+      const event = createTestEvent({ timestamp, event: 'Test Event' })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const responses = await testDestination.testAction('logEventV2', { event, useDefaultMappings: true })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+      expect(responses[0].options.json).toMatchObject({
+        api_key: undefined,
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            event_type: 'Test Event',
+            city: 'San Francisco',
+            country: 'United States'
+          })
+        ])
+      })
+    })
+
+    it('should change casing for device type when value is ios', async () => {
+      const event = createTestEvent({
+        event: 'Test Event',
+        context: {
+          device: {
+            id: 'foo',
+            type: 'ios'
+          }
+        }
+      })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const responses = await testDestination.testAction('logEventV2', { event, useDefaultMappings: true })
+      expect(responses[0].options.json).toMatchObject({
+        api_key: undefined,
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            device_id: 'foo',
+            platform: 'iOS'
+          })
+        ])
+      })
+    })
+
+    it('should change casing for device type when value is android', async () => {
+      const event = createTestEvent({
+        event: 'Test Event',
+        context: {
+          device: {
+            id: 'foo',
+            type: 'android'
+          }
+        }
+      })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const responses = await testDestination.testAction('logEventV2', { event, useDefaultMappings: true })
+      expect(responses[0].options.json).toMatchObject({
+        api_key: undefined,
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            device_id: 'foo',
+            platform: 'Android'
+          })
+        ])
+      })
+    })
+
+    it('should accept null for user_id', async () => {
+      const event = createTestEvent({ timestamp, userId: null, event: 'Null User' })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const responses = await testDestination.testAction('logEventV2', { event, useDefaultMappings: true })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+      expect(responses[0].options.json).toMatchObject({
+        api_key: undefined,
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            event_type: 'Null User',
+            user_id: null
+          })
+        ])
+      })
+    })
+
+    it('should work with default mappings without generating additional events from products array', async () => {
+      const event = createTestEvent({
+        event: 'Order Completed',
+        timestamp,
+        properties: {
+          revenue: 1_999,
+          products: [
+            {
+              quantity: 1,
+              productId: 'Bowflex Treadmill 10',
+              price: 1_999
+            }
+          ]
+        }
+      })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const responses = await testDestination.testAction('logEventV2', { event, useDefaultMappings: true })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        api_key: undefined,
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            event_type: 'Order Completed',
+            event_properties: event.properties,
+            library: 'segment'
+          })
+        ])
+      })
+    })
+
+    it('should allow alternate revenue names at the root level', async () => {
+      //understand that this is basically just testing mapping kit which is already tested
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const event = createTestEvent({
+        event: 'Order Completed',
+        timestamp,
+        properties: {
+          revenue: 1_999,
+          bitcoin_rev: 9_999
+        }
+      })
+
+      const mapping = {
+        revenue: {
+          '@path': '$.properties.bitcoin_rev'
+        }
+      }
+
+      const responses = await testDestination.testAction('logEventV2', { event, mapping, useDefaultMappings: true })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        api_key: undefined,
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            event_type: 'Order Completed',
+            event_properties: event.properties
+          })
+        ])
+      })
+    })
+
+    it('should not inject userData if the default mapping is not satisfied and utm / referrer are not provided', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        traits: {
+          'some-trait-key': 'some-trait-value'
+        },
+        context: {
+          'some-context': 'yep'
+        }
+      })
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+      const responses = await testDestination.testAction('logEventV2', { event, useDefaultMappings: true })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+
+      expect(responses[0].options.json).toMatchObject({
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            event_type: 'Test Event',
+            event_properties: {},
+            user_properties: {
+              'some-trait-key': 'some-trait-value'
+            },
+            use_batch_endpoint: false
+          })
+        ])
+      })
+    })
+
+    it('should support referrer and utm properties in logEvent call to amplitude', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        traits: {
+          'some-trait-key': 'some-trait-value'
+        },
+        context: {
+          page: {
+            referrer: 'some-referrer'
+          },
+          campaign: {
+            name: 'TPS Innovation Newsletter',
+            source: 'Newsletter',
+            medium: 'email',
+            term: 'tps reports',
+            content: 'image link'
+          }
+        }
+      })
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+      const responses = await testDestination.testAction('logEventV2', { event, useDefaultMappings: true })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+      expect(responses[0].options.json).toMatchObject({
+        api_key: undefined,
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            event_type: 'Test Event',
+            user_properties: expect.objectContaining({
+              'some-trait-key': 'some-trait-value',
+              $set: {
+                utm_source: 'Newsletter',
+                utm_medium: 'email',
+                utm_campaign: 'TPS Innovation Newsletter',
+                utm_term: 'tps reports',
+                utm_content: 'image link',
+                referrer: 'some-referrer'
+              },
+              $setOnce: {
+                initial_utm_source: 'Newsletter',
+                initial_utm_medium: 'email',
+                initial_utm_campaign: 'TPS Innovation Newsletter',
+                initial_utm_term: 'tps reports',
+                initial_utm_content: 'image link',
+                initial_referrer: 'some-referrer'
+              }
+            })
+          })
+        ])
+      })
+    })
+
+    it('should support parsing userAgent when the setting is true', async () => {
+      const event = createTestEvent({
+        anonymousId: '6fd32a7e-3c56-44c2-bd32-62bbec44c53d',
+        timestamp,
+        event: 'Test Event',
+        context: {
+          userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36'
+        }
+      })
+      const mapping = {
+        userAgentParsing: true
+      }
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+      const responses = await testDestination.testAction('logEventV2', { event, mapping, useDefaultMappings: true })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+      expect(responses[0].options.json).toMatchInlineSnapshot(`
+        Object {
+          "api_key": undefined,
+          "events": Array [
+            Object {
+              "device_id": "6fd32a7e-3c56-44c2-bd32-62bbec44c53d",
+              "device_model": "Mac OS",
+              "device_type": undefined,
+              "event_properties": Object {},
+              "event_type": "Test Event",
+              "library": "segment",
+              "os_name": "Chrome",
+              "os_version": "53",
+              "time": 1629213675449,
+              "use_batch_endpoint": false,
+              "user_id": "user1234",
+              "user_properties": Object {},
+            },
+          ],
+          "options": undefined,
+        }
+      `)
+    })
+
+    it('should support session_id from `integrations.Actions Amplitude.session_id`', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        anonymousId: 'julio',
+        integrations: {
+          // @ts-expect-error integrations should accept complext objects;
+          'Actions Amplitude': {
+            session_id: '1234567890'
+          }
+        }
+      })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const responses = await testDestination.testAction('logEventV2', { event, useDefaultMappings: true })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+
+      expect(responses[0].options.json).toMatchInlineSnapshot(`
+        Object {
+          "api_key": undefined,
+          "events": Array [
+            Object {
+              "city": "San Francisco",
+              "country": "United States",
+              "device_id": "julio",
+              "device_model": "iPhone",
+              "device_type": "mobile",
+              "event_properties": Object {},
+              "event_type": "Test Event",
+              "ip": "8.8.8.8",
+              "language": "en-US",
+              "library": "segment",
+              "location_lat": 40.2964197,
+              "location_lng": -76.9411617,
+              "os_name": "Mobile Safari",
+              "os_version": "9",
+              "platform": "Web",
+              "session_id": -23074351200000,
+              "time": 1629213675449,
+              "use_batch_endpoint": false,
+              "user_id": "user1234",
+              "user_properties": Object {},
+            },
+          ],
+          "options": undefined,
+        }
+      `)
+    })
+
+    it('should send data to the EU endpoint', async () => {
+      const event = createTestEvent({ timestamp, event: 'Test Event' })
+
+      nock('https://api.eu.amplitude.com/2').post('/httpapi').reply(200, {})
+      const responses = await testDestination.testAction('logEventV2', {
+        event,
+        useDefaultMappings: true,
+        settings: {
+          apiKey: '',
+          secretKey: '',
+          endpoint: 'europe'
+        }
+      })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+      expect(responses[0].options.json).toMatchObject({
+        api_key: '',
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            event_type: 'Test Event',
+            city: 'San Francisco',
+            country: 'United States'
+          })
+        ])
+      })
+    })
+
+    it('should send data to the batch EU endpoint when specified in settings', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event'
+      })
+
+      nock('https://api.eu.amplitude.com').post('/batch').reply(200, {})
+      const responses = await testDestination.testAction('logEventV2', {
+        event,
+        useDefaultMappings: true,
+        settings: {
+          apiKey: '',
+          secretKey: '',
+          endpoint: 'europe'
+        },
+        mapping: {
+          use_batch_endpoint: true
+        }
+      })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+      expect(responses[0].options.json).toMatchObject({
+        api_key: '',
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            event_type: 'Test Event',
+            city: 'San Francisco',
+            country: 'United States'
+          })
+        ])
+      })
+    })
+
+    it.only('should correctly handle the default mappings for setOnce, setAlways, and add', async () => {
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        traits: {
+          'some-trait-key': 'some-trait-value'
+        },
+        context: {
+          page: {
+            referrer: 'some-referrer'
+          },
+          campaign: {
+            name: 'TPS Innovation Newsletter',
+            source: 'Newsletter',
+            medium: 'email',
+            term: 'tps reports',
+            content: 'image link'
+          }
+        }
+      })
+
+      const responses = await testDestination.testAction('logEventV2', { event, useDefaultMappings: true })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        api_key: undefined,
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            user_properties: expect.objectContaining({
+              $set: {
+                referrer: 'some-referrer',
+                utm_campaign: 'TPS Innovation Newsletter',
+                utm_content: 'image link',
+                utm_medium: 'email',
+                utm_source: 'Newsletter',
+                utm_term: 'tps reports'
+              },
+              $setOnce: {
+                initial_referrer: 'some-referrer',
+                initial_utm_campaign: 'TPS Innovation Newsletter',
+                initial_utm_content: 'image link',
+                initial_utm_medium: 'email',
+                initial_utm_source: 'Newsletter',
+                initial_utm_term: 'tps reports'
+              }
+            })
+          })
+        ])
+      })
+    })
+
+    it('should work when setOnce, setAlways, and add are empty', async () => {
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        traits: {
+          'some-trait-key': 'some-trait-value'
+        },
+        context: {
+          page: {
+            referrer: 'some-referrer'
+          },
+          campaign: {
+            name: 'TPS Innovation Newsletter',
+            source: 'Newsletter',
+            medium: 'email',
+            term: 'tps reports',
+            content: 'image link'
+          }
+        }
+      })
+
+      const mapping = {
+        setOnce: {},
+        setAlways: {},
+        add: {}
+      }
+
+      const responses = await testDestination.testAction('logEventV2', { event, mapping, useDefaultMappings: true })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        api_key: undefined,
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            user_properties: expect.objectContaining({
+              'some-trait-key': 'some-trait-value'
+            })
+          })
+        ])
+      })
+    })
+  })
+
   it('should not send parsed user agent properties when setting is false', async () => {
     const event = createTestEvent({
       timestamp: '2021-04-12T16:32:37.710Z',

--- a/packages/destination-actions/src/destinations/amplitude/compact.ts
+++ b/packages/destination-actions/src/destinations/amplitude/compact.ts
@@ -10,5 +10,5 @@ import { Payload as LogV2Payload } from './logEventV2/generated-types'
 export default function compact(
   object: LogV2Payload['setOnce'] | LogV2Payload['setAlways'] | LogV2Payload['add']
 ): boolean {
-  return Object.keys(Object.fromEntries(Object.entries(object ?? {}).filter(([_, v]) => v))).length > 0
+  return Object.keys(Object.fromEntries(Object.entries(object ?? {}).filter(([_, v]) => v !== ''))).length > 0
 }

--- a/packages/destination-actions/src/destinations/amplitude/compact.ts
+++ b/packages/destination-actions/src/destinations/amplitude/compact.ts
@@ -1,13 +1,13 @@
 import { Payload as LogV2Payload } from './logEventV2/generated-types'
 
 /**
- * takes a object and removes all keys with a falsey value. Then checks if the object is empty or not
+ * Takes an object and removes all keys with a false value. Then, checks if the object is empty or not.
  *
  * @param object the setAlways, setOnce, or add object from the LogEvent payload
  * @returns a boolean signifying whether the resulting object is empty or not
  */
 
-export default function removeEmptyKeysAndCheckIfEmpty(
+export default function compact(
   object: LogV2Payload['setOnce'] | LogV2Payload['setAlways'] | LogV2Payload['add']
 ): boolean {
   return Object.keys(Object.fromEntries(Object.entries(object ?? {}).filter(([_, v]) => v))).length > 0

--- a/packages/destination-actions/src/destinations/amplitude/compact.ts
+++ b/packages/destination-actions/src/destinations/amplitude/compact.ts
@@ -1,7 +1,7 @@
 import { Payload as LogV2Payload } from './logEventV2/generated-types'
 
 /**
- * Takes an object and removes all keys with a false value. Then, checks if the object is empty or not.
+ * Takes an object and removes all keys with a "falsey" value. Then, checks if the object is empty or not.
  *
  * @param object the setAlways, setOnce, or add object from the LogEvent payload
  * @returns a boolean signifying whether the resulting object is empty or not

--- a/packages/destination-actions/src/destinations/amplitude/emptyObject.ts
+++ b/packages/destination-actions/src/destinations/amplitude/emptyObject.ts
@@ -1,0 +1,14 @@
+import { Payload as LogV2Payload } from './logEventV2/generated-types'
+
+/**
+ * takes a object and removes all keys with a falsey value. Then checks if the object is empty or not
+ *
+ * @param object the setAlways, setOnce, or add object from the LogEvent payload
+ * @returns a boolean signifying whether the resulting object is empty or not
+ */
+
+export default function removeEmptyKeysAndCheckIfEmpty(
+  object: LogV2Payload['setOnce'] | LogV2Payload['setAlways'] | LogV2Payload['add']
+): boolean {
+  return Object.keys(Object.fromEntries(Object.entries(object ?? {}).filter(([_, v]) => v))).length > 0
+}

--- a/packages/destination-actions/src/destinations/amplitude/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/index.ts
@@ -15,8 +15,8 @@ const presets: DestinationDefinition['presets'] = [
   {
     name: 'Track Calls',
     subscribe: 'type = "track" and event != "Order Completed"',
-    partnerAction: 'logEvent',
-    mapping: defaultValues(logEvent.fields)
+    partnerAction: 'logEventV2',
+    mapping: defaultValues(logEventV2.fields)
   },
   {
     name: 'Order Completed Calls',
@@ -27,9 +27,9 @@ const presets: DestinationDefinition['presets'] = [
   {
     name: 'Page Calls',
     subscribe: 'type = "page"',
-    partnerAction: 'logEvent',
+    partnerAction: 'logEventV2',
     mapping: {
-      ...defaultValues(logEvent.fields),
+      ...defaultValues(logEventV2.fields),
       event_type: {
         '@template': 'Viewed {{name}}'
       }
@@ -38,9 +38,9 @@ const presets: DestinationDefinition['presets'] = [
   {
     name: 'Screen Calls',
     subscribe: 'type = "screen"',
-    partnerAction: 'logEvent',
+    partnerAction: 'logEventV2',
     mapping: {
-      ...defaultValues(logEvent.fields),
+      ...defaultValues(logEventV2.fields),
       event_type: {
         '@template': 'Viewed {{name}}'
       }

--- a/packages/destination-actions/src/destinations/amplitude/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/index.ts
@@ -8,6 +8,8 @@ import logPurchase from './logPurchase'
 import type { Settings } from './generated-types'
 import { getEndpointByRegion } from './regional-endpoints'
 
+import logEventV2 from './logEventV2'
+
 /** used in the quick setup */
 const presets: DestinationDefinition['presets'] = [
   {
@@ -123,7 +125,8 @@ const destination: DestinationDefinition<Settings> = {
     identifyUser,
     mapUser,
     groupIdentifyUser,
-    logPurchase
+    logPurchase,
+    logEventV2
   }
 }
 

--- a/packages/destination-actions/src/destinations/amplitude/logEventV2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEventV2/generated-types.ts
@@ -178,11 +178,11 @@ export interface Payload {
     [k: string]: unknown
   }[]
   /**
-   * The following fields will be set only once per session when using AJS2 as the source
+   * The following fields will be set only once per session when using AJS2 as the source.
    */
   setOnce?: {
     /**
-     * The referrer of the web request
+     * The referrer of the web request.
      */
     initial_referrer?: string
     initial_utm_source?: string
@@ -193,7 +193,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * The following fields will be set every session when using AJS2 as the source
+   * The following fields will be set every session when using AJS2 as the source.
    */
   setAlways?: {
     referrer?: string
@@ -219,7 +219,7 @@ export interface Payload {
    */
   userAgent?: string
   /**
-   * Enabling this setting will set the Device manufacturer, Device Model and OS Name properties based on the user agent string provided in the userAgent field
+   * Enabling this setting will set the Device manufacturer, Device Model and OS Name properties based on the user agent string provided in the userAgent field.
    */
   userAgentParsing?: boolean
   /**

--- a/packages/destination-actions/src/destinations/amplitude/logEventV2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEventV2/generated-types.ts
@@ -1,0 +1,229 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * A readable ID specified by you. Must have a minimum length of 5 characters. Required unless device ID is present. **Note:** If you send a request with a user ID that is not in the Amplitude system yet, then the user tied to that ID will not be marked new until their first event.
+   */
+  user_id?: string | null
+  /**
+   * A device-specific identifier, such as the Identifier for Vendor on iOS. Required unless user ID is present. If a device ID is not sent with the event, it will be set to a hashed version of the user ID.
+   */
+  device_id?: string
+  /**
+   * A unique identifier for your event.
+   */
+  event_type: string
+  /**
+   * The start time of the session, necessary if you want to associate events with a particular system. To use automatic Amplitude session tracking in browsers, enable Analytics 2.0 on your connected source.
+   */
+  session_id?: string | number
+  /**
+   * The timestamp of the event. If time is not sent with the event, it will be set to the request upload time.
+   */
+  time?: string | number
+  /**
+   * An object of key-value pairs that represent additional data to be sent along with the event. You can store property values in an array, but note that Amplitude only supports one-dimensional arrays. Date values are transformed into string values. Object depth may not exceed 40 layers.
+   */
+  event_properties?: {
+    [k: string]: unknown
+  }
+  /**
+   * An object of key-value pairs that represent additional data tied to the user. You can store property values in an array, but note that Amplitude only supports one-dimensional arrays. Date values are transformed into string values. Object depth may not exceed 40 layers.
+   */
+  user_properties?: {
+    [k: string]: unknown
+  }
+  /**
+   * Groups of users for the event as an event-level group. You can only track up to 5 groups. **Note:** This Amplitude feature is only available to Enterprise customers who have purchased the Accounts add-on.
+   */
+  groups?: {
+    [k: string]: unknown
+  }
+  /**
+   * The current version of your application.
+   */
+  app_version?: string
+  /**
+   * Platform of the device.
+   */
+  platform?: string
+  /**
+   * The name of the mobile operating system or browser that the user is using.
+   */
+  os_name?: string
+  /**
+   * The version of the mobile operating system or browser the user is using.
+   */
+  os_version?: string
+  /**
+   * The device brand that the user is using.
+   */
+  device_brand?: string
+  /**
+   * The device manufacturer that the user is using.
+   */
+  device_manufacturer?: string
+  /**
+   * The device model that the user is using.
+   */
+  device_model?: string
+  /**
+   * The carrier that the user is using.
+   */
+  carrier?: string
+  /**
+   * The current country of the user.
+   */
+  country?: string
+  /**
+   * The current region of the user.
+   */
+  region?: string
+  /**
+   * The current city of the user.
+   */
+  city?: string
+  /**
+   * The current Designated Market Area of the user.
+   */
+  dma?: string
+  /**
+   * The language set by the user.
+   */
+  language?: string
+  /**
+   * The price of the item purchased. Required for revenue data if the revenue field is not sent. You can use negative values to indicate refunds.
+   */
+  price?: number
+  /**
+   * The quantity of the item purchased. Defaults to 1 if not specified.
+   */
+  quantity?: number
+  /**
+   * Revenue = price * quantity. If you send all 3 fields of price, quantity, and revenue, then (price * quantity) will be used as the revenue value. You can use negative values to indicate refunds. **Note:** You will need to explicitly set this if you are using the Amplitude in cloud-mode.
+   */
+  revenue?: number
+  /**
+   * An identifier for the item purchased. You must send a price and quantity or revenue with this field.
+   */
+  productId?: string
+  /**
+   * The type of revenue for the item purchased. You must send a price and quantity or revenue with this field.
+   */
+  revenueType?: string
+  /**
+   * The current Latitude of the user.
+   */
+  location_lat?: number
+  /**
+   * The current Longitude of the user.
+   */
+  location_lng?: number
+  /**
+   * The IP address of the user. Use "$remote" to use the IP address on the upload request. Amplitude will use the IP address to reverse lookup a user's location (city, country, region, and DMA). Amplitude has the ability to drop the location and IP address from events once it reaches our servers. You can submit a request to Amplitude's platform specialist team here to configure this for you.
+   */
+  ip?: string
+  /**
+   * Identifier for Advertiser. _(iOS)_
+   */
+  idfa?: string
+  /**
+   * Identifier for Vendor. _(iOS)_
+   */
+  idfv?: string
+  /**
+   * Google Play Services advertising ID. _(Android)_
+   */
+  adid?: string
+  /**
+   * Android ID (not the advertising ID). _(Android)_
+   */
+  android_id?: string
+  /**
+   * An incrementing counter to distinguish events with the same user ID and timestamp from each other. Amplitude recommends you send an event ID, increasing over time, especially if you expect events to occur simultanenously.
+   */
+  event_id?: number
+  /**
+   * Amplitude will deduplicate subsequent events sent with this ID we have already seen before within the past 7 days. Amplitude recommends generating a UUID or using some combination of device ID, user ID, event type, event ID, and time.
+   */
+  insert_id?: string
+  /**
+   * The name of the library that generated the event.
+   */
+  library?: string
+  /**
+   * The list of products purchased.
+   */
+  products?: {
+    /**
+     * The price of the item purchased. Required for revenue data if the revenue field is not sent. You can use negative values to indicate refunds.
+     */
+    price?: number
+    /**
+     * The quantity of the item purchased. Defaults to 1 if not specified.
+     */
+    quantity?: number
+    /**
+     * Revenue = price * quantity. If you send all 3 fields of price, quantity, and revenue, then (price * quantity) will be used as the revenue value. You can use negative values to indicate refunds.
+     */
+    revenue?: number
+    /**
+     * An identifier for the item purchased. You must send a price and quantity or revenue with this field.
+     */
+    productId?: string
+    /**
+     * The type of revenue for the item purchased. You must send a price and quantity or revenue with this field.
+     */
+    revenueType?: string
+    [k: string]: unknown
+  }[]
+  /**
+   * The following fields will be set only once per session when using AJS2 as the source
+   */
+  setOnce?: {
+    /**
+     * The referrer of the web request
+     */
+    initial_referrer?: string
+    initial_utm_source?: string
+    initial_utm_medium?: string
+    initial_utm_campaign?: string
+    initial_utm_term?: string
+    initial_utm_content?: string
+    [k: string]: unknown
+  }
+  /**
+   * The following fields will be set every session when using AJS2 as the source
+   */
+  setAlways?: {
+    referrer?: string
+    utm_source?: string
+    utm_medium?: string
+    utm_campaign?: string
+    utm_term?: string
+    utm_content?: string
+    [k: string]: unknown
+  }
+  /**
+   * Increment a user property by a number with add. If the user property doesn't have a value set yet, it's initialized to 0.
+   */
+  add?: {
+    [k: string]: unknown
+  }
+  /**
+   * If true, events are sent to Amplitude's `batch` endpoint rather than their `httpapi` events endpoint. Enabling this setting may help reduce 429s – or throttling errors – from Amplitude. More information about Amplitude's throttling is available in [their docs](https://developers.amplitude.com/docs/batch-event-upload-api#429s-in-depth).
+   */
+  use_batch_endpoint?: boolean
+  /**
+   * The user agent of the device sending the event.
+   */
+  userAgent?: string
+  /**
+   * Enabling this setting will set the Device manufacturer, Device Model and OS Name properties based on the user agent string provided in the userAgent field
+   */
+  userAgentParsing?: boolean
+  /**
+   * Amplitude has a default minimum id length of 5 characters for user_id and device_id fields. This field allows the minimum to be overridden to allow shorter id lengths.
+   */
+  min_id_length?: number | null
+}

--- a/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
@@ -1,6 +1,6 @@
 import { ActionDefinition, omit, removeUndefined } from '@segment/actions-core'
 import dayjs from 'dayjs'
-import removeEmptyKeysAndCheckIfEmpty from '../emptyObject'
+import compact from '../compact'
 import { eventSchema } from '../event-schema'
 import type { Settings } from '../generated-types'
 import { getEndpointByRegion } from '../regional-endpoints'
@@ -214,7 +214,9 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (library) {
-      if (library === 'analytics.js') properties.platform = 'Web'
+      if (library === 'analytics.js') {
+        properties.platform = 'Web'
+      }
     }
 
     if (time && dayjs.utc(time).isValid()) {
@@ -229,13 +231,13 @@ const action: ActionDefinition<Settings, Payload> = {
       options = { min_id_length }
     }
 
-    if (removeEmptyKeysAndCheckIfEmpty(setOnce)) {
+    if (compact(setOnce)) {
       properties.user_properties = { ...properties.user_properties, $setOnce: setOnce }
     }
-    if (removeEmptyKeysAndCheckIfEmpty(setAlways)) {
+    if (compact(setAlways)) {
       properties.user_properties = { ...properties.user_properties, $set: setAlways }
     }
-    if (removeEmptyKeysAndCheckIfEmpty(add)) {
+    if (compact(add)) {
       properties.user_properties = { ...properties.user_properties, $add: add }
     }
 

--- a/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
@@ -1,0 +1,264 @@
+import { ActionDefinition, omit, removeUndefined } from '@segment/actions-core'
+import dayjs from 'dayjs'
+import removeEmptyKeysAndCheckIfEmpty from '../emptyObject'
+import { eventSchema } from '../event-schema'
+import type { Settings } from '../generated-types'
+import { getEndpointByRegion } from '../regional-endpoints'
+import { parseUserAgentProperties } from '../user-agent'
+import type { Payload } from './generated-types'
+
+export interface AmplitudeEvent extends Omit<Payload, 'products' | 'time' | 'session_id'> {
+  library?: string
+  time?: number
+  session_id?: number
+  options?: {
+    min_id_length: number
+  }
+}
+
+const revenueKeys = ['revenue', 'price', 'productId', 'quantity', 'revenueType']
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Log Event V2',
+  description: 'Send an event to Amplitude',
+  fields: {
+    ...eventSchema,
+    products: {
+      label: 'Products',
+      description: 'The list of products purchased.',
+      type: 'object',
+      multiple: true,
+      additionalProperties: true,
+      properties: {
+        price: {
+          label: 'Price',
+          type: 'number',
+          description:
+            'The price of the item purchased. Required for revenue data if the revenue field is not sent. You can use negative values to indicate refunds.'
+        },
+        quantity: {
+          label: 'Quantity',
+          type: 'integer',
+          description: 'The quantity of the item purchased. Defaults to 1 if not specified.'
+        },
+        revenue: {
+          label: 'Revenue',
+          type: 'number',
+          description:
+            'Revenue = price * quantity. If you send all 3 fields of price, quantity, and revenue, then (price * quantity) will be used as the revenue value. You can use negative values to indicate refunds.'
+        },
+        productId: {
+          label: 'Product ID',
+          type: 'string',
+          description:
+            'An identifier for the item purchased. You must send a price and quantity or revenue with this field.'
+        },
+        revenueType: {
+          label: 'Revenue Type',
+          type: 'string',
+          description:
+            'The type of revenue for the item purchased. You must send a price and quantity or revenue with this field.'
+        }
+      },
+      default: {
+        '@arrayPath': [
+          '$.properties.products',
+          {
+            price: {
+              '@path': 'price'
+            },
+            revenue: {
+              '@path': 'revenue'
+            },
+            quantity: {
+              '@path': 'quantity'
+            },
+            productId: {
+              '@path': 'productId'
+            },
+            revenueType: {
+              '@path': 'revenueType'
+            }
+          }
+        ]
+      }
+    },
+    setOnce: {
+      label: 'Set Once',
+      description: 'The following fields will be set only once per session when using AJS2 as the source',
+      type: 'object',
+      additionalProperties: true,
+      properties: {
+        initial_referrer: {
+          label: 'Initial Referrer',
+          type: 'string',
+          description: 'The referrer of the web request'
+        },
+        initial_utm_source: {
+          label: 'Initial UTM Source',
+          type: 'string'
+        },
+        initial_utm_medium: {
+          label: 'Initial UTM Medium',
+          type: 'string'
+        },
+        initial_utm_campaign: {
+          label: 'Initial UTM Campaign',
+          type: 'string'
+        },
+        initial_utm_term: {
+          label: 'Initial UTM Term',
+          type: 'string'
+        },
+        initial_utm_content: {
+          label: 'Initial UTM Content',
+          type: 'string'
+        }
+      },
+      default: {
+        initial_referrer: { '@path': '$.context.page.referrer' },
+        initial_utm_source: { '@path': '$.context.campaign.source' },
+        initial_utm_medium: { '@path': '$.context.campaign.medium' },
+        initial_utm_campaign: { '@path': '$.context.campaign.name' },
+        initial_utm_term: { '@path': '$.context.campaign.term' },
+        initial_utm_content: { '@path': '$.context.campaign.content' }
+      }
+    },
+    setAlways: {
+      label: 'Set Always',
+      description: 'The following fields will be set every session when using AJS2 as the source',
+      type: 'object',
+      additionalProperties: true,
+      properties: {
+        referrer: {
+          label: 'Referrer',
+          type: 'string'
+        },
+        utm_source: {
+          label: 'UTM Source',
+          type: 'string'
+        },
+        utm_medium: {
+          label: 'UTM Medium',
+          type: 'string'
+        },
+        utm_campaign: {
+          label: 'UTM Campaign',
+          type: 'string'
+        },
+        utm_term: {
+          label: 'UTM Term',
+          type: 'string'
+        },
+        utm_content: {
+          label: 'UTM Content',
+          type: 'string'
+        }
+      },
+      default: {
+        referrer: { '@path': '$.context.page.referrer' },
+        utm_source: { '@path': '$.context.campaign.source' },
+        utm_medium: { '@path': '$.context.campaign.medium' },
+        utm_campaign: { '@path': '$.context.campaign.name' },
+        utm_term: { '@path': '$.context.campaign.term' },
+        utm_content: { '@path': '$.context.campaign.content' }
+      }
+    },
+    add: {
+      label: 'Add',
+      description:
+        "Increment a user property by a number with add. If the user property doesn't have a value set yet, it's initialized to 0.",
+      type: 'object',
+      additionalProperties: true,
+      defaultObjectUI: 'keyvalue'
+    },
+    use_batch_endpoint: {
+      label: 'Use Batch Endpoint',
+      description:
+        "If true, events are sent to Amplitude's `batch` endpoint rather than their `httpapi` events endpoint. Enabling this setting may help reduce 429s – or throttling errors – from Amplitude. More information about Amplitude's throttling is available in [their docs](https://developers.amplitude.com/docs/batch-event-upload-api#429s-in-depth).",
+      type: 'boolean',
+      default: false
+    },
+    userAgent: {
+      label: 'User Agent',
+      type: 'string',
+      description: 'The user agent of the device sending the event.',
+      default: {
+        '@path': '$.context.userAgent'
+      }
+    },
+    userAgentParsing: {
+      label: 'User Agent Parsing',
+      type: 'boolean',
+      description:
+        'Enabling this setting will set the Device manufacturer, Device Model and OS Name properties based on the user agent string provided in the userAgent field',
+      default: true
+    },
+    min_id_length: {
+      label: 'Minimum ID Length',
+      description:
+        'Amplitude has a default minimum id length of 5 characters for user_id and device_id fields. This field allows the minimum to be overridden to allow shorter id lengths.',
+      allowNull: true,
+      type: 'integer'
+    }
+  },
+  perform: (request, { payload, settings }) => {
+    const { time, session_id, userAgent, userAgentParsing, min_id_length, library, setOnce, setAlways, add, ...rest } =
+      omit(payload, revenueKeys)
+    const properties = rest as AmplitudeEvent
+    let options
+
+    if (properties.platform) {
+      properties.platform = properties.platform.replace(/ios/i, 'iOS').replace(/android/i, 'Android')
+    }
+
+    if (library) {
+      if (library === 'analytics.js') properties.platform = 'Web'
+    }
+
+    if (time && dayjs.utc(time).isValid()) {
+      properties.time = dayjs.utc(time).valueOf()
+    }
+
+    if (session_id && dayjs.utc(session_id).isValid()) {
+      properties.session_id = dayjs.utc(session_id).valueOf()
+    }
+
+    if (min_id_length && min_id_length > 0) {
+      options = { min_id_length }
+    }
+
+    if (removeEmptyKeysAndCheckIfEmpty(setOnce)) {
+      properties.user_properties = { ...properties.user_properties, $setOnce: setOnce }
+    }
+    if (removeEmptyKeysAndCheckIfEmpty(setAlways)) {
+      properties.user_properties = { ...properties.user_properties, $set: setAlways }
+    }
+    if (removeEmptyKeysAndCheckIfEmpty(add)) {
+      properties.user_properties = { ...properties.user_properties, $add: add }
+    }
+
+    const events: AmplitudeEvent[] = [
+      {
+        // Conditionally parse user agent using amplitude's library
+        ...(userAgentParsing && parseUserAgentProperties(userAgent)),
+        // Make sure any top-level properties take precedence over user-agent properties
+        ...removeUndefined(properties),
+        library: 'segment'
+      }
+    ]
+
+    const endpoint = getEndpointByRegion(payload.use_batch_endpoint ? 'batch' : 'httpapi', settings.endpoint)
+
+    return request(endpoint, {
+      method: 'post',
+      json: {
+        api_key: settings.apiKey,
+        events,
+        options
+      }
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
@@ -21,6 +21,7 @@ const revenueKeys = ['revenue', 'price', 'productId', 'quantity', 'revenueType']
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Log Event V2',
   description: 'Send an event to Amplitude',
+  defaultSubscription: 'type = "track"',
   fields: {
     ...eventSchema,
     products: {

--- a/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
@@ -86,14 +86,14 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     setOnce: {
       label: 'Set Once',
-      description: 'The following fields will be set only once per session when using AJS2 as the source',
+      description: 'The following fields will be set only once per session when using AJS2 as the source.',
       type: 'object',
       additionalProperties: true,
       properties: {
         initial_referrer: {
           label: 'Initial Referrer',
           type: 'string',
-          description: 'The referrer of the web request'
+          description: 'The referrer of the web request.'
         },
         initial_utm_source: {
           label: 'Initial UTM Source',
@@ -127,7 +127,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     setAlways: {
       label: 'Set Always',
-      description: 'The following fields will be set every session when using AJS2 as the source',
+      description: 'The following fields will be set every session when using AJS2 as the source.',
       type: 'object',
       additionalProperties: true,
       properties: {
@@ -192,7 +192,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'User Agent Parsing',
       type: 'boolean',
       description:
-        'Enabling this setting will set the Device manufacturer, Device Model and OS Name properties based on the user agent string provided in the userAgent field',
+        'Enabling this setting will set the Device manufacturer, Device Model and OS Name properties based on the user agent string provided in the userAgent field.',
       default: true
     },
     min_id_length: {
@@ -231,15 +231,18 @@ const action: ActionDefinition<Settings, Payload> = {
       options = { min_id_length }
     }
 
-    if (compact(setOnce)) {
-      properties.user_properties = { ...properties.user_properties, $setOnce: setOnce }
+    const setUserProperties = (
+      name: '$setOnce' | '$set' | '$add',
+      obj: Payload['setOnce'] | Payload['setAlways'] | Payload['add']
+    ) => {
+      if (compact(obj)) {
+        properties.user_properties = { ...properties.user_properties, [name]: obj }
+      }
     }
-    if (compact(setAlways)) {
-      properties.user_properties = { ...properties.user_properties, $set: setAlways }
-    }
-    if (compact(add)) {
-      properties.user_properties = { ...properties.user_properties, $add: add }
-    }
+
+    setUserProperties('$setOnce', setOnce)
+    setUserProperties('$set', setAlways)
+    setUserProperties('$add', add)
 
     const events: AmplitudeEvent[] = [
       {


### PR DESCRIPTION
This PR addresses [JIRA ACT-146](https://segment.atlassian.net/browse/ACT-146) & [Design Doc](https://paper.dropbox.com/doc/Amplitude-Transparency-and-control-over-setsetOnce--BocP0wAMd7029sN0gSA2eaSoAg-7PxGzLWcZJFtaA5pbAT7C)

In it we create a new Amplitude action called `Log Event V2`. This new action retains the same functionality as the previous `Log Event`. However, in this new object we remove the legacy fields `utm_properties` and `referrer` in favor of three new object fields - `setAlways`, `setOnce` and `add`. The goal of these new fields is to replace the previous legacy fields since they undergo some hidden things in the background of the `perform` block that wasn't clear to users. This change should make it much clearer to the user what is happening to their data, as well as allow for greater customizability as to what fields get passed to Amplitude in their respective `$set`, `$setOnce`, and `$add` fields.

This PR also updates the amplitude presets to use the new `Log Event V2` by default that way any new instances are setup with the newer version.

## Testing

Testing completed successfully in both local (action-tester) and stage via a stage deploy of `action-destinations` repo.

- creation of new action - correct default trigger and mappings ✅
- sent test event with `section 4` of mappings UI - event sent correctly ✅
- sent test event through `event-tester` - event sent correctly ✅

### Using new action to send event (through actions-ui) with new `setOnce`, `setAlways` and `add` fields initialized
https://user-images.githubusercontent.com/98849774/193703595-dbd27d3f-8184-4d12-98a7-6e9cf5c1b61b.mov

### Using new action to send event (through event-tester) with new `setOnce`, `setAlways` and `add` fields initialized
https://user-images.githubusercontent.com/98849774/193704047-ee78cc8f-6545-494d-a142-ce5a17625e47.mov


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
