### PR TITLE
Fixed `defaultObjectUI` for object fields

### DIFF
--- a/packages/destination-actions/src/destinations/segment/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment/segment-properties.ts
@@ -48,7 +48,7 @@ export const application: InputField = {
   label: 'Application',
   description: 'Dictionary of information about the current application.',
   type: 'object',
-  defaultObjectUI: 'object',
+  defaultObjectUI: 'keyvalue',
   properties: {
     name: {
       label: 'Name',
@@ -78,7 +78,7 @@ export const campaign_parameters: InputField = {
   description:
     'Dictionary of information about the campaign that resulted in the API call. This maps directly to the common UTM campaign parameters.',
   type: 'object',
-  defaultObjectUI: 'object',
+  defaultObjectUI: 'keyvalue',
   properties: {
     name: {
       label: 'Name',
@@ -112,7 +112,7 @@ export const device: InputField = {
   label: 'Device',
   description: 'Dictionary of information about the device the API call originated from.',
   type: 'object',
-  defaultObjectUI: 'object',
+  defaultObjectUI: 'keyvalue',
   properties: {
     id: {
       label: 'ID',
@@ -173,7 +173,7 @@ export const location: InputField = {
   label: 'Location',
   description: 'Dictionary of information about the user’s current location.',
   type: 'object',
-  defaultObjectUI: 'object',
+  defaultObjectUI: 'keyvalue',
   properties: {
     city: {
       label: 'City',
@@ -207,7 +207,7 @@ export const network: InputField = {
   label: 'Network',
   description: 'Dictionary of information about the current network connection.',
   type: 'object',
-  defaultObjectUI: 'object',
+  defaultObjectUI: 'keyvalue',
   properties: {
     bluetooth: {
       label: 'Bluetooth',
@@ -236,7 +236,7 @@ export const operating_system: InputField = {
   label: 'Operating System',
   description: 'Dictionary of information about the operating system.',
   type: 'object',
-  defaultObjectUI: 'object',
+  defaultObjectUI: 'keyvalue',
   properties: {
     name: {
       label: 'Name',
@@ -255,7 +255,7 @@ export const page: InputField = {
   label: 'Page',
   description: 'Dictionary of information about the current page in the browser.',
   type: 'object',
-  defaultObjectUI: 'object',
+  defaultObjectUI: 'keyvalue',
   properties: {
     path: {
       label: 'Path',
@@ -289,7 +289,7 @@ export const screen: InputField = {
   label: 'Screen',
   description: 'Dictionary of information about the device’s screen.',
   type: 'object',
-  defaultObjectUI: 'object',
+  defaultObjectUI: 'keyvalue',
   properties: {
     density: {
       label: 'Density',
@@ -331,7 +331,7 @@ export const properties: InputField = {
   label: 'Properties',
   description: 'Free-form dictionary of properties that describe the screen.',
   type: 'object',
-  defaultObjectUI: 'object',
+  defaultObjectUI: 'keyvalue',
   additionalProperties: true
 }
 


### PR DESCRIPTION
This PR fixes `defaultObjectUI` for object type fields.

## Testing
Testing completed successfully in Testing and Prod.
Jira Ref: https://segment.atlassian.net/browse/HGI-233

Test Documents:
[Segment RETL - Stage Testing Document](https://docs.google.com/document/d/1LUmSECloRH2z8f0XESqf-29L4z9G1g2s-PQnthdV-kk/)
[Segment RETL - E2E Prod Testing (US)](https://docs.google.com/document/d/16UX0oDq0rjgl0U6QjKW-SWjP1W2k3WKMP6fI3UcaXR8)
[Segment RETL - E2E Prod Testing (EU)](https://docs.google.com/document/d/1qcd9E1OJfLjEfZFJoxB-ACv87dHuGgvZLFEG5U4F7tU)

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
