### PR TITLE
Mapping Mixpanel '$ip' for 'identifyUser'

### DIFF
--- a/packages/destination-actions/src/destinations/mixpanel/identifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/identifyUser/__tests__/index.test.ts
@@ -57,6 +57,7 @@ describe('Mixpanel.identifyUser', () => {
         data: JSON.stringify({
           $token: MIXPANEL_PROJECT_TOKEN,
           $distinct_id: 'user1234',
+          $ip: '8.8.8.8',
           $set: {
             abc: '123',
             $created: '2022-10-12T00:00:00.000Z',
@@ -109,6 +110,7 @@ describe('Mixpanel.identifyUser', () => {
         data: JSON.stringify({
           $token: MIXPANEL_PROJECT_TOKEN,
           $distinct_id: 'user1234',
+          $ip: '8.8.8.8',
           $set: {
             abc: '123'
           }
@@ -153,6 +155,7 @@ describe('Mixpanel.identifyUser', () => {
         data: JSON.stringify({
           $token: MIXPANEL_PROJECT_TOKEN,
           $distinct_id: 'user1234',
+          $ip: '8.8.8.8',
           $set: {
             abc: '123'
           }
@@ -199,6 +202,7 @@ describe('Mixpanel.identifyUser', () => {
         data: JSON.stringify({
           $token: MIXPANEL_PROJECT_TOKEN,
           $distinct_id: 'user1234',
+          $ip: '8.8.8.8',
           $set: {
             abc: '123'
           }

--- a/packages/destination-actions/src/destinations/mixpanel/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/identifyUser/generated-types.ts
@@ -2,6 +2,10 @@
 
 export interface Payload {
   /**
+   * The IP address of the user. This is only used for geolocation and won't be stored.
+   */
+  ip?: string
+  /**
    * The unique user identifier set by you
    */
   user_id?: string | null

--- a/packages/destination-actions/src/destinations/mixpanel/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/identifyUser/index.ts
@@ -10,6 +10,14 @@ const action: ActionDefinition<Settings, Payload> = {
     'Set the user ID for a particular device ID or update user properties. Learn more about [User Profiles](https://help.mixpanel.com/hc/en-us/articles/115004501966?source=segment-actions) and [Identity Management](https://help.mixpanel.com/hc/en-us/articles/360041039771-Getting-Started-with-Identity-Management?source=segment-actions).',
   defaultSubscription: 'type = "identify"',
   fields: {
+    ip: {
+      label: 'IP Address',
+      type: 'string',
+      description: "The IP address of the user. This is only used for geolocation and won't be stored.",
+      default: {
+        '@path': '$.context.ip'
+      }
+    },
     user_id: {
       label: 'User ID',
       type: 'string',
@@ -79,6 +87,7 @@ const action: ActionDefinition<Settings, Payload> = {
       const data = {
         $token: settings.projectToken,
         $distinct_id: payload.user_id,
+        $ip: payload.ip,
         $set: traits
       }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->


For `identifyUser` call, we need to explicitly map `$ip` from `context.ip` to get the correct geo location for each user,   otherwise, it will be resolved as `Boardman, Oregon`.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
