### PR TITLE
LIBWEB-1233 Braze - allow deferring initialization

### DIFF
--- a/packages/browser-destinations/src/destinations/braze/__tests__/initialization.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/initialization.test.ts
@@ -1,4 +1,5 @@
 import { Analytics, Context } from '@segment/analytics-next'
+import { Subscription } from 'src/lib/browser-destinations'
 import brazeDestination, { destination } from '../index'
 
 describe('initialization', () => {
@@ -76,5 +77,60 @@ describe('initialization', () => {
         </script>,
       ]
     `)
+  })
+
+  test('can defer braze initialization when deferUntilIdentified is on', async () => {
+    const [updateUserProfile, trackEvent] = await brazeDestination({
+      api_key: 'b_123',
+      deferUntilIdentified: true,
+      subscriptions: destination.presets?.map((sub) => ({ ...sub, enabled: true })) as Subscription[],
+      ...settings
+    })
+
+    jest.spyOn(destination.actions.trackEvent, 'perform')
+    const initializeSpy = jest.spyOn(destination, 'initialize')
+
+    const analytics = new Analytics({ writeKey: '123' })
+
+    await analytics.register(updateUserProfile, trackEvent)
+
+    // Spy on the braze APIs now that braze has been loaded.
+    const { instance: braze } = await initializeSpy.mock.results[0].value
+    const logCustomEventSpy = jest.spyOn(braze, 'logCustomEvent')
+
+    await analytics.track?.({
+      type: 'track',
+      event: 'UFC',
+      properties: {
+        goat: 'hasbulla'
+      }
+    })
+
+    expect(destination.actions.trackEvent.perform).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instance: expect.objectContaining({
+          logCustomEvent: expect.any(Function)
+        })
+      }),
+
+      expect.objectContaining({
+        payload: { eventName: 'UFC', eventProperties: { goat: 'hasbulla' } }
+      })
+    )
+
+    expect(analytics.user().id()).toBe(null)
+    expect(logCustomEventSpy).not.toHaveBeenCalled()
+
+    await analytics.identify('27413')
+
+    await analytics.track?.({
+      type: 'track',
+      event: 'FIFA',
+      properties: {
+        goat: 'deno'
+      }
+    })
+
+    expect(logCustomEventSpy).toHaveBeenCalledWith('FIFA', { goat: 'deno' })
   })
 })

--- a/packages/browser-destinations/src/destinations/braze/__tests__/initialization.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/initialization.test.ts
@@ -96,6 +96,7 @@ describe('initialization', () => {
 
     // Spy on the braze APIs now that braze has been loaded.
     const { instance: braze } = await initializeSpy.mock.results[0].value
+    const openSessionSpy = jest.spyOn(braze, 'openSession')
     const logCustomEventSpy = jest.spyOn(braze, 'logCustomEvent')
 
     await analytics.track?.({
@@ -119,6 +120,7 @@ describe('initialization', () => {
     )
 
     expect(analytics.user().id()).toBe(null)
+    expect(openSessionSpy).not.toHaveBeenCalled()
     expect(logCustomEventSpy).not.toHaveBeenCalled()
 
     await analytics.identify('27413')
@@ -131,6 +133,7 @@ describe('initialization', () => {
       }
     })
 
+    expect(openSessionSpy).toHaveBeenCalled()
     expect(logCustomEventSpy).toHaveBeenCalledWith('FIFA', { goat: 'deno' })
   })
 })

--- a/packages/browser-destinations/src/destinations/braze/__tests__/trackEvent.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/trackEvent.test.ts
@@ -31,10 +31,10 @@ testSdkVersions.forEach((sdkVersion) => {
       jest.spyOn(destination.actions.trackEvent, 'perform')
       const initializeSpy = jest.spyOn(destination, 'initialize')
 
-      await trackEvent.load(Context.system(), {} as Analytics)
+      await trackEvent.load(Context.system(), new Analytics({ writeKey: '123' }))
 
       // Spy on the braze APIs now that braze has been loaded.
-      const braze = await initializeSpy.mock.results[0].value
+      const { instance: braze } = await initializeSpy.mock.results[0].value
       const logCustomEventSpy = jest.spyOn(braze, 'logCustomEvent')
 
       await trackEvent.track?.(
@@ -49,7 +49,9 @@ testSdkVersions.forEach((sdkVersion) => {
 
       expect(destination.actions.trackEvent.perform).toHaveBeenCalledWith(
         expect.objectContaining({
-          logCustomEvent: expect.any(Function)
+          instance: expect.objectContaining({
+            logCustomEvent: expect.any(Function)
+          })
         }),
 
         expect.objectContaining({

--- a/packages/browser-destinations/src/destinations/braze/__tests__/trackPurchase.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/trackPurchase.test.ts
@@ -30,10 +30,10 @@ testSdkVersions.forEach((sdkVersion) => {
       ]
     })
 
-    await trackPurchase.load(Context.system(), {} as Analytics)
+    await trackPurchase.load(Context.system(), new Analytics({ writeKey: '123' }))
 
     // Spy on the braze APIs now that braze has been loaded.
-    const braze = await initializeSpy.mock.results[0].value
+    const { instance: braze } = await initializeSpy.mock.results[0].value
     const brazeLogPurchase = jest.spyOn(braze, 'logPurchase').mockReturnValue(true)
 
     await trackPurchase.track?.(

--- a/packages/browser-destinations/src/destinations/braze/__tests__/updateUserProfile.test.ts
+++ b/packages/browser-destinations/src/destinations/braze/__tests__/updateUserProfile.test.ts
@@ -54,7 +54,7 @@ describe('updateUserProfile', () => {
       ]
     })
 
-    await event.load(Context.system(), {} as Analytics)
+    await event.load(Context.system(), new Analytics({ writeKey: '123' }))
     await event.identify?.(
       new Context({
         type: 'identify',
@@ -66,7 +66,9 @@ describe('updateUserProfile', () => {
 
     expect(destination.actions.updateUserProfile.perform).toHaveBeenCalledWith(
       expect.objectContaining({
-        changeUser: expect.any(Function)
+        instance: expect.objectContaining({
+          changeUser: expect.any(Function)
+        })
       }),
 
       expect.objectContaining({
@@ -115,7 +117,9 @@ describe('updateUserProfile', () => {
 
     expect(destination.actions.updateUserProfile.perform).toHaveBeenCalledWith(
       expect.objectContaining({
-        changeUser: expect.any(Function)
+        instance: expect.objectContaining({
+          changeUser: expect.any(Function)
+        })
       }),
 
       expect.objectContaining({

--- a/packages/browser-destinations/src/destinations/braze/braze-types.ts
+++ b/packages/browser-destinations/src/destinations/braze/braze-types.ts
@@ -5,6 +5,5 @@ export type BrazeType = typeof braze | typeof appboy
 
 export type BrazeDestinationClient = {
   instance: BrazeType
-  initialized: boolean
-  initialize: () => void
+  ready: () => boolean
 }

--- a/packages/browser-destinations/src/destinations/braze/braze-types.ts
+++ b/packages/browser-destinations/src/destinations/braze/braze-types.ts
@@ -2,3 +2,9 @@ import type braze from '@braze/web-sdk'
 import type appboy from '@braze/web-sdk-v3'
 
 export type BrazeType = typeof braze | typeof appboy
+
+export type BrazeDestinationClient = {
+  instance: BrazeType
+  initialized: boolean
+  initialize: () => void
+}

--- a/packages/browser-destinations/src/destinations/braze/debounce/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/debounce/index.ts
@@ -1,4 +1,4 @@
-import { BrazeType } from '../braze-types'
+import { BrazeDestinationClient } from '../braze-types'
 import type { ID, SegmentEvent, User } from '@segment/analytics-next'
 import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
 import type { Settings } from '../generated-types'
@@ -37,7 +37,7 @@ function shouldSendToBraze(event: SegmentEvent) {
   return JSON.stringify(cachedUser.traits) !== JSON.stringify(traits)
 }
 
-const action: BrowserActionDefinition<Settings, BrazeType, Payload> = {
+const action: BrowserActionDefinition<Settings, BrazeDestinationClient, Payload> = {
   title: 'Debounce Middleware',
   description:
     'When enabled, it ensures that only events where at least one changed trait value are sent to Braze, and events with duplicate traits are not sent.',

--- a/packages/browser-destinations/src/destinations/braze/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/braze/generated-types.ts
@@ -22,6 +22,10 @@ export interface Settings {
    */
   allowUserSuppliedJavascript?: boolean
   /**
+   * If enabled, this setting delays initialization of the Braze SDK until the user has been identified. When enabled, events for anonymous users will no longer be sent to Braze.
+   */
+  deferUntilIdentified?: boolean
+  /**
    * Version to which user events sent to Braze will be associated with. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)
    */
   appVersion?: string

--- a/packages/browser-destinations/src/destinations/braze/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/index.ts
@@ -8,7 +8,7 @@ import updateUserProfile from './updateUserProfile'
 import trackPurchase from './trackPurchase'
 import debounce, { resetUserCache } from './debounce'
 import { defaultValues, DestinationDefinition } from '@segment/actions-core'
-import { BrazeType } from './braze-types'
+import { BrazeDestinationClient } from './braze-types'
 
 declare global {
   interface Window {
@@ -49,7 +49,7 @@ const presets: DestinationDefinition['presets'] = [
   }
 ]
 
-export const destination: BrowserDestinationDefinition<Settings, BrazeType> = {
+export const destination: BrowserDestinationDefinition<Settings, BrazeDestinationClient> = {
   name: 'Braze Web Mode (Actions)',
   slug: 'actions-braze-web',
   mode: 'device',
@@ -117,6 +117,14 @@ export const destination: BrowserDestinationDefinition<Settings, BrazeType> = {
       description:
         'To indicate that you trust the Braze dashboard users to write non-malicious Javascript click actions, set this property to true. If enableHtmlInAppMessages is true, this option will also be set to true. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)',
       label: 'Allow User Supplied Javascript',
+      default: false,
+      type: 'boolean',
+      required: false
+    },
+    deferUntilIdentified: {
+      description:
+        'If enabled, this setting delays initialization of the Braze SDK until the user has been identified. When enabled, events for anonymous users will no longer be sent to Braze.',
+      label: 'Only Track Known Users',
       default: false,
       type: 'boolean',
       required: false
@@ -266,7 +274,7 @@ export const destination: BrowserDestinationDefinition<Settings, BrazeType> = {
         'By default, sessions time out after 30 minutes of inactivity. Provide a value for this configuration option to override that default with a value of your own.'
     }
   },
-  initialize: async ({ settings }, dependencies) => {
+  initialize: async ({ settings, analytics }, dependencies) => {
     try {
       const {
         endpoint,
@@ -277,6 +285,7 @@ export const destination: BrowserDestinationDefinition<Settings, BrazeType> = {
         versionSettings,
         // @ts-expect-error same as above.
         subscriptions,
+        deferUntilIdentified,
         ...expectedConfig
       } = settings
 
@@ -290,28 +299,40 @@ export const destination: BrowserDestinationDefinition<Settings, BrazeType> = {
         await dependencies.loadScript(`https://js.appboycdn.com/web-sdk/${version}/braze.no-module.min.js`)
       }
 
-      const brazeObject: BrazeType = version.indexOf('3.') === 0 ? window.appboy : window.braze
+      const shouldInit = !deferUntilIdentified || (deferUntilIdentified && typeof analytics.user().id() === 'string')
 
-      brazeObject.initialize(api_key, {
-        baseUrl: window.BRAZE_BASE_URL || endpoint,
-        ...expectedConfig
-      })
+      const client: BrazeDestinationClient = {
+        instance: version.indexOf('3.') === 0 ? window.appboy : window.braze,
+        initialized: shouldInit,
+        initialize: () => {
+          client.instance.initialize(api_key, {
+            baseUrl: window.BRAZE_BASE_URL || endpoint,
+            ...expectedConfig
+          })
 
-      if (brazeObject.addSdkMetadata) {
-        brazeObject.addSdkMetadata([brazeObject.BrazeSdkMetadata.SEGMENT])
-      }
+          if (typeof client.instance.addSdkMetadata === 'function') {
+            client.instance.addSdkMetadata([client.instance.BrazeSdkMetadata.SEGMENT])
+          }
 
-      if (automaticallyDisplayMessages) {
-        if ('display' in brazeObject) {
-          brazeObject.display.automaticallyShowNewInAppMessages()
-        } else {
-          brazeObject.automaticallyShowInAppMessages()
+          if (automaticallyDisplayMessages) {
+            if ('display' in client.instance) {
+              client.instance.display.automaticallyShowNewInAppMessages()
+            } else {
+              client.instance.automaticallyShowInAppMessages()
+            }
+          }
+
+          client.instance.openSession()
+
+          client.initialized = true
         }
       }
 
-      brazeObject.openSession()
+      if (shouldInit) {
+        client.initialize()
+      }
 
-      return brazeObject
+      return client
     } catch (e) {
       throw new Error(`Failed to initialize Braze ${e}`)
     }

--- a/packages/browser-destinations/src/destinations/braze/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/trackEvent/index.ts
@@ -1,9 +1,9 @@
 import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { BrazeType } from '../braze-types'
+import { BrazeDestinationClient } from '../braze-types'
 
-const action: BrowserActionDefinition<Settings, BrazeType, Payload> = {
+const action: BrowserActionDefinition<Settings, BrazeDestinationClient, Payload> = {
   title: 'Track Event',
   description: 'Reports that the current user performed a custom named event.',
   defaultSubscription: 'type = "track" and event != "Order Completed"',
@@ -29,7 +29,7 @@ const action: BrowserActionDefinition<Settings, BrazeType, Payload> = {
     }
   },
   perform: (client, event) => {
-    client.logCustomEvent(event.payload.eventName, event.payload.eventProperties)
+    client.initialized && client.instance.logCustomEvent(event.payload.eventName, event.payload.eventProperties)
   }
 }
 

--- a/packages/browser-destinations/src/destinations/braze/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/trackEvent/index.ts
@@ -29,7 +29,11 @@ const action: BrowserActionDefinition<Settings, BrazeDestinationClient, Payload>
     }
   },
   perform: (client, event) => {
-    client.initialized && client.instance.logCustomEvent(event.payload.eventName, event.payload.eventProperties)
+    if (!client.ready()) {
+      return
+    }
+
+    client.instance.logCustomEvent(event.payload.eventName, event.payload.eventProperties)
   }
 }
 

--- a/packages/browser-destinations/src/destinations/braze/trackPurchase/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/trackPurchase/index.ts
@@ -1,10 +1,10 @@
-import { BrazeType } from '../braze-types'
+import { BrazeDestinationClient } from '../braze-types'
 import { omit } from '@segment/actions-core'
 import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
-const action: BrowserActionDefinition<Settings, BrazeType, Payload> = {
+const action: BrowserActionDefinition<Settings, BrazeDestinationClient, Payload> = {
   title: 'Track Purchase',
   defaultSubscription: 'type = "track" and event = "Order Completed"',
   description: 'Reports that the current user made an in-app purchase.',
@@ -53,6 +53,10 @@ const action: BrowserActionDefinition<Settings, BrazeType, Payload> = {
     }
   },
   perform: (client, data) => {
+    if (!client.initialized) {
+      return
+    }
+
     const payload = data.payload
 
     const reservedKeys = Object.keys(action.fields.products.properties ?? {})
@@ -60,7 +64,7 @@ const action: BrowserActionDefinition<Settings, BrazeType, Payload> = {
 
     if (purchaseProperties?.products && Array.isArray(purchaseProperties?.products)) {
       purchaseProperties?.products?.forEach((product) => {
-        const result = client.logPurchase(
+        const result = client.instance.logPurchase(
           (product.product_id as string | number).toString(),
           product.price,
           product.currency ?? 'USD',

--- a/packages/browser-destinations/src/destinations/braze/trackPurchase/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/trackPurchase/index.ts
@@ -53,7 +53,7 @@ const action: BrowserActionDefinition<Settings, BrazeDestinationClient, Payload>
     }
   },
   perform: (client, data) => {
-    if (!client.initialized) {
+    if (!client.ready()) {
       return
     }
 

--- a/packages/browser-destinations/src/destinations/braze/updateUserProfile/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/updateUserProfile/index.ts
@@ -149,9 +149,8 @@ const action: BrowserActionDefinition<Settings, BrazeDestinationClient, Payload>
   },
 
   perform: (client, { payload }) => {
-    // client is initialized here when tracking unidentifed user has been disabled
-    if (!client.initialized) {
-      client.initialize()
+    if (!client.ready()) {
+      return
     }
 
     // TODO - addAlias / addToCustomAttributeArray?

--- a/packages/browser-destinations/src/destinations/braze/updateUserProfile/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/updateUserProfile/index.ts
@@ -3,9 +3,9 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import * as braze from '@braze/web-sdk'
 import dayjs from '../../../lib/dayjs'
-import { BrazeType } from '../braze-types'
+import { BrazeDestinationClient } from '../braze-types'
 
-const action: BrowserActionDefinition<Settings, BrazeType, Payload> = {
+const action: BrowserActionDefinition<Settings, BrazeDestinationClient, Payload> = {
   title: 'Update User Profile',
   description: 'Updates a users profile attributes in Braze',
   defaultSubscription: 'type = "identify" or type = "group"',
@@ -149,12 +149,17 @@ const action: BrowserActionDefinition<Settings, BrazeType, Payload> = {
   },
 
   perform: (client, { payload }) => {
-    // TODO - addAlias / addToCustomAttributeArray?
-    if (payload.external_id !== undefined) {
-      client.changeUser(payload.external_id)
+    // client is initialized here when tracking unidentifed user has been disabled
+    if (!client.initialized) {
+      client.initialize()
     }
 
-    const user = client.getUser()
+    // TODO - addAlias / addToCustomAttributeArray?
+    if (payload.external_id !== undefined) {
+      client.instance.changeUser(payload.external_id)
+    }
+
+    const user = client.instance.getUser()
     if (!user) return
 
     payload.country !== undefined && user.setCountry(payload.country)

--- a/packages/destination-actions/src/destinations/twilio/sendSMS.types.ts
+++ b/packages/destination-actions/src/destinations/twilio/sendSMS.types.ts
@@ -1,0 +1,12 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The Phone Number to send a SMS to
+   */
+  To: string
+  /**
+   * The message body
+   */
+  Body: string
+}


### PR DESCRIPTION
This patch adds a new setting for Braze web mode destination, `deferUntilIndentified` which defers calling Braze SDK's `initialize`. This is useful when customers want to save their Braze MAU's.

Testing method:

- Used the Actions tester to start a dev server that compiles and servers a chosen device mode destination (Braze in this case)
- Transplanted the URL at which braze was being served by action tester into the load-script file in analytics-next repo
- Analytics-next was now consuming the local dev build of braze instead of the remotely hosted version
- Tested against `analytics-next/examples/standalone-playground/index-local` to make sure the setting was behaving as expected