### PR TITLE
[Google Ads Conversions] GA Changes

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Settings {
   /**
-   * You will find this information in the event snippet for your conversion action, for example `send_to: AW-CONVERSION_ID/AW-CONVERSION_LABEL`. In the sample snippet, AW-CONVERSION_ID stands for the conversion ID unique to your account. Enter the conversion Id, without the AW- prefix.
+   * You will find this information in the event snippet for your conversion action, for example `send_to: AW-CONVERSION_ID/AW-CONVERSION_LABEL`. In the sample snippet, AW-CONVERSION_ID stands for the conversion ID unique to your account. Enter the conversion Id, without the AW- prefix. **Required if you are using a mapping that sends data to the legacy Google Enhanced Conversions API.**
    */
   conversionTrackingId?: string
   /**

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -21,7 +21,7 @@ interface UserInfoResponse {
 const destination: DestinationDefinition<Settings> = {
   // NOTE: We need to match the name with the creation name in DB.
   // This is not the value used in the UI.
-  name: 'Google Enhanced Conversions',
+  name: 'Google Ads Conversions',
   slug: 'actions-google-enhanced-conversions',
   mode: 'cloud',
   authentication: {
@@ -30,7 +30,7 @@ const destination: DestinationDefinition<Settings> = {
       conversionTrackingId: {
         label: 'Conversion ID',
         description:
-          'You will find this information in the event snippet for your conversion action, for example `send_to: AW-CONVERSION_ID/AW-CONVERSION_LABEL`. In the sample snippet, AW-CONVERSION_ID stands for the conversion ID unique to your account. Enter the conversion Id, without the AW- prefix.',
+          'You will find this information in the event snippet for your conversion action, for example `send_to: AW-CONVERSION_ID/AW-CONVERSION_LABEL`. In the sample snippet, AW-CONVERSION_ID stands for the conversion ID unique to your account. Enter the conversion Id, without the AW- prefix. **Required if you are using a mapping that sends data to the legacy Google Enhanced Conversions API.**',
         type: 'string'
       },
       customerId: {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
@@ -24,8 +24,8 @@ interface GoogleError {
 }
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Post Conversion',
-  description: 'Send a conversion event to Google Ads.',
+  title: 'Upload Enhanced Conversion (Legacy)',
+  description: 'Upload a conversion enhancement to the legacy Google Enhanced Conversions API.',
   fields: {
     // Required Fields - These fields are required by Google's EC API to successfully match conversions.
     conversion_label: {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/generated-types.ts
@@ -42,7 +42,7 @@ export interface Payload {
    */
   currency?: string
   /**
-   * The environment this conversion was recorded on, e.g. APP or WEB.
+   * The environment this conversion was recorded on, e.g. APP or WEB. Sending the environment field requires an allowlist in your Google Ads account. Leave this field blank if your account has not been allowlisted.
    */
   conversion_environment?: string
   /**

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -106,7 +106,8 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       choices: [
         { label: 'APP', value: 'APP' },
-        { label: 'WEB', value: 'WEB' }
+        { label: 'WEB', value: 'WEB' },
+        { label: 'UNSPECIFIED', value: 'UNSPECIFIED' }
       ]
     },
     merchant_id: {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -101,12 +101,12 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     conversion_environment: {
       label: 'Conversion Environment',
-      description: 'The environment this conversion was recorded on, e.g. APP or WEB.',
+      description:
+        'The environment this conversion was recorded on, e.g. APP or WEB. Sending the environment field requires an allowlist in your Google Ads account. Leave this field blank if your account has not been allowlisted.',
       type: 'string',
       choices: [
         { label: 'APP', value: 'APP' },
-        { label: 'WEB', value: 'WEB' },
-        { label: 'UNSPECIFIED', value: 'UNSPECIFIED' }
+        { label: 'WEB', value: 'WEB' }
       ]
     },
     merchant_id: {


### PR DESCRIPTION
This PR addresses [STRATCONN-1576](https://segment.atlassian.net/browse/STRATCONN-1576) & [STRATCONN-1577](https://segment.atlassian.net/browse/STRATCONN-1577) to rename the destination, rename an action and update descriptions to some fields for GA release. 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._
![Screen Shot 2022-12-08 at 3 54 14 PM](https://user-images.githubusercontent.com/99763167/206591226-70a14de8-ba1a-4c8a-90e2-7cd3531e454f.png)

![Screen Shot 2022-12-08 at 3 48 28 PM](https://user-images.githubusercontent.com/99763167/206591085-9130fafb-fbeb-4bfe-9730-4f9351bd93c0.png)

![Screen Shot 2022-12-08 at 3 48 17 PM](https://user-images.githubusercontent.com/99763167/206591056-5bedea06-19b8-40e1-9f8d-846316288415.png)

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
