### PR TITLE
ACT-362 Brackets Support

### DIFF
--- a/packages/core/src/__tests__/get.iso.test.ts
+++ b/packages/core/src/__tests__/get.iso.test.ts
@@ -22,6 +22,7 @@ const fixtures: Record<string, unknown> = {
   a: obj.a,
   'a.b': obj.a.b,
   "['a'].b": obj.a.b,
+  '["a"].b': obj.a.b,
   'a.b.c': obj.a.b.c,
   'a.b.d': obj.a.b.d,
   'a.b.e': obj.a.b.e,

--- a/packages/core/src/__tests__/get.iso.test.ts
+++ b/packages/core/src/__tests__/get.iso.test.ts
@@ -10,13 +10,18 @@ const obj = {
     },
     h: null
   },
-  u: undefined
+  u: undefined,
+  '[txt] non': true,
+  '[txt] nest': {
+    inner: true
+  }
 }
 
 const fixtures: Record<string, unknown> = {
   '': obj,
   a: obj.a,
   'a.b': obj.a.b,
+  "['a'].b": obj.a.b,
   'a.b.c': obj.a.b.c,
   'a.b.d': obj.a.b.d,
   'a.b.e': obj.a.b.e,
@@ -24,6 +29,8 @@ const fixtures: Record<string, unknown> = {
   'a.b.f[0].g': obj.a.b.f[0].g,
   'a.h': obj.a.h,
   'a.b.x': undefined,
+  '[txt] non': true,
+  '[txt] nest.inner': true,
   u: undefined
 }
 

--- a/packages/core/src/__tests__/get.test.ts
+++ b/packages/core/src/__tests__/get.test.ts
@@ -21,6 +21,8 @@ const fixtures: Record<string, unknown> = {
   '': obj,
   a: obj.a,
   'a.b': obj.a.b,
+  "['a'].b": obj.a.b,
+  '["a"].b': obj.a.b,
   'a.b.c': obj.a.b.c,
   'a.b.d': obj.a.b.d,
   'a.b.e': obj.a.b.e,
@@ -28,12 +30,10 @@ const fixtures: Record<string, unknown> = {
   'a.b.f[0].g': obj.a.b.f[0].g,
   'a.h': obj.a.h,
   'a.b.x': undefined,
+  '[txt] non': true,
+  '[txt] nest.inner': true,
   u: undefined
 }
-
-/** note that this test is basically a duplicate of the get.test.ts file,
- * only with the tests that safari can't handle due to its lack of lookbehind (ES2018)
- * grouping removed so it passes in webkit */
 
 describe('get', () => {
   for (const path of Object.keys(fixtures)) {

--- a/packages/core/src/get.ts
+++ b/packages/core/src/get.ts
@@ -7,7 +7,6 @@ let arrayRe: RegExp
 
 try {
   arrayRe = new RegExp(`\\[(?="|'|\\d)|\\.|(?<="|'|\\d)]+`, 'g')
-  // arrayRe = /\[(?="|'|\d)|\.|(?<="|'|\d)]+/g
 } catch (e) {
   //safari does not support lookbehind operator so we will default
   //to a simpler approach wherein [bar] will not be a valid key

--- a/packages/core/src/get.ts
+++ b/packages/core/src/get.ts
@@ -6,7 +6,8 @@
 let arrayRe: RegExp
 
 try {
-  arrayRe = /\[(?="|'|\d)|\.|(?<="|'|\d)]+/g
+  // eslint-disable-next-line no-useless-escape
+  arrayRe = new RegExp(`\[(?="|'|\d)|\.|(?<="|'|\d)]+`, 'g')
 } catch (e) {
   //safari does not support lookbehind operator so we will default
   //to a simpler approach wherein [bar] will not be a valid key

--- a/packages/core/src/get.ts
+++ b/packages/core/src/get.ts
@@ -2,6 +2,7 @@
  * Lightweight alternative to lodash.get with similar coverage
  * Supports basic path lookup via dot notation `'foo.bar[0].baz'` or an array ['foo', 'bar', '0', 'baz']
  */
+
 export function get<T = unknown>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   obj: any,
@@ -15,7 +16,13 @@ export function get<T = unknown>(
 
   // Check if path is string or array. Regex : ensure that we do not have '.' and brackets.
   // Regex explained: https://regexr.com/58j0k
-  const pathArray = Array.isArray(path) ? path : (path.match(/([^[.\]])+/g) as string[])
+  const pathArray = Array.isArray(path)
+    ? path
+    : path
+        .split(/\[(?='|\d)|\.|(?<='|\d)]+/g)
+        .filter((f) => f)
+        .map((s) => s.replace(/'/g, ''))
+  // const pathArray = Array.isArray(path) ? path : (path.match(/([^[.\]])+/g) as string[])
 
   // Find value if exist return otherwise return undefined value
   return pathArray.reduce((prevObj, key) => prevObj && prevObj[key], obj)

--- a/packages/core/src/get.ts
+++ b/packages/core/src/get.ts
@@ -19,9 +19,9 @@ export function get<T = unknown>(
   const pathArray = Array.isArray(path)
     ? path
     : path
-        .split(/\[(?='|\d)|\.|(?<='|\d)]+/g)
+        .split(/\[(?="|'|\d)|\.|(?<="|'|\d)]+/g)
         .filter((f) => f)
-        .map((s) => s.replace(/'/g, ''))
+        .map((s) => s.replace(/'|"/g, ''))
   // const pathArray = Array.isArray(path) ? path : (path.match(/([^[.\]])+/g) as string[])
 
   // Find value if exist return otherwise return undefined value

--- a/packages/core/src/get.ts
+++ b/packages/core/src/get.ts
@@ -6,8 +6,8 @@
 let arrayRe: RegExp
 
 try {
-  // eslint-disable-next-line no-useless-escape
-  arrayRe = new RegExp(`\[(?="|'|\d)|\.|(?<="|'|\d)]+`, 'g')
+  arrayRe = new RegExp(`\\[(?="|'|\\d)|\\.|(?<="|'|\\d)]+`, 'g')
+  // arrayRe = /\[(?="|'|\d)|\.|(?<="|'|\d)]+/g
 } catch (e) {
   //safari does not support lookbehind operator so we will default
   //to a simpler approach wherein [bar] will not be a valid key

--- a/packages/core/src/get.ts
+++ b/packages/core/src/get.ts
@@ -3,6 +3,16 @@
  * Supports basic path lookup via dot notation `'foo.bar[0].baz'` or an array ['foo', 'bar', '0', 'baz']
  */
 
+let arrayRe: RegExp
+
+try {
+  arrayRe = /\[(?="|'|\d)|\.|(?<="|'|\d)]+/g
+} catch (e) {
+  //safari does not support lookbehind operator so we will default
+  //to a simpler approach wherein [bar] will not be a valid key
+  arrayRe = /\[|\.|]+/g
+}
+
 export function get<T = unknown>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   obj: any,
@@ -22,7 +32,7 @@ export function get<T = unknown>(
   const pathArray = Array.isArray(path)
     ? path
     : path
-        .split(/\[(?="|'|\d)|\.|(?<="|'|\d)]+/g)
+        .split(arrayRe)
         .filter((f) => f)
         .map((s) => s.replace(/'|"/g, ''))
 

--- a/packages/core/src/get.ts
+++ b/packages/core/src/get.ts
@@ -14,15 +14,17 @@ export function get<T = unknown>(
   // Not defined
   if (path === null || path == undefined) return undefined
 
-  // Check if path is string or array. Regex : ensure that we do not have '.' and brackets.
-  // Regex explained: https://regexr.com/58j0k
+  // Check if path is string or array. Regex : splits the path into valid array of path chunks
+  // we support an extra edge case that lodash does not around brackets
+  // a['b'] = ['a','b']
+  // a[b] = ['a[b]'] //brackets without numeric index or a string are considered part of the key
+  // Regex explained: https://regexr.com/74m2m
   const pathArray = Array.isArray(path)
     ? path
     : path
         .split(/\[(?="|'|\d)|\.|(?<="|'|\d)]+/g)
         .filter((f) => f)
         .map((s) => s.replace(/'|"/g, ''))
-  // const pathArray = Array.isArray(path) ? path : (path.match(/([^[.\]])+/g) as string[])
 
   // Find value if exist return otherwise return undefined value
   return pathArray.reduce((prevObj, key) => prevObj && prevObj[key], obj)

--- a/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
@@ -520,20 +520,6 @@ describe('@path', () => {
     expect(output).toStrictEqual({ neat: 'bar' })
   })
 
-  test('invalid bracket-spaced nested value', () => {
-    const output = transform(
-      { neat: { '@path': "$.integrations['Actions Amplitude'].session_id" } },
-      {
-        integrations: {
-          'Actions Amplitude': {
-            session_id: 'bar'
-          }
-        }
-      }
-    )
-    expect(output).toStrictEqual({})
-  })
-
   test('invalid nested value type', () => {
     const output = transform({ neat: { '@path': '$.foo.bar.baz' } }, { foo: 'bar' })
     expect(output).toStrictEqual({})


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Adds support for nonstandard but valid JS keys in path and template directives where brackets are included in the key itself. 

ie `{"[key]":"value"}`

## Testing

Tested in action tester in both safari and chrome + added new suite of browser tests based on @silesky 's awesome work

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
