### PR TITLE
Changing error type as IntegrationError to avoid unnecessary sentry alarm

### DIFF
--- a/packages/destination-actions/src/destinations/sendgrid/sendgrid-properties.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/sendgrid-properties.ts
@@ -1,4 +1,4 @@
-import { InputField, RequestClient } from '@segment/actions-core'
+import { InputField, RequestClient, IntegrationError } from '@segment/actions-core'
 import { Payload } from './updateUserProfile/generated-types'
 
 export const customFields: InputField = {
@@ -62,8 +62,10 @@ const convertCustomFieldNamesToIds = (customFields: any, accountCustomFields: Cu
       )[0]
       actualKey = matchingCustomField.id
     } else {
-      throw new Error(
-        `Unknown custom field '${key}'. To see your defined custom fields, visit https://mc.sendgrid.com/custom-fields`
+      throw new IntegrationError(
+        `Unknown custom field '${key}'. To see your defined custom fields, visit https://mc.sendgrid.com/custom-fields`,
+        'Invalid value',
+        400
       )
     }
     result[actualKey] = customFields[key]


### PR DESCRIPTION

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Changing expected integration error  as IntegrationError to avoid unnecessary sentry alarm


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
