### PR TITLE
[LinkedIn Audiences] Validate oauthed user's credentials and access.

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-audiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/__tests__/index.test.ts
@@ -6,8 +6,20 @@ const testDestination = createTestIntegration(Definition)
 
 describe('Linkedin Audiences', () => {
   describe('testAuthentication', () => {
-    it('should validate authentication inputs', async () => {
-      nock('https://api.linkedin.com/rest/adAccounts').get(/.*/).reply(200, {})
+    it('should not throw an error if all the appropriate credentials are available', async () => {
+      const mockProfileResponse = {
+        id: '123'
+      }
+
+      // Validate that the user exists in LinkedIn.
+      nock('https://api.linkedin.com/rest/me').get(/.*/).reply(200, mockProfileResponse)
+
+      const mockAdAccountResponse = {
+        role: 'ACCOUNT_BILLING_ADMIN'
+      }
+
+      // Validate that the user has permission to write to DMP Segments (audiences) in the LinkedIn Ad Account.
+      nock('https://api.linkedin.com/rest/adAccounts').get(/.*/).reply(200, mockAdAccountResponse)
 
       const authData = {
         ad_account_id: 'testId',
@@ -18,6 +30,102 @@ describe('Linkedin Audiences', () => {
       }
 
       await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
+    })
+
+    it('should throw an error if the user has not completed the oauth flow', async () => {
+      const authData = {
+        ad_account_id: 'testId'
+      }
+
+      await expect(testDestination.testAuthentication(authData)).rejects.toThrowError(
+        'Credentials are invalid:  Please authenticate via Oauth before updating other settings and/or enabling the destination.'
+      )
+    })
+
+    it('should throw an error if the oauth token is invalid', async () => {
+      nock('https://api.linkedin.com/rest/me').get(/.*/).reply(401)
+
+      const authData = {
+        ad_account_id: 'testId',
+        oauth: {
+          access_token: '123',
+          refresh_token: '123'
+        }
+      }
+
+      await expect(testDestination.testAuthentication(authData)).rejects.toThrowError(
+        'Credentials are invalid:  Invalid LinkedIn Oauth access token. Please reauthenticate to retrieve a valid access token before updating other settings and/or enabling the destination.'
+      )
+    })
+
+    it('should throw an error if an ad account in LinkedIn is not found', async () => {
+      const mockProfileResponse = {
+        id: '123'
+      }
+
+      nock('https://api.linkedin.com/rest/me').get(/.*/).reply(200, mockProfileResponse)
+      nock('https://api.linkedin.com/rest/adAccounts').get(/.*/).reply(404)
+
+      const authData = {
+        ad_account_id: 'testId',
+        oauth: {
+          access_token: '123',
+          refresh_token: '123'
+        }
+      }
+
+      await expect(testDestination.testAuthentication(authData)).rejects.toThrowError(
+        'Credentials are invalid:  Invalid LinkedIn Ad Account id. Please verify that the LinkedIn Ad Account exists and that you have access to it.'
+      )
+    })
+
+    it('should throw an error if the user does not have write permissions to the LinkedIn ad account', async () => {
+      const mockProfileResponse = {
+        id: '123'
+      }
+
+      // Validate that the user exists in LinkedIn.
+      nock('https://api.linkedin.com/rest/me').get(/.*/).reply(200, mockProfileResponse)
+
+      const mockAdAccountResponse = {
+        role: 'VIEWER'
+      }
+
+      nock('https://api.linkedin.com/rest/adAccounts').get(/.*/).reply(200, mockAdAccountResponse)
+
+      const authData = {
+        ad_account_id: 'testId',
+        oauth: {
+          access_token: '123',
+          refresh_token: '123'
+        }
+      }
+
+      await expect(testDestination.testAuthentication(authData)).rejects.toThrowError(
+        "Credentials are invalid:  It looks like you don't have access to this LinkedIn Ad Account. Please reach out to a LinkedIn Ad Account Admin on your team to grant access."
+      )
+    })
+
+    it('should throw the raw error from LinkedIn if the error is not handled elsewhere in the `testAuthentication` method', async () => {
+      const mockProfileResponse = {
+        id: '123'
+      }
+
+      nock('https://api.linkedin.com/rest/me').get(/.*/).reply(200, mockProfileResponse)
+
+      nock('https://api.linkedin.com/rest/adAccounts').get(/.*/).reply(500)
+
+      const authData = {
+        ad_account_id: 'testId',
+        oauth: {
+          access_token: '123',
+          refresh_token: '123'
+        }
+      }
+
+      await expect(testDestination.testAuthentication(authData)).rejects.toThrowError(
+        'Credentials are invalid: 500 Internal Server Error'
+      )
     })
   })
 })

--- a/packages/destination-actions/src/destinations/linkedin-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/index.ts
@@ -11,6 +11,14 @@ interface RefreshTokenResponse {
   token_type: string
 }
 
+interface ProfileAPIResponse {
+  id: string
+}
+
+interface AdAccountUserResponse {
+  role: string
+}
+
 const destination: DestinationDefinition<Settings> = {
   // We  need to match `name` with the creationName in the db.
   // The name used in the UI is "LinkedIn Audiences".
@@ -29,14 +37,58 @@ const destination: DestinationDefinition<Settings> = {
       }
     },
     testAuthentication: async (request, { settings, auth }) => {
-      return await request(`https://api.linkedin.com/rest/adAccounts/${settings.ad_account_id}`, {
-        method: 'GET',
-        headers: {
-          'X-Restli-Protocol-Version': '2.0.0',
-          'LinkedIn-Version': LINKEDIN_API_VERSION,
-          authorization: `Bearer ${auth?.accessToken}`
+      if (!auth?.accessToken) {
+        throw new Error('Please authenticate via Oauth before updating other settings and/or enabling the destination.')
+      }
+
+      let firstRes
+
+      try {
+        // GET the current user's id from LinkedIn's profile API: https://learn.microsoft.com/en-us/linkedin/shared/integrations/people/profile-api?context=linkedin%2Fcompliance%2Fcontext&view=li-lms-unversioned&preserve-view=true#request
+        // We request `r_basicprofile` scope when a user oauths into LinkedIn, so we retrieve the "Basic Profile Fields": https://learn.microsoft.com/en-us/linkedin/shared/references/v2/profile/basic-profile
+        firstRes = await request<ProfileAPIResponse>(`https://api.linkedin.com/rest/me`, {
+          method: 'GET'
+        })
+      } catch (e: any) {
+        if (e.message === 'Unauthorized') {
+          throw new Error(
+            'Invalid LinkedIn Oauth access token. Please reauthenticate to retrieve a valid access token before updating other settings and/or enabling the destination.'
+          )
         }
-      })
+        throw e
+      }
+
+      const userId = firstRes?.data?.id
+
+      let secondRes
+
+      try {
+        // GET the current user's permissions for this specific Ad Account: https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-account-users?view=li-lms-2022-09&tabs=http#get-ad-account-user
+        // If the user's role is VIEWER, then they won't have adequate permission to send batch updates to any DMP Segment audience in this LinkedIn account.
+        secondRes = await request<AdAccountUserResponse>(
+          `https://api.linkedin.com/rest/adAccountUsers/account=urn:li:sponsoredAccount:${settings.ad_account_id}&user=urn:li:person:${userId}`,
+          {
+            method: 'GET'
+          }
+        )
+      } catch (e: any) {
+        if (e.message === 'Not Found') {
+          throw new Error(
+            'Invalid LinkedIn Ad Account id. Please verify that the LinkedIn Ad Account exists and that you have access to it.'
+          )
+        }
+        throw e
+      }
+
+      const userRole = secondRes?.data.role
+
+      if (userRole === 'VIEWER') {
+        throw new Error(
+          "It looks like you don't have access to this LinkedIn Ad Account. Please reach out to a LinkedIn Ad Account Admin on your team to grant access."
+        )
+      }
+
+      return true
     },
     refreshAccessToken: async (request, { auth }) => {
       const res = await request<RefreshTokenResponse>('https://www.linkedin.com/oauth/v2/accessToken', {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

- This PR adds logic to programmatically test users' LinkedIn credentials and return a human-readable, actionable error in `app` when the credentials are not valid. "Not valid" here means that the user does not have WRITE permission to a valid LinkedIn audience.
- These enhancements are based on direct feedback from the LinkedIn team. Shipping these enhancements is prerequisites to LinkedIn approving Segment's release of this destination.
- Jira: https://segment.atlassian.net/browse/HGI-105

## Testing
- Testing completed successfully locally and in stage. See stage test results [here](https://paper.dropbox.com/doc/LinkedIn-Audiences-testAuthentication-Testing--BqnfoBvoRmlLnv32jRexWwAbAg-Lig1ub0yOjTY1iRLlmmw3).

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
