### PR TITLE
[LinkedIn Audiences] Add default subscription.

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
@@ -8,6 +8,7 @@ import { LinkedInAudiences } from '../api'
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Sync To LinkedIn DMP Segment',
   description: 'Syncs contacts from a Personas Audience to a LinkedIn DMP Segment.',
+  defaultSubscription: 'event = "Audience Entered" or event = "Audience Exited"',
   fields: {
     dmp_segment_name: {
       label: 'DMP Segment Display Name',


### PR DESCRIPTION
- This PR adds a default subscription for LinkedIn's only action. When setting up new subscriptions, users see the following populate to the Segment UI:

<img width="839" alt="Screen Shot 2022-11-02 at 11 35 51 AM" src="https://user-images.githubusercontent.com/11224497/199574074-8dfc1abd-f636-4020-8332-2e0a7f8ce4c8.png">

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
