### PR TITLE
Ensure we always have an event name

### DIFF
--- a/packages/destination-actions/src/destinations/heap/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/heap/trackEvent/index.ts
@@ -119,7 +119,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const heapPayload: HeapEvent = {
       app_id: settings.appId,
-      event: getEventName(payload),
+      event: payload.type ? payload.type : 'track',
       properties: eventProperties,
       idempotency_key: payload.message_id
     }
@@ -144,18 +144,6 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'post',
       json: heapPayload
     })
-  }
-}
-
-const getEventName = (payload: Payload) => {
-  switch (payload.type) {
-    case 'track':
-      return payload.event
-    case 'page':
-    case 'screen':
-      return payload.name
-    default:
-      return undefined
   }
 }
 


### PR DESCRIPTION
We were getting 400s because in some cases the event name was undefined. 

## Testing


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
