### PR TITLE
Add initial Loops action destination

### DIFF
--- a/packages/destination-actions/src/destinations/loops/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/loops/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-loops destination: createContact action - all fields 1`] = `
+Object {
+  "email": "beurnu@liwo.kr",
+}
+`;
+
+exports[`Testing snapshot for actions-loops destination: createContact action - required fields 1`] = `
+Object {
+  "email": "beurnu@liwo.kr",
+}
+`;

--- a/packages/destination-actions/src/destinations/loops/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/loops/__tests__/index.test.ts
@@ -1,0 +1,21 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Loops', () => {
+  describe('testAuthentication', () => {
+    it('should validate authentication inputs', async () => {
+      nock('https://app.loops.so/api/v1/api-key').get(/.*/).matchHeader('authorization', `Bearer testId`).reply(200, {
+        success: true
+      })
+
+      const authData = {
+        apiKey: 'testId'
+      }
+
+      await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/loops/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/loops/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-loops'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/loops/createContact/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/loops/createContact/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Loops's createContact destination action: all fields 1`] = `
+Object {
+  "email": "do@zalwi.tv",
+}
+`;
+
+exports[`Testing snapshot for Loops's createContact destination action: required fields 1`] = `
+Object {
+  "email": "do@zalwi.tv",
+}
+`;

--- a/packages/destination-actions/src/destinations/loops/createContact/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/loops/createContact/__tests__/index.test.ts
@@ -1,0 +1,34 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+const LOOPS_API_KEY = 'some random secret'
+
+describe('Loops.createContact', () => {
+  it('should validate action fields', async () => {
+    try {
+      await testDestination.testAction('createContact', {
+        settings: { apiKey: LOOPS_API_KEY }
+      })
+    } catch (err) {
+      expect(err.message).toContain("missing the required field 'email'.")
+    }
+  })
+
+  it('should work', async () => {
+    nock('https://app.loops.so/api/v1').post('/contacts/create', { email: 'test@example.com' }).reply(200, {
+      success: true,
+      id: 'someId'
+    })
+
+    const responses = await testDestination.testAction('createContact', {
+      mapping: { email: 'test@example.com' },
+      settings: { apiKey: LOOPS_API_KEY }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+  })
+})

--- a/packages/destination-actions/src/destinations/loops/createContact/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/loops/createContact/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'createContact'
+const destinationSlug = 'Loops'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/loops/createContact/generated-types.ts
+++ b/packages/destination-actions/src/destinations/loops/createContact/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Email address for the contact.
+   */
+  email: string
+}

--- a/packages/destination-actions/src/destinations/loops/createContact/index.ts
+++ b/packages/destination-actions/src/destinations/loops/createContact/index.ts
@@ -12,7 +12,14 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'Email address for the contact.',
       type: 'string',
       format: 'email',
-      required: true
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.email' },
+          then: { '@path': '$.traits.email' },
+          else: { '@path': '$.email' }
+        }
+      }
     }
   },
   perform: (request, { payload }) => {

--- a/packages/destination-actions/src/destinations/loops/createContact/index.ts
+++ b/packages/destination-actions/src/destinations/loops/createContact/index.ts
@@ -1,0 +1,28 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Create a contact',
+  description: 'Create a contact in Loops',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    email: {
+      label: 'Contact Email',
+      description: 'Email address for the contact.',
+      type: 'string',
+      format: 'email',
+      required: true
+    }
+  },
+  perform: (request, { payload }) => {
+    return request('https://app.loops.so/api/v1/contacts/create', {
+      method: 'post',
+      json: {
+        email: payload.email
+      }
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/loops/generated-types.ts
+++ b/packages/destination-actions/src/destinations/loops/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your Loops API Key
+   */
+  apiKey: string
+}

--- a/packages/destination-actions/src/destinations/loops/index.ts
+++ b/packages/destination-actions/src/destinations/loops/index.ts
@@ -1,0 +1,37 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import createContact from './createContact'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Loops',
+  slug: 'actions-loops',
+  mode: 'cloud',
+
+  extendRequest: ({ settings }) => {
+    return {
+      headers: { Authorization: `Bearer ${settings.apiKey}`, 'Content-Type': 'application/json' }
+    }
+  },
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      apiKey: {
+        label: 'API Key',
+        description: 'Your Loops API Key',
+        type: 'string',
+        required: true
+      }
+    },
+    testAuthentication: (request) => {
+      return request('https://app.loops.so/api/v1/api-key', { method: 'GET' })
+    }
+  },
+
+  actions: {
+    createContact
+  }
+}
+
+export default destination


### PR DESCRIPTION
Adding an initial action for https://loops.so

## Testing
- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
