### PR TITLE
[HGI-264] Change `event_name` field to required

### DIFF
--- a/packages/destination-actions/src/destinations/segment/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -409,6 +409,7 @@ Object {
   "context": Object {
     "groupId": "CYyxkIddLM",
   },
+  "event": "CYyxkIddLM",
   "properties": Object {},
   "userId": "CYyxkIddLM",
 }

--- a/packages/destination-actions/src/destinations/segment/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment/segment-properties.ts
@@ -35,7 +35,8 @@ export const screen_name: InputField = {
 export const event_name: InputField = {
   label: 'Event Name',
   description: 'Name of the action that a user has performed.',
-  type: 'string'
+  type: 'string',
+  required: true
 }
 
 export const page_category: InputField = {

--- a/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -77,6 +77,7 @@ Object {
   "context": Object {
     "groupId": "ET^Xg5cIGF]2ok",
   },
+  "event": "ET^Xg5cIGF]2ok",
   "properties": Object {},
   "userId": "ET^Xg5cIGF]2ok",
 }

--- a/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/index.test.ts
@@ -9,7 +9,10 @@ const testDestination = createTestIntegration(Destination)
 beforeEach(() => nock.cleanAll())
 
 // Default Page Mapping
-const defaultPageMapping = {
+const defaultTrackMapping = {
+  event_name: {
+    '@path': '$.event'
+  },
   user_id: {
     '@path': '$.userId'
   },
@@ -26,13 +29,18 @@ describe('Segment.sendTrack', () => {
     const event = createTestEvent({
       properties: {
         plan: 'Business'
-      }
+      },
+      event: 'Test Event'
     })
 
     await expect(
       testDestination.testAction('sendTrack', {
         event,
-        mapping: {}
+        mapping: {
+          event_name: {
+            '@path': '$.event'
+          }
+        }
       })
     ).rejects.toThrowError(MissingUserOrAnonymousIdThrowableError)
   })
@@ -43,13 +51,14 @@ describe('Segment.sendTrack', () => {
         plan: 'Business'
       },
       userId: 'test-user-ufi5bgkko5',
-      anonymousId: 'arky4h2sh7k'
+      anonymousId: 'arky4h2sh7k',
+      event: 'Test Event'
     })
 
     await expect(
       testDestination.testAction('sendTrack', {
         event,
-        mapping: defaultPageMapping,
+        mapping: defaultTrackMapping,
         settings: {
           source_write_key: 'test-source-write-key',
           endpoint: 'incorrect-endpoint'
@@ -68,12 +77,13 @@ describe('Segment.sendTrack', () => {
         plan: 'Business'
       },
       userId: 'test-user-ufi5bgkko5',
-      anonymousId: 'arky4h2sh7k'
+      anonymousId: 'arky4h2sh7k',
+      event: 'Test Event'
     })
 
     const responses = await testDestination.testAction('sendTrack', {
       event,
-      mapping: defaultPageMapping,
+      mapping: defaultTrackMapping,
       settings: {
         source_write_key: 'test-source-write-key',
         endpoint: DEFAULT_SEGMENT_ENDPOINT

--- a/packages/destination-actions/src/destinations/segment/sendTrack/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/generated-types.ts
@@ -16,7 +16,7 @@ export interface Payload {
   /**
    * Name of the action that a user has performed.
    */
-  event_name?: string
+  event_name: string
   /**
    * Dictionary of information about the current application.
    */


### PR DESCRIPTION
This PR changes `event_name` field in Segment RETL Destination to Required.

## Testing
Testing completed successfully in local and staging.
![image](https://user-images.githubusercontent.com/109198085/206250126-f788d04b-483c-4fbc-aa3b-bd111e778c33.png)


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
