### PR TITLE
Populate refreshTokenUrl in getAuthData return value

### DIFF
--- a/packages/core/src/__tests__/parse-settings.test.ts
+++ b/packages/core/src/__tests__/parse-settings.test.ts
@@ -1,7 +1,7 @@
-import { getOAuth2Data, updateOAuthSettings } from '../destination-kit/parse-settings'
+import { getOAuth2Data, updateOAuthSettings, getAuthData } from '../destination-kit/parse-settings'
 
 describe('oauth settings', () => {
-  test('should return oauth data', () => {
+  test('getOAuth2Data should return oauth data', () => {
     const settings = {
       one: '1',
       two: '2',
@@ -14,6 +14,28 @@ describe('oauth settings', () => {
     }
 
     const result = getOAuth2Data(settings)
+
+    const expectedResult = {
+      accessToken: 'test-access-token',
+      refreshToken: 'test-refresh-token',
+      refreshTokenUrl: 'test.xyz'
+    }
+    expect(result).toEqual(expectedResult)
+  })
+
+  test('getAuthData should return oauth data', () => {
+    const settings = {
+      one: '1',
+      two: '2',
+      oauth: {
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
+        refresh_token_url: 'test.xyz'
+      },
+      three: '3'
+    }
+
+    const result = getAuthData(settings)
 
     const expectedResult = {
       accessToken: 'test-access-token',

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -96,8 +96,6 @@ export interface OAuth2ClientCredentials extends AuthTokens {
   clientId: string
   /** Used to authenticate the identity of the application to the partner API when the application requests to access a user’s account, must be kept private between the application and the API. */
   clientSecret: string
-  /** The refresh token url used to get an updated access token. This value is configured in the developer portal. **/
-  refreshTokenUrl: string
 }
 
 export interface RefreshAccessTokenResult {

--- a/packages/core/src/destination-kit/parse-settings.ts
+++ b/packages/core/src/destination-kit/parse-settings.ts
@@ -15,7 +15,7 @@ export interface AuthTokens {
   /** OAuth2 refresh token */
   refreshToken: string
   /** The refresh token url used to get an updated access token. This value is configured in the developer portal. **/
-  refreshTokenUrl: string
+  refreshTokenUrl?: string
 }
 
 /**

--- a/packages/core/src/destination-kit/parse-settings.ts
+++ b/packages/core/src/destination-kit/parse-settings.ts
@@ -14,6 +14,8 @@ export interface AuthTokens {
   accessToken: string
   /** OAuth2 refresh token */
   refreshToken: string
+  /** The refresh token url used to get an updated access token. This value is configured in the developer portal. **/
+  refreshTokenUrl: string
 }
 
 /**
@@ -24,7 +26,11 @@ export interface AuthTokens {
  */
 export function getAuthData(settings: JSONObject): AuthTokens {
   const oauthData = getOAuth2Data(settings)
-  return { accessToken: oauthData.accessToken, refreshToken: oauthData.refreshToken }
+  return {
+    accessToken: oauthData.accessToken,
+    refreshToken: oauthData.refreshToken,
+    refreshTokenUrl: oauthData.refreshTokenUrl
+  }
 }
 
 /**


### PR DESCRIPTION
Looks like I missed updating this function in #886 since this `getAuthData` function is what we _actually_ use internally for action tester to refresh the token.

The other function `getOAuth2Data` seems to be used in the refresh flow in our event processing pipeline.

Might be a good idea to consolidate these at some point.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
