### PR TITLE
Revert "google-sheets: Set insertDataOption=INSERT_ROWS (#808)"

### DIFF
--- a/packages/destination-actions/src/destinations/google-sheets/__tests__/__snapshots__/googleapis.snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/google-sheets/__tests__/__snapshots__/googleapis.snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Google Sheets Testing snapshots for googleapis library: append 1`] = `
 Array [
-  "https://sheets.googleapis.com/v4/spreadsheets/myId/values/myName!B:B:append?valueInputOption=myFormat,insertDataOption=INSERT_ROWS",
+  "https://sheets.googleapis.com/v4/spreadsheets/myId/values/myName!B:B:append?valueInputOption=myFormat",
   Object {
     "json": Object {
       "values": Array [

--- a/packages/destination-actions/src/destinations/google-sheets/googleapis/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/googleapis/index.ts
@@ -53,7 +53,7 @@ export class GoogleSheets {
 
   append = async (mappingSettings: MappingSettings, range: string, values: string[][]) => {
     return this.request(
-      `https://sheets.googleapis.com/${API_VERSION}/spreadsheets/${mappingSettings.spreadsheetId}/values/${mappingSettings.spreadsheetName}!${range}:append?valueInputOption=${mappingSettings.dataFormat},insertDataOption=INSERT_ROWS`,
+      `https://sheets.googleapis.com/${API_VERSION}/spreadsheets/${mappingSettings.spreadsheetId}/values/${mappingSettings.spreadsheetName}!${range}:append?valueInputOption=${mappingSettings.dataFormat}`,
       {
         method: 'post',
         json: {


### PR DESCRIPTION
This reverts commit 3204384c6d5b5f5c0d40115424df9a827a9693c2.

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
