### PR TITLE
Changed mobile_ad_id to hashed_mobile_ad_id

### DIFF
--- a/packages/destination-actions/src/destinations/snap-conversions-api/_tests_/index.test.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/_tests_/index.test.ts
@@ -367,7 +367,7 @@ describe('Snap Conversions API ', () => {
       expect(responses[0].status).toBe(200)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"integration\\":\\"segment\\",\\"event_type\\":\\"PURCHASE\\",\\"event_conversion_type\\":\\"WEB\\",\\"timestamp\\":1652368875449,\\"mobile_ad_id\\":\\"5af103f270fdc673b5e121ea929d1e47b2cee679e2059226a23c4cba37f8c9a9\\",\\"pixel_id\\":\\"test123\\"}"`
+        `"{\\"integration\\":\\"segment\\",\\"event_type\\":\\"PURCHASE\\",\\"event_conversion_type\\":\\"WEB\\",\\"timestamp\\":1652368875449,\\"hashed_mobile_ad_id\\":\\"5af103f270fdc673b5e121ea929d1e47b2cee679e2059226a23c4cba37f8c9a9\\",\\"pixel_id\\":\\"test123\\"}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/snap-conversions-api/snap-capi-properties.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/snap-capi-properties.ts
@@ -352,7 +352,7 @@ export const formatPayload = (payload: Payload): Object => {
     event_tag: payload?.event_tag,
     timestamp: Date.parse(payload?.timestamp),
     hashed_email: hash(payload?.email),
-    mobile_ad_id: hash(payload?.mobile_ad_id),
+    hashed_mobile_ad_id: hash(payload?.mobile_ad_id),
     uuid_c1: payload?.uuid_c1,
     hashed_idfv: hash(payload?.idfv),
     hashed_phone_number: hash(payload?.phone_number),


### PR DESCRIPTION

Corrected Snap Conversions API integration so that it sends Mobile Ad ID to Snap as hashed_mobile_ad_id instead of mobile_ad_id.

## Testing

Updated parameter name in the unit tests and ran them. I also tested using the local server.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
