### PR TITLE
Add new @case directive that supports lower() and upper() functions

### DIFF
--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -180,7 +180,14 @@ export interface PathDirective {
   '@path': string
 }
 
-export type Directive = IfDirective | TemplateDirective | PathDirective
+export interface CaseDirective {
+  '@case': {
+    operator: string
+    value: FieldValue
+  }
+}
+
+export type Directive = IfDirective | TemplateDirective | PathDirective | CaseDirective
 
 /**
  * A function to configure a request client instance with options

--- a/packages/core/src/mapping-kit/README.md
+++ b/packages/core/src/mapping-kit/README.md
@@ -63,6 +63,7 @@ Output:
   - [@template](#template)
   - [@literal](#literal)
   - [@arrayPath](#array-path)
+  - [@case](#case)
 
 <!-- tocstop -->
 
@@ -448,13 +449,14 @@ Mappings:
 
 ### @arrayPath
 
-The @arrayPath directive resolves a value at a given path (much like @path), but allows you to specify the shape of each item in the resulting array. You can use directives for each key in the given shape, relative to the root object. 
+The @arrayPath directive resolves a value at a given path (much like @path), but allows you to specify the shape of each item in the resulting array. You can use directives for each key in the given shape, relative to the root object.
 
-Typically, the root object is expected to be an array, which will be iterated to produce the resulting array from the specified item shape. It is not required that the root object be an array. 
+Typically, the root object is expected to be an array, which will be iterated to produce the resulting array from the specified item shape. It is not required that the root object be an array.
 
 For the item shape to be respected, the root object must be either an array of plain objects OR a singular plain object. If the root object is a singular plain object, it will be arrified into an array of 1.
 
 Input:
+
 ```json
 {
   "properties": {
@@ -464,6 +466,7 @@ Input:
 ```
 
 Mapping:
+
 ```json
 {
   "@arrayPath": ["$.properties.products"]
@@ -471,6 +474,7 @@ Mapping:
 ```
 
 Result:
+
 ```json
 [
   {
@@ -483,15 +487,20 @@ Result:
 ```
 
 Mappings with item shape:
+
 ```json
 {
-  "@arrayPath": ["$.properties.products", {
-    "some_other_key": { "@path": "$.productId" }
-  }]
+  "@arrayPath": [
+    "$.properties.products",
+    {
+      "some_other_key": { "@path": "$.productId" }
+    }
+  ]
 }
 ```
 
 Result:
+
 ```json
 [
   {
@@ -501,4 +510,37 @@ Result:
     "some_other_key": 2
   }
 ]
+```
+
+### @case
+
+The @case directive changes a string value at a given path to its respective lowercase() or uppercase() representation.
+
+While this directive does expect a string value at the given path, it can handle other types and will simply resolve to whatever is found if it is not a string.
+
+Input:
+
+```json
+{
+  "properties": {
+    "message": "THIS STRING IS IN ALL CAPS"
+  }
+}
+```
+
+Mapping:
+
+```json
+{
+  "@case": {
+    "operator": "lower",
+    "value": { "@path": "$.properties.message" }
+  }
+}
+```
+
+Result:
+
+```json
+"this is a string in all caps"
 ```

--- a/packages/core/src/mapping-kit/__tests__/index.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.test.ts
@@ -203,22 +203,20 @@ describe('@if', () => {
   })
 })
 
-describe('@case', () => {
-  const payload = { a: 1, b: 'MAKE ME LOWER CASE', c: 'make me upper case', d: null, e: '', f: false }
+describe.only('@case', () => {
+  const payload = {
+    a: 1,
+    b: 'MAKE ME LOWER CASE',
+    c: 'make me upper case',
+    d: null,
+    e: '',
+    f: false,
+    g: 'mIXeD StRinG CasING W/ NuMBErs 190wdB',
+    h: { key1: 'with values', key2: ['hi', true, null] }
+  }
 
-  test('operator', () => {
+  test('handle string-input transformations', () => {
     let output = transform(
-      {
-        '@case': {
-          operator: 'lower',
-          value: { '@path': '$.a' }
-        }
-      },
-      payload
-    )
-    expect(output).toStrictEqual(undefined)
-
-    output = transform(
       {
         '@case': {
           operator: 'lower',
@@ -244,17 +242,6 @@ describe('@case', () => {
       {
         '@case': {
           operator: 'lower',
-          value: { '@path': '$.d' }
-        }
-      },
-      payload
-    )
-    expect(output).toStrictEqual(undefined)
-
-    output = transform(
-      {
-        '@case': {
-          operator: 'lower',
           value: { '@path': '$.e' }
         }
       },
@@ -266,12 +253,112 @@ describe('@case', () => {
       {
         '@case': {
           operator: 'lower',
+          value: { '@path': '$.g' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual('mixed string casing w/ numbers 190wdb')
+
+    output = transform(
+      {
+        '@case': {
+          operator: 'upper',
+          value: { '@path': '$.g' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual('MIXED STRING CASING W/ NUMBERS 190WDB')
+  })
+
+  test('handle non-string-input correctly', () => {
+    let output = transform(
+      {
+        '@case': {
+          operator: 'lower',
+          value: { '@path': '$.a' }
+        }
+      },
+      payload
+    )
+    console.log('number', output)
+    expect(output).toStrictEqual(1)
+
+    output = transform(
+      {
+        '@case': {
+          operator: 'lower',
+          value: { '@path': '$.d' }
+        }
+      },
+      payload
+    )
+    console.log('null', output)
+    expect(output).toStrictEqual(null)
+
+    output = transform(
+      {
+        '@case': {
+          operator: 'lower',
           value: { '@path': '$.f' }
         }
       },
       payload
     )
-    expect(output).toStrictEqual(undefined)
+    console.log('boolean', output)
+    expect(output).toStrictEqual(false)
+
+    output = transform(
+      {
+        '@case': {
+          operator: 'lower',
+          value: { '@path': '$.h' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual({ key1: 'with values', key2: ['hi', true, null] })
+  })
+
+  test('Correctly handle errors', () => {
+    let test = () => {
+      transform(
+        {
+          '@case': {
+            wrongKey: 'lower',
+            value: { '@path': '$.b' }
+          }
+        },
+        payload
+      )
+    }
+
+    expect(test).toThrow(Error)
+    expect(test).toThrow('@case requires a "operator" key')
+
+    test = () =>
+      transform(
+        {
+          '@case': {
+            operator: 'unsupported snake',
+            value: { '@path': '$.b' }
+          }
+        },
+        payload
+      )
+    expect(test).toThrow(Error)
+    expect(test).toThrow('operator key should have a value of "lower" or "upper"')
+
+    test = () =>
+      transform(
+        {
+          '@case': 'not an object'
+        },
+        payload
+      )
+    expect(test).toThrow(Error)
+    expect(test).toThrow('/@case should be an object but it is a string.')
   })
 })
 

--- a/packages/core/src/mapping-kit/__tests__/index.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.test.ts
@@ -203,7 +203,7 @@ describe('@if', () => {
   })
 })
 
-describe.only('@case', () => {
+describe('@case', () => {
   const payload = {
     a: 1,
     b: 'MAKE ME LOWER CASE',
@@ -282,7 +282,6 @@ describe.only('@case', () => {
       },
       payload
     )
-    console.log('number', output)
     expect(output).toStrictEqual(1)
 
     output = transform(
@@ -294,7 +293,6 @@ describe.only('@case', () => {
       },
       payload
     )
-    console.log('null', output)
     expect(output).toStrictEqual(null)
 
     output = transform(
@@ -306,7 +304,6 @@ describe.only('@case', () => {
       },
       payload
     )
-    console.log('boolean', output)
     expect(output).toStrictEqual(false)
 
     output = transform(

--- a/packages/core/src/mapping-kit/__tests__/index.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.test.ts
@@ -203,6 +203,78 @@ describe('@if', () => {
   })
 })
 
+describe.only('@case', () => {
+  const payload = { a: 1, b: 'MAKE ME LOWER CASE', c: 'make me upper case', d: null, e: '', f: false }
+
+  test('operator', () => {
+    let output = transform(
+      {
+        '@case': {
+          operator: 'lower',
+          value: { '@path': '$.a' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual(undefined)
+
+    output = transform(
+      {
+        '@case': {
+          operator: 'lower',
+          value: { '@path': '$.b' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual('make me lower case')
+
+    output = transform(
+      {
+        '@case': {
+          operator: 'upper',
+          value: { '@path': '$.c' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual('MAKE ME UPPER CASE')
+
+    output = transform(
+      {
+        '@case': {
+          operator: 'lower',
+          value: { '@path': '$.d' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual(undefined)
+
+    output = transform(
+      {
+        '@case': {
+          operator: 'lower',
+          value: { '@path': '$.e' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual('')
+
+    output = transform(
+      {
+        '@case': {
+          operator: 'lower',
+          value: { '@path': '$.f' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual(undefined)
+  })
+})
+
 describe('@arrayPath', () => {
   const data = {
     products: [

--- a/packages/core/src/mapping-kit/__tests__/index.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.test.ts
@@ -203,7 +203,7 @@ describe('@if', () => {
   })
 })
 
-describe.only('@case', () => {
+describe('@case', () => {
   const payload = { a: 1, b: 'MAKE ME LOWER CASE', c: 'make me upper case', d: null, e: '', f: false }
 
   test('operator', () => {

--- a/packages/core/src/mapping-kit/__tests__/index.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.test.ts
@@ -215,7 +215,7 @@ describe('@case', () => {
     h: { key1: 'with values', key2: ['hi', true, null] }
   }
 
-  test('handle string-input transformations', () => {
+  test('handle string-input transformations by performing correct operation', () => {
     let output = transform(
       {
         '@case': {
@@ -272,7 +272,7 @@ describe('@case', () => {
     expect(output).toStrictEqual('MIXED STRING CASING W/ NUMBERS 190WDB')
   })
 
-  test('handle non-string-input correctly', () => {
+  test('handle non-string-input correctly by returning the given value unmodified', () => {
     let output = transform(
       {
         '@case': {
@@ -318,7 +318,7 @@ describe('@case', () => {
     expect(output).toStrictEqual({ key1: 'with values', key2: ['hi', true, null] })
   })
 
-  test('Correctly handle errors', () => {
+  test('Throw errors when directive is not setup correctly', () => {
     let test = () => {
       transform(
         {

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -74,6 +74,33 @@ registerDirective('@if', (opts, payload) => {
   }
 })
 
+registerDirective('@case', (opts, payload) => {
+  // let condition = false
+
+  if (!isObject(opts)) {
+    throw new Error('@case requires an object with a "operator" key')
+  }
+
+  if (!opts.operator) {
+    throw new Error('@case requires a "operator" key')
+  }
+
+  const operator = opts.operator
+  if (opts.value) {
+    const value = resolve(opts.value, payload)
+    if (typeof value === 'string') {
+      switch (operator) {
+        case 'lower':
+          return value.toLowerCase()
+        case 'upper':
+          return value.toUpperCase()
+        default:
+          throw new Error('operator key should have a value of "lower" or "upper"')
+      }
+    }
+  }
+})
+
 registerDirective('@arrayPath', (data, payload) => {
   if (!Array.isArray(data)) {
     throw new Error(`@arrayPath expected array, got ${realTypeOf(data)}`)

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -98,6 +98,7 @@ registerDirective('@case', (opts, payload) => {
           throw new Error('operator key should have a value of "lower" or "upper"')
       }
     }
+    return value
   }
 })
 

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -75,8 +75,6 @@ registerDirective('@if', (opts, payload) => {
 })
 
 registerDirective('@case', (opts, payload) => {
-  // let condition = false
-
   if (!isObject(opts)) {
     throw new Error('@case requires an object with a "operator" key')
   }

--- a/packages/core/src/mapping-kit/validate.ts
+++ b/packages/core/src/mapping-kit/validate.ts
@@ -225,7 +225,7 @@ directive('@case', (v, stack) => {
     v,
     {
       operator: { optional: validateString },
-      value: { optional: validateDirectiveOrRaw }
+      value: { optional: validateDirectiveOrString }
     },
     stack
   )

--- a/packages/core/src/mapping-kit/validate.ts
+++ b/packages/core/src/mapping-kit/validate.ts
@@ -105,6 +105,16 @@ function validateDirectiveOrString(v: unknown, stack: string[] = []) {
   }
 }
 
+function validateString(v: unknown, stack: string[] = []) {
+  const type = realTypeOrDirective(v)
+  switch (type) {
+    case 'string':
+      return
+    default:
+      throw new ValidationError(`should be a string but it is ${indefiniteArticle(type)} ${type}`, stack)
+  }
+}
+
 function validateObject(value: unknown, stack: string[] = []) {
   const type = realTypeOrDirective(value)
   if (type !== 'object') {
@@ -205,6 +215,17 @@ directive('@if', (v, stack) => {
       exists: { optional: validateDirectiveOrRaw },
       then: { optional: validateDirectiveOrRaw },
       else: { optional: validateDirectiveOrRaw }
+    },
+    stack
+  )
+})
+
+directive('@case', (v, stack) => {
+  validateObjectWithFields(
+    v,
+    {
+      operator: { optional: validateString },
+      value: { optional: validateDirectiveOrRaw }
     },
     stack
   )

--- a/packages/core/src/mapping-kit/validate.ts
+++ b/packages/core/src/mapping-kit/validate.ts
@@ -107,12 +107,10 @@ function validateDirectiveOrString(v: unknown, stack: string[] = []) {
 
 function validateString(v: unknown, stack: string[] = []) {
   const type = realTypeOrDirective(v)
-  switch (type) {
-    case 'string':
-      return
-    default:
-      throw new ValidationError(`should be a string but it is ${indefiniteArticle(type)} ${type}`, stack)
+  if (type !== 'string') {
+    throw new ValidationError(`should be a string but it is ${indefiniteArticle(type)} ${type}`, stack)
   }
+  return
 }
 
 function validateObject(value: unknown, stack: string[] = []) {


### PR DESCRIPTION
This PR addresses [JIRA ACT-92](https://segment.atlassian.net/browse/ACT-92)

In it, we add a new `@case` directive that will allow mapping a string from its value in the incoming event to its equivalent `toLowercase()` or `toUppercase()` value. This change will have to be accompanied by a change in `app` that supports these new directives, but that is non-blocking since this PR needs to be implemented first.

App PR `need approval!` https://github.com/segmentio/app/pull/14554

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

Added unit tests to ensure correct functionality.

Did stage deploy of integrations with these changes bundled in & ran a `yarn add @segment/actions-core`. Manually ran a `graphql` request to update the `city` field to use the new `@case` directive. Clearly the UI is not currently equipped to know how to render this new directive, but the event-preview can give you the correct value as shown below. The `city` field is not using the new directive and thus its value is "ATLANTA", whereas `city` is using the new `@case` with `operator:lower` so its value is "atlanta"

![Screen Shot 2022-10-25 at 7 09 05 PM](https://user-images.githubusercontent.com/98849774/197918604-ba7824df-2ca5-45fe-a76a-8ef02da97373.png)

I also did the same to an `Actions Slack` destination and then sent an event through dispatch to see if it was handled correctly. It was!

| Event sent to slack destination  | Resolved message appearing in slack |
| ------------- | ------------- |
| ![Screen Shot 2022-10-25 at 7 26 47 PM](https://user-images.githubusercontent.com/98849774/197920219-0ec03613-5f40-4e45-a127-98931b14c947.png) | ![Screen Shot 2022-10-25 at 7 27 18 PM](https://user-images.githubusercontent.com/98849774/197920241-f57891df-d209-4716-97e9-a00bd7a79e13.png) |

-------

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
