### PR TITLE
[STRATCONN-1717] SFMC Post Testing Improvements

### DIFF
--- a/packages/browser-destinations/src/destinations/wisepops/setCustomProperties/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/wisepops/setCustomProperties/generated-types.ts
@@ -8,19 +8,15 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * This lets you to store the properties as a nested object. If you set the property `name` with the prefix `group`, you'll access it in Wisepops as `group.name`.
-   */
-  prefix?: string
-  /**
-   * A unique identifier. Typically a user or group ID.
+   * A unique identifier. Typically, a user ID or group ID.
    */
   id?: string
   /**
-   * What property name should be used to set the entity ID as a Wisepops custom property?
+   * How to name the entity ID among the other custom properties?
    */
   idProperty?: string
   /**
-   * By default, custom properties persist across pages. Enable temporary properties to limit them to the current page only.
+   * This lets you define the properties as a nested object. If you set the property `"name"` with the prefix `"group"`, you'll access it in Wisepops as `"group.name"`.
    */
-  temporary?: boolean
+  prefix?: string
 }

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtension/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtension/generated-types.ts
@@ -2,15 +2,15 @@
 
 export interface Payload {
   /**
-   * The key of the data extension that you want to store contact information in. The data extension must be predefined in SFMC. Segment recommends storing all contact information in a single data extension. The key is required if a Data Extension ID is not provided.
+   * The external key of the data extension that you want to store information in. The data extension must be predefined in SFMC. The external key is required if a Data Extension ID is not provided.
    */
   key?: string
   /**
-   * The ID of the data extension that you want to store contact information in. The data extension must be predefined in SFMC. Segment recommends storing all contact information in a single data extension. The ID is required if a Data Extension Key is not provided.
+   * The ID of the data extension that you want to store information in. The data extension must be predefined in SFMC. The ID is required if a Data Extension Key is not provided.
    */
   id?: string
   /**
-   * The primary key(s) that uniquely identify a contact in the data extension. At a minimum, Contact Key must exist in your data extension as a Primary Key. On the left-hand side, input the SFMC key name. On the right-hand side, map the Segment field that contains the corresponding value. When multiple primary keys are provided, SFMC will update an existing row if all primary keys match, otherwise a new row will be created.
+   * The primary key(s) that uniquely identify a row in the data extension. On the left-hand side, input the SFMC key name. On the right-hand side, map the Segment field that contains the corresponding value. When multiple primary keys are provided, SFMC will update an existing row if all primary keys match, otherwise a new row will be created
    */
   keys: {
     /**

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtension/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtension/index.ts
@@ -5,7 +5,7 @@ import { key, id, keys, enable_batching, values_contactFields } from '../sfmc-pr
 import { upsertRows } from '../sfmc-operations'
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Contact Data Extension',
+  title: 'Send Contact to Data Extension',
   defaultSubscription: 'type = "identify"',
   description: 'Upsert contact data as rows into an existing data extension in Salesforce Marketing Cloud.',
   fields: {

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtension/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtension/generated-types.ts
@@ -2,15 +2,15 @@
 
 export interface Payload {
   /**
-   * The key of the data extension that you want to store contact information in. The data extension must be predefined in SFMC. Segment recommends storing all contact information in a single data extension. The key is required if a Data Extension ID is not provided.
+   * The external key of the data extension that you want to store information in. The data extension must be predefined in SFMC. The external key is required if a Data Extension ID is not provided.
    */
   key?: string
   /**
-   * The ID of the data extension that you want to store contact information in. The data extension must be predefined in SFMC. Segment recommends storing all contact information in a single data extension. The ID is required if a Data Extension Key is not provided.
+   * The ID of the data extension that you want to store information in. The data extension must be predefined in SFMC. The ID is required if a Data Extension Key is not provided.
    */
   id?: string
   /**
-   * The primary key(s) that uniquely identify a contact in the data extension. At a minimum, Contact Key must exist in your data extension as a Primary Key. On the left-hand side, input the SFMC key name. On the right-hand side, map the Segment field that contains the corresponding value. When multiple primary keys are provided, SFMC will update an existing row if all primary keys match, otherwise a new row will be created.
+   * The primary key(s) that uniquely identify a row in the data extension. On the left-hand side, input the SFMC key name. On the right-hand side, map the Segment field that contains the corresponding value. When multiple primary keys are provided, SFMC will update an existing row if all primary keys match, otherwise a new row will be created
    */
   keys: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-properties.ts
@@ -19,21 +19,21 @@ export const contactKeyAPIEvent: InputField = {
 export const key: InputField = {
   label: 'Data Extension Key',
   description:
-    'The key of the data extension that you want to store contact information in. The data extension must be predefined in SFMC. Segment recommends storing all contact information in a single data extension. The key is required if a Data Extension ID is not provided.',
+    'The external key of the data extension that you want to store information in. The data extension must be predefined in SFMC. The external key is required if a Data Extension ID is not provided.',
   type: 'string'
 }
 
 export const id: InputField = {
   label: 'Data Extension ID',
   description:
-    'The ID of the data extension that you want to store contact information in. The data extension must be predefined in SFMC. Segment recommends storing all contact information in a single data extension. The ID is required if a Data Extension Key is not provided.',
+    'The ID of the data extension that you want to store information in. The data extension must be predefined in SFMC. The ID is required if a Data Extension Key is not provided.',
   type: 'string'
 }
 
 export const keys: InputField = {
   label: 'Data Extension Primary Keys',
   description:
-    'The primary key(s) that uniquely identify a contact in the data extension. At a minimum, Contact Key must exist in your data extension as a Primary Key. On the left-hand side, input the SFMC key name. On the right-hand side, map the Segment field that contains the corresponding value. When multiple primary keys are provided, SFMC will update an existing row if all primary keys match, otherwise a new row will be created.',
+    'The primary key(s) that uniquely identify a row in the data extension. On the left-hand side, input the SFMC key name. On the right-hand side, map the Segment field that contains the corresponding value. When multiple primary keys are provided, SFMC will update an existing row if all primary keys match, otherwise a new row will be created',
   type: 'object',
   required: true,
   defaultObjectUI: 'keyvalue:only',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Rename the contact data extension action to “Send Contact to Data Extension”

Update the Following Descriptions: 

Data Extension Key:

'The external key of the data extension that you want to store information in. The data extension must be predefined in SFMC. The external key is required if a Data Extension ID is not provided.',

Data Extension ID:

 'The ID of the data extension that you want to store information in. The data extension must be predefined in SFMC. The ID is required if a Data Extension Key is not provided.',

Primary keys:

'The primary key(s) that uniquely identify a row in the data extension. On the left-hand side, input the SFMC key name. On the right-hand side, map the Segment field that contains the corresponding value. When multiple primary keys are provided, SFMC will update an existing row if all primary keys match, otherwise a new row will be created.',

## Testing

Testing not required because only updating descriptions. 

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
