### PR TITLE
Add lead_id field in the event payload

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-conversions/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/__tests__/index.test.ts
@@ -273,6 +273,72 @@ describe('Tiktok Conversions', () => {
       )
     })
 
+    it('should send a successful lead_event event to reportWebEvent', async () => {
+      const event = createTestEvent({
+        timestamp: timestamp,
+        event: 'lead_event',
+        messageId: 'corey123',
+        type: 'track',
+        properties: {
+          email: 'coreytest1231@gmail.com',
+          phone: '+1555-555-5555',
+          lead_id: '2229012621312',
+          currency: 'USD',
+          value: 100,
+          query: 'shoes',
+          price: 100,
+          quantity: 2,
+          category: 'Air Force One (Size S)',
+          product_id: 'abc123'
+        },
+        context: {
+          page: {
+            url: 'http://demo.mywebsite.com?a=b&ttclid=123ATXSfe',
+            referrer: 'https://google.com/'
+          },
+          userAgent:
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57',
+          ip: '0.0.0.0'
+        },
+        userId: 'testId123'
+      })
+
+      nock('https://business-api.tiktok.com/open_api/v1.2/pixel/track').post('/').reply(200, {})
+      const responses = await testDestination.testAction('reportWebEvent', {
+        event,
+        settings,
+        useDefaultMappings: true,
+        mapping: {
+          event: 'lead_event',
+          contents: {
+            '@arrayPath': [
+              '$.properties',
+              {
+                price: {
+                  '@path': '$.price'
+                },
+                quantity: {
+                  '@path': '$.quantity'
+                },
+                content_type: {
+                  '@path': '$.category'
+                },
+                content_id: {
+                  '@path': '$.product_id'
+                }
+              }
+            ]
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"pixel_code\\":\\"test\\",\\"event\\":\\"lead_event\\",\\"event_id\\":\\"corey123_seg\\",\\"timestamp\\":\\"2021-09-2T15:21:15.449Z\\",\\"context\\":{\\"user\\":{\\"external_id\\":\\"481f202262e9c5ccc48d24e60798fadaa5f6ff1f8369f7ab927c04c3aa682a7f\\",\\"phone_number\\":\\"910a625c4ba147b544e6bd2f267e130ae14c591b6ba9c25cb8573322dedbebd0\\",\\"email\\":\\"eb9869a32b532840dd6aa714f7a872d21d6f650fc5aa933d9feefc64708969c7\\",\\"lead_id\\":\\"2229012621312\\"},\\"ad\\":{\\"callback\\":\\"123ATXSfe\\"},\\"page\\":{\\"url\\":\\"http://demo.mywebsite.com?a=b&ttclid=123ATXSfe\\",\\"referrer\\":\\"https://google.com/\\"},\\"ip\\":\\"0.0.0.0\\",\\"user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57\\"},\\"properties\\":{\\"contents\\":[{\\"price\\":100,\\"quantity\\":2,\\"content_type\\":\\"Air Force One (Size S)\\",\\"content_id\\":\\"abc123\\"}],\\"currency\\":\\"USD\\",\\"value\\":100,\\"query\\":\\"shoes\\"},\\"partner_name\\":\\"Segment\\"}"`
+      )
+    })
+
     it('should send test_event_code if present in mapping', async () => {
       const event = createTestEvent({
         timestamp: timestamp,

--- a/packages/destination-actions/src/destinations/tiktok-conversions/reportWebEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/reportWebEvent/generated-types.ts
@@ -30,6 +30,10 @@ export interface Payload {
    */
   ttclid?: string
   /**
+   * ID of TikTok leads. Every lead will have its own lead_id when exported from TikTok. This feature is in Beta. Please contact your TikTok representative to inquire regarding availability
+   */
+  lead_id?: string
+  /**
    * The page URL where the conversion event took place.
    */
   url?: string

--- a/packages/destination-actions/src/destinations/tiktok-conversions/reportWebEvent/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/reportWebEvent/index.ts
@@ -73,7 +73,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     ttclid: {
-      label: 'TikTok Click  ID',
+      label: 'TikTok Click ID',
       description:
         'The value of the ttclid used to match website visitor events with TikTok ads. The ttclid is valid for 7 days. See [Set up ttclid](https://ads.tiktok.com/marketing_api/docs?rid=4eezrhr6lg4&id=1681728034437121) for details.',
       type: 'string',
@@ -82,6 +82,19 @@ const action: ActionDefinition<Settings, Payload> = {
           exists: { '@path': '$.properties.ttclid' },
           then: { '@path': '$.properties.ttclid' },
           else: { '@path': '$.traits.ttclid' }
+        }
+      }
+    },
+    lead_id: {
+      label: 'TikTok Lead ID',
+      description:
+        'ID of TikTok leads. Every lead will have its own lead_id when exported from TikTok. This feature is in Beta. Please contact your TikTok representative to inquire regarding availability',
+      type: 'string',
+      default: {
+        '@if': {
+          exists: { '@path': '$.properties.lead_id' },
+          then: { '@path': '$.properties.lead_id' },
+          else: { '@path': '$.traits.lead_id' }
         }
       }
     },
@@ -216,7 +229,8 @@ const action: ActionDefinition<Settings, Payload> = {
           user: {
             external_id: userData.hashedExternalId,
             phone_number: userData.hashedPhoneNumber,
-            email: userData.hashedEmail
+            email: userData.hashedEmail,
+            lead_id: payload.lead_id
           },
           ad: {
             callback: payload.ttclid ? payload.ttclid : urlTtclid ? urlTtclid : undefined


### PR DESCRIPTION
This PR updates the TikTok conversions destination:
1. Add lead_id under context > user object in the event payload

## Testing
1. local server testing
<img width="1892" alt="Screen Shot 2022-09-27 at 11 39 01 PM" src="https://user-images.githubusercontent.com/104384385/192724004-9833db35-7c27-4ea5-b4e2-6ac7375fa75f.png">
2. add 1 unit test to test lead_id field and event name "lead_event"  
<img width="905" alt="Screen Shot 2022-09-28 at 12 24 15 AM" src="https://user-images.githubusercontent.com/104384385/192724211-e4736d5a-11ed-4a7b-a9ac-82c73517eee8.png">

- [x] Added [unit tests]
- [x] Tested end-to-end using the [local server])
- [ ] [Segmenters] Tested in the staging environment
