### PR TITLE
[STRATCONN-1857] Update setting description in Google Ads Conversions

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Settings {
   /**
-   * You will find this information in the event snippet for your conversion action, for example `send_to: AW-CONVERSION_ID/AW-CONVERSION_LABEL`. In the sample snippet, AW-CONVERSION_ID stands for the conversion ID unique to your account. Enter the conversion Id, without the AW- prefix. **Required if you are using a mapping that sends data to the legacy Google Enhanced Conversions API.**
+   * You will find this information in the event snippet for your conversion action, for example `send_to: AW-CONVERSION_ID/AW-CONVERSION_LABEL`. In the sample snippet, AW-CONVERSION_ID stands for the conversion ID unique to your account. Enter the conversion ID, without the AW- prefix. **Required if you are using a mapping that sends data to the legacy Google Enhanced Conversions API (i.e. Upload Enhanced Conversion (Legacy) Action).**
    */
   conversionTrackingId?: string
   /**

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -30,7 +30,7 @@ const destination: DestinationDefinition<Settings> = {
       conversionTrackingId: {
         label: 'Conversion ID',
         description:
-          'You will find this information in the event snippet for your conversion action, for example `send_to: AW-CONVERSION_ID/AW-CONVERSION_LABEL`. In the sample snippet, AW-CONVERSION_ID stands for the conversion ID unique to your account. Enter the conversion Id, without the AW- prefix. **Required if you are using a mapping that sends data to the legacy Google Enhanced Conversions API.**',
+          'You will find this information in the event snippet for your conversion action, for example `send_to: AW-CONVERSION_ID/AW-CONVERSION_LABEL`. In the sample snippet, AW-CONVERSION_ID stands for the conversion ID unique to your account. Enter the conversion ID, without the AW- prefix. **Required if you are using a mapping that sends data to the legacy Google Enhanced Conversions API (i.e. Upload Enhanced Conversion (Legacy) Action).**',
         type: 'string'
       },
       customerId: {


### PR DESCRIPTION
This PR addresses [STRATCONN-1857](https://segment.atlassian.net/browse/STRATCONN-1857) to make the settings description more clear. Since we use 2 different API's for this destination, there are different settings that are required based on which API endpoint the action you are using is sending data to. This change will hopefully make it more clear that you only need `conversionTrackingId` for the `Upload Enhanced Conversion (Legacy) Action`.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment


[STRATCONN-1857]: https://segment.atlassian.net/browse/STRATCONN-1857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ