### PR TITLE
Add support for new 'blank' field on @if directive

### DIFF
--- a/packages/core/src/mapping-kit/__tests__/index.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.test.ts
@@ -99,7 +99,7 @@ describe('@literal', () => {
   })
 })
 
-describe.only('@if', () => {
+describe('@if', () => {
   const payload = { a: 1, b: true, c: false, d: null, e: '' }
 
   test('exists', () => {

--- a/packages/core/src/mapping-kit/__tests__/index.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.test.ts
@@ -99,8 +99,8 @@ describe('@literal', () => {
   })
 })
 
-describe('@if', () => {
-  const payload = { a: 1, b: true, c: false, d: null }
+describe.only('@if', () => {
+  const payload = { a: 1, b: true, c: false, d: null, e: '' }
 
   test('exists', () => {
     let output = transform(
@@ -131,6 +131,68 @@ describe('@if', () => {
       {
         '@if': {
           exists: { '@path': '$.x' },
+          then: 1,
+          else: 2
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual(2)
+
+    output = transform(
+      {
+        '@if': {
+          exists: { '@path': '$.e' },
+          then: 1,
+          else: 2
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual(1)
+  })
+
+  test('blank', () => {
+    let output = transform(
+      {
+        '@if': {
+          blank: { '@path': '$.a' },
+          then: 1,
+          else: 2
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual(1)
+
+    output = transform(
+      {
+        '@if': {
+          blank: { '@path': '$.d' },
+          then: 1,
+          else: 2
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual(2)
+
+    output = transform(
+      {
+        '@if': {
+          blank: { '@path': '$.x' },
+          then: 1,
+          else: 2
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual(2)
+
+    output = transform(
+      {
+        '@if': {
+          blank: { '@path': '$.e' },
           then: 1,
           else: 2
         }

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -57,11 +57,14 @@ registerDirective('@if', (opts, payload) => {
     throw new Error('@if requires an object with an "exists" key')
   }
 
-  if (opts.exists !== undefined) {
+  if (!opts.exists && !opts.blank) {
+    throw new Error('@if requires an "exists" key or a "blank" key')
+  } else if (opts.exists !== undefined) {
     const value = resolve(opts.exists, payload)
     condition = value !== undefined && value !== null
-  } else {
-    throw new Error('@if requires an "exists" key')
+  } else if (opts.blank !== undefined) {
+    const value = resolve(opts.blank, payload)
+    condition = value !== undefined && value !== null && value != +''
   }
 
   if (condition && opts.then !== undefined) {

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -64,7 +64,7 @@ registerDirective('@if', (opts, payload) => {
     condition = value !== undefined && value !== null
   } else if (opts.blank !== undefined) {
     const value = resolve(opts.blank, payload)
-    condition = value !== undefined && value !== null && value != +''
+    condition = value !== undefined && value !== null && value != ''
   }
 
   if (condition && opts.then !== undefined) {


### PR DESCRIPTION
This PR addresses [JIRA ACT-200](https://segment.atlassian.net/browse/ACT-200)

In it we update the action version of `mapping-kit` to handle the `blank` field on the `@if` directive. This new field will bypass the first field in the `coalesce(field1, field2)` if it has a value of null, undefined, OR empty string `""`. 

Instead of changing the functionality of the `exists` field on the `@if` directive, we decided to add the new field `blank`. This will allow partners who depend on the current functionality of the `@if` directive to keep things working exactly as as-is, while also allowing for partners who want to bypass empty string field to do so. To implement this feature an update to the `coalesce` function in `app` will need to be made to allow partners to choose whether they want to allow or skip empty string values in the coalesce function.

Corresponding `app` PR: https://github.com/segmentio/app/pull/14462

## Testing

Added unit tests to mimic the behavior we will expect.

This new functionality will not be used until proper support is added in `app`. Testing will be done there.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
