### PR TITLE
Pipedrive actions PE-20

### DIFF
--- a/packages/destination-actions/src/destinations/pipedrive/createUpdateActivity/generated-types.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/createUpdateActivity/generated-types.ts
@@ -42,7 +42,7 @@ export interface Payload {
    */
   description?: string
   /**
-   * Note of the Activity (HTML format)
+   * Note of the Activity (Accepts plain text and HTML)
    */
   note?: string
   /**
@@ -50,7 +50,7 @@ export interface Payload {
    */
   due_date?: string
   /**
-   * Due time of the Activity in UTC. Format: HH:MM
+   * Due time of the Activity. Format: HH:MM
    */
   due_time?: string
   /**

--- a/packages/destination-actions/src/destinations/pipedrive/createUpdateActivity/index.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/createUpdateActivity/index.ts
@@ -9,20 +9,23 @@ const fieldHandler = PipedriveClient.fieldHandler
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Create or update an Activity',
   description: "Update an Activity in Pipedrive or create one if it doesn't exist.",
-  defaultSubscription: 'type = "track"',
+  defaultSubscription: 'type = "track" and event = "Activity Upserted"',
   fields: {
     activity_id: {
       label: 'Activity ID',
       description: 'ID of Activity in Pipedrive to Update. If left empty, a new one will be created',
       type: 'integer',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.properties.activity_id'
+      }
     },
     person_match_field: {
       label: 'Person match field',
       description: 'If present, used instead of field in settings to find existing person in Pipedrive.',
       type: 'string',
       required: false,
-      dynamic: true,
+      dynamic: true
     },
     person_match_value: {
       label: 'Person match value',
@@ -33,13 +36,12 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.userId'
       }
     },
-
     organization_match_field: {
       label: 'Organization match field',
       description: 'If present, used instead of field in settings to find existing organization in Pipedrive.',
       type: 'string',
       required: false,
-      dynamic: true,
+      dynamic: true
     },
     organization_match_value: {
       label: 'Organization match value',
@@ -47,16 +49,15 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: false,
       default: {
-        '@path': '$.userId'
+        '@path': '$.context.groupId'
       }
     },
-
     deal_match_field: {
       label: 'Deal match field',
       description: 'If present, used instead of field in settings to find existing deal in Pipedrive.',
       type: 'string',
       required: false,
-      dynamic: true,
+      dynamic: true
     },
     deal_match_value: {
       label: 'Deal match value',
@@ -64,60 +65,83 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: false,
       default: {
-        '@path': '$.userId'
+        '@path': '$.properties.deal_id'
       }
     },
-
     subject: {
       label: 'Activity Subject',
       description:
         'Subject of the Activity. When value for subject is not set, it will be given a default value `Call`.',
       type: 'string',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.properties.subject'
+      }
     },
     type: {
       label: 'Type',
       description:
         'Type of the Activity. This is in correlation with the key_string parameter of ActivityTypes. When value for type is not set, it will be given a default value `Call`',
       type: 'string',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.properties.type'
+      }
     },
     description: {
       label: 'Description',
       description:
         'Additional details about the Activity that is synced to your external calendar. Unlike the note added to the Activity, the description is publicly visible to any guests added to the Activity.',
       type: 'string',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.properties.description'
+      }
     },
     note: {
       label: 'Note',
-      description: 'Note of the Activity (HTML format)',
+      description: 'Note of the Activity (Accepts plain text and HTML)',
       type: 'string',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.properties.note'
+      }
     },
     due_date: {
       label: 'Due Date',
       description: 'Due date of the Activity. Format: YYYY-MM-DD',
       type: 'string',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.properties.due_date'
+      }
     },
     due_time: {
       label: 'Due Time',
-      description: 'Due time of the Activity in UTC. Format: HH:MM',
+      description: 'Due time of the Activity. Format: HH:MM',
       type: 'string',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.properties.due_time'
+      }
     },
     duration: {
       label: 'Duration',
       description: 'Duration of the Activity. Format: HH:MM',
       type: 'string',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.properties.duration'
+      }
     },
     done: {
       label: 'Done',
       description: 'Whether the Activity is done or not.',
       type: 'boolean',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.properties.done'
+      }
     }
   },
 

--- a/packages/destination-actions/src/destinations/pipedrive/createUpdateDeal/index.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/createUpdateDeal/index.ts
@@ -9,9 +9,9 @@ import { addCustomFieldsFromPayloadToEntity } from '../utils'
 const fieldHandler = PipedriveClient.fieldHandler
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Create or Update a Deal',
+  title: 'Create or update a Deal',
   description: "Update a Deal in Pipedrive or create it if it doesn't exist yet.",
-  defaultSubscription: 'type = "track"',
+  defaultSubscription: 'type = "track" and event = "Deal Upserted"',
   fields: {
     deal_match_field: {
       label: 'Deal match field',
@@ -26,7 +26,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: false,
       default: {
-        '@path': '$.userId'
+        '@path': '$.properties.deal_id'
       }
     },
     person_match_field: {
@@ -45,7 +45,6 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.userId'
       }
     },
-
     organization_match_field: {
       label: 'Organization match field',
       description: 'If present, used instead of field in settings to find existing organization in Pipedrive.',
@@ -59,35 +58,46 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: false,
       default: {
-        '@path': '$.userId'
+        '@path': '$.context.groupId'
       }
     },
-
     title: {
       label: 'Title',
       description: 'Deal title  (required for new Leads)',
       type: 'string',
-      required: true
+      required: true,
+      default: {
+        '@path': '$.properties.title'
+      }
     },
     value: {
       label: 'Value',
       description: 'Value of the deal. If omitted, value will be set to 0.',
       type: 'string',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.properties.value'
+      }
     },
     currency: {
       label: 'Currency',
       description:
         'Currency of the deal. Accepts a 3-character currency code. If omitted, currency will be set to the default currency of the authorized user.',
       type: 'string',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.properties.currency'
+      }
     },
     stage_id: {
       label: 'Stage ID',
       description:
         "The ID of a stage this Deal will be placed in a pipeline (note that you can't supply the ID of the pipeline as this will be assigned automatically based on stage_id). If omitted, the deal will be placed in the first stage of the default pipeline.",
       type: 'number',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.properties.stage_id'
+      }
     },
     status: {
       label: 'Status',
@@ -105,20 +115,29 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Expected Close Date',
       description: 'The expected close date of the Deal. In ISO 8601 format: YYYY-MM-DD.',
       type: 'string',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.properties.expected_close_date'
+      }
     },
     probability: {
       label: 'Success Probability',
       description:
         'Deal success probability percentage. Used/shown only when deal_probability for the pipeline of the deal is enabled.',
       type: 'number',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.properties.success_probability'
+      }
     },
     lost_reason: {
       label: 'Lost Reason',
       description: 'Optional message about why the deal was lost (to be used when status=lost)',
       type: 'string',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.properties.lost_reason'
+      }
     },
     visible_to: {
       label: 'Visible To',
@@ -188,6 +207,10 @@ const action: ActionDefinition<Settings, Payload> = {
         400
       )
     }
+    if (!deal.id)
+      if (payload.deal_match_field && payload.deal_match_value)
+        // if there's no deal.id then we're doing a create operation, so we should include the deal_match field info so it's recorded on the new entity
+        Object.assign(deal, { [payload.deal_match_field]: payload.deal_match_value })
 
     addCustomFieldsFromPayloadToEntity(payload, deal)
 

--- a/packages/destination-actions/src/destinations/pipedrive/createUpdateLead/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/createUpdateLead/__tests__/index.test.ts
@@ -6,7 +6,7 @@ const testDestination = createTestIntegration(Destination)
 
 const PIPEDRIVE_API_KEY = 'random string'
 const PIPEDRIVE_DOMAIN = 'companydomain'
-const LEAD_ID = 31337
+const LEAD_ID = '31337'
 
 describe('Pipedrive.createUpdateLead', () => {
   it('should create lead', async () => {
@@ -34,12 +34,12 @@ describe('Pipedrive.createUpdateLead', () => {
 
   it('should update lead', async () => {
     const scope = nock(`https://${PIPEDRIVE_DOMAIN}.pipedrive.com/api/v1`)
-      .put(`/leads/${LEAD_ID}`, {
+      .patch(`/leads/${LEAD_ID}`, {
         title: 'New Title',
         organization_id: 520,
         value: {
-          currency: 'EUR',
-          amount: 3256.41
+          amount: 3256.41,
+          currency: 'EUR'
         }
       })
       .query({ api_token: PIPEDRIVE_API_KEY })
@@ -59,10 +59,8 @@ describe('Pipedrive.createUpdateLead', () => {
         title: 'New Title',
         organization_match_field: 'someOrgField',
         organization_match_value: 'Pipedrive OÜ',
-        value: {
-          currency: 'EUR',
-          amount: 3256.41
-        },
+        amount: 3256.41,
+        currency: 'EUR',
         lead_id: LEAD_ID
       },
       settings: { apiToken: PIPEDRIVE_API_KEY, domain: PIPEDRIVE_DOMAIN }

--- a/packages/destination-actions/src/destinations/pipedrive/createUpdateLead/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/createUpdateLead/__tests__/snapshot.test.ts
@@ -69,7 +69,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       .reply(200, {
         data: [{ id: 42 }]
       })
-    nock(basePath).persist().put(/.*/).reply(200)
+    nock(basePath).persist().patch(/.*/).reply(200)
 
     const event = createTestEvent({
       properties: eventData

--- a/packages/destination-actions/src/destinations/pipedrive/createUpdateLead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/createUpdateLead/generated-types.ts
@@ -4,7 +4,7 @@ export interface Payload {
   /**
    * ID of Lead in Pipedrive to Update. If left empty, a new one will be created
    */
-  lead_id?: number
+  lead_id?: string
   /**
    * If present, used instead of field in settings to find existing person in Pipedrive.
    */
@@ -28,13 +28,11 @@ export interface Payload {
   /**
    * Potential value of the lead
    */
-  value?: {
-    amount?: number
-    /**
-     * Three-letter code of the currency, e.g. USD
-     */
-    currency?: string
-  }
+  amount?: number
+  /**
+   * Three-letter code of the currency, e.g. USD
+   */
+  currency?: string
   /**
    * The date of when the Deal which will be created from the Lead is expected to be closed. In ISO 8601 format: YYYY-MM-DD.
    */
@@ -47,10 +45,4 @@ export interface Payload {
    * If the lead is created, use this timestamp as the creation timestamp. Format: YYY-MM-DD HH:MM:SS
    */
   add_time?: string | number
-  /**
-   * New values for custom fields.
-   */
-  custom_fields?: {
-    [k: string]: unknown
-  }
 }

--- a/packages/destination-actions/src/destinations/pipedrive/createUpdateNote/generated-types.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/createUpdateNote/generated-types.ts
@@ -6,9 +6,9 @@ export interface Payload {
    */
   note_id?: number
   /**
-   * ID of Lead in Pipedrive to link to.  One of Lead, Person, Organization or Deal must be linked!
+   * ID of Lead in Pipedrive to link to. One of Lead, Person, Organization or Deal must be linked!
    */
-  lead_id?: number
+  lead_id?: string
   /**
    * If present, used instead of field in settings to find existing person in Pipedrive.
    */
@@ -34,7 +34,7 @@ export interface Payload {
    */
   deal_match_value?: string
   /**
-   * Content of the note in HTML format. Subject to sanitization on the back-end.
+   * Content of the note in text or HTML format. Subject to sanitization on the back-end.
    */
   content: string
 }

--- a/packages/destination-actions/src/destinations/pipedrive/createUpdateNote/index.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/createUpdateNote/index.ts
@@ -8,28 +8,34 @@ import { IntegrationError } from '@segment/actions-core'
 const fieldHandler = PipedriveClient.fieldHandler
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Create or Update a Note',
+  title: 'Create or update a Note',
   description: "Update a Note in Pipedrive or create it if it doesn't exist yet.",
-  defaultSubscription: 'type = "track"',
+  defaultSubscription: 'type = "track" and event = "Note Upserted"',
   fields: {
     note_id: {
       label: 'Note ID',
       description: 'ID of Note in Pipedrive to Update. If left empty, a new one will be created',
       type: 'integer',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.properties.note_id'
+      }
     },
     lead_id: {
       label: 'Lead ID',
-      description: 'ID of Lead in Pipedrive to link to.  One of Lead, Person, Organization or Deal must be linked!',
-      type: 'integer',
-      required: false
+      description: 'ID of Lead in Pipedrive to link to. One of Lead, Person, Organization or Deal must be linked!',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.properties.lead_id'
+      }
     },
     person_match_field: {
       label: 'Person match field',
       description: 'If present, used instead of field in settings to find existing person in Pipedrive.',
       type: 'string',
       required: false,
-      dynamic: true,
+      dynamic: true
     },
     person_match_value: {
       label: 'Person match value',
@@ -40,13 +46,12 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.userId'
       }
     },
-
     organization_match_field: {
       label: 'Organization match field',
       description: 'If present, used instead of field in settings to find existing organization in Pipedrive.',
       type: 'string',
       required: false,
-      dynamic: true,
+      dynamic: true
     },
     organization_match_value: {
       label: 'Organization match value',
@@ -54,16 +59,15 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: false,
       default: {
-        '@path': '$.userId'
+        '@path': '$.context.groupId'
       }
     },
-
     deal_match_field: {
       label: 'Deal match field',
       description: 'If present, used instead of field in settings to find existing deal in Pipedrive.',
       type: 'string',
       required: false,
-      dynamic: true,
+      dynamic: true
     },
     deal_match_value: {
       label: 'Deal match value',
@@ -71,15 +75,17 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: false,
       default: {
-        '@path': '$.userId'
+        '@path': '$.properties.deal_id'
       }
     },
-
     content: {
       label: 'Note Content',
-      description: 'Content of the note in HTML format. Subject to sanitization on the back-end.',
+      description: 'Content of the note in text or HTML format. Subject to sanitization on the back-end.',
       type: 'string',
-      required: true
+      required: true,
+      default: {
+        '@path': '$.properties.content'
+      }
     }
   },
 

--- a/packages/destination-actions/src/destinations/pipedrive/createUpdateOrganization/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/createUpdateOrganization/__tests__/index.test.ts
@@ -11,21 +11,25 @@ const ORGANIZATION_ID = 33333
 describe('Pipedrive.createUpdateOrganization', () => {
   it('should create organization if none exists', async () => {
     const scope = nock(`https://${PIPEDRIVE_DOMAIN}.pipedrive.com/api/v1`)
-      .post('/organizations', { name: 'Acme Corp' })
+      .post('/organizations', { name: 'Acme Corp', custom_org_id: 'non_existant_custom_org_id_value' })
       .query({ api_token: PIPEDRIVE_API_KEY })
       .reply(200)
 
     scope
       .get(/.*/)
       .query((q) => {
-        return q.field_key === 'name' && q.field_type === 'organizationField' && q.term === 'Does not exist'
+        return (
+          q.field_key === 'custom_org_id' &&
+          q.field_type === 'organizationField' &&
+          q.term === 'non_existant_custom_org_id_value'
+        )
       })
       .reply(200, {
         data: []
       })
 
     await testDestination.testAction('createUpdateOrganization', {
-      mapping: { name: 'Acme Corp', match_field: 'name', match_value: 'Does not exist' },
+      mapping: { name: 'Acme Corp', match_field: 'custom_org_id', match_value: 'non_existant_custom_org_id_value' },
       settings: { apiToken: PIPEDRIVE_API_KEY, domain: PIPEDRIVE_DOMAIN }
     })
 

--- a/packages/destination-actions/src/destinations/pipedrive/createUpdateOrganization/index.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/createUpdateOrganization/index.ts
@@ -25,14 +25,17 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: true,
       default: {
-        '@path': '$.userId'
+        '@path': '$.groupId'
       }
     },
     name: {
       label: 'Organization Name',
       description: 'Name of the organization',
       type: 'string',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.traits.name'
+      }
     },
     visible_to: {
       label: 'Visible To',
@@ -43,7 +46,10 @@ const action: ActionDefinition<Settings, Payload> = {
         { label: 'Owner & followers (private)', value: 1 },
         { label: 'Entire company (shared)', value: 3 }
       ],
-      required: false
+      required: false,
+      default: {
+        '@path': '$.traits.visible_to'
+      }
     },
     add_time: {
       label: 'Created At',
@@ -51,7 +57,6 @@ const action: ActionDefinition<Settings, Payload> = {
         'If the organization is created, use this timestamp as the creation timestamp. Format: YYY-MM-DD HH:MM:SS',
       type: 'datetime'
     },
-
     custom_fields: {
       label: 'Custom fields',
       description: 'New values for custom fields.',
@@ -76,6 +81,11 @@ const action: ActionDefinition<Settings, Payload> = {
       add_time: payload.add_time ? `${payload.add_time}` : undefined,
       visible_to: payload.visible_to
     }
+
+    if (!organizationId)
+      if (payload.match_field && payload.match_value)
+        // if doing a create, write the match_field and match_value data to the new Organization object's custom field
+        Object.assign(organization, { [payload.match_field]: payload.match_value })
 
     addCustomFieldsFromPayloadToEntity(payload, organization)
 

--- a/packages/destination-actions/src/destinations/pipedrive/createUpdateOrganization/index.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/createUpdateOrganization/index.ts
@@ -46,10 +46,7 @@ const action: ActionDefinition<Settings, Payload> = {
         { label: 'Owner & followers (private)', value: 1 },
         { label: 'Entire company (shared)', value: 3 }
       ],
-      required: false,
-      default: {
-        '@path': '$.traits.visible_to'
-      }
+      required: false
     },
     add_time: {
       label: 'Created At',

--- a/packages/destination-actions/src/destinations/pipedrive/createUpdatePerson/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/createUpdatePerson/__tests__/index.test.ts
@@ -11,21 +11,25 @@ const PERSON_ID = 33333
 describe('Pipedrive.createUpdatePerson', () => {
   it('should create person if none exists', async () => {
     const scope = nock(`https://${PIPEDRIVE_DOMAIN}.pipedrive.com/api/v1`)
-      .post('/persons', { name: 'Acme Corp' })
+      .post('/persons', { name: 'Acme Corp', person_external_id: 'test_person_external_id_value' })
       .query({ api_token: PIPEDRIVE_API_KEY })
       .reply(200)
 
     scope
       .get(/.*/)
       .query((q) => {
-        return q.field_key === 'name' && q.field_type === 'personField' && q.term === 'Does not exist'
+        return (
+          q.field_key === 'person_external_id' &&
+          q.field_type === 'personField' &&
+          q.term === 'test_person_external_id_value'
+        )
       })
       .reply(200, {
         data: []
       })
 
     await testDestination.testAction('createUpdatePerson', {
-      mapping: { name: 'Acme Corp', match_field: 'name', match_value: 'Does not exist' },
+      mapping: { name: 'Acme Corp', match_field: 'person_external_id', match_value: 'test_person_external_id_value' },
       settings: { apiToken: PIPEDRIVE_API_KEY, domain: PIPEDRIVE_DOMAIN }
     })
 

--- a/packages/destination-actions/src/destinations/pipedrive/createUpdatePerson/index.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/createUpdatePerson/index.ts
@@ -32,21 +32,30 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Person Name',
       description: 'Name of the person',
       type: 'string',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.traits.name'
+      }
     },
     email: {
       label: 'Email Address',
       description: 'Email addresses for this person.',
       type: 'string',
       required: false,
-      multiple: true
+      multiple: true,
+      default: {
+        '@path': '$.traits.email'
+      }
     },
     phone: {
       label: 'Phone Number',
       description: 'Phone numbers for the person.',
       type: 'string',
       required: false,
-      multiple: true
+      multiple: true,
+      default: {
+        '@path': '$.traits.phone'
+      }
     },
     visible_to: {
       label: 'Visible To',
@@ -91,6 +100,11 @@ const action: ActionDefinition<Settings, Payload> = {
       add_time: payload.add_time ? `${payload.add_time}` : undefined,
       visible_to: payload.visible_to
     }
+
+    if (!personId)
+      if (payload.match_field)
+        // if doing a create, include the match_field and match_value data so that it gets written to the new object
+        Object.assign(person, { [payload.match_field]: payload.match_value })
 
     addCustomFieldsFromPayloadToEntity(payload, person)
 

--- a/packages/destination-actions/src/destinations/pipedrive/index.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/index.ts
@@ -1,6 +1,6 @@
 import createUpdateOrganization from './createUpdateOrganization'
 import createUpdatePerson from './createUpdatePerson'
-import type { DestinationDefinition } from '@segment/actions-core'
+import { defaultValues, DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
 import createUpdateActivity from './createUpdateActivity'
@@ -78,7 +78,27 @@ const destination: DestinationDefinition<Settings> = {
     createUpdateDeal,
     createUpdateLead,
     createUpdateNote
-  }
+  },
+  presets: [
+    {
+      name: 'Create or Update a Person',
+      subscribe: 'type = "identify"',
+      partnerAction: 'createUpdatePerson',
+      mapping: defaultValues(createUpdatePerson.fields)
+    },
+    {
+      name: 'Create or Update an Organization',
+      subscribe: 'type = "group"',
+      partnerAction: 'createUpdateOrganization',
+      mapping: defaultValues(createUpdateOrganization.fields)
+    },
+    {
+      name: 'Create or Update an Activity',
+      subscribe: 'type = "track" and event = "Activity Upserted"',
+      partnerAction: 'createUpdateActivity',
+      mapping: defaultValues(createUpdateActivity.fields)
+    }
+  ]
 }
 
 export default destination

--- a/packages/destination-actions/src/destinations/pipedrive/pipedriveApi/leads.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/pipedriveApi/leads.ts
@@ -7,10 +7,15 @@ export interface Lead extends Record<string, unknown> {
   expected_close_date?: string
   visible_to?: number
 
-  id?: number
+  id?: string
   person_id?: number
   organization_id?: number
   add_time?: string
+}
+
+export type LeadValue = {
+  amount?: number
+  currency?: string
 }
 
 export async function createUpdateLead(client: PipedriveClient, lead: Lead): Promise<ModifiedResponse> {

--- a/packages/destination-actions/src/destinations/pipedrive/pipedriveApi/notes.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/pipedriveApi/notes.ts
@@ -5,7 +5,7 @@ export interface Note extends Record<string, unknown> {
   content: string
   add_time?: string
   deal_id?: number
-  lead_id?: number
+  lead_id?: string
   person_id?: number
   org_id?: number
 }

--- a/packages/destination-actions/src/destinations/pipedrive/pipedriveApi/pipedrive-client.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/pipedriveApi/pipedrive-client.ts
@@ -125,7 +125,8 @@ class PipedriveClient {
     if (item.id) {
       const id = item.id
       delete item['id']
-      return this.put(`${itemPath}/${id}`, item)
+      if (itemPath == 'leads') return this.patch(`${itemPath}/${id}`, item)
+      else return this.put(`${itemPath}/${id}`, item)
     }
     return this.post(itemPath, item)
   }
@@ -138,7 +139,11 @@ class PipedriveClient {
     return this.reqWithPayload(path, payload, 'put')
   }
 
-  async reqWithPayload(path: string, payload: Record<string, unknown>, method: 'post' | 'put') {
+  async patch(path: string, payload: Record<string, unknown>): Promise<ModifiedResponse> {
+    return this.reqWithPayload(path, payload, 'patch')
+  }
+
+  async reqWithPayload(path: string, payload: Record<string, unknown>, method: 'post' | 'put' | 'patch') {
     PipedriveClient.filterPayload(payload)
     const urlBase = `https://${this.settings.domain}.pipedrive.com/api/v1`
     return this._request(`${urlBase}/${path}`, {


### PR DESCRIPTION
## Summary
 - Updating all 6 Actions to add default field mappings where reasonable. Corrected some default mappings which would have caused customer confusion. 
 - Fixed the broken Dynamic Fields on Actions which had Dynamic Fields. They were requesting to incorrect URLs. 
 - Updated payloads being sent to Pipedrive to handle when users provide Pipedrive entity IDs or when users provide external identifiers for entities.  

## Testing
 - Tested locally with Actions Tester
 - Signed up for trial Pipedrive account and did manual tests for all of the following: 
 -- Creating a Node, Updating a Node 
 -- Creating a Person, Updating a Person
 -- Creating an Organization, Updating an Organization
 -- Creating a Deal, Updating a Deal
 -- Creating a Lead, Updating a Lead
 -- Creating a Activity, Updating a Activity
 
- For all of the above tested the Dynamic Fields and made sure that related entities were connected correctly. 

- Deployed to Stage and Tested. Noticed some basic issues which are now fixed in this PR. 
