### PR TITLE
[HGI-228] Fixes undefined sentry error in HubSpot upsertContact

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/upsertContact/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertContact/index.ts
@@ -175,7 +175,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
       return response
     } catch (ex) {
-      if ((ex as HTTPError)?.response.status == 404) {
+      if ((ex as HTTPError)?.response?.status == 404) {
         const result = await createContact(request, contactProperties)
 
         // cache contact_id for it to be available for company action


### PR DESCRIPTION
This PR fixes [this sentry](https://sentry.io/organizations/segment/issues/3730332557/?project=1110287&referrer=slack). It was due to missing coalesce operator.

## Testing

Not required. Single line change where missing coalescing operator has been added.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
