### PR TITLE
fail validation when description is missing

### DIFF
--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -77,6 +77,7 @@ export default class Validate extends Command {
 
       //Validate descriptions
       if (!action.description) {
+        this.isInvalid = true
         errors.push(new Error(`The action "${actionKey}" is missing a description.`))
       }
       for (const [fieldKey, field] of Object.entries(action.fields)) {
@@ -151,7 +152,9 @@ export default class Validate extends Command {
           }
           if (typeof fieldValues?.default !== typ) {
             errors.push(
-              new Error(`The default value for field "${field}" is of type "${typeof fieldValues?.default}", but the type is set to "${typ}".`)
+              new Error(
+                `The default value for field "${field}" is of type "${typeof fieldValues?.default}", but the type is set to "${typ}".`
+              )
             )
           }
         }


### PR DESCRIPTION
Update validation script to fail on missing descriptions. #960 has the fix for the error itself, whereas this one just fixes the validation error

## Testing
Testing completed locally
- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
