### PR TITLE
Add to HubSpot Cloud event name description

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
@@ -20,7 +20,7 @@ const action: ActionDefinition<Settings, Payload> = {
     eventName: {
       label: 'Event Name',
       description:
-        'The internal event name assigned by HubSpot. This can be found in your HubSpot account. Events must be predefined in HubSpot. Learn how to find the internal name in [HubSpot’s documentation](https://knowledge.hubspot.com/analytics-tools/create-custom-behavioral-events).',
+        'The internal event name assigned by HubSpot.  This can be found in your HubSpot account. Events must be predefined in HubSpot. Please input the full internal event name including the `pe` prefix (i.e. `pe<HubID>_event_name`). Learn how to find the internal name in [HubSpot’s documentation](https://knowledge.hubspot.com/analytics-tools/create-custom-behavioral-events).',
       type: 'string',
       required: true
     },

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
@@ -20,7 +20,7 @@ const action: ActionDefinition<Settings, Payload> = {
     eventName: {
       label: 'Event Name',
       description:
-        'The internal event name assigned by HubSpot.  This can be found in your HubSpot account. Events must be predefined in HubSpot. Please input the full internal event name including the `pe` prefix (i.e. `pe<HubID>_event_name`). Learn how to find the internal name in [HubSpot’s documentation](https://knowledge.hubspot.com/analytics-tools/create-custom-behavioral-events).',
+        'The internal event name assigned by HubSpot. This can be found in your HubSpot account. Events must be predefined in HubSpot. Please input the full internal event name including the `pe` prefix (i.e. `pe<HubID>_event_name`). Learn how to find the internal name in [HubSpot’s documentation](https://knowledge.hubspot.com/analytics-tools/create-custom-behavioral-events).',
       type: 'string',
       required: true
     },


### PR DESCRIPTION
_A summary of your pull request, including the what change you're making and why._
Received feedback from GTM that it is confusing that the `pe<HubId>` prefix must be included in the event name mapping. This just updates the description to make that clearer.

## Testing
No testing required as this is only a description update.
