### PR TITLE
[Amplitude] Fix session_id formatting in amplitude actions

### DIFF
--- a/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
@@ -348,7 +348,7 @@ describe('Amplitude', () => {
         event: 'Test Event',
         anonymousId: 'julio',
         integrations: {
-          // @ts-expect-error integrations should accept complext objects;
+          // @ts-expect-error integrations should accept complex objects;
           'Actions Amplitude': {
             session_id: '1234567890'
           }
@@ -401,7 +401,7 @@ describe('Amplitude', () => {
         event: 'Test Event',
         anonymousId: 'julio',
         integrations: {
-          // @ts-expect-error integrations should accept complext objects;
+          // @ts-expect-error integrations should accept complex objects;
           'Actions Amplitude': {
             session_id: 1234567890
           }
@@ -910,7 +910,7 @@ describe('Amplitude', () => {
         event: 'Test Event',
         anonymousId: 'julio',
         integrations: {
-          // @ts-expect-error integrations should accept complext objects;
+          // @ts-expect-error integrations should accept complex objects;
           'Actions Amplitude': {
             session_id: '1234567890'
           }
@@ -963,7 +963,7 @@ describe('Amplitude', () => {
         event: 'Test Event',
         anonymousId: 'julio',
         integrations: {
-          // @ts-expect-error integrations should accept complext objects;
+          // @ts-expect-error integrations should accept complex objects;
           'Actions Amplitude': {
             session_id: 1234567890
           }
@@ -1410,7 +1410,7 @@ describe('Amplitude', () => {
         event: 'Test Event',
         anonymousId: 'julio',
         integrations: {
-          // @ts-expect-error integrations should accept complext objects;
+          // @ts-expect-error integrations should accept complex objects;
           'Actions Amplitude': {
             session_id: '1234567890'
           }
@@ -1463,7 +1463,7 @@ describe('Amplitude', () => {
         event: 'Test Event',
         anonymousId: 'julio',
         integrations: {
-          // @ts-expect-error integrations should accept complext objects;
+          // @ts-expect-error integrations should accept complex objects;
           'Actions Amplitude': {
             session_id: 1234567890
           }

--- a/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
@@ -383,7 +383,7 @@ describe('Amplitude', () => {
               "os_name": "iOS",
               "os_version": "9.1",
               "platform": "Web",
-              "session_id": -23074351200000,
+              "session_id": 1234567890,
               "time": 1629213675449,
               "use_batch_endpoint": false,
               "user_id": "user1234",
@@ -393,6 +393,59 @@ describe('Amplitude', () => {
           "options": undefined,
         }
       `)
+    })
+
+    it('supports session_id from `integrations.Actions Amplitude.session_id` in number format', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        anonymousId: 'julio',
+        integrations: {
+          // @ts-expect-error integrations should accept complext objects;
+          'Actions Amplitude': {
+            session_id: 1234567890
+          }
+        }
+      })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const responses = await testDestination.testAction('logPurchase', { event, useDefaultMappings: true })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+
+      expect(responses[0].options.json).toMatchInlineSnapshot(`
+          Object {
+            "api_key": undefined,
+            "events": Array [
+              Object {
+                "city": "San Francisco",
+                "country": "United States",
+                "device_id": "julio",
+                "device_model": "iPhone",
+                "device_type": "mobile",
+                "event_properties": Object {},
+                "event_type": "Test Event",
+                "ip": "8.8.8.8",
+                "language": "en-US",
+                "library": "segment",
+                "location_lat": 40.2964197,
+                "location_lng": -76.9411617,
+                "os_name": "iOS",
+                "os_version": "9.1",
+                "platform": "Web",
+                "session_id": 1234567890,
+                "time": 1629213675449,
+                "use_batch_endpoint": false,
+                "user_id": "user1234",
+                "user_properties": Object {},
+              },
+            ],
+            "options": undefined,
+          }
+        `)
     })
 
     it('should send data to the EU endpoint', async () => {
@@ -892,7 +945,60 @@ describe('Amplitude', () => {
                 "os_name": "iOS",
                 "os_version": "9.1",
                 "platform": "Web",
-                "session_id": -23074351200000,
+                "session_id": 1234567890,
+                "time": 1629213675449,
+                "use_batch_endpoint": false,
+                "user_id": "user1234",
+                "user_properties": Object {},
+              },
+            ],
+            "options": undefined,
+          }
+        `)
+    })
+
+    it('supports session_id from `integrations.Actions Amplitude.session_id` in number format', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        anonymousId: 'julio',
+        integrations: {
+          // @ts-expect-error integrations should accept complext objects;
+          'Actions Amplitude': {
+            session_id: 1234567890
+          }
+        }
+      })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const responses = await testDestination.testAction('logEvent', { event, useDefaultMappings: true })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+
+      expect(responses[0].options.json).toMatchInlineSnapshot(`
+          Object {
+            "api_key": undefined,
+            "events": Array [
+              Object {
+                "city": "San Francisco",
+                "country": "United States",
+                "device_id": "julio",
+                "device_model": "iPhone",
+                "device_type": "mobile",
+                "event_properties": Object {},
+                "event_type": "Test Event",
+                "ip": "8.8.8.8",
+                "language": "en-US",
+                "library": "segment",
+                "location_lat": 40.2964197,
+                "location_lng": -76.9411617,
+                "os_name": "iOS",
+                "os_version": "9.1",
+                "platform": "Web",
+                "session_id": 1234567890,
                 "time": 1629213675449,
                 "use_batch_endpoint": false,
                 "user_id": "user1234",
@@ -1339,7 +1445,60 @@ describe('Amplitude', () => {
                 "os_name": "iOS",
                 "os_version": "9.1",
                 "platform": "Web",
-                "session_id": -23074351200000,
+                "session_id": 1234567890,
+                "time": 1629213675449,
+                "use_batch_endpoint": false,
+                "user_id": "user1234",
+                "user_properties": Object {},
+              },
+            ],
+            "options": undefined,
+          }
+        `)
+    })
+
+    it('supports session_id from `integrations.Actions Amplitude.session_id` in number format', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        anonymousId: 'julio',
+        integrations: {
+          // @ts-expect-error integrations should accept complext objects;
+          'Actions Amplitude': {
+            session_id: 1234567890
+          }
+        }
+      })
+
+      nock('https://api2.amplitude.com/2').post('/httpapi').reply(200, {})
+
+      const responses = await testDestination.testAction('logEventV2', { event, useDefaultMappings: true })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+
+      expect(responses[0].options.json).toMatchInlineSnapshot(`
+          Object {
+            "api_key": undefined,
+            "events": Array [
+              Object {
+                "city": "San Francisco",
+                "country": "United States",
+                "device_id": "julio",
+                "device_model": "iPhone",
+                "device_type": "mobile",
+                "event_properties": Object {},
+                "event_type": "Test Event",
+                "ip": "8.8.8.8",
+                "language": "en-US",
+                "library": "segment",
+                "location_lat": 40.2964197,
+                "location_lng": -76.9411617,
+                "os_name": "iOS",
+                "os_version": "9.1",
+                "platform": "Web",
+                "session_id": 1234567890,
                 "time": 1629213675449,
                 "use_batch_endpoint": false,
                 "user_id": "user1234",

--- a/packages/destination-actions/src/destinations/amplitude/__tests__/convert-timestamp.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude/__tests__/convert-timestamp.test.ts
@@ -1,0 +1,18 @@
+import { formatSessionId } from '../convert-timestamp'
+
+describe('Amplitude - Convert timestamp - format session_id', () => {
+  it('should convert string to number', () => {
+    const result = formatSessionId('987654321')
+    expect(result).toEqual(987654321)
+  })
+
+  it('should return number as it is', () => {
+    const result = formatSessionId(987654321)
+    expect(result).toEqual(987654321)
+  })
+
+  it('should convert string to unix timestamp', () => {
+    const result = formatSessionId('2000-10-31T01:30:00.000-05:00')
+    expect(result).toEqual(972973800000)
+  })
+})

--- a/packages/destination-actions/src/destinations/amplitude/__tests__/convert-timestamp.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude/__tests__/convert-timestamp.test.ts
@@ -15,4 +15,9 @@ describe('Amplitude - Convert timestamp - format session_id', () => {
     const result = formatSessionId('2000-10-31T01:30:00.000-05:00')
     expect(result).toEqual(972973800000)
   })
+
+  it('should convert string to unix timestamp', () => {
+    const result = formatSessionId('2021-06-08')
+    expect(result).toEqual(1623110400000)
+  })
 })

--- a/packages/destination-actions/src/destinations/amplitude/convert-timestamp.ts
+++ b/packages/destination-actions/src/destinations/amplitude/convert-timestamp.ts
@@ -1,0 +1,12 @@
+import dayjs from '../../lib/dayjs'
+
+export function formatSessionId(session_id: string | number): number {
+  // Timestamps may be on a `string` field, so check if the string is only
+  // numbers. If it is, convert it into a Number since it's probably already a unix timestamp.
+  // DayJS doesn't parse unix timestamps correctly outside of the `.unix()`
+  // initializer.
+  if (typeof session_id === 'string' && /^\d+$/.test(session_id)) {
+    return Number(session_id)
+  }
+  return dayjs.utc(session_id).valueOf()
+}

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
@@ -9,6 +9,7 @@ import { convertReferrerProperty } from '../referrer'
 import { mergeUserProperties } from '../merge-user-properties'
 import { parseUserAgentProperties } from '../user-agent'
 import { getEndpointByRegion } from '../regional-endpoints'
+import { formatSessionId } from '../convert-timestamp'
 
 export interface AmplitudeEvent extends Omit<Payload, 'products' | 'time' | 'session_id'> {
   library?: string
@@ -179,7 +180,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (session_id && dayjs.utc(session_id).isValid()) {
-      properties.session_id = dayjs.utc(session_id).valueOf()
+      properties.session_id = formatSessionId(session_id)
     }
 
     if (Object.keys(payload.utm_properties ?? {}).length || payload.referrer) {

--- a/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
@@ -6,6 +6,7 @@ import type { Settings } from '../generated-types'
 import { getEndpointByRegion } from '../regional-endpoints'
 import { parseUserAgentProperties } from '../user-agent'
 import type { Payload } from './generated-types'
+import { formatSessionId } from '../convert-timestamp'
 
 export interface AmplitudeEvent extends Omit<Payload, 'products' | 'time' | 'session_id'> {
   library?: string
@@ -224,7 +225,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (session_id && dayjs.utc(session_id).isValid()) {
-      properties.session_id = dayjs.utc(session_id).valueOf()
+      properties.session_id = formatSessionId(session_id)
     }
 
     if (min_id_length && min_id_length > 0) {

--- a/packages/destination-actions/src/destinations/amplitude/logPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logPurchase/index.ts
@@ -9,6 +9,7 @@ import { convertReferrerProperty } from '../referrer'
 import { mergeUserProperties } from '../merge-user-properties'
 import { parseUserAgentProperties } from '../user-agent'
 import { getEndpointByRegion } from '../regional-endpoints'
+import { formatSessionId } from '../convert-timestamp'
 
 export interface AmplitudeEvent extends Omit<Payload, 'products' | 'trackRevenuePerProduct' | 'time' | 'session_id'> {
   library?: string
@@ -220,7 +221,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (session_id && dayjs.utc(session_id).isValid()) {
-      properties.session_id = dayjs.utc(session_id).valueOf()
+      properties.session_id = formatSessionId(session_id)
     }
 
     if (Object.keys(payload.utm_properties ?? {}).length || payload.referrer) {


### PR DESCRIPTION
JIRA Ticket - https://segment.atlassian.net/browse/HGI-203

Before passing the session_id in DayJs npm function to format, I have added a check that if the session_id is a string and contains only numbers then typecast it from string to number and return without formatting

Why: Because if the session_id is a string and contains only numbers then it's probably already a unix timestamp. DayJS doesn't parse unix timestamps correctly outside of the `.unix()` initializer.

This fix is similar to formatting used in [Intercom](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/intercom/util.ts#L52)

## Testing

<img width="1512" alt="Screenshot 2022-12-05 at 3 33 28 PM" src="https://user-images.githubusercontent.com/109586712/205687517-8c130187-18de-4d0f-a17f-bba2f342e460.png">


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
