### PR TITLE
Add anonymous id as a user property

### DIFF
--- a/packages/browser-destinations/src/destinations/heap/trackEvent/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/heap/trackEvent/generated-types.ts
@@ -11,4 +11,8 @@ export interface Payload {
   properties?: {
     [k: string]: unknown
   }
+  /**
+   * The segment anonymous identifier for the user
+   */
+  anonymousId?: string
 }

--- a/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
@@ -27,12 +27,24 @@ const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
       default: {
         '@path': '$.properties'
       }
+    },
+    anonymousId: {
+      type: 'string',
+      required: false,
+      description: 'The segment anonymous identifier for the user',
+      label: 'Anonymous ID',
+      default: {
+        '@path': '$.anonymousId'
+      }
     }
   },
   perform: (heap, event) => {
     const defaultEventProperties = { segment_library: HEAP_SEGMENT_LIBRARY_NAME }
     const eventProperties = Object.assign(defaultEventProperties, event.payload.properties ?? {})
     heap.track(event.payload.name, eventProperties)
+    if (event.payload.anonymousId) {
+      heap.addUserProperties({ anonymous_id: event.payload.anonymousId })
+    }
   }
 }
 


### PR DESCRIPTION
Adding the anonymous id as a user property to the events. 

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
