### PR TITLE
1plusx asset api

### DIFF
--- a/packages/browser-destinations/src/destinations/wisepops/setCustomProperties/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/wisepops/setCustomProperties/generated-types.ts
@@ -8,19 +8,15 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * This lets you to store the properties as a nested object. If you set the property `name` with the prefix `group`, you'll access it in Wisepops as `group.name`.
-   */
-  prefix?: string
-  /**
-   * A unique identifier. Typically a user or group ID.
+   * A unique identifier. Typically, a user ID or group ID.
    */
   id?: string
   /**
-   * What property name should be used to set the entity ID as a Wisepops custom property?
+   * How to name the entity ID among the other custom properties?
    */
   idProperty?: string
   /**
-   * By default, custom properties persist across pages. Enable temporary properties to limit them to the current page only.
+   * This lets you define the properties as a nested object. If you set the property `"name"` with the prefix `"group"`, you'll access it in Wisepops as `"group.name"`.
    */
-  temporary?: boolean
+  prefix?: string
 }

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-1plusx-asset-api destination: sendAssetData action - all fields 1`] = `
+Object {
+  "ope_content": "ElP)krdS65",
+  "ope_title": "ElP)krdS65",
+  "testType": "ElP)krdS65",
+}
+`;
+
+exports[`Testing snapshot for actions-1plusx-asset-api destination: sendAssetData action - required fields 1`] = `Object {}`;

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/__tests__/index.test.ts
@@ -1,0 +1,232 @@
+//import nock from 'nock'
+//import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+//import oneplusx_asset_api from '../index'
+
+//const testDestination = createTestIntegration(oneplusx_asset_api)
+
+//describe('1Plusx Asset Api', () => {
+//  describe('sendAssetData', () => {
+
+//  })
+//})
+
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import oneplusx_asset_api from '../index'
+import { ExecuteInput } from '@segment/actions-core'
+import { Settings } from '../generated-types'
+
+const testDestination = createTestIntegration(oneplusx_asset_api)
+
+// Define settings values
+const client_id = '123abc'
+const client_secret = '456def'
+const client_name = 'test01'
+
+describe('1Plusx Asset Api', () => {
+  describe('sendAssetData', () => {
+    it('should authenticate with the API and receive the token', async () => {
+      const accessToken = '12345abcde'
+      const authData: Partial<ExecuteInput<Settings, undefined>> = {
+        auth: {
+          accessToken,
+          refreshToken: ''
+        }
+      }
+
+      const extendedRequest = testDestination.extendRequest?.(authData as ExecuteInput<Settings, undefined>)
+      expect(extendedRequest?.headers?.['authorization']).toContain(`Bearer ${accessToken}`)
+    })
+    it('should send asset data with default mappigs', async () => {
+      const event = createTestEvent({
+        userId: 'user123',
+        timestamp: '2021-07-12T23:02:40.563Z',
+        event: 'Test Event',
+        type: 'track',
+        properties: {
+          asset_uri: 'Video:123456',
+          title: 'Solace',
+          content: 'Detailed desciption of the asset'
+        },
+        context: {
+          app: {
+            version: '1.0'
+          },
+          page: {
+            url: 'https://segment.com/'
+          },
+          userAgent:
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57'
+        }
+      })
+      const asset_uri = 'Video:123456'
+      nock(`https://${client_name}.assets.tagger.opecloud.com`).post(`/v2/native/asset/${asset_uri}`).reply(200)
+
+      const responses = await testDestination.testAction('sendAssetData', {
+        event,
+        settings: {
+          client_id,
+          client_secret,
+          client_name
+        },
+        mapping: {
+          asset_uri: {
+            '@path': '$.properties.asset_uri'
+          }
+        },
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        ope_title: 'Solace',
+        ope_content: 'Detailed desciption of the asset'
+      })
+    })
+
+    it('should send asset data without custom fields', async () => {
+      const event = createTestEvent({
+        userId: 'user123',
+        timestamp: '2021-07-12T23:02:40.563Z',
+        event: 'Test Event',
+        type: 'track',
+        properties: {
+          asset_uri: 'Video:123456',
+          video_title: 'Solace',
+          video_content: 'Detailed desciption of the asset',
+          genre: ['Thriller', 'Horror'],
+          actors: ['Hopkins', 'Affleck']
+        }
+      })
+      const asset_uri = 'Video:123456'
+      nock(`https://${client_name}.assets.tagger.opecloud.com`).post(`/v2/native/asset/${asset_uri}`).reply(200)
+
+      const responses = await testDestination.testAction('sendAssetData', {
+        event,
+        settings: {
+          client_id,
+          client_secret,
+          client_name
+        },
+        mapping: {
+          asset_uri: {
+            '@path': '$.properties.asset_uri'
+          },
+          ope_title: {
+            '@path': '$.properties.video_title'
+          },
+          ope_content: {
+            '@path': '$.properties.video_content'
+          }
+        },
+        useDefaultMappings: false
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        ope_title: 'Solace',
+        ope_content: 'Detailed desciption of the asset'
+      })
+    })
+
+    it('should send asset data with custom fields', async () => {
+      const event = createTestEvent({
+        anonymousId: 'anon-user123',
+        userId: 'user123',
+        timestamp: '2021-07-12T23:02:40.563Z',
+        event: 'Test Event',
+        type: 'track',
+        properties: {
+          asset_uri: 'Video:123456',
+          title: 'Solace',
+          content: 'Detailed desciption of the asset',
+          genre: ['Thriller', 'Horror'],
+          actors: ['Hopkins', 'Affleck']
+        }
+      })
+      const asset_uri = 'Video:123456'
+      nock(`https://${client_name}.assets.tagger.opecloud.com`).post(`/v2/native/asset/${asset_uri}`).reply(200)
+
+      const responses = await testDestination.testAction('sendAssetData', {
+        event,
+        settings: {
+          client_id,
+          client_secret,
+          client_name
+        },
+        mapping: {
+          asset_uri: {
+            '@path': '$.properties.asset_uri'
+          },
+          ope_title: {
+            '@path': '$.properties.title'
+          },
+          ope_content: {
+            '@path': '$.properties.content'
+          },
+          custom_fields: {
+            genre: { '@path': '$.properties.genre' },
+            actors: { '@path': '$.properties.actors' }
+          }
+        },
+        useDefaultMappings: true
+      })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        ope_title: 'Solace',
+        ope_content: 'Detailed desciption of the asset',
+        genre: ['Thriller', 'Horror'],
+        actors: ['Hopkins', 'Affleck']
+      })
+    })
+
+    it('should send asset data if optional ope_ props are missing and useDefaultMappings=false', async () => {
+      const event = createTestEvent({
+        anonymousId: 'anon-user123',
+        userId: 'user123',
+        timestamp: '2021-07-12T23:02:40.563Z',
+        event: 'Test Event',
+        type: 'track',
+        properties: {
+          asset_uri: 'Video:123456',
+          title: 'Solace',
+          content: 'Detailed desciption of the asset',
+          genre: 'Thriller',
+          actors: 'Hopkins'
+        }
+      })
+      const asset_uri = 'Video:123456'
+      nock(`https://${client_name}.assets.tagger.opecloud.com`).post(`/v2/native/asset/${asset_uri}`).reply(200)
+
+      const responses = await testDestination.testAction('sendAssetData', {
+        event,
+        settings: {
+          client_id,
+          client_name,
+          client_secret
+        },
+        mapping: {
+          asset_uri: {
+            '@path': '$.properties.asset_uri'
+          },
+          custom_fields: {
+            genre: { '@path': '$.properties.genre' },
+            actors: { '@path': '$.properties.actors' }
+          }
+        },
+        useDefaultMappings: false
+      })
+
+      console.log(responses[0].options.json)
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        genre: 'Thriller',
+        actors: 'Hopkins'
+      })
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/__tests__/index.test.ts
@@ -44,7 +44,7 @@ describe('1Plusx Asset Api', () => {
         event: 'Test Event',
         type: 'track',
         properties: {
-          asset_uri: 'Video:123456',
+          asset_uri: 'test_id:123456',
           title: 'Solace',
           content: 'Detailed desciption of the asset'
         },
@@ -59,8 +59,8 @@ describe('1Plusx Asset Api', () => {
             'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57'
         }
       })
-      const asset_uri = 'Video:123456'
-      nock(`https://${client_name}.assets.tagger.opecloud.com`).post(`/v2/native/asset/${asset_uri}`).reply(200)
+      const encoded_asset_uri = encodeURIComponent('test_id:123456')
+      nock(`https://${client_name}.assets.tagger.opecloud.com`).put(`/v2/native/asset/${encoded_asset_uri}`).reply(200)
 
       const responses = await testDestination.testAction('sendAssetData', {
         event,
@@ -92,15 +92,15 @@ describe('1Plusx Asset Api', () => {
         event: 'Test Event',
         type: 'track',
         properties: {
-          asset_uri: 'Video:123456',
+          asset_uri: 'test_id:123456',
           video_title: 'Solace',
           video_content: 'Detailed desciption of the asset',
           genre: ['Thriller', 'Horror'],
           actors: ['Hopkins', 'Affleck']
         }
       })
-      const asset_uri = 'Video:123456'
-      nock(`https://${client_name}.assets.tagger.opecloud.com`).post(`/v2/native/asset/${asset_uri}`).reply(200)
+      const encoded_asset_uri = encodeURIComponent('test_id:123456')
+      nock(`https://${client_name}.assets.tagger.opecloud.com`).put(`/v2/native/asset/${encoded_asset_uri}`).reply(200)
 
       const responses = await testDestination.testAction('sendAssetData', {
         event,
@@ -139,15 +139,15 @@ describe('1Plusx Asset Api', () => {
         event: 'Test Event',
         type: 'track',
         properties: {
-          asset_uri: 'Video:123456',
+          asset_uri: 'test_id:123456',
           title: 'Solace',
           content: 'Detailed desciption of the asset',
           genre: ['Thriller', 'Horror'],
           actors: ['Hopkins', 'Affleck']
         }
       })
-      const asset_uri = 'Video:123456'
-      nock(`https://${client_name}.assets.tagger.opecloud.com`).post(`/v2/native/asset/${asset_uri}`).reply(200)
+      const encoded_asset_uri = encodeURIComponent('test_id:123456')
+      nock(`https://${client_name}.assets.tagger.opecloud.com`).put(`/v2/native/asset/${encoded_asset_uri}`).reply(200)
 
       const responses = await testDestination.testAction('sendAssetData', {
         event,
@@ -191,15 +191,15 @@ describe('1Plusx Asset Api', () => {
         event: 'Test Event',
         type: 'track',
         properties: {
-          asset_uri: 'Video:123456',
+          asset_uri: 'test_id:123456',
           title: 'Solace',
           content: 'Detailed desciption of the asset',
           genre: 'Thriller',
           actors: 'Hopkins'
         }
       })
-      const asset_uri = 'Video:123456'
-      nock(`https://${client_name}.assets.tagger.opecloud.com`).post(`/v2/native/asset/${asset_uri}`).reply(200)
+      const encoded_asset_uri = encodeURIComponent('test_id:123456')
+      nock(`https://${client_name}.assets.tagger.opecloud.com`).put(`/v2/native/asset/${encoded_asset_uri}`).reply(200)
 
       const responses = await testDestination.testAction('sendAssetData', {
         event,

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/__tests__/index.test.ts
@@ -1,15 +1,3 @@
-//import nock from 'nock'
-//import { createTestEvent, createTestIntegration } from '@segment/actions-core'
-//import oneplusx_asset_api from '../index'
-
-//const testDestination = createTestIntegration(oneplusx_asset_api)
-
-//describe('1Plusx Asset Api', () => {
-//  describe('sendAssetData', () => {
-
-//  })
-//})
-
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import oneplusx_asset_api from '../index'
@@ -19,9 +7,9 @@ import { Settings } from '../generated-types'
 const testDestination = createTestIntegration(oneplusx_asset_api)
 
 // Define settings values
-const client_id = '123abc'
+const key_id = '123abc'
 const client_secret = '456def'
-const client_name = 'test01'
+const client_id = 'test01'
 
 describe('1Plusx Asset Api', () => {
   describe('sendAssetData', () => {
@@ -60,14 +48,14 @@ describe('1Plusx Asset Api', () => {
         }
       })
       const encoded_asset_uri = encodeURIComponent('test_id:123456')
-      nock(`https://${client_name}.assets.tagger.opecloud.com`).put(`/v2/native/asset/${encoded_asset_uri}`).reply(200)
+      nock(`https://${client_id}.assets.tagger.opecloud.com`).put(`/v2/native/asset/${encoded_asset_uri}`).reply(200)
 
       const responses = await testDestination.testAction('sendAssetData', {
         event,
         settings: {
           client_id,
           client_secret,
-          client_name
+          key_id
         },
         mapping: {
           asset_uri: {
@@ -100,14 +88,14 @@ describe('1Plusx Asset Api', () => {
         }
       })
       const encoded_asset_uri = encodeURIComponent('test_id:123456')
-      nock(`https://${client_name}.assets.tagger.opecloud.com`).put(`/v2/native/asset/${encoded_asset_uri}`).reply(200)
+      nock(`https://${client_id}.assets.tagger.opecloud.com`).put(`/v2/native/asset/${encoded_asset_uri}`).reply(200)
 
       const responses = await testDestination.testAction('sendAssetData', {
         event,
         settings: {
           client_id,
           client_secret,
-          client_name
+          key_id
         },
         mapping: {
           asset_uri: {
@@ -147,14 +135,14 @@ describe('1Plusx Asset Api', () => {
         }
       })
       const encoded_asset_uri = encodeURIComponent('test_id:123456')
-      nock(`https://${client_name}.assets.tagger.opecloud.com`).put(`/v2/native/asset/${encoded_asset_uri}`).reply(200)
+      nock(`https://${client_id}.assets.tagger.opecloud.com`).put(`/v2/native/asset/${encoded_asset_uri}`).reply(200)
 
       const responses = await testDestination.testAction('sendAssetData', {
         event,
         settings: {
           client_id,
           client_secret,
-          client_name
+          key_id
         },
         mapping: {
           asset_uri: {
@@ -199,14 +187,14 @@ describe('1Plusx Asset Api', () => {
         }
       })
       const encoded_asset_uri = encodeURIComponent('test_id:123456')
-      nock(`https://${client_name}.assets.tagger.opecloud.com`).put(`/v2/native/asset/${encoded_asset_uri}`).reply(200)
+      nock(`https://${client_id}.assets.tagger.opecloud.com`).put(`/v2/native/asset/${encoded_asset_uri}`).reply(200)
 
       const responses = await testDestination.testAction('sendAssetData', {
         event,
         settings: {
           client_id,
-          client_name,
-          client_secret
+          client_secret,
+          key_id
         },
         mapping: {
           asset_uri: {

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-1plusx-asset-api'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/generated-types.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/generated-types.ts
@@ -6,7 +6,7 @@ export interface Settings {
    */
   client_name: string
   /**
-   * Your 1plusX Client ID. Available in 1plusX UI in the "API Keys" section.
+   * Your 1plusX Client (Key) ID. Available in 1plusX UI in the "API Keys" section.
    */
   client_id: string
   /**

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/generated-types.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/generated-types.ts
@@ -1,0 +1,16 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your 1plusX Client Name. Please refer to your 1PlusX representative to obtain it.
+   */
+  client_name: string
+  /**
+   * Your 1plusX Client ID. Available in 1plusX UI in the "API Keys" section.
+   */
+  client_id: string
+  /**
+   * Your 1plusX Client Secret. Available in 1plusX UI in the "API Keys" section.
+   */
+  client_secret: string
+}

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/generated-types.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/generated-types.ts
@@ -2,15 +2,15 @@
 
 export interface Settings {
   /**
-   * Your 1plusX Client Name. Please refer to your 1PlusX representative to obtain it.
-   */
-  client_name: string
-  /**
-   * Your 1plusX Client (Key) ID. Available in 1plusX UI in the "API Keys" section.
+   * Your 1plusX Client ID. Please refer to your 1PlusX representative to obtain it.
    */
   client_id: string
   /**
-   * Your 1plusX Client Secret. Available in 1plusX UI in the "API Keys" section.
+   * Your 1plusX Key ID. Available in 1plusX UI in the "API Keys" section.
+   */
+  key_id: string
+  /**
+   * Your 1plusX Secret. Available in 1plusX UI in the "API Keys" section.
    */
   client_secret: string
 }

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/index.ts
@@ -1,0 +1,68 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import sendAssetData from './sendAssetData'
+
+interface RefreshTokenResponse {
+  access_token: string
+}
+
+const destination: DestinationDefinition<Settings> = {
+  name: '1Plusx Asset Api',
+  slug: 'actions-1plusx-asset-api',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'oauth2',
+    fields: {
+      client_name: {
+        label: 'Client Name',
+        description: 'Your 1plusX Client Name. Please refer to your 1PlusX representative to obtain it.',
+        type: 'string',
+        required: true
+      },
+      client_id: {
+        label: 'Client ID',
+        description: 'Your 1plusX Client ID. Available in 1plusX UI in the "API Keys" section.',
+        type: 'string',
+        required: true
+      },
+      client_secret: {
+        label: 'Client Secret',
+        description: 'Your 1plusX Client Secret. Available in 1plusX UI in the "API Keys" section.',
+        type: 'string',
+        required: true
+      }
+    },
+
+    refreshAccessToken: async (request, { settings }) => {
+      console.log('refreshAccessToken start')
+      // Refresh access token using client_id and client_secret provided in the Settings
+      const res = await request<RefreshTokenResponse>('https://ui.1plusx.io/api/auth/token', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Basic ' + btoa(settings.client_id + ':' + settings.client_secret)
+        },
+        body: '{"grant_type":"client_credentials"}'
+      })
+      console.log('refresh token')
+      return { accessToken: res.data.access_token }
+    }
+  },
+  extendRequest({ auth }) {
+    console.log('access token ' + auth?.accessToken)
+    console.log('extendRequest starts')
+    return {
+      headers: {
+        authorization: `Bearer ${auth?.accessToken}`
+      }
+    }
+  },
+
+  actions: {
+    sendAssetData
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/index.ts
@@ -15,14 +15,12 @@ const destination: DestinationDefinition<Settings> = {
   authentication: {
     scheme: 'oauth2',
     fields: {
-      // update to client_id. Was "client_name"
       client_id: {
         label: 'Client ID',
         description: 'Your 1plusX Client ID. Please refer to your 1PlusX representative to obtain it.',
         type: 'string',
         required: true
       },
-      // update to key_id. Was "client_id"
       key_id: {
         label: 'Key ID',
         description: 'Your 1plusX Key ID. Available in 1plusX UI in the "API Keys" section.',

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/index.ts
@@ -34,19 +34,34 @@ const destination: DestinationDefinition<Settings> = {
         required: true
       }
     },
-
-    refreshAccessToken: async (request, { settings }) => {
-      console.log('refreshAccessToken start')
-      // Refresh access token using client_id and client_secret provided in the Settings
+    testAuthentication: async (request, { settings }) => {
       const res = await request<RefreshTokenResponse>('https://ui.1plusx.io/api/auth/token', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: 'Basic ' + btoa(settings.client_id + ':' + settings.client_secret)
+          Authorization: `Basic ${Buffer.from(settings.client_id + ':' + settings.client_secret).toString('base64')}`
         },
         body: '{"grant_type":"client_credentials"}'
       })
-      console.log('refresh token')
+      if (res.status == 200) {
+        return { accessToken: res.data.access_token }
+      } else {
+        throw new Error(res.status + res.statusText)
+      }
+    },
+    refreshAccessToken: async (request, { settings }) => {
+      console.log('refreshAccessToken start')
+      // Refresh access token using client_id and client_secret provided in the Settings
+
+      const res = await request<RefreshTokenResponse>('https://ui.1plusx.io/api/auth/token', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${Buffer.from(settings.client_id + ':' + settings.client_secret).toString('base64')}`
+        },
+        body: '{"grant_type":"client_credentials"}'
+      })
+      console.log('refreshed token')
       return { accessToken: res.data.access_token }
     }
   },

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/index.ts
@@ -50,9 +50,7 @@ const destination: DestinationDefinition<Settings> = {
       }
     },
     refreshAccessToken: async (request, { settings }) => {
-      console.log('refreshAccessToken start')
       // Refresh access token using client_id and client_secret provided in the Settings
-
       const res = await request<RefreshTokenResponse>('https://ui.1plusx.io/api/auth/token', {
         method: 'POST',
         headers: {
@@ -66,8 +64,6 @@ const destination: DestinationDefinition<Settings> = {
     }
   },
   extendRequest({ auth }) {
-    //console.log('access token ' + auth?.accessToken)
-    console.log('extendRequest starts')
     return {
       headers: {
         authorization: `Bearer ${auth?.accessToken}`

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/index.ts
@@ -23,14 +23,14 @@ const destination: DestinationDefinition<Settings> = {
       },
       client_id: {
         label: 'Client ID',
-        description: 'Your 1plusX Client ID. Available in 1plusX UI in the "API Keys" section.',
-        type: 'string',
+        description: 'Your 1plusX Client (Key) ID. Available in 1plusX UI in the "API Keys" section.',
+        type: 'password',
         required: true
       },
       client_secret: {
         label: 'Client Secret',
         description: 'Your 1plusX Client Secret. Available in 1plusX UI in the "API Keys" section.',
-        type: 'string',
+        type: 'password',
         required: true
       }
     },

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/index.ts
@@ -66,7 +66,7 @@ const destination: DestinationDefinition<Settings> = {
     }
   },
   extendRequest({ auth }) {
-    console.log('access token ' + auth?.accessToken)
+    //console.log('access token ' + auth?.accessToken)
     console.log('extendRequest starts')
     return {
       headers: {

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/index.ts
@@ -15,21 +15,23 @@ const destination: DestinationDefinition<Settings> = {
   authentication: {
     scheme: 'oauth2',
     fields: {
-      client_name: {
-        label: 'Client Name',
-        description: 'Your 1plusX Client Name. Please refer to your 1PlusX representative to obtain it.',
+      // update to client_id. Was "client_name"
+      client_id: {
+        label: 'Client ID',
+        description: 'Your 1plusX Client ID. Please refer to your 1PlusX representative to obtain it.',
         type: 'string',
         required: true
       },
-      client_id: {
-        label: 'Client ID',
-        description: 'Your 1plusX Client (Key) ID. Available in 1plusX UI in the "API Keys" section.',
+      // update to key_id. Was "client_id"
+      key_id: {
+        label: 'Key ID',
+        description: 'Your 1plusX Key ID. Available in 1plusX UI in the "API Keys" section.',
         type: 'password',
         required: true
       },
       client_secret: {
-        label: 'Client Secret',
-        description: 'Your 1plusX Client Secret. Available in 1plusX UI in the "API Keys" section.',
+        label: 'Secret',
+        description: 'Your 1plusX Secret. Available in 1plusX UI in the "API Keys" section.',
         type: 'password',
         required: true
       }
@@ -39,7 +41,7 @@ const destination: DestinationDefinition<Settings> = {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Basic ${Buffer.from(settings.client_id + ':' + settings.client_secret).toString('base64')}`
+          Authorization: `Basic ${Buffer.from(settings.key_id + ':' + settings.client_secret).toString('base64')}`
         },
         body: '{"grant_type":"client_credentials"}'
       })
@@ -55,11 +57,11 @@ const destination: DestinationDefinition<Settings> = {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Basic ${Buffer.from(settings.client_id + ':' + settings.client_secret).toString('base64')}`
+          Authorization: `Basic ${Buffer.from(settings.key_id + ':' + settings.client_secret).toString('base64')}`
         },
         body: '{"grant_type":"client_credentials"}'
       })
-      console.log('refreshed token')
+
       return { accessToken: res.data.access_token }
     }
   },

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/index.ts
@@ -35,7 +35,7 @@ const destination: DestinationDefinition<Settings> = {
       }
     },
     testAuthentication: async (request, { settings }) => {
-      const res = await request<RefreshTokenResponse>('https://ui.1plusx.io/api/auth/token', {
+      const res = await request<RefreshTokenResponse>('https://us.1plusx.io/api/auth/token', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -51,7 +51,7 @@ const destination: DestinationDefinition<Settings> = {
     },
     refreshAccessToken: async (request, { settings }) => {
       // Refresh access token using client_id and client_secret provided in the Settings
-      const res = await request<RefreshTokenResponse>('https://ui.1plusx.io/api/auth/token', {
+      const res = await request<RefreshTokenResponse>('https://us.1plusx.io/api/auth/token', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/generated-types.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/generated-types.ts
@@ -1,0 +1,22 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The asset's unique identifier
+   */
+  asset_uri: string
+  /**
+   * User friendly description of the asset in the UI
+   */
+  ope_title?: string
+  /**
+   * Textual content of the asset processing using NLP alogrithms
+   */
+  ope_content?: string
+  /**
+   * Custom fields to include with the event
+   */
+  custom_fields?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/generated-types.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * The asset's unique identifier
+   * The asset's unique identifier. Please make sure to map only the fields where values don't include space character
    */
   asset_uri: string
   /**

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/index.ts
@@ -51,7 +51,6 @@ const action: ActionDefinition<Settings, Payload> = {
     //Convert custom_field values to strings as per 1plusX requirements
     const cleanProps = mapValues(custom_fields, function (value) {
       //Drop arrays and objects
-      // TODO still must include Date!
       if (typeof value === 'object' && !(value instanceof Array) && !(value instanceof Date)) return
       //Pass strings straight through
       else if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value
@@ -61,7 +60,7 @@ const action: ActionDefinition<Settings, Payload> = {
     })
     // Encoding asset_uri
     const encoded_asset_uri = encodeURIComponent(payload.asset_uri)
-    const endpoint = `https://${settings.client_name}.assets.tagger.opecloud.com/v2/native/asset/${encoded_asset_uri}`
+    const endpoint = `https://${settings.client_id}.assets.tagger.opecloud.com/v2/native/asset/${encoded_asset_uri}`
     return request(endpoint, {
       method: 'put',
       json: {

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/index.ts
@@ -41,7 +41,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'object'
     }
   },
-  perform: (request, { settings, payload }) => {
+  perform: async (request, { settings, payload }) => {
     //Create cleanPayload with custom_fields and asset_uri
     //Removed custom_fields as these must be unnested
     //Removed asset_uri as it should only be used as a part of the API endpoint and not the outgoing payload
@@ -61,14 +61,19 @@ const action: ActionDefinition<Settings, Payload> = {
     // Encoding asset_uri
     const encoded_asset_uri = encodeURIComponent(payload.asset_uri)
     const endpoint = `https://${settings.client_name}.assets.tagger.opecloud.com/v2/native/asset/${encoded_asset_uri}`
-
-    return request(endpoint, {
+    const pp = await request(endpoint, {
       method: 'put',
       json: {
         ...cleanPayload,
         ...cleanProps
       }
     })
+    console.log(
+      console.log(
+        `Event: ${JSON.stringify({ ...cleanPayload, ...cleanProps })}. Reponse: ${pp.status}  ${pp.statusText}`
+      )
+    )
+    return pp
   }
 }
 export default action

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/index.ts
@@ -62,7 +62,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const endpoint = `https://${settings.client_name}.assets.tagger.opecloud.com/v2/native/asset/${payload.asset_uri}`
 
     return request(endpoint, {
-      method: 'post',
+      method: 'put',
       json: {
         ...cleanPayload,
         ...cleanProps

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/index.ts
@@ -41,7 +41,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'object'
     }
   },
-  perform: async (request, { settings, payload }) => {
+  perform: (request, { settings, payload }) => {
     //Create cleanPayload with custom_fields and asset_uri
     //Removed custom_fields as these must be unnested
     //Removed asset_uri as it should only be used as a part of the API endpoint and not the outgoing payload
@@ -61,19 +61,13 @@ const action: ActionDefinition<Settings, Payload> = {
     // Encoding asset_uri
     const encoded_asset_uri = encodeURIComponent(payload.asset_uri)
     const endpoint = `https://${settings.client_name}.assets.tagger.opecloud.com/v2/native/asset/${encoded_asset_uri}`
-    const pp = await request(endpoint, {
+    return request(endpoint, {
       method: 'put',
       json: {
         ...cleanPayload,
         ...cleanProps
       }
     })
-    console.log(
-      console.log(
-        `Event: ${JSON.stringify({ ...cleanPayload, ...cleanProps })}. Reponse: ${pp.status}  ${pp.statusText}`
-      )
-    )
-    return pp
   }
 }
 export default action

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/index.ts
@@ -10,11 +10,12 @@ const action: ActionDefinition<Settings, Payload> = {
     //A user identifier must be in the form IDSPACE:ID, i.e. idfa:6D92078A-8246-4BA4-AE5B-76104861E7DC
     asset_uri: {
       label: 'Asset ID',
-      description: "The asset's unique identifier",
+      description:
+        "The asset's unique identifier. Please make sure to map only the fields where values don't include space character",
       type: 'string',
       required: true,
       default: {
-        '@template': 'ASSETnamespace:ASSETid'
+        '@template': 'NAMESPACE:asset_uri'
       }
     },
     ope_title: {

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/index.ts
@@ -1,0 +1,73 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import mapValues from 'lodash/mapValues'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Send Asset Data',
+  description: 'Send Asset data into 1PlusX',
+  fields: {
+    //A user identifier must be in the form IDSPACE:ID, i.e. idfa:6D92078A-8246-4BA4-AE5B-76104861E7DC
+    asset_uri: {
+      label: 'Asset ID',
+      description: "The asset's unique identifier",
+      type: 'string',
+      required: true,
+      default: {
+        '@template': 'ASSETnamespace:ASSETid'
+      }
+    },
+    ope_title: {
+      label: 'Asset Title',
+      description: 'User friendly description of the asset in the UI',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.properties.title'
+      }
+    },
+    ope_content: {
+      label: 'Asset Content',
+      description: 'Textual content of the asset processing using NLP alogrithms',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.properties.content'
+      }
+    },
+    custom_fields: {
+      label: 'Custom Fields',
+      description: 'Custom fields to include with the event',
+      type: 'object'
+    }
+  },
+  perform: (request, { settings, payload }) => {
+    //Create cleanPayload with custom_fields and asset_uri
+    //Removed custom_fields as these must be unnested
+    //Removed asset_uri as it should only be used as a part of the API endpoint and not the outgoing payload
+    const { custom_fields, asset_uri, ...cleanPayload } = payload
+
+    //Convert custom_field values to strings as per 1plusX requirements
+    const cleanProps = mapValues(custom_fields, function (value) {
+      //Drop arrays and objects
+      // TODO still must include Date!
+      if (typeof value === 'object' && !(value instanceof Array) && !(value instanceof Date)) return
+      //Pass strings straight through
+      else if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value
+      //Otherwise stringify all other data types
+      else if (value instanceof Array) return value
+      else return JSON.stringify(value)
+    })
+
+    const endpoint = `https://${settings.client_name}.assets.tagger.opecloud.com/v2/native/asset/${payload.asset_uri}`
+
+    return request(endpoint, {
+      method: 'post',
+      json: {
+        ...cleanPayload,
+        ...cleanProps
+      }
+    })
+  }
+}
+export default action

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/index.ts
@@ -59,7 +59,9 @@ const action: ActionDefinition<Settings, Payload> = {
       else return JSON.stringify(value)
     })
 
-    const endpoint = `https://${settings.client_name}.assets.tagger.opecloud.com/v2/native/asset/${payload.asset_uri}`
+    const endpoint = encodeURI(
+      `https://${settings.client_name}.assets.tagger.opecloud.com/v2/native/asset/${payload.asset_uri}`
+    )
 
     return request(endpoint, {
       method: 'put',

--- a/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx-asset-api/sendAssetData/index.ts
@@ -58,10 +58,9 @@ const action: ActionDefinition<Settings, Payload> = {
       else if (value instanceof Array) return value
       else return JSON.stringify(value)
     })
-
-    const endpoint = encodeURI(
-      `https://${settings.client_name}.assets.tagger.opecloud.com/v2/native/asset/${payload.asset_uri}`
-    )
+    // Encoding asset_uri
+    const encoded_asset_uri = encodeURIComponent(payload.asset_uri)
+    const endpoint = `https://${settings.client_name}.assets.tagger.opecloud.com/v2/native/asset/${encoded_asset_uri}`
 
     return request(endpoint, {
       method: 'put',

--- a/packages/destination-actions/src/destinations/1plusx/sendEvent/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx/sendEvent/index.ts
@@ -118,7 +118,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const endpoint = settings.use_test_endpoint
       ? `https://tagger-test.opecloud.com/${settings.client_id}/v2/native/event`
-      : `https://tagger.opecloud.com/${settings.client_id}/v2/native/event`
+      : `https://${settings.client_id}.tagger.opecloud.com/${settings.client_id}/v2/native/event`
 
     return request(endpoint, {
       method: 'post',

--- a/packages/destination-actions/src/destinations/1plusx/sendPageview/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx/sendPageview/index.ts
@@ -116,7 +116,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const endpoint = settings.use_test_endpoint
       ? `https://tagger-test.opecloud.com/${settings.client_id}/v2/native/event`
-      : `https://tagger.opecloud.com/${settings.client_id}/v2/native/event`
+      : `https://${settings.client_id}.tagger.opecloud.com/${settings.client_id}/v2/native/event`
 
     return request(endpoint, {
       method: 'post',

--- a/packages/destination-actions/src/destinations/1plusx/sendUserData/index.ts
+++ b/packages/destination-actions/src/destinations/1plusx/sendUserData/index.ts
@@ -117,7 +117,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const endpoint = settings.use_test_endpoint
       ? `https://tagger-test.opecloud.com/${settings.client_id}/v2/native/event`
-      : `https://tagger.opecloud.com/${settings.client_id}/v2/native/event`
+      : `https://${settings.client_id}.tagger.opecloud.com/${settings.client_id}/v2/native/event`
 
     return request(endpoint, {
       method: 'post',

--- a/packages/destination-actions/src/destinations/index.ts
+++ b/packages/destination-actions/src/destinations/index.ts
@@ -63,7 +63,6 @@ register('62ded0cf5753c743883ca0f3', './intercom')
 register('631a6f32946dd8197e9cab66', './sendgrid')
 register('632b1116e0cb83902f3fd717', './hubspot')
 register('636d38db78d7834347d76c44', './1plusx-asset-api')
-register('635fea9131814aa2aa18a640', './google-sheets-partner')
 register('6371eee1ae5e324869aa8b1b', './segment')
 
 function register(id: MetadataId, destinationPath: string) {

--- a/packages/destination-actions/src/destinations/index.ts
+++ b/packages/destination-actions/src/destinations/index.ts
@@ -62,6 +62,8 @@ register('61dc4e96894a6d7954cc6e45', './voyage')
 register('62ded0cf5753c743883ca0f3', './intercom')
 register('631a6f32946dd8197e9cab66', './sendgrid')
 register('632b1116e0cb83902f3fd717', './hubspot')
+register('636d38db78d7834347d76c44', './1plusx-asset-api')
+register('635fea9131814aa2aa18a640', './google-sheets-partner')
 register('6371eee1ae5e324869aa8b1b', './segment')
 
 function register(id: MetadataId, destinationPath: string) {


### PR DESCRIPTION
This PR does the following:
1. adds a new Segment actions destination integrating with 1plusX Asset API (actions-1plusx-asset-api). The integration implements OAuth authentication and includes one type of the mapping.
2. updates the URL in the existing 1plusX destination (User API, slug actions-1plusx) to https://{settings.client_id}.tagger.opecloud.com/{settings.client_id]/v2/native/event (adds client_id variable in the domain portion) per request from 1PlusX team.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
All unit tests pass.
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
Tested mapping functionality. Mappings work as expected.
- [x] [Segmenters] Tested in the staging environment. 
Tested authentication and sending the requests to 1PlusX API. Received 200 success responses. Test results can be found [here](https://docs.google.com/document/d/1YHfb53g9daE0oAr4VietFP0ZDtXAvt_xLOYfPWBgjLM/edit?usp=sharing).
