### PR TITLE
feat: engage support for whatsapp

### DIFF
--- a/packages/destination-actions/package.json
+++ b/packages/destination-actions/package.json
@@ -31,6 +31,7 @@
     "typecheck": "tsc -p tsconfig.build.json --noEmit"
   },
   "devDependencies": {
+    "@types/google-libphonenumber": "^7.4.23",
     "@types/jest": "^27.0.0",
     "jest": "^27.3.1",
     "nock": "^13.1.4"
@@ -43,6 +44,7 @@
     "cheerio": "^1.0.0-rc.10",
     "dayjs": "^1.10.7",
     "escape-goat": "^3",
+    "google-libphonenumber": "^3.2.31",
     "liquidjs": "^9.37.0",
     "lodash": "^4.17.21"
   },

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/generated-types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/generated-types.ts
@@ -2,6 +2,10 @@
 
 export interface Payload {
   /**
+   * What type of message is being sent?
+   */
+  messageType?: string
+  /**
    * User ID in Segment
    */
   userId: string

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
 import { Liquid as LiquidJs } from 'liquidjs'
 
 import type { ActionDefinition, RequestOptions } from '@segment/actions-core'
@@ -5,6 +6,13 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { IntegrationError } from '@segment/actions-core'
 import { StatsClient } from '@segment/actions-core/src/destination-kit'
+
+import { PhoneNumberFormat } from 'google-libphonenumber'
+import { PhoneNumberUtil } from 'google-libphonenumber'
+
+// Get an instance of `PhoneNumberUtil`.
+const phoneUtil = PhoneNumberUtil.getInstance()
+
 const Liquid = new LiquidJs()
 
 const getProfileApiEndpoint = (environment: string): string => {
@@ -50,6 +58,11 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Send SMS using Twilio',
   defaultSubscription: 'type = "track" and event = "Audience Entered"',
   fields: {
+    messageType: {
+      label: 'Message type (e.g. whatsapp, sms, etc.)',
+      description: 'What type of message is being sent?',
+      type: 'string'
+    },
     userId: {
       label: 'User ID',
       description: 'User ID in Segment',
@@ -165,7 +178,7 @@ const action: ActionDefinition<Settings, Payload> = {
       return
     } else if (['subscribed', 'true'].includes(externalId.subscriptionStatus)) {
       statsClient?.incr('actions-personas-messaging-twilio.subscribed', 1, tags)
-      const phone = payload.toNumber || externalId.id
+      let phone = payload.toNumber || externalId.id
       if (!phone) {
         return
       }
@@ -194,8 +207,30 @@ const action: ActionDefinition<Settings, Payload> = {
         throw new IntegrationError(`Unable to parse templating in SMS`, `SMS templating parse failure`, 400)
       }
 
+      const externalIdValue = phone
+
+      if (payload.messageType === 'whatsapp') {
+        try {
+          // Defaulting to US for now as that's where most users will seemingly be. Though
+          // any number already given in e164 format should parse correctly even with the
+          // default region being US.
+          const parsedPhone = phoneUtil.parse(phone, 'US')
+          phone = phoneUtil.format(parsedPhone, PhoneNumberFormat.E164)
+          phone = `whatsapp:${phone}`
+        } catch (error: unknown) {
+          tags?.push('type:invalid_phone_e164')
+          statsClient?.incr('actions-personas-messaging-twilio.error', 1, tags)
+          throw new IntegrationError(
+            'The string supplied did not seem to be a phone number. Phone number must be able to be formatted to e164 for whatsapp.',
+            `INVALID_PHONE`,
+            400
+          )
+        }
+      }
+
       const body = new URLSearchParams({
         Body: parsedBody,
+        // Assuming this is in the right format for whatsapp.
         From: payload.from,
         To: phone
       })
@@ -206,7 +241,7 @@ const action: ActionDefinition<Settings, Payload> = {
         ...payload.customArgs,
         space_id: settings.spaceId,
         __segment_internal_external_id_key__: EXTERNAL_ID_KEY,
-        __segment_internal_external_id_value__: phone
+        __segment_internal_external_id_value__: externalIdValue
       }
 
       if (webhookUrl && customArgs) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2750,6 +2750,11 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/google-libphonenumber@^7.4.23":
+  version "7.4.23"
+  resolved "https://registry.yarnpkg.com/@types/google-libphonenumber/-/google-libphonenumber-7.4.23.tgz#c44c9125d45f042943694d605fd8d8d796cafc3b"
+  integrity sha512-C3ydakLTQa8HxtYf9ge4q6uT9krDX8smSIxmmW3oACFi5g5vv6T068PRExF7UyWbWpuYiDG8Nm24q2X5XhcZWw==
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -6664,6 +6669,11 @@ globby@^11.0.1, globby@^11.0.2, globby@^11.0.3, globby@^11.0.4:
     ignore "^5.1.4"
     merge2 "^1.3.0"
     slash "^3.0.0"
+
+google-libphonenumber@^3.2.31:
+  version "3.2.31"
+  resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.2.31.tgz#d2c4d4c8d7385be70b515086e4d28dd20da50600"
+  integrity sha512-l3bzAkfN4ITICKvuqEiY7JN06RxDAviOoKMtD2KfGYjGK3btPO8Xav7k0fgmf1Ud/pEm523yBh1/s/xDtKEvnw==
 
 got@^5.0.0:
   version "5.7.1"


### PR DESCRIPTION
Extends the Engage Twilio destination to include whatsapp support. To do this we need another setting for which I decided to with an enum like field with the default being SMS. Secondly, for the whatsapp Twilio API we need to format the to number to an e164 format which may not always be straightforward so I added a dependency.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
