### PR TITLE
create a google-sheets stub destination for oauth-managed testing

### DIFF
--- a/packages/destination-actions/src/destinations/google-sheets-dev/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-sheets-dev/generated-types.ts
@@ -1,0 +1,3 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {}

--- a/packages/destination-actions/src/destinations/google-sheets-dev/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets-dev/index.ts
@@ -1,0 +1,59 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import postSheet from '../google-sheets/postSheet'
+interface RefreshTokenResponse {
+  access_token: string
+  scope: string
+  expires_in: number
+  token_type: string
+}
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Google Sheets (dev only)',
+  slug: 'actions-google-sheets-dev',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'oauth-managed',
+    fields: {},
+    // testAuthentication: (request) => {
+    //   // Return a request that tests/validates the user's credentials.
+    //   // If you do not have a way to validate the authentication fields safely,
+    //   // you can remove the `testAuthentication` function, though discouraged.
+    // },
+    refreshAccessToken: async (request, { auth }) => {
+      if (!auth.refreshTokenUrl) throw new Error('destination misconfigured: missing refresh token URL')
+      const res = await request<RefreshTokenResponse>(auth.refreshTokenUrl, {
+        method: 'POST',
+        body: new URLSearchParams({
+          refresh_token: auth.refreshToken,
+          client_id: auth.clientId,
+          client_secret: auth.clientSecret,
+          grant_type: 'refresh_token'
+        })
+      })
+
+      return { accessToken: res.data.access_token }
+    }
+  },
+  extendRequest({ auth }) {
+    return {
+      headers: {
+        authorization: `Bearer ${auth?.accessToken}`
+      }
+    }
+  },
+
+  // onDelete: async (request, { settings, payload }) => {
+  //   // Return a request that performs a GDPR delete for the provided Segment userId or anonymousId
+  //   // provided in the payload. If your destination does not support GDPR deletion you should not
+  //   // implement this function and should remove it completely.
+  // },
+
+  actions: {
+    postSheet
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/google-sheets-dev/postSheet.types.ts
+++ b/packages/destination-actions/src/destinations/google-sheets-dev/postSheet.types.ts
@@ -1,0 +1,43 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Property which uniquely identifies each row in the spreadsheet.
+   */
+  record_identifier: string
+  /**
+   * Describes the nature of the operation being performed. Only supported values are 'new' and 'updated'.
+   */
+  operation_type: string
+  /**
+   * The identifier of the spreadsheet. You can find this value in the URL of the spreadsheet. e.g. https://docs.google.com/spreadsheets/d/{SPREADSHEET_ID}/edit
+   */
+  spreadsheet_id: string
+  /**
+   * The name of the spreadsheet. You can find this value on the tab at the bottom of the spreadsheet. Please provide a valid name of a sheet that already exists.
+   */
+  spreadsheet_name: string
+  /**
+   * The way Google will interpret values. If you select raw, values will not be parsed and will be stored as-is. If you select user entered, values will be parsed as if you typed them into the UI. Numbers will stay as numbers, but strings may be converted to numbers, dates, etc. following the same rules that are applied when entering text into a cell via the Google Sheets UI.
+   */
+  data_format: string
+  /**
+   *
+   *   The fields to write to the spreadsheet.
+   *
+   *   On the left-hand side, input the name of the field as it will appear in the Google Sheet.
+   *
+   *   On the right-hand side, select the field from your data model that maps to the given field in your sheet.
+   *
+   *   ---
+   *
+   *
+   */
+  fields: {
+    [k: string]: unknown
+  }
+  /**
+   * Set as true to ensure Segment sends data to Google Sheets in batches. Please do not set to false.
+   */
+  enable_batching?: boolean
+}

--- a/packages/destination-actions/src/destinations/index.ts
+++ b/packages/destination-actions/src/destinations/index.ts
@@ -65,6 +65,7 @@ register('631a6f32946dd8197e9cab66', './sendgrid')
 register('632b1116e0cb83902f3fd717', './hubspot')
 register('636d38db78d7834347d76c44', './1plusx-asset-api')
 register('6371eee1ae5e324869aa8b1b', './segment')
+register('63936c37dbc54a052e34e30e', './google-sheets-dev')
 
 function register(id: MetadataId, destinationPath: string) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
We are creating a new stub destination for testing E2E PROD for our release testing party.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
