### PR TITLE
[Salesforce] - Bulk API CSV generation fixes

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
@@ -164,34 +164,26 @@ describe('Salesforce Utils', () => {
       expect(csv).toEqual(expected)
     })
 
-    /* 
-    If a field value contains a comma, a new line, or a double quote, the field value must be contained within double quotes: 
-      for example, "Director of Operations, Western Region".
-
-    If a field value contains a double quote, the double quote must be escaped by preceding it with another double quote: 
-      for example, "This is the ""gold"" standard".
-    */
-
-    it('should correctly escape special characters', async () => {
+    it('should correctly escape double quotes', async () => {
       const updatePayloads: GenericPayload[] = [
         {
           operation: 'update',
           enable_batching: true,
           bulkUpdateRecordId: '00',
-          name: 'Sponge "Bob" "Square" "pants"'
+          name: 'Sponge ""Bob"" "Square" "pants"'
         },
         {
           operation: 'update',
           enable_batching: true,
           bulkUpdateRecordId: '01',
-          name: 'Tentacles, Squidward',
+          name: 'Tentacles, "Squidward"',
           description:
             'Squidward Tentacles is a fictional character in the American animated television series "SpongeBob SquarePants".\n He is voiced by actor Rodger Bumpass and first appeared on television in the series\' pilot episode on May 1, 1999.'
         }
       ]
 
       const csv = buildCSVData(updatePayloads, 'Id')
-      const expected = `Name,Description,Id\n"Sponge ""Bob"" ""Square"" ""pants""",#N/A,"00"\n"Tentacles, Squidward","Squidward Tentacles is a fictional character in the American animated television series ""SpongeBob SquarePants"".\n He is voiced by actor Rodger Bumpass and first appeared on television in the series' pilot episode on May 1, 1999.","01"\n`
+      const expected = `Name,Description,Id\n"Sponge """"Bob"""" ""Square"" ""pants""",#N/A,"00"\n"Tentacles, ""Squidward""","Squidward Tentacles is a fictional character in the American animated television series ""SpongeBob SquarePants"".\n He is voiced by actor Rodger Bumpass and first appeared on television in the series' pilot episode on May 1, 1999.","01"\n`
       expect(csv).toEqual(expected)
     })
   })

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
@@ -163,5 +163,36 @@ describe('Salesforce Utils', () => {
 
       expect(csv).toEqual(expected)
     })
+
+    /* 
+    If a field value contains a comma, a new line, or a double quote, the field value must be contained within double quotes: 
+      for example, "Director of Operations, Western Region".
+
+    If a field value contains a double quote, the double quote must be escaped by preceding it with another double quote: 
+      for example, "This is the ""gold"" standard".
+    */
+
+    it('should correctly escape special characters', async () => {
+      const updatePayloads: GenericPayload[] = [
+        {
+          operation: 'update',
+          enable_batching: true,
+          bulkUpdateRecordId: '00',
+          name: 'Sponge "Bob" "Square" "pants"'
+        },
+        {
+          operation: 'update',
+          enable_batching: true,
+          bulkUpdateRecordId: '01',
+          name: 'Tentacles, Squidward',
+          description:
+            'Squidward Tentacles is a fictional character in the American animated television series "SpongeBob SquarePants".\n He is voiced by actor Rodger Bumpass and first appeared on television in the series\' pilot episode on May 1, 1999.'
+        }
+      ]
+
+      const csv = buildCSVData(updatePayloads, 'Id')
+      const expected = `Name,Description,Id\n"Sponge ""Bob"" ""Square"" ""pants""",#N/A,"00"\n"Tentacles, Squidward","Squidward Tentacles is a fictional character in the American animated television series ""SpongeBob SquarePants"".\n He is voiced by actor Rodger Bumpass and first appeared on television in the series' pilot episode on May 1, 1999.","01"\n`
+      expect(csv).toEqual(expected)
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
@@ -164,6 +164,36 @@ describe('Salesforce Utils', () => {
       expect(csv).toEqual(expected)
     })
 
+    it('should handle null data correctly', async () => {
+      const nullPayloads: GenericPayload[] = [
+        {
+          operation: 'upsert',
+          enable_batching: true,
+          bulkUpsertExternalId: {
+            externalIdName: 'test__c',
+            externalIdValue: '00'
+          },
+          name: 'SpongeBob Squarepants',
+          description: undefined
+        },
+        {
+          operation: 'upsert',
+          enable_batching: true,
+          bulkUpsertExternalId: {
+            externalIdName: 'test__c',
+            externalIdValue: '01'
+          },
+          name: 'Squidward Tentacles',
+          description: undefined
+        }
+      ]
+
+      const csv = buildCSVData(nullPayloads, 'test__c')
+      const expected = `Name,Description,test__c\n"SpongeBob Squarepants",#N/A,"00"\n"Squidward Tentacles",#N/A,"01"\n`
+
+      expect(csv).toEqual(expected)
+    })
+
     it('should correctly escape double quotes', async () => {
       const updatePayloads: GenericPayload[] = [
         {

--- a/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
@@ -105,9 +105,9 @@ const buildCSVFromHeaderMap = (
         const column = headerMap.get(key) as [[string, number]]
 
         if (column !== undefined && column.length > 0 && column[column.length - 1][1] === i) {
-          const value = column.pop()
-          if (value !== undefined) {
-            row += `"${value[0]}",`
+          const valueTuple = column.pop()
+          if (valueTuple !== undefined && valueTuple[0] !== undefined && valueTuple[0] !== null) {
+            row += `"${valueTuple[0]}",`
             noValueFound = false
           }
         }
@@ -157,6 +157,7 @@ export const buildCSVData = (payloads: GenericPayload[], uniqueIdName: string): 
 
   csv += `${uniqueIdName}\n` + buildCSVFromHeaderMap(payloads, headerMap, payloads.length)
 
+  console.log('csv', csv)
   return csv
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
@@ -163,7 +163,6 @@ export const buildCSVData = (payloads: GenericPayload[], uniqueIdName: string): 
 
   csv += `${uniqueIdName}\n` + buildCSVFromHeaderMap(payloads, headerMap, payloads.length)
 
-  console.log('csv', csv)
   return csv
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
@@ -23,6 +23,12 @@ const validateHeaderField = (field: string): void => {
   }
 }
 
+// Salesforce bulk API CSVs require double quotes to be escaped with another double quote.
+// https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/datafiles_csv_valid_record_rows.htm
+const escapeDoubleQuotes = (value: string): string => {
+  return value.replace(/"/g, '""')
+}
+
 /**
  * Iterates over each payload in the batch, and creates a map which represents each column in the CSV file.
  *
@@ -107,7 +113,7 @@ const buildCSVFromHeaderMap = (
         if (column !== undefined && column.length > 0 && column[column.length - 1][1] === i) {
           const valueTuple = column.pop()
           if (valueTuple !== undefined && valueTuple[0] !== undefined && valueTuple[0] !== null) {
-            row += `"${valueTuple[0]}",`
+            row += `"${escapeDoubleQuotes(valueTuple[0])}",`
             noValueFound = false
           }
         }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

This PR fixes two bugs discovered while testing Bulk API support:
1. When a field is explicitly set to `null` we will write `null` to the CSV, rather than the `#N/A` value that Salesforce expects. This results in a CSV parse error downstream which aborts the entire batch. [Ticket](https://segment.atlassian.net/browse/STRATCONN-1762)
2. Double quotes inside a value were not being escaped. Salesforce requires that any double quotes are escaped with another double quote (ex: `this is a "quote"` should be sent as `this is a ""quote""`). This also resulted in a downstream CSV parsing error which aborted the entire batch. [Ticket](https://segment.atlassian.net/browse/STRATCONN-1738)

## Testing
Tested successfully in staging.

1. Null values now correctly handled:
Tested by first updating a record with field `testdate` to "12/8/2022"
<img width="393" alt="Screen Shot 2022-12-08 at 3 52 51 PM" src="https://user-images.githubusercontent.com/27820201/206591476-549f9c80-86ac-472a-99ff-424fdf6c98fe.png">

Then successfully bulk updating that record with a `null` date:
<img width="485" alt="Screen Shot 2022-12-08 at 3 37 02 PM" src="https://user-images.githubusercontent.com/27820201/206591551-b7409900-cc8d-480e-86c0-4e69946cea07.png">

The record then has its date field removed:
<img width="593" alt="Screen Shot 2022-12-08 at 3 53 48 PM" src="https://user-images.githubusercontent.com/27820201/206591611-402330f1-4121-44b8-b07c-79e1ae3c973b.png">

2. Quotes now correctly handled:
Sent through events with quotes in the string:
<img width="1145" alt="Screen Shot 2022-12-08 at 3 32 08 PM" src="https://user-images.githubusercontent.com/27820201/206591686-027c8b57-717d-4751-a986-91323b1d47ed.png">

Able to update the name field with quotes:
<img width="408" alt="Screen Shot 2022-12-08 at 3 31 51 PM" src="https://user-images.githubusercontent.com/27820201/206591753-a5406bc5-d261-4808-a5d0-1c0464702f2f.png">

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
