### PR TITLE
Joe ayoub segment hgi 149

### DIFF
--- a/packages/destination-actions/src/destinations/braze/__tests__/braze.test.ts
+++ b/packages/destination-actions/src/destinations/braze/__tests__/braze.test.ts
@@ -98,6 +98,36 @@ describe(Braze.name, () => {
         `"One of \\"external_id\\" or \\"user_alias\\" or \\"braze_id\\" is required."`
       )
     })
+
+    it('should allow email address with unicode local part to be sent to Braze', async () => {
+      nock('https://rest.iad-01.braze.com').post('/users/track').reply(200, {})
+
+      const event = createTestEvent({
+        type: 'identify',
+        traits: {
+          email: 'ünîcòde_émail_locał_part@segment.com'
+        },
+        event: undefined,
+        receivedAt
+      })
+
+      const responses = await testDestination.testAction('updateUserProfile', {
+        event,
+        settings,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+      expect(responses[0].options.json).toMatchObject({
+        attributes: expect.arrayContaining([
+          expect.objectContaining({
+            email: 'ünîcòde_émail_locał_part@segment.com'
+          })
+        ])
+      })
+    })
   })
 
   describe('trackEvent', () => {

--- a/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
+++ b/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
@@ -146,7 +146,6 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Email',
       description: "The user's email",
       type: 'string',
-      format: 'email',
       allowNull: true,
       default: {
         '@path': '$.traits.email'


### PR DESCRIPTION
## Description

PR to remove AJV email formatter for updateUserProfile Action in the Braze Actions Cloud Mode Destination.

Braze allows unicode characters in the local part of an email address (the part before the @ symbol). Segment's AJV email formatter was preventing payloads with such email addresses from being sent to Braze. 

Decision made in consultation with Braze team, Kiara, Brennan and Dan L to remove the email formatter and allow any string value to be sent as an email address to Braze. 

Discussion is in the JIRA ticket: https://segment.atlassian.net/browse/HGI-149 

## Testing

- Added unit test to check that emails with unicode local part will be sent to Braze
- Tested with Actions Tester 
- NOT tested in Staging