### PR TITLE
[Salesforce] - Do not require a company field for leads

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/lead/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/index.ts
@@ -140,8 +140,8 @@ const action: ActionDefinition<Settings, Payload> = {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)
 
     if (payload.operation === 'create') {
-      if (!payload.company || !payload.last_name) {
-        throw new IntegrationError('Missing company or last_name value', 'Misconfigured required field', 400)
+      if (!payload.last_name) {
+        throw new IntegrationError('Missing last_name value', 'Misconfigured required field', 400)
       }
       return await sf.createRecord(payload, OBJECT_NAME)
     }
@@ -153,8 +153,8 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (payload.operation === 'upsert') {
-      if (!payload.company || !payload.last_name) {
-        throw new IntegrationError('Missing company or last_name value', 'Misconfigured required field', 400)
+      if (!payload.last_name) {
+        throw new IntegrationError('Missing last_name value', 'Misconfigured required field', 400)
       }
       return await sf.upsertRecord(payload, OBJECT_NAME)
     }
@@ -163,8 +163,8 @@ const action: ActionDefinition<Settings, Payload> = {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)
 
     if (payload[0].operation === 'upsert') {
-      if (!payload[0].company || !payload[0].last_name) {
-        throw new IntegrationError('Missing company or last_name value', 'Misconfigured required field', 400)
+      if (!payload[0].last_name) {
+        throw new IntegrationError('Missing last_name value', 'Misconfigured required field', 400)
       }
     }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

The Salesforce Lead object does not _always_ [require a company field](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_lead.htm#:~:text=Note-,If%20person%20account%20record%20types%20have%20been%20enabled%2C%20and%20if%20the%20value%20of%20Company%20is%20null%2C%20the%20lead%20converts%20to%20a%20person%20account.,-CompanyDunsNumber). If a customer has "Person accounts" enabled then this field is not required. We currently always require the company field to send new leads and this conflicts with the "Person accounts" functionality. 

This PR removes the requirement for that field.
Users without "Person Accounts" enabled who send a payload without `company` will receive an error from Salesforce.

## Testing
Tested by sending a payload without the `company` field to Salesforce. 
<img width="1596" alt="Screenshot 2023-01-10 at 11 56 22 AM" src="https://user-images.githubusercontent.com/27820201/212972599-7679df49-e5ec-406b-a109-041c21f981ef.png">

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
