### PR TITLE
[STRATCONN-1670] Add self managed bearer token to AT Cloud

### DIFF
--- a/packages/destination-actions/src/destinations/adobe-target/adobeTarget_operations.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/adobeTarget_operations.ts
@@ -58,7 +58,9 @@ export default class AdobeTarget {
         { method: 'get' }
       )
     } catch (error) {
-      return new IntegrationError('No profile found in Adobe Target with this mbox3rdPartyId', 'Profile not found', 404)
+      if (error instanceof Error) {
+        return new IntegrationError(error.message, error.stack, error.message == 'Forbidden' ? 403 : 400)
+      }
     }
 
     return undefined

--- a/packages/destination-actions/src/destinations/adobe-target/generated-types.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/generated-types.ts
@@ -5,4 +5,8 @@ export interface Settings {
    * Your Adobe Target client code. To find your client code in Adobe Target, navigate to **Administration > Implementation**. The client code is shown at the top under Account Details.
    */
   client_code: string
+  /**
+   * Self managed bearer token generated via [Adobe's authentication API](https://developers.adobetarget.com/api/#authentication-tokens). Expires every 90 days.
+   */
+  bearer_token?: string
 }

--- a/packages/destination-actions/src/destinations/adobe-target/generated-types.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/generated-types.ts
@@ -6,7 +6,7 @@ export interface Settings {
    */
   client_code: string
   /**
-   * Self managed bearer token generated via [Adobe's authentication API](https://developers.adobetarget.com/api/#authentication-tokens). Expires every 90 days.
+   * If you choose to require authentication for Adobe Target's Profile API, you will need to generate an authentication token. Tokens can be generated in your Adobe Target account under the Implementation Settings tab or via the [Adobe.IO Authentication Token API](https://developers.adobetarget.com/api/#authentication-tokens). Input the authentication token here. Note: Authentication tokens expire so a new token will need to be generated and updated here prior to expiration.
    */
   bearer_token?: string
 }

--- a/packages/destination-actions/src/destinations/adobe-target/index.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/index.ts
@@ -19,7 +19,7 @@ const destination: DestinationDefinition<Settings> = {
         required: true
       },
       bearer_token: {
-        label: 'Bearer Token',
+        label: 'Authentication Token',
         description:
           "If you choose to require authentication for Adobe Target's Profile API, you will need to generate an authentication token. Tokens can be generated in your Adobe Target account under the Implementation Settings tab or via the [Adobe.IO Authentication Token API](https://developers.adobetarget.com/api/#authentication-tokens). Input the authentication token here. Note: Authentication tokens expire so a new token will need to be generated and updated here prior to expiration.",
         type: 'string'

--- a/packages/destination-actions/src/destinations/adobe-target/index.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/index.ts
@@ -17,8 +17,24 @@ const destination: DestinationDefinition<Settings> = {
           'Your Adobe Target client code. To find your client code in Adobe Target, navigate to **Administration > Implementation**. The client code is shown at the top under Account Details.',
         type: 'string',
         required: true
+      },
+      bearer_token: {
+        label: 'Bearer Token',
+        description:
+          "Self managed bearer token generated via [Adobe's authentication API](https://developers.adobetarget.com/api/#authentication-tokens). Expires every 90 days.",
+        type: 'string'
       }
     }
+  },
+  extendRequest({ settings }) {
+    if (settings.bearer_token) {
+      return {
+        headers: {
+          Authorization: `Bearer ${settings.bearer_token}`
+        }
+      }
+    }
+    return {}
   },
   actions: {
     updateProfile

--- a/packages/destination-actions/src/destinations/adobe-target/index.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/index.ts
@@ -21,7 +21,7 @@ const destination: DestinationDefinition<Settings> = {
       bearer_token: {
         label: 'Bearer Token',
         description:
-          "Self managed bearer token generated via [Adobe's authentication API](https://developers.adobetarget.com/api/#authentication-tokens). Expires every 90 days.",
+          "If you choose to require authentication for Adobe Target's Profile API, you will need to generate an authentication token. Tokens can be generated in your Adobe Target account under the Implementation Settings tab or via the [Adobe.IO Authentication Token API](https://developers.adobetarget.com/api/#authentication-tokens). Input the authentication token here. Note: Authentication tokens expire so a new token will need to be generated and updated here prior to expiration.",
         type: 'string'
       }
     }

--- a/packages/destination-actions/src/destinations/adobe-target/updateProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/updateProfile/__tests__/index.test.ts
@@ -62,11 +62,21 @@ describe('AdobeTarget', () => {
       })
 
       expect(responses.length).toBe(2)
-      expect(responses[0].status).toBe(200)
-      expect(responses[1].status).toBe(200)
       expect(responses[1].url).toBe(
         'https://segmentexchangepartn.tt.omtrdc.net/m2/segmentexchangepartn/profile/update?mbox3rdPartyId=123-test&profile.city=New%20York%20City&profile.name=Rajul&profile.age=21&profile.param1=value1&profile.param2=value2'
       )
+      responses.forEach((response) => {
+        expect(response.request.headers).toMatchInlineSnapshot(`
+          Headers {
+            Symbol(map): Object {
+              "user-agent": Array [
+                "Segment (Actions)",
+              ],
+            },
+          }
+        `)
+        expect(response.status).toBe(200)
+      })
     })
     it('Handle a Nested Event', async () => {
       nock(
@@ -270,6 +280,77 @@ describe('AdobeTarget', () => {
       expect(responses[1].url).toBe(
         'https://segmentexchangepartn.tt.omtrdc.net/m2/segmentexchangepartn/profile/update?mbox3rdPartyId=123-test&profile.address.city=New%20York%20City&profile.name=Rajul&profile.param1=value1&profile.param2=value2'
       )
+    })
+
+    it('uses bearer token if provided', async () => {
+      const authSettings = {
+        bearer_token: 'test-token',
+        ...settings
+      }
+
+      const event = createTestEvent({
+        type: 'identify',
+        userId: '123-test',
+        traits: {
+          name: 'Rajul',
+          age: '21',
+          city: 'New York City',
+          zipCode: '12345',
+          param1: 'value1',
+          param2: 'value2'
+        }
+      })
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+
+      const responses = await testDestination.testAction('updateProfile', {
+        event,
+        settings: authSettings,
+        mapping: {
+          traits: {
+            city: {
+              '@path': '$.traits.city'
+            },
+            name: {
+              '@path': '$.traits.name'
+            },
+            age: {
+              '@path': '$.traits.age'
+            },
+            param1: {
+              '@path': '$.traits.param1'
+            },
+            param2: {
+              '@path': '$.traits.param2'
+            }
+          },
+          user_id: {
+            '@path': '$.userId'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(2)
+      expect(responses[1].url).toBe(
+        'https://segmentexchangepartn.tt.omtrdc.net/m2/segmentexchangepartn/profile/update?mbox3rdPartyId=123-test&profile.city=New%20York%20City&profile.name=Rajul&profile.age=21&profile.param1=value1&profile.param2=value2'
+      )
+
+      responses.forEach((response) => {
+        expect(response.request.headers).toMatchInlineSnapshot(`
+          Headers {
+            Symbol(map): Object {
+              "authorization": Array [
+                "Bearer test-token",
+              ],
+              "user-agent": Array [
+                "Segment (Actions)",
+              ],
+            },
+          }
+        `)
+        expect(response.status).toBe(200)
+      })
     })
   })
   it('should handle default mappings', async () => {


### PR DESCRIPTION
This PR adds the capability to use authentication within Adobe Target Cloud. 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
