### PR TITLE
Add document to global object

### DIFF
--- a/packages/cli-internal/bin/run
+++ b/packages/cli-internal/bin/run
@@ -5,6 +5,7 @@ const dom = new JSDOM(`<!DOCTYPE html><p>Hello world</p>`)
 global.window = dom.window
 global.navigator = dom.window.navigator
 global.Element = dom.window.Element
+global.document = dom.window.document
 
 const path = require('path')
 const { register } = require('tsconfig-paths')

--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -5,6 +5,7 @@ const dom = new JSDOM(`<!DOCTYPE html><p>Hello world</p>`)
 global.window = dom.window
 global.navigator = dom.window.navigator
 global.Element = dom.window.Element
+global.document = dom.window.document
 
 const path = require('path')
 const { register } = require('tsconfig-paths')


### PR DESCRIPTION
One of our Partners is using the npm package of their library, and the package accesses `document` directly but our CLI commands such as generate types fail to import the package as `document` is undefined on the global context. Including document in the global context to solve the issue. 

## Testing
Tested with the Partner's branch of code, and type generation works as expected with the fix. 


