### PR TITLE
Add MMS (Media) support to the Twilio action

### DIFF
--- a/packages/destination-actions/src/destinations/twilio/__tests__/twilio.test.ts
+++ b/packages/destination-actions/src/destinations/twilio/__tests__/twilio.test.ts
@@ -14,7 +14,8 @@ describe('Twilio', () => {
         event: 'Test Event',
         properties: {
           To: '+17758638863',
-          Body: 'Hello, World!'
+          Body: 'Hello, World!',
+          MediaUrl: 'https://demo.twilio.com/owl.png'
         }
       })
 
@@ -33,6 +34,9 @@ describe('Twilio', () => {
           },
           Body: {
             '@path': '$.properties.Body'
+          },
+          MediaUrl: {
+            '@path': '$.properties.MediaUrl'
           }
         },
         useDefaultMappings: true
@@ -50,6 +54,8 @@ describe('Twilio', () => {
             "+17758638863",
             "Body",
             "Hello, World!",
+            "MediaUrl",
+            "https://demo.twilio.com/owl.png",
           ],
           Symbol(context): null,
         }

--- a/packages/destination-actions/src/destinations/twilio/sendSms/generated-types.ts
+++ b/packages/destination-actions/src/destinations/twilio/sendSms/generated-types.ts
@@ -9,4 +9,8 @@ export interface Payload {
    * The message body
    */
   Body: string
+  /**
+   * The URL of the media to send with the message.
+   */
+  MediaUrl?: string
 }

--- a/packages/destination-actions/src/destinations/twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/twilio/sendSms/index.ts
@@ -18,6 +18,12 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'The message body',
       type: 'text',
       required: true
+    },
+    MediaUrl: {
+      label: 'Media URL',
+      description: 'The URL of the media to send with the message.',
+      type: 'string',
+      required: false
     }
   },
   perform: (request, data) => {


### PR DESCRIPTION
This PR adds a `MediaUrl` field to the Twilio action which provides support for sending [MMS messages](https://www.twilio.com/docs/sms/send-messages?code-sample=code-send-an-sms-message&code-language=Node.js&code-sdk-version=3.x#include-media-in-your-messages).


## Testing

- [X] Added [unit test](https://github.com/segmentio/action-destinations/compare/main...ricardo-rossi:action-destinations:twilio-action-mms-support?expand=1#diff-865f75ee551ac19d3ea8f21fb201441e1f451103b7651bc2ebdaab8820b72baf) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
