### PR TITLE
Add Sabil (Web) Action Destination

### DIFF
--- a/packages/browser-destinations/src/destinations/sabil/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/sabil/__tests__/index.test.ts
@@ -1,0 +1,16 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import sabil, { destination } from '../index'
+import { subscriptions, TEST_CLIENT_ID } from '../test-utils'
+
+test('load Sabil', async () => {
+  const [event] = await sabil({
+    client_id: TEST_CLIENT_ID,
+    subscriptions
+  })
+
+  jest.spyOn(destination, 'initialize')
+
+  await event.load(Context.system(), {} as Analytics)
+  expect(destination.initialize).toHaveBeenCalled()
+  expect(window.Sabil).toHaveProperty('attach')
+})

--- a/packages/browser-destinations/src/destinations/sabil/attach/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/sabil/attach/__tests__/index.test.ts
@@ -1,0 +1,25 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import sabil from '../../index'
+import { subscriptions, TEST_CLIENT_ID, TEST_USER_ID } from '../../test-utils'
+
+describe('Sabil.attach', () => {
+  it('should call attach on identify event', async () => {
+    const [plugin] = await sabil({
+      client_id: TEST_CLIENT_ID,
+      subscriptions
+    })
+    window.Sabil = {
+      attach: jest.fn()
+    }
+    await plugin.load(Context.system(), {} as Analytics)
+    const spy = jest.spyOn(window.Sabil, 'attach')
+
+    await plugin.identify?.(
+      new Context({
+        type: 'identify',
+        userId: TEST_USER_ID
+      })
+    )
+    expect(spy).toHaveBeenCalled()
+  })
+})

--- a/packages/browser-destinations/src/destinations/sabil/attach/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/sabil/attach/generated-types.ts
@@ -1,0 +1,14 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID of the user
+   */
+  user_id: string
+  /**
+   * A key-value object that will be stored alongside the user, device and access records. This will be available to in any webhooks or API calls. Useful if you want to remote logout a device or invalidate a session from the backend via webhook.
+   */
+  metadata?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/src/destinations/sabil/attach/index.ts
+++ b/packages/browser-destinations/src/destinations/sabil/attach/index.ts
@@ -1,0 +1,38 @@
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import Sabil from '../types'
+
+// Change from unknown to the partner SDK types
+const action: BrowserActionDefinition<Settings, Sabil, Payload> = {
+  title: 'Attach',
+  description: 'Attach a device to the user.',
+  defaultSubscription: 'type = "identify"',
+  platform: 'web',
+  fields: {
+    user_id: {
+      type: 'string',
+      required: true,
+      label: 'User ID',
+      description: 'The ID of the user ',
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    metadata: {
+      type: 'object',
+      required: false,
+      label: 'Metadata',
+      description:
+        'A key-value object that will be stored alongside the user, device and access records. This will be available to in any webhooks or API calls. Useful if you want to remote logout a device or invalidate a session from the backend via webhook.'
+    }
+  },
+  async perform(sabil, { settings, payload }) {
+    if (typeof payload.user_id !== 'string') {
+      return
+    }
+    await sabil.attach({ user: payload.user_id, client_id: settings.client_id, debug: true })
+  }
+}
+
+export default action

--- a/packages/browser-destinations/src/destinations/sabil/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/sabil/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your project API client ID. You can find it in your Sabil [dashboard](https://dashboard.sabil.io/api_keys)
+   */
+  client_id: string
+}

--- a/packages/browser-destinations/src/destinations/sabil/index.ts
+++ b/packages/browser-destinations/src/destinations/sabil/index.ts
@@ -1,0 +1,44 @@
+import type { Settings } from './generated-types'
+import type { BrowserDestinationDefinition } from '../../lib/browser-destinations'
+import { browserDestination } from '../../runtime/shim'
+import Sabil from './types'
+
+import attach from './attach'
+
+declare global {
+  interface Window {
+    Sabil: Sabil
+  }
+}
+
+export const destination: BrowserDestinationDefinition<Settings, Sabil> = {
+  name: 'Sabil',
+  slug: 'actions-sabil',
+  mode: 'device',
+
+  settings: {
+    client_id: {
+      description:
+        'Your project API client ID. You can find it in your Sabil [dashboard](https://dashboard.sabil.io/api_keys)',
+      label: 'Client ID',
+      required: true,
+      type: 'string'
+    }
+  },
+
+  initialize: async (_options, deps) => {
+    try {
+      await deps.loadScript('https://cdn.sabil.io/global.js')
+      await deps.resolveWhen(() => Object.prototype.hasOwnProperty.call(window, 'Sabil'), 100)
+      return window.Sabil
+    } catch (err) {
+      throw new Error('Could not load the Sabil js package')
+    }
+  },
+
+  actions: {
+    attach
+  }
+}
+
+export default browserDestination(destination)

--- a/packages/browser-destinations/src/destinations/sabil/test-utils.ts
+++ b/packages/browser-destinations/src/destinations/sabil/test-utils.ts
@@ -1,0 +1,18 @@
+import { Subscription } from '../../lib/browser-destinations'
+
+export const TEST_CLIENT_ID = 'c8d82ede-c8e4-4bd0-8240-5c723f83fe3f'
+export const TEST_USER_ID = 'segment_test_user_id'
+
+export const subscriptions: Subscription[] = [
+  {
+    partnerAction: 'attach',
+    name: 'Attach',
+    enabled: true,
+    subscribe: 'type = "identify"',
+    mapping: {
+      user_id: {
+        '@path': '$.userId'
+      }
+    }
+  }
+]

--- a/packages/browser-destinations/src/destinations/sabil/types.ts
+++ b/packages/browser-destinations/src/destinations/sabil/types.ts
@@ -1,0 +1,5 @@
+type Sabil = {
+  attach: Function
+}
+
+export default Sabil

--- a/yarn.lock
+++ b/yarn.lock
@@ -4077,9 +4077,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001265:
-  version "1.0.30001269"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001269.tgz#3a71bee03df627364418f9fd31adfc7aa1cc2d56"
-  integrity sha512-UOy8okEVs48MyHYgV+RdW1Oiudl1H6KolybD6ZquD0VcrPSgj25omXO1S7rDydjpqaISCwA8Pyx+jUQKZwWO5w==
+  version "1.0.30001431"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz"
+  integrity sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
_A summary of your pull request, including the what change you're making and why._

This PR introduces the official web action destination for [Sabil](https://sabil.io]. The integration is relatively simple. A single action is exposed (attach) to link a device to a user. 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
