### PR TITLE
Added click_id, os_version, and device_model parameters to Snap Conversions API destination

### DIFF
--- a/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/generated-types.ts
@@ -70,7 +70,7 @@ export interface Payload {
    */
   currency?: string
   /**
-   * Transaction ID or order ID tied to the conversion event. Please refer to the [Snapchat Marketing API docs](https://marketingapi.snapchat.com/docs/conversion.html#deduplication) for information on how this field is used for deduplication against Snap Pixel SDK and App Adds Kit events.
+   * Transaction ID or order ID tied to the conversion event. Please refer to the [Snapchat Marketing API docs](https://marketingapi.snapchat.com/docs/conversion.html#deduplication) for information on how this field is used for deduplication against Snap Pixel SDK and App Ads Kit events.
    */
   transaction_id?: string
   /**
@@ -93,4 +93,16 @@ export interface Payload {
    * A string indicating the sign up method.
    */
   sign_up_method?: string
+  /**
+   * The user’s OS version.
+   */
+  os_version?: string
+  /**
+   * The user’s device model.
+   */
+  device_model?: string
+  /**
+   * The ID value stored in the landing page URL's `&ScCid=` query parameter. Using this ID improves ad measurement performance. We also encourage advertisers who are using `click_id` to pass the full url in the `page_url` field. For more details, please refer to [Sending a Click ID](#sending-a-click-id)
+   */
+  click_id?: string
 }

--- a/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/index.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/index.ts
@@ -27,7 +27,10 @@ import {
   sign_up_method,
   formatPayload,
   CURRENCY_ISO_4217_CODES,
-  conversionType
+  conversionType,
+  device_model,
+  os_version,
+  click_id
 } from '../snap-capi-properties'
 
 const CONVERSION_EVENT_URL = 'https://tr.snapchat.com/v2/conversion'
@@ -59,7 +62,10 @@ const action: ActionDefinition<Settings, Payload> = {
     client_dedup_id: client_dedup_id,
     search_string: search_string,
     page_url: page_url,
-    sign_up_method: sign_up_method
+    sign_up_method: sign_up_method,
+    os_version: os_version,
+    device_model: device_model,
+    click_id: click_id
   },
   perform: (request, data) => {
     const payload: Object = formatPayload(data.payload)

--- a/packages/destination-actions/src/destinations/snap-conversions-api/snap-capi-properties.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/snap-capi-properties.ts
@@ -232,7 +232,7 @@ export const currency: InputField = {
 export const transaction_id: InputField = {
   label: 'Transaction ID',
   description:
-    'Transaction ID or order ID tied to the conversion event. Please refer to the [Snapchat Marketing API docs](https://marketingapi.snapchat.com/docs/conversion.html#deduplication) for information on how this field is used for deduplication against Snap Pixel SDK and App Adds Kit events.',
+    'Transaction ID or order ID tied to the conversion event. Please refer to the [Snapchat Marketing API docs](https://marketingapi.snapchat.com/docs/conversion.html#deduplication) for information on how this field is used for deduplication against Snap Pixel SDK and App Ads Kit events.',
   type: 'string',
   default: {
     '@path': '$.properties.order_id'
@@ -273,6 +273,25 @@ export const page_url: InputField = {
 export const sign_up_method: InputField = {
   label: 'Sign Up Method',
   description: 'A string indicating the sign up method.',
+  type: 'string'
+}
+
+export const device_model: InputField = {
+  label: 'Device Model',
+  description: 'The user’s device model.',
+  type: 'string'
+}
+
+export const os_version: InputField = {
+  label: 'OS Version',
+  description: 'The user’s OS version.',
+  type: 'string'
+}
+
+export const click_id: InputField = {
+  label: 'Click ID',
+  description:
+    "The ID value stored in the landing page URL's `&ScCid=` query parameter. Using this ID improves ad measurement performance. We also encourage advertisers who are using `click_id` to pass the full url in the `page_url` field. For more details, please refer to [Sending a Click ID](#sending-a-click-id)",
   type: 'string'
 }
 
@@ -349,6 +368,9 @@ export const formatPayload = (payload: Payload): Object => {
     client_dedup_id: payload?.client_dedup_id,
     search_string: payload?.search_string,
     page_url: payload?.page_url,
-    sign_up_method: payload?.sign_up_method
+    sign_up_method: payload?.sign_up_method,
+    device_model: payload?.device_model,
+    os_version: payload?.os_version,
+    click_id: payload?.click_id
   }
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

We added a few new parameters to CAPI, so I added them to the Segment integration. The added parameters are as follows:

- `click_id`
- `os_version`
- `device_model`

For more information about the `click_id`, parameter, please refer to [this documentation](https://marketingapi.snapchat.com/docs/conversion.html#sending-a-click-id).

You can find information about these three parameters in the [Conversion Parameters table](https://marketingapi.snapchat.com/docs/conversion.html#conversion-parameters) in the Conversions API doc.

## Testing

- Performed test using the local server.
- Ran the unit tests with the command `yarn cloud test --testPathPattern=src/destinations/snap-conversions-api`

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
