### PR TITLE
Use project lerna when running cli scripts.

### DIFF
--- a/packages/cli-internal/src/commands/push-browser-destinations.ts
+++ b/packages/cli-internal/src/commands/push-browser-destinations.ts
@@ -174,10 +174,10 @@ export default class PushBrowserDestinations extends Command {
 
 async function syncToS3(env: string): Promise<string> {
   if (env === 'production') {
-    return execa.commandSync(`lerna run deploy-prod`).stdout
+    return execa.commandSync(`yarn lerna run deploy-prod`).stdout
   }
 
-  return execa.commandSync(`lerna run deploy-stage`).stdout
+  return execa.commandSync(`yarn lerna run deploy-stage`).stdout
 }
 
 function asJson(obj: unknown) {

--- a/packages/cli/src/lib/web-bundles.ts
+++ b/packages/cli/src/lib/web-bundles.ts
@@ -17,8 +17,8 @@ export function webBundles(): { [destination: string]: string } {
 export function build(env: string): string {
   execa.commandSync(`rm -rf ${DIST_DIR}`)
   if (env === 'production') {
-    return execa.commandSync('lerna run build-web').stdout
+    return execa.commandSync('yarn lerna run build-web').stdout
   }
 
-  return execa.commandSync('lerna run build-web-stage').stdout
+  return execa.commandSync('yarn lerna run build-web-stage').stdout
 }


### PR DESCRIPTION
Use project lerna when running scripts.

Gets rid of the install global lerna step here: https://paper.dropbox.com/doc/Destination-Actions-for-Web--Budz8M50gd96Ve9pcjGNz_~OAg-2wY6GP2cdQa11LVZtkA3i

- Significantly, this avoid unexpected behavior with lerna version mismatches between local install and global install.

