### PR TITLE
[HGI-262] - Introduce State Context to action destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ The `perform` method accepts two arguments, (1) the request client instance (ext
 - `statsContext` - An object, containing a `statsClient` and `tags`. Stats can only be used by internal Twilio/Segment employees. Stats cannot be used for Partner builds.
 - `logger` - Logger can only be used by internal Twilio/Segment employees. Logger cannot be used for Partner builds.
 - `transactionContext` - An object, containing transaction variables and a method to update transaction variables which are required for few segment developed actions. Transaction Context cannot be used for Partner builds.
+- `stateContext` - An object, containing context variables and a method to get and set context variables which are required for few segment developed actions. State Context cannot be used for Partner builds.
 
 A basic example:
 

--- a/packages/core/src/__tests__/destination-kit.test.ts
+++ b/packages/core/src/__tests__/destination-kit.test.ts
@@ -510,8 +510,8 @@ describe('destination kit', () => {
           setTransaction: (key: string, value: string) => ({ [key]: value })
         } as TransactionContext,
         stateContext: {
-          getState: (_key: string, _cb?: (res?: string) => any): any => {},
-          setState: (
+          getRequestContext: (_key: string, _cb?: (res?: string) => any): any => {},
+          setResponseContext: (
             _key: string,
             _value: string,
             _ttl: { hour?: number; minute?: number; second?: number }

--- a/packages/core/src/__tests__/destination-kit.test.ts
+++ b/packages/core/src/__tests__/destination-kit.test.ts
@@ -1,4 +1,5 @@
 import {
+  StateContext,
   Destination,
   DestinationDefinition,
   Logger,
@@ -103,8 +104,8 @@ const destinationWithOptions: DestinationDefinition<JSONObject> = {
       description: 'Send events to a custom event in API',
       defaultSubscription: 'type = "track"',
       fields: {},
-      perform: (_request, { features, statsContext, logger, transactionContext }) => {
-        return { features, statsContext, logger, transactionContext }
+      perform: (_request, { features, statsContext, logger, transactionContext, stateContext }) => {
+        return { features, statsContext, logger, transactionContext, stateContext }
       }
     }
   }
@@ -291,7 +292,7 @@ describe('destination kit', () => {
       try {
         await destinationTest.refreshAccessToken(testSettings, oauthData)
         fail('test should have thrown a NotImplemented error')
-      } catch (e) {
+      } catch (e: any) {
         expect(e.status).toEqual(501)
         expect(e.message).toEqual('refreshAccessToken is only valid with oauth2 authentication scheme')
         expect(e.code).toEqual('NotImplemented')
@@ -474,6 +475,57 @@ describe('destination kit', () => {
             statsContext: {},
             logger: eventOptions.logger,
             transactionContext: eventOptions.transactionContext
+          }
+        }
+      ])
+    })
+  })
+
+  describe('stateContext', () => {
+    test('should not crash when stateContext is passed to the perform handler', async () => {
+      const destinationTest = new Destination(destinationWithOptions)
+      const testEvent: SegmentEvent = {
+        properties: { field_one: 'test input' },
+        userId: '3456fff',
+        type: 'track'
+      }
+      const testSettings = {
+        apiSecret: 'test_key',
+        subscription: {
+          subscribe: 'type = "track"',
+          partnerAction: 'customEvent',
+          mapping: {
+            clientId: '23455343467',
+            name: 'fancy_event',
+            parameters: { field_one: 'rogue one' }
+          }
+        }
+      }
+      const eventOptions = {
+        features: {},
+        statsContext: {} as StatsContext,
+        logger: { name: 'test-integration', level: 'debug' } as Logger,
+        transactionContext: {
+          transaction: { contact_id: '801' },
+          setTransaction: (key: string, value: string) => ({ [key]: value })
+        } as TransactionContext,
+        stateContext: {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          getState: (key: string, cb?: (res?: string) => any): any => {},
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          setState: (key: string, value: string, ttl: { hour?: number; minute?: number; second?: number }): void => {}
+        } as StateContext
+      }
+      const res = await destinationTest.onEvent(testEvent, testSettings, eventOptions)
+      expect(res).toEqual([
+        { output: 'Mappings resolved' },
+        {
+          output: {
+            features: {},
+            statsContext: {},
+            logger: eventOptions.logger,
+            transactionContext: eventOptions.transactionContext,
+            stateContext: eventOptions.stateContext
           }
         }
       ])

--- a/packages/core/src/__tests__/destination-kit.test.ts
+++ b/packages/core/src/__tests__/destination-kit.test.ts
@@ -510,10 +510,12 @@ describe('destination kit', () => {
           setTransaction: (key: string, value: string) => ({ [key]: value })
         } as TransactionContext,
         stateContext: {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          getState: (key: string, cb?: (res?: string) => any): any => {},
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          setState: (key: string, value: string, ttl: { hour?: number; minute?: number; second?: number }): void => {}
+          getState: (_key: string, _cb?: (res?: string) => any): any => {},
+          setState: (
+            _key: string,
+            _value: string,
+            _ttl: { hour?: number; minute?: number; second?: number }
+          ): void => {}
         } as StateContext
       }
       const res = await destinationTest.onEvent(testEvent, testSettings, eventOptions)

--- a/packages/core/src/create-test-integration.ts
+++ b/packages/core/src/create-test-integration.ts
@@ -1,5 +1,5 @@
 import { createTestEvent } from './create-test-event'
-import { Destination, TransactionContext } from './destination-kit'
+import { StateContext, Destination, TransactionContext } from './destination-kit'
 import { mapValues } from './map-values'
 import type { DestinationDefinition, StatsContext, Logger } from './destination-kit'
 import type { JSONObject } from './json-object'
@@ -34,12 +34,13 @@ interface InputData<Settings> {
   auth?: AuthTokens
   /**
    * The features available in the request based on the customer's sourceID;
-   * `features`, `stats`, `logger` and `transactionContext` are for internal Twilio/Segment use only.
+   * `features`, `stats`, `logger` , `transactionContext` and `stateContext` are for internal Twilio/Segment use only.
    */
   features?: Features
   statsContext?: StatsContext
   logger?: Logger
   transactionContext?: TransactionContext
+  stateContext?: StateContext
 }
 
 class TestDestination<T> extends Destination<T> {
@@ -65,7 +66,8 @@ class TestDestination<T> extends Destination<T> {
       features,
       statsContext,
       logger,
-      transactionContext
+      transactionContext,
+      stateContext
     }: InputData<T>
   ): Promise<Destination['responses']> {
     mapping = mapping ?? {}
@@ -84,7 +86,8 @@ class TestDestination<T> extends Destination<T> {
       features: features ?? {},
       statsContext: statsContext ?? ({} as StatsContext),
       logger: logger ?? ({} as Logger),
-      transactionContext: transactionContext ?? ({} as TransactionContext)
+      transactionContext: transactionContext ?? ({} as TransactionContext),
+      stateContext: stateContext ?? ({} as StateContext)
     })
 
     const responses = this.responses
@@ -104,7 +107,8 @@ class TestDestination<T> extends Destination<T> {
       features,
       statsContext,
       logger,
-      transactionContext
+      transactionContext,
+      stateContext
     }: Omit<InputData<T>, 'event'> & { events?: SegmentEvent[] }
   ): Promise<Destination['responses']> {
     mapping = mapping ?? {}
@@ -127,7 +131,8 @@ class TestDestination<T> extends Destination<T> {
       features: features ?? {},
       statsContext: statsContext ?? ({} as StatsContext),
       logger: logger ?? ({} as Logger),
-      transactionContext: transactionContext ?? ({} as TransactionContext)
+      transactionContext: transactionContext ?? ({} as TransactionContext),
+      stateContext: stateContext ?? ({} as StateContext)
     })
 
     const responses = this.responses

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -12,7 +12,7 @@ import { validateSchema } from '../schema-validation'
 import { AuthTokens } from './parse-settings'
 import { IntegrationError } from '../errors'
 import { removeEmptyValues } from '../remove-empty-values'
-import { Logger, StatsContext, TransactionContext } from './index'
+import { Logger, StatsContext, TransactionContext, StateContext } from './index'
 
 type MaybePromise<T> = T | Promise<T>
 type RequestClient = ReturnType<typeof createRequestClient>
@@ -83,6 +83,7 @@ interface ExecuteBundle<T = unknown, Data = unknown> {
   statsContext?: StatsContext | undefined
   logger?: Logger | undefined
   transactionContext?: TransactionContext
+  stateContext?: StateContext
 }
 
 /**
@@ -145,7 +146,8 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
       features: bundle.features,
       statsContext: bundle.statsContext,
       logger: bundle.logger,
-      transactionContext: bundle.transactionContext
+      transactionContext: bundle.transactionContext,
+      stateContext: bundle.stateContext
     }
 
     // Construct the request client and perform the action
@@ -192,7 +194,8 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
         features: bundle.features,
         statsContext: bundle.statsContext,
         logger: bundle.logger,
-        transactionContext: bundle.transactionContext
+        transactionContext: bundle.transactionContext,
+        stateContext: bundle.stateContext
       }
       await this.performRequest(this.definition.performBatch, data)
     }

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -183,6 +183,7 @@ interface EventInput<Settings> {
   readonly statsContext?: StatsContext
   readonly logger?: Logger
   readonly transactionContext?: TransactionContext
+  readonly stateContext?: StateContext
 }
 
 interface BatchEventInput<Settings> {
@@ -196,6 +197,7 @@ interface BatchEventInput<Settings> {
   readonly statsContext?: StatsContext
   readonly logger?: Logger
   readonly transactionContext?: TransactionContext
+  readonly stateContext?: StateContext
 }
 
 export interface DecoratedResponse extends ModifiedResponse {
@@ -210,6 +212,7 @@ interface OnEventOptions {
   statsContext?: StatsContext
   logger?: Logger
   transactionContext?: TransactionContext
+  stateContext?: StateContext
 }
 
 /** Transaction variables and setTransaction method are passed from mono service for few Segment built integrations.
@@ -218,6 +221,14 @@ interface OnEventOptions {
 export interface TransactionContext {
   transaction: Record<string, string>
   setTransaction: (key: string, value: string) => void
+}
+
+export interface StateContext {
+  // setState reads the `context` field from the request
+  getState(key: string, cb?: (res?: string) => any): any
+  // setState sets values in the `setContext` field in the response
+  // values set on the response will be available on subsequent requests
+  setState(key: string, value: string, ttl: { hour?: number; minute?: number; second?: number }): void
 }
 
 export interface StatsClient {
@@ -369,7 +380,17 @@ export class Destination<Settings = JSONObject> {
 
   protected async executeAction(
     actionSlug: string,
-    { event, mapping, settings, auth, features, statsContext, logger, transactionContext }: EventInput<Settings>
+    {
+      event,
+      mapping,
+      settings,
+      auth,
+      features,
+      statsContext,
+      logger,
+      transactionContext,
+      stateContext
+    }: EventInput<Settings>
   ): Promise<Result[]> {
     const action = this.actions[actionSlug]
     if (!action) {
@@ -384,13 +405,24 @@ export class Destination<Settings = JSONObject> {
       features,
       statsContext,
       logger,
-      transactionContext
+      transactionContext,
+      stateContext
     })
   }
 
   public async executeBatch(
     actionSlug: string,
-    { events, mapping, settings, auth, features, statsContext, logger, transactionContext }: BatchEventInput<Settings>
+    {
+      events,
+      mapping,
+      settings,
+      auth,
+      features,
+      statsContext,
+      logger,
+      transactionContext,
+      stateContext
+    }: BatchEventInput<Settings>
   ) {
     const action = this.actions[actionSlug]
     if (!action) {
@@ -405,7 +437,8 @@ export class Destination<Settings = JSONObject> {
       features,
       statsContext,
       logger,
-      transactionContext
+      transactionContext,
+      stateContext
     })
 
     return [{ output: 'successfully processed batch of events' }]
@@ -440,7 +473,8 @@ export class Destination<Settings = JSONObject> {
       features: options?.features || {},
       statsContext: options?.statsContext || ({} as StatsContext),
       logger: options?.logger,
-      transactionContext: options?.transactionContext
+      transactionContext: options?.transactionContext,
+      stateContext: options?.stateContext
     }
 
     let results: Result[] | null = null

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -224,11 +224,11 @@ export interface TransactionContext {
 }
 
 export interface StateContext {
-  // setState reads the `context` field from the request
-  getState(key: string, cb?: (res?: string) => any): any
-  // setState sets values in the `setContext` field in the response
+  // getRequestContext reads the `context` field from the request
+  getRequestContext(key: string, cb?: (res?: string) => any): any
+  // setResponseContext sets values in the `setContext` field in the response
   // values set on the response will be available on subsequent requests
-  setState(key: string, value: string, ttl: { hour?: number; minute?: number; second?: number }): void
+  setResponseContext(key: string, value: string, ttl: { hour?: number; minute?: number; second?: number }): void
 }
 
 export interface StatsClient {

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -1,4 +1,4 @@
-import { Logger, StatsContext, TransactionContext } from './index'
+import { StateContext, Logger, StatsContext, TransactionContext } from './index'
 import type { RequestOptions } from '../request-client'
 import type { JSONObject } from '../json-object'
 import { AuthTokens } from './parse-settings'
@@ -27,12 +27,13 @@ export interface ExecuteInput<Settings, Payload> {
   readonly auth?: AuthTokens
   /**
    * The features available in the request based on the customer's sourceID;
-   * `features`,`stats`, `logger` and `transactionContext` are for internal Twilio/Segment use only.
+   * `features`,`stats`, `logger` , `transactionContext` and `cohortContext` are for internal Twilio/Segment use only.
    */
   readonly features?: Features
   readonly statsContext?: StatsContext
   readonly logger?: Logger
   readonly transactionContext?: TransactionContext
+  readonly stateContext?: StateContext
 }
 
 export interface DynamicFieldResponse {

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -27,7 +27,7 @@ export interface ExecuteInput<Settings, Payload> {
   readonly auth?: AuthTokens
   /**
    * The features available in the request based on the customer's sourceID;
-   * `features`,`stats`, `logger` , `transactionContext` and `cohortContext` are for internal Twilio/Segment use only.
+   * `features`,`stats`, `logger` , `transactionContext` and `stateContext` are for internal Twilio/Segment use only.
    */
   readonly features?: Features
   readonly statsContext?: StatsContext


### PR DESCRIPTION
https://segment.atlassian.net/jira/software/projects/HGI/boards/512?assignee=63617339fc0cc7a600b03c6b&selectedIssue=HGI-262

This PR is to add support for caching context and made it available to action destination to cache context and use it in same framework.

Integrations PR :- https://github.com/segmentio/integrations/pull/2447

**Please refer to below doc if you wanna understand about stateContext/executionContext**
https://paper.dropbox.com/doc/Integrations-Interface-Specification--BuywbLvPUPQqHbag0Xbd7FfPAg-18u19AJu14EOpRBG3agRj

Testing
Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing.

- [x]  Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x]  Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x]  [Segmenters] Tested in the staging environment

Testing completed successfully in Staging.Please look into this docs for further
https://docs.google.com/document/d/1BvV0LbT1aCYEeHw-vU7eo-aV4XplZNAs6j4gAZEWhwo/edit



[HGI-262]: https://segment.atlassian.net/browse/HGI-262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ