### PR TITLE
[STRATCONN-1698]  Google Ads uploadConversionAdjustment fixes

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadConversionAdjustment.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadConversionAdjustment.test.ts
@@ -37,7 +37,7 @@ describe('GoogleEnhancedConversions', () => {
         mapping: {
           gclid: '123a',
           conversion_action: '12345',
-          adjustment_type: 'UNSPECIFIED',
+          adjustment_type: 'ENHANCEMENT',
           conversion_timestamp: timestamp
         },
         useDefaultMappings: true,
@@ -47,7 +47,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversionAdjustments\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"UNSPECIFIED\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"123a\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"restatementValue\\":{},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"},{\\"addressInfo\\":{\\"hashedFirstName\\":\\"4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332\\",\\"hashedLastName\\":\\"fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7\\"}}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"}],\\"partialFailure\\":true}"`
+        `"{\\"conversionAdjustments\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"ENHANCEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"123a\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"},{\\"addressInfo\\":{\\"hashedFirstName\\":\\"4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332\\",\\"hashedLastName\\":\\"fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7\\"}}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)
@@ -72,7 +72,7 @@ describe('GoogleEnhancedConversions', () => {
       try {
         await testDestination.testAction('uploadConversionAdjustment', {
           event,
-          mapping: { gclid: '123a', conversion_action: '12345', adjustment_type: 'UNSPECIFIED' },
+          mapping: { gclid: '123a', conversion_action: '12345', adjustment_type: 'ENHANCEMENT' },
           useDefaultMappings: true,
           settings: {}
         })
@@ -82,7 +82,7 @@ describe('GoogleEnhancedConversions', () => {
       }
     })
 
-    it('fails if conversion_type is enhancement and orderid not set', async () => {
+    it('sends restatement_value for restatements', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -96,111 +96,26 @@ describe('GoogleEnhancedConversions', () => {
         .post('')
         .reply(201, { results: [{}] })
 
-      try {
-        await testDestination.testAction('uploadConversionAdjustment', {
-          event,
-          mapping: { gclid: '123a', conversion_action: '12345', adjustment_type: 'ENHANCEMENT' },
-          useDefaultMappings: true,
-          settings: {
-            customerId
-          }
-        })
-        fail('the test should have thrown an error')
-      } catch (e) {
-        expect(e.message).toBe('Order ID required for enhancements')
-      }
-    })
-
-    it('fails if conversion_type is not enhancement and gclid not set', async () => {
-      const event = createTestEvent({
-        timestamp,
-        event: 'Test Event',
-        properties: {
-          email: 'test@gmail.com',
-          phone: '1234567890'
+      const responses = await testDestination.testAction('uploadConversionAdjustment', {
+        event,
+        mapping: {
+          gclid: '123a',
+          conversion_action: '12345',
+          adjustment_type: 'RESTATEMENT',
+          conversion_timestamp: timestamp
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
         }
       })
 
-      nock(`https://googleads.googleapis.com/v11/customers/${customerId}:uploadConversionAdjustments`)
-        .post('')
-        .reply(201, { results: [{}] })
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversionAdjustments\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"RESTATEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"123a\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{}}],\\"partialFailure\\":true}"`
+      )
 
-      try {
-        await testDestination.testAction('uploadConversionAdjustment', {
-          event,
-          mapping: { conversion_action: '12345', adjustment_type: 'UNKNOWN' },
-          useDefaultMappings: true,
-          settings: {
-            customerId
-          }
-        })
-        fail('the test should have thrown an error')
-      } catch (e) {
-        expect(e.message).toBe('GCLID and conversion timestamp required for chosen conversion type')
-      }
-    })
-
-    it('fails if conversion_type is not enhancement and conversion_timestamp not set', async () => {
-      const event = createTestEvent({
-        timestamp,
-        event: 'Test Event',
-        properties: {
-          email: 'test@gmail.com',
-          phone: '1234567890'
-        }
-      })
-
-      nock(`https://googleads.googleapis.com/v11/customers/${customerId}:uploadConversionAdjustments`)
-        .post('')
-        .reply(201, { results: [{}] })
-
-      try {
-        await testDestination.testAction('uploadConversionAdjustment', {
-          event,
-          mapping: { gclid: '123a', conversion_action: '12345', adjustment_type: 'RETRACTION' },
-          useDefaultMappings: true,
-          settings: {
-            customerId
-          }
-        })
-        fail('the test should have thrown an error')
-      } catch (e) {
-        expect(e.message).toBe('GCLID and conversion timestamp required for chosen conversion type')
-      }
-    })
-
-    it('fails if conversion_type is not restatement and restatement_value not set', async () => {
-      const event = createTestEvent({
-        timestamp,
-        event: 'Test Event',
-        properties: {
-          email: 'test@gmail.com',
-          phone: '1234567890'
-        }
-      })
-
-      nock(`https://googleads.googleapis.com/v11/customers/${customerId}:uploadConversionAdjustments`)
-        .post('')
-        .reply(201, { results: [{}] })
-
-      try {
-        await testDestination.testAction('uploadConversionAdjustment', {
-          event,
-          mapping: {
-            gclid: '123a',
-            conversion_action: '12345',
-            adjustment_type: 'RESTATEMENT',
-            conversion_timestamp: timestamp
-          },
-          useDefaultMappings: true,
-          settings: {
-            customerId
-          }
-        })
-        fail('the test should have thrown an error')
-      } catch (e) {
-        expect(e.message).toBe('Restatement value required for restatements')
-      }
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
     })
   })
 })

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -63,3 +63,10 @@ export function handleGoogleErrors(response: ModifiedResponse<PartialErrorRespon
     throw new IntegrationError(response.data.partialFailureError.message, 'INVALID_ARGUMENT', 400)
   }
 }
+
+export function convertTimestamp(timestamp: string | undefined): string | undefined {
+  if (!timestamp) {
+    return undefined
+  }
+  return timestamp.replace(/T/, ' ').replace(/\..+/, '+00:00')
+}

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/index.ts
@@ -1,7 +1,7 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { formatCustomVariables, getCustomVariables, handleGoogleErrors } from '../functions'
+import { convertTimestamp, formatCustomVariables, getCustomVariables, handleGoogleErrors } from '../functions'
 import { GoogleAdsAPI, PartialErrorResponse } from '../types'
 import { ModifiedResponse } from '@segment/actions-core'
 
@@ -81,8 +81,8 @@ const action: ActionDefinition<Settings, Payload> = {
     const request_object: { [key: string]: any } = {
       conversionAction: `customers/${settings.customerId}/conversionActions/${payload.conversion_action}`,
       callerId: payload.caller_id,
-      callStartDateTime: payload.call_timestamp.replace(/T/, ' ').replace(/\..+/, '+00:00'),
-      conversionDateTime: payload.conversion_timestamp.replace(/T/, ' ').replace(/\..+/, '+00:00'),
+      callStartDateTime: convertTimestamp(payload.call_timestamp),
+      conversionDateTime: convertTimestamp(payload.conversion_timestamp),
       conversionValue: payload.value,
       currencyCode: payload.currency
     }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -2,7 +2,7 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { CartItem, GoogleAdsAPI, PartialErrorResponse } from '../types'
-import { formatCustomVariables, hash, getCustomVariables, handleGoogleErrors } from '../functions'
+import { formatCustomVariables, hash, getCustomVariables, handleGoogleErrors, convertTimestamp } from '../functions'
 import { ModifiedResponse } from '@segment/actions-core'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -203,7 +203,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const request_object: { [key: string]: any } = {
       conversionAction: `customers/${settings.customerId}/conversionActions/${payload.conversion_action}`,
-      conversionDateTime: payload.conversion_timestamp.replace(/T/, ' ').replace(/\..+/, '+00:00'),
+      conversionDateTime: convertTimestamp(payload.conversion_timestamp),
       gclid: payload.gclid,
       gbraid: payload.gbraid,
       wbraid: payload.wbraid,


### PR DESCRIPTION
This PR addresses [STRATCONN-1698](https://segment.atlassian.net/browse/STRATCONN-1698)  to make some small changes to the `uploadConversionAdjustment` action. 
1. Remove the validations we had in place so we can just fall back on Google to return errors if variables are missing.
2. Remove the `UNKNOWN` and `UNSPECIFIED` options that we had for conversion adjustments. 
3. Only send `restatment_value` with RESTATEMENTS. 

This PR also moved the timestamp formatting into a function to help DRY the code a bit more.

## Testing
STAGE Results
Google error shown when parameters are missing.
![Screen Shot 2022-10-18 at 12 30 33 PM](https://user-images.githubusercontent.com/99763167/196526130-513d32a6-1e1f-44a0-bedd-4072c99ec020.png)

UNKNOWN and UNSPECIFIED no longer options
![Screen Shot 2022-10-18 at 12 26 59 PM](https://user-images.githubusercontent.com/99763167/196525519-3a5fa26a-8236-4689-a1dc-2ce0ac3c30b7.png)

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
