### PR TITLE
[STRATCONN-1423] & [STRATCONN-1763] update viewItem and selectPromotion actions GA4

### DIFF
--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
@@ -368,65 +368,6 @@ describe('GA4', () => {
       }
     })
 
-    it('should throw error when promotion name and id is missing', async () => {
-      nock('https://www.google-analytics.com/mp/collect')
-        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
-        .reply(201, {})
-      const event = createTestEvent({
-        event: 'Promotion Clicked',
-        userId: '3456fff',
-        anonymousId: 'anon-567890',
-        type: 'track',
-        properties: {
-          promotion_id: 'promo_1',
-          creative: 'top_banner_2',
-          name: '75% store-wide shoe sale',
-          position: 'home_banner_top',
-          items: [
-            {
-              item_id: 'SKU_12345',
-              item_name: 'jeggings',
-              coupon: 'SUMMER_FUN',
-              discount: 2.22,
-              creative_slot: 'featured_app_1',
-              location_id: 'L_12345',
-              affiliation: 'Google Store',
-              item_brand: 'Gucci',
-              item_category: 'pants',
-              item_variant: 'Black',
-              price: 9.99,
-              currency: 'USD'
-            }
-          ]
-        }
-      })
-
-      try {
-        await testDestination.testAction('selectPromotion', {
-          event,
-          settings: {
-            apiSecret,
-            measurementId
-          },
-          mapping: {
-            clientId: {
-              '@path': '$.anonymousId'
-            },
-            location_id: {
-              '@path': '$.properties.promotion_id'
-            },
-            items: {
-              '@path': '$.properties.items'
-            }
-          },
-          useDefaultMappings: true
-        })
-        fail('the test should have thrown an error')
-      } catch (e) {
-        expect(e.message).toBe('One of promotion name or promotion id is required.')
-      }
-    })
-
     it('should throw error when item currency is invalid', async () => {
       nock('https://www.google-analytics.com/mp/collect')
         .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
@@ -49,7 +49,7 @@ describe('GA4', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"quantity\\":1,\\"price\\":12.99}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"12345abcde\\",\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"price\\":12.99,\\"quantity\\":1}],\\"engagement_time_msec\\":1}}],\\"user_properties\\":{\\"hello\\":{\\"value\\":\\"world\\"},\\"a\\":{\\"value\\":\\"1\\"},\\"b\\":{\\"value\\":\\"2\\"},\\"c\\":{\\"value\\":\\"3\\"}},\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -184,7 +184,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"USD\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"quantity\\":1}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 
@@ -242,7 +242,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"quantity\\":1,\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
+        `"{\\"client_id\\":\\"3456fff\\",\\"events\\":[{\\"name\\":\\"view_item\\",\\"params\\":{\\"currency\\":\\"usd\\",\\"items\\":[{\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Monopoly: 3rd Edition\\",\\"coupon\\":\\"MAYDEALS\\",\\"item_brand\\":\\"Hasbro\\",\\"item_category\\":\\"Games\\",\\"item_variant\\":\\"200 pieces\\",\\"price\\":18.99,\\"quantity\\":1}],\\"value\\":18.99,\\"engagement_time_msec\\":1}}],\\"timestamp_micros\\":1655936458905000}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
@@ -75,14 +75,6 @@ const action: ActionDefinition<Settings, Payload> = {
           verifyCurrency(product.currency)
         }
 
-        if (product.promotion_id === undefined && product.promotion_name === undefined) {
-          throw new IntegrationError(
-            'One of promotion name or promotion id is required.',
-            'Misconfigured required field',
-            400
-          )
-        }
-
         return product as PromotionProductItem
       })
     }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
@@ -55,19 +55,7 @@ const action: ActionDefinition<Settings, Payload> = {
           verifyCurrency(product.currency)
         }
 
-        return {
-          item_id: product.item_id,
-          item_name: product.item_name,
-          quantity: product.quantity,
-          affiliation: product.affiliation,
-          coupon: product.coupon,
-          discount: product.discount,
-          item_brand: product.item_brand,
-          item_category: product.item_category,
-          item_variant: product.item_variant,
-          price: product.price,
-          currency: product.currency
-        } as ProductItem
+        return product as ProductItem
       })
     }
 


### PR DESCRIPTION

Currently the `viewItem` Action for GA4 was dropping some of the item parameters. This PR updates the `viewItem` Action, by sending all the parameters. 

Currently the `selectPromotion` Action for GA4 required `promotion_name` or `promotion_id` to be passed however this is not a required field according the the [google docs](https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference/events#select_promotion). This PR removes the extra validation.

## Testing

[Testing Doc](https://paper.dropbox.com/doc/GA-Testing-Update-viewItem-selectPromotion-Action--BvpePIN1~CCKMD4YK9KhkOmOAg-sKiFM4VYidxwmJSzdCSCc)

- [x ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
