### PR TITLE
Joe ayoub segment hgi 173

### DIFF
--- a/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
@@ -8,6 +8,66 @@ const timestamp = '2021-08-17T15:21:15.449Z'
 
 describe('Amplitude', () => {
   describe('logPurchase', () => {
+    it('should set library value if library directive is configured', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        context: { library: { name: 'node.js', version: '1.2.3' } }
+      })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const mapping = {
+        library: { '@path': '$.context.library.name' }
+      }
+
+      const responses = await testDestination.testAction('logPurchase', {
+        event,
+        mapping,
+        useDefaultMappings: true
+      })
+
+      expect(responses[0].options.json).toMatchObject({
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            library: 'node.js'
+          })
+        ])
+      })
+    })
+
+    it('should set library value to "segment" if library directive is not configured', async () => {
+      const event = createTestEvent({ timestamp, event: 'Test Event' })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const responses = await testDestination.testAction('logPurchase', { event, useDefaultMappings: true })
+
+      expect(responses[0].options.json).toMatchObject({
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            library: 'segment'
+          })
+        ])
+      })
+    })
+
+    it('should set platform = "Web" if library_hidden = analytics.js', async () => {
+      const event = createTestEvent({ timestamp, event: 'Test Event' })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const responses = await testDestination.testAction('logPurchase', { event, useDefaultMappings: true })
+
+      expect(responses[0].options.json).toMatchObject({
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            platform: 'Web'
+          })
+        ])
+      })
+    })
+
     it('should work with default mappings', async () => {
       const event = createTestEvent({ timestamp, event: 'Test Event' })
 
@@ -521,6 +581,66 @@ describe('Amplitude', () => {
   })
 
   describe('logEvent', () => {
+    it('should set library value if library directive is configured', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        context: { library: { name: 'node.js', version: '1.2.3' } }
+      })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const mapping = {
+        library: { '@path': '$.context.library.name' }
+      }
+
+      const responses = await testDestination.testAction('logEvent', {
+        event,
+        mapping,
+        useDefaultMappings: true
+      })
+
+      expect(responses[0].options.json).toMatchObject({
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            library: 'node.js'
+          })
+        ])
+      })
+    })
+
+    it('should set library value to "segment" if library directive is not configured', async () => {
+      const event = createTestEvent({ timestamp, event: 'Test Event' })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const responses = await testDestination.testAction('logEvent', { event, useDefaultMappings: true })
+
+      expect(responses[0].options.json).toMatchObject({
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            library: 'segment'
+          })
+        ])
+      })
+    })
+
+    it('should set platform = "Web" if library_hidden = analytics.js', async () => {
+      const event = createTestEvent({ timestamp, event: 'Test Event' })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const responses = await testDestination.testAction('logEvent', { event, useDefaultMappings: true })
+
+      expect(responses[0].options.json).toMatchObject({
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            platform: 'Web'
+          })
+        ])
+      })
+    })
+
     it('should work with default mappings', async () => {
       const event = createTestEvent({ timestamp, event: 'Test Event' })
 
@@ -922,6 +1042,66 @@ describe('Amplitude', () => {
   })
 
   describe('logEvent V2', () => {
+    it('should set library value if library directive is configured', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        context: { library: { name: 'node.js', version: '1.2.3' } }
+      })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const mapping = {
+        library: { '@path': '$.context.library.name' }
+      }
+
+      const responses = await testDestination.testAction('logEventV2', {
+        event,
+        mapping,
+        useDefaultMappings: true
+      })
+
+      expect(responses[0].options.json).toMatchObject({
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            library: 'node.js'
+          })
+        ])
+      })
+    })
+
+    it('should set library value to "segment" if library directive is not configured', async () => {
+      const event = createTestEvent({ timestamp, event: 'Test Event' })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const responses = await testDestination.testAction('logEventV2', { event, useDefaultMappings: true })
+
+      expect(responses[0].options.json).toMatchObject({
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            library: 'segment'
+          })
+        ])
+      })
+    })
+
+    it('should set platform = "Web" if library_hidden = analytics.js', async () => {
+      const event = createTestEvent({ timestamp, event: 'Test Event' })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const responses = await testDestination.testAction('logEventV2', { event, useDefaultMappings: true })
+
+      expect(responses[0].options.json).toMatchObject({
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            platform: 'Web'
+          })
+        ])
+      })
+    })
+
     it('works with default mappings', async () => {
       const event = createTestEvent({ timestamp, event: 'Test Event' })
 
@@ -1461,6 +1641,103 @@ describe('Amplitude', () => {
   })
 
   describe('identifyUser', () => {
+    it('should set library value if library directive is configured', async () => {
+      const event = createTestEvent({
+        anonymousId: 'some-anonymous-id',
+        timestamp: '2021-04-12T16:32:37.710Z',
+        type: 'group',
+        userId: 'some-user-id',
+        traits: {
+          'some-trait-key': 'some-trait-value'
+        }
+      })
+
+      const mapping = {
+        library: { '@path': '$.context.library.name' }
+      }
+
+      nock('https://api2.amplitude.com').post('/identify').reply(200, {})
+      const responses = await testDestination.testAction('identifyUser', { event, mapping, useDefaultMappings: true })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+      expect(responses[0].options.body).toMatchInlineSnapshot(`
+        URLSearchParams {
+          Symbol(query): Array [
+            "api_key",
+            "undefined",
+            "identification",
+            "{\\"os_name\\":\\"Mobile Safari\\",\\"os_version\\":\\"9\\",\\"device_model\\":\\"iPhone\\",\\"device_type\\":\\"mobile\\",\\"user_id\\":\\"some-user-id\\",\\"device_id\\":\\"some-anonymous-id\\",\\"user_properties\\":{\\"some-trait-key\\":\\"some-trait-value\\"},\\"country\\":\\"United States\\",\\"city\\":\\"San Francisco\\",\\"language\\":\\"en-US\\",\\"platform\\":\\"Web\\",\\"library\\":\\"analytics.js\\"}",
+            "options",
+            "undefined",
+          ],
+          Symbol(context): null,
+        }
+      `)
+    })
+
+    it('should set library value to "segment" if library directive is not configured', async () => {
+      const event = createTestEvent({
+        anonymousId: 'some-anonymous-id',
+        timestamp: '2021-04-12T16:32:37.710Z',
+        type: 'group',
+        userId: 'some-user-id',
+        traits: {
+          'some-trait-key': 'some-trait-value'
+        }
+      })
+
+      nock('https://api2.amplitude.com').post('/identify').reply(200, {})
+      const responses = await testDestination.testAction('identifyUser', { event, useDefaultMappings: true })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+      expect(responses[0].options.body).toMatchInlineSnapshot(`
+        URLSearchParams {
+          Symbol(query): Array [
+            "api_key",
+            "undefined",
+            "identification",
+            "{\\"os_name\\":\\"Mobile Safari\\",\\"os_version\\":\\"9\\",\\"device_model\\":\\"iPhone\\",\\"device_type\\":\\"mobile\\",\\"user_id\\":\\"some-user-id\\",\\"device_id\\":\\"some-anonymous-id\\",\\"user_properties\\":{\\"some-trait-key\\":\\"some-trait-value\\"},\\"country\\":\\"United States\\",\\"city\\":\\"San Francisco\\",\\"language\\":\\"en-US\\",\\"platform\\":\\"Web\\",\\"library\\":\\"segment\\"}",
+            "options",
+            "undefined",
+          ],
+          Symbol(context): null,
+        }
+      `)
+    })
+
+    it('should set platform = "Web" if library_hidden = analytics.js', async () => {
+      const event = createTestEvent({
+        anonymousId: 'some-anonymous-id',
+        timestamp: '2021-04-12T16:32:37.710Z',
+        type: 'group',
+        userId: 'some-user-id',
+        traits: {
+          'some-trait-key': 'some-trait-value'
+        }
+      })
+
+      nock('https://api2.amplitude.com').post('/identify').reply(200, {})
+      const responses = await testDestination.testAction('identifyUser', { event, useDefaultMappings: true })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+      expect(responses[0].options.body).toMatchInlineSnapshot(`
+        URLSearchParams {
+          Symbol(query): Array [
+            "api_key",
+            "undefined",
+            "identification",
+            "{\\"os_name\\":\\"Mobile Safari\\",\\"os_version\\":\\"9\\",\\"device_model\\":\\"iPhone\\",\\"device_type\\":\\"mobile\\",\\"user_id\\":\\"some-user-id\\",\\"device_id\\":\\"some-anonymous-id\\",\\"user_properties\\":{\\"some-trait-key\\":\\"some-trait-value\\"},\\"country\\":\\"United States\\",\\"city\\":\\"San Francisco\\",\\"language\\":\\"en-US\\",\\"platform\\":\\"Web\\",\\"library\\":\\"segment\\"}",
+            "options",
+            "undefined",
+          ],
+          Symbol(context): null,
+        }
+      `)
+    })
+
     it('should work with default mappings', async () => {
       const event = createTestEvent({
         anonymousId: 'some-anonymous-id',
@@ -1770,6 +2047,60 @@ describe('Amplitude', () => {
       group_type: 'some-type',
       group_value: 'some-value'
     }
+
+    it('should set library value if library directive is configured', async () => {
+      nock('https://api2.amplitude.com').post('/identify').reply(200, {})
+      nock('https://api2.amplitude.com').post('/groupidentify').reply(200, {})
+
+      const [response] = await testDestination.testAction('groupIdentifyUser', {
+        event,
+        mapping: { ...mapping, ...{ library: { '@path': '$.context.library.name' } } },
+        useDefaultMappings: true
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.data).toMatchObject({})
+      expect(response.options.body).toMatchInlineSnapshot(`
+        URLSearchParams {
+          Symbol(query): Array [
+            "api_key",
+            "undefined",
+            "identification",
+            "[{\\"device_id\\":\\"some-anonymous-id\\",\\"groups\\":{\\"some-type\\":\\"some-value\\"},\\"insert_id\\":\\"some-insert-id\\",\\"library\\":\\"analytics.js\\",\\"time\\":1618245157710,\\"user_id\\":\\"some-user-id\\",\\"user_properties\\":{\\"some-type\\":\\"some-value\\"}}]",
+            "options",
+            "undefined",
+          ],
+          Symbol(context): null,
+        }
+      `)
+    })
+
+    it('should set library value to "segment" if library directive is not configured', async () => {
+      nock('https://api2.amplitude.com').post('/identify').reply(200, {})
+      nock('https://api2.amplitude.com').post('/groupidentify').reply(200, {})
+
+      const [response] = await testDestination.testAction('groupIdentifyUser', {
+        event,
+        mapping,
+        useDefaultMappings: true
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.data).toMatchObject({})
+      expect(response.options.body).toMatchInlineSnapshot(`
+        URLSearchParams {
+          Symbol(query): Array [
+            "api_key",
+            "undefined",
+            "identification",
+            "[{\\"device_id\\":\\"some-anonymous-id\\",\\"groups\\":{\\"some-type\\":\\"some-value\\"},\\"insert_id\\":\\"some-insert-id\\",\\"library\\":\\"segment\\",\\"time\\":1618245157710,\\"user_id\\":\\"some-user-id\\",\\"user_properties\\":{\\"some-type\\":\\"some-value\\"}}]",
+            "options",
+            "undefined",
+          ],
+          Symbol(context): null,
+        }
+      `)
+    })
 
     it('should fire identify call to Amplitude', async () => {
       nock('https://api2.amplitude.com').post('/identify').reply(200, {})

--- a/packages/destination-actions/src/destinations/amplitude/event-schema.ts
+++ b/packages/destination-actions/src/destinations/amplitude/event-schema.ts
@@ -300,9 +300,7 @@ export const eventSchema: Record<string, InputField> = {
   library: {
     label: 'Library',
     type: 'string',
-    description: 'The name of the library that generated the event.',
-    default: {
-      '@path': '$.context.library.name'
-    }
+    description:
+      'The name of the library that generated the event. If nothing is provided, Segment will send "segment" as the Library.'
   }
 }

--- a/packages/destination-actions/src/destinations/amplitude/event-schema.ts
+++ b/packages/destination-actions/src/destinations/amplitude/event-schema.ts
@@ -302,5 +302,13 @@ export const eventSchema: Record<string, InputField> = {
     type: 'string',
     description:
       'The name of the library that generated the event. If nothing is provided, Segment will send "segment" as the Library.'
+  },
+  library_hidden: {
+    label: 'Library Hidden',
+    type: 'hidden',
+    description: 'The name of the library which generated the event, taken from context.library.name',
+    default: {
+      '@path': '$.context.library.name'
+    }
   }
 }

--- a/packages/destination-actions/src/destinations/amplitude/groupIdentifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/groupIdentifyUser/generated-types.ts
@@ -39,4 +39,8 @@ export interface Payload {
    * The name of the library that generated the event. If nothing is provided, Segment will send "segment" as the Library.
    */
   library?: string
+  /**
+   * The name of the library which generated the event, taken from context.library.name
+   */
+  library_hidden?: string
 }

--- a/packages/destination-actions/src/destinations/amplitude/groupIdentifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/groupIdentifyUser/generated-types.ts
@@ -35,4 +35,8 @@ export interface Payload {
    * Amplitude has a default minimum id lenght of 5 characters for user_id and device_id fields. This field allows the minimum to be overridden to allow shorter id lengths.
    */
   min_id_length?: number | null
+  /**
+   * The name of the library that generated the event. If nothing is provided, Segment will send "segment" as the Library.
+   */
+  library?: string
 }

--- a/packages/destination-actions/src/destinations/amplitude/groupIdentifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/groupIdentifyUser/index.ts
@@ -74,6 +74,12 @@ const action: ActionDefinition<Settings, Payload> = {
         'Amplitude has a default minimum id lenght of 5 characters for user_id and device_id fields. This field allows the minimum to be overridden to allow shorter id lengths.',
       allowNull: true,
       type: 'integer'
+    },
+    library: {
+      label: 'Library',
+      type: 'string',
+      description:
+        'The name of the library that generated the event. If nothing is provided, Segment will send "segment" as the Library.'
     }
   },
   perform: async (request, { payload, settings }) => {
@@ -94,7 +100,7 @@ const action: ActionDefinition<Settings, Payload> = {
             device_id: payload.device_id,
             groups: groupAssociation,
             insert_id: payload.insert_id,
-            library: 'segment',
+            library: payload.library ?? 'segment',
             time: dayjs.utc(payload.time).valueOf(),
             user_id: payload.user_id,
             user_properties: groupAssociation
@@ -114,7 +120,7 @@ const action: ActionDefinition<Settings, Payload> = {
             group_properties: payload.group_properties,
             group_value: payload.group_value,
             group_type: payload.group_type,
-            library: 'segment'
+            library: payload.library ?? 'segment'
           }
         ]),
         options

--- a/packages/destination-actions/src/destinations/amplitude/groupIdentifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/groupIdentifyUser/index.ts
@@ -80,6 +80,14 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       description:
         'The name of the library that generated the event. If nothing is provided, Segment will send "segment" as the Library.'
+    },
+    library_hidden: {
+      label: 'Library Hidden',
+      type: 'hidden',
+      description: 'The name of the library which generated the event, taken from context.library.name',
+      default: {
+        '@path': '$.context.library.name'
+      }
     }
   },
   perform: async (request, { payload, settings }) => {

--- a/packages/destination-actions/src/destinations/amplitude/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/identifyUser/generated-types.ts
@@ -115,4 +115,8 @@ export interface Payload {
    * The name of the library that generated the event. If nothing is provided, Segment will send "segment" as the Library.
    */
   library?: string
+  /**
+   * The name of the library which generated the event, taken from context.library.name
+   */
+  library_hidden?: string
 }

--- a/packages/destination-actions/src/destinations/amplitude/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/identifyUser/generated-types.ts
@@ -112,7 +112,7 @@ export interface Payload {
    */
   min_id_length?: number | null
   /**
-   * The name of the library that generated the event.
+   * The name of the library that generated the event. If nothing is provided, Segment will send "segment" as the Library.
    */
   library?: string
 }

--- a/packages/destination-actions/src/destinations/amplitude/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/identifyUser/index.ts
@@ -237,10 +237,8 @@ const action: ActionDefinition<Settings, Payload> = {
     library: {
       label: 'Library',
       type: 'string',
-      description: 'The name of the library that generated the event.',
-      default: {
-        '@path': '$.context.library.name'
-      }
+      description:
+        'The name of the library that generated the event. If nothing is provided, Segment will send "segment" as the Library.'
     }
   },
 
@@ -275,7 +273,7 @@ const action: ActionDefinition<Settings, Payload> = {
       ...(userAgentParsing && parseUserAgentProperties(userAgent)),
       // Make sure any top-level properties take precedence over user-agent properties
       ...removeUndefined(properties),
-      library: 'segment'
+      library: library ?? 'segment'
     })
 
     return request(getEndpointByRegion('identify', settings.endpoint), {

--- a/packages/destination-actions/src/destinations/amplitude/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/identifyUser/index.ts
@@ -239,11 +239,20 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       description:
         'The name of the library that generated the event. If nothing is provided, Segment will send "segment" as the Library.'
+    },
+    library_hidden: {
+      label: 'Library Hidden',
+      type: 'hidden',
+      description: 'The name of the library which generated the event, taken from context.library.name',
+      default: {
+        '@path': '$.context.library.name'
+      }
     }
   },
 
   perform: (request, { payload, settings }) => {
-    const { utm_properties, referrer, userAgent, userAgentParsing, min_id_length, library, ...rest } = payload
+    const { utm_properties, referrer, userAgent, userAgentParsing, min_id_length, library, library_hidden, ...rest } =
+      payload
 
     let options
     const properties = rest as AmplitudeEvent
@@ -252,8 +261,8 @@ const action: ActionDefinition<Settings, Payload> = {
       properties.platform = properties.platform.replace(/ios/i, 'iOS').replace(/android/i, 'Android')
     }
 
-    if (library === 'analytics.js') {
-      properties.platform = 'Web'
+    if (library_hidden) {
+      if (library_hidden === 'analytics.js') properties.platform = 'Web'
     }
 
     if (Object.keys(utm_properties ?? {}).length || referrer) {

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/generated-types.ts
@@ -152,6 +152,10 @@ export interface Payload {
    */
   library?: string
   /**
+   * The name of the library which generated the event, taken from context.library.name
+   */
+  library_hidden?: string
+  /**
    * The list of products purchased.
    */
   products?: {

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/generated-types.ts
@@ -148,7 +148,7 @@ export interface Payload {
    */
   insert_id?: string
   /**
-   * The name of the library that generated the event.
+   * The name of the library that generated the event. If nothing is provided, Segment will send "segment" as the Library.
    */
   library?: string
   /**

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
@@ -200,7 +200,7 @@ const action: ActionDefinition<Settings, Payload> = {
         ...(userAgentParsing && parseUserAgentProperties(userAgent)),
         // Make sure any top-level properties take precedence over user-agent properties
         ...removeUndefined(properties),
-        library: 'segment'
+        library: library ?? 'segment'
       }
     ]
 

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
@@ -161,8 +161,18 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: (request, { payload, settings }) => {
     // Omit revenue properties initially because we will manually stitch those into events as prescribed
-    const { time, session_id, userAgent, userAgentParsing, utm_properties, referrer, min_id_length, library, ...rest } =
-      omit(payload, revenueKeys)
+    const {
+      time,
+      session_id,
+      userAgent,
+      userAgentParsing,
+      utm_properties,
+      referrer,
+      min_id_length,
+      library,
+      library_hidden,
+      ...rest
+    } = omit(payload, revenueKeys)
     const properties = rest as AmplitudeEvent
     let options
 
@@ -170,8 +180,8 @@ const action: ActionDefinition<Settings, Payload> = {
       properties.platform = properties.platform.replace(/ios/i, 'iOS').replace(/android/i, 'Android')
     }
 
-    if (library) {
-      if (library === 'analytics.js') properties.platform = 'Web'
+    if (library_hidden) {
+      if (library_hidden === 'analytics.js') properties.platform = 'Web'
     }
 
     if (time && dayjs.utc(time).isValid()) {

--- a/packages/destination-actions/src/destinations/amplitude/logEventV2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEventV2/generated-types.ts
@@ -152,6 +152,10 @@ export interface Payload {
    */
   library?: string
   /**
+   * The name of the library which generated the event, taken from context.library.name
+   */
+  library_hidden?: string
+  /**
    * The list of products purchased.
    */
   products?: {

--- a/packages/destination-actions/src/destinations/amplitude/logEventV2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEventV2/generated-types.ts
@@ -148,7 +148,7 @@ export interface Payload {
    */
   insert_id?: string
   /**
-   * The name of the library that generated the event.
+   * The name of the library that generated the event. If nothing is provided, Segment will send "segment" as the Library.
    */
   library?: string
   /**

--- a/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
@@ -204,8 +204,19 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: (request, { payload, settings }) => {
-    const { time, session_id, userAgent, userAgentParsing, min_id_length, library, setOnce, setAlways, add, ...rest } =
-      omit(payload, revenueKeys)
+    const {
+      time,
+      session_id,
+      userAgent,
+      userAgentParsing,
+      min_id_length,
+      library,
+      library_hidden,
+      setOnce,
+      setAlways,
+      add,
+      ...rest
+    } = omit(payload, revenueKeys)
     const properties = rest as AmplitudeEvent
     let options
 
@@ -213,10 +224,8 @@ const action: ActionDefinition<Settings, Payload> = {
       properties.platform = properties.platform.replace(/ios/i, 'iOS').replace(/android/i, 'Android')
     }
 
-    if (library) {
-      if (library === 'analytics.js') {
-        properties.platform = 'Web'
-      }
+    if (library_hidden) {
+      if (library_hidden === 'analytics.js') properties.platform = 'Web'
     }
 
     if (time && dayjs.utc(time).isValid()) {

--- a/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
@@ -250,7 +250,7 @@ const action: ActionDefinition<Settings, Payload> = {
         ...(userAgentParsing && parseUserAgentProperties(userAgent)),
         // Make sure any top-level properties take precedence over user-agent properties
         ...removeUndefined(properties),
-        library: 'segment'
+        library: library ?? 'segment'
       }
     ]
 

--- a/packages/destination-actions/src/destinations/amplitude/logPurchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logPurchase/generated-types.ts
@@ -152,7 +152,7 @@ export interface Payload {
    */
   insert_id?: string
   /**
-   * The name of the library that generated the event.
+   * The name of the library that generated the event. If nothing is provided, Segment will send "segment" as the Library.
    */
   library?: string
   /**

--- a/packages/destination-actions/src/destinations/amplitude/logPurchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logPurchase/generated-types.ts
@@ -156,6 +156,10 @@ export interface Payload {
    */
   library?: string
   /**
+   * The name of the library which generated the event, taken from context.library.name
+   */
+  library_hidden?: string
+  /**
    * The list of products purchased.
    */
   products?: {

--- a/packages/destination-actions/src/destinations/amplitude/logPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logPurchase/index.ts
@@ -243,7 +243,7 @@ const action: ActionDefinition<Settings, Payload> = {
         ...removeUndefined(properties),
         // Conditionally track revenue with main event
         ...(products.length && trackRevenuePerProduct ? {} : getRevenueProperties(payload)),
-        library: 'segment'
+        library: library ? library : 'segment'
       }
     ]
 
@@ -255,7 +255,7 @@ const action: ActionDefinition<Settings, Payload> = {
         event_properties: product,
         event_type: 'Product Purchased',
         insert_id: properties.insert_id ? `${properties.insert_id}-${events.length + 1}` : undefined,
-        library: 'segment'
+        library: library ?? 'segment'
       })
     }
 

--- a/packages/destination-actions/src/destinations/amplitude/logPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logPurchase/index.ts
@@ -202,6 +202,7 @@ const action: ActionDefinition<Settings, Payload> = {
       referrer,
       min_id_length,
       library,
+      library_hidden,
       ...rest
     } = omit(payload, revenueKeys)
     const properties = rest as AmplitudeEvent
@@ -211,8 +212,8 @@ const action: ActionDefinition<Settings, Payload> = {
       properties.platform = properties.platform.replace(/ios/i, 'iOS').replace(/android/i, 'Android')
     }
 
-    if (library) {
-      if (library === 'analytics.js') properties.platform = 'Web'
+    if (library_hidden) {
+      if (library_hidden === 'analytics.js') properties.platform = 'Web'
     }
 
     if (time && dayjs.utc(time).isValid()) {
@@ -243,7 +244,7 @@ const action: ActionDefinition<Settings, Payload> = {
         ...removeUndefined(properties),
         // Conditionally track revenue with main event
         ...(products.length && trackRevenuePerProduct ? {} : getRevenueProperties(payload)),
-        library: library ? library : 'segment'
+        library: library ?? 'segment'
       }
     ]
 


### PR DESCRIPTION
PR for https://segment.atlassian.net/browse/HGI-173 

Ticket title: "Amplitude Actions always passes Library as 'segment' regardless of the mapped value" 

## Changes

Updated logic in logPurchase, logEventV2, logEvent, identifyUser and groupIdentifyUser Actions to the following: 
 - removed default library field mapping directive
 - for mappings where no library field mapping directive is set, the library value will be set to 'segment'
 - for mappings where the library field directive is set, it will be respected

Updated logic in logPurchase, logEventV2, logEvent and identifyUser Actions to the following: 
 - pre-existing logic was setting platform field to 'Web' if the label field value returned 'analytics.js'. 
 - this logic was going to break due to deleting the default directive on the library field
 - so a new 'hidden' field called library_hidden was introduced
 - platform field is not set to 'Web' via the library_hidden field if $.context.library.name === 'analytics.js'. 

## Testing

Added unit tests in all of the affected Actions, to test for the following scenarios where applicable: 
 - 1) should set library value if library directive is configured
 - 2) should set library value to "segment" if library directive is not configured
 - 3) should set platform = "Web" if library_hidden = analytics.js

I ran all new tests and they passed. 
I also tested each change using the action-tester
I did **not** test in the Staging Environment. 
