### PR TITLE
Add descriptions to Actable Predictive actions

### DIFF
--- a/packages/destination-actions/src/destinations/actable-predictive/sendCustomEvent/index.ts
+++ b/packages/destination-actions/src/destinations/actable-predictive/sendCustomEvent/index.ts
@@ -5,7 +5,7 @@ import { API_URL, formatTimestampAsUnixSeconds } from '../index'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Custom Event',
-  description: 'Send a custom event to Actable for prediction.',
+  description: 'Send a custom event to Actable for prediction. Use this to supply events that are not in Actable \'s customer view.',
   fields: {
     customer_id: {
       label: 'Customer ID',

--- a/packages/destination-actions/src/destinations/actable-predictive/sendEmailEvent/index.ts
+++ b/packages/destination-actions/src/destinations/actable-predictive/sendEmailEvent/index.ts
@@ -5,7 +5,7 @@ import { API_URL, formatTimestampAsUnixSeconds } from '../index'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Email Event',
-  description: '',
+  description: 'Send an email event to Actable for prediction. Use this to supply clicks, opens, and unsubscribes.',
   fields: {
     customer_id: {
       label: 'Customer ID',

--- a/packages/destination-actions/src/destinations/actable-predictive/sendTransactionEvent/index.ts
+++ b/packages/destination-actions/src/destinations/actable-predictive/sendTransactionEvent/index.ts
@@ -41,7 +41,7 @@ function formatPurchasePayload(purchaseEvent: Payload) {
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Transaction Event',
-  description: '',
+  description: 'Send a purchase event to Actable for prediction. Purchase events should be in v2 Commerce Spec.',
   fields: {
     customer_id: {
       label: 'Customer ID',

--- a/packages/destination-actions/src/destinations/actable-predictive/sendWebEvent/index.ts
+++ b/packages/destination-actions/src/destinations/actable-predictive/sendWebEvent/index.ts
@@ -5,7 +5,7 @@ import { API_URL, formatTimestampAsUnixSeconds } from '../index'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Web Activity Event',
-  description: '',
+  description: 'Send a Web (or app) event to Actable for prediction. Use this to supply events like page views, link clicks, etc.',
   fields: {
     customer_id: {
       label: 'Customer ID',


### PR DESCRIPTION
## Description
Actable Predictive's Action Destination does not include descriptions for all actions. This has broken the destination in private beta. This PR adds descriptions.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
