### PR TITLE
Update validate() method to use correct types & update tests accordingly

### DIFF
--- a/packages/destination-subscriptions/src/__tests__/validate.test.ts
+++ b/packages/destination-subscriptions/src/__tests__/validate.test.ts
@@ -197,7 +197,7 @@ test('operators - less than', () => {
     }
 
     expect(validate(ast, { properties: { value: 5 } })).toEqual(true)
-    expect(validate(ast, { properties: { value: '5' } })).toEqual(true)
+    expect(validate(ast, { properties: { value: '5' } })).toEqual(false)
     expect(validate(ast, { properties: { value: 10 } })).toEqual(false)
     expect(validate(ast, { properties: { value: '10' } })).toEqual(false)
   }
@@ -219,9 +219,9 @@ test('operators - less than or equal', () => {
     }
 
     expect(validate(ast, { properties: { value: 5 } })).toEqual(true)
-    expect(validate(ast, { properties: { value: '5' } })).toEqual(true)
+    expect(validate(ast, { properties: { value: '5' } })).toEqual(false)
     expect(validate(ast, { properties: { value: 10 } })).toEqual(true)
-    expect(validate(ast, { properties: { value: '10' } })).toEqual(true)
+    expect(validate(ast, { properties: { value: '10' } })).toEqual(false)
     expect(validate(ast, { properties: { value: 11 } })).toEqual(false)
     expect(validate(ast, { properties: { value: '11' } })).toEqual(false)
   }
@@ -243,7 +243,7 @@ test('operators - greater than', () => {
     }
 
     expect(validate(ast, { properties: { value: 11 } })).toEqual(true)
-    expect(validate(ast, { properties: { value: '11' } })).toEqual(true)
+    expect(validate(ast, { properties: { value: '11' } })).toEqual(false)
     expect(validate(ast, { properties: { value: 10 } })).toEqual(false)
     expect(validate(ast, { properties: { value: '10' } })).toEqual(false)
     expect(validate(ast, { properties: { value: 5 } })).toEqual(false)
@@ -267,9 +267,9 @@ test('operators - greater than or equal', () => {
     }
 
     expect(validate(ast, { properties: { value: 11 } })).toEqual(true)
-    expect(validate(ast, { properties: { value: '11' } })).toEqual(true)
+    expect(validate(ast, { properties: { value: '11' } })).toEqual(false)
     expect(validate(ast, { properties: { value: 10 } })).toEqual(true)
-    expect(validate(ast, { properties: { value: '10' } })).toEqual(true)
+    expect(validate(ast, { properties: { value: '10' } })).toEqual(false)
     expect(validate(ast, { properties: { value: 5 } })).toEqual(false)
     expect(validate(ast, { properties: { value: '5' } })).toEqual(false)
   }

--- a/packages/destination-subscriptions/src/validate.ts
+++ b/packages/destination-subscriptions/src/validate.ts
@@ -76,13 +76,13 @@ const validateValue = (actual: unknown, operator: Operator, expected?: string | 
     case '!=':
       return actual !== String(expected)
     case '<':
-      return Number(actual) < Number(expected)
+      return typeof actual === 'number' && Number(actual) < Number(expected)
     case '<=':
-      return Number(actual) <= Number(expected)
+      return typeof actual === 'number' && Number(actual) <= Number(expected)
     case '>':
-      return Number(actual) > Number(expected)
+      return typeof actual === 'number' && Number(actual) > Number(expected)
     case '>=':
-      return Number(actual) >= Number(expected)
+      return typeof actual === 'number' && Number(actual) >= Number(expected)
     case 'contains':
       return typeof actual === 'string' && actual.includes(String(expected))
     case 'not_contains':


### PR DESCRIPTION
This PR addresses JIRA [ACT-74](https://segment.atlassian.net/jira/software/projects/ACT/boards/510?selectedIssue=ACT-74)

In it we update the `destination-subscriptions` `validate()` method to ensure that the operators `<` `>` `<=` `>=` are only given fields with `type === 'number'`, otherwise we return false.

This pattern is consistent with how we currently check the string operators such as `begins with`, `ends with`, `contains` are only passed a field of `type === 'string'`

## Testing

Published new pacakge of `destination-subscriptions` => installed in `app` => deployed `app` feature branch to stage => noticed that only valid events with `numbers` for the value were matching instead of ones with `strings` 🎉

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
