### PR TITLE
remove escaping logic and flag

### DIFF
--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -122,7 +122,7 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
     const results: Result[] = []
 
     // Resolve/transform the mapping with the input data
-    let payload = transform(bundle.mapping, bundle.data, bundle.features) as Payload
+    let payload = transform(bundle.mapping, bundle.data) as Payload
     results.push({ output: 'Mappings resolved' })
 
     // Remove empty values (`null`, `undefined`, `''`) when not explicitly accepted

--- a/packages/core/src/mapping-kit/__tests__/index.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.test.ts
@@ -395,17 +395,8 @@ describe('@template', () => {
     expect(output).toStrictEqual('Hello, World!')
   })
 
-  test('escaping', () => {
+  test('no escaping', () => {
     const output = transform({ '@template': '<blink>{{a}} {{{a}}}</blink>' }, { a: '<b>Hi</b>' })
-    expect(output).toStrictEqual('<blink>&lt;b&gt;Hi&lt;&#x2F;b&gt; <b>Hi</b></blink>')
-  })
-
-  test('no escaping if flag is on', () => {
-    const output = transform(
-      { '@template': '<blink>{{a}} {{{a}}}</blink>' },
-      { a: '<b>Hi</b>' },
-      { actionsEscapeOff: true }
-    )
     expect(output).toStrictEqual('<blink><b>Hi</b> <b>Hi</b></blink>')
   })
 

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -9,8 +9,8 @@ import { arrify } from '../arrify'
 
 export type InputData = { [key: string]: unknown }
 export type Features = { [key: string]: boolean }
-type Directive = (options: JSONValue, payload: JSONObject, features?: Features) => JSONLike
-type StringDirective = (value: string, payload: JSONObject, features?: Features) => JSONLike
+type Directive = (options: JSONValue, payload: JSONObject) => JSONLike
+type StringDirective = (value: string, payload: JSONObject) => JSONLike
 
 interface Directives {
   [directive: string]: Directive | undefined
@@ -28,17 +28,17 @@ function registerDirective(name: string, fn: Directive): void {
 }
 
 function registerStringDirective(name: string, fn: StringDirective): void {
-  registerDirective(name, (value, payload, features) => {
+  registerDirective(name, (value, payload) => {
     const str = resolve(value, payload)
     if (typeof str !== 'string') {
       throw new Error(`${name}: expected string, got ${realTypeOf(str)}`)
     }
 
-    return fn(str, payload, features)
+    return fn(str, payload)
   })
 }
 
-function runDirective(obj: JSONObject, payload: JSONObject, features?: Features): JSONLike {
+function runDirective(obj: JSONObject, payload: JSONObject): JSONLike {
   const name = Object.keys(obj).find((key) => key.startsWith('@')) as string
   const directiveFn = directives[name]
   const value = obj[name]
@@ -47,7 +47,7 @@ function runDirective(obj: JSONObject, payload: JSONObject, features?: Features)
     throw new Error(`${name} is not a valid directive, got ${realTypeOf(directiveFn)}`)
   }
 
-  return directiveFn(value, payload, features)
+  return directiveFn(value, payload)
 }
 
 registerDirective('@if', (opts, payload) => {
@@ -98,8 +98,8 @@ registerStringDirective('@path', (path, payload) => {
   return get(payload, path.replace('$.', ''))
 })
 
-registerStringDirective('@template', (template: string, payload, features) => {
-  return render(template, payload, features)
+registerStringDirective('@template', (template: string, payload) => {
+  return render(template, payload)
 })
 
 // Literal should be used in place of 'empty' template strings as they will not resolve correctly
@@ -111,26 +111,25 @@ registerDirective('@literal', (value, payload) => {
  * Resolves a mapping value/object by applying the input payload based on directives
  * @param mapping - the mapping directives or raw values to resolve
  * @param payload - the input data to apply to the mapping directives
- * @param features - the object of feature flags (optional)
  * @todo support arrays or array directives?
  */
-function resolve(mapping: JSONLike, payload: JSONObject, features?: Features): JSONLike {
+function resolve(mapping: JSONLike, payload: JSONObject): JSONLike {
   if (!isObject(mapping) && !isArray(mapping)) {
     return mapping
   }
 
   if (isDirective(mapping)) {
-    return runDirective(mapping, payload, features)
+    return runDirective(mapping, payload)
   }
 
   if (Array.isArray(mapping)) {
-    return mapping.map((value) => resolve(value, payload, features))
+    return mapping.map((value) => resolve(value, payload))
   }
 
   const resolved: JSONLikeObject = {}
 
   for (const key of Object.keys(mapping)) {
-    resolved[key] = resolve(mapping[key], payload, features)
+    resolved[key] = resolve(mapping[key], payload)
   }
 
   return resolved
@@ -141,9 +140,8 @@ function resolve(mapping: JSONLike, payload: JSONObject, features?: Features): J
  * based on the directives and raw values defined in the mapping object
  * @param mapping - the directives and raw values
  * @param data - the input data to apply to directives
- * @param features - the object of feature flags (optional)
  */
-export function transform(mapping: JSONLikeObject, data: InputData | undefined = {}, features?: Features): JSONObject {
+export function transform(mapping: JSONLikeObject, data: InputData | undefined = {}): JSONObject {
   const realType = realTypeOf(data)
   if (realType !== 'object') {
     throw new Error(`data must be an object, got ${realType}`)
@@ -152,7 +150,7 @@ export function transform(mapping: JSONLikeObject, data: InputData | undefined =
   // throws if the mapping config is invalid
   validate(mapping)
 
-  const resolved = resolve(mapping, data as JSONObject, features)
+  const resolved = resolve(mapping, data as JSONObject)
   const cleaned = removeUndefined(resolved)
 
   // Cast because we know there are no `undefined` values anymore

--- a/packages/core/src/mapping-kit/placeholders.ts
+++ b/packages/core/src/mapping-kit/placeholders.ts
@@ -1,47 +1,21 @@
 import { get } from '../get'
 import { realTypeOf } from '../real-type-of'
-import { Features } from './index'
-
-const entityMap: Record<string, string> = {
-  '&': '&amp;',
-  '<': '&lt;',
-  '>': '&gt;',
-  '"': '&quot;',
-  "'": '&#39;',
-  '/': '&#x2F;',
-  '`': '&#x60;',
-  '=': '&#x3D;'
-}
-
-function escapeHtml(value: unknown): string | unknown {
-  if (typeof value !== 'string') return value
-
-  return value.replace(/[&<>"'`=/]/g, (match) => {
-    return entityMap[match]
-  })
-}
 
 /**
  * Replaces curly brace placeholders in a template with real content
  */
-export function render(template: string, data: unknown = {}, features?: Features): string {
+export function render(template: string, data: unknown = {}): string {
   if (typeof template !== 'string') {
     throw new TypeError(`Invalid template! Template should be a "string" but ${realTypeOf(template)} was given.`)
   }
 
-  function replacer(chars: number, escape: boolean) {
+  function replacer(chars: number) {
     return (match: string): string => {
       // Remove the wrapping curly braces
       match = match.slice(chars, -chars).trim()
 
       // Grab the value from data, if it exists
       const value = get(data, match)
-
-      // Replace with the value (or empty string) only if flag isn't set
-      const actionsEscapeOff = features && features.actionsEscapeOff
-      if (escape && !actionsEscapeOff) {
-        return String(escapeHtml(value) ?? '')
-      }
 
       return (value ?? '') as string
     }
@@ -50,8 +24,8 @@ export function render(template: string, data: unknown = {}, features?: Features
   return (
     template
       // Replace unescaped content
-      .replace(/\{\{\{([^}]+)\}\}\}/g, replacer(3, false))
+      .replace(/\{\{\{([^}]+)\}\}\}/g, replacer(3))
       // Replace escaped content
-      .replace(/\{\{([^}]+)\}\}/g, replacer(2, true))
+      .replace(/\{\{([^}]+)\}\}/g, replacer(2))
   )
 }


### PR DESCRIPTION
This PR removes the escaping logic and flag added by this [PR](https://github.com/segmentio/action-destinations/pull/657). The flag has been turned on fully for quite some time and it's been determined that the escaping logic is no longer necessary.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
