### PR TITLE
fix for Pipedrive field sync issue PE-20

### DIFF
--- a/packages/destination-actions/src/destinations/pipedrive/pipedriveApi/pipedrive-client.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/pipedriveApi/pipedrive-client.ts
@@ -20,13 +20,20 @@ const searchFieldMap: SearchFieldTypes = {
   organization: 'organizationField'
 }
 
+const searchFieldMapForDynamicFields = {
+  deal: 'dealFields',
+  person: 'personFields',
+  product: 'productFields',
+  organization: 'organizationFields'
+}
+
 interface PipedriveFieldTypes extends SearchFieldTypes {
   activity: 'activityFields'
   note: 'noteFields'
 }
 
-const pipedriveFieldMap: PipedriveFieldTypes = {
-  ...searchFieldMap,
+const pipedriveFieldMap = {
+  ...searchFieldMapForDynamicFields,
   activity: 'activityFields',
   note: 'noteFields'
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

Pipedrive Destination was built by the Pipedrive team. Customers have been reporting issues relating to a dynamic field which is not populating correctly. This is happening because the wrong URL is being requested. This fix corrects the URLs for the Dynamic fields. 

## Testing

This has only been manually tested with the actions tester. I attempted to get this to Staging but there seems to be issues getting it deployed. However I think this change should go do Production for the following reasons: 
1. The Integration is now not available for new customers to add. 
2. It's in Private Beta and only a couple of customers have configured it
3. This is a crucial fix which most customers will rely on. 

Once the fix has been verified in production I'll add a unit test.  

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
