### PR TITLE
[STRATCONN-1329] 'content_category' left out of outgoing request in code for FBCAPI 

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/viewContent.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/viewContent.test.ts
@@ -79,7 +79,7 @@ describe('FacebookConversionsApi', () => {
       expect(responses[0].status).toBe(201)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"data\\":[{\\"event_name\\":\\"ViewContent\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"content_ids\\":[\\"ABC123\\",\\"XYZ789\\"],\\"content_name\\":\\"Oreo's Quadruple Stack\\",\\"content_type\\":\\"product\\",\\"contents\\":[{\\"id\\":\\"ABC123\\",\\"quantity\\":2},{\\"id\\":\\"XYZ789\\",\\"quantity\\":3}]}}]}"`
+        `"{\\"data\\":[{\\"event_name\\":\\"ViewContent\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"content_ids\\":[\\"ABC123\\",\\"XYZ789\\"],\\"content_name\\":\\"Oreo's Quadruple Stack\\",\\"content_type\\":\\"product\\",\\"contents\\":[{\\"id\\":\\"ABC123\\",\\"quantity\\":2},{\\"id\\":\\"XYZ789\\",\\"quantity\\":3}],\\"content_category\\":\\"Cookies\\"}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
@@ -117,7 +117,8 @@ const action: ActionDefinition<Settings, Payload> = {
                 content_ids: payload.content_ids,
                 content_name: payload.content_name,
                 content_type: payload.content_type,
-                contents: payload.contents
+                contents: payload.contents,
+                content_category: payload.content_category
               },
               data_processing_options: data_options,
               data_processing_options_country: country_code,


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_This PR adds `content_category` to the `viewContent` action._

More information: [JIRA TICKET](https://segment.atlassian.net/jira/software/c/projects/STRATCONN/boards/310?modal=detail&selectedIssue=STRATCONN-1689)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
