### PR TITLE
[STRATCONN-1702] Add error handling to updateProfile action in Adobe Target Cloud

### DIFF
--- a/packages/destination-actions/src/destinations/adobe-target/adobeTarget_operations.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/adobeTarget_operations.ts
@@ -59,7 +59,7 @@ export default class AdobeTarget {
       )
     } catch (error) {
       if (error instanceof Error) {
-        return new IntegrationError(error.message, error.stack, error.message == 'Forbidden' ? 403 : 400)
+        return new IntegrationError(error.message, error.message == 'Forbidden' ? '403' : '400')
       }
     }
 

--- a/packages/destination-actions/src/destinations/adobe-target/updateProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/updateProfile/__tests__/index.test.ts
@@ -8,12 +8,13 @@ const settings = {
   client_id: '123-test'
 }
 
-beforeEach((done) => {
-  nock.cleanAll()
-  done()
-})
-
 describe('AdobeTarget', () => {
+  beforeEach((done) => {
+    nock.cleanAll()
+    nock.abortPendingRequests()
+    done()
+  })
+
   describe('updateProfile', () => {
     it('Handle a Basic Event', async () => {
       nock(
@@ -221,61 +222,6 @@ describe('AdobeTarget', () => {
         })
       ).rejects.toThrowError("The root value is missing the required field 'traits'.")
     })
-
-    it('should throw an error for invalid cliend code', async () => {
-      nock(
-        `https://${settings.client_code}.tt.omtrdc.net/rest/v1/profiles/thirdPartyId/${settings.client_id}?client=FAKE`
-      )
-        .get(/.*/)
-        .reply(400, {})
-      nock(
-        `https://${settings.client_code}.tt.omtrdc.net/m2/${settings.client_code}/profile/update?mbox3rdPartyId=FAKE`
-      )
-        .post(/.*/)
-        .reply(400, {})
-      const event = createTestEvent({
-        type: 'identify',
-        userId: '123-test',
-        traits: {
-          name: 'Rajul',
-          age: '21',
-          city: 'New York City',
-          zipCode: '12345',
-          param1: 'value1',
-          param2: 'value2'
-        }
-      })
-
-      await expect(
-        testDestination.testAction('updateProfile', {
-          event,
-          settings,
-          mapping: {
-            traits: {
-              city: {
-                '@path': '$.traits.city'
-              },
-              name: {
-                '@path': '$.traits.name'
-              },
-              age: {
-                '@path': '$.traits.age'
-              },
-              param1: {
-                '@path': '$.traits.param1'
-              },
-              param2: {
-                '@path': '$.traits.param2'
-              }
-            },
-            user_id: {
-              '@path': '$.userId'
-            }
-          }
-        })
-      ).rejects.toThrowError('Bad Request')
-    })
-
     it('removes null values from nested event', async () => {
       nock(
         `https://${settings.client_code}.tt.omtrdc.net/rest/v1/profiles/thirdPartyId/${settings.client_id}?client=${settings.client_code}`
@@ -340,7 +286,6 @@ describe('AdobeTarget', () => {
         'https://segmentexchangepartn.tt.omtrdc.net/m2/segmentexchangepartn/profile/update?mbox3rdPartyId=123-test&profile.address.city=New%20York%20City&profile.name=Rajul&profile.param1=value1&profile.param2=value2'
       )
     })
-
     it('uses bearer token if provided', async () => {
       const authSettings = {
         bearer_token: 'test-token',
@@ -360,8 +305,8 @@ describe('AdobeTarget', () => {
         }
       })
 
-      nock(/.*/).persist().get(/.*/).reply(200)
-      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).get(/.*/).reply(200)
+      nock(/.*/).post(/.*/).reply(200)
 
       const responses = await testDestination.testAction('updateProfile', {
         event,
@@ -412,6 +357,7 @@ describe('AdobeTarget', () => {
       })
     })
   })
+
   it('should handle default mappings', async () => {
     nock(
       `https://${settings.client_code}.tt.omtrdc.net/rest/v1/profiles/thirdPartyId/${settings.client_id}?client=${settings.client_code}`
@@ -471,5 +417,57 @@ describe('AdobeTarget', () => {
     expect(responses[1].url).toBe(
       'https://segmentexchangepartn.tt.omtrdc.net/m2/segmentexchangepartn/profile/update?mbox3rdPartyId=123-test&profile.address.city=New%20York%20City&profile.address.zipCode=12345&profile.param1=value1&profile.param2=value2'
     )
+  })
+
+  it('should throw an error for invalid cliend code', async () => {
+    nock(
+      `https://${settings.client_code}.tt.omtrdc.net/rest/v1/profiles/thirdPartyId/${settings.client_id}?client=FAKE`
+    )
+      .get(/.*/)
+      .reply(400, {})
+    nock(`https://${settings.client_code}.tt.omtrdc.net/m2/${settings.client_code}/profile/update?mbox3rdPartyId=FAKE`)
+      .post(/.*/)
+      .reply(400, {})
+    const event = createTestEvent({
+      type: 'identify',
+      userId: '123-test',
+      traits: {
+        name: 'Rajul',
+        age: '21',
+        city: 'New York City',
+        zipCode: '12345',
+        param1: 'value1',
+        param2: 'value2'
+      }
+    })
+
+    await expect(
+      testDestination.testAction('updateProfile', {
+        event,
+        settings,
+        mapping: {
+          traits: {
+            city: {
+              '@path': '$.traits.city'
+            },
+            name: {
+              '@path': '$.traits.name'
+            },
+            age: {
+              '@path': '$.traits.age'
+            },
+            param1: {
+              '@path': '$.traits.param1'
+            },
+            param2: {
+              '@path': '$.traits.param2'
+            }
+          },
+          user_id: {
+            '@path': '$.userId'
+          }
+        }
+      })
+    ).rejects.toThrowError('Bad Request')
   })
 })

--- a/packages/destination-actions/src/destinations/adobe-target/updateProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/updateProfile/__tests__/index.test.ts
@@ -8,6 +8,11 @@ const settings = {
   client_id: '123-test'
 }
 
+beforeEach((done) => {
+  nock.cleanAll()
+  done()
+})
+
 describe('AdobeTarget', () => {
   describe('updateProfile', () => {
     it('Handle a Basic Event', async () => {

--- a/packages/destination-actions/src/destinations/adobe-target/updateProfile/index.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/updateProfile/index.ts
@@ -39,7 +39,7 @@ const action: ActionDefinition<Settings, Payload> = {
       return await at.updateProfile()
     } catch (error) {
       if (error instanceof Error) {
-        throw new IntegrationError(error.message, error.stack, error.message == 'Forbidden' ? 403 : 400)
+        throw new IntegrationError(error.message, error.message == 'Forbidden' ? '403' : '400')
       }
     }
   }

--- a/packages/destination-actions/src/destinations/adobe-target/updateProfile/index.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/updateProfile/index.ts
@@ -1,4 +1,5 @@
 import type { ActionDefinition } from '@segment/actions-core'
+import { IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import AdobeTarget from '../adobeTarget_operations'
 import type { Payload } from './generated-types'
@@ -33,8 +34,14 @@ const action: ActionDefinition<Settings, Payload> = {
   },
 
   perform: async (request, { settings, payload }) => {
-    const at: AdobeTarget = new AdobeTarget(payload.user_id, settings.client_code, payload.traits, request)
-    return await at.updateProfile()
+    try {
+      const at: AdobeTarget = new AdobeTarget(payload.user_id, settings.client_code, payload.traits, request)
+      return await at.updateProfile()
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new IntegrationError(error.message, error.stack, error.message == 'Forbidden' ? 403 : 400)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
# What’s the problem?

Some exceptions are being improperly handled by the Adobe Target Cloud code. That means that the UI will render unhelpful error messages like this one:


![Screen Shot 2022-11-02 at 10 47 17 AM](https://user-images.githubusercontent.com/316711/199616474-528d0243-d3f8-43d2-bd35-eb8c7fa4af14.png)

# Bug Diagnosis and Reproduction Steps

It appears that any error thrown by the web client will result in an unhandled exception. In the example above inside Marin’s dashboard, the lack of authentication token while Authentication is enforced results in said error.

In another test, the Client Code setting was deliberately set to a bogus value. This resulted in `Httperror: Bad Request at Requestclient.exe` errors.

Given that none of the errors are properly handled nor helpful it is advisable to look into the error payloads to see if it’s possible to parse them and return better error messages.

## A Peek Inside Error Messages

Two things to note:

- Error message bodies come back in XML.
- Error messages come back with specific error messages.

Therefore, error messages can be parsed and properly reported.


Error #1 -  `Httperror: Bad Request at Requestclient.exe`  - Invalid Client Code

```
    <com.adobe.tnt.profileservice.crud.ResponseErrorBody>
            <status>400</status>
            <message>Invalid client code - segmentexchangepart</message>
    </com.adobe.tnt.profileservice.crud.ResponseErrorBody>
```

Error #2 - Forbidden 

```
    <com.adobe.tnt.profileservice.crud.ResponseErrorBody>
      <status>403</status>
      <message>Authentication failed, make sure a valid token is provided</message>
    </com.adobe.tnt.profileservice.crud.ResponseErrorBody>
```

# What are we implementing?

A wrap for the API call. We are adding a try catch block to Parse for known errors (Forbidden) and return 400 for the rest (which seem to be the most common). 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
