### PR TITLE
Actions segment profiles

### DIFF
--- a/packages/destination-actions/src/destinations/index.ts
+++ b/packages/destination-actions/src/destinations/index.ts
@@ -66,6 +66,7 @@ register('632b1116e0cb83902f3fd717', './hubspot')
 register('636d38db78d7834347d76c44', './1plusx-asset-api')
 register('6371eee1ae5e324869aa8b1b', './segment')
 register('63936c37dbc54a052e34e30e', './google-sheets-dev')
+register('639c2dbb1309fdcad13951b6', './segment-profiles')
 
 function register(id: MetadataId, destinationPath: string) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/destination-actions/src/destinations/segment-profiles/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-segment-profiles destination: sendGroup action - all fields 1`] = `
+Object {
+  "anonymousId": "cZE8HyAL0!BF#)WQb^",
+  "groupId": "cZE8HyAL0!BF#)WQb^",
+  "traits": Object {
+    "testType": "cZE8HyAL0!BF#)WQb^",
+  },
+  "userId": "cZE8HyAL0!BF#)WQb^",
+}
+`;
+
+exports[`Testing snapshot for actions-segment-profiles destination: sendGroup action - required fields 1`] = `
+Object {
+  "anonymousId": "cZE8HyAL0!BF#)WQb^",
+  "groupId": "cZE8HyAL0!BF#)WQb^",
+  "traits": Object {},
+  "userId": "cZE8HyAL0!BF#)WQb^",
+}
+`;
+
+exports[`Testing snapshot for actions-segment-profiles destination: sendIdentify action - all fields 1`] = `
+Object {
+  "anonymousId": "hIC1OAmWa[Q!&d%o",
+  "groupId": "hIC1OAmWa[Q!&d%o",
+  "traits": Object {
+    "testType": "hIC1OAmWa[Q!&d%o",
+  },
+  "userId": "hIC1OAmWa[Q!&d%o",
+}
+`;
+
+exports[`Testing snapshot for actions-segment-profiles destination: sendIdentify action - required fields 1`] = `
+Object {
+  "anonymousId": "hIC1OAmWa[Q!&d%o",
+  "groupId": "hIC1OAmWa[Q!&d%o",
+  "traits": Object {},
+  "userId": "hIC1OAmWa[Q!&d%o",
+}
+`;

--- a/packages/destination-actions/src/destinations/segment-profiles/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/__tests__/index.test.ts
@@ -1,16 +1,30 @@
 import nock from 'nock'
 import { createTestIntegration } from '@segment/actions-core'
 import Definition from '../index'
+import { Settings } from '../generated-types'
+import { SEGMENT_ENDPOINTS, DEFAULT_SEGMENT_ENDPOINT } from '../properties'
 
 const testDestination = createTestIntegration(Definition)
 
 describe('Segment Profiles', () => {
   describe('testAuthentication', () => {
     it('should validate authentication inputs', async () => {
-      nock('https://your.destination.endpoint').get('*').reply(200, {})
+      const segmentPAPIToken = 'segment-papi-token'
+
+      nock(SEGMENT_ENDPOINTS[DEFAULT_SEGMENT_ENDPOINT].papi, {
+        reqheaders: {
+          // Check if the request has the correct authorization header
+          authorization: (value) => value === `Bearer ${segmentPAPIToken}`
+        }
+      })
+        .get(/.*/)
+        .reply(200, {})
 
       // This should match your authentication.fields
-      const authData = {}
+      const authData: Settings = {
+        segment_papi_token: segmentPAPIToken,
+        endpoint: DEFAULT_SEGMENT_ENDPOINT
+      }
 
       await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
     })

--- a/packages/destination-actions/src/destinations/segment-profiles/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/__tests__/index.test.ts
@@ -1,0 +1,18 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Segment Profiles', () => {
+  describe('testAuthentication', () => {
+    it('should validate authentication inputs', async () => {
+      nock('https://your.destination.endpoint').get('*').reply(200, {})
+
+      // This should match your authentication.fields
+      const authData = {}
+
+      await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/segment-profiles/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/__tests__/snapshot.test.ts
@@ -1,6 +1,7 @@
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import { generateTestData } from '../../../lib/test-data'
 import destination from '../index'
+import { DEFAULT_SEGMENT_ENDPOINT } from '../properties'
 import nock from 'nock'
 
 const testDestination = createTestIntegration(destination)
@@ -24,7 +25,7 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
       const responses = await testDestination.testAction(actionSlug, {
         event: event,
         mapping: event.properties,
-        settings: settingsData,
+        settings: { ...settingsData, endpoint: DEFAULT_SEGMENT_ENDPOINT },
         auth: undefined
       })
 
@@ -58,7 +59,7 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
       const responses = await testDestination.testAction(actionSlug, {
         event: event,
         mapping: event.properties,
-        settings: settingsData,
+        settings: { ...settingsData, endpoint: DEFAULT_SEGMENT_ENDPOINT },
         auth: undefined
       })
 

--- a/packages/destination-actions/src/destinations/segment-profiles/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-segment-profiles'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/segment-profiles/errors.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/errors.ts
@@ -1,0 +1,13 @@
+import { IntegrationError } from '@segment/actions-core'
+
+export const MissingUserOrAnonymousIdThrowableError = new IntegrationError(
+  'Either `Anonymous ID` or `User ID` must be defined.',
+  'Missing Required Field',
+  400
+)
+
+export const InvalidEndpointSelectedThrowableError = new IntegrationError(
+  'A valid endpoint must be selected. Please check your Segment settings.',
+  'Misconfigured Endpoint',
+  400
+)

--- a/packages/destination-actions/src/destinations/segment-profiles/errors.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/errors.ts
@@ -1,4 +1,16 @@
-import { IntegrationError } from '@segment/actions-core'
+import { HTTPError, IntegrationError } from '@segment/actions-core'
+
+export class SegmentPublicAPIError extends HTTPError {
+  response: Response & {
+    errors: {
+      type: string
+      message?: string
+      field?: string
+      data?: string
+      status?: number
+    }
+  }
+}
 
 export const MissingUserOrAnonymousIdThrowableError = new IntegrationError(
   'Either `Anonymous ID` or `User ID` must be defined.',

--- a/packages/destination-actions/src/destinations/segment-profiles/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/generated-types.ts
@@ -1,0 +1,3 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {}

--- a/packages/destination-actions/src/destinations/segment-profiles/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Settings {
   /**
-   * The **Write Key** of a Segment source.
+   * The Segment Public API requires that you have an authentication token before you send requests. [This document](https://docs.segmentapis.com/tag/Getting-Started#section/Get-an-API-token) explains how to setup a token.
    */
-  source_write_key: string
+  segment_papi_token: string
   /**
    * The region to send your data.
    */
-  endpoint?: string
+  endpoint: string
 }

--- a/packages/destination-actions/src/destinations/segment-profiles/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/generated-types.ts
@@ -1,3 +1,12 @@
 // Generated file. DO NOT MODIFY IT BY HAND.
 
-export interface Settings {}
+export interface Settings {
+  /**
+   * The **Write Key** of a Segment source.
+   */
+  source_write_key: string
+  /**
+   * The region to send your data.
+   */
+  endpoint?: string
+}

--- a/packages/destination-actions/src/destinations/segment-profiles/helperFunctions.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/helperFunctions.ts
@@ -1,0 +1,89 @@
+import { ModifiedResponse, RequestClient, DynamicFieldResponse, DynamicFieldItem } from '@segment/actions-core'
+import { PAGINATION_COUNT, SEGMENT_ENDPOINTS, DEFAULT_SEGMENT_ENDPOINT } from './properties'
+import { SegmentPublicAPIError } from './errors'
+
+interface SourceListItemMetadata {
+  id: string
+  slug: string
+  name: string
+  description: string
+}
+
+interface SourceListItem {
+  id: string
+  slug: string
+  name: string
+  workspaceId: string
+  enabled: boolean
+  writeKeys: string[]
+  metadata: SourceListItemMetadata
+}
+
+interface SourcesListPagination {
+  current: number
+  previous?: string
+  next?: string
+  totalEntries: number
+}
+
+interface SourcesResponse {
+  data: {
+    sources: SourceListItem[]
+    pagination: SourcesListPagination
+  }
+}
+
+interface GetEngageSpaceParams {
+  endpoint: string
+  bearerToken: string
+}
+
+export async function getEngageSpaces(
+  request: RequestClient,
+  data: GetEngageSpaceParams
+): Promise<DynamicFieldResponse> {
+  let cursor = 'MA=='
+  const choices: DynamicFieldItem[] = []
+  let response: ModifiedResponse<SourcesResponse>
+
+  const segmentPAPIEndpoint = SEGMENT_ENDPOINTS[data.endpoint || DEFAULT_SEGMENT_ENDPOINT].papi
+
+  do {
+    // https://api.segmentapis.build/sources?pagination%5Bcount%5D=<COUNT>&pagination%5Bcursor%5D=<PAGE>Í
+    const publicApiUrl = `${segmentPAPIEndpoint}/sources?pagination%5Bcount%5D=${PAGINATION_COUNT}&pagination%5Bcursor%5D=${cursor}`
+
+    try {
+      response = await request<SourcesResponse>(publicApiUrl, {
+        method: 'GET',
+        skipResponseCloning: true
+      })
+
+      for (const source of response.data.data.sources) {
+        if (source.metadata.slug !== 'personas-compute') {
+          continue
+        }
+
+        choices.push({
+          label: source.name,
+          value: source.writeKeys[0]
+        })
+      }
+    } catch (err) {
+      return {
+        choices: [],
+        error: {
+          message: (err as SegmentPublicAPIError)?.response?.errors?.message ?? 'Unknown Error',
+          code: (err as SegmentPublicAPIError)?.response?.statusText ?? 'Unknown Error'
+        }
+      }
+    }
+
+    if (response.data.data.pagination.next) {
+      cursor = response.data.data.pagination.next
+    }
+  } while (response.data.data.pagination.next)
+
+  return {
+    choices
+  }
+}

--- a/packages/destination-actions/src/destinations/segment-profiles/helperFunctions.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/helperFunctions.ts
@@ -87,3 +87,7 @@ export async function getEngageSpaces(
     choices
   }
 }
+
+export function generateSegmentAPIAuthHeaders(writeKey: string): string {
+  return `Basic ${Buffer.from(writeKey + ':').toString('base64')}`
+}

--- a/packages/destination-actions/src/destinations/segment-profiles/helperFunctions.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/helperFunctions.ts
@@ -49,11 +49,14 @@ export async function getEngageSpaces(
   const segmentPAPIEndpoint = SEGMENT_ENDPOINTS[data.endpoint || DEFAULT_SEGMENT_ENDPOINT].papi
 
   do {
-    // https://api.segmentapis.build/sources?pagination%5Bcount%5D=<COUNT>&pagination%5Bcursor%5D=<PAGE>Í
+    // https://api.segmentapis.build/sources?pagination%5Bcount%5D=<COUNT>&pagination%5Bcursor%5D=<PAGE>
     const publicApiUrl = `${segmentPAPIEndpoint}/sources?pagination%5Bcount%5D=${PAGINATION_COUNT}&pagination%5Bcursor%5D=${cursor}`
 
     try {
       response = await request<SourcesResponse>(publicApiUrl, {
+        headers: {
+          authorization: `Bearer ${data.bearerToken}`
+        },
         method: 'GET',
         skipResponseCloning: true
       })
@@ -89,5 +92,8 @@ export async function getEngageSpaces(
 }
 
 export function generateSegmentAPIAuthHeaders(writeKey: string): string {
+  // Segment's Tracking API uses HTTP Basic Authentication with the
+  // Source Write Key. A colon needs to be added to the end of the
+  // write key and then base64 encoded. Eg: BASE64(WriteKey + ':')
   return `Basic ${Buffer.from(writeKey + ':').toString('base64')}`
 }

--- a/packages/destination-actions/src/destinations/segment-profiles/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/index.ts
@@ -1,22 +1,56 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
+import { DEFAULT_SEGMENT_ENDPOINT, SEGMENT_ENDPOINTS } from './properties'
+
+import sendGroup from './sendGroup'
+
+import sendIdentify from './sendIdentify'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Segment Profiles',
   slug: 'actions-segment-profiles',
   mode: 'cloud',
-
   authentication: {
     scheme: 'custom',
-    fields: {},
-    testAuthentication: (_request) => {
-      // Return a request that tests/validates the user's credentials.
-      // If you do not have a way to validate the authentication fields safely,
-      // you can remove the `testAuthentication` function, though discouraged.
+    fields: {
+      source_write_key: {
+        label: 'Source Write Key',
+        description: 'The **Write Key** of a Segment source.',
+        type: 'string',
+        required: true
+      },
+      endpoint: {
+        label: 'Endpoint Region',
+        description: 'The region to send your data.',
+        type: 'string',
+        format: 'text',
+        choices: Object.keys(SEGMENT_ENDPOINTS).map((key) => ({
+          label: SEGMENT_ENDPOINTS[key].label,
+          value: key
+        })),
+        default: DEFAULT_SEGMENT_ENDPOINT
+      }
+    },
+    testAuthentication: async (request, { settings }) => {
+      const { source_write_key, endpoint } = settings
+
+      return request(
+        `${SEGMENT_ENDPOINTS[endpoint || DEFAULT_SEGMENT_ENDPOINT].cdn}/projects/${source_write_key}/settings`
+      )
+    }
+  },
+  extendRequest({ settings }) {
+    return {
+      headers: {
+        authorization: `Basic ${Buffer.from(settings.source_write_key + ':').toString('base64')}`
+      }
     }
   },
 
-  actions: {}
+  actions: {
+    sendGroup,
+    sendIdentify
+  }
 }
 
 export default destination

--- a/packages/destination-actions/src/destinations/segment-profiles/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/index.ts
@@ -35,17 +35,13 @@ const destination: DestinationDefinition<Settings> = {
     },
     testAuthentication: async (request, { settings }) => {
       const { endpoint } = settings
-      return request(SEGMENT_ENDPOINTS[endpoint || DEFAULT_SEGMENT_ENDPOINT].papi)
+      return request(SEGMENT_ENDPOINTS[endpoint || DEFAULT_SEGMENT_ENDPOINT].papi, {
+        headers: {
+          authorization: `Bearer ${settings.segment_papi_token}`
+        }
+      })
     }
   },
-  extendRequest({ settings }) {
-    return {
-      headers: {
-        authorization: `Bearer ${settings.segment_papi_token}`
-      }
-    }
-  },
-
   actions: {
     sendGroup,
     sendIdentify

--- a/packages/destination-actions/src/destinations/segment-profiles/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/index.ts
@@ -13,9 +13,10 @@ const destination: DestinationDefinition<Settings> = {
   authentication: {
     scheme: 'custom',
     fields: {
-      source_write_key: {
-        label: 'Source Write Key',
-        description: 'The **Write Key** of a Segment source.',
+      segment_papi_token: {
+        label: 'Segment Public API Token',
+        description:
+          'The Segment Public API requires that you have an authentication token before you send requests. [This document](https://docs.segmentapis.com/tag/Getting-Started#section/Get-an-API-token) explains how to setup a token.',
         type: 'string',
         required: true
       },
@@ -28,21 +29,19 @@ const destination: DestinationDefinition<Settings> = {
           label: SEGMENT_ENDPOINTS[key].label,
           value: key
         })),
-        default: DEFAULT_SEGMENT_ENDPOINT
+        default: DEFAULT_SEGMENT_ENDPOINT,
+        required: true
       }
     },
     testAuthentication: async (request, { settings }) => {
-      const { source_write_key, endpoint } = settings
-
-      return request(
-        `${SEGMENT_ENDPOINTS[endpoint || DEFAULT_SEGMENT_ENDPOINT].cdn}/projects/${source_write_key}/settings`
-      )
+      const { endpoint } = settings
+      return request(SEGMENT_ENDPOINTS[endpoint || DEFAULT_SEGMENT_ENDPOINT].papi)
     }
   },
   extendRequest({ settings }) {
     return {
       headers: {
-        authorization: `Basic ${Buffer.from(settings.source_write_key + ':').toString('base64')}`
+        authorization: `Bearer ${settings.segment_papi_token}`
       }
     }
   },

--- a/packages/destination-actions/src/destinations/segment-profiles/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/index.ts
@@ -1,0 +1,22 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Segment Profiles',
+  slug: 'actions-segment-profiles',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {},
+    testAuthentication: (_request) => {
+      // Return a request that tests/validates the user's credentials.
+      // If you do not have a way to validate the authentication fields safely,
+      // you can remove the `testAuthentication` function, though discouraged.
+    }
+  },
+
+  actions: {}
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/segment-profiles/properties.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/properties.ts
@@ -2,19 +2,30 @@ interface SegmentEndpoint {
   label: string
   url: string
   cdn: string
+  papi: string
 }
 
 export const SEGMENT_ENDPOINTS: { [key: string]: SegmentEndpoint } = {
   north_america: {
     label: 'North America',
     url: 'https://api.segment.io/v1',
-    cdn: 'https://cdn.segment.com/v1'
+    cdn: 'https://cdn.segment.com/v1',
+    papi: 'https://api.segmentapis.com'
   },
   europe: {
     label: 'Europe',
     url: 'https://events.eu1.segmentapis.com/v1',
-    cdn: 'https://cdn.segment.com/v1'
+    cdn: 'https://cdn.segment.com/v1',
+    papi: 'https://eu1.api.segmentapis.com'
+  },
+  stage: {
+    label: 'Staging',
+    url: 'https://api.segment.build/v1',
+    cdn: 'https://cdn.segment.build/v1',
+    papi: 'https://api.segmentapis.build'
   }
 }
 
 export const DEFAULT_SEGMENT_ENDPOINT = 'north_america'
+
+export const PAGINATION_COUNT = 10

--- a/packages/destination-actions/src/destinations/segment-profiles/properties.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/properties.ts
@@ -1,0 +1,20 @@
+interface SegmentEndpoint {
+  label: string
+  url: string
+  cdn: string
+}
+
+export const SEGMENT_ENDPOINTS: { [key: string]: SegmentEndpoint } = {
+  north_america: {
+    label: 'North America',
+    url: 'https://api.segment.io/v1',
+    cdn: 'https://cdn.segment.com/v1'
+  },
+  europe: {
+    label: 'Europe',
+    url: 'https://events.eu1.segmentapis.com/v1',
+    cdn: 'https://cdn.segment.com/v1'
+  }
+}
+
+export const DEFAULT_SEGMENT_ENDPOINT = 'north_america'

--- a/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
@@ -1,0 +1,28 @@
+import { InputField } from '@segment/actions-core/src/destination-kit/types'
+
+export const user_id: InputField = {
+  label: 'User ID',
+  description: 'Unique identifier for the user in your database. A userId or an anonymousId is required.',
+  type: 'string'
+}
+
+export const anonymous_id: InputField = {
+  label: 'Anonymous ID',
+  description:
+    'A pseudo-unique substitute for a User ID, for cases when you don’t have an absolutely unique identifier. A userId or an anonymousId is required.',
+  type: 'string'
+}
+
+export const group_id: InputField = {
+  label: 'Group ID',
+  description: 'The group or account ID a user is associated with.',
+  type: 'string'
+}
+
+export const traits: InputField = {
+  label: 'Traits',
+  description: 'Free-form dictionary of traits that describe the user or group of users.',
+  type: 'object',
+  defaultObjectUI: 'keyvalue',
+  additionalProperties: true
+}

--- a/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
@@ -26,3 +26,11 @@ export const traits: InputField = {
   defaultObjectUI: 'keyvalue',
   additionalProperties: true
 }
+
+export const engage_space: InputField = {
+  label: 'Engage Space',
+  description: 'The engage space to use for creating a record.',
+  type: 'string',
+  required: true,
+  dynamic: true
+}

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/__snapshots__/index.test.ts.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SegmentProfiles.sendGroup Should send an group event to Segment 1`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Basic ZW5nYWdlLXNwYWNlLXdyaXRla2V5Og==",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`SegmentProfiles.sendGroup Should send an group event to Segment 2`] = `
+Object {
+  "anonymousId": "arky4h2sh7k",
+  "groupId": "test-group-ks2i7e",
+  "traits": Object {
+    "industry": "Technology",
+    "name": "Example Corp",
+  },
+  "userId": "test-user-ufi5bgkko5",
+}
+`;

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for SegmentProfiles's sendGroup destination action: all fields 1`] = `
+Object {
+  "anonymousId": "tKaa(2A",
+  "groupId": "tKaa(2A",
+  "traits": Object {
+    "testType": "tKaa(2A",
+  },
+  "userId": "tKaa(2A",
+}
+`;
+
+exports[`Testing snapshot for SegmentProfiles's sendGroup destination action: required fields 1`] = `
+Object {
+  "anonymousId": "tKaa(2A",
+  "groupId": "tKaa(2A",
+  "traits": Object {},
+  "userId": "tKaa(2A",
+}
+`;

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/index.test.ts
@@ -21,7 +21,8 @@ const defaultGroupMapping = {
   },
   traits: {
     '@path': '$.traits'
-  }
+  },
+  engage_space: 'engage-space-writekey'
 }
 
 describe('SegmentProfiles.sendGroup', () => {
@@ -40,7 +41,8 @@ describe('SegmentProfiles.sendGroup', () => {
         mapping: {
           group_id: {
             '@path': '$.groupId'
-          }
+          },
+          engage_space: 'engage-space-writekey'
         }
       })
     ).rejects.toThrowError(MissingUserOrAnonymousIdThrowableError)
@@ -61,7 +63,7 @@ describe('SegmentProfiles.sendGroup', () => {
         event,
         mapping: defaultGroupMapping,
         settings: {
-          source_write_key: 'test-source-write-key',
+          segment_papi_token: 'segment-papi-token',
           endpoint: 'incorrect-endpoint'
         }
       })
@@ -87,21 +89,14 @@ describe('SegmentProfiles.sendGroup', () => {
       event,
       mapping: defaultGroupMapping,
       settings: {
-        source_write_key: 'test-source-write-key',
+        segment_papi_token: 'segment-papi-token',
         endpoint: DEFAULT_SEGMENT_ENDPOINT
       }
     })
 
     expect(responses.length).toBe(1)
     expect(responses[0].status).toEqual(200)
-    expect(responses[0].options.json).toMatchObject({
-      userId: event.userId,
-      anonymousId: event.anonymousId,
-      groupId: event.groupId,
-      traits: {
-        ...event.traits
-      },
-      context: {}
-    })
+    expect(responses[0].options.headers).toMatchSnapshot()
+    expect(responses[0].options.json).toMatchSnapshot()
   })
 })

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/index.test.ts
@@ -1,0 +1,107 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { MissingUserOrAnonymousIdThrowableError, InvalidEndpointSelectedThrowableError } from '../../errors'
+import { SEGMENT_ENDPOINTS, DEFAULT_SEGMENT_ENDPOINT } from '../../properties'
+
+const testDestination = createTestIntegration(Destination)
+
+beforeEach(() => nock.cleanAll())
+
+// Default Group Mapping
+const defaultGroupMapping = {
+  user_id: {
+    '@path': '$.userId'
+  },
+  anonymous_id: {
+    '@path': '$.anonymousId'
+  },
+  group_id: {
+    '@path': '$.groupId'
+  },
+  traits: {
+    '@path': '$.traits'
+  }
+}
+
+describe('SegmentProfiles.sendGroup', () => {
+  test('Should throw an error if `userId or` `anonymousId` is not defined', async () => {
+    const event = createTestEvent({
+      traits: {
+        name: 'Example Corp',
+        industry: 'Technology'
+      },
+      groupId: 'test-group-ks2i7e'
+    })
+
+    await expect(
+      testDestination.testAction('sendGroup', {
+        event,
+        mapping: {
+          group_id: {
+            '@path': '$.groupId'
+          }
+        }
+      })
+    ).rejects.toThrowError(MissingUserOrAnonymousIdThrowableError)
+  })
+  test('Should throw an error if Segment Endpoint is incorrectly defined', async () => {
+    const event = createTestEvent({
+      traits: {
+        name: 'Example Corp',
+        industry: 'Technology'
+      },
+      userId: 'test-user-ufi5bgkko5',
+      anonymousId: 'arky4h2sh7k',
+      groupId: 'test-group-ks2i7e'
+    })
+
+    await expect(
+      testDestination.testAction('sendGroup', {
+        event,
+        mapping: defaultGroupMapping,
+        settings: {
+          source_write_key: 'test-source-write-key',
+          endpoint: 'incorrect-endpoint'
+        }
+      })
+    ).rejects.toThrowError(InvalidEndpointSelectedThrowableError)
+  })
+
+  test('Should send an group event to Segment', async () => {
+    // Mock: Segment Group Call
+    const segmentEndpoint = SEGMENT_ENDPOINTS[DEFAULT_SEGMENT_ENDPOINT].url
+    nock(segmentEndpoint).post('/group').reply(200, { success: true })
+
+    const event = createTestEvent({
+      traits: {
+        name: 'Example Corp',
+        industry: 'Technology'
+      },
+      userId: 'test-user-ufi5bgkko5',
+      anonymousId: 'arky4h2sh7k',
+      groupId: 'test-group-ks2i7e'
+    })
+
+    const responses = await testDestination.testAction('sendGroup', {
+      event,
+      mapping: defaultGroupMapping,
+      settings: {
+        source_write_key: 'test-source-write-key',
+        endpoint: DEFAULT_SEGMENT_ENDPOINT
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toEqual(200)
+    expect(responses[0].options.json).toMatchObject({
+      userId: event.userId,
+      anonymousId: event.anonymousId,
+      groupId: event.groupId,
+      traits: {
+        ...event.traits
+      },
+      context: {}
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'sendGroup'
+const destinationSlug = 'SegmentProfiles'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/snapshot.test.ts
@@ -1,6 +1,7 @@
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import { generateTestData } from '../../../../lib/test-data'
 import destination from '../../index'
+import { DEFAULT_SEGMENT_ENDPOINT } from '../../properties'
 import nock from 'nock'
 
 const testDestination = createTestIntegration(destination)
@@ -24,7 +25,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const responses = await testDestination.testAction(actionSlug, {
       event: event,
       mapping: event.properties,
-      settings: settingsData,
+      settings: { ...settingsData, endpoint: DEFAULT_SEGMENT_ENDPOINT },
       auth: undefined
     })
 
@@ -57,7 +58,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const responses = await testDestination.testAction(actionSlug, {
       event: event,
       mapping: event.properties,
-      settings: settingsData,
+      settings: { ...settingsData, endpoint: DEFAULT_SEGMENT_ENDPOINT },
       auth: undefined
     })
 

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/generated-types.ts
@@ -2,6 +2,10 @@
 
 export interface Payload {
   /**
+   * The engage space to use for creating a record.
+   */
+  engage_space: string
+  /**
    * Unique identifier for the user in your database. A userId or an anonymousId is required.
    */
   user_id?: string

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/generated-types.ts
@@ -1,0 +1,22 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Unique identifier for the user in your database. A userId or an anonymousId is required.
+   */
+  user_id?: string
+  /**
+   * A pseudo-unique substitute for a User ID, for cases when you don’t have an absolutely unique identifier. A userId or an anonymousId is required.
+   */
+  anonymous_id?: string
+  /**
+   * The group or account ID a user is associated with.
+   */
+  group_id: string
+  /**
+   * Free-form dictionary of traits that describe the user or group of users.
+   */
+  traits?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/index.ts
@@ -2,7 +2,7 @@ import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { user_id, anonymous_id, group_id, traits, engage_space } from '../segment-properties'
-import { getEngageSpaces } from '../helperFunctions'
+import { getEngageSpaces, generateSegmentAPIAuthHeaders } from '../helperFunctions'
 import { SEGMENT_ENDPOINTS } from '../properties'
 import { MissingUserOrAnonymousIdThrowableError, InvalidEndpointSelectedThrowableError } from '../errors'
 
@@ -46,7 +46,10 @@ const action: ActionDefinition<Settings, Payload> = {
     const selectedSegmentEndpoint = SEGMENT_ENDPOINTS[settings.endpoint].url
     return request(`${selectedSegmentEndpoint}/group`, {
       method: 'POST',
-      json: groupPayload
+      json: groupPayload,
+      headers: {
+        authorization: generateSegmentAPIAuthHeaders(payload.engage_space)
+      }
     })
   }
 }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/index.ts
@@ -1,7 +1,8 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { user_id, anonymous_id, group_id, traits } from '../segment-properties'
+import { user_id, anonymous_id, group_id, traits, engage_space } from '../segment-properties'
+import { getEngageSpaces } from '../helperFunctions'
 import { SEGMENT_ENDPOINTS } from '../properties'
 import { MissingUserOrAnonymousIdThrowableError, InvalidEndpointSelectedThrowableError } from '../errors'
 
@@ -10,10 +11,19 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Send a group call to Segment’s tracking API. This is used to associate an individual user with a group',
   defaultSubscription: 'type = "group"',
   fields: {
+    engage_space,
     user_id,
     anonymous_id,
     group_id: { ...group_id, required: true },
     traits
+  },
+  dynamicFields: {
+    engage_space: async (request, { settings }) => {
+      return getEngageSpaces(request, {
+        endpoint: settings.endpoint,
+        bearerToken: settings.segment_papi_token
+      })
+    }
   },
   perform: (request, { payload, settings }) => {
     if (!payload.anonymous_id && !payload.user_id) {

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/index.test.ts.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Segment.sendIdentify Should send an identify event to Segment 1`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Basic ZW5nYWdlLXNwYWNlLXdyaXRla2V5Og==",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Segment.sendIdentify Should send an identify event to Segment 2`] = `
+Object {
+  "anonymousId": "arky4h2sh7k",
+  "groupId": undefined,
+  "traits": Object {
+    "email": "test-user@test-company.com",
+    "name": "Test User",
+  },
+  "userId": "test-user-ufi5bgkko5",
+}
+`;

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for SegmentProfiles's sendIdentify destination action: all fields 1`] = `
+Object {
+  "anonymousId": "mV[ZQcEVgZO$MX",
+  "groupId": "mV[ZQcEVgZO$MX",
+  "traits": Object {
+    "testType": "mV[ZQcEVgZO$MX",
+  },
+  "userId": "mV[ZQcEVgZO$MX",
+}
+`;
+
+exports[`Testing snapshot for SegmentProfiles's sendIdentify destination action: required fields 1`] = `
+Object {
+  "anonymousId": "mV[ZQcEVgZO$MX",
+  "groupId": "mV[ZQcEVgZO$MX",
+  "traits": Object {},
+  "userId": "mV[ZQcEVgZO$MX",
+}
+`;

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/index.test.ts
@@ -18,7 +18,8 @@ const defaultIdentifyMapping = {
   },
   traits: {
     '@path': '$.traits'
-  }
+  },
+  engage_space: 'engage-space-writekey'
 }
 
 describe('Segment.sendIdentify', () => {
@@ -34,7 +35,9 @@ describe('Segment.sendIdentify', () => {
     await expect(
       testDestination.testAction('sendIdentify', {
         event,
-        mapping: {}
+        mapping: {
+          engage_space: 'engage-space-writekey'
+        }
       })
     ).rejects.toThrowError(MissingUserOrAnonymousIdThrowableError)
   })
@@ -55,7 +58,7 @@ describe('Segment.sendIdentify', () => {
         event,
         mapping: defaultIdentifyMapping,
         settings: {
-          source_write_key: 'test-source-write-key',
+          segment_papi_token: 'segment-papi-token',
           endpoint: 'incorrect-endpoint'
         }
       })
@@ -81,20 +84,14 @@ describe('Segment.sendIdentify', () => {
       event,
       mapping: defaultIdentifyMapping,
       settings: {
-        source_write_key: 'test-source-write-key',
+        segment_papi_token: 'segment-papi-token',
         endpoint: DEFAULT_SEGMENT_ENDPOINT
       }
     })
 
     expect(responses.length).toBe(1)
     expect(responses[0].status).toEqual(200)
-    expect(responses[0].options.json).toMatchObject({
-      userId: event.userId,
-      anonymousId: event.anonymousId,
-      traits: {
-        ...event.traits
-      },
-      context: {}
-    })
+    expect(responses[0].options.headers).toMatchSnapshot()
+    expect(responses[0].options.json).toMatchSnapshot()
   })
 })

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/index.test.ts
@@ -1,0 +1,100 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { SEGMENT_ENDPOINTS, DEFAULT_SEGMENT_ENDPOINT } from '../../properties'
+import { MissingUserOrAnonymousIdThrowableError, InvalidEndpointSelectedThrowableError } from '../../errors'
+
+const testDestination = createTestIntegration(Destination)
+
+beforeEach(() => nock.cleanAll())
+
+// Default Identify Mapping
+const defaultIdentifyMapping = {
+  user_id: {
+    '@path': '$.userId'
+  },
+  anonymous_id: {
+    '@path': '$.anonymousId'
+  },
+  traits: {
+    '@path': '$.traits'
+  }
+}
+
+describe('Segment.sendIdentify', () => {
+  test('Should throw an error if `userId or` `anonymousId` is not defined', async () => {
+    const event = createTestEvent({
+      type: 'identify',
+      traits: {
+        name: 'Test User',
+        email: 'test-user@test-company.com'
+      }
+    })
+
+    await expect(
+      testDestination.testAction('sendIdentify', {
+        event,
+        mapping: {}
+      })
+    ).rejects.toThrowError(MissingUserOrAnonymousIdThrowableError)
+  })
+
+  test('Should throw an error if Segment Endpoint is incorrectly defined', async () => {
+    const event = createTestEvent({
+      type: 'identify',
+      traits: {
+        name: 'Test User',
+        email: 'test-user@test-company.com'
+      },
+      userId: 'test-user-ufi5bgkko5',
+      anonymousId: 'arky4h2sh7k'
+    })
+
+    await expect(
+      testDestination.testAction('sendIdentify', {
+        event,
+        mapping: defaultIdentifyMapping,
+        settings: {
+          source_write_key: 'test-source-write-key',
+          endpoint: 'incorrect-endpoint'
+        }
+      })
+    ).rejects.toThrowError(InvalidEndpointSelectedThrowableError)
+  })
+
+  test('Should send an identify event to Segment', async () => {
+    // Mock: Segment Identify Call
+    const segmentEndpoint = SEGMENT_ENDPOINTS[DEFAULT_SEGMENT_ENDPOINT].url
+    nock(segmentEndpoint).post('/identify').reply(200, { success: true })
+
+    const event = createTestEvent({
+      type: 'identify',
+      traits: {
+        name: 'Test User',
+        email: 'test-user@test-company.com'
+      },
+      userId: 'test-user-ufi5bgkko5',
+      anonymousId: 'arky4h2sh7k'
+    })
+
+    const responses = await testDestination.testAction('sendIdentify', {
+      event,
+      mapping: defaultIdentifyMapping,
+      settings: {
+        source_write_key: 'test-source-write-key',
+        endpoint: DEFAULT_SEGMENT_ENDPOINT
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toEqual(200)
+    expect(responses[0].options.json).toMatchObject({
+      userId: event.userId,
+      anonymousId: event.anonymousId,
+      traits: {
+        ...event.traits
+      },
+      context: {}
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'sendIdentify'
+const destinationSlug = 'SegmentProfiles'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/snapshot.test.ts
@@ -1,6 +1,7 @@
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import { generateTestData } from '../../../../lib/test-data'
 import destination from '../../index'
+import { DEFAULT_SEGMENT_ENDPOINT } from '../../properties'
 import nock from 'nock'
 
 const testDestination = createTestIntegration(destination)
@@ -24,7 +25,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const responses = await testDestination.testAction(actionSlug, {
       event: event,
       mapping: event.properties,
-      settings: settingsData,
+      settings: { ...settingsData, endpoint: DEFAULT_SEGMENT_ENDPOINT },
       auth: undefined
     })
 
@@ -57,7 +58,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const responses = await testDestination.testAction(actionSlug, {
       event: event,
       mapping: event.properties,
-      settings: settingsData,
+      settings: { ...settingsData, endpoint: DEFAULT_SEGMENT_ENDPOINT },
       auth: undefined
     })
 

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/generated-types.ts
@@ -1,0 +1,22 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Unique identifier for the user in your database. A userId or an anonymousId is required.
+   */
+  user_id?: string
+  /**
+   * A pseudo-unique substitute for a User ID, for cases when you don’t have an absolutely unique identifier. A userId or an anonymousId is required.
+   */
+  anonymous_id?: string
+  /**
+   * The group or account ID a user is associated with.
+   */
+  group_id?: string
+  /**
+   * Free-form dictionary of traits that describe the user or group of users.
+   */
+  traits?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/generated-types.ts
@@ -2,6 +2,10 @@
 
 export interface Payload {
   /**
+   * The engage space to use for creating a record.
+   */
+  engage_space: string
+  /**
    * Unique identifier for the user in your database. A userId or an anonymousId is required.
    */
   user_id?: string

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
@@ -2,7 +2,7 @@ import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { user_id, anonymous_id, group_id, traits, engage_space } from '../segment-properties'
-import { getEngageSpaces } from '../helperFunctions'
+import { getEngageSpaces, generateSegmentAPIAuthHeaders } from '../helperFunctions'
 import { SEGMENT_ENDPOINTS } from '../properties'
 import { MissingUserOrAnonymousIdThrowableError, InvalidEndpointSelectedThrowableError } from '../errors'
 
@@ -45,9 +45,12 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     const selectedSegmentEndpoint = SEGMENT_ENDPOINTS[settings.endpoint].url
-    return request(`${selectedSegmentEndpoint}/group`, {
+    return request(`${selectedSegmentEndpoint}/identify`, {
       method: 'POST',
-      json: groupPayload
+      json: groupPayload,
+      headers: {
+        authorization: generateSegmentAPIAuthHeaders(payload.engage_space)
+      }
     })
   }
 }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
@@ -1,7 +1,8 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { user_id, anonymous_id, group_id, traits } from '../segment-properties'
+import { user_id, anonymous_id, group_id, traits, engage_space } from '../segment-properties'
+import { getEngageSpaces } from '../helperFunctions'
 import { SEGMENT_ENDPOINTS } from '../properties'
 import { MissingUserOrAnonymousIdThrowableError, InvalidEndpointSelectedThrowableError } from '../errors'
 
@@ -11,10 +12,19 @@ const action: ActionDefinition<Settings, Payload> = {
     'Send an identify call to Segment’s tracking API. This is used to tie your users to their actions and record traits about them.',
   defaultSubscription: 'type = "identify"',
   fields: {
+    engage_space,
     user_id,
     anonymous_id,
     group_id,
     traits
+  },
+  dynamicFields: {
+    engage_space: async (request, { settings }) => {
+      return getEngageSpaces(request, {
+        endpoint: settings.endpoint,
+        bearerToken: settings.segment_papi_token
+      })
+    }
   },
   perform: (request, { payload, settings }) => {
     if (!payload.anonymous_id && !payload.user_id) {

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
@@ -1,0 +1,45 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { user_id, anonymous_id, group_id, traits } from '../segment-properties'
+import { SEGMENT_ENDPOINTS } from '../properties'
+import { MissingUserOrAnonymousIdThrowableError, InvalidEndpointSelectedThrowableError } from '../errors'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Send Identify',
+  description:
+    'Send an identify call to Segment’s tracking API. This is used to tie your users to their actions and record traits about them.',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    user_id,
+    anonymous_id,
+    group_id,
+    traits
+  },
+  perform: (request, { payload, settings }) => {
+    if (!payload.anonymous_id && !payload.user_id) {
+      throw MissingUserOrAnonymousIdThrowableError
+    }
+    const groupPayload: Object = {
+      userId: payload?.user_id,
+      anonymousId: payload?.anonymous_id,
+      groupId: payload?.group_id,
+      traits: {
+        ...payload?.traits
+      }
+    }
+
+    // Throw an error if endpoint is not defined or invalid
+    if (!settings.endpoint || !(settings.endpoint in SEGMENT_ENDPOINTS)) {
+      throw InvalidEndpointSelectedThrowableError
+    }
+
+    const selectedSegmentEndpoint = SEGMENT_ENDPOINTS[settings.endpoint].url
+    return request(`${selectedSegmentEndpoint}/group`, {
+      method: 'POST',
+      json: groupPayload
+    })
+  }
+}
+
+export default action


### PR DESCRIPTION
This PR introduces LinkedIn Audiences to the action-destinations repo. This deployment will support internal testing only, and will not be rolled out to customers until later.

Jira: https://segment.atlassian.net/browse/HGI-298
PRD: https://docs.google.com/document/d/1U0MnrkjAashvNd5ZAxhVOCCwpHsQB5UWrpiqSe4DjvQ
SDD: https://docs.google.com/document/d/1MPbZ87ea4NULYqFj-fTwjUNUAnezTE9lutN75qXH6mE

Staging Test Document: https://docs.google.com/document/d/1j_JA-X9AyVv1ere4DYZbYMCzo6RDtUgXphzu1K4dDrQ

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [X] [Segmenters] Tested in the staging environment


[HGI-298]: https://segment.atlassian.net/browse/HGI-298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ