### PR TITLE
Fixes the push-browser-destinations command for amplitude/fullstory

### DIFF
--- a/packages/browser-destinations/src/destinations/fullstory/index.ts
+++ b/packages/browser-destinations/src/destinations/fullstory/index.ts
@@ -17,7 +17,7 @@ declare global {
 export const segmentEventSource = 'segment-browser-actions'
 
 export const destination: BrowserDestinationDefinition<Settings, FS> = {
-  name: 'Fullstory',
+  name: 'Fullstory (Actions)',
   slug: 'actions-fullstory',
   mode: 'device',
   presets: [

--- a/packages/cli-internal/src/commands/push-browser-destinations.ts
+++ b/packages/cli-internal/src/commands/push-browser-destinations.ts
@@ -81,6 +81,8 @@ export default class PushBrowserDestinations extends Command {
     const pluginsToCreate = []
     const pluginsToUpdate = []
 
+    // These destinations differ from their creation name but were published before we added that check.
+    // These are exempted from the creation name check for backwards-compabitibility reasons.
     const definitionCreationNameExceptions = new Set(['Amplitude (Actions)', 'Fullstory (Actions)'])
 
     for (const metadata of metadatas) {

--- a/packages/cli-internal/src/commands/push-browser-destinations.ts
+++ b/packages/cli-internal/src/commands/push-browser-destinations.ts
@@ -81,6 +81,8 @@ export default class PushBrowserDestinations extends Command {
     const pluginsToCreate = []
     const pluginsToUpdate = []
 
+    const definitionCreationNameExceptions = new Set(['Amplitude (Actions)'])
+
     for (const metadata of metadatas) {
       this.spinner.start(`Saving remote plugin for ${metadata.name}`)
       const entry = manifest[metadata.id]
@@ -100,7 +102,10 @@ export default class PushBrowserDestinations extends Command {
       // `metadataId` is guaranteed to be unique
       const existingPlugin = remotePlugins.find((p) => p.metadataId === metadata.id)
 
-      if (metadata.creationName !== entry.definition.name) {
+      if (
+        metadata.creationName !== entry.definition.name &&
+        !definitionCreationNameExceptions.has(entry.definition.name)
+      ) {
         this.spinner.fail()
         throw new Error(
           `The definition name '${entry.definition.name}' should always match the control plane creationName '${metadata.creationName}'.`

--- a/packages/cli-internal/src/commands/push-browser-destinations.ts
+++ b/packages/cli-internal/src/commands/push-browser-destinations.ts
@@ -91,7 +91,9 @@ export default class PushBrowserDestinations extends Command {
         metadataId: metadata.id,
         // The name of the remote plugin should match the creationName for consistency with our other systems,
         // as users might rely on the name of the name of the remote plugin in the integrations object.
-        name: metadata.creationName,
+        name: definitionCreationNameExceptions.has(entry.definition.name)
+          ? entry.definition.name
+          : metadata.creationName,
         // This MUST match the way webpack exports the libraryName in the umd bundle
         // TODO make this more automatic for consistency
         libraryName: `${entry.directory}Destination`,

--- a/packages/cli-internal/src/commands/push-browser-destinations.ts
+++ b/packages/cli-internal/src/commands/push-browser-destinations.ts
@@ -81,7 +81,7 @@ export default class PushBrowserDestinations extends Command {
     const pluginsToCreate = []
     const pluginsToUpdate = []
 
-    const definitionCreationNameExceptions = new Set(['Amplitude (Actions)'])
+    const definitionCreationNameExceptions = new Set(['Amplitude (Actions)', 'Fullstory (Actions)'])
 
     for (const metadata of metadatas) {
       this.spinner.start(`Saving remote plugin for ${metadata.name}`)


### PR DESCRIPTION
This PR fixes publishing browser destinations using the `./bin/run push-browser-destinations` command. Currently Amplitude/Fullstory either throw an error or changes the published name.

The command does a check to ensure that a destination's name matches the destination's creation name. If they don't match, an error is thrown. This is typically desired behavior because the `integrations` object uses the creation name.

2 destinations currently fail this check:
- Amplitude
- Fullstory

Unfortunately users may already be using the destination name to enable/disable them in analytics-next. For example, users could disable Fullstory's trackEvent action by setting `{ integrations: { 'Fullstory (Actions) trackEvent': false } }` in analytics-next since the destination name was used as the plugin name.

To maintain this compatibility for Amplitude/Fullstory, I made them part of an exception set so the creationName check doesn't apply to them.

### Why did you change Fullstory's name?

Fullstory is currently published as `Fullstory (Actions)`. This was changed in #629 to `Fullstory` in order to match the creation name but that change was never published - due to concerns about customers relying on `Fullstory (Actions)` in the integration object with analytics-next. This PR reverts that change as well.

## Testing

I tested these changes by running `./bin/run push-browser-destinations` selecting all of our destinations. With these changes, the only diff is the bundle URLs:
![image](https://user-images.githubusercontent.com/14189820/198191787-769ca568-43ca-40ed-9e6c-75ce1adb70b8.png)

