### PR TITLE
Add refresh token url to oauth settings

### DIFF
--- a/packages/core/src/__tests__/destination-kit.test.ts
+++ b/packages/core/src/__tests__/destination-kit.test.ts
@@ -285,7 +285,8 @@ describe('destination kit', () => {
         accessToken: 'test-access-token',
         refreshToken: 'refresh-token',
         clientId: 'test-clientid',
-        clientSecret: 'test-clientsecret'
+        clientSecret: 'test-clientsecret',
+        refreshTokenUrl: 'abc123.xyz'
       }
       try {
         await destinationTest.refreshAccessToken(testSettings, oauthData)
@@ -306,7 +307,8 @@ describe('destination kit', () => {
         accessToken: 'test-access-token',
         refreshToken: 'refresh-token',
         clientId: 'test-clientid',
-        clientSecret: 'test-clientsecret'
+        clientSecret: 'test-clientsecret',
+        refreshTokenUrl: 'abc123.xyz'
       }
       const res = await destinationTest.refreshAccessToken(testSettings, oauthData)
 

--- a/packages/core/src/__tests__/parse-settings.test.ts
+++ b/packages/core/src/__tests__/parse-settings.test.ts
@@ -7,7 +7,8 @@ describe('oauth settings', () => {
       two: '2',
       oauth: {
         access_token: 'test-access-token',
-        refresh_token: 'test-refresh-token'
+        refresh_token: 'test-refresh-token',
+        refresh_token_url: 'test.xyz'
       },
       three: '3'
     }
@@ -16,7 +17,8 @@ describe('oauth settings', () => {
 
     const expectedResult = {
       accessToken: 'test-access-token',
-      refreshToken: 'test-refresh-token'
+      refreshToken: 'test-refresh-token',
+      refreshTokenUrl: 'test.xyz'
     }
     expect(result).toEqual(expectedResult)
   })
@@ -33,7 +35,8 @@ describe('oauth settings', () => {
       accessToken: undefined,
       clientId: undefined,
       clientSecret: undefined,
-      refreshToken: undefined
+      refreshToken: undefined,
+      refreshTokenUrl: undefined
     }
     expect(result).toEqual(expectedResult)
   })

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -96,6 +96,8 @@ export interface OAuth2ClientCredentials extends AuthTokens {
   clientId: string
   /** Used to authenticate the identity of the application to the partner API when the application requests to access a user’s account, must be kept private between the application and the API. */
   clientSecret: string
+  /** The refresh token url used to get an updated access token. This value is configured in the developer portal. **/
+  refreshTokenUrl: string
 }
 
 export interface RefreshAccessTokenResult {

--- a/packages/core/src/destination-kit/parse-settings.ts
+++ b/packages/core/src/destination-kit/parse-settings.ts
@@ -6,6 +6,7 @@ interface OAuthSettings {
   refresh_token: string
   clientId: string
   clientSecret: string
+  refresh_token_url: string
 }
 
 export interface AuthTokens {
@@ -37,7 +38,8 @@ export function getOAuth2Data(settings: JSONObject): OAuth2ClientCredentials {
     accessToken: (oauth as unknown as OAuthSettings)?.access_token,
     refreshToken: (oauth as unknown as OAuthSettings)?.refresh_token,
     clientId: (oauth as unknown as OAuthSettings)?.clientId,
-    clientSecret: (oauth as unknown as OAuthSettings)?.clientSecret
+    clientSecret: (oauth as unknown as OAuthSettings)?.clientSecret,
+    refreshTokenUrl: (oauth as unknown as OAuthSettings)?.refresh_token_url
   } as OAuth2ClientCredentials
 }
 


### PR DESCRIPTION
We're passing in the refresh URL configured in our new developer portal in the settings object. This change just makes sure that the refresh url is part of the `auth` object passing into the `refreshAccessToken` function.
## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
