### PR TITLE
Mixpanel Actions: add a strict mode setting for the Mixpanel Import API

### DIFF
--- a/packages/destination-actions/src/destinations/mixpanel/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/generated-types.ts
@@ -17,4 +17,8 @@ export interface Settings {
    * This value, if it's not blank, will be sent as segment_source_name to Mixpanel for every event/page/screen call.
    */
   sourceName?: string
+  /**
+   * This value, if it's 1 (recommended), Mixpanel will validate the events you are trying to send and return errors per event that failed. Learn more about the Mixpanel [Import Events API](https://developer.mixpanel.com/reference/import-events)
+   */
+  strictMode?: string
 }

--- a/packages/destination-actions/src/destinations/mixpanel/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/index.ts
@@ -7,7 +7,7 @@ import identifyUser from './identifyUser'
 import groupIdentifyUser from './groupIdentifyUser'
 
 import alias from './alias'
-import { ApiRegions } from './utils'
+import { ApiRegions, StrictMode } from './utils'
 
 import trackPurchase from './trackPurchase'
 
@@ -94,6 +94,14 @@ const destination: DestinationDefinition<Settings> = {
         description:
           "This value, if it's not blank, will be sent as segment_source_name to Mixpanel for every event/page/screen call.",
         type: 'string',
+      },
+      strictMode: {
+        label: 'Strict Mode',
+        description:
+          "This value, if it's 1 (recommended), Mixpanel will validate the events you are trying to send and return errors per event that failed. Learn more about the Mixpanel [Import Events API](https://developer.mixpanel.com/reference/import-events)",
+        type: 'string',
+        choices: Object.values(StrictMode).map((strictMode) => ({ label: strictMode, value: strictMode })),
+        default: StrictMode.ON
       }
     },
     testAuthentication: (request, { settings }) => {

--- a/packages/destination-actions/src/destinations/mixpanel/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackEvent/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
-import { ApiRegions } from '../../utils'
+import { ApiRegions, StrictMode } from '../../utils'
 
 const testDestination = createTestIntegration(Destination)
 const MIXPANEL_API_SECRET = 'test-api-key'
@@ -143,6 +143,83 @@ describe('Mixpanel.trackEvent', () => {
         properties: expect.objectContaining({
           segment_source_name: undefined
         })
+      }
+    ])
+  })
+
+  it('should use strict mode end point by default', async () => {
+    const event = createTestEvent({ timestamp, event: 'Test Event' })
+
+    nock('https://api.mixpanel.com').post('/import?strict=1').reply(200, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        projectToken: MIXPANEL_PROJECT_TOKEN,
+        apiSecret: MIXPANEL_API_SECRET,
+        apiRegion: ApiRegions.US
+      }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.json).toMatchObject([
+      {
+        event: 'Test Event',
+        properties: expect.objectContaining(expectedProperties)
+      }
+    ])
+  })
+
+  it('should use strict mode end point when the strict mode setting is on', async () => {
+    const event = createTestEvent({ timestamp, event: 'Test Event' })
+
+    nock('https://api.mixpanel.com').post('/import?strict=1').reply(200, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        projectToken: MIXPANEL_PROJECT_TOKEN,
+        apiSecret: MIXPANEL_API_SECRET,
+        apiRegion: ApiRegions.US,
+        strictMode: StrictMode.ON
+      }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.json).toMatchObject([
+      {
+        event: 'Test Event',
+        properties: expect.objectContaining(expectedProperties)
+      }
+    ])
+  })
+
+  it('should not use strict mode end point when the strict mode setting is off', async () => {
+    const event = createTestEvent({ timestamp, event: 'Test Event' })
+
+    nock('https://api.mixpanel.com').post('/import?strict=0').reply(200, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        projectToken: MIXPANEL_PROJECT_TOKEN,
+        apiSecret: MIXPANEL_API_SECRET,
+        apiRegion: ApiRegions.US,
+        strictMode: StrictMode.OFF
+      }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.json).toMatchObject([
+      {
+        event: 'Test Event',
+        properties: expect.objectContaining(expectedProperties)
       }
     ])
   })

--- a/packages/destination-actions/src/destinations/mixpanel/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackEvent/index.ts
@@ -18,7 +18,8 @@ const getEventFromPayload = (payload: Payload, settings: Settings): MixpanelEven
 
 const processData = async (request: RequestClient, settings: Settings, payload: Payload[]) => {
   const events = payload.map((value) => getEventFromPayload(value, settings))
-  return request(`${ getApiServerUrl(settings.apiRegion) }/import?strict=1`, {
+
+  return request(`${ getApiServerUrl(settings.apiRegion) }/import?strict=${ settings.strictMode ?? `1` }`, {
     method: 'post',
     json: events,
     headers: {

--- a/packages/destination-actions/src/destinations/mixpanel/trackPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackPurchase/index.ts
@@ -51,7 +51,7 @@ const getPurchaseEventsFromPayload = (payload: Payload, settings: Settings): Mix
 
 const processData = async (request: RequestClient, settings: Settings, payload: Payload[]) => {
   const events = payload.map((value) => getPurchaseEventsFromPayload(value, settings)).flat()
-  return request(`${ getApiServerUrl(settings.apiRegion) }/import?strict=1`, {
+  return request(`${ getApiServerUrl(settings.apiRegion) }/import?strict=${ settings.strictMode ?? `1` }`, {
     method: 'post',
     json: events,
     headers: {

--- a/packages/destination-actions/src/destinations/mixpanel/utils.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/utils.ts
@@ -3,6 +3,11 @@ export enum ApiRegions {
   EU = 'EU 🇪🇺'
 }
 
+export enum StrictMode {
+  ON = '1',
+  OFF = '0'
+}
+
 export function getConcatenatedName(firstName: unknown, lastName: unknown, name: unknown): unknown {
   return (
     name ?? (firstName && lastName ? `${ firstName } ${ lastName }` : undefined)


### PR DESCRIPTION
This PR adds a strict mode setting to the Mixpanel Actions, when the setting is set to 1 (by default and recommended), Mixpanel will validate the events you are trying to send and return errors per event that failed. This is consistent with [Mixpanel import API](https://developer.mixpanel.com/reference/import-events)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
