### PR TITLE
Add function to transform unsupported custom field data types

### DIFF
--- a/packages/destination-actions/src/destinations/sendgrid/__tests__/sendgrid-properties.test.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/__tests__/sendgrid-properties.test.ts
@@ -1,0 +1,32 @@
+import { tranformValueToAcceptedDataType } from '../sendgrid-properties'
+
+describe('tranformValueToAcceptedDataType', () => {
+  it('should transform a boolean value into a string', () => {
+    expect(tranformValueToAcceptedDataType(true)).toBe('true')
+  })
+
+  it('should transform an array value into a string', () => {
+    expect(tranformValueToAcceptedDataType([1, 2, 3])).toBe('[1,2,3]')
+  })
+
+  it('should transform an object value into a string', () => {
+    expect(tranformValueToAcceptedDataType({ a: 1 })).toBe('{"a":1}')
+  })
+
+  it('should transform nested arrays and objects into a string', () => {
+    const data = [[1, 2, 3], { a: 1, b: 2, c: { d: 3, e: ['f', 'g'] } }]
+    expect(tranformValueToAcceptedDataType(data)).toBe('[[1,2,3],{"a":1,"b":2,"c":{"d":3,"e":["f","g"]}}]')
+  })
+
+  it('should return the value for number types', () => {
+    expect(tranformValueToAcceptedDataType(123)).toBe(123)
+  })
+
+  it('should return the value for string types', () => {
+    expect(tranformValueToAcceptedDataType('Hello, test')).toBe('Hello, test')
+  })
+
+  it('should return the value for date types', () => {
+    expect(tranformValueToAcceptedDataType('2022-11-01T00:00:00Z')).toBe('2022-11-01T00:00:00Z')
+  })
+})

--- a/packages/destination-actions/src/destinations/sendgrid/sendgrid-properties.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/sendgrid-properties.ts
@@ -73,6 +73,27 @@ const convertCustomFieldNamesToIds = (customFields: any, accountCustomFields: Cu
   }, {})
 }
 
+// This function transforms data types for values that the Sendgrid MC API does not accept (boolean, array, object) and
+// transforms them into a type that is accepted
+export const tranformValueToAcceptedDataType = (value: any): any => {
+  // typeof for arrays is also 'object', so this branch will transform boolean, arrays, and objects
+  if (typeof value === 'boolean' || typeof value === 'object') {
+    return JSON.stringify(value)
+  } else {
+    return value
+  }
+}
+
+const transformValuesToAcceptedDataTypes = (data: any): any => {
+  const tranformedData: any = {}
+
+  for (const property in data) {
+    tranformedData[property] = tranformValueToAcceptedDataType(data[property])
+  }
+
+  return tranformedData
+}
+
 export const convertPayload = (payload: Payload, accountCustomFields: CustomField[]) => {
   const { state, primary_email, enable_batching, customFields, ...rest } = payload
 
@@ -81,5 +102,11 @@ export const convertPayload = (payload: Payload, accountCustomFields: CustomFiel
     ? convertCustomFieldNamesToIds(customFields, accountCustomFields)
     : customFields
 
-  return { ...rest, state_province_region: state, email: primary_email, custom_fields: updatedCustomFields }
+  return {
+    ...rest,
+    state_province_region: state,
+    email: primary_email,
+    // We only need to transform custom fields because reserved fields are types Sendgrid MC API accepts
+    custom_fields: transformValuesToAcceptedDataTypes(updatedCustomFields)
+  }
 }


### PR DESCRIPTION
## Summary

I am updating the way we handle custom field values when sending payloads to the Sendgrid MC action destination.  Sendgrid only allows for 3 field types when defining a custom field in Sendgrid: number, text, and date.  If a user configures to send a value from Segment via the action destination to one of their custom fields that is not one of these three data types (i.e. a boolean value). the request will fail.

The update in this PR is to transform data types that are common in Segment use cases but are not supported in Sendgrid to a type that is supported by Sendgrid.  In this PR, we add a function called `tranformValueToAcceptedDataType` that will transform a boolean, array, or object value to a stringified version of the value.  This means the value `true` will become `"true"` 🎉 .  So long as the user has set the custom field data type to text in Sendgrid, the values will now be implicitly converted by the action destination to string and sent successfully via the Sendgrid MC API with this update.

## Testing

I added some tests for the new `tranformValueToAcceptedDataType` helper function.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
