### PR TITLE
Actions Segment Profiles for Reverse ETL - Minor Fixes

### DIFF
--- a/packages/destination-actions/src/destinations/segment-profiles/properties.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/properties.ts
@@ -17,12 +17,6 @@ export const SEGMENT_ENDPOINTS: { [key: string]: SegmentEndpoint } = {
     url: 'https://events.eu1.segmentapis.com/v1',
     cdn: 'https://cdn.segment.com/v1',
     papi: 'https://eu1.api.segmentapis.com'
-  },
-  stage: {
-    label: 'Staging',
-    url: 'https://api.segment.build/v1',
-    cdn: 'https://cdn.segment.build/v1',
-    papi: 'https://api.segmentapis.build'
   }
 }
 

--- a/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
@@ -29,7 +29,8 @@ export const traits: InputField = {
 
 export const engage_space: InputField = {
   label: 'Engage Space',
-  description: 'The engage space to use for creating a record.',
+  description:
+    'The Engage Space to use for creating a record. *Note: This field shows list of internal sources associated with your Engaged Spaces. Changes made to the Engage Space name in **Settings** will not reflect in this list unless the source associated with the Engage Space is renamed explicitly.*',
   type: 'string',
   required: true,
   dynamic: true

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * The engage space to use for creating a record.
+   * The Engage Space to use for creating a record. *Note: This field shows list of internal sources associated with your Engaged Spaces. Changes made to the Engage Space name in **Settings** will not reflect in this list unless the source associated with the Engage Space is renamed explicitly.*
    */
   engage_space: string
   /**

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * The engage space to use for creating a record.
+   * The Engage Space to use for creating a record. *Note: This field shows list of internal sources associated with your Engaged Spaces. Changes made to the Engage Space name in **Settings** will not reflect in this list unless the source associated with the Engage Space is renamed explicitly.*
    */
   engage_space: string
   /**


### PR DESCRIPTION
This PR has the following changes in Actions Segment Profiles for Reverse ETL.
* Removes the Stage dropdown field in the Region selection dropbox
* Updated to description text in description

## Testing
Testing not required as this PR introduces minor fixes.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
