### PR TITLE
[STRATCONN-1686] Google Ads pre-beta fixes

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadCallConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadCallConversion.test.ts
@@ -22,11 +22,11 @@ describe('GoogleEnhancedConversions', () => {
 
       nock(`https://googleads.googleapis.com/v11/customers/${customerId}:uploadCallConversions`)
         .post('')
-        .reply(201, { partialFailureError: { code: 0, message: '' }, results: [{}] })
+        .reply(201, { results: [{}] })
 
       const responses = await testDestination.testAction('uploadCallConversion', {
         event,
-        mapping: { conversion_action: '12345', caller_id: '+1234567890' },
+        mapping: { conversion_action: '12345', caller_id: '+1234567890', call_timestamp: timestamp },
         useDefaultMappings: true,
         settings: {
           customerId
@@ -34,7 +34,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\"}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\"}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)
@@ -71,11 +71,16 @@ describe('GoogleEnhancedConversions', () => {
 
       nock(`https://googleads.googleapis.com/v11/customers/${customerId}:uploadCallConversions`)
         .post('')
-        .reply(201, { partialFailureError: { code: 0, message: '' }, results: [{}] })
+        .reply(201, { results: [{}] })
 
       const responses = await testDestination.testAction('uploadCallConversion', {
         event,
-        mapping: { conversion_action: '12345', caller_id: '+1234567890', custom_variables: { username: 'spongebob' } },
+        mapping: {
+          conversion_action: '12345',
+          caller_id: '+1234567890',
+          call_timestamp: timestamp,
+          custom_variables: { username: 'spongebob' }
+        },
         useDefaultMappings: true,
         settings: {
           customerId
@@ -83,7 +88,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[1].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(2)
@@ -104,12 +109,12 @@ describe('GoogleEnhancedConversions', () => {
 
       nock(`https://googleads.googleapis.com/v11/customers/${customerId}:uploadCallConversions`)
         .post('')
-        .reply(201, { partialFailureError: { code: 0, message: '' }, results: [{}] })
+        .reply(201, { results: [{}] })
 
       try {
         await testDestination.testAction('uploadCallConversion', {
           event,
-          mapping: { conversion_action: '12345', caller_id: '+1234567890' },
+          mapping: { conversion_action: '12345', caller_id: '+1234567890', call_timestamp: timestamp },
           useDefaultMappings: true,
           settings: {}
         })

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
@@ -30,7 +30,7 @@ describe('GoogleEnhancedConversions', () => {
 
       nock(`https://googleads.googleapis.com/v11/customers/${customerId}:uploadClickConversions`)
         .post('')
-        .reply(201, { partialFailureError: { code: 0, message: '' }, results: [{}] })
+        .reply(201, { results: [{}] })
 
       const responses = await testDestination.testAction('uploadClickConversion', {
         event,
@@ -72,7 +72,7 @@ describe('GoogleEnhancedConversions', () => {
 
       nock(`https://googleads.googleapis.com/v11/customers/${customerId}:uploadClickConversions`)
         .post('')
-        .reply(201, { partialFailureError: { code: 0, message: '' }, results: [{}] })
+        .reply(201, { results: [{}] })
 
       const responses = await testDestination.testAction('uploadClickConversion', {
         event,
@@ -128,7 +128,7 @@ describe('GoogleEnhancedConversions', () => {
 
       nock(`https://googleads.googleapis.com/v11/customers/${customerId}:uploadClickConversions`)
         .post('')
-        .reply(201, { partialFailureError: { code: 0, message: '' }, results: [{}] })
+        .reply(201, { results: [{}] })
 
       const responses = await testDestination.testAction('uploadClickConversion', {
         event,

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadConversionAdjustment.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadConversionAdjustment.test.ts
@@ -30,7 +30,7 @@ describe('GoogleEnhancedConversions', () => {
 
       nock(`https://googleads.googleapis.com/v11/customers/${customerId}:uploadConversionAdjustments`)
         .post('')
-        .reply(201, { partialFailureError: { code: 0, message: '' }, results: [{}] })
+        .reply(201, { results: [{}] })
 
       const responses = await testDestination.testAction('uploadConversionAdjustment', {
         event,
@@ -67,7 +67,7 @@ describe('GoogleEnhancedConversions', () => {
 
       nock(`https://googleads.googleapis.com/v11/customers/${customerId}:uploadConversionAdjustments`)
         .post('')
-        .reply(201, { partialFailureError: { code: 0, message: '' }, results: [{}] })
+        .reply(201, { results: [{}] })
 
       try {
         await testDestination.testAction('uploadConversionAdjustment', {
@@ -94,7 +94,7 @@ describe('GoogleEnhancedConversions', () => {
 
       nock(`https://googleads.googleapis.com/v11/customers/${customerId}:uploadConversionAdjustments`)
         .post('')
-        .reply(201, { partialFailureError: { code: 0, message: '' }, results: [{}] })
+        .reply(201, { results: [{}] })
 
       try {
         await testDestination.testAction('uploadConversionAdjustment', {
@@ -123,7 +123,7 @@ describe('GoogleEnhancedConversions', () => {
 
       nock(`https://googleads.googleapis.com/v11/customers/${customerId}:uploadConversionAdjustments`)
         .post('')
-        .reply(201, { partialFailureError: { code: 0, message: '' }, results: [{}] })
+        .reply(201, { results: [{}] })
 
       try {
         await testDestination.testAction('uploadConversionAdjustment', {
@@ -152,7 +152,7 @@ describe('GoogleEnhancedConversions', () => {
 
       nock(`https://googleads.googleapis.com/v11/customers/${customerId}:uploadConversionAdjustments`)
         .post('')
-        .reply(201, { partialFailureError: { code: 0, message: '' }, results: [{}] })
+        .reply(201, { results: [{}] })
 
       try {
         await testDestination.testAction('uploadConversionAdjustment', {
@@ -181,7 +181,7 @@ describe('GoogleEnhancedConversions', () => {
 
       nock(`https://googleads.googleapis.com/v11/customers/${customerId}:uploadConversionAdjustments`)
         .post('')
-        .reply(201, { partialFailureError: { code: 0, message: '' }, results: [{}] })
+        .reply(201, { results: [{}] })
 
       try {
         await testDestination.testAction('uploadConversionAdjustment', {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -59,7 +59,7 @@ export async function getCustomVariables(
    See here: https://developers.google.com/google-ads/api/docs/best-practices/partial-failures
  */
 export function handleGoogleErrors(response: ModifiedResponse<PartialErrorResponse>) {
-  if (response.data.partialFailureError.code !== 0) {
+  if (response.data.partialFailureError) {
     throw new IntegrationError(response.data.partialFailureError.message, 'INVALID_ARGUMENT', 400)
   }
 }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/generated-types.ts
@@ -4,7 +4,7 @@ export interface Payload {
   /**
    * The ID of the conversion action associated with this conversion. To find the Conversion Action ID, click on your conversion in Google Ads and get the value for `ctId` in the URL. For example, if the URL is `https://ads.google.com/aw/conversions/detail?ocid=00000000&ctId=570000000`, your Conversion Action ID is `570000000`.
    */
-  conversion_action: string
+  conversion_action: number
   /**
    * The caller ID from which this call was placed. Caller ID is expected to be in E.164 format with preceding + sign, e.g. "+16502531234".
    */
@@ -12,7 +12,7 @@ export interface Payload {
   /**
    * The date time at which the call occurred. The timezone must be specified. The format is "yyyy-mm-dd hh:mm:ss+|-hh:mm", e.g. "2019-01-01 12:32:45-08:00".
    */
-  call_timestamp?: string
+  call_timestamp: string
   /**
    * The date time at which the conversion occurred. Must be after the click time. The timezone must be specified. The format is "yyyy-mm-dd hh:mm:ss+|-hh:mm", e.g. "2019-01-01 12:32:45-08:00".
    */

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/index.ts
@@ -13,7 +13,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Conversion Action ID',
       description:
         'The ID of the conversion action associated with this conversion. To find the Conversion Action ID, click on your conversion in Google Ads and get the value for `ctId` in the URL. For example, if the URL is `https://ads.google.com/aw/conversions/detail?ocid=00000000&ctId=570000000`, your Conversion Action ID is `570000000`.',
-      type: 'string',
+      type: 'number',
       required: true
     },
     caller_id: {
@@ -27,7 +27,8 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Call Timestamp',
       description:
         'The date time at which the call occurred. The timezone must be specified. The format is "yyyy-mm-dd hh:mm:ss+|-hh:mm", e.g. "2019-01-01 12:32:45-08:00".',
-      type: 'string'
+      type: 'string',
+      required: true
     },
     conversion_timestamp: {
       label: 'Conversion Timestamp',
@@ -80,7 +81,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const request_object: { [key: string]: any } = {
       conversionAction: `customers/${settings.customerId}/conversionActions/${payload.conversion_action}`,
       callerId: payload.caller_id,
-      callStartDateTime: payload.call_timestamp?.replace(/T/, ' ').replace(/\..+/, '+00:00'),
+      callStartDateTime: payload.call_timestamp.replace(/T/, ' ').replace(/\..+/, '+00:00'),
       conversionDateTime: payload.conversion_timestamp.replace(/T/, ' ').replace(/\..+/, '+00:00'),
       conversionValue: payload.value,
       currencyCode: payload.currency

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/generated-types.ts
@@ -4,7 +4,7 @@ export interface Payload {
   /**
    * The ID of the conversion action associated with this conversion. To find the Conversion Action ID, click on your conversion in Google Ads and get the value for `ctId` in the URL. For example, if the URL is `https://ads.google.com/aw/conversions/detail?ocid=00000000&ctId=570000000`, your Conversion Action ID is `570000000`.
    */
-  conversion_action: string
+  conversion_action: number
   /**
    * The Google click ID (gclid) associated with this conversion.
    */

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -13,7 +13,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Conversion Action ID',
       description:
         'The ID of the conversion action associated with this conversion. To find the Conversion Action ID, click on your conversion in Google Ads and get the value for `ctId` in the URL. For example, if the URL is `https://ads.google.com/aw/conversions/detail?ocid=00000000&ctId=570000000`, your Conversion Action ID is `570000000`.',
-      type: 'string',
+      type: 'number',
       required: true
     },
     gclid: {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/generated-types.ts
@@ -4,7 +4,7 @@ export interface Payload {
   /**
    * The ID of the conversion action associated with this conversion. To find the Conversion Action ID, click on your conversion in Google Ads and get the value for `ctId` in the URL. For example, if the URL is `https://ads.google.com/aw/conversions/detail?ocid=00000000&ctId=570000000`, your Conversion Action ID is `570000000`.
    */
-  conversion_action: string
+  conversion_action: number
   /**
    * The adjustment type. See [Google’s documentation](https://developers.google.com/google-ads/api/reference/rpc/v11/ConversionAdjustmentTypeEnum.ConversionAdjustmentType) for details on each type.
    */

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
@@ -13,7 +13,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Conversion Action ID',
       description:
         'The ID of the conversion action associated with this conversion. To find the Conversion Action ID, click on your conversion in Google Ads and get the value for `ctId` in the URL. For example, if the URL is `https://ads.google.com/aw/conversions/detail?ocid=00000000&ctId=570000000`, your Conversion Action ID is `570000000`.',
-      type: 'string',
+      type: 'number',
       required: true
     },
     adjustment_type: {


### PR DESCRIPTION
This PR addresses [STRATCONN-1686](https://segment.atlassian.net/browse/STRATCONN-1686) to do some pre-beta fixes.

1. Make “Conversion Action” a number type for all 3 of the new actions
2. Make “Call Timestamp” required in the Upload Call Conversion action
3. Fix error handling to solve  `Cannot read property 'code' of undefined` error when an event is valid/successful. 
![Screen Shot 2022-10-11 at 3 18 14 PM](https://user-images.githubusercontent.com/99763167/195218925-536c1551-3554-467b-9280-88a099a42e1f.png)


## Testing

Successfully tested in staging to get actions to go through and errors still show up.

Conversion Adjustment:
![Screen Shot 2022-10-11 at 4 27 19 PM](https://user-images.githubusercontent.com/99763167/195218224-1326b8f7-6257-40a0-9184-a13d04b80b31.png)

Successful Conversion:
![Screen Shot 2022-10-11 at 4 34 32 PM](https://user-images.githubusercontent.com/99763167/195217872-cf5e8569-1849-4c1b-a8fa-4d277a514529.png)

Error Conversion:
![Screen Shot 2022-10-11 at 4 47 00 PM](https://user-images.githubusercontent.com/99763167/195218357-1f45bd40-01e0-46a5-bfd2-8086db73a98b.png)


_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
