### PR TITLE
Add support for facebook conversions api test_event_code

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
@@ -4,11 +4,17 @@ import Destination from '../index'
 import { API_VERSION } from '../constants'
 
 const testDestination = createTestIntegration(Destination)
-
 const settings = {
   pixelId: '123321',
+  testEventCode: '',
   token: process.env.TOKEN
 }
+const settingsWithTestEventCode = {
+  pixelId: '123321',
+  testEventCode: '1234567890',
+  token: process.env.TOKEN
+}
+
 describe('FacebookConversionsApi', () => {
   describe('AddToCart', () => {
     it('should handle a basic event', async () => {
@@ -411,6 +417,63 @@ describe('FacebookConversionsApi', () => {
           }
         })
       ).rejects.toThrowError("The root value is missing the required field 'user_data'.")
+    })
+
+    it('should send test_event_code if present in settings', async () => {
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settingsWithTestEventCode.pixelId}`)
+        .post(`/events`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Product Added',
+        userId: 'abc123',
+        timestamp: '1631210000',
+        properties: {
+          action_source: 'email',
+          currency: 'USD',
+          value: 12.12,
+          email: 'nicholas.aguilar@segment.com',
+          traits: {
+            city: 'Gotham',
+            country: 'United States',
+            last_name: 'Wayne'
+          }
+        }
+      })
+
+      const responses = await testDestination.testAction('addToCart', {
+        event,
+        settings: settingsWithTestEventCode,
+        mapping: {
+          currency: {
+            '@path': '$.properties.currency'
+          },
+          value: {
+            '@path': '$.properties.value'
+          },
+          user_data: {
+            email: {
+              '@path': '$.properties.email'
+            }
+          },
+          action_source: {
+            '@path': '$.properties.action_source'
+          },
+          event_time: {
+            '@path': '$.timestamp'
+          },
+          custom_data: {
+            '@path': '$.properties.traits'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"AddToCart\\",\\"event_time\\":\\"1631210000\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"city\\":\\"Gotham\\",\\"country\\":\\"United States\\",\\"last_name\\":\\"Wayne\\",\\"currency\\":\\"USD\\",\\"value\\":12.12}}],\\"test_event_code\\":\\"1234567890\\"}"`
+      )
     })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
@@ -4,17 +4,11 @@ import Destination from '../index'
 import { API_VERSION } from '../constants'
 
 const testDestination = createTestIntegration(Destination)
+
 const settings = {
   pixelId: '123321',
-  testEventCode: '',
   token: process.env.TOKEN
 }
-const settingsWithTestEventCode = {
-  pixelId: '123321',
-  testEventCode: '1234567890',
-  token: process.env.TOKEN
-}
-
 describe('FacebookConversionsApi', () => {
   describe('AddToCart', () => {
     it('should handle a basic event', async () => {
@@ -417,63 +411,6 @@ describe('FacebookConversionsApi', () => {
           }
         })
       ).rejects.toThrowError("The root value is missing the required field 'user_data'.")
-    })
-
-    it('should send test_event_code if present in settings', async () => {
-      nock(`https://graph.facebook.com/v${API_VERSION}/${settingsWithTestEventCode.pixelId}`)
-        .post(`/events`)
-        .reply(201, {})
-
-      const event = createTestEvent({
-        event: 'Product Added',
-        userId: 'abc123',
-        timestamp: '1631210000',
-        properties: {
-          action_source: 'email',
-          currency: 'USD',
-          value: 12.12,
-          email: 'nicholas.aguilar@segment.com',
-          traits: {
-            city: 'Gotham',
-            country: 'United States',
-            last_name: 'Wayne'
-          }
-        }
-      })
-
-      const responses = await testDestination.testAction('addToCart', {
-        event,
-        settings: settingsWithTestEventCode,
-        mapping: {
-          currency: {
-            '@path': '$.properties.currency'
-          },
-          value: {
-            '@path': '$.properties.value'
-          },
-          user_data: {
-            email: {
-              '@path': '$.properties.email'
-            }
-          },
-          action_source: {
-            '@path': '$.properties.action_source'
-          },
-          event_time: {
-            '@path': '$.timestamp'
-          },
-          custom_data: {
-            '@path': '$.properties.traits'
-          }
-        }
-      })
-
-      expect(responses.length).toBe(1)
-      expect(responses[0].status).toBe(201)
-
-      expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"data\\":[{\\"event_name\\":\\"AddToCart\\",\\"event_time\\":\\"1631210000\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"city\\":\\"Gotham\\",\\"country\\":\\"United States\\",\\"last_name\\":\\"Wayne\\",\\"currency\\":\\"USD\\",\\"value\\":12.12}}],\\"test_event_code\\":\\"1234567890\\"}"`
-      )
     })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/custom.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/custom.test.ts
@@ -6,6 +6,12 @@ import { API_VERSION } from '../constants'
 const testDestination = createTestIntegration(Destination)
 const settings = {
   pixelId: '123321',
+  testEventCode: '',
+  token: process.env.TOKEN
+}
+const settingsWithTestEventCode = {
+  pixelId: '123321',
+  testEventCode: '1234567890',
   token: process.env.TOKEN
 }
 
@@ -153,6 +159,62 @@ describe('FacebookConversionsApi', () => {
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
         `"{\\"data\\":[{\\"event_name\\":\\"identify\\",\\"event_time\\":\\"2015-02-23T22:28:55.111Z\\",\\"action_source\\":\\"website\\",\\"event_id\\":\\"022bb90c-bbac-11e4-8dfc-aa07a5b093db\\",\\"user_data\\":{\\"external_id\\":\\"df73b86ff613b9d7008c175ae3c3aa3f2c1ea1674a80cac85274d58048e44127\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36\\"},\\"custom_data\\":{\\"action_source\\":\\"website\\",\\"timestamp\\":\\"1633473963\\"}}]}"`
+      )
+    })
+
+    it('should send test_event_code if present in settings', async () => {
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settingsWithTestEventCode.pixelId}`)
+        .post(`/events`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        anonymousId: '507f191e810c19729de860ea',
+        context: {
+          ip: '8.8.8.8',
+          userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36'
+        },
+        messageId: '022bb90c-bbac-11e4-8dfc-aa07a5b093db',
+        receivedAt: '2015-02-23T22:28:55.387Z',
+        sentAt: '2015-02-23T22:28:55.111Z',
+        timestamp: '2015-02-23T22:28:55.111Z',
+        traits: {
+          name: 'Peter Gibbons',
+          email: 'peter@example.com',
+          plan: 'premium',
+          logins: 5,
+          address: {
+            street: '6th St',
+            city: 'San Francisco',
+            state: 'CA',
+            postalCode: '94103',
+            country: 'USA'
+          }
+        },
+        properties: {
+          action_source: 'website',
+          timestamp: '1633473963'
+        },
+        type: 'identify',
+        userId: '97980cfea0067',
+        event: 'identify'
+      })
+
+      const responses = await testDestination.testAction('custom', {
+        event,
+        settings: settingsWithTestEventCode,
+        useDefaultMappings: true,
+        mapping: {
+          action_source: { '@path': '$.properties.action_source' },
+          custom_data: { '@path': '$.properties' }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"identify\\",\\"event_time\\":\\"2015-02-23T22:28:55.111Z\\",\\"action_source\\":\\"website\\",\\"event_id\\":\\"022bb90c-bbac-11e4-8dfc-aa07a5b093db\\",\\"user_data\\":{\\"external_id\\":\\"df73b86ff613b9d7008c175ae3c3aa3f2c1ea1674a80cac85274d58048e44127\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36\\"},\\"custom_data\\":{\\"action_source\\":\\"website\\",\\"timestamp\\":\\"1633473963\\"}}],\\"test_event_code\\":\\"1234567890\\"}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/custom.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/custom.test.ts
@@ -6,12 +6,6 @@ import { API_VERSION } from '../constants'
 const testDestination = createTestIntegration(Destination)
 const settings = {
   pixelId: '123321',
-  testEventCode: '',
-  token: process.env.TOKEN
-}
-const settingsWithTestEventCode = {
-  pixelId: '123321',
-  testEventCode: '1234567890',
   token: process.env.TOKEN
 }
 
@@ -159,62 +153,6 @@ describe('FacebookConversionsApi', () => {
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
         `"{\\"data\\":[{\\"event_name\\":\\"identify\\",\\"event_time\\":\\"2015-02-23T22:28:55.111Z\\",\\"action_source\\":\\"website\\",\\"event_id\\":\\"022bb90c-bbac-11e4-8dfc-aa07a5b093db\\",\\"user_data\\":{\\"external_id\\":\\"df73b86ff613b9d7008c175ae3c3aa3f2c1ea1674a80cac85274d58048e44127\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36\\"},\\"custom_data\\":{\\"action_source\\":\\"website\\",\\"timestamp\\":\\"1633473963\\"}}]}"`
-      )
-    })
-
-    it('should send test_event_code if present in settings', async () => {
-      nock(`https://graph.facebook.com/v${API_VERSION}/${settingsWithTestEventCode.pixelId}`)
-        .post(`/events`)
-        .reply(201, {})
-
-      const event = createTestEvent({
-        anonymousId: '507f191e810c19729de860ea',
-        context: {
-          ip: '8.8.8.8',
-          userAgent:
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36'
-        },
-        messageId: '022bb90c-bbac-11e4-8dfc-aa07a5b093db',
-        receivedAt: '2015-02-23T22:28:55.387Z',
-        sentAt: '2015-02-23T22:28:55.111Z',
-        timestamp: '2015-02-23T22:28:55.111Z',
-        traits: {
-          name: 'Peter Gibbons',
-          email: 'peter@example.com',
-          plan: 'premium',
-          logins: 5,
-          address: {
-            street: '6th St',
-            city: 'San Francisco',
-            state: 'CA',
-            postalCode: '94103',
-            country: 'USA'
-          }
-        },
-        properties: {
-          action_source: 'website',
-          timestamp: '1633473963'
-        },
-        type: 'identify',
-        userId: '97980cfea0067',
-        event: 'identify'
-      })
-
-      const responses = await testDestination.testAction('custom', {
-        event,
-        settings: settingsWithTestEventCode,
-        useDefaultMappings: true,
-        mapping: {
-          action_source: { '@path': '$.properties.action_source' },
-          custom_data: { '@path': '$.properties' }
-        }
-      })
-
-      expect(responses.length).toBe(1)
-      expect(responses[0].status).toBe(201)
-
-      expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"data\\":[{\\"event_name\\":\\"identify\\",\\"event_time\\":\\"2015-02-23T22:28:55.111Z\\",\\"action_source\\":\\"website\\",\\"event_id\\":\\"022bb90c-bbac-11e4-8dfc-aa07a5b093db\\",\\"user_data\\":{\\"external_id\\":\\"df73b86ff613b9d7008c175ae3c3aa3f2c1ea1674a80cac85274d58048e44127\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36\\"},\\"custom_data\\":{\\"action_source\\":\\"website\\",\\"timestamp\\":\\"1633473963\\"}}],\\"test_event_code\\":\\"1234567890\\"}"`
       )
     })
   })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/initiateCheckout.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/initiateCheckout.test.ts
@@ -6,8 +6,15 @@ import { API_VERSION } from '../constants'
 const testDestination = createTestIntegration(Destination)
 const settings = {
   pixelId: '123321',
+  testEventCode: '',
   token: process.env.TOKEN
 }
+const settingsWithTestEventCode = {
+  pixelId: '123321',
+  testEventCode: '1234567890',
+  token: process.env.TOKEN
+}
+
 describe('FacebookConversionsApi', () => {
   describe('InitiateCheckout', () => {
     it('should handle basic mapping overrides', async () => {
@@ -168,6 +175,42 @@ describe('FacebookConversionsApi', () => {
           }
         })
       ).rejects.toThrowError("The root value is missing the required field 'user_data'.")
+    })
+
+    it('should send test_event_code if present in settings', async () => {
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settingsWithTestEventCode.pixelId}`)
+        .post(`/events`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Checkout Started',
+        timestamp: '1631210020',
+        messageId: 'test',
+        properties: {
+          userId: 'testuser1234',
+          action_source: 'email',
+          currency: 'USD',
+          revenue: 12.12,
+          products: [
+            { product_id: '123', quantity: 1, price: 100 },
+            { product_id: '345', quantity: 2, price: 50 }
+          ]
+        }
+      })
+
+      const responses = await testDestination.testAction('initiateCheckout', {
+        event,
+        settings: settingsWithTestEventCode,
+        useDefaultMappings: true,
+        mapping: { action_source: { '@path': '$.properties.action_source' } }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"InitiateCheckout\\",\\"event_time\\":\\"1631210020\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"test\\",\\"user_data\\":{\\"external_id\\":\\"831c237928e6212bedaa4451a514ace3174562f6761f6a157a2fe5082b36e2fb\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"contents\\":[{\\"id\\":\\"123\\",\\"quantity\\":1,\\"item_price\\":100},{\\"id\\":\\"345\\",\\"quantity\\":2,\\"item_price\\":50}]}}],\\"test_event_code\\":\\"1234567890\\"}"`
+      )
     })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/initiateCheckout.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/initiateCheckout.test.ts
@@ -6,15 +6,8 @@ import { API_VERSION } from '../constants'
 const testDestination = createTestIntegration(Destination)
 const settings = {
   pixelId: '123321',
-  testEventCode: '',
   token: process.env.TOKEN
 }
-const settingsWithTestEventCode = {
-  pixelId: '123321',
-  testEventCode: '1234567890',
-  token: process.env.TOKEN
-}
-
 describe('FacebookConversionsApi', () => {
   describe('InitiateCheckout', () => {
     it('should handle basic mapping overrides', async () => {
@@ -175,42 +168,6 @@ describe('FacebookConversionsApi', () => {
           }
         })
       ).rejects.toThrowError("The root value is missing the required field 'user_data'.")
-    })
-
-    it('should send test_event_code if present in settings', async () => {
-      nock(`https://graph.facebook.com/v${API_VERSION}/${settingsWithTestEventCode.pixelId}`)
-        .post(`/events`)
-        .reply(201, {})
-
-      const event = createTestEvent({
-        event: 'Checkout Started',
-        timestamp: '1631210020',
-        messageId: 'test',
-        properties: {
-          userId: 'testuser1234',
-          action_source: 'email',
-          currency: 'USD',
-          revenue: 12.12,
-          products: [
-            { product_id: '123', quantity: 1, price: 100 },
-            { product_id: '345', quantity: 2, price: 50 }
-          ]
-        }
-      })
-
-      const responses = await testDestination.testAction('initiateCheckout', {
-        event,
-        settings: settingsWithTestEventCode,
-        useDefaultMappings: true,
-        mapping: { action_source: { '@path': '$.properties.action_source' } }
-      })
-
-      expect(responses.length).toBe(1)
-      expect(responses[0].status).toBe(201)
-
-      expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"data\\":[{\\"event_name\\":\\"InitiateCheckout\\",\\"event_time\\":\\"1631210020\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"test\\",\\"user_data\\":{\\"external_id\\":\\"831c237928e6212bedaa4451a514ace3174562f6761f6a157a2fe5082b36e2fb\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"contents\\":[{\\"id\\":\\"123\\",\\"quantity\\":1,\\"item_price\\":100},{\\"id\\":\\"345\\",\\"quantity\\":2,\\"item_price\\":50}]}}],\\"test_event_code\\":\\"1234567890\\"}"`
-      )
     })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/pageView.test.ts
@@ -4,11 +4,17 @@ import Destination from '../index'
 import { API_VERSION } from '../constants'
 
 const testDestination = createTestIntegration(Destination)
-
 const settings = {
   pixelId: '123321',
+  testEventCode: '',
   token: process.env.TOKEN
 }
+const settingsWithTestEventCode = {
+  pixelId: '123321',
+  testEventCode: '1234567890',
+  token: process.env.TOKEN
+}
+
 describe('FacebookConversionsApi', () => {
   describe('PageView', () => {
     it('should handle a basic event', async () => {
@@ -136,6 +142,38 @@ describe('FacebookConversionsApi', () => {
           }
         })
       ).rejects.toThrowError("The root value is missing the required field 'user_data'.")
+    })
+
+    it('should send test_event_code if present in settings', async () => {
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settingsWithTestEventCode.pixelId}`)
+        .post(`/events`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        type: 'page',
+        userId: 'abc123',
+        timestamp: '1631210020',
+        messageId: 'test',
+        properties: {
+          timestamp: 1631210000,
+          action_source: 'email',
+          email: 'nicholas.aguilar@segment.com'
+        }
+      })
+
+      const responses = await testDestination.testAction('pageView', {
+        event,
+        settings: settingsWithTestEventCode,
+        useDefaultMappings: true,
+        mapping: { action_source: { '@path': '$.properties.action_source' } }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"PageView\\",\\"event_time\\":\\"1631210020\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"test\\",\\"user_data\\":{\\"external_id\\":\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"}}],\\"test_event_code\\":\\"1234567890\\"}"`
+      )
     })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/pageView.test.ts
@@ -4,17 +4,11 @@ import Destination from '../index'
 import { API_VERSION } from '../constants'
 
 const testDestination = createTestIntegration(Destination)
+
 const settings = {
   pixelId: '123321',
-  testEventCode: '',
   token: process.env.TOKEN
 }
-const settingsWithTestEventCode = {
-  pixelId: '123321',
-  testEventCode: '1234567890',
-  token: process.env.TOKEN
-}
-
 describe('FacebookConversionsApi', () => {
   describe('PageView', () => {
     it('should handle a basic event', async () => {
@@ -142,38 +136,6 @@ describe('FacebookConversionsApi', () => {
           }
         })
       ).rejects.toThrowError("The root value is missing the required field 'user_data'.")
-    })
-
-    it('should send test_event_code if present in settings', async () => {
-      nock(`https://graph.facebook.com/v${API_VERSION}/${settingsWithTestEventCode.pixelId}`)
-        .post(`/events`)
-        .reply(201, {})
-
-      const event = createTestEvent({
-        type: 'page',
-        userId: 'abc123',
-        timestamp: '1631210020',
-        messageId: 'test',
-        properties: {
-          timestamp: 1631210000,
-          action_source: 'email',
-          email: 'nicholas.aguilar@segment.com'
-        }
-      })
-
-      const responses = await testDestination.testAction('pageView', {
-        event,
-        settings: settingsWithTestEventCode,
-        useDefaultMappings: true,
-        mapping: { action_source: { '@path': '$.properties.action_source' } }
-      })
-
-      expect(responses.length).toBe(1)
-      expect(responses[0].status).toBe(201)
-
-      expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"data\\":[{\\"event_name\\":\\"PageView\\",\\"event_time\\":\\"1631210020\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"test\\",\\"user_data\\":{\\"external_id\\":\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\",\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"}}],\\"test_event_code\\":\\"1234567890\\"}"`
-      )
     })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/purchase.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/purchase.test.ts
@@ -4,10 +4,15 @@ import Destination from '../index'
 import { API_VERSION } from '../constants'
 
 const testDestination = createTestIntegration(Destination)
-
 const settings = {
   pixelId: '123321',
+  testEventCode: '',
   token: 'EAAtest'
+}
+const settingsWithTestEventCode = {
+  pixelId: '123321',
+  testEventCode: '1234567890',
+  token: process.env.TOKEN
 }
 
 describe('purchase', () => {
@@ -191,5 +196,77 @@ describe('purchase', () => {
         }
       })
     ).rejects.toThrowError("The root value is missing the required field 'user_data'.")
+  })
+
+  it('should send test_event_code if present in settings', async () => {
+    nock(`https://graph.facebook.com/v${API_VERSION}/${settingsWithTestEventCode.pixelId}`)
+      .post(`/events`)
+      .reply(201, {})
+
+    const event = createTestEvent({
+      event: 'Order Completed',
+      userId: 'abc123',
+      timestamp: '1631210063',
+      properties: {
+        action_source: 'email',
+        currency: 'USD',
+        value: 12.12,
+        email: 'nicholas.aguilar@segment.com',
+        content_name: 'Shoes',
+        content_type: 'product',
+        contents: [
+          { id: 'ABC123', quantity: 2 },
+          { id: 'XYZ789', quantity: 3 }
+        ],
+        content_ids: ['ABC123', 'XYZ789'],
+        num_items: 2
+      }
+    })
+
+    const responses = await testDestination.testAction('purchase', {
+      event,
+      settings: settingsWithTestEventCode,
+      mapping: {
+        currency: {
+          '@path': '$.properties.currency'
+        },
+        value: {
+          '@path': '$.properties.value'
+        },
+        user_data: {
+          email: {
+            '@path': '$.properties.email'
+          }
+        },
+        action_source: {
+          '@path': '$.properties.action_source'
+        },
+        event_time: {
+          '@path': '$.timestamp'
+        },
+        contents: {
+          '@path': '$.properties.contents'
+        },
+        num_items: {
+          '@path': '$.properties.num_items'
+        },
+        content_name: {
+          '@path': '$.properties.content_name'
+        },
+        content_type: {
+          '@path': '$.properties.content_type'
+        },
+        content_ids: {
+          '@path': '$.properties.content_ids'
+        }
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(201)
+
+    expect(responses[0].options.body).toMatchInlineSnapshot(
+      `"{\\"data\\":[{\\"event_name\\":\\"Purchase\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"content_ids\\":[\\"ABC123\\",\\"XYZ789\\"],\\"content_name\\":\\"Shoes\\",\\"content_type\\":\\"product\\",\\"contents\\":[{\\"id\\":\\"ABC123\\",\\"quantity\\":2},{\\"id\\":\\"XYZ789\\",\\"quantity\\":3}],\\"num_items\\":2}}],\\"test_event_code\\":\\"1234567890\\"}"`
+    )
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/purchase.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/purchase.test.ts
@@ -4,15 +4,10 @@ import Destination from '../index'
 import { API_VERSION } from '../constants'
 
 const testDestination = createTestIntegration(Destination)
+
 const settings = {
   pixelId: '123321',
-  testEventCode: '',
   token: 'EAAtest'
-}
-const settingsWithTestEventCode = {
-  pixelId: '123321',
-  testEventCode: '1234567890',
-  token: process.env.TOKEN
 }
 
 describe('purchase', () => {
@@ -196,77 +191,5 @@ describe('purchase', () => {
         }
       })
     ).rejects.toThrowError("The root value is missing the required field 'user_data'.")
-  })
-
-  it('should send test_event_code if present in settings', async () => {
-    nock(`https://graph.facebook.com/v${API_VERSION}/${settingsWithTestEventCode.pixelId}`)
-      .post(`/events`)
-      .reply(201, {})
-
-    const event = createTestEvent({
-      event: 'Order Completed',
-      userId: 'abc123',
-      timestamp: '1631210063',
-      properties: {
-        action_source: 'email',
-        currency: 'USD',
-        value: 12.12,
-        email: 'nicholas.aguilar@segment.com',
-        content_name: 'Shoes',
-        content_type: 'product',
-        contents: [
-          { id: 'ABC123', quantity: 2 },
-          { id: 'XYZ789', quantity: 3 }
-        ],
-        content_ids: ['ABC123', 'XYZ789'],
-        num_items: 2
-      }
-    })
-
-    const responses = await testDestination.testAction('purchase', {
-      event,
-      settings: settingsWithTestEventCode,
-      mapping: {
-        currency: {
-          '@path': '$.properties.currency'
-        },
-        value: {
-          '@path': '$.properties.value'
-        },
-        user_data: {
-          email: {
-            '@path': '$.properties.email'
-          }
-        },
-        action_source: {
-          '@path': '$.properties.action_source'
-        },
-        event_time: {
-          '@path': '$.timestamp'
-        },
-        contents: {
-          '@path': '$.properties.contents'
-        },
-        num_items: {
-          '@path': '$.properties.num_items'
-        },
-        content_name: {
-          '@path': '$.properties.content_name'
-        },
-        content_type: {
-          '@path': '$.properties.content_type'
-        },
-        content_ids: {
-          '@path': '$.properties.content_ids'
-        }
-      }
-    })
-
-    expect(responses.length).toBe(1)
-    expect(responses[0].status).toBe(201)
-
-    expect(responses[0].options.body).toMatchInlineSnapshot(
-      `"{\\"data\\":[{\\"event_name\\":\\"Purchase\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"content_ids\\":[\\"ABC123\\",\\"XYZ789\\"],\\"content_name\\":\\"Shoes\\",\\"content_type\\":\\"product\\",\\"contents\\":[{\\"id\\":\\"ABC123\\",\\"quantity\\":2},{\\"id\\":\\"XYZ789\\",\\"quantity\\":3}],\\"num_items\\":2}}],\\"test_event_code\\":\\"1234567890\\"}"`
-    )
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/search.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/search.test.ts
@@ -6,8 +6,15 @@ import { API_VERSION } from '../constants'
 const testDestination = createTestIntegration(Destination)
 const settings = {
   pixelId: '123321',
+  testEventCode: '',
   token: process.env.TOKEN
 }
+const settingsWithTestEventCode = {
+  pixelId: '123321',
+  testEventCode: '1234567890',
+  token: process.env.TOKEN
+}
+
 describe('FacebookConversionsApi', () => {
   describe('Search', () => {
     it('should handle a basic event', async () => {
@@ -144,6 +151,74 @@ describe('FacebookConversionsApi', () => {
           }
         })
       ).rejects.toThrowError("The root value is missing the required field 'user_data'.")
+    })
+
+    it('should send test_event_code if present in settings', async () => {
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settingsWithTestEventCode.pixelId}`)
+        .post(`/events`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Products Searched',
+        userId: 'abc123',
+        timestamp: '1631210063',
+        properties: {
+          action_source: 'email',
+          currency: 'USD',
+          value: 12.12,
+          email: 'nicholas.aguilar@segment.com',
+          content_category: 'Cookies',
+          content_ids: ['ABC123', 'XYZ789'],
+          contents: [
+            { id: 'ABC123', quantity: 2 },
+            { id: 'XYZ789', quantity: 3 }
+          ],
+          search_string: 'Oreo`s Quadruple Stack'
+        }
+      })
+
+      const responses = await testDestination.testAction('search', {
+        event,
+        settings: settingsWithTestEventCode,
+        mapping: {
+          currency: {
+            '@path': '$.properties.currency'
+          },
+          value: {
+            '@path': '$.properties.value'
+          },
+          user_data: {
+            email: {
+              '@path': '$.properties.email'
+            }
+          },
+          action_source: {
+            '@path': '$.properties.action_source'
+          },
+          event_time: {
+            '@path': '$.timestamp'
+          },
+          search_string: {
+            '@path': '$.properties.search_string'
+          },
+          contents: {
+            '@path': '$.properties.contents'
+          },
+          content_ids: {
+            '@path': '$.properties.content_ids'
+          },
+          content_category: {
+            '@path': '$.properties.content_category'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"Search\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"content_ids\\":[\\"ABC123\\",\\"XYZ789\\"],\\"contents\\":[{\\"id\\":\\"ABC123\\",\\"quantity\\":2},{\\"id\\":\\"XYZ789\\",\\"quantity\\":3}],\\"content_category\\":\\"Cookies\\",\\"value\\":12.12,\\"search_string\\":\\"Oreo\`s Quadruple Stack\\"}}],\\"test_event_code\\":\\"1234567890\\"}"`
+      )
     })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/search.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/search.test.ts
@@ -6,15 +6,8 @@ import { API_VERSION } from '../constants'
 const testDestination = createTestIntegration(Destination)
 const settings = {
   pixelId: '123321',
-  testEventCode: '',
   token: process.env.TOKEN
 }
-const settingsWithTestEventCode = {
-  pixelId: '123321',
-  testEventCode: '1234567890',
-  token: process.env.TOKEN
-}
-
 describe('FacebookConversionsApi', () => {
   describe('Search', () => {
     it('should handle a basic event', async () => {
@@ -151,74 +144,6 @@ describe('FacebookConversionsApi', () => {
           }
         })
       ).rejects.toThrowError("The root value is missing the required field 'user_data'.")
-    })
-
-    it('should send test_event_code if present in settings', async () => {
-      nock(`https://graph.facebook.com/v${API_VERSION}/${settingsWithTestEventCode.pixelId}`)
-        .post(`/events`)
-        .reply(201, {})
-
-      const event = createTestEvent({
-        event: 'Products Searched',
-        userId: 'abc123',
-        timestamp: '1631210063',
-        properties: {
-          action_source: 'email',
-          currency: 'USD',
-          value: 12.12,
-          email: 'nicholas.aguilar@segment.com',
-          content_category: 'Cookies',
-          content_ids: ['ABC123', 'XYZ789'],
-          contents: [
-            { id: 'ABC123', quantity: 2 },
-            { id: 'XYZ789', quantity: 3 }
-          ],
-          search_string: 'Oreo`s Quadruple Stack'
-        }
-      })
-
-      const responses = await testDestination.testAction('search', {
-        event,
-        settings: settingsWithTestEventCode,
-        mapping: {
-          currency: {
-            '@path': '$.properties.currency'
-          },
-          value: {
-            '@path': '$.properties.value'
-          },
-          user_data: {
-            email: {
-              '@path': '$.properties.email'
-            }
-          },
-          action_source: {
-            '@path': '$.properties.action_source'
-          },
-          event_time: {
-            '@path': '$.timestamp'
-          },
-          search_string: {
-            '@path': '$.properties.search_string'
-          },
-          contents: {
-            '@path': '$.properties.contents'
-          },
-          content_ids: {
-            '@path': '$.properties.content_ids'
-          },
-          content_category: {
-            '@path': '$.properties.content_category'
-          }
-        }
-      })
-
-      expect(responses.length).toBe(1)
-      expect(responses[0].status).toBe(201)
-
-      expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"data\\":[{\\"event_name\\":\\"Search\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"content_ids\\":[\\"ABC123\\",\\"XYZ789\\"],\\"contents\\":[{\\"id\\":\\"ABC123\\",\\"quantity\\":2},{\\"id\\":\\"XYZ789\\",\\"quantity\\":3}],\\"content_category\\":\\"Cookies\\",\\"value\\":12.12,\\"search_string\\":\\"Oreo\`s Quadruple Stack\\"}}],\\"test_event_code\\":\\"1234567890\\"}"`
-      )
     })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/viewContent.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/viewContent.test.ts
@@ -6,8 +6,15 @@ import { API_VERSION } from '../constants'
 const testDestination = createTestIntegration(Destination)
 const settings = {
   pixelId: '123321',
+  testEventCode: '',
   token: process.env.TOKEN
 }
+const settingsWithTestEventCode = {
+  pixelId: '123321',
+  testEventCode: '1234567890',
+  token: process.env.TOKEN
+}
+
 describe('FacebookConversionsApi', () => {
   describe('ViewContent', () => {
     it('should handle a basic event', async () => {
@@ -151,6 +158,81 @@ describe('FacebookConversionsApi', () => {
           }
         })
       ).rejects.toThrowError("The root value is missing the required field 'user_data'.")
+    })
+
+    it('should send test_event_code if present in settings', async () => {
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settingsWithTestEventCode.pixelId}`)
+        .post(`/events`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Product Viewed',
+        userId: 'abc123',
+        timestamp: '1631210063',
+        properties: {
+          action_source: 'email',
+          currency: 'USD',
+          value: 12.12,
+          email: 'nicholas.aguilar@segment.com',
+          content_category: 'Cookies',
+          content_name: "Oreo's Quadruple Stack",
+          content_type: 'product',
+          content_ids: ['ABC123', 'XYZ789'],
+          contents: [
+            { id: 'ABC123', quantity: 2 },
+            { id: 'XYZ789', quantity: 3 }
+          ]
+        }
+      })
+
+      const responses = await testDestination.testAction('viewContent', {
+        event,
+        settings: settingsWithTestEventCode,
+        mapping: {
+          currency: {
+            '@path': '$.properties.currency'
+          },
+          value: {
+            '@path': '$.properties.value'
+          },
+          user_data: {
+            email: {
+              '@path': '$.properties.email'
+            }
+          },
+          action_source: {
+            '@path': '$.properties.action_source'
+          },
+          event_time: {
+            '@path': '$.timestamp'
+          },
+          search_string: {
+            '@path': '$.properties.search_string'
+          },
+          contents: {
+            '@path': '$.properties.contents'
+          },
+          content_ids: {
+            '@path': '$.properties.content_ids'
+          },
+          content_category: {
+            '@path': '$.properties.content_category'
+          },
+          content_type: {
+            '@path': '$.properties.content_type'
+          },
+          content_name: {
+            '@path': '$.properties.content_name'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"ViewContent\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"content_ids\\":[\\"ABC123\\",\\"XYZ789\\"],\\"content_name\\":\\"Oreo's Quadruple Stack\\",\\"content_type\\":\\"product\\",\\"contents\\":[{\\"id\\":\\"ABC123\\",\\"quantity\\":2},{\\"id\\":\\"XYZ789\\",\\"quantity\\":3}],\\"content_category\\":\\"Cookies\\"}}],\\"test_event_code\\":\\"1234567890\\"}"`
+      )
     })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/viewContent.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/viewContent.test.ts
@@ -6,15 +6,8 @@ import { API_VERSION } from '../constants'
 const testDestination = createTestIntegration(Destination)
 const settings = {
   pixelId: '123321',
-  testEventCode: '',
   token: process.env.TOKEN
 }
-const settingsWithTestEventCode = {
-  pixelId: '123321',
-  testEventCode: '1234567890',
-  token: process.env.TOKEN
-}
-
 describe('FacebookConversionsApi', () => {
   describe('ViewContent', () => {
     it('should handle a basic event', async () => {
@@ -158,81 +151,6 @@ describe('FacebookConversionsApi', () => {
           }
         })
       ).rejects.toThrowError("The root value is missing the required field 'user_data'.")
-    })
-
-    it('should send test_event_code if present in settings', async () => {
-      nock(`https://graph.facebook.com/v${API_VERSION}/${settingsWithTestEventCode.pixelId}`)
-        .post(`/events`)
-        .reply(201, {})
-
-      const event = createTestEvent({
-        event: 'Product Viewed',
-        userId: 'abc123',
-        timestamp: '1631210063',
-        properties: {
-          action_source: 'email',
-          currency: 'USD',
-          value: 12.12,
-          email: 'nicholas.aguilar@segment.com',
-          content_category: 'Cookies',
-          content_name: "Oreo's Quadruple Stack",
-          content_type: 'product',
-          content_ids: ['ABC123', 'XYZ789'],
-          contents: [
-            { id: 'ABC123', quantity: 2 },
-            { id: 'XYZ789', quantity: 3 }
-          ]
-        }
-      })
-
-      const responses = await testDestination.testAction('viewContent', {
-        event,
-        settings: settingsWithTestEventCode,
-        mapping: {
-          currency: {
-            '@path': '$.properties.currency'
-          },
-          value: {
-            '@path': '$.properties.value'
-          },
-          user_data: {
-            email: {
-              '@path': '$.properties.email'
-            }
-          },
-          action_source: {
-            '@path': '$.properties.action_source'
-          },
-          event_time: {
-            '@path': '$.timestamp'
-          },
-          search_string: {
-            '@path': '$.properties.search_string'
-          },
-          contents: {
-            '@path': '$.properties.contents'
-          },
-          content_ids: {
-            '@path': '$.properties.content_ids'
-          },
-          content_category: {
-            '@path': '$.properties.content_category'
-          },
-          content_type: {
-            '@path': '$.properties.content_type'
-          },
-          content_name: {
-            '@path': '$.properties.content_name'
-          }
-        }
-      })
-
-      expect(responses.length).toBe(1)
-      expect(responses[0].status).toBe(201)
-
-      expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"data\\":[{\\"event_name\\":\\"ViewContent\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"content_ids\\":[\\"ABC123\\",\\"XYZ789\\"],\\"content_name\\":\\"Oreo's Quadruple Stack\\",\\"content_type\\":\\"product\\",\\"contents\\":[{\\"id\\":\\"ABC123\\",\\"quantity\\":2},{\\"id\\":\\"XYZ789\\",\\"quantity\\":3}],\\"content_category\\":\\"Cookies\\"}}],\\"test_event_code\\":\\"1234567890\\"}"`
-      )
     })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
@@ -122,7 +122,8 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_country: country_code,
               data_processing_options_state: state_code
             }
-          ]
+          ],
+          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
@@ -122,8 +122,7 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_country: country_code,
               data_processing_options_state: state_code
             }
-          ],
-          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+          ]
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
@@ -68,7 +68,8 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_country: country_code,
               data_processing_options_state: state_code
             }
-          ]
+          ],
+          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
@@ -68,8 +68,7 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_country: country_code,
               data_processing_options_state: state_code
             }
-          ],
-          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+          ]
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/generated-types.ts
@@ -5,4 +5,8 @@ export interface Settings {
    * Your Facebook Pixel ID
    */
   pixelId: string
+  /**
+   * Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. You'll want to remove your Test Event Code when sending real traffic through this integration.
+   */
+  testEventCode?: string
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/generated-types.ts
@@ -5,8 +5,4 @@ export interface Settings {
    * Your Facebook Pixel ID
    */
   pixelId: string
-  /**
-   * Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. You'll want to remove your Test Event Code when sending real traffic through this integration.
-   */
-  testEventCode?: string
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/index.ts
@@ -21,12 +21,19 @@ const destination: DestinationDefinition<Settings> = {
         description: 'Your Facebook Pixel ID',
         type: 'string',
         required: true
+      },
+      testEventCode: {
+        label: 'Test Event Code',
+        type: 'string',
+        description:
+          'Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. You\'ll want to remove your Test Event Code when sending real traffic through this integration.',
+        required: false
       }
-    },
+    }
   },
   extendRequest: () => {
     return {
-      headers: { authorization: `Bearer ${process.env.ACTIONS_FB_CAPI_SYSTEM_USER_TOKEN}`}
+      headers: { authorization: `Bearer ${process.env.ACTIONS_FB_CAPI_SYSTEM_USER_TOKEN}` }
     }
   },
   actions: {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/index.ts
@@ -21,19 +21,12 @@ const destination: DestinationDefinition<Settings> = {
         description: 'Your Facebook Pixel ID',
         type: 'string',
         required: true
-      },
-      testEventCode: {
-        label: 'Test Event Code',
-        type: 'string',
-        description:
-          'Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. You\'ll want to remove your Test Event Code when sending real traffic through this integration.',
-        required: false
       }
-    }
+    },
   },
   extendRequest: () => {
     return {
-      headers: { authorization: `Bearer ${process.env.ACTIONS_FB_CAPI_SYSTEM_USER_TOKEN}` }
+      headers: { authorization: `Bearer ${process.env.ACTIONS_FB_CAPI_SYSTEM_USER_TOKEN}`}
     }
   },
   actions: {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
@@ -123,7 +123,8 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_country: country_code,
               data_processing_options_state: state_code
             }
-          ]
+          ],
+          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
@@ -123,8 +123,7 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_country: country_code,
               data_processing_options_state: state_code
             }
-          ],
-          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+          ]
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/index.ts
@@ -65,7 +65,8 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_country: country_code,
               data_processing_options_state: state_code
             }
-          ]
+          ],
+          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/index.ts
@@ -65,8 +65,7 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_country: country_code,
               data_processing_options_state: state_code
             }
-          ],
-          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+          ]
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
@@ -128,7 +128,8 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_country: country_code,
               data_processing_options_state: state_code
             }
-          ]
+          ],
+          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
@@ -128,8 +128,7 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_country: country_code,
               data_processing_options_state: state_code
             }
-          ],
-          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+          ]
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
@@ -127,7 +127,8 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_country: country_code,
               data_processing_options_state: state_code
             }
-          ]
+          ],
+          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
@@ -127,8 +127,7 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_country: country_code,
               data_processing_options_state: state_code
             }
-          ],
-          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+          ]
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
@@ -124,7 +124,8 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_country: country_code,
               data_processing_options_state: state_code
             }
-          ]
+          ],
+          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
@@ -124,8 +124,7 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_country: country_code,
               data_processing_options_state: state_code
             }
-          ],
-          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+          ]
         }
       }
     )


### PR DESCRIPTION
It's hard to see realtime events come into the Facebook Events Manager as it only lets you view events that came in the day before (or at least that came a few hours ago).

In order to help customers see that events are coming through when they create a connection to Facebook through Segment and to help them test their events, Segment needs to allow a field called `test_event_code`.

The `test_event_code` field needs to be in the top-level request body outside of the data and the value needs to be the one Facebook provides in their Event Manager Test Events UI.

More info could be also found in this ticket: https://github.com/segmentio/action-destinations/issues/903

This PR adds the support of the `test_event_code` to the destination settings. If `test_event_code` is added by the user, a `test_event_code`property is added to every facebook payload.

## Testing
- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [X] [Segmenters] Tested in the staging environment
