### PR TITLE
fixing a couple of issues with new Ironclad destination

### DIFF
--- a/packages/destination-actions/src/destinations/ironclad/RecordAction/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/ironclad/RecordAction/__tests__/index.test.ts
@@ -18,7 +18,7 @@ const settingsProd = {
 
 const payload = {
   sig: 'test-user-njs1haohmb',
-  group_id: '1335'
+  group_id: 1335
 }
 
 describe('Ironclad.recordAction', () => {

--- a/packages/destination-actions/src/destinations/ironclad/RecordAction/generated-types.ts
+++ b/packages/destination-actions/src/destinations/ironclad/RecordAction/generated-types.ts
@@ -10,9 +10,9 @@ export interface Payload {
    */
   event_name?: string
   /**
-   * The ID of the Clickwrap Group associated with the acceptance event.
+   * The ID of the Clickwrap Group associated with the acceptance event. Needs to be an integer
    */
-  group_id: string
+  group_id: number
   /**
    * The type of event being logged, the available choices are displayed, agreed, and disagreed.
    */

--- a/packages/destination-actions/src/destinations/ironclad/RecordAction/index.ts
+++ b/packages/destination-actions/src/destinations/ironclad/RecordAction/index.ts
@@ -31,7 +31,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     group_id: {
       label: 'Clickwrap Group Id',
-      description: 'The ID of the Clickwrap Group associated with the acceptance event.',
+      description: 'The ID of the Clickwrap Group associated with the acceptance event. Needs to be an integer',
       type: 'integer',
       required: true
     },

--- a/packages/destination-actions/src/destinations/ironclad/RecordAction/index.ts
+++ b/packages/destination-actions/src/destinations/ironclad/RecordAction/index.ts
@@ -26,14 +26,13 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'The name of the event coming from the source, this is an additional information field before the call goes to Ironclad.',
       type: 'string',
-      default: { '@path': 'event' },
+      default: { '@path': '$.event' },
       required: false
     },
     group_id: {
       label: 'Clickwrap Group Id',
       description: 'The ID of the Clickwrap Group associated with the acceptance event.',
-      type: 'string',
-      default: '',
+      type: 'integer',
       required: true
     },
     event_type: {

--- a/packages/destination-actions/src/destinations/ironclad/generated-types.ts
+++ b/packages/destination-actions/src/destinations/ironclad/generated-types.ts
@@ -8,9 +8,9 @@ export interface Settings {
   /**
    * Turn this ON, to send requests to the staging server, ONLY if Clickwrap support instructs you to do so.
    */
-  staging_endpoint: boolean
+  staging_endpoint?: boolean
   /**
    * Test Mode, whether or not to process the acceptance in test_mode. Defaults to false, Toggle to ON to enable it.
    */
-  test_mode: boolean
+  test_mode?: boolean
 }

--- a/packages/destination-actions/src/destinations/ironclad/index.ts
+++ b/packages/destination-actions/src/destinations/ironclad/index.ts
@@ -16,7 +16,6 @@ const destination: DestinationDefinition<Settings> = {
         description:
           'Site Access ID. An ID that’s unique for each site within your account. Information on finding your sid can be found in the authentication section.',
         type: 'string',
-        default: '',
         required: true
       },
       staging_endpoint: {
@@ -24,7 +23,6 @@ const destination: DestinationDefinition<Settings> = {
         description:
           'Turn this ON, to send requests to the staging server, ONLY if Clickwrap support instructs you to do so.',
         type: 'boolean',
-        required: true,
         default: false
       },
       test_mode: {
@@ -32,7 +30,6 @@ const destination: DestinationDefinition<Settings> = {
         description:
           'Test Mode, whether or not to process the acceptance in test_mode. Defaults to false, Toggle to ON to enable it.',
         type: 'boolean',
-        required: true,
         default: false
       }
     }


### PR DESCRIPTION
## Description
Ironclad is a new Destination which was deployed yesterday. No customer is using it. 
After deployment we noticed that there were some mapping issues which needed fixing in the settings and Action mappings. 

These are: 

Change group_id type from string to integer 
 
Fix event_name field 
 - correct the default from  
default: { '@path': '$event' },
 To  
default: { '@path': '$.event' },
 
Fix sid setting field
 - remove the default line 

Fix staging_endpoint setting field
 - remove the required field line 

Fix test_mode setting field
 - remove the required field line 

## Testing
 - Testing will be done in production once deployment has taken place. 
