### PR TITLE
Create test command for partners to run that doesn't include internal suites

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint": "eslint '**/*.ts' --cache",
     "subscriptions": "yarn workspace @segment/destination-subscriptions",
     "test": "lerna run test --stream",
+    "test-partners": "lerna run test --stream --ignore @segment/actions-core --ignore @segment/actions-cli --ignore @segment/ajv-human-errors",
     "typecheck": "lerna run typecheck --stream",
     "alpha": "lerna publish prerelease --pre-dist-tag next --allow-branch '**' --no-git-tag-version",
     "prepare": "husky install"


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

## Description

A few customers have been seeing actions-core tests failing due to optional dependencies not being installed (#169) so we'll be including a new test command `yarn test-partners` that ignores most internal suites. 

Another possible solution is JUST to run tests for `action-destinations` and `browser-destinations`, but i was a bit uncertain about the origins of `actions-shared` and `destination-subscriptions`

Tests being ignored are
 - @segment/actions-core 
 - @segment/actions-cli 
 - @segment/ajv-human-errors

Tests being run for partners are:
  - @segment/actions-shared
  - @segment/browser-destinations
  - @segment/actions-cli-internal (but this is skipped internally)
  - @segment/action-destinations
  - @segment/destination-subscriptions

## Testing

Tests pass locally 😆

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
