### PR TITLE
Stratconn 1760- For salesforce, Record matcher operator added now we able to build query with "OR" and "AND" operator.

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
@@ -172,7 +172,7 @@ describe('Salesforce', () => {
       await expect(
         sf.updateRecord(
           {
-            recordMatcherOperator: 'HELLO I AM INVALID',
+            recordMatcherOperator: 'NOR',
             traits: {
               email: { key: 'sponge@seamail.com' },
               NoOfEmployees: [1, 2]
@@ -180,7 +180,7 @@ describe('Salesforce', () => {
           },
           'Lead'
         )
-      ).rejects.toThrowError('Invalid SOQL operator - HELLO I AM INVALID')
+      ).rejects.toThrowError('Invalid SOQL operator - NOR')
     })
 
     it('should fail when trait value is of an unsupported datatype - object or arrays', async () => {

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
@@ -141,6 +141,48 @@ describe('Salesforce', () => {
       )
     })
 
+    it('should support the AND soql operator', async () => {
+      const query = encodeURIComponent(
+        `SELECT Id FROM Lead WHERE email = 'sponge@seamail.com' AND isDeleted = false AND NumberOfEmployees = 3`
+      )
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/query`)
+        .get(`/?q=${query}`)
+        .reply(201, {
+          Id: 'abc123',
+          totalSize: 1,
+          records: [{ Id: '123456' }]
+        })
+
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).patch('/Lead/123456').reply(201, {})
+
+      await sf.updateRecord(
+        {
+          recordMatcherOperator: 'AND',
+          traits: {
+            email: 'sponge@seamail.com',
+            isDeleted: false,
+            NumberOfEmployees: 3
+          }
+        },
+        'Lead'
+      )
+    })
+
+    it('should fail when the soql operator is not OR and not AND', async () => {
+      await expect(
+        sf.updateRecord(
+          {
+            recordMatcherOperator: 'HELLO I AM INVALID',
+            traits: {
+              email: { key: 'sponge@seamail.com' },
+              NoOfEmployees: [1, 2]
+            }
+          },
+          'Lead'
+        )
+      ).rejects.toThrowError('Invalid SOQL operator - HELLO I AM INVALID')
+    })
+
     it('should fail when trait value is of an unsupported datatype - object or arrays', async () => {
       await expect(
         sf.updateRecord(

--- a/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
@@ -10,9 +10,9 @@ export interface Payload {
    */
   enable_batching?: boolean
   /**
-   * The Salesforce operator performed. The available operator to use multiple Record Matchers.
+   * This field affects how Segment uses the record matchers to query Salesforce records. By default, Segment uses the "OR" operator to query Salesforce for a record. If you would like to query Salesforce records using a combination of multiple record matchers, change this to "AND".
    */
-  operator?: string
+  recordMatcherOperator?: string
   /**
    * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
    *

--- a/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   enable_batching?: boolean
   /**
+   * The Salesforce operator performed. The available operator to use multiple Record Matchers.
+   */
+  operator?: string
+  /**
    * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
    *
    *   Any field can function as a matcher, including Record ID, External IDs, standard fields and custom fields. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.

--- a/packages/destination-actions/src/destinations/salesforce/account/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account/index.ts
@@ -8,7 +8,8 @@ import {
   operation,
   traits,
   validateLookup,
-  enable_batching
+  enable_batching,
+  operator
 } from '../sf-properties'
 import type { Payload } from './generated-types'
 
@@ -21,6 +22,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     operation: operation,
     enable_batching: enable_batching,
+    operator: operator,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,
     bulkUpdateRecordId: bulkUpdateRecordId,

--- a/packages/destination-actions/src/destinations/salesforce/account/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account/index.ts
@@ -9,7 +9,7 @@ import {
   traits,
   validateLookup,
   enable_batching,
-  operator
+  recordMatcherOperator
 } from '../sf-properties'
 import type { Payload } from './generated-types'
 
@@ -22,7 +22,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     operation: operation,
     enable_batching: enable_batching,
-    operator: operator,
+    recordMatcherOperator: recordMatcherOperator,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,
     bulkUpdateRecordId: bulkUpdateRecordId,

--- a/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   operation: string
   /**
+   * The Salesforce operator performed. The available operator to use multiple Record Matchers.
+   */
+  operator?: string
+  /**
    * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
   enable_batching?: boolean

--- a/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
@@ -6,9 +6,9 @@ export interface Payload {
    */
   operation: string
   /**
-   * The Salesforce operator performed. The available operator to use multiple Record Matchers.
+   * This field affects how Segment uses the record matchers to query Salesforce records. By default, Segment uses the "OR" operator to query Salesforce for a record. If you would like to query Salesforce records using a combination of multiple record matchers, change this to "AND".
    */
-  operator?: string
+  recordMatcherOperator?: string
   /**
    * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */

--- a/packages/destination-actions/src/destinations/salesforce/cases/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases/index.ts
@@ -8,7 +8,8 @@ import {
   operation,
   traits,
   validateLookup,
-  enable_batching
+  enable_batching,
+  operator
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
 
@@ -19,6 +20,7 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Create, update, or upsert cases in Salesforce.',
   fields: {
     operation: operation,
+    operator: operator,
     enable_batching: enable_batching,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,

--- a/packages/destination-actions/src/destinations/salesforce/cases/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases/index.ts
@@ -9,7 +9,7 @@ import {
   traits,
   validateLookup,
   enable_batching,
-  operator
+  recordMatcherOperator
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
 
@@ -20,7 +20,7 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Create, update, or upsert cases in Salesforce.',
   fields: {
     operation: operation,
-    operator: operator,
+    recordMatcherOperator: recordMatcherOperator,
     enable_batching: enable_batching,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,

--- a/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   operation: string
   /**
+   * The Salesforce operator performed. The available operator to use multiple Record Matchers.
+   */
+  operator?: string
+  /**
    * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
   enable_batching?: boolean

--- a/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
@@ -6,9 +6,9 @@ export interface Payload {
    */
   operation: string
   /**
-   * The Salesforce operator performed. The available operator to use multiple Record Matchers.
+   * This field affects how Segment uses the record matchers to query Salesforce records. By default, Segment uses the "OR" operator to query Salesforce for a record. If you would like to query Salesforce records using a combination of multiple record matchers, change this to "AND".
    */
-  operator?: string
+  recordMatcherOperator?: string
   /**
    * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */

--- a/packages/destination-actions/src/destinations/salesforce/contact/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact/index.ts
@@ -9,7 +9,7 @@ import {
   traits,
   validateLookup,
   enable_batching,
-  operator
+  recordMatcherOperator
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
 
@@ -20,7 +20,7 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Create, update, or upsert contacts in Salesforce.',
   fields: {
     operation: operation,
-    operator: operator,
+    recordMatcherOperator: recordMatcherOperator,
     enable_batching: enable_batching,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,

--- a/packages/destination-actions/src/destinations/salesforce/contact/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact/index.ts
@@ -8,7 +8,8 @@ import {
   operation,
   traits,
   validateLookup,
-  enable_batching
+  enable_batching,
+  operator
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
 
@@ -19,6 +20,7 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Create, update, or upsert contacts in Salesforce.',
   fields: {
     operation: operation,
+    operator: operator,
     enable_batching: enable_batching,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,

--- a/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   operation: string
   /**
+   * The Salesforce operator performed. The available operator to use multiple Record Matchers.
+   */
+  operator?: string
+  /**
    * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
   enable_batching?: boolean

--- a/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
@@ -6,9 +6,9 @@ export interface Payload {
    */
   operation: string
   /**
-   * The Salesforce operator performed. The available operator to use multiple Record Matchers.
+   * This field affects how Segment uses the record matchers to query Salesforce records. By default, Segment uses the "OR" operator to query Salesforce for a record. If you would like to query Salesforce records using a combination of multiple record matchers, change this to "AND".
    */
-  operator?: string
+  recordMatcherOperator?: string
   /**
    * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */

--- a/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
@@ -8,7 +8,8 @@ import {
   traits,
   customFields,
   validateLookup,
-  enable_batching
+  enable_batching,
+  operator
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
 
@@ -17,6 +18,7 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Create, update, or upsert records in any custom or standard object in Salesforce.',
   fields: {
     operation: operation,
+    operator: operator,
     enable_batching: enable_batching,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,

--- a/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
@@ -9,7 +9,7 @@ import {
   customFields,
   validateLookup,
   enable_batching,
-  operator
+  recordMatcherOperator
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
 
@@ -18,7 +18,7 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Create, update, or upsert records in any custom or standard object in Salesforce.',
   fields: {
     operation: operation,
-    operator: operator,
+    recordMatcherOperator: recordMatcherOperator,
     enable_batching: enable_batching,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,

--- a/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   operation: string
   /**
+   * The Salesforce operator performed. The available operator to use multiple Record Matchers.
+   */
+  operator?: string
+  /**
    * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
   enable_batching?: boolean

--- a/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
@@ -6,9 +6,9 @@ export interface Payload {
    */
   operation: string
   /**
-   * The Salesforce operator performed. The available operator to use multiple Record Matchers.
+   * This field affects how Segment uses the record matchers to query Salesforce records. By default, Segment uses the "OR" operator to query Salesforce for a record. If you would like to query Salesforce records using a combination of multiple record matchers, change this to "AND".
    */
-  operator?: string
+  recordMatcherOperator?: string
   /**
    * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */

--- a/packages/destination-actions/src/destinations/salesforce/lead/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/index.ts
@@ -8,7 +8,8 @@ import {
   operation,
   traits,
   validateLookup,
-  enable_batching
+  enable_batching,
+  operator
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
 
@@ -20,6 +21,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "identify"',
   fields: {
     operation: operation,
+    operator: operator,
     enable_batching: enable_batching,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,

--- a/packages/destination-actions/src/destinations/salesforce/lead/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/index.ts
@@ -9,7 +9,7 @@ import {
   traits,
   validateLookup,
   enable_batching,
-  operator
+  recordMatcherOperator
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
 
@@ -21,7 +21,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "identify"',
   fields: {
     operation: operation,
-    operator: operator,
+    recordMatcherOperator: recordMatcherOperator,
     enable_batching: enable_batching,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,

--- a/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   operation: string
   /**
+   * The Salesforce operator performed. The available operator to use multiple Record Matchers.
+   */
+  operator?: string
+  /**
    * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
   enable_batching?: boolean

--- a/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
@@ -6,9 +6,9 @@ export interface Payload {
    */
   operation: string
   /**
-   * The Salesforce operator performed. The available operator to use multiple Record Matchers.
+   * This field affects how Segment uses the record matchers to query Salesforce records. By default, Segment uses the "OR" operator to query Salesforce for a record. If you would like to query Salesforce records using a combination of multiple record matchers, change this to "AND".
    */
-  operator?: string
+  recordMatcherOperator?: string
   /**
    * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */

--- a/packages/destination-actions/src/destinations/salesforce/opportunity/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity/index.ts
@@ -8,7 +8,8 @@ import {
   operation,
   traits,
   validateLookup,
-  enable_batching
+  enable_batching,
+  operator
 } from '../sf-properties'
 import type { Payload } from './generated-types'
 
@@ -19,6 +20,7 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Create, update, or upsert opportunities in Salesforce.',
   fields: {
     operation: operation,
+    operator: operator,
     enable_batching: enable_batching,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,

--- a/packages/destination-actions/src/destinations/salesforce/opportunity/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity/index.ts
@@ -9,7 +9,7 @@ import {
   traits,
   validateLookup,
   enable_batching,
-  operator
+  recordMatcherOperator
 } from '../sf-properties'
 import type { Payload } from './generated-types'
 
@@ -20,7 +20,7 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Create, update, or upsert opportunities in Salesforce.',
   fields: {
     operation: operation,
-    operator: operator,
+    recordMatcherOperator: recordMatcherOperator,
     enable_batching: enable_batching,
     traits: traits,
     bulkUpsertExternalId: bulkUpsertExternalId,

--- a/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
@@ -79,7 +79,7 @@ export default class Salesforce {
       return await this.baseUpdate(payload.traits['Id'] as string, sobject, payload)
     }
 
-    const [recordId, err] = await this.lookupTraits(payload.traits, sobject)
+    const [recordId, err] = await this.lookupTraits(payload.traits, sobject, payload.operator ?? 'OR')
 
     if (err) {
       throw err
@@ -93,7 +93,7 @@ export default class Salesforce {
       throw new IntegrationError('Undefined Traits when using upsert operation', 'Undefined Traits', 400)
     }
 
-    const [recordId, err] = await this.lookupTraits(payload.traits, sobject)
+    const [recordId, err] = await this.lookupTraits(payload.traits, sobject, payload.operator ?? 'OR')
 
     if (err) {
       if (err.status === 404) {
@@ -283,7 +283,7 @@ export default class Salesforce {
     }
   }
 
-  private buildQuery = (traits: object, sobject: string) => {
+  private buildQuery = (traits: object, sobject: string, operator: string) => {
     let soql = `SELECT Id FROM ${sobject} WHERE `
 
     const entries = Object.entries(traits)
@@ -292,7 +292,7 @@ export default class Salesforce {
       let token = `${this.removeInvalidChars(key)} = ${this.typecast(value)}`
 
       if (i < entries.length - 1) {
-        token += ' OR '
+        token += ' ' + operator + ' ' // We need to change here...
       }
 
       soql += token
@@ -301,8 +301,12 @@ export default class Salesforce {
     return soql
   }
 
-  private lookupTraits = async (traits: object, sobject: string): Promise<[string, IntegrationError | undefined]> => {
-    const SOQLQuery = encodeURIComponent(this.buildQuery(traits, sobject))
+  private lookupTraits = async (
+    traits: object,
+    sobject: string,
+    operator: string
+  ): Promise<[string, IntegrationError | undefined]> => {
+    const SOQLQuery = encodeURIComponent(this.buildQuery(traits, sobject, operator))
 
     const res = await this.request<LookupResponseData>(
       `${this.instanceUrl}services/data/${API_VERSION}/query/?q=${SOQLQuery}`,

--- a/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
@@ -14,6 +14,12 @@ const throwBulkMismatchError = () => {
   throw new IntegrationError(errorMsg, errorMsg, 400)
 }
 
+const validateSOQLOperator = (operator: string | undefined) => {
+  if (!operator || (operator !== 'OR' && operator !== 'AND')) {
+    throw new IntegrationError(`Invalid SOQL operator - ${operator}`, 'Invalid SOQL operator', 400)
+  }
+}
+
 interface Records {
   Id?: string
 }
@@ -50,6 +56,8 @@ interface SalesforceError {
   }
 }
 
+type SOQLOperator = 'OR' | 'AND'
+
 export default class Salesforce {
   instanceUrl: string
   request: RequestClient
@@ -79,7 +87,12 @@ export default class Salesforce {
       return await this.baseUpdate(payload.traits['Id'] as string, sobject, payload)
     }
 
-    const [recordId, err] = await this.lookupTraits(payload.traits, sobject, payload.recordMatcherOperator ?? 'OR')
+    validateSOQLOperator(payload.recordMatcherOperator)
+    const [recordId, err] = await this.lookupTraits(
+      payload.traits,
+      sobject,
+      payload.recordMatcherOperator as SOQLOperator
+    )
 
     if (err) {
       throw err
@@ -93,7 +106,12 @@ export default class Salesforce {
       throw new IntegrationError('Undefined Traits when using upsert operation', 'Undefined Traits', 400)
     }
 
-    const [recordId, err] = await this.lookupTraits(payload.traits, sobject, payload.recordMatcherOperator ?? 'OR')
+    validateSOQLOperator(payload.recordMatcherOperator)
+    const [recordId, err] = await this.lookupTraits(
+      payload.traits,
+      sobject,
+      payload.recordMatcherOperator as SOQLOperator
+    )
 
     if (err) {
       if (err.status === 404) {
@@ -283,7 +301,7 @@ export default class Salesforce {
     }
   }
 
-  private buildQuery = (traits: object, sobject: string, operator: string) => {
+  private buildQuery = (traits: object, sobject: string, soqlOperator: SOQLOperator) => {
     let soql = `SELECT Id FROM ${sobject} WHERE `
 
     const entries = Object.entries(traits)
@@ -292,7 +310,7 @@ export default class Salesforce {
       let token = `${this.removeInvalidChars(key)} = ${this.typecast(value)}`
 
       if (i < entries.length - 1) {
-        token += ' ' + operator + ' '
+        token += ' ' + soqlOperator + ' '
       }
 
       soql += token
@@ -304,9 +322,9 @@ export default class Salesforce {
   private lookupTraits = async (
     traits: object,
     sobject: string,
-    operator: string
+    soqlOperator: SOQLOperator
   ): Promise<[string, IntegrationError | undefined]> => {
-    const SOQLQuery = encodeURIComponent(this.buildQuery(traits, sobject, operator))
+    const SOQLQuery = encodeURIComponent(this.buildQuery(traits, sobject, soqlOperator))
 
     const res = await this.request<LookupResponseData>(
       `${this.instanceUrl}services/data/${API_VERSION}/query/?q=${SOQLQuery}`,

--- a/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
@@ -19,6 +19,7 @@ const validateSOQLOperator = (operator: string | undefined): SOQLOperator => {
     throw new IntegrationError(`Invalid SOQL operator - ${operator}`, 'Invalid SOQL operator', 400)
   }
 
+  // 'OR' is the default operator. Therefore, when we encounter 'undefined' we will return 'OR'.
   if (operator === undefined) {
     return 'OR'
   }

--- a/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
@@ -79,7 +79,7 @@ export default class Salesforce {
       return await this.baseUpdate(payload.traits['Id'] as string, sobject, payload)
     }
 
-    const [recordId, err] = await this.lookupTraits(payload.traits, sobject, payload.operator ?? 'OR')
+    const [recordId, err] = await this.lookupTraits(payload.traits, sobject, payload.recordMatcherOperator ?? 'OR')
 
     if (err) {
       throw err
@@ -93,7 +93,7 @@ export default class Salesforce {
       throw new IntegrationError('Undefined Traits when using upsert operation', 'Undefined Traits', 400)
     }
 
-    const [recordId, err] = await this.lookupTraits(payload.traits, sobject, payload.operator ?? 'OR')
+    const [recordId, err] = await this.lookupTraits(payload.traits, sobject, payload.recordMatcherOperator ?? 'OR')
 
     if (err) {
       if (err.status === 404) {

--- a/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
@@ -316,7 +316,6 @@ export default class Salesforce {
       i += 1
     }
 
-    console.log('soqlOperator', soqlOperator)
     return soql
   }
 

--- a/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
@@ -292,7 +292,7 @@ export default class Salesforce {
       let token = `${this.removeInvalidChars(key)} = ${this.typecast(value)}`
 
       if (i < entries.length - 1) {
-        token += ' ' + operator + ' ' // We need to change here...
+        token += ' ' + operator + ' '
       }
 
       soql += token

--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -53,7 +53,6 @@ export const recordMatcherOperator: InputField = {
   description:
     'This field affects how Segment uses the record matchers to query Salesforce records. By default, Segment uses the "OR" operator to query Salesforce for a record. If you would like to query Salesforce records using a combination of multiple record matchers, change this to "AND".',
   type: 'string',
-  required: false,
   choices: [
     { label: 'OR', value: 'OR' },
     { label: 'AND', value: 'AND' }

--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -48,6 +48,17 @@ export const bulkUpdateRecordId: InputField = {
   type: 'string'
 }
 
+export const operator: InputField = {
+  label: 'Operator',
+  description: 'The Salesforce operator performed. The available operator to use multiple Record Matchers.',
+  type: 'string',
+  required: false,
+  choices: [
+    { label: 'Or', value: 'OR' },
+    { label: 'And', value: 'AND' }
+  ]
+}
+
 export const traits: InputField = {
   label: 'Record Matchers',
   description: `The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
@@ -80,6 +91,7 @@ export const customFields: InputField = {
 interface Payload {
   operation?: string
   traits?: object
+  operator?: string
 }
 
 export const validateLookup = (payload: Payload) => {

--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -48,6 +48,8 @@ export const bulkUpdateRecordId: InputField = {
   type: 'string'
 }
 
+// Any actions configured before this field was added will have an undefined value for this field.
+// We default to the 'OR' when consuming this field if it is undefined.
 export const recordMatcherOperator: InputField = {
   label: 'Record Matchers Operator',
   description:

--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -57,7 +57,8 @@ export const recordMatcherOperator: InputField = {
   choices: [
     { label: 'OR', value: 'OR' },
     { label: 'AND', value: 'AND' }
-  ]
+  ],
+  default: 'OR'
 }
 
 export const traits: InputField = {

--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -48,14 +48,15 @@ export const bulkUpdateRecordId: InputField = {
   type: 'string'
 }
 
-export const operator: InputField = {
-  label: 'Operator',
-  description: 'The Salesforce operator performed. The available operator to use multiple Record Matchers.',
+export const recordMatcherOperator: InputField = {
+  label: 'Record Matchers Operator',
+  description:
+    'This field affects how Segment uses the record matchers to query Salesforce records. By default, Segment uses the "OR" operator to query Salesforce for a record. If you would like to query Salesforce records using a combination of multiple record matchers, change this to "AND".',
   type: 'string',
   required: false,
   choices: [
-    { label: 'Or', value: 'OR' },
-    { label: 'And', value: 'AND' }
+    { label: 'OR', value: 'OR' },
+    { label: 'AND', value: 'AND' }
   ]
 }
 
@@ -91,7 +92,6 @@ export const customFields: InputField = {
 interface Payload {
   operation?: string
   traits?: object
-  operator?: string
 }
 
 export const validateLookup = (payload: Payload) => {


### PR DESCRIPTION
This PR adds an "AND" operator to the Salesforce SOQL options. This allows users to construct queries where each condition is joined by an "AND". 

Ticket: https://segment.atlassian.net/browse/STRATCONN-1760

## Testing
Tested successfully in stage: [Flagon](https://flagon.segment.build/families/centrifuge-destinations/gates/actions-versions-3.120.0)

These screenshots show me updating a record which has `name = "Bulk Update 12.12" AND Industry = "Manufacturing"`.
The query is correctly constructed with an "AND":
<img width="1680" alt="Screen Shot 2022-12-12 at 4 57 24 PM" src="https://user-images.githubusercontent.com/27820201/207201527-045a7de6-fab6-42ee-9e83-be5d144ec437.png">


| Original Record | Updated Record |
|-----------|-----------|
| <img width="1276" alt="Screen Shot 2022-12-12 at 4 48 17 PM" src="https://user-images.githubusercontent.com/27820201/207201627-c8208ad2-c754-4a0b-8f15-32c85d80be8b.png"> | <img width="1266" alt="Screen Shot 2022-12-12 at 4 58 53 PM" src="https://user-images.githubusercontent.com/27820201/207201647-40461b87-6a41-4801-9825-358ce24012ef.png">
   |

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
