### PR TITLE
[Salesforce Bulk] - Fix issue where we call `.replace` on non-string values 

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
@@ -217,26 +217,32 @@ describe('Salesforce Utils', () => {
       expect(csv).toEqual(expected)
     })
 
-    it('should handle numeric data correctly', async () => {
+    it('should handle non-string data correctly', async () => {
       const updatePayloads: GenericPayload[] = [
         {
           operation: 'update',
           enable_batching: true,
           bulkUpdateRecordId: '00',
           name: 'Krusty Krab',
-          number_of_employees: 2
+          number_of_employees: 2,
+          customFields: {
+            sellsKrabbyPatties__c: true
+          }
         },
         {
           operation: 'update',
           enable_batching: true,
           bulkUpdateRecordId: '01',
           name: 'Chum Bucket',
-          number_of_employees: 1
+          number_of_employees: 1,
+          customFields: {
+            sellsKrabbyPatties__c: false
+          }
         }
       ]
 
       const csv = buildCSVData(updatePayloads, 'Id')
-      const expected = `Name,NumberOfEmployees,Id\n"Krusty Krab","2","00"\n"Chum Bucket","1","01"\n`
+      const expected = `Name,NumberOfEmployees,sellsKrabbyPatties__c,Id\n"Krusty Krab","2","true","00"\n"Chum Bucket","1","false","01"\n`
       expect(csv).toEqual(expected)
     })
   })

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
@@ -216,5 +216,28 @@ describe('Salesforce Utils', () => {
       const expected = `Name,Description,Id\n"Sponge """"Bob"""" ""Square"" ""pants""",#N/A,"00"\n"Tentacles, ""Squidward""","Squidward Tentacles is a fictional character in the American animated television series ""SpongeBob SquarePants"".\n He is voiced by actor Rodger Bumpass and first appeared on television in the series' pilot episode on May 1, 1999.","01"\n`
       expect(csv).toEqual(expected)
     })
+
+    it('should handle numeric data correctly', async () => {
+      const updatePayloads: GenericPayload[] = [
+        {
+          operation: 'update',
+          enable_batching: true,
+          bulkUpdateRecordId: '00',
+          name: 'Krusty Krab',
+          number_of_employees: 2
+        },
+        {
+          operation: 'update',
+          enable_batching: true,
+          bulkUpdateRecordId: '01',
+          name: 'Chum Bucket',
+          number_of_employees: 1
+        }
+      ]
+
+      const csv = buildCSVData(updatePayloads, 'Id')
+      const expected = `Name,NumberOfEmployees,Id\n"Krusty Krab","2","00"\n"Chum Bucket","1","01"\n`
+      expect(csv).toEqual(expected)
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
@@ -26,6 +26,8 @@ const validateHeaderField = (field: string): void => {
 // Salesforce bulk API CSVs require double quotes to be escaped with another double quote.
 // https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/datafiles_csv_valid_record_rows.htm
 const escapeDoubleQuotes = (value: string): string => {
+  if (typeof value !== 'string') return value
+
   return value.replace(/"/g, '""')
 }
 
@@ -159,6 +161,7 @@ export const buildCSVData = (payloads: GenericPayload[], uniqueIdName: string): 
 
   csv += `${uniqueIdName}\n` + buildCSVFromHeaderMap(payloads, headerMap, payloads.length)
 
+  console.log('csv', csv)
   return csv
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
@@ -163,7 +163,6 @@ export const buildCSVData = (payloads: GenericPayload[], uniqueIdName: string): 
 
   csv += `${uniqueIdName}\n` + buildCSVFromHeaderMap(payloads, headerMap, payloads.length)
 
-  console.log('csv', csv)
   return csv
 }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR fixes an issue where we were calling `.replace` on non-string values while generating the SF Bulk CSV file. It is fixed by updating the `escapeDoubleQuotes` method to do nothing if it is called on non-strings (bools and numbers).

Original Sentry errors: https://sentry.io/organizations/segment/issues/3832330162/?project=1110287&query=is%3Aunresolved&referrer=issue-stream 

## Testing
Reproduced the sentry issue by passing in a number:
<img width="1340" alt="Screen Shot 2023-01-04 at 9 27 49 AM" src="https://user-images.githubusercontent.com/27820201/210614255-17b93f9e-11f7-4748-8137-b69ba9ae80a3.png">

After fix applied the error no longer occurs:
<img width="1461" alt="Screen Shot 2023-01-04 at 9 26 44 AM" src="https://user-images.githubusercontent.com/27820201/210614364-efbda4df-a162-4768-a8d0-94afb1312e3e.png">

Salesforce correctly updates the record:
<img width="1185" alt="Screen Shot 2023-01-04 at 9 27 07 AM" src="https://user-images.githubusercontent.com/27820201/210614472-c1458c59-0d26-4f22-90b3-b55765ff5e4e.png">

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
