### PR TITLE
Fixed upsertCompany and upsertCustomObjectRecord

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/upsertCompany/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCompany/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -5,7 +5,6 @@ Object {
   "properties": Object {
     "address": "F9hZOtvgHY(T6dF5vS7",
     "city": "F9hZOtvgHY(T6dF5vS7",
-    "createdate": "F9hZOtvgHY(T6dF5vS7",
     "description": "F9hZOtvgHY(T6dF5vS7",
     "domain": "F9hZOtvgHY(T6dF5vS7",
     "industry": "F9hZOtvgHY(T6dF5vS7",

--- a/packages/destination-actions/src/destinations/hubspot/upsertCompany/generated-types.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCompany/generated-types.ts
@@ -20,10 +20,6 @@ export interface Payload {
    */
   description?: string
   /**
-   * The date the company was added to your account.
-   */
-  createdate?: string
-  /**
    * The street address of the company.
    */
   address?: string

--- a/packages/destination-actions/src/destinations/hubspot/upsertCompany/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCompany/index.ts
@@ -151,14 +151,6 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.traits.description'
       }
     },
-    createdate: {
-      label: 'Company Create Date',
-      description: 'The date the company was added to your account.',
-      type: 'string',
-      default: {
-        '@path': '$.traits.createdAt'
-      }
-    },
     address: {
       label: 'Street Address',
       description: 'The street address of the company.',
@@ -256,7 +248,6 @@ const action: ActionDefinition<Settings, Payload> = {
     const companyProperties = {
       name: payload.name,
       description: payload.description,
-      createdate: payload.createdate,
       address: payload.address,
       city: payload.city,
       state: payload.state,

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
@@ -18,7 +18,7 @@ interface GetSchemasResponse {
 // To avoid slug name changes in future, naming it as upsertCustomObjectRecord straight away.
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Create Custom Object Record',
-  description: 'Create records in any HubSpot standard or custom object.',
+  description: 'Create records of Deals, Tickets or other Custom Objects in HubSpot.',
   fields: {
     objectType: {
       label: 'Object Type',


### PR DESCRIPTION
This PR resolves minor issues which were discovered during phase 2 of E2E testing.

- Removed a Read Only field 'createdate' from upsertCompany which would cause HubSpot APIs to throw error if this field is used in payload.
- Fixed description in upsertCustomObjectRecord

## Testing
Testing completed successfully in staging.
Errors were discovered during E2E testing in Prod environment.
Test document: https://docs.google.com/document/d/1xtbr6aJlmrWsKY3PuTgUCBV2st1jP0JGb4f3iPShUUU

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
