### PR TITLE
Ripe browser destination

### DIFF
--- a/packages/browser-destinations/src/destinations/ripe/alias/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/ripe/alias/__tests__/index.test.ts
@@ -1,0 +1,100 @@
+import type { Subscription } from '../../../../lib/browser-destinations'
+import { Analytics, Context } from '@segment/analytics-next'
+import RipeDestination, { destination } from '../../index'
+import { RipeSDK } from '../../types'
+
+import { loadScript } from '../../../../runtime/load-script'
+
+jest.mock('../../../../runtime/load-script')
+beforeEach(async () => {
+  ;(loadScript as jest.Mock).mockResolvedValue(true)
+})
+
+const subscriptions: Subscription[] = [
+  {
+    partnerAction: 'alias',
+    name: 'Alias user',
+    enabled: true,
+    subscribe: 'type = "alias"',
+    mapping: {
+      userId: {
+        '@path': '$.userId'
+      },
+      anonymousId: {
+        '@path': '$.anonymousId'
+      }
+    }
+  }
+]
+
+describe('Ripe.alias', () => {
+  test('it maps userId and passes it into RipeSDK.alias', async () => {
+    window.Ripe = {
+      init: jest.fn().mockResolvedValueOnce('123'),
+      alias: jest.fn().mockResolvedValueOnce(undefined),
+      setIds: jest.fn().mockResolvedValueOnce(undefined)
+    } as unknown as RipeSDK
+
+    const [event] = await RipeDestination({
+      subscriptions,
+      apiKey: '123'
+    })
+
+    const ajs = new Analytics({ writeKey: '123' })
+    await event.load(Context.system(), ajs)
+    jest.spyOn(destination.actions.alias, 'perform')
+
+    await event.alias?.(
+      new Context({
+        type: 'alias',
+        userId: 'newId'
+      })
+    )
+
+    expect(destination.actions.alias.perform).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        payload: {
+          userId: 'newId'
+        }
+      })
+    )
+
+    expect(window.Ripe.alias).toHaveBeenCalledWith('newId')
+  })
+
+  test('it maps anonymousId if userId is not set and passes it into RipeSDK.alias', async () => {
+    window.Ripe = {
+      init: jest.fn().mockResolvedValueOnce('123'),
+      alias: jest.fn().mockResolvedValueOnce(undefined),
+      setIds: jest.fn().mockResolvedValueOnce(undefined)
+    } as unknown as RipeSDK
+
+    const [event] = await RipeDestination({
+      subscriptions,
+      apiKey: '123'
+    })
+
+    const ajs = new Analytics({ writeKey: '123' })
+    await event.load(Context.system(), ajs)
+    jest.spyOn(destination.actions.alias, 'perform')
+
+    await event.alias?.(
+      new Context({
+        type: 'alias',
+        anonymousId: 'anonymousId'
+      })
+    )
+
+    expect(destination.actions.alias.perform).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        payload: {
+          anonymousId: 'anonymousId'
+        }
+      })
+    )
+
+    expect(window.Ripe.alias).toHaveBeenCalledWith('anonymousId')
+  })
+})

--- a/packages/browser-destinations/src/destinations/ripe/alias/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/ripe/alias/generated-types.ts
@@ -1,0 +1,16 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The new user ID, if user ID is not set
+   */
+  anonymousId: string
+  /**
+   * The ID associated with the user
+   */
+  userId?: string
+  /**
+   * The ID associated groupId
+   */
+  groupId?: string
+}

--- a/packages/browser-destinations/src/destinations/ripe/alias/index.ts
+++ b/packages/browser-destinations/src/destinations/ripe/alias/index.ts
@@ -1,0 +1,46 @@
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { RipeSDK } from '../types'
+
+const action: BrowserActionDefinition<Settings, RipeSDK, Payload> = {
+  title: 'Alias',
+  description: 'Alias a user to new user ID in Ripe',
+  defaultSubscription: 'type = "alias"',
+  platform: 'web',
+  fields: {
+    anonymousId: {
+      type: 'string',
+      required: true,
+      description: 'The new user ID, if user ID is not set',
+      label: 'Anonymous ID',
+      default: { '@path': '$.anonymousId' }
+    },
+    userId: {
+      type: 'string',
+      required: false,
+      description: 'The ID associated with the user',
+      label: 'User ID',
+      default: { '@path': '$.userId' }
+    },
+    groupId: {
+      type: 'string',
+      required: false,
+      description: 'The ID associated groupId',
+      label: 'Group ID',
+      default: { '@path': '$.groupId' }
+    }
+  },
+  perform: async (ripe, { payload }) => {
+    await ripe.setIds(payload.anonymousId, payload.userId, payload.groupId)
+    if (payload.userId) {
+      return ripe.alias(payload.userId)
+    }
+
+    if (payload.anonymousId) {
+      return ripe.alias(payload.anonymousId)
+    }
+  }
+}
+
+export default action

--- a/packages/browser-destinations/src/destinations/ripe/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/ripe/generated-types.ts
@@ -1,0 +1,12 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * The version of the Ripe Widget SDK to use
+   */
+  sdkVersion?: string
+  /**
+   * The Ripe API key found in the Ripe App
+   */
+  apiKey: string
+}

--- a/packages/browser-destinations/src/destinations/ripe/group/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/ripe/group/__tests__/index.test.ts
@@ -1,0 +1,71 @@
+import type { Subscription } from '../../../../lib/browser-destinations'
+import { Analytics, Context } from '@segment/analytics-next'
+import RipeDestination, { destination } from '../../index'
+
+import { loadScript } from '../../../../runtime/load-script'
+import { RipeSDK } from '../../types'
+
+jest.mock('../../../../runtime/load-script')
+beforeEach(async () => {
+  ;(loadScript as jest.Mock).mockResolvedValue(true)
+})
+
+const subscriptions: Subscription[] = [
+  {
+    partnerAction: 'group',
+    name: 'Group user',
+    enabled: true,
+    subscribe: 'type = "group"',
+    mapping: {
+      groupId: {
+        '@path': '$.groupId'
+      },
+      traits: {
+        '@path': '$.traits'
+      }
+    }
+  }
+]
+
+describe('Ripe.group', () => {
+  test('it maps the event name and properties and passes them into RipeSDK.track', async () => {
+    window.Ripe = {
+      init: jest.fn().mockResolvedValueOnce('123'),
+      group: jest.fn().mockResolvedValueOnce(undefined),
+      setIds: jest.fn().mockResolvedValueOnce(undefined)
+    } as unknown as RipeSDK
+
+    const [event] = await RipeDestination({
+      subscriptions,
+      apiKey: '123'
+    })
+
+    const ajs = new Analytics({ writeKey: '123' })
+    await event.load(Context.system(), ajs)
+    jest.spyOn(destination.actions.group, 'perform')
+
+    await event.group?.(
+      new Context({
+        type: 'group',
+        groupId: 'groupId1',
+        traits: {
+          is_new_group: true
+        }
+      })
+    )
+
+    expect(destination.actions.group.perform).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        payload: {
+          groupId: 'groupId1',
+          traits: {
+            is_new_group: true
+          }
+        }
+      })
+    )
+
+    expect(window.Ripe.group).toHaveBeenCalledWith('groupId1', expect.objectContaining({ is_new_group: true }))
+  })
+})

--- a/packages/browser-destinations/src/destinations/ripe/group/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/ripe/group/generated-types.ts
@@ -1,0 +1,22 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The new user ID, if user ID is not set
+   */
+  anonymousId: string
+  /**
+   * The ID associated with the user
+   */
+  userId?: string
+  /**
+   * The ID associated groupId
+   */
+  groupId: string
+  /**
+   * Traits to associate with the group
+   */
+  traits?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/src/destinations/ripe/group/index.ts
+++ b/packages/browser-destinations/src/destinations/ripe/group/index.ts
@@ -1,0 +1,47 @@
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { RipeSDK } from '../types'
+
+const action: BrowserActionDefinition<Settings, RipeSDK, Payload> = {
+  title: 'Group',
+  description: 'Group user in Ripe',
+  defaultSubscription: 'type = "group"',
+  platform: 'web',
+  fields: {
+    anonymousId: {
+      type: 'string',
+      required: true,
+      description: 'The new user ID, if user ID is not set',
+      label: 'Anonymous ID',
+      default: { '@path': '$.anonymousId' }
+    },
+    userId: {
+      type: 'string',
+      required: false,
+      description: 'The ID associated with the user',
+      label: 'User ID',
+      default: { '@path': '$.userId' }
+    },
+    groupId: {
+      type: 'string',
+      required: true,
+      description: 'The ID associated groupId',
+      label: 'Group ID',
+      default: { '@path': '$.groupId' }
+    },
+    traits: {
+      type: 'object',
+      label: 'Traits',
+      description: 'Traits to associate with the group',
+      required: false,
+      default: { '@path': '$.traits' }
+    }
+  },
+  perform: async (ripe, { payload }) => {
+    await ripe.setIds(payload.anonymousId, payload.userId, payload.groupId)
+    return ripe.group(payload.groupId, payload.traits)
+  }
+}
+
+export default action

--- a/packages/browser-destinations/src/destinations/ripe/identify/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/ripe/identify/__tests__/index.test.ts
@@ -1,0 +1,74 @@
+import type { Subscription } from '../../../../lib/browser-destinations'
+import { Analytics, Context } from '@segment/analytics-next'
+import RipeDestination, { destination } from '../../index'
+import { RipeSDK } from '../../types'
+
+import { loadScript } from '../../../../runtime/load-script'
+
+jest.mock('../../../../runtime/load-script')
+beforeEach(async () => {
+  ;(loadScript as jest.Mock).mockResolvedValue(true)
+})
+
+const subscriptions: Subscription[] = [
+  {
+    partnerAction: 'identify',
+    name: 'Identify user',
+    enabled: true,
+    subscribe: 'type = "identify"',
+    mapping: {
+      userId: {
+        '@path': '$.userId'
+      },
+      traits: {
+        '@path': '$.traits'
+      }
+    }
+  }
+]
+
+describe('Ripe.identify', () => {
+  test('it maps userId and traits and passes them into RipeSDK.identify', async () => {
+    window.Ripe = {
+      init: jest.fn().mockResolvedValueOnce('123'),
+      identify: jest.fn().mockResolvedValueOnce(undefined),
+      setIds: jest.fn().mockResolvedValueOnce(undefined)
+    } as unknown as RipeSDK
+
+    const [event] = await RipeDestination({
+      subscriptions,
+      apiKey: '123'
+    })
+
+    const ajs = new Analytics({ writeKey: '123' })
+    await event.load(Context.system(), ajs)
+    jest.spyOn(destination.actions.identify, 'perform')
+
+    await event.identify?.(
+      new Context({
+        type: 'identify',
+        userId: 'userId',
+        traits: {
+          name: 'Simon'
+        }
+      })
+    )
+
+    expect(destination.actions.identify.perform).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        payload: {
+          userId: 'userId',
+          traits: {
+            name: 'Simon'
+          }
+        }
+      })
+    )
+
+    expect(window.Ripe.identify).toHaveBeenCalledWith(
+      expect.stringMatching('userId'),
+      expect.objectContaining({ name: 'Simon' })
+    )
+  })
+})

--- a/packages/browser-destinations/src/destinations/ripe/identify/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/ripe/identify/generated-types.ts
@@ -1,0 +1,22 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The new user ID, if user ID is not set
+   */
+  anonymousId: string
+  /**
+   * The ID associated with the user
+   */
+  userId?: string
+  /**
+   * The ID associated groupId
+   */
+  groupId?: string
+  /**
+   * Traits to associate with the user
+   */
+  traits?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/src/destinations/ripe/identify/index.ts
+++ b/packages/browser-destinations/src/destinations/ripe/identify/index.ts
@@ -1,0 +1,47 @@
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { RipeSDK } from '../types'
+
+const action: BrowserActionDefinition<Settings, RipeSDK, Payload> = {
+  title: 'Identify',
+  description: 'Identify user in Ripe',
+  defaultSubscription: 'type = "identify"',
+  platform: 'web',
+  fields: {
+    anonymousId: {
+      type: 'string',
+      required: true,
+      description: 'The new user ID, if user ID is not set',
+      label: 'Anonymous ID',
+      default: { '@path': '$.anonymousId' }
+    },
+    userId: {
+      type: 'string',
+      required: false,
+      description: 'The ID associated with the user',
+      label: 'User ID',
+      default: { '@path': '$.userId' }
+    },
+    groupId: {
+      type: 'string',
+      required: false,
+      description: 'The ID associated groupId',
+      label: 'Group ID',
+      default: { '@path': '$.groupId' }
+    },
+    traits: {
+      type: 'object',
+      label: 'Traits',
+      description: 'Traits to associate with the user',
+      required: false,
+      default: { '@path': '$.traits' }
+    }
+  },
+  perform: async (ripe, { payload }) => {
+    await ripe.setIds(payload.anonymousId, payload.userId, payload.groupId)
+    return ripe.identify(payload.userId, payload.traits)
+  }
+}
+
+export default action

--- a/packages/browser-destinations/src/destinations/ripe/index.ts
+++ b/packages/browser-destinations/src/destinations/ripe/index.ts
@@ -1,0 +1,110 @@
+import type { Settings } from './generated-types'
+import type { BrowserDestinationDefinition } from '../../lib/browser-destinations'
+import { browserDestination } from '../../runtime/shim'
+import { RipeSDK } from './types'
+
+import group from './group'
+import identify from './identify'
+import track from './track'
+
+import { defaultValues } from '@segment/actions-core'
+import { initScript } from './init-script'
+
+import page from './page'
+
+import alias from './alias'
+
+const defaultVersion = 'latest'
+
+declare global {
+  interface Window {
+    Ripe: RipeSDK
+  }
+}
+
+export const destination: BrowserDestinationDefinition<Settings, RipeSDK> = {
+  name: 'Ripe',
+  slug: 'actions-ripe',
+  mode: 'device',
+
+  settings: {
+    sdkVersion: {
+      description: 'The version of the Ripe Widget SDK to use',
+      label: 'SDK Version',
+      type: 'string',
+      choices: [
+        {
+          value: 'latest',
+          label: 'latest'
+        }
+      ],
+      default: defaultVersion,
+      required: false
+    },
+    apiKey: {
+      description: 'The Ripe API key found in the Ripe App',
+      label: 'API Key',
+      type: 'string',
+      required: true
+    }
+  },
+
+  initialize: async ({ settings }, deps) => {
+    initScript()
+
+    const { sdkVersion, apiKey } = settings
+    const version = sdkVersion ?? defaultVersion
+
+    await deps
+      .loadScript(`https://storage.googleapis.com/sdk.getripe.com/sdk/${version}/sdk.umd.js`)
+      .catch((err) => console.error('Unable to load Ripe SDK script', err))
+
+    await deps.resolveWhen(() => Object.prototype.hasOwnProperty.call(window, 'Ripe'), 100)
+    await window.Ripe.init(apiKey)
+
+    return window.Ripe
+  },
+
+  actions: {
+    alias,
+    group,
+    identify,
+    page,
+    track
+  },
+
+  presets: [
+    {
+      name: 'Alias user',
+      subscribe: 'type = "alias"',
+      partnerAction: 'alias',
+      mapping: defaultValues(alias.fields)
+    },
+    {
+      name: 'Group user',
+      subscribe: 'type = "group"',
+      partnerAction: 'group',
+      mapping: defaultValues(group.fields)
+    },
+    {
+      name: 'Identify user',
+      subscribe: 'type = "identify"',
+      partnerAction: 'identify',
+      mapping: defaultValues(identify.fields)
+    },
+    {
+      name: 'Page view',
+      subscribe: 'type = "page"',
+      partnerAction: 'page',
+      mapping: defaultValues(page.fields)
+    },
+    {
+      name: 'Track event',
+      subscribe: 'type = "track"',
+      partnerAction: 'track',
+      mapping: defaultValues(track.fields)
+    }
+  ]
+}
+
+export default browserDestination(destination)

--- a/packages/browser-destinations/src/destinations/ripe/init-script.ts
+++ b/packages/browser-destinations/src/destinations/ripe/init-script.ts
@@ -1,0 +1,17 @@
+/* eslint-disable */
+// @ts-nocheck
+export function initScript() {
+  if (window.Ripe) {
+    return
+  }
+
+  window.Ripe = []
+  ;['alias', 'group', 'identify', 'init', 'page', 'setIds', 'track'].forEach(function (method) {
+    window.Ripe[method] = function () {
+      let args = Array.from(arguments)
+      args.unshift(method)
+      window.Ripe.push(args)
+      return window.Ripe
+    }
+  })
+}

--- a/packages/browser-destinations/src/destinations/ripe/page/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/ripe/page/__tests__/index.test.ts
@@ -1,0 +1,82 @@
+import type { Subscription } from '../../../../lib/browser-destinations'
+import { Analytics, Context } from '@segment/analytics-next'
+import RipeDestination, { destination } from '../../index'
+import { RipeSDK } from '../../types'
+
+import { loadScript } from '../../../../runtime/load-script'
+
+jest.mock('../../../../runtime/load-script')
+beforeEach(async () => {
+  ;(loadScript as jest.Mock).mockResolvedValue(true)
+})
+
+const subscriptions: Subscription[] = [
+  {
+    partnerAction: 'page',
+    name: 'Page view',
+    enabled: true,
+    subscribe: 'type = "page"',
+    mapping: {
+      anonymousId: {
+        '@path': '$.anonymousId'
+      },
+      category: {
+        '@path': '$.category'
+      },
+      name: {
+        '@path': '$.name'
+      },
+      properties: {
+        '@path': '$.properties'
+      }
+    }
+  }
+]
+
+describe('Ripe.page', () => {
+  test('it maps pageview properties and passes them into RipeSDK.page', async () => {
+    window.Ripe = {
+      init: jest.fn().mockResolvedValueOnce('123'),
+      page: jest.fn().mockResolvedValueOnce(undefined),
+      setIds: jest.fn().mockResolvedValueOnce(undefined)
+    } as unknown as RipeSDK
+
+    const [event] = await RipeDestination({
+      subscriptions,
+      apiKey: '123'
+    })
+
+    const ajs = new Analytics({ writeKey: '123' })
+    await event.load(Context.system(), ajs)
+    jest.spyOn(destination.actions.page, 'perform')
+
+    await event.page?.(
+      new Context({
+        anonymousId: 'anonymousId',
+        type: 'page',
+        category: 'main',
+        name: 'page2',
+        properties: {
+          previous: 'page1'
+        }
+      })
+    )
+
+    expect(destination.actions.page.perform).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        payload: {
+          anonymousId: 'anonymousId',
+          category: 'main',
+          name: 'page2',
+          properties: {
+            previous: 'page1'
+          }
+        }
+      })
+    )
+
+    expect(window.Ripe.page).toHaveBeenCalledWith('main', 'page2', expect.objectContaining({ previous: 'page1' }))
+    expect(window.Ripe.setIds).toHaveBeenCalledWith('anonymousId', undefined, undefined)
+  })
+})

--- a/packages/browser-destinations/src/destinations/ripe/page/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/ripe/page/generated-types.ts
@@ -1,0 +1,30 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The new user ID, if user ID is not set
+   */
+  anonymousId: string
+  /**
+   * The ID associated with the user
+   */
+  userId?: string
+  /**
+   * The ID associated groupId
+   */
+  groupId?: string
+  /**
+   * The category of the page
+   */
+  category?: string
+  /**
+   * The name of the page
+   */
+  name?: string
+  /**
+   * Page properties
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/src/destinations/ripe/page/index.ts
+++ b/packages/browser-destinations/src/destinations/ripe/page/index.ts
@@ -1,0 +1,61 @@
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { RipeSDK } from '../types'
+
+const action: BrowserActionDefinition<Settings, RipeSDK, Payload> = {
+  title: 'Page',
+  description: 'Register page view in Ripe',
+  defaultSubscription: 'type = "page"',
+  platform: 'web',
+  fields: {
+    anonymousId: {
+      type: 'string',
+      required: true,
+      description: 'The new user ID, if user ID is not set',
+      label: 'Anonymous ID',
+      default: { '@path': '$.anonymousId' }
+    },
+    userId: {
+      type: 'string',
+      required: false,
+      description: 'The ID associated with the user',
+      label: 'User ID',
+      default: { '@path': '$.userId' }
+    },
+    groupId: {
+      type: 'string',
+      required: false,
+      description: 'The ID associated groupId',
+      label: 'Group ID',
+      default: { '@path': '$.groupId' }
+    },
+    category: {
+      type: 'string',
+      required: false,
+      description: 'The category of the page',
+      label: 'Category',
+      default: { '@path': '$.category' }
+    },
+    name: {
+      type: 'string',
+      required: false,
+      description: 'The name of the page',
+      label: 'Name',
+      default: { '@path': '$.name' }
+    },
+    properties: {
+      type: 'object',
+      required: false,
+      description: 'Page properties',
+      label: 'Properties',
+      default: { '@path': '$.properties' }
+    }
+  },
+  perform: async (ripe, { payload }) => {
+    await ripe.setIds(payload.anonymousId, payload.userId, payload.groupId)
+    return ripe.page(payload.category, payload.name, payload.properties)
+  }
+}
+
+export default action

--- a/packages/browser-destinations/src/destinations/ripe/track/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/ripe/track/__tests__/index.test.ts
@@ -1,0 +1,77 @@
+import type { Subscription } from '../../../../lib/browser-destinations'
+import { Analytics, Context } from '@segment/analytics-next'
+import RipeDestination, { destination } from '../../index'
+import { RipeSDK } from '../../types'
+
+import { loadScript } from '../../../../runtime/load-script'
+
+jest.mock('../../../../runtime/load-script')
+beforeEach(async () => {
+  ;(loadScript as jest.Mock).mockResolvedValue(true)
+})
+
+const subscriptions: Subscription[] = [
+  {
+    partnerAction: 'track',
+    name: 'Track user',
+    enabled: true,
+    subscribe: 'type = "track"',
+    mapping: {
+      anonymousId: {
+        '@path': '$.anonymousId'
+      },
+      event: {
+        '@path': '$.event'
+      },
+      properties: {
+        '@path': '$.properties'
+      }
+    }
+  }
+]
+
+describe('Ripe.track', () => {
+  test('it maps the event name and properties and passes them into RipeSDK.track', async () => {
+    window.Ripe = {
+      init: jest.fn().mockResolvedValueOnce('123'),
+      setIds: jest.fn().mockResolvedValueOnce(undefined),
+      track: jest.fn().mockResolvedValueOnce(undefined)
+    } as unknown as RipeSDK
+
+    const [event] = await RipeDestination({
+      subscriptions,
+      apiKey: '123'
+    })
+
+    const ajs = new Analytics({ writeKey: '123' })
+    await event.load(Context.system(), ajs)
+    jest.spyOn(destination.actions.track, 'perform')
+
+    await event.track?.(
+      new Context({
+        type: 'track',
+        anonymousId: 'anonymousId',
+        event: 'Form Submitted',
+        properties: {
+          is_new_lead: true
+        }
+      })
+    )
+
+    expect(destination.actions.track.perform).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        payload: {
+          anonymousId: 'anonymousId',
+          event: 'Form Submitted',
+          properties: {
+            is_new_lead: true
+          }
+        }
+      })
+    )
+
+    expect(window.Ripe.track).toHaveBeenCalledWith('Form Submitted', expect.objectContaining({ is_new_lead: true }))
+    expect(window.Ripe.setIds).toHaveBeenCalledWith('anonymousId', undefined, undefined)
+  })
+})

--- a/packages/browser-destinations/src/destinations/ripe/track/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/ripe/track/generated-types.ts
@@ -1,0 +1,26 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The new user ID, if user ID is not set
+   */
+  anonymousId: string
+  /**
+   * The ID associated with the user
+   */
+  userId?: string
+  /**
+   * The ID associated groupId
+   */
+  groupId?: string
+  /**
+   * The event name
+   */
+  event: string
+  /**
+   * Properties to send with the event
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/src/destinations/ripe/track/index.ts
+++ b/packages/browser-destinations/src/destinations/ripe/track/index.ts
@@ -1,0 +1,56 @@
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { RipeSDK } from '../types'
+
+const action: BrowserActionDefinition<Settings, RipeSDK, Payload> = {
+  title: 'Track',
+  description: 'Send user events to Ripe',
+  defaultSubscription: 'type = "track"',
+  platform: 'web',
+  fields: {
+    anonymousId: {
+      type: 'string',
+      required: true,
+      description: 'The new user ID, if user ID is not set',
+      label: 'Anonymous ID',
+      default: { '@path': '$.anonymousId' }
+    },
+    userId: {
+      type: 'string',
+      required: false,
+      description: 'The ID associated with the user',
+      label: 'User ID',
+      default: { '@path': '$.userId' }
+    },
+    groupId: {
+      type: 'string',
+      required: false,
+      description: 'The ID associated groupId',
+      label: 'Group ID',
+      default: { '@path': '$.groupId' }
+    },
+    event: {
+      type: 'string',
+      required: true,
+      description: 'The event name',
+      label: 'Event Name',
+      default: { '@path': '$.event' }
+    },
+    properties: {
+      type: 'object',
+      required: false,
+      description: 'Properties to send with the event',
+      label: 'Event properties',
+      default: { '@path': '$.properties' }
+    }
+  },
+  perform: async (ripe, { payload }) => {
+    await ripe.setIds(payload.anonymousId, payload.userId, payload.groupId)
+    if (payload?.event) {
+      return ripe.track(payload.event, payload.properties)
+    }
+  }
+}
+
+export default action

--- a/packages/browser-destinations/src/destinations/ripe/types.ts
+++ b/packages/browser-destinations/src/destinations/ripe/types.ts
@@ -1,0 +1,9 @@
+export interface RipeSDK {
+  alias: (userId: string) => Promise<void>
+  group: (groupId: string, traits?: Record<string, unknown>) => Promise<void>
+  identify: (userId?: string | undefined | null, traits?: Record<string, unknown>) => Promise<void>
+  init: (apiKey: string) => Promise<void>
+  page: (category?: string, name?: string, properties?: Record<string, unknown>) => Promise<void>
+  setIds: (anonymousId: string, userId?: string, groupId?: string) => Promise<void>
+  track: (event: string, properties?: Record<string, unknown>) => Promise<void>
+}


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This is the Ripe browser destination implementation, as part of the December 2022 Cohort. 

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
