### PR TITLE
fix for pe-52

### DIFF
--- a/packages/destination-actions/src/destinations/heap/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/heap/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -19,6 +19,7 @@ Object {
 exports[`Testing snapshot for actions-heap destination: trackEvent action - all fields 1`] = `
 Object {
   "app_id": "kFJwrNh$DP38FB",
+  "event": "track",
   "idempotency_key": "kFJwrNh$DP38FB",
   "identity": "kFJwrNh$DP38FB",
   "properties": Object {
@@ -33,6 +34,7 @@ Object {
 exports[`Testing snapshot for actions-heap destination: trackEvent action - required fields 1`] = `
 Object {
   "app_id": "kFJwrNh$DP38FB",
+  "event": "track",
   "idempotency_key": "kFJwrNh$DP38FB",
   "identity": "kFJwrNh$DP38FB",
   "properties": Object {

--- a/packages/destination-actions/src/destinations/heap/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/heap/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Testing snapshot for Heap's trackEvent destination action: all fields 1`] = `
 Object {
   "app_id": "xqYHVWXiU0In",
+  "event": "track",
   "idempotency_key": "xqYHVWXiU0In",
   "identity": "xqYHVWXiU0In",
   "properties": Object {
@@ -17,6 +18,7 @@ Object {
 exports[`Testing snapshot for Heap's trackEvent destination action: required fields 1`] = `
 Object {
   "app_id": "xqYHVWXiU0In",
+  "event": "track",
   "idempotency_key": "xqYHVWXiU0In",
   "identity": "xqYHVWXiU0In",
   "properties": Object {

--- a/packages/destination-actions/src/destinations/heap/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/heap/trackEvent/index.ts
@@ -148,15 +148,26 @@ const action: ActionDefinition<Settings, Payload> = {
 }
 
 const getEventName = (payload: Payload) => {
+  let eventName: string | undefined
   switch (payload.type) {
     case 'track':
-      return payload.event
+      eventName = payload.event
+      break
     case 'page':
+      eventName = payload.name ? payload.name : 'Page Viewed'
+      break
     case 'screen':
-      return payload.name
+      eventName = payload.name ? payload.name : 'Screen Viewed'
+      break
     default:
-      return undefined
+      eventName = 'track'
+      break
   }
+
+  if (!eventName) {
+    return 'track'
+  }
+  return eventName
 }
 
 export default action


### PR DESCRIPTION
## Description
The code in this change was created by a Heap Engineer ( @murphpdx ). 
I added a minor tweak for "Page Viewed". 

This PR fixes an issue where events to Heap may not contain an event name. This caused an incident sev-2-crooked-squirrel. 

## Testing
Testing was done locally with Actions Tester. The Heap Engineer was present when tested. 
Note: there is only 1 customer using this Integration, and the Integration is in Private Beta.
