### PR TITLE
[ACT-362] adds additional bracket support to path conversion in get

### DIFF
--- a/packages/core/src/__tests__/get.test.ts
+++ b/packages/core/src/__tests__/get.test.ts
@@ -22,6 +22,7 @@ const fixtures: Record<string, unknown> = {
   a: obj.a,
   'a.b': obj.a.b,
   "['a'].b": obj.a.b,
+  '["a"].b': obj.a.b,
   'a.b.c': obj.a.b.c,
   'a.b.d': obj.a.b.d,
   'a.b.e': obj.a.b.e,

--- a/packages/core/src/__tests__/get.test.ts
+++ b/packages/core/src/__tests__/get.test.ts
@@ -10,13 +10,18 @@ const obj = {
     },
     h: null
   },
-  u: undefined
+  u: undefined,
+  '[txt] non': true,
+  '[txt] nest': {
+    inner: true
+  }
 }
 
 const fixtures: Record<string, unknown> = {
   '': obj,
   a: obj.a,
   'a.b': obj.a.b,
+  "['a'].b": obj.a.b,
   'a.b.c': obj.a.b.c,
   'a.b.d': obj.a.b.d,
   'a.b.e': obj.a.b.e,
@@ -24,6 +29,8 @@ const fixtures: Record<string, unknown> = {
   'a.b.f[0].g': obj.a.b.f[0].g,
   'a.h': obj.a.h,
   'a.b.x': undefined,
+  '[txt] non': true,
+  '[txt] nest.inner': true,
   u: undefined
 }
 

--- a/packages/core/src/get.ts
+++ b/packages/core/src/get.ts
@@ -2,6 +2,7 @@
  * Lightweight alternative to lodash.get with similar coverage
  * Supports basic path lookup via dot notation `'foo.bar[0].baz'` or an array ['foo', 'bar', '0', 'baz']
  */
+
 export function get<T = unknown>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   obj: any,
@@ -15,7 +16,13 @@ export function get<T = unknown>(
 
   // Check if path is string or array. Regex : ensure that we do not have '.' and brackets.
   // Regex explained: https://regexr.com/58j0k
-  const pathArray = Array.isArray(path) ? path : (path.match(/([^[.\]])+/g) as string[])
+  const pathArray = Array.isArray(path)
+    ? path
+    : path
+        .split(/\[(?='|\d)|\.|(?<='|\d)]+/g)
+        .filter((f) => f)
+        .map((s) => s.replace(/'/g, ''))
+  // const pathArray = Array.isArray(path) ? path : (path.match(/([^[.\]])+/g) as string[])
 
   // Find value if exist return otherwise return undefined value
   return pathArray.reduce((prevObj, key) => prevObj && prevObj[key], obj)

--- a/packages/core/src/get.ts
+++ b/packages/core/src/get.ts
@@ -19,9 +19,9 @@ export function get<T = unknown>(
   const pathArray = Array.isArray(path)
     ? path
     : path
-        .split(/\[(?='|\d)|\.|(?<='|\d)]+/g)
+        .split(/\[(?="|'|\d)|\.|(?<="|'|\d)]+/g)
         .filter((f) => f)
-        .map((s) => s.replace(/'/g, ''))
+        .map((s) => s.replace(/'|"/g, ''))
   // const pathArray = Array.isArray(path) ? path : (path.match(/([^[.\]])+/g) as string[])
 
   // Find value if exist return otherwise return undefined value

--- a/packages/core/src/get.ts
+++ b/packages/core/src/get.ts
@@ -3,6 +3,16 @@
  * Supports basic path lookup via dot notation `'foo.bar[0].baz'` or an array ['foo', 'bar', '0', 'baz']
  */
 
+let arrayRe: RegExp
+
+try {
+  arrayRe = /\[(?="|'|\d)|\.|(?<="|'|\d)]+/g
+} catch (e) {
+  //safari does not support lookbehind operator so we will default
+  //to a simpler approach wherein [bar] will not be a valid key
+  arrayRe = /\[|\.|]+/g
+}
+
 export function get<T = unknown>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   obj: any,
@@ -22,7 +32,7 @@ export function get<T = unknown>(
   const pathArray = Array.isArray(path)
     ? path
     : path
-        .split(/\[(?="|'|\d)|\.|(?<="|'|\d)]+/g)
+        .split(arrayRe)
         .filter((f) => f)
         .map((s) => s.replace(/'|"/g, ''))
 

--- a/packages/core/src/get.ts
+++ b/packages/core/src/get.ts
@@ -14,15 +14,17 @@ export function get<T = unknown>(
   // Not defined
   if (path === null || path == undefined) return undefined
 
-  // Check if path is string or array. Regex : ensure that we do not have '.' and brackets.
-  // Regex explained: https://regexr.com/58j0k
+  // Check if path is string or array. Regex : splits the path into valid array of path chunks
+  // we support an extra edge case that lodash does not around brackets
+  // a['b'] = ['a','b']
+  // a[b] = ['a[b]'] //brackets without numeric index or a string are considered part of the key
+  // Regex explained: https://regexr.com/74m2m
   const pathArray = Array.isArray(path)
     ? path
     : path
         .split(/\[(?="|'|\d)|\.|(?<="|'|\d)]+/g)
         .filter((f) => f)
         .map((s) => s.replace(/'|"/g, ''))
-  // const pathArray = Array.isArray(path) ? path : (path.match(/([^[.\]])+/g) as string[])
 
   // Find value if exist return otherwise return undefined value
   return pathArray.reduce((prevObj, key) => prevObj && prevObj[key], obj)

--- a/packages/core/src/mapping-kit/__tests__/index.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.test.ts
@@ -520,20 +520,6 @@ describe('@path', () => {
     expect(output).toStrictEqual({ neat: 'bar' })
   })
 
-  test('invalid bracket-spaced nested value', () => {
-    const output = transform(
-      { neat: { '@path': "$.integrations['Actions Amplitude'].session_id" } },
-      {
-        integrations: {
-          'Actions Amplitude': {
-            session_id: 'bar'
-          }
-        }
-      }
-    )
-    expect(output).toStrictEqual({})
-  })
-
   test('invalid nested value type', () => {
     const output = transform({ neat: { '@path': '$.foo.bar.baz' } }, { foo: 'bar' })
     expect(output).toStrictEqual({})


### PR DESCRIPTION
Currently the actions path directive does not support objects with brackets in their key:

`const example = {'[im valid]':123456}`

This pull request adds support for arbitrary [] in keys. However keys that contain [] but also a numeric index or a quoted string will still be treated as individual keys:

a[txt] - treated as a single key `a[txt]`
a['txt'] treated as the keys `a`,`txt`
a[0] treated as the keys `a`, `0`

## Testing
<img width="1460" alt="Screen Shot 2022-12-16 at 9 34 55 AM" src="https://user-images.githubusercontent.com/1529402/208133547-7c0aecda-dc62-4783-ba5a-7c128084d224.png">

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
