### PR TITLE
Add Additional LogRocket Config Options

### DIFF
--- a/packages/browser-destinations/src/destinations/logrocket/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/logrocket/__tests__/index.test.ts
@@ -1,19 +1,105 @@
 import { Analytics, Context } from '@segment/analytics-next'
 import plugins, { destination } from '../index'
 import { mockWorkerAndXMLHttpRequest, subscriptions } from '../test_utilities'
+import Logrocket from 'logrocket'
+
+jest.mock('logrocket')
+
+const appID = 'log/rocket'
 
 describe('Logrocket', () => {
   beforeAll(mockWorkerAndXMLHttpRequest)
   afterAll(jest.restoreAllMocks)
 
   test('can load', async () => {
-    const [event] = await plugins({ appID: 'log/rocket', subscriptions })
+    const [event] = await plugins({
+      appID,
+      networkSanitization: false,
+      inputSanitization: false,
+      subscriptions
+    })
 
     jest.spyOn(destination, 'initialize')
+    jest.spyOn(Logrocket, 'init')
 
     await event.load(Context.system(), {} as Analytics)
     expect(destination.initialize).toHaveBeenCalled()
+    expect(Logrocket.init).toHaveBeenCalled()
 
     expect(window._LRLogger).toBeDefined()
+  })
+
+  test('supplies the input sanitization parameter', async () => {
+    const [event] = await plugins({
+      appID,
+      networkSanitization: false,
+      inputSanitization: true,
+      subscriptions
+    })
+
+    jest.spyOn(Logrocket, 'init')
+
+    await event.load(Context.system(), {} as Analytics)
+    expect(Logrocket.init).toHaveBeenCalledWith(appID, expect.objectContaining({ dom: { inputSanitizer: true } }))
+  })
+
+  describe('network sanitizer', () => {
+    test('redacts requests when configured', async () => {
+      const [event] = await plugins({
+        appID,
+        networkSanitization: true,
+        inputSanitization: false,
+        subscriptions
+      })
+
+      const spy = jest.spyOn(Logrocket, 'init')
+
+      await event.load(Context.system(), {} as Analytics)
+      expect(Logrocket.init).toHaveBeenCalledWith(appID, expect.objectContaining({ dom: { inputSanitizer: false } }))
+      const requestSanitizer: RequestSanitizer = spy.mock.calls[0][1]?.network?.requestSanitizer
+
+      if (!requestSanitizer) fail('request sanitizer null')
+
+      const mockRequest = {
+        body: 'hello',
+        headers: { goodbye: 'moon' },
+        reqId: 'something',
+        url: 'neat',
+        method: 'get'
+      }
+
+      const sanitizedResult = requestSanitizer(mockRequest)
+
+      expect(sanitizedResult).toEqual(expect.objectContaining({ body: undefined, headers: {} }))
+    })
+
+    test('does not modify requests if disabled', async () => {
+      const [event] = await plugins({
+        appID,
+        networkSanitization: false,
+        inputSanitization: false,
+        subscriptions
+      })
+
+      const spy = jest.spyOn(Logrocket, 'init')
+
+      await event.load(Context.system(), {} as Analytics)
+      expect(Logrocket.init).toHaveBeenCalledWith(appID, expect.objectContaining({ dom: { inputSanitizer: false } }))
+      const requestSanitizer: RequestSanitizer = spy.mock.calls[0][1]?.network?.requestSanitizer
+
+      if (!requestSanitizer) fail('request sanitizer null')
+
+      const mockRequest = {
+        body: 'hello',
+        headers: { goodbye: 'moon' },
+        reqId: 'something',
+        url: 'neat',
+        method: 'get'
+      }
+
+      const sanitizedResult = requestSanitizer(mockRequest)
+
+      expect(sanitizedResult).toEqual(mockRequest)
+    })
   })
 })

--- a/packages/browser-destinations/src/destinations/logrocket/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/logrocket/generated-types.ts
@@ -5,4 +5,12 @@ export interface Settings {
    * The LogRocket app ID.
    */
   appID: string
+  /**
+   * Sanitize all network request and response bodies from session recordings.
+   */
+  networkSanitization: boolean
+  /**
+   * Obfuscate all user-input elements (like <input> and <select>) from session recordings.
+   */
+  inputSanitization: boolean
 }

--- a/packages/browser-destinations/src/destinations/logrocket/index.ts
+++ b/packages/browser-destinations/src/destinations/logrocket/index.ts
@@ -10,8 +10,12 @@ import { defaultValues } from '@segment/actions-core'
 declare global {
   interface Window {
     LogRocket: LR
+    logRocketSettings?: LogRocketSettings
     _LRLogger: () => void
   }
+
+  type LogRocketSettings = NonNullable<Parameters<LR['init']>[1]>
+  type RequestSanitizer = NonNullable<LogRocketSettings['network']>['requestSanitizer']
 }
 // Switch from unknown to the partner SDK client types
 export const destination: BrowserDestinationDefinition<Settings, LR> = {
@@ -40,11 +44,42 @@ export const destination: BrowserDestinationDefinition<Settings, LR> = {
       label: 'LogRocket App',
       type: 'string',
       required: true
+    },
+    networkSanitization: {
+      description: 'Sanitize all network request and response bodies from session recordings.',
+      label: 'Network Sanitization',
+      type: 'boolean',
+      required: true,
+      default: false
+    },
+    inputSanitization: {
+      description: 'Obfuscate all user-input elements (like <input> and <select>) from session recordings.',
+      label: 'Input Sanitization',
+      type: 'boolean',
+      required: true,
+      default: false
     }
   },
 
-  initialize: async ({ settings: { appID } }, deps) => {
-    LogRocket.init(appID)
+  initialize: async ({ settings: { appID, inputSanitization: inputSanitizer, networkSanitization } }, deps) => {
+    const requestSanitizer: RequestSanitizer = (request) => {
+      if (networkSanitization) {
+        request.body = undefined
+        request.headers = {}
+      }
+
+      return request
+    }
+    const settings: LogRocketSettings = {
+      dom: {
+        inputSanitizer
+      },
+      network: {
+        requestSanitizer,
+        responseSanitizer: requestSanitizer
+      }
+    }
+    LogRocket.init(appID, window.logRocketSettings || settings)
     await deps.resolveWhen(() => Object.prototype.hasOwnProperty.call(window, '_LRLogger'), 100)
     return LogRocket
   },

--- a/packages/browser-destinations/src/destinations/logrocket/index.ts
+++ b/packages/browser-destinations/src/destinations/logrocket/index.ts
@@ -50,14 +50,14 @@ export const destination: BrowserDestinationDefinition<Settings, LR> = {
       label: 'Network Sanitization',
       type: 'boolean',
       required: true,
-      default: false
+      default: true
     },
     inputSanitization: {
       description: 'Obfuscate all user-input elements (like <input> and <select>) from session recordings.',
       label: 'Input Sanitization',
       type: 'boolean',
       required: true,
-      default: false
+      default: true
     }
   },
 


### PR DESCRIPTION
In testing our integration, we realized that we needed additional options to ease the configuration process for our users. This adds a couple of additional settings.

The segment platform will receive the same events regardless of these toggles, they are merely flags to our sdk to tweak its internal behavior.

## Testing

Reviewers: You can use `noel-org/segment-app-public` as a logrocket app ID to see events firing. 

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
