### PR TITLE
[STRATCONN-1664] SFMC Post Testing Improvements 

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtension/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtension/generated-types.ts
@@ -22,7 +22,7 @@ export interface Payload {
   /**
    * The fields in the data extension that contain data about a contact, such as Email, Last Name, etc. Fields must be created in the data extension before sending data for it. On the left-hand side, input the SFMC field name exactly how it appears in the data extension. On the right-hand side, map the Segment field that contains the corresponding value.
    */
-  values?: {
+  values: {
     [k: string]: unknown
   }
   /**

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtension/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtension/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { key, id, keys, values, enable_batching } from '../sfmc-properties'
+import { key, id, keys, enable_batching, values_contactFields } from '../sfmc-properties'
 import { upsertRows } from '../sfmc-operations'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -26,7 +26,7 @@ const action: ActionDefinition<Settings, Payload> = {
         contactKey: { '@path': '$.userId' }
       }
     },
-    values: values,
+    values: values_contactFields,
     enable_batching: enable_batching
   },
   perform: async (request, { settings, payload }) => {

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtension/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtension/generated-types.ts
@@ -16,9 +16,9 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * The fields in the data extension that contain data about a contact, such as Email, Last Name, etc. Fields must be created in the data extension before sending data for it. On the left-hand side, input the SFMC field name exactly how it appears in the data extension. On the right-hand side, map the Segment field that contains the corresponding value.
+   * The fields in the data extension that contain data about an event, such as Product Name, Revenue, Event Time, etc. Fields must be created in the data extension before sending data for it. On the left-hand side, input the SFMC field name exactly how it appears in the data extension. On the right-hand side, map the Segment field that contains the corresponding value.
    */
-  values?: {
+  values: {
     [k: string]: unknown
   }
   /**

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtension/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtension/index.ts
@@ -1,7 +1,7 @@
 import { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { key, id, keys, values, enable_batching } from '../sfmc-properties'
+import { key, id, keys, enable_batching, values_dataExtensionFields } from '../sfmc-properties'
 import { upsertRows } from '../sfmc-operations'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -11,7 +11,7 @@ const action: ActionDefinition<Settings, Payload> = {
     key: key,
     id: id,
     keys: { ...keys, required: true },
-    values: values,
+    values: values_dataExtensionFields,
     enable_batching: enable_batching
   },
   perform: async (request, { settings, payload }) => {

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/index.ts
@@ -25,21 +25,21 @@ const destination: DestinationDefinition<Settings> = {
         required: true
       },
       account_id: {
-        label: 'account id',
+        label: 'Account ID',
         description:
           'Your Salesforce Marketing Cloud account identifier (or MID). See more information on how to find your MID [here](https://help.salesforce.com/s/articleView?id=sf.mc_overview_determine_your_marketing_cloud_instance.htm&type=5).',
         type: 'string',
         required: true
       },
       client_id: {
-        label: 'client_id',
+        label: 'Client ID',
         description:
           'Your Salesforce Marketing Cloud client ID. The client ID is issued when you create an API integration in [Installed Packages](https://developer.salesforce.com/docs/marketing/marketing-cloud/guide/install-packages.html).',
         type: 'string',
         required: true
       },
       client_secret: {
-        label: 'client_secret',
+        label: 'Client Secret',
         description:
           'Your Salesforce Marketing Cloud client secret. The client secret is issued when you create an API integration in Installed Packages.',
         type: 'password',

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-properties.ts
@@ -40,12 +40,22 @@ export const keys: InputField = {
   additionalProperties: true
 }
 
-export const values: InputField = {
+export const values_contactFields: InputField = {
   label: 'Contact Fields',
   description:
     'The fields in the data extension that contain data about a contact, such as Email, Last Name, etc. Fields must be created in the data extension before sending data for it. On the left-hand side, input the SFMC field name exactly how it appears in the data extension. On the right-hand side, map the Segment field that contains the corresponding value.',
   type: 'object',
-  defaultObjectUI: 'keyvalue:only'
+  defaultObjectUI: 'keyvalue:only',
+  required: true
+}
+
+export const values_dataExtensionFields: InputField = {
+  label: 'Data Extension Fields',
+  description:
+    'The fields in the data extension that contain data about an event, such as Product Name, Revenue, Event Time, etc. Fields must be created in the data extension before sending data for it. On the left-hand side, input the SFMC field name exactly how it appears in the data extension. On the right-hand side, map the Segment field that contains the corresponding value.',
+  type: 'object',
+  defaultObjectUI: 'keyvalue:only',
+  required: true
 }
 
 export const eventDefinitionKey: InputField = {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

1. Updated the following field labels: 

- `client_id `→ Client ID

- `client_secret` → Client Secret

- `account_id` → Account ID 

2. Updated the description and label for values for dataExtension Action 

- Label: `Data Extension Fields`

- Description: `The fields in the data extension that contain data about an event, such as Product Name, Revenue, Event Time, etc. Fields must be created in the data extension before sending data for it. On the left-hand side, input the SFMC field name exactly how it appears in the data extension. On the right-hand side, map the Segment field that contains the corresponding value.`

3. Updated `values` for both `dataExtension` & `contactDataExtension` Action to `required:true` 

## Testing



- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
