### PR TITLE
Transform special traits to Mixpanel reserved properties

### DIFF
--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing snapshot for Mixpanel's groupIdentifyUser destination action: all fields 1`] = `"data=%7B%22%24token%22%3A%22%251srs%22%2C%22%24group_key%22%3A%22company%22%2C%22%24group_id%22%3A%22Mixpanel%22%2C%22%24set%22%3A%7B%22hello%22%3A%22world%22%2C%22company%22%3A%22Mixpanel%22%7D%2C%22segment_source_name%22%3A%22%251srs%22%7D"`;
+exports[`Testing snapshot for Mixpanel's groupIdentifyUser destination action: all fields 1`] = `"data=%7B%22%24token%22%3A%22%251srs%22%2C%22%24group_key%22%3A%22company%22%2C%22%24group_id%22%3A%22Mixpanel%22%2C%22%24set%22%3A%7B%22hello%22%3A%22world%22%2C%22company%22%3A%22Mixpanel%22%7D%7D"`;
 
-exports[`Testing snapshot for Mixpanel's groupIdentifyUser destination action: required fields 1`] = `"data=%7B%22%24token%22%3A%22%251srs%22%2C%22%24group_key%22%3A%22company%22%2C%22%24group_id%22%3A%22Mixpanel%22%2C%22%24set%22%3A%7B%22hello%22%3A%22world%22%2C%22company%22%3A%22Mixpanel%22%7D%2C%22segment_source_name%22%3A%22%251srs%22%7D"`;
+exports[`Testing snapshot for Mixpanel's groupIdentifyUser destination action: required fields 1`] = `"data=%7B%22%24token%22%3A%22%251srs%22%2C%22%24group_key%22%3A%22company%22%2C%22%24group_id%22%3A%22Mixpanel%22%2C%22%24set%22%3A%7B%22hello%22%3A%22world%22%2C%22company%22%3A%22Mixpanel%22%7D%7D"`;
 
 exports[`Testing snapshot for Mixpanel's groupIdentifyUser destination action: required fields 2`] = `
 Headers {

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/index.test.ts
@@ -40,7 +40,7 @@ describe('Mixpanel.groupIdentifyUser', () => {
           $set: {
             hello: 'world',
             company: 'Mixpanel',
-            $name: 'test' // validate name -> $name
+            $name: 'test'
           }
         })
       })

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/index.test.ts
@@ -220,8 +220,7 @@ describe('Mixpanel.groupIdentifyUser', () => {
           $set: {
             hello: 'world',
             company: 'Mixpanel'
-          },
-          segment_source_name: 'example segment source name'
+          }
         })
       })
     )

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/index.test.ts
@@ -13,7 +13,7 @@ describe('Mixpanel.groupIdentifyUser', () => {
     const event = createTestEvent({
       timestamp,
       groupId: 'test-group-id',
-      traits: { hello: 'world', company: 'Mixpanel' }
+      traits: { hello: 'world', company: 'Mixpanel', name: 'test' }
     })
 
     nock('https://api.mixpanel.com').post('/groups').reply(200, {})
@@ -39,7 +39,8 @@ describe('Mixpanel.groupIdentifyUser', () => {
           $group_id: 'Mixpanel',
           $set: {
             hello: 'world',
-            company: 'Mixpanel'
+            company: 'Mixpanel',
+            $name: 'test' // validate name -> $name
           }
         })
       })

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
@@ -1,4 +1,4 @@
-import { omit, ActionDefinition, IntegrationError } from '@segment/actions-core'
+import { ActionDefinition, IntegrationError, omit } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import { getApiServerUrl } from '../utils'
 import type { Payload } from './generated-types'
@@ -32,7 +32,7 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.traits'
       }
-    },
+    }
   },
   perform: (request, { payload, settings }) => {
     const group_key = payload.group_key || '$group_id'
@@ -48,14 +48,13 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const traits = {
       ...omit(payload.traits, ['name']),
-      $name: payload.traits.name,  // transform to Mixpanel reserved property
+      $name: payload.traits.name  // transform to Mixpanel reserved property
     }
     const data = {
       $token: settings.projectToken,
       $group_key: group_key,
       $group_id: group_id,
       $set: traits,
-      segment_source_name: settings.sourceName
     }
 
     return request(`${ getApiServerUrl(settings.apiRegion) }/groups`, {

--- a/packages/destination-actions/src/destinations/mixpanel/identifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/identifyUser/__tests__/index.test.ts
@@ -10,7 +10,7 @@ const timestamp = '2021-08-17T15:21:15.449Z'
 
 describe('Mixpanel.identifyUser', () => {
   it('should validate action fields', async () => {
-    const event = createTestEvent({ timestamp, traits: { abc: '123' } })
+    const event = createTestEvent({ timestamp, traits: { abc: '123', name: 'Joe' } })
 
     nock('https://api.mixpanel.com').post('/engage').reply(200, {})
     nock('https://api.mixpanel.com').post('/track').reply(200, {})
@@ -47,7 +47,8 @@ describe('Mixpanel.identifyUser', () => {
           $token: MIXPANEL_PROJECT_TOKEN,
           $distinct_id: 'user1234',
           $set: {
-            abc: '123'
+            abc: '123',
+            $name: 'Joe' // transformed to reserved property $name
           }
         })
       })

--- a/packages/destination-actions/src/destinations/mixpanel/identifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/identifyUser/__tests__/index.test.ts
@@ -10,7 +10,18 @@ const timestamp = '2021-08-17T15:21:15.449Z'
 
 describe('Mixpanel.identifyUser', () => {
   it('should validate action fields', async () => {
-    const event = createTestEvent({ timestamp, traits: { abc: '123', name: 'Joe' } })
+    const event = createTestEvent({
+      timestamp, traits: {
+        abc: '123',
+        created: '2022-10-12T00:00:00.000Z',
+        email: 'joe@mixpanel.com',
+        firstName: 'Joe',
+        lastName: 'Doe',
+        username: 'Joe Doe',
+        phone: '12345678',
+        name: 'Joe',
+      }
+    })
 
     nock('https://api.mixpanel.com').post('/engage').reply(200, {})
     nock('https://api.mixpanel.com').post('/track').reply(200, {})
@@ -48,7 +59,13 @@ describe('Mixpanel.identifyUser', () => {
           $distinct_id: 'user1234',
           $set: {
             abc: '123',
-            $name: 'Joe' // transformed to reserved property $name
+            $created: '2022-10-12T00:00:00.000Z',
+            $email: 'joe@mixpanel.com',
+            $first_name: 'Joe',
+            $last_name: 'Doe',
+            $name: 'Joe',
+            $username: 'Joe Doe',
+            $phone: '12345678'
           }
         })
       })

--- a/packages/destination-actions/src/destinations/mixpanel/identifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/identifyUser/__tests__/index.test.ts
@@ -184,8 +184,7 @@ describe('Mixpanel.identifyUser', () => {
           $distinct_id: 'user1234',
           $set: {
             abc: '123'
-          },
-          segment_source_name: 'example segment source name'
+          }
         })
       })
     )

--- a/packages/destination-actions/src/destinations/mixpanel/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/identifyUser/index.ts
@@ -67,13 +67,12 @@ const action: ActionDefinition<Settings, Payload> = {
     if (payload.traits && Object.keys(payload.traits).length > 0) {
       const traits = {
         ...omit(payload.traits, ['name']),
-        $name: payload.traits.name,  // transform to Mixpanel reserved property
+        $name: payload.traits.name  // transform to Mixpanel reserved property
       }
       const data = {
         $token: settings.projectToken,
         $distinct_id: payload.user_id,
-        $set: traits,
-        segment_source_name: settings.sourceName
+        $set: traits
       }
 
       const engageResponse = request(`${ apiServerUrl }/engage`, {

--- a/packages/destination-actions/src/destinations/mixpanel/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/identifyUser/index.ts
@@ -66,8 +66,15 @@ const action: ActionDefinition<Settings, Payload> = {
 
     if (payload.traits && Object.keys(payload.traits).length > 0) {
       const traits = {
-        ...omit(payload.traits, ['name']),
-        $name: payload.traits.name  // transform to Mixpanel reserved property
+        ...omit(payload.traits, ['created', 'email', 'firstName', 'lastName', 'name', 'username', 'phone']),
+        // to fit the Mixpanel expectations, transform the special traits to Mixpanel reserved property
+        $created: payload.traits.created,
+        $email: payload.traits.email,
+        $first_name: payload.traits.firstName,
+        $last_name: payload.traits.lastName,
+        $name: payload.traits.name,
+        $username: payload.traits.username,
+        $phone: payload.traits.phone
       }
       const data = {
         $token: settings.projectToken,

--- a/packages/destination-actions/src/destinations/mixpanel/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/identifyUser/index.ts
@@ -1,4 +1,4 @@
-import { ActionDefinition, IntegrationError } from '@segment/actions-core'
+import { ActionDefinition, IntegrationError, omit } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
@@ -57,7 +57,7 @@ const action: ActionDefinition<Settings, Payload> = {
         }
       }
 
-      const identifyResponse = await request(`${apiServerUrl}/track`, {
+      const identifyResponse = await request(`${ apiServerUrl }/track`, {
         method: 'post',
         body: new URLSearchParams({ data: JSON.stringify(identifyEvent) })
       })
@@ -65,14 +65,18 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (payload.traits && Object.keys(payload.traits).length > 0) {
+      const traits = {
+        ...omit(payload.traits, ['name']),
+        $name: payload.traits.name,  // transform to Mixpanel reserved property
+      }
       const data = {
         $token: settings.projectToken,
         $distinct_id: payload.user_id,
-        $set: payload.traits,
+        $set: traits,
         segment_source_name: settings.sourceName
       }
 
-      const engageResponse = request(`${apiServerUrl}/engage`, {
+      const engageResponse = request(`${ apiServerUrl }/engage`, {
         method: 'post',
         body: new URLSearchParams({ data: JSON.stringify(data) })
       })

--- a/packages/destination-actions/src/destinations/mixpanel/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackEvent/index.ts
@@ -54,7 +54,7 @@ const getEventFromPayload = (payload: Payload, settings: Settings): MixpanelEven
       $source: 'segment',
       $wifi_enabled: payload.wifi,
       mp_country_code: payload.country,
-      mp_lib: payload.library_name && `Segment: ${payload.library_name}`,
+      mp_lib: payload.library_name && `Segment: ${ payload.library_name }`,
       segment_source_name: settings.sourceName,
       utm_campaign: utm.utm_campaign,
       utm_content: utm.utm_content,
@@ -69,11 +69,11 @@ const getEventFromPayload = (payload: Payload, settings: Settings): MixpanelEven
 
 const processData = async (request: RequestClient, settings: Settings, payload: Payload[]) => {
   const events = payload.map((value) => getEventFromPayload(value, settings))
-  return request(`${getApiServerUrl(settings.apiRegion)}/import?strict=1`, {
+  return request(`${ getApiServerUrl(settings.apiRegion) }/import?strict=1`, {
     method: 'post',
     json: events,
     headers: {
-      authorization: `Basic ${Buffer.from(`${settings.apiSecret}:`).toString('base64')}`
+      authorization: `Basic ${ Buffer.from(`${ settings.apiSecret }:`).toString('base64') }`
     }
   })
 }
@@ -121,6 +121,13 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.timestamp'
       }
+    },
+    $source: {
+      label: '$source',
+      type: 'string',
+      description:
+        '',
+      default: 'segment'
     },
     event_properties: {
       label: 'Event Properties',

--- a/packages/destination-actions/src/destinations/mixpanel/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackEvent/index.ts
@@ -122,13 +122,6 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.timestamp'
       }
     },
-    $source: {
-      label: '$source',
-      type: 'string',
-      description:
-        '',
-      default: 'segment'
-    },
     event_properties: {
       label: 'Event Properties',
       type: 'object',


### PR DESCRIPTION
This PR adds transformation of special traits including 'created', 'email', 'firstName', 'lastName', 'name', 'username', and 'phone' to Mixpanel reserved properties for compatibility with Mixpanel classic integration(https://segment.com/docs/connections/destinations/catalog/mixpanel/#group-using-device-mode). 

This PR also removed the misplaced `segment_source_name` property for the `$set` call. 

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
