### PR TITLE
update web destination builds to target window

### DIFF
--- a/packages/browser-destinations/webpack.config.js
+++ b/packages/browser-destinations/webpack.config.js
@@ -12,7 +12,7 @@ const entries = files.reduce((acc, current) => {
   const [_dot, _src, _destinations, destination, ..._rest] = current.split('/')
   return {
     ...acc,
-    [destination]: current,
+    [destination]: current
   }
 }, {})
 
@@ -40,12 +40,12 @@ const unobfuscatedOutput = {
   mode: process.env.NODE_ENV || 'development',
   devtool: 'source-map',
   output: {
-    filename: (file) => process.env.NODE_ENV === 'development' ? `${file.chunk.name}.js` : `${file.chunk.name}/[contenthash].js`,
+    filename: (file) =>
+      process.env.NODE_ENV === 'development' ? `${file.chunk.name}.js` : `${file.chunk.name}/[contenthash].js`,
     path: path.resolve(__dirname, 'dist/web'),
     publicPath: 'auto', // Needed for customers using custom CDNs with analytics.js
     library: '[name]Destination',
-    libraryTarget: 'umd',
-    umdNamedDefine: true,
+    libraryTarget: 'window',
     libraryExport: 'default'
   },
   module: {
@@ -111,15 +111,17 @@ const obfuscatedOutput = {
   ...unobfuscatedOutput,
   devServer: {
     ...unobfuscatedOutput.devServer,
-    port: 9001,
+    port: 9001
   },
   output: {
     ...unobfuscatedOutput.output,
-     filename: (file) => {
-       const obfuscatedOutputName = Buffer.from(file.chunk.name).toString('base64').replace(/=/g, '');
-       return process.env.NODE_ENV === 'development' ? `${obfuscatedOutputName}.js` : `${obfuscatedOutputName}/[contenthash].js`
-     },
+    filename: (file) => {
+      const obfuscatedOutputName = Buffer.from(file.chunk.name).toString('base64').replace(/=/g, '')
+      return process.env.NODE_ENV === 'development'
+        ? `${obfuscatedOutputName}.js`
+        : `${obfuscatedOutputName}/[contenthash].js`
+    }
   }
- }
+}
 
 module.exports = [unobfuscatedOutput, obfuscatedOutput]


### PR DESCRIPTION
This PR updates the web action destinations library target from `umd` to `window`.

## UMD vs Window

The `umd` target is meant for bundles that support cjs, amd (require), and script installation (window). The bundles we build for web destinations are only loaded via script tags, and analytics-next expects the destination to exist on the `window` object.

## Why make this change?

When targeting `umd`, the library fails to load if the website it is loaded on is using `amd`. This is because the umd loader logic will conditionally choose to use cjs/amd/global exports depending on what it detects is available.

Example of the umd loader:
```js
"object" == typeof exports && "object" == typeof module ? 
  module.exports = t() : "function" == typeof define && define.amd ?
    define("heapDestination", [], t) : "object" == typeof exports ? 
      exports.heapDestination = t() : window.heapDestination = t() 
```

Since these bundles are only recognized by analytics-next when attached to `window`, we don't actually need to support `umd`. When we eventually allow importing these destination packages directly we can support cjs/esm as separate builds so this change now doesn't make that work harder in the future.

## Testing

I tested this change using the action-tester and in stage with my own website that has requirejs loaded on it.

Before these changes, you can see that the bundles are loaded, but the 3rd party libraries are not (Braze and Heap in this case):
<img width="1508" alt="broken" src="https://user-images.githubusercontent.com/14189820/195956717-cdc75c40-9fe3-48bd-b008-88b5445e6222.png">

After these changes, 3rd party libraries are loading correctly and events are being sent (Braze and Heap):
<img width="1378" alt="works" src="https://user-images.githubusercontent.com/14189820/195956718-7cc29493-26ab-418c-96bb-8cf7d8851bb7.png">

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
