### PR TITLE
HubSpot Cloud Mode - Added `createNewCompany` and `associateContact` flags

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -42,7 +42,6 @@ Object {
 exports[`Testing snapshot for actions-hubspot-cloud destination: upsertCompany action - required fields 1`] = `
 Object {
   "properties": Object {
-    "name": "xz1CFcz1FfyLPZgppeg",
     "segment_group_id": "xz1CFcz1FfyLPZgppeg",
   },
 }

--- a/packages/destination-actions/src/destinations/hubspot/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -19,9 +19,34 @@ Object {
 }
 `;
 
-exports[`Testing snapshot for actions-hubspot-cloud destination: upsertCompany action - all fields 1`] = `[IntegrationError: Identify (Upsert Contact) must be called before Group (Upsert Company) for the HubSpot Cloud (Actions) destination.]`;
+exports[`Testing snapshot for actions-hubspot-cloud destination: upsertCompany action - all fields 1`] = `
+Object {
+  "properties": Object {
+    "address": "xz1CFcz1FfyLPZgppeg",
+    "city": "xz1CFcz1FfyLPZgppeg",
+    "description": "xz1CFcz1FfyLPZgppeg",
+    "domain": "xz1CFcz1FfyLPZgppeg",
+    "industry": "xz1CFcz1FfyLPZgppeg",
+    "lifecyclestage": "xz1cfcz1ffylpzgppeg",
+    "name": "xz1CFcz1FfyLPZgppeg",
+    "numberofemployees": 6931055592341504,
+    "phone": "xz1CFcz1FfyLPZgppeg",
+    "segment_group_id": "xz1CFcz1FfyLPZgppeg",
+    "state": "xz1CFcz1FfyLPZgppeg",
+    "testType": "xz1CFcz1FfyLPZgppeg",
+    "zip": "xz1CFcz1FfyLPZgppeg",
+  },
+}
+`;
 
-exports[`Testing snapshot for actions-hubspot-cloud destination: upsertCompany action - required fields 1`] = `[IntegrationError: Identify (Upsert Contact) must be called before Group (Upsert Company) for the HubSpot Cloud (Actions) destination.]`;
+exports[`Testing snapshot for actions-hubspot-cloud destination: upsertCompany action - required fields 1`] = `
+Object {
+  "properties": Object {
+    "name": "xz1CFcz1FfyLPZgppeg",
+    "segment_group_id": "xz1CFcz1FfyLPZgppeg",
+  },
+}
+`;
 
 exports[`Testing snapshot for actions-hubspot-cloud destination: upsertContact action - all fields 1`] = `
 Object {

--- a/packages/destination-actions/src/destinations/hubspot/upsertCompany/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCompany/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -23,7 +23,6 @@ Object {
 exports[`Testing snapshot for HubSpot's upsertCompany destination action: required fields 1`] = `
 Object {
   "properties": Object {
-    "name": "F9hZOtvgHY(T6dF5vS7",
     "segment_group_id": "F9hZOtvgHY(T6dF5vS7",
   },
 }

--- a/packages/destination-actions/src/destinations/hubspot/upsertCompany/generated-types.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCompany/generated-types.ts
@@ -6,6 +6,14 @@ export interface Payload {
    */
   groupid: string
   /**
+   * If true, Segment will attempt to update an existing company in HubSpot and if no company is found, Segment will create a new company. If false, Segment will only attempt to update an existing company and never create a new company. This is set to true by default.
+   */
+  createNewCompany: boolean
+  /**
+   * If true, Segment will associate the company with the user identified in your payload. If no contact is found in HubSpot, an error is thrown and the company is not created/updated. If false, Segment will not attempt to associate a contact with the company and companies can be created/updated without requiring a contact association. This is set to true by default.
+   */
+  associateContact: boolean
+  /**
    * The unique field(s) used to search for an existing company in HubSpot to update. By default, Segment creates a custom property to store groupId for each company and uses this property to search for companies. If a company is not found, the fields provided here are then used to search. If a company is still not found, a new one is created.
    */
   companysearchfields: {

--- a/packages/destination-actions/src/destinations/hubspot/upsertCompany/generated-types.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCompany/generated-types.ts
@@ -22,7 +22,7 @@ export interface Payload {
   /**
    * The name of the company.
    */
-  name: string
+  name?: string
   /**
    * A short statement about the company’s mission and goals.
    */

--- a/packages/destination-actions/src/destinations/hubspot/upsertCompany/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCompany/index.ts
@@ -160,7 +160,6 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Company Name',
       description: 'The name of the company.',
       type: 'string',
-      required: true,
       default: {
         '@path': '$.traits.name'
       }


### PR DESCRIPTION
This PR addresses changes in `HGI-249` and `HGI-250` to make HubSpot Cloud Mode (Actions) compatible with RETL.

Added the following required fields
![image](https://user-images.githubusercontent.com/109198085/206234044-d3a2d4dd-b7ae-4dc5-bb28-65e1959f86d9.png)

Changed the following fields from Required to Optional
![image](https://user-images.githubusercontent.com/109198085/206269563-863a1108-7ea2-4aa3-b064-6bad5602e92c.png)

## Testing
Tests completed in local environment.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
