### PR TITLE
Remove requiredness of Pardot sandbox toggle

### DIFF
--- a/packages/destination-actions/src/destinations/actions-pardot/index.ts
+++ b/packages/destination-actions/src/destinations/actions-pardot/index.ts
@@ -34,8 +34,7 @@ const destination: DestinationDefinition<Settings> = {
         description:
           'Enable to authenticate into a sandbox instance. You can log in to a sandbox by appending the sandbox name to your Salesforce username. For example, if a username for a production org is user@acme.com and the sandbox is named `test`, the username to log in to the sandbox is user@acme.com.test. If you are already authenticated, please disconnect and reconnect with your sandbox username.',
         type: 'boolean',
-        default: false,
-        required: true
+        default: false
       }
     },
     refreshAccessToken: async (request, { auth, settings }) => {


### PR DESCRIPTION
_A summary of your pull request, including the what change you're making and why._
It appears that having the sandbox toggle as required causes some bugginess in the UI where you are unable to save the destination without toggling sandbox to on.  We should remove requiredness of this field since it already as a default of `false`.

## Testing
