### PR TITLE
Sendgrid As Destination: adding custom fields simplification

### DIFF
--- a/packages/destination-actions/src/destinations/sendgrid/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/index.ts
@@ -27,6 +27,15 @@ const destination: DestinationDefinition<Settings> = {
     }
   },
 
+  extendRequest({ settings }) {
+    return {
+      headers: {
+        Authorization: `Bearer ${settings.sendGridApiKey}`,
+        Accept: 'application/json'
+      }
+    }
+  },
+
   actions: {
     updateUserProfile
   }

--- a/packages/destination-actions/src/destinations/sendgrid/sendgrid-properties.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/sendgrid-properties.ts
@@ -28,16 +28,15 @@ interface APIData {
 // Fetch all custom field definitions for the account using the Sendgrid API
 // https://docs.sendgrid.com/api-reference/custom-fields/get-all-field-definitions
 export const fetchAccountCustomFields = async (request: RequestClient): Promise<CustomField[]> => {
-  return await request('https://api.sendgrid.com/v3/marketing/field_definitions').then((response): CustomField[] => {
-    const data: APIData = response.data as APIData
-    const customFields: CustomField[] = data.custom_fields as CustomField[]
-    return customFields.map(
-      // Strip out other fields provided by the API and return only what we need
-      ({ id, name }: CustomField): CustomField => {
-        return { id, name }
-      }
-    )
-  })
+  const response = await request('https://api.sendgrid.com/v3/marketing/field_definitions')
+  const data: APIData = response.data as APIData
+  const customFields: CustomField[] = data.custom_fields as CustomField[]
+  return customFields.map(
+    // Strip out other fields provided by the API and return only what we need
+    ({ id, name }: CustomField): CustomField => {
+      return { id, name }
+    }
+  )
 }
 
 // Check if a custom field key in the Segment payload is a valid Sendgrid custom field name or ID for in the customer's

--- a/packages/destination-actions/src/destinations/sendgrid/sendgrid-properties.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/sendgrid-properties.ts
@@ -1,4 +1,4 @@
-import { InputField } from '@segment/actions-core'
+import { InputField, RequestClient } from '@segment/actions-core'
 import { Payload } from './updateUserProfile/generated-types'
 
 export const customFields: InputField = {
@@ -16,7 +16,63 @@ export const customFields: InputField = {
   defaultObjectUI: 'keyvalue'
 }
 
-export const convertPayload = (payload: Payload) => {
+export interface CustomField {
+  id: string
+  name: string
+}
+
+interface APIData {
+  custom_fields?: CustomField[]
+}
+
+// Fetch all custom field definitions for the account using the Sendgrid API
+// https://docs.sendgrid.com/api-reference/custom-fields/get-all-field-definitions
+export const fetchAccountCustomFields = async (request: RequestClient): Promise<CustomField[]> => {
+  return await request('https://api.sendgrid.com/v3/marketing/field_definitions').then((response): CustomField[] => {
+    const data: APIData = response.data as APIData
+    const customFields: CustomField[] = data.custom_fields as CustomField[]
+    return customFields.map(
+      // Strip out other fields provided by the API and return only what we need
+      ({ id, name }: CustomField): CustomField => {
+        return { id, name }
+      }
+    )
+  })
+}
+
+// Check if a custom field key in the Segment payload is a valid Sendgrid custom field name or ID for in the customer's
+// account. If it is a valid ID, do nothing. If it is a valid name, use the corresponding ID instead. If it is neither,
+// throw an error and give the user guidance.
+const convertCustomFieldNamesToIds = (customFields: any, accountCustomFields: CustomField[]): any => {
+  const field_ids = accountCustomFields.map((field) => field.id)
+  const field_names = accountCustomFields.map((field) => field.name.toLowerCase())
+
+  return Object.keys(customFields).reduce((result: any, key: string) => {
+    let actualKey: string = key
+    if (field_ids.includes(key)) {
+      actualKey = key
+    } else if (field_names.includes(key.toLowerCase())) {
+      const matchingCustomField: CustomField = accountCustomFields.filter(
+        (field: CustomField) => field.name.toLowerCase() === key.toLowerCase()
+      )[0]
+      actualKey = matchingCustomField.id
+    } else {
+      throw new Error(
+        `Unknown custom field '${key}'. To see your defined custom fields, visit https://mc.sendgrid.com/custom-fields`
+      )
+    }
+    result[actualKey] = customFields[key]
+    return result
+  }, {})
+}
+
+export const convertPayload = (payload: Payload, accountCustomFields: CustomField[]) => {
   const { state, primary_email, enable_batching, customFields, ...rest } = payload
-  return { ...rest, state_province_region: state, email: primary_email, custom_fields: customFields }
+
+  // If there are any custom fields, convert their key from sendgrid Name to sendgrid ID if needed
+  const updatedCustomFields = customFields
+    ? convertCustomFieldNamesToIds(customFields, accountCustomFields)
+    : customFields
+
+  return { ...rest, state_province_region: state, email: primary_email, custom_fields: updatedCustomFields }
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->


<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_Sendgrid As Destination: adding custom fields simplification_

With this customer can use SendGrid custom-fields name while doing field mapping.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
