### PR TITLE
Do not load heap if it's already loaded

### DIFF
--- a/packages/browser-destinations/src/destinations/heap/index.ts
+++ b/packages/browser-destinations/src/destinations/heap/index.ts
@@ -57,6 +57,10 @@ export const destination: BrowserDestinationDefinition<Settings, HeapApi> = {
   },
 
   initialize: async ({ settings }, deps) => {
+    if (window.heap) {
+      return window.heap
+    }
+
     const config = {
       disableTextCapture: settings.disableTextCapture || false,
       secureCookie: settings.secureCookie || false
@@ -68,6 +72,7 @@ export const destination: BrowserDestinationDefinition<Settings, HeapApi> = {
     window.heap.config = config
 
     await deps.loadScript(`https://cdn.heapanalytics.com/js/heap-${settings.appId}.js`)
+    // Explained here: https://stackoverflow.com/questions/14859058/why-does-the-segment-io-loader-script-push-method-names-args-onto-a-queue-which
     await deps.resolveWhen(() => Object.prototype.hasOwnProperty.call(window, 'heap'), 100)
 
     return window.heap


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

The heap snippet will fail if we load it more than once. This does a check to see if it's already been loaded and will bail if that's the case. 

## Testing

I don't think we can really test this one locally.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
