### PR TITLE
Update Adobe Target Cloud Error Codes

### DIFF
--- a/packages/destination-actions/src/destinations/adobe-target/adobeTarget_operations.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/adobeTarget_operations.ts
@@ -41,8 +41,9 @@ export default class AdobeTarget {
     } else {
       const traits = getNestedObjects(this.traits)
       if (traits) {
-        const requestUrl = `https://${this.clientCode}.tt.omtrdc.net/m2/${this.clientCode
-          }/profile/update?mbox3rdPartyId=${this.userId}&${objectToQueryString(traits)}`
+        const requestUrl = `https://${this.clientCode}.tt.omtrdc.net/m2/${
+          this.clientCode
+        }/profile/update?mbox3rdPartyId=${this.userId}&${objectToQueryString(traits)}`
 
         return this.request(requestUrl, {
           method: 'POST'
@@ -67,14 +68,14 @@ export default class AdobeTarget {
         // If we throw a 404, Centrifuge will discard the job and it will never be retried. Thereforce, we are throwing a 500.
         // Unless the API is failing, errors from this endpoint will reference that the user profile does not exist.
         // The 500 error code also works in Centrifuge in the scenario where the API is down. Hence, its choice as a trigger for a retry.
-        const errorCode = error.message == 'Forbidden' ? 403 : 500
+        const errorCode = error.message == 'Forbidden' ? '403' : '500'
 
-        if (errorCode == 500) {
+        if (errorCode == '500') {
           // For now, we will keep track of the number of times we run this flow.
           statsContext?.statsClient.incr('actions-adobe-target.profile-not-found', 1, statsContext.tags)
         }
 
-        throw new IntegrationError(error.message, error.stack, errorCode)
+        throw new IntegrationError(error.message, errorCode)
       }
     }
 

--- a/packages/destination-actions/src/destinations/adobe-target/adobeTarget_operations.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/adobeTarget_operations.ts
@@ -1,4 +1,5 @@
 import { RequestClient, IntegrationError } from '@segment/actions-core'
+import { StatsContext } from '@segment/actions-core/src/destination-kit'
 
 function getNestedObjects(obj: { [x: string]: any }, objectPath = '', attributes: { [x: string]: string } = {}) {
   // Do not run on null or undefined
@@ -33,16 +34,15 @@ export default class AdobeTarget {
     this.request = request
   }
 
-  updateProfile = async () => {
-    const err = await this.lookupProfile(this.userId, this.clientCode)
+  updateProfile = async (statsContext: StatsContext | undefined) => {
+    const err = await this.lookupProfile(this.userId, this.clientCode, statsContext)
     if (err) {
       throw err
     } else {
       const traits = getNestedObjects(this.traits)
       if (traits) {
-        const requestUrl = `https://${this.clientCode}.tt.omtrdc.net/m2/${
-          this.clientCode
-        }/profile/update?mbox3rdPartyId=${this.userId}&${objectToQueryString(traits)}`
+        const requestUrl = `https://${this.clientCode}.tt.omtrdc.net/m2/${this.clientCode
+          }/profile/update?mbox3rdPartyId=${this.userId}&${objectToQueryString(traits)}`
 
         return this.request(requestUrl, {
           method: 'POST'
@@ -51,7 +51,11 @@ export default class AdobeTarget {
     }
   }
 
-  private lookupProfile = async (userId: string, clientCode: string): Promise<IntegrationError | undefined> => {
+  private lookupProfile = async (
+    userId: string,
+    clientCode: string,
+    statsContext: StatsContext | undefined
+  ): Promise<IntegrationError | undefined> => {
     try {
       await this.request(
         `https://${clientCode}.tt.omtrdc.net/rest/v1/profiles/thirdPartyId/${userId}?client=${clientCode}`,
@@ -59,7 +63,18 @@ export default class AdobeTarget {
       )
     } catch (error) {
       if (error instanceof Error) {
-        return new IntegrationError(error.message, error.message == 'Forbidden' ? '403' : '400')
+        // We are changing the error code here because Adobe Target's platform takes up to an hour to create/update a profile.
+        // If we throw a 404, Centrifuge will discard the job and it will never be retried. Thereforce, we are throwing a 500.
+        // Unless the API is failing, errors from this endpoint will reference that the user profile does not exist.
+        // The 500 error code also works in Centrifuge in the scenario where the API is down. Hence, its choice as a trigger for a retry.
+        const errorCode = error.message == 'Forbidden' ? 403 : 500
+
+        if (errorCode == 500) {
+          // For now, we will keep track of the number of times we run this flow.
+          statsContext?.statsClient.incr('actions-adobe-target.profile-not-found', 1, statsContext.tags)
+        }
+
+        throw new IntegrationError(error.message, error.stack, errorCode)
       }
     }
 

--- a/packages/destination-actions/src/destinations/adobe-target/updateProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/updateProfile/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
+import { StatsClient, StatsContext } from '@segment/actions-core/src/destination-kit'
 
 const testDestination = createTestIntegration(Destination)
 const settings = {
@@ -445,6 +446,16 @@ describe('AdobeTarget', () => {
       testDestination.testAction('updateProfile', {
         event,
         settings,
+        statsContext: {
+          statsClient: {
+            incr: jest.fn(),
+            observe: jest.fn(),
+            _name: jest.fn(),
+            _tags: jest.fn(),
+            set: jest.fn(),
+            histogram: jest.fn()
+          } as StatsClient
+        } as StatsContext,
         mapping: {
           traits: {
             city: {

--- a/packages/destination-actions/src/destinations/adobe-target/updateProfile/index.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/updateProfile/index.ts
@@ -1,5 +1,4 @@
 import type { ActionDefinition } from '@segment/actions-core'
-import { IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import AdobeTarget from '../adobeTarget_operations'
 import type { Payload } from './generated-types'
@@ -33,15 +32,9 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
 
-  perform: async (request, { settings, payload }) => {
-    try {
-      const at: AdobeTarget = new AdobeTarget(payload.user_id, settings.client_code, payload.traits, request)
-      return await at.updateProfile()
-    } catch (error) {
-      if (error instanceof Error) {
-        throw new IntegrationError(error.message, error.message == 'Forbidden' ? '403' : '400')
-      }
-    }
+  perform: async (request, { settings, payload, statsContext }) => {
+    const at: AdobeTarget = new AdobeTarget(payload.user_id, settings.client_code, payload.traits, request)
+    return await at.updateProfile(statsContext)
   }
 }
 


### PR DESCRIPTION
# The Problem

We have two new destinations in Public Beta, Adobe Target Web and Adobe Target Cloud. They work in conjunction with each other. Adobe Target Web (ATW) creates and updates users that belong to an audience. Adobe Target Cloud (ATC) updates users that belong to an audience. ATC does not have the capability to create users because Adobe’s REST API doesn’t allow it. Therefore, it relies on ATW to create them and it works with those user records and updates them accordingly.

ATW’s user creation has approximately a one hour delay, causing a bunch of requests performed by ATC to return 404. This results in data loss because Centrifuge does not retry errors that hold a 404 error code.

Eventually, some of those requests will become 200s but that’s because users continue to use the platform that send events to Segment in the first place and not because we retry to send the data.


# Proposed Solution

Change the Error Status Code so the job is retried + add a custom retry time for this destination.

Change the error code from 404 to 500 so Centrifuge interprets it as a failure and retries it. Combine this with a custom retry time and kick start the retried job in a time (60 min) that allows the user creation to happen on Adobe’s Cloud Side.

# Dependencies

This PR depends on https://github.com/segmentio/integrations-go/pull/333 where the custom retry time is set.
## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
