### PR TITLE
Fixes a missing export statement

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,7 @@ export type {
 
 export type {
   DynamicFieldResponse,
+  DynamicFieldError,
   DynamicFieldItem,
   InputField,
   GlobalSetting,


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->


This PR fixes a missing export statement for the `DynamicFieldError` type which causes a build error in `fab-5-engine`. 

## Testing

Tested locally by manually adding the export to the `node_modules` `index.d.ts` file, which fixes the build error.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
