### PR TITLE
Revert "Subscribe to more events (#971)"

### DIFF
--- a/packages/destination-actions/src/destinations/heap/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/heap/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -19,6 +19,7 @@ Object {
 exports[`Testing snapshot for actions-heap destination: trackEvent action - all fields 1`] = `
 Object {
   "app_id": "kFJwrNh$DP38FB",
+  "event": "kFJwrNh$DP38FB",
   "idempotency_key": "kFJwrNh$DP38FB",
   "identity": "kFJwrNh$DP38FB",
   "properties": Object {
@@ -32,6 +33,7 @@ Object {
 exports[`Testing snapshot for actions-heap destination: trackEvent action - required fields 1`] = `
 Object {
   "app_id": "kFJwrNh$DP38FB",
+  "event": "kFJwrNh$DP38FB",
   "idempotency_key": "kFJwrNh$DP38FB",
   "identity": "kFJwrNh$DP38FB",
   "properties": Object {

--- a/packages/destination-actions/src/destinations/heap/index.ts
+++ b/packages/destination-actions/src/destinations/heap/index.ts
@@ -8,7 +8,7 @@ import identifyUser from './identifyUser'
 const presets: DestinationDefinition['presets'] = [
   {
     name: 'Track Calls',
-    subscribe: 'type = "track" or type = "page" or type = "screen"',
+    subscribe: 'type = "track"',
     partnerAction: 'trackEvent',
     mapping: defaultValues(trackEvent.fields)
   },

--- a/packages/destination-actions/src/destinations/heap/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/heap/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Testing snapshot for Heap's trackEvent destination action: all fields 1`] = `
 Object {
   "app_id": "xqYHVWXiU0In",
+  "event": "xqYHVWXiU0In",
   "idempotency_key": "xqYHVWXiU0In",
   "identity": "xqYHVWXiU0In",
   "properties": Object {
@@ -16,6 +17,7 @@ Object {
 exports[`Testing snapshot for Heap's trackEvent destination action: required fields 1`] = `
 Object {
   "app_id": "xqYHVWXiU0In",
+  "event": "xqYHVWXiU0In",
   "idempotency_key": "xqYHVWXiU0In",
   "identity": "xqYHVWXiU0In",
   "properties": Object {

--- a/packages/destination-actions/src/destinations/heap/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/heap/trackEvent/__tests__/index.test.ts
@@ -124,29 +124,4 @@ describe('Heap.trackEvent', () => {
     expect(responses[0].status).toBe(200)
     expect(responses[0].data).toMatchObject({})
   })
-
-  it('should get event field for different event type', async () => {
-    const event: Partial<SegmentEvent> = createTestEvent({
-      timestamp,
-      event: undefined,
-      userId,
-      messageId,
-      name: 'Home Page',
-      type: 'page'
-    })
-    body.identity = userId
-    body.event = 'Home Page'
-    nock('https://heapanalytics.com').post('/api/track', body).reply(200, body)
-
-    const responses = await testDestination.testAction('trackEvent', {
-      event,
-      useDefaultMappings: true,
-      settings: {
-        appId: HEAP_TEST_APP_ID
-      }
-    })
-    expect(responses.length).toBe(1)
-    expect(responses[0].status).toBe(200)
-    expect(responses[0].data).toEqual(expect.objectContaining({ event: 'Home Page' }))
-  })
 })

--- a/packages/destination-actions/src/destinations/heap/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/heap/trackEvent/generated-types.ts
@@ -14,9 +14,9 @@ export interface Payload {
    */
   anonymous_id?: string | null
   /**
-   * Name of the user action. This only exists on track events. Limited to 1024 characters.
+   * The name of the event. Limited to 1024 characters.
    */
-  event?: string
+  event: string
   /**
    * An object with key-value properties you want associated with the event. Each key and property must either be a number or string with fewer than 1024 characters.
    */
@@ -31,12 +31,4 @@ export interface Payload {
    * The name of the SDK used to send events
    */
   library_name?: string
-  /**
-   * The type of call. Can be track, page, or screen.
-   */
-  type: string
-  /**
-   * The name of the page or screen being viewed. This only exists for page and screen events.
-   */
-  name?: string
 }

--- a/packages/destination-actions/src/destinations/heap/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/heap/trackEvent/index.ts
@@ -11,7 +11,7 @@ type HeapEvent = {
   app_id: string
   identity?: string
   user_id?: number
-  event: string | undefined
+  event: string
   properties: {
     [k: string]: unknown
   }
@@ -22,7 +22,7 @@ type HeapEvent = {
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track Event',
   description: 'Send an event to Heap.',
-  defaultSubscription: 'type = "track" or type = "page" or type = "screen"',
+  defaultSubscription: 'type = "track"',
   fields: {
     message_id: {
       label: 'Message ID',
@@ -53,9 +53,10 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     event: {
-      label: 'Track Event Type',
+      label: 'Event Type',
       type: 'string',
-      description: 'Name of the user action. This only exists on track events. Limited to 1024 characters.',
+      description: 'The name of the event. Limited to 1024 characters.',
+      required: true,
       default: {
         '@path': '$.event'
       }
@@ -84,23 +85,6 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.context.library.name'
       }
-    },
-    type: {
-      label: 'Type',
-      type: 'string',
-      description: 'The type of call. Can be track, page, or screen.',
-      required: true,
-      default: {
-        '@path': '$.type'
-      }
-    },
-    name: {
-      label: 'Page or Screen Name',
-      type: 'string',
-      description: 'The name of the page or screen being viewed. This only exists for page and screen events.',
-      default: {
-        '@path': '$.name'
-      }
     }
   },
   perform: (request, { payload, settings }) => {
@@ -117,7 +101,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const eventProperties = Object.assign(defaultEventProperties, flatten)
     const event: HeapEvent = {
       app_id: settings.appId,
-      event: getEventName(payload),
+      event: payload.event,
       properties: eventProperties,
       idempotency_key: payload.message_id
     }
@@ -138,18 +122,6 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'post',
       json: event
     })
-  }
-}
-
-const getEventName = (payload: Payload) => {
-  switch (payload.type) {
-    case 'track':
-      return payload.event
-    case 'page':
-    case 'screen':
-      return payload.name
-    default:
-      return undefined
   }
 }
 


### PR DESCRIPTION
This reverts commit b0192dc2f909ee6f6db9b60773b9c39af891e59f.
Reverts changes to `actions-heap-cloud` in response to sev-2-crooked-squirrel-2023-01-19-mitigated.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
