### PR TITLE
Launchpad Segment Integration

### DIFF
--- a/packages/destination-actions/src/destinations/launchpad/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchpad/generated-types.ts
@@ -1,0 +1,7 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  apiRegion: string
+  apiSecret: string
+  sourceName: string
+}

--- a/packages/destination-actions/src/destinations/launchpad/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchpad/generated-types.ts
@@ -1,7 +1,16 @@
 // Generated file. DO NOT MODIFY IT BY HAND.
 
 export interface Settings {
-  apiRegion: string
+  /**
+   * Launchpad project secret. You can find that in the settings in your Launchpad.pm account.
+   */
   apiSecret: string
-  sourceName: string
+  /**
+   * Learn about [EU data residency](https://help.launchpad.pm).
+   */
+  apiRegion?: string
+  /**
+   * This value, if it's not blank, will be sent as segment_source_name to Launchpad for every event/page/screen call.
+   */
+  sourceName?: string
 }

--- a/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -6,6 +6,7 @@ Object {
     "group_id": "$WBBWnR",
     "group_testType": "$WBBWnR",
   },
+  "api_key": "$WBBWnR",
   "distinct_id": "$WBBWnR",
   "event": "$identify",
   "type": "screen",
@@ -16,8 +17,8 @@ exports[`Testing snapshot for Launchpad's groupIdentifyUser destination action: 
 Object {
   "$set": Object {
     "group_id": "$WBBWnR",
-    "group_testType": "$WBBWnR",
   },
+  "api_key": "$WBBWnR",
   "event": "$identify",
   "type": "screen",
 }

--- a/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Launchpad's groupIdentifyUser destination action: all fields 1`] = `
+Object {
+  "$set": Object {
+    "group_id": "$WBBWnR",
+    "group_testType": "$WBBWnR",
+  },
+  "distinct_id": "$WBBWnR",
+  "event": "$identify",
+  "type": "screen",
+}
+`;
+
+exports[`Testing snapshot for Launchpad's groupIdentifyUser destination action: required fields 1`] = `
+Object {
+  "$set": Object {
+    "group_id": "$WBBWnR",
+    "group_testType": "$WBBWnR",
+  },
+  "event": "$identify",
+  "type": "screen",
+}
+`;

--- a/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -6,11 +6,22 @@ Object {
     "group_id": "$WBBWnR",
     "group_testType": "$WBBWnR",
   },
-  "anonymoudId": "$WBBWnR",
+  "anonymoud_id": "$WBBWnR",
   "api_key": "$WBBWnR",
   "distinct_id": "$WBBWnR",
   "event": "$identify",
   "type": "screen",
-  "userId": "$WBBWnR",
+  "user_id": "$WBBWnR",
+}
+`;
+
+exports[`Testing snapshot for Launchpad's groupIdentifyUser destination action: required fields 1`] = `
+Object {
+  "$set": Object {
+    "group_id": "$WBBWnR",
+  },
+  "api_key": "$WBBWnR",
+  "event": "$identify",
+  "type": "screen",
 }
 `;

--- a/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -6,20 +6,11 @@ Object {
     "group_id": "$WBBWnR",
     "group_testType": "$WBBWnR",
   },
+  "anonymoudId": "$WBBWnR",
   "api_key": "$WBBWnR",
   "distinct_id": "$WBBWnR",
   "event": "$identify",
   "type": "screen",
-}
-`;
-
-exports[`Testing snapshot for Launchpad's groupIdentifyUser destination action: required fields 1`] = `
-Object {
-  "$set": Object {
-    "group_id": "$WBBWnR",
-  },
-  "api_key": "$WBBWnR",
-  "event": "$identify",
-  "type": "screen",
+  "userId": "$WBBWnR",
 }
 `;

--- a/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/__tests__/index.test.ts
@@ -1,0 +1,84 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { SegmentEvent } from '@segment/actions-core'
+import { IntegrationError } from '@segment/actions-core'
+
+const launchpadAPISecret = 'lp-api-key'
+const timestamp = '2023-01-28T15:21:15.449Z'
+
+const testDestination = createTestIntegration(Destination)
+
+const expectedTraits = {
+  group_name: 'Launchpad',
+  group_industry: 'Technology',
+  group_employees: 3,
+  group_plan: '1',
+  'group_ARR(m)': 1503
+}
+
+const testGroupIdentify: SegmentEvent = {
+  messageId: 'test-message-t73406chv4',
+  timestamp: timestamp,
+  type: 'group',
+  groupId: '12381923812',
+  userId: 'stephen@launchpad.pm',
+  traits: {
+    name: 'Launchpad',
+    industry: 'Technology',
+    employees: 3,
+    plan: '1',
+    'ARR(m)': 1503
+  }
+}
+
+const testGroupIdentifyNoTraits: SegmentEvent = {
+  messageId: 'test-message-t73406chv4',
+  timestamp: timestamp,
+  type: 'group',
+  groupId: '12381923812',
+  userId: 'stephen@launchpad.pm',
+  traits: {}
+}
+
+describe('Launchpad.groupIdentifyUser', () => {
+  it('should convert the type and event name', async () => {
+    nock('https://data.launchpad.pm').post('/capture').reply(200, {})
+
+    const responses = await testDestination.testAction('groupIdentifyUser', {
+      event: testGroupIdentify,
+      useDefaultMappings: true,
+      settings: {
+        apiSecret: launchpadAPISecret,
+        sourceName: 'example segment source name'
+      }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.json).toMatchObject({
+      event: '$identify',
+      type: 'screen',
+      $set: expect.objectContaining(expectedTraits)
+    })
+  })
+
+  describe('Launchpad.groupIdentifyUser', () => {
+    it('when no traits it should give a 400 back', async () => {
+      nock('https://data.launchpad.pm').post('/capture').reply(400, {})
+
+      try {
+        await testDestination.testAction('groupIdentifyUser', {
+          event: testGroupIdentifyNoTraits,
+          useDefaultMappings: true,
+          settings: {
+            apiSecret: launchpadAPISecret,
+            sourceName: 'example segment source name'
+          }
+        })
+      } catch (error) {
+        expect(error).toBeInstanceOf(IntegrationError)
+      }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/__tests__/index.test.ts
@@ -2,7 +2,6 @@ import nock from 'nock'
 import { createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 import { SegmentEvent } from '@segment/actions-core'
-import { IntegrationError } from '@segment/actions-core'
 
 const launchpadAPISecret = 'lp-api-key'
 const timestamp = '2023-01-28T15:21:15.449Z'
@@ -32,15 +31,6 @@ const testGroupIdentify: SegmentEvent = {
   }
 }
 
-const testGroupIdentifyNoTraits: SegmentEvent = {
-  messageId: 'test-message-t73406chv4',
-  timestamp: timestamp,
-  type: 'group',
-  groupId: '12381923812',
-  userId: 'stephen@launchpad.pm',
-  traits: {}
-}
-
 describe('Launchpad.groupIdentifyUser', () => {
   it('should convert the type and event name', async () => {
     nock('https://data.launchpad.pm').post('/capture').reply(200, {})
@@ -60,25 +50,6 @@ describe('Launchpad.groupIdentifyUser', () => {
       event: '$identify',
       type: 'screen',
       $set: expect.objectContaining(expectedTraits)
-    })
-  })
-
-  describe('Launchpad.groupIdentifyUser', () => {
-    it('when no traits it should give a 400 back', async () => {
-      nock('https://data.launchpad.pm').post('/capture').reply(400, {})
-
-      try {
-        await testDestination.testAction('groupIdentifyUser', {
-          event: testGroupIdentifyNoTraits,
-          useDefaultMappings: true,
-          settings: {
-            apiSecret: launchpadAPISecret,
-            sourceName: 'example segment source name'
-          }
-        })
-      } catch (error) {
-        expect(error).toBeInstanceOf(IntegrationError)
-      }
     })
   })
 })

--- a/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'groupIdentifyUser'
+const destinationSlug = 'Launchpad'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/__tests__/snapshot.test.ts
@@ -20,6 +20,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const event = createTestEvent({
       properties: eventData
     })
+    event.userId = 'user1234'
 
     const responses = await testDestination.testAction(actionSlug, {
       event: event,

--- a/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * The group key you specified in Launchpad under Project settings. If this is not specified, it will be defaulted to "$group_id".
+   * The group key you specified in Launchpad under the company corresponding to the group. If this is not specified, it will be defaulted to "$group_id". This is helpful when you have a group of companies that should be joined together as in when you have a multinational.
    */
   groupKey?: string
   /**
@@ -12,11 +12,15 @@ export interface Payload {
   /**
    * The properties to set on the group profile.
    */
-  traits: {
+  traits?: {
     [k: string]: unknown
   }
   /**
    * The unique user identifier set by you
    */
   userId?: string | null
+  /**
+   * The generated anonymous ID for the user
+   */
+  anonymousId?: string | null
 }

--- a/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/generated-types.ts
@@ -1,0 +1,22 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The group key you specified in Launchpad under Project settings. If this is not specified, it will be defaulted to "$group_id".
+   */
+  groupKey?: string
+  /**
+   * The unique identifier of the group. If there is a trait that matches the group key, it will override this value.
+   */
+  groupId: string
+  /**
+   * The properties to set on the group profile.
+   */
+  traits: {
+    [k: string]: unknown
+  }
+  /**
+   * The unique user identifier set by you
+   */
+  userId?: string | null
+}

--- a/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/generated-types.ts
@@ -16,11 +16,11 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * The unique user identifier set by you
+   * A unique ID for a known user. This will be used as the Distinct ID. This field is required if the Anonymous ID field is empty
    */
-  userId?: string | null
+  userId?: string
   /**
-   * The generated anonymous ID for the user
+   * A unique ID for an anonymous user. This will be used as the Distinct ID if the User ID field is empty. This field is required if the User ID field is empty
    */
-  anonymousId?: string | null
+  anonymousId?: string
 }

--- a/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/index.ts
@@ -2,7 +2,6 @@ import { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import { getApiServerUrl } from '../utils'
 import type { Payload } from './generated-types'
-import { IntegrationError } from '@segment/actions-core'
 
 const groupIdentifyUser: ActionDefinition<Settings, Payload> = {
   title: 'Group Identify User',
@@ -60,8 +59,6 @@ const groupIdentifyUser: ActionDefinition<Settings, Payload> = {
     const groupId = payload.groupId
     const apiServerUrl = getApiServerUrl(settings.apiRegion)
     let transformed_traits
-
-    if (!payload.anonymousId || !payload.userId) throw new IntegrationError('User ID or AnonymousId required', '400')
 
     if (payload.traits) {
       transformed_traits = {

--- a/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/launchpad/groupIdentifyUser/index.ts
@@ -1,0 +1,78 @@
+import { ActionDefinition, IntegrationError } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import { getApiServerUrl } from '../utils'
+import type { Payload } from './generated-types'
+
+const groupIdentifyUser: ActionDefinition<Settings, Payload> = {
+  title: 'Group Identify User',
+  description:
+    'Updates or adds properties to a group profile. The profile is created if it does not exist. [Learn more about Group Analytics.](https://help.Launchpad.pm)',
+  defaultSubscription: 'type = "group"',
+  fields: {
+    groupKey: {
+      label: 'Group Key',
+      type: 'string',
+      description:
+        'The group key you specified in Launchpad under Project settings. If this is not specified, it will be defaulted to "$group_id".'
+    },
+    groupId: {
+      label: 'Group ID',
+      type: 'string',
+      description:
+        'The unique identifier of the group. If there is a trait that matches the group key, it will override this value.',
+      required: true,
+      default: {
+        '@path': '$.groupId'
+      }
+    },
+    traits: {
+      label: 'Group Properties',
+      type: 'object',
+      description: 'The properties to set on the group profile.',
+      required: true,
+      default: {
+        '@path': '$.traits'
+      }
+    },
+    userId: {
+      label: 'User ID',
+      type: 'string',
+      allowNull: true,
+      description: 'The unique user identifier set by you',
+      default: {
+        '@path': '$.userId'
+      }
+    }
+  },
+
+  perform: async (request, { payload, settings }) => {
+    if (!payload.traits || Object.keys(payload.traits).length === 0) {
+      throw new IntegrationError('"traits" is a required field', 'Missing required fields', 400)
+    }
+    const groupId = payload.groupId
+    const apiServerUrl = getApiServerUrl(settings.apiRegion)
+
+    const transformed_traits = {
+      ...Object.fromEntries(Object.entries(payload.traits).map(([k, v]) => [`group_${k}`, v]))
+    }
+
+    const groupIdentifyEvent = {
+      event: '$identify',
+      type: 'screen',
+      $set: {
+        group_id: groupId,
+        ...transformed_traits
+      },
+      distinct_id: payload.userId,
+      api_key: settings.apiSecret
+    }
+    const groupIdentifyResponse = await request(`${apiServerUrl}capture`, {
+      method: 'post',
+      json: groupIdentifyEvent
+    })
+
+    return groupIdentifyResponse
+  }
+}
+
+export default groupIdentifyUser

--- a/packages/destination-actions/src/destinations/launchpad/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/launchpad/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -6,11 +6,24 @@ Object {
   "$set": Object {
     "testType": "5SpoCjYek1jtNwUC",
   },
-  "anonymoudId": "5SpoCjYek1jtNwUC",
+  "anonymous_id": "5SpoCjYek1jtNwUC",
   "api_key": "5SpoCjYek1jtNwUC",
   "distinct_id": "5SpoCjYek1jtNwUC",
   "event": "$identify",
   "type": "screen",
-  "userId": "5SpoCjYek1jtNwUC",
+  "user_id": "5SpoCjYek1jtNwUC",
+}
+`;
+
+exports[`Testing snapshot for Launchpad's identifyUser destination action: required fields 1`] = `
+Object {
+  "$set": Object {
+    "testType": "5SpoCjYek1jtNwUC",
+  },
+  "api_key": "5SpoCjYek1jtNwUC",
+  "distinct_id": "user1234",
+  "event": "$identify",
+  "type": "screen",
+  "user_id": "user1234",
 }
 `;

--- a/packages/destination-actions/src/destinations/launchpad/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/launchpad/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -6,20 +6,11 @@ Object {
   "$set": Object {
     "testType": "5SpoCjYek1jtNwUC",
   },
+  "anonymoudId": "5SpoCjYek1jtNwUC",
   "api_key": "5SpoCjYek1jtNwUC",
   "distinct_id": "5SpoCjYek1jtNwUC",
   "event": "$identify",
   "type": "screen",
-}
-`;
-
-exports[`Testing snapshot for Launchpad's identifyUser destination action: required fields 1`] = `
-Object {
-  "$set": Object {
-    "testType": "5SpoCjYek1jtNwUC",
-  },
-  "api_key": "5SpoCjYek1jtNwUC",
-  "event": "$identify",
-  "type": "screen",
+  "userId": "5SpoCjYek1jtNwUC",
 }
 `;

--- a/packages/destination-actions/src/destinations/launchpad/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/launchpad/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Launchpad's identifyUser destination action: all fields 1`] = `
+Object {
+  "$ip": "5SpoCjYek1jtNwUC",
+  "$set": Object {
+    "testType": "5SpoCjYek1jtNwUC",
+  },
+  "distinct_id": "5SpoCjYek1jtNwUC",
+  "event": "$identify",
+  "type": "screen",
+}
+`;
+
+exports[`Testing snapshot for Launchpad's identifyUser destination action: required fields 1`] = `
+Object {
+  "$set": Object {
+    "testType": "5SpoCjYek1jtNwUC",
+  },
+  "event": "$identify",
+  "type": "screen",
+}
+`;

--- a/packages/destination-actions/src/destinations/launchpad/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/launchpad/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -6,6 +6,7 @@ Object {
   "$set": Object {
     "testType": "5SpoCjYek1jtNwUC",
   },
+  "api_key": "5SpoCjYek1jtNwUC",
   "distinct_id": "5SpoCjYek1jtNwUC",
   "event": "$identify",
   "type": "screen",
@@ -17,6 +18,7 @@ Object {
   "$set": Object {
     "testType": "5SpoCjYek1jtNwUC",
   },
+  "api_key": "5SpoCjYek1jtNwUC",
   "event": "$identify",
   "type": "screen",
 }

--- a/packages/destination-actions/src/destinations/launchpad/identifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/launchpad/identifyUser/__tests__/index.test.ts
@@ -1,0 +1,76 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { SegmentEvent } from '@segment/actions-core'
+
+const launchpadAPISecret = 'lp-api-key'
+const timestamp = '2023-01-28T15:21:15.449Z'
+
+const testDestination = createTestIntegration(Destination)
+
+const expectedTraits = {
+  email: 'steve@launchpad.pm',
+  name: 'Steve Jobs',
+  plan: '1',
+  group: 'Launchpad',
+  title: 'CEO'
+}
+const testIdentify: SegmentEvent = {
+  anonymousId: '947336ec-2294-4813-92e6-fe4a01efbf63',
+  integrations: {},
+  messageId: 'ajs-next-11e27cb3f0a3e4e8074e9965ed19a151',
+  timestamp: timestamp,
+  traits: {
+    email: 'steve@launchpad.pm',
+    name: 'Steve Jobs',
+    plan: '1',
+    group: 'Launchpad',
+    title: 'CEO'
+  },
+  type: 'identify',
+  userId: 'steve@launchpad.pm'
+}
+
+describe('Launchpad.identifyUser', () => {
+  it('should convert the type and event name', async () => {
+    nock('https://data.launchpad.pm').post('/capture').reply(200, {})
+
+    const responses = await testDestination.testAction('identifyUser', {
+      event: testIdentify,
+      useDefaultMappings: true,
+      settings: {
+        apiSecret: launchpadAPISecret,
+        sourceName: 'example segment source name'
+      }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.json).toMatchObject({
+      event: '$identify',
+      type: 'screen',
+      $set: expect.objectContaining(expectedTraits)
+    })
+  })
+
+  it('should send segment_source_name property if sourceName setting is defined', async () => {
+    nock('https://data.launchpad.pm').post('/capture').reply(200, {})
+
+    const responses = await testDestination.testAction('identifyUser', {
+      event: testIdentify,
+      useDefaultMappings: true,
+      settings: {
+        apiSecret: launchpadAPISecret,
+        sourceName: 'example segment source name'
+      }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.json).toMatchObject({
+      event: '$identify',
+      type: 'screen',
+      $set: expect.objectContaining(expectedTraits)
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/launchpad/identifyUser/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/launchpad/identifyUser/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'identifyUser'
+const destinationSlug = 'Launchpad'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/launchpad/identifyUser/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/launchpad/identifyUser/__tests__/snapshot.test.ts
@@ -20,7 +20,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const event = createTestEvent({
       properties: eventData
     })
-    event.properties.userId = 'user1234'
+    if (event && event.properties) event.properties.userId = 'user1234'
 
     const responses = await testDestination.testAction(actionSlug, {
       event: event,

--- a/packages/destination-actions/src/destinations/launchpad/identifyUser/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/launchpad/identifyUser/__tests__/snapshot.test.ts
@@ -20,6 +20,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const event = createTestEvent({
       properties: eventData
     })
+    event.properties.userId = 'user1234'
 
     const responses = await testDestination.testAction(actionSlug, {
       event: event,

--- a/packages/destination-actions/src/destinations/launchpad/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchpad/identifyUser/generated-types.ts
@@ -1,0 +1,22 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The IP address of the user. This is only used for geolocation and won't be stored.
+   */
+  ip?: string
+  /**
+   * The unique user identifier set by you
+   */
+  userId?: string | null
+  /**
+   * The generated anonymous ID for the user
+   */
+  anonymousId?: string | null
+  /**
+   * Properties to set on the user profile
+   */
+  traits: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/launchpad/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchpad/identifyUser/generated-types.ts
@@ -6,13 +6,13 @@ export interface Payload {
    */
   ip?: string
   /**
-   * The unique user identifier set by you.
+   * A unique ID for a known user. This will be used as the Distinct ID. This field is required if the Anonymous ID field is empty
    */
-  userId?: string | null
+  userId?: string
   /**
-   * The generated anonymous ID for the user.
+   * A unique ID for an anonymous user. This will be used as the Distinct ID if the User ID field is empty. This field is required if the User ID field is empty
    */
-  anonymousId?: string | null
+  anonymousId?: string
   /**
    * Properties that you want to set on the user profile and you would want to segment by later.
    */

--- a/packages/destination-actions/src/destinations/launchpad/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchpad/identifyUser/generated-types.ts
@@ -6,15 +6,15 @@ export interface Payload {
    */
   ip?: string
   /**
-   * The unique user identifier set by you
+   * The unique user identifier set by you.
    */
   userId?: string | null
   /**
-   * The generated anonymous ID for the user
+   * The generated anonymous ID for the user.
    */
   anonymousId?: string | null
   /**
-   * Properties to set on the user profile
+   * Properties that you want to set on the user profile and you would want to segment by later.
    */
   traits: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/launchpad/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchpad/identifyUser/generated-types.ts
@@ -8,7 +8,7 @@ export interface Payload {
   /**
    * A unique ID for a known user. This will be used as the Distinct ID. This field is required if the Anonymous ID field is empty
    */
-  userId: string
+  userId?: string
   /**
    * A unique ID for an anonymous user. This will be used as the Distinct ID if the User ID field is empty. This field is required if the User ID field is empty
    */

--- a/packages/destination-actions/src/destinations/launchpad/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchpad/identifyUser/generated-types.ts
@@ -8,7 +8,7 @@ export interface Payload {
   /**
    * A unique ID for a known user. This will be used as the Distinct ID. This field is required if the Anonymous ID field is empty
    */
-  userId?: string
+  userId: string
   /**
    * A unique ID for an anonymous user. This will be used as the Distinct ID if the User ID field is empty. This field is required if the User ID field is empty
    */

--- a/packages/destination-actions/src/destinations/launchpad/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/launchpad/identifyUser/index.ts
@@ -21,7 +21,6 @@ const identifyUser: ActionDefinition<Settings, Payload> = {
     userId: {
       label: 'User ID',
       type: 'string',
-      required: true,
       description:
         'A unique ID for a known user. This will be used as the Distinct ID. This field is required if the Anonymous ID field is empty',
       default: {

--- a/packages/destination-actions/src/destinations/launchpad/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/launchpad/identifyUser/index.ts
@@ -1,0 +1,107 @@
+import { ActionDefinition, omit } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+import { getApiServerUrl, getConcatenatedName } from '../utils'
+
+const identifyUser: ActionDefinition<Settings, Payload> = {
+  title: 'Identify User',
+  description: 'Set the user ID for a particular device ID or update user properties.',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    ip: {
+      label: 'IP Address',
+      type: 'string',
+      description: "The IP address of the user. This is only used for geolocation and won't be stored.",
+      default: {
+        '@path': '$.context.ip'
+      }
+    },
+    userId: {
+      label: 'User ID',
+      type: 'string',
+      allowNull: true,
+      description: 'The unique user identifier set by you',
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    anonymousId: {
+      label: 'Anonymous ID',
+      type: 'string',
+      allowNull: true,
+      description: 'The generated anonymous ID for the user',
+      default: {
+        '@path': '$.anonymousId'
+      }
+    },
+    traits: {
+      label: 'User Properties',
+      type: 'object',
+      required: true,
+      description: 'Properties to set on the user profile',
+      default: {
+        '@path': '$.traits'
+      }
+    }
+  },
+
+  perform: async (request, { payload, settings }) => {
+    const apiServerUrl = getApiServerUrl(settings.apiRegion)
+
+    if (payload.anonymousId && !payload.traits) {
+      const identifyEvent = {
+        event: '$identify',
+        type: 'screen',
+        $set: {
+          $distinct_id: payload.userId,
+          $anonymous_id: payload.anonymousId,
+          segment_source_name: settings.sourceName
+        },
+        distinct_id: payload.anonymousId,
+        api_key: settings.apiSecret
+      }
+      const identifyResponse = await request(`${apiServerUrl}capture`, {
+        method: 'post',
+        json: identifyEvent
+      })
+
+      return identifyResponse
+    }
+
+    if (payload.traits && Object.keys(payload.traits).length > 0) {
+      const concatenatedName = getConcatenatedName(
+        payload.traits.firstName,
+        payload.traits.lastName,
+        payload.traits.name
+      )
+      const traits = {
+        ...omit(payload.traits, ['created', 'email', 'firstName', 'lastName', 'name', 'username', 'phone']),
+        // to fit the Launchpad expectations, transform the special traits to Launchpad reserved property
+        $created: payload.traits.created,
+        $email: payload.traits.email,
+        $first_name: payload.traits.firstName,
+        $last_name: payload.traits.lastName,
+        $name: concatenatedName,
+        $username: payload.traits.username,
+        $phone: payload.traits.phone,
+        ...payload.traits
+      }
+      const data = {
+        distinct_id: payload.userId,
+        $ip: payload.ip,
+        $set: traits,
+        event: '$identify',
+        type: 'screen',
+        api_key: settings.apiSecret
+      }
+      const identifyResponse = request(`${apiServerUrl}capture`, {
+        method: 'post',
+        json: data
+      })
+      return identifyResponse
+    }
+  }
+}
+
+export default identifyUser

--- a/packages/destination-actions/src/destinations/launchpad/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/launchpad/identifyUser/index.ts
@@ -3,7 +3,6 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
 import { getApiServerUrl, getConcatenatedName } from '../utils'
-import { IntegrationError } from '@segment/actions-core'
 
 const identifyUser: ActionDefinition<Settings, Payload> = {
   title: 'Identify User',
@@ -22,6 +21,7 @@ const identifyUser: ActionDefinition<Settings, Payload> = {
     userId: {
       label: 'User ID',
       type: 'string',
+      required: true,
       description:
         'A unique ID for a known user. This will be used as the Distinct ID. This field is required if the Anonymous ID field is empty',
       default: {
@@ -51,8 +51,6 @@ const identifyUser: ActionDefinition<Settings, Payload> = {
   perform: async (request, { payload, settings }) => {
     const apiServerUrl = getApiServerUrl(settings.apiRegion)
     let traits
-
-    if (!payload.anonymousId || !payload.userId) throw new IntegrationError('User ID or AnonymousId required', '400')
 
     if (payload.traits && Object.keys(payload.traits).length > 0) {
       const concatenatedName = getConcatenatedName(

--- a/packages/destination-actions/src/destinations/launchpad/index.ts
+++ b/packages/destination-actions/src/destinations/launchpad/index.ts
@@ -1,0 +1,115 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import { defaultValues } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import trackEvent from './trackEvent'
+import identifyUser from './identifyUser'
+import groupIdentifyUser from './groupIdentifyUser'
+
+//import { ApiRegions, StrictMode } from './utils'
+
+/** used in the quick setup */
+const presets: DestinationDefinition['presets'] = [
+  {
+    name: 'Track Calls',
+    subscribe: 'type = "track" and event != "Order Completed"',
+    partnerAction: 'trackEvent',
+    mapping: defaultValues(trackEvent.fields)
+  },
+  {
+    name: 'Page Calls',
+    subscribe: 'type = "page"',
+    partnerAction: 'trackEvent',
+    mapping: {
+      ...defaultValues(trackEvent.fields),
+      event: {
+        '@template': 'Viewed {{name}}'
+      }
+    }
+  },
+  {
+    name: 'Screen Calls',
+    subscribe: 'type = "screen"',
+    partnerAction: 'trackEvent',
+    mapping: {
+      ...defaultValues(trackEvent.fields),
+      event: {
+        '@template': 'Viewed {{name}}'
+      }
+    }
+  },
+  {
+    name: 'Identify Calls',
+    subscribe: 'type = "identify"',
+    partnerAction: 'identifyUser',
+    mapping: defaultValues(identifyUser.fields)
+  },
+  {
+    name: 'Group Calls',
+    subscribe: 'type = "group"',
+    partnerAction: 'groupIdentifyUser',
+    mapping: defaultValues(groupIdentifyUser.fields)
+  }
+]
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Launchpad (Actions)',
+  slug: 'actions-launchpad',
+  mode: 'cloud',
+  // authentication: {
+  //   scheme: 'custom',
+  //   fields: {
+  //     // projectToken: {
+  //     //   label: 'Project Token',
+  //     //   description: 'Launchpad project token.',
+  //     //   type: 'string',
+  //     //   required: true
+  //     // },
+  //     // TODO: maybe we should just require service account instead?
+  //     apiSecret: {
+  //       label: 'Secret Key',
+  //       description: 'Launchpad project secret.',
+  //       type: 'string',
+  //       required: true
+  //     },
+  //     apiRegion: {
+  //       label: 'Data Residency',
+  //       description:
+  //         'Learn about [EU data residency](https://help.launchpad.pm)',
+  //       type: 'string',
+  //       choices: Object.values(ApiRegions).map((apiRegion) => ({ label: apiRegion, value: apiRegion })),
+  //       default: ApiRegions.US
+  //     },
+  //     sourceName: {
+  //       label: 'Source Name',
+  //       description:
+  //         "This value, if it's not blank, will be sent as segment_source_name to Launchpad for every event/page/screen call.",
+  //       type: 'string',
+  //     },
+  //     strictMode: {
+  //       label: 'Strict Mode',
+  //       description:
+  //         "This value, if it's 1 (recommended), Launchpad will validate the events you are trying to send and return errors per event that failed. Learn more about the Launchpad [Import Events API](https://developer.launchpad.pm)",
+  //       type: 'string',
+  //       choices: Object.values(StrictMode).map((strictMode) => ({ label: strictMode, value: strictMode })),
+  //       default: StrictMode.ON
+  //     }
+  //   },
+  //   testAuthentication: (request, { settings }) => {
+  //     return request(`https://data.launchpad.pm/api/app/validate-project-credentials/`, { /
+  //       method: 'post',
+  //       body: JSON.stringify({
+  //         api_secret: settings.apiSecret,
+  //       })
+  //     })
+  //   }
+  // },
+  presets,
+  actions: {
+    trackEvent,
+    identifyUser,
+    groupIdentifyUser
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/launchpad/index.ts
+++ b/packages/destination-actions/src/destinations/launchpad/index.ts
@@ -6,7 +6,7 @@ import trackEvent from './trackEvent'
 import identifyUser from './identifyUser'
 import groupIdentifyUser from './groupIdentifyUser'
 
-//import { ApiRegions, StrictMode } from './utils'
+import { ApiRegions } from './utils'
 
 /** used in the quick setup */
 const presets: DestinationDefinition['presets'] = [
@@ -56,54 +56,38 @@ const destination: DestinationDefinition<Settings> = {
   name: 'Launchpad (Actions)',
   slug: 'actions-launchpad',
   mode: 'cloud',
-  // authentication: {
-  //   scheme: 'custom',
-  //   fields: {
-  //     // projectToken: {
-  //     //   label: 'Project Token',
-  //     //   description: 'Launchpad project token.',
-  //     //   type: 'string',
-  //     //   required: true
-  //     // },
-  //     // TODO: maybe we should just require service account instead?
-  //     apiSecret: {
-  //       label: 'Secret Key',
-  //       description: 'Launchpad project secret.',
-  //       type: 'string',
-  //       required: true
-  //     },
-  //     apiRegion: {
-  //       label: 'Data Residency',
-  //       description:
-  //         'Learn about [EU data residency](https://help.launchpad.pm)',
-  //       type: 'string',
-  //       choices: Object.values(ApiRegions).map((apiRegion) => ({ label: apiRegion, value: apiRegion })),
-  //       default: ApiRegions.US
-  //     },
-  //     sourceName: {
-  //       label: 'Source Name',
-  //       description:
-  //         "This value, if it's not blank, will be sent as segment_source_name to Launchpad for every event/page/screen call.",
-  //       type: 'string',
-  //     },
-  //     strictMode: {
-  //       label: 'Strict Mode',
-  //       description:
-  //         "This value, if it's 1 (recommended), Launchpad will validate the events you are trying to send and return errors per event that failed. Learn more about the Launchpad [Import Events API](https://developer.launchpad.pm)",
-  //       type: 'string',
-  //       choices: Object.values(StrictMode).map((strictMode) => ({ label: strictMode, value: strictMode })),
-  //       default: StrictMode.ON
-  //     }
-  //   },
-  //   testAuthentication: (request, { settings }) => {
-  //     return request(`https://data.launchpad.pm/api/app/validate-project-credentials/`, { /
-  //       method: 'post',
-  //       body: JSON.stringify({
-  //         api_secret: settings.apiSecret,
-  //       })
-  //     })
-  //   }
-  // },
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      apiSecret: {
+        label: 'Secret Key',
+        description: 'Launchpad project secret. You can find that in the settings in your Launchpad.pm account.',
+        type: 'password',
+        required: true
+      },
+      apiRegion: {
+        label: 'Data Residency',
+        description: 'Learn about [EU data residency](https://help.launchpad.pm).',
+        type: 'string',
+        choices: Object.values(ApiRegions).map((apiRegion) => ({ label: apiRegion, value: apiRegion })),
+        default: ApiRegions.US
+      },
+      sourceName: {
+        label: 'Source Name',
+        description:
+          "This value, if it's not blank, will be sent as segment_source_name to Launchpad for every event/page/screen call.",
+        type: 'string'
+      }
+    },
+    testAuthentication: (request, { settings }) => {
+      return request(`https://backend.launchpad.pm/api/data/validate-project-credentials/`, {
+        method: 'post',
+        body: JSON.stringify({
+          api_secret: settings.apiSecret
+        })
+      })
+    }
+  },
   presets,
   actions: {
     trackEvent,

--- a/packages/destination-actions/src/destinations/launchpad/launchpad-types.ts
+++ b/packages/destination-actions/src/destinations/launchpad/launchpad-types.ts
@@ -16,7 +16,7 @@ export type LaunchpadEventProperties = {
   distinct_id: string | undefined // 'test_segment_user'
   id?: string | null // this is just to maintain backwards compatibility  with the classic segment integration, I'm not completely sure what the purpose of this was.
   segment_source_name?: string // 'readme'
-  time?: number
+  time?: string | number | undefined
   properties?: [k: string] | unknown //event props
   traits?: [k: string] | unknown
   context?: [k: string] | unknown

--- a/packages/destination-actions/src/destinations/launchpad/launchpad-types.ts
+++ b/packages/destination-actions/src/destinations/launchpad/launchpad-types.ts
@@ -1,0 +1,36 @@
+export type LaunchpadEventProperties = {
+  anonymous_id?: string // 'anon-2134'
+  browser_version?: string // '9.0'
+  browser?: string // 'Mobile Safari'
+  current_url?: string // 'https?://segment.com/academy/'
+  device?: string // 'maguro'
+  group_id?: string // 'groupId123'
+  identified_id?: string // 'user1234'
+  messageId?: string // '859d3955-363f-590a-9aa4-b4f49b582437'
+  ip?: string | unknown // '192.168.1.1'
+  os_version?: string // '8.1.3'
+  os?: string // 'iPhone OS'
+  referrer?: string
+  user_id?: string
+  source: string // 'segment'
+  distinct_id: string | undefined // 'test_segment_user'
+  id?: string | null // this is just to maintain backwards compatibility  with the classic segment integration, I'm not completely sure what the purpose of this was.
+  segment_source_name?: string // 'readme'
+  time?: number
+  properties?: [k: string] | unknown //event props
+  traits?: [k: string] | unknown
+  context?: [k: string] | unknown
+}
+
+export type LaunchpadEvent = {
+  event?: string
+  properties?: LaunchpadEventProperties
+  batch?: LPBatchEvent[]
+  api_key: string
+}
+
+export type LPBatchEvent = {
+  event: string
+  properties: LaunchpadEventProperties
+  timestamp?: string
+}

--- a/packages/destination-actions/src/destinations/launchpad/launchpad-types.ts
+++ b/packages/destination-actions/src/destinations/launchpad/launchpad-types.ts
@@ -25,12 +25,5 @@ export type LaunchpadEventProperties = {
 export type LaunchpadEvent = {
   event?: string
   properties?: LaunchpadEventProperties
-  batch?: LPBatchEvent[]
   api_key: string
-}
-
-export type LPBatchEvent = {
-  event: string
-  properties: LaunchpadEventProperties
-  timestamp?: string
 }

--- a/packages/destination-actions/src/destinations/launchpad/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/launchpad/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Launchpad's trackEvent destination action: all fields 1`] = `
+Array [
+  Object {
+    "event": "8I03tIp&]#vR",
+    "properties": Object {
+      "anonymous_id": "8I03tIp&]#vR",
+      "context": Object {
+        "testType": "8I03tIp&]#vR",
+      },
+      "distinct_id": "8I03tIp&]#vR",
+      "group_id": "8I03tIp&]#vR",
+      "id": "8I03tIp&]#vR",
+      "identified_id": "8I03tIp&]#vR",
+      "messageId": "8I03tIp&]#vR",
+      "properties": Object {
+        "testType": "8I03tIp&]#vR",
+      },
+      "source": "segment",
+      "time": 1612137600000,
+      "traits": Object {
+        "testType": "8I03tIp&]#vR",
+      },
+      "user_id": "8I03tIp&]#vR",
+    },
+  },
+]
+`;
+
+exports[`Testing snapshot for Launchpad's trackEvent destination action: required fields 1`] = `
+Array [
+  Object {
+    "event": "8I03tIp&]#vR",
+    "properties": Object {
+      "id": "8I03tIp&]#vR",
+      "messageId": "d20q4eco4n9zb39b",
+      "source": "segment",
+      "time": 1675003620086,
+    },
+  },
+]
+`;

--- a/packages/destination-actions/src/destinations/launchpad/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/launchpad/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Testing snapshot for Launchpad's trackEvent destination action: all fields 1`] = `
 Array [
   Object {
+    "api_key": "8I03tIp&]#vR",
     "event": "8I03tIp&]#vR",
     "properties": Object {
       "anonymous_id": "8I03tIp&]#vR",
@@ -11,14 +12,13 @@ Array [
       },
       "distinct_id": "8I03tIp&]#vR",
       "group_id": "8I03tIp&]#vR",
-      "id": "8I03tIp&]#vR",
       "identified_id": "8I03tIp&]#vR",
       "messageId": "8I03tIp&]#vR",
       "properties": Object {
         "testType": "8I03tIp&]#vR",
       },
-      "source": "segment",
-      "time": 1612137600000,
+      "segment_source_name": "8I03tIp&]#vR",
+      "time": "2021-02-01T00:00:00.000Z",
       "traits": Object {
         "testType": "8I03tIp&]#vR",
       },
@@ -31,12 +31,14 @@ Array [
 exports[`Testing snapshot for Launchpad's trackEvent destination action: required fields 1`] = `
 Array [
   Object {
+    "api_key": "8I03tIp&]#vR",
     "event": "8I03tIp&]#vR",
     "properties": Object {
-      "id": "8I03tIp&]#vR",
-      "messageId": "x9ojcttowbe99ol6",
-      "source": "segment",
-      "time": 1675102363539,
+      "anonymous_id": "8I03tIp&]#vR",
+      "distinct_id": "8I03tIp&]#vR",
+      "messageId": "8I03tIp&]#vR",
+      "segment_source_name": "8I03tIp&]#vR",
+      "time": "2021-02-01T00:00:00.000Z",
     },
   },
 ]

--- a/packages/destination-actions/src/destinations/launchpad/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/launchpad/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,43 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing snapshot for Launchpad's trackEvent destination action: all fields 1`] = `
-Array [
-  Object {
-    "api_key": "8I03tIp&]#vR",
-    "event": "8I03tIp&]#vR",
-    "properties": Object {
-      "anonymous_id": "8I03tIp&]#vR",
-      "context": Object {
-        "testType": "8I03tIp&]#vR",
-      },
-      "distinct_id": "8I03tIp&]#vR",
-      "group_id": "8I03tIp&]#vR",
-      "identified_id": "8I03tIp&]#vR",
-      "messageId": "8I03tIp&]#vR",
-      "properties": Object {
-        "testType": "8I03tIp&]#vR",
-      },
-      "segment_source_name": "8I03tIp&]#vR",
-      "time": "2021-02-01T00:00:00.000Z",
-      "traits": Object {
-        "testType": "8I03tIp&]#vR",
-      },
-      "user_id": "8I03tIp&]#vR",
+Object {
+  "api_key": "8I03tIp&]#vR",
+  "event": "8I03tIp&]#vR",
+  "properties": Object {
+    "anonymous_id": "8I03tIp&]#vR",
+    "context": Object {
+      "testType": "8I03tIp&]#vR",
     },
+    "distinct_id": "8I03tIp&]#vR",
+    "group_id": "8I03tIp&]#vR",
+    "messageId": "8I03tIp&]#vR",
+    "properties": Object {
+      "testType": "8I03tIp&]#vR",
+    },
+    "segment_source_name": "8I03tIp&]#vR",
+    "time": "2021-02-01T00:00:00.000Z",
+    "traits": Object {
+      "testType": "8I03tIp&]#vR",
+    },
+    "user_id": "8I03tIp&]#vR",
   },
-]
+}
 `;
 
 exports[`Testing snapshot for Launchpad's trackEvent destination action: required fields 1`] = `
-Array [
-  Object {
-    "api_key": "8I03tIp&]#vR",
-    "event": "8I03tIp&]#vR",
-    "properties": Object {
-      "messageId": "8I03tIp&]#vR",
-      "segment_source_name": "8I03tIp&]#vR",
-      "time": "2021-02-01T00:00:00.000Z",
-    },
+Object {
+  "api_key": "8I03tIp&]#vR",
+  "event": "8I03tIp&]#vR",
+  "properties": Object {
+    "messageId": "8I03tIp&]#vR",
+    "segment_source_name": "8I03tIp&]#vR",
+    "time": "2021-02-01T00:00:00.000Z",
   },
-]
+}
 `;

--- a/packages/destination-actions/src/destinations/launchpad/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/launchpad/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -34,8 +34,6 @@ Array [
     "api_key": "8I03tIp&]#vR",
     "event": "8I03tIp&]#vR",
     "properties": Object {
-      "anonymous_id": "8I03tIp&]#vR",
-      "distinct_id": "8I03tIp&]#vR",
       "messageId": "8I03tIp&]#vR",
       "segment_source_name": "8I03tIp&]#vR",
       "time": "2021-02-01T00:00:00.000Z",

--- a/packages/destination-actions/src/destinations/launchpad/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/launchpad/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -34,9 +34,9 @@ Array [
     "event": "8I03tIp&]#vR",
     "properties": Object {
       "id": "8I03tIp&]#vR",
-      "messageId": "d20q4eco4n9zb39b",
+      "messageId": "x9ojcttowbe99ol6",
       "source": "segment",
-      "time": 1675003620086,
+      "time": 1675102363539,
     },
   },
 ]

--- a/packages/destination-actions/src/destinations/launchpad/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/launchpad/trackEvent/__tests__/index.test.ts
@@ -1,0 +1,103 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { ApiRegions } from '../../utils'
+
+const testDestination = createTestIntegration(Destination)
+
+const launchpadAPISecret = 'lp-api-key'
+const timestamp = '2023-01-28T15:21:15.449Z'
+
+const mustHaveProps = {
+  distinct_id: 'user1234',
+  identified_id: 'user1234',
+  ip: '8.8.8.8',
+  properties: {},
+  traits: {},
+  user_id: 'user1234'
+}
+
+describe('Launchpad.trackEvent', () => {
+  it('should always return distinct id', async () => {
+    const event = createTestEvent({ timestamp, event: 'Test Event' })
+
+    nock('https://data.launchpad.pm').post('/capture').reply(200, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        apiSecret: launchpadAPISecret,
+        apiRegion: ApiRegions.EU,
+        sourceName: 'segment'
+      }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.json).toMatchObject([
+      {
+        event: 'Test Event',
+        properties: expect.objectContaining(mustHaveProps)
+      }
+    ])
+  })
+
+  it('should default to the EU endpoint if apiRegion setting is undefined', async () => {
+    const event = createTestEvent({ timestamp, event: 'Test Event' })
+
+    nock('https://data.launchpad.pm').post('/capture').reply(200, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        apiSecret: launchpadAPISecret,
+        sourceName: 'segment'
+      }
+    })
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.json).toMatchObject([
+      {
+        event: 'Test Event',
+        properties: expect.objectContaining(mustHaveProps)
+      }
+    ])
+  })
+
+  it('should use batching when there is more than one event', async () => {
+    const events = [
+      createTestEvent({ timestamp, event: 'Test Event' }),
+      createTestEvent({ timestamp, event: 'Test Event2' })
+    ]
+
+    nock('https://data.launchpad.pm').post('/batch').reply(200, {})
+
+    const responses = await testDestination.testBatchAction('trackEvent', {
+      events,
+      useDefaultMappings: true,
+      settings: {
+        apiSecret: launchpadAPISecret,
+        sourceName: 'segment'
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.json).toMatchObject({
+      batch: [
+        {
+          event: 'Test Event',
+          properties: expect.objectContaining(mustHaveProps)
+        },
+        {
+          event: 'Test Event2',
+          properties: expect.objectContaining(mustHaveProps)
+        }
+      ],
+      api_key: launchpadAPISecret
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/launchpad/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/launchpad/trackEvent/__tests__/index.test.ts
@@ -10,7 +10,6 @@ const timestamp = '2023-01-28T15:21:15.449Z'
 
 const mustHaveProps = {
   distinct_id: 'user1234',
-  identified_id: 'user1234',
   ip: '8.8.8.8',
   properties: {},
   traits: {},
@@ -35,12 +34,10 @@ describe('Launchpad.trackEvent', () => {
     expect(responses.length).toBe(1)
     expect(responses[0].status).toBe(200)
     expect(responses[0].data).toMatchObject({})
-    expect(responses[0].options.json).toMatchObject([
-      {
-        event: 'Test Event',
-        properties: expect.objectContaining(mustHaveProps)
-      }
-    ])
+    expect(responses[0].options.json).toMatchObject({
+      event: 'Test Event',
+      properties: expect.objectContaining(mustHaveProps)
+    })
   })
 
   it('should default to the EU endpoint if apiRegion setting is undefined', async () => {
@@ -58,46 +55,9 @@ describe('Launchpad.trackEvent', () => {
     })
     expect(responses[0].status).toBe(200)
     expect(responses[0].data).toMatchObject({})
-    expect(responses[0].options.json).toMatchObject([
-      {
-        event: 'Test Event',
-        properties: expect.objectContaining(mustHaveProps)
-      }
-    ])
-  })
-
-  it('should use batching when there is more than one event', async () => {
-    const events = [
-      createTestEvent({ timestamp, event: 'Test Event' }),
-      createTestEvent({ timestamp, event: 'Test Event2' })
-    ]
-
-    nock('https://data.launchpad.pm').post('/batch').reply(200, {})
-
-    const responses = await testDestination.testBatchAction('trackEvent', {
-      events,
-      useDefaultMappings: true,
-      settings: {
-        apiSecret: launchpadAPISecret,
-        sourceName: 'segment'
-      }
-    })
-
-    expect(responses.length).toBe(1)
-    expect(responses[0].status).toBe(200)
-    expect(responses[0].data).toMatchObject({})
     expect(responses[0].options.json).toMatchObject({
-      batch: [
-        {
-          event: 'Test Event',
-          properties: expect.objectContaining(mustHaveProps)
-        },
-        {
-          event: 'Test Event2',
-          properties: expect.objectContaining(mustHaveProps)
-        }
-      ],
-      api_key: launchpadAPISecret
+      event: 'Test Event',
+      properties: expect.objectContaining(mustHaveProps)
     })
   })
 })

--- a/packages/destination-actions/src/destinations/launchpad/trackEvent/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/launchpad/trackEvent/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'trackEvent'
+const destinationSlug = 'Launchpad'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/launchpad/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchpad/trackEvent/generated-types.ts
@@ -6,13 +6,13 @@ export interface Payload {
    */
   event: string
   /**
-   * A distinct ID randomly generated prior to calling identify.
-   */
-  anonymousId: string
-  /**
-   * The distinct ID after calling identify.
+   * A unique ID for a known user. This will be used as the Distinct ID. This field is required if the Anonymous ID field is empty
    */
   userId?: string
+  /**
+   * A unique ID for an anonymous user. This will be used as the Distinct ID if the User ID field is empty. This field is required if the User ID field is empty
+   */
+  anonymousId?: string
   /**
    * The unique identifier of the group that performed this event.
    */

--- a/packages/destination-actions/src/destinations/launchpad/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchpad/trackEvent/generated-types.ts
@@ -1,0 +1,50 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The name of the action being performed.
+   */
+  event: string
+  /**
+   * A distinct ID randomly generated prior to calling identify.
+   */
+  anonymousId?: string
+  /**
+   * The distinct ID after calling identify.
+   */
+  userId?: string
+  /**
+   * The unique identifier of the group that performed this event.
+   */
+  groupId?: string
+  /**
+   * A random id that is unique to an event. Launchpad uses $insert_id to deduplicate events.
+   */
+  messageId?: string
+  /**
+   * The timestamp of the event. Launchpad expects epoch timestamp in millisecond or second. Please note, Launchpad only accepts this field as the timestamp. If the field is empty, it will be set to the time Launchpad servers receive it.
+   */
+  timestamp?: string | number
+  /**
+   * An object of key-value pairs that represent additional data to be sent along with the event.
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+  /**
+   * An object of key-value pairs that represent additional data tied to the user.
+   */
+  traits?: {
+    [k: string]: unknown
+  }
+  /**
+   * An object of key-value pairs that provides useful context about the event.
+   */
+  context?: {
+    [k: string]: unknown
+  }
+  /**
+   * Set as true to ensure Segment sends data to Launchpad in batches.
+   */
+  enable_batching?: boolean
+}

--- a/packages/destination-actions/src/destinations/launchpad/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchpad/trackEvent/generated-types.ts
@@ -8,7 +8,7 @@ export interface Payload {
   /**
    * A distinct ID randomly generated prior to calling identify.
    */
-  anonymousId?: string
+  anonymousId: string
   /**
    * The distinct ID after calling identify.
    */
@@ -20,11 +20,11 @@ export interface Payload {
   /**
    * A random id that is unique to an event. Launchpad uses $insert_id to deduplicate events.
    */
-  messageId?: string
+  messageId: string
   /**
    * The timestamp of the event. Launchpad expects epoch timestamp in millisecond or second. Please note, Launchpad only accepts this field as the timestamp. If the field is empty, it will be set to the time Launchpad servers receive it.
    */
-  timestamp?: string | number
+  timestamp: string | number
   /**
    * An object of key-value pairs that represent additional data to be sent along with the event.
    */
@@ -32,7 +32,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * An object of key-value pairs that represent additional data tied to the user.
+   * An object of key-value pairs that represent additional data tied to the user. This is used for segmentation within the platform.
    */
   traits?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/launchpad/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/launchpad/trackEvent/index.ts
@@ -1,0 +1,107 @@
+import { ActionDefinition, RequestClient } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { LaunchpadEvent, LPBatchEvent } from '../launchpad-types'
+import { getApiServerUrl } from '../utils'
+import dayjs from '../../../lib/dayjs'
+import { LaunchpadEventProperties } from '../launchpad-types'
+import { eventProperties } from './launchpad-properties'
+
+function generateGUID(maxlen?: number) {
+  const guid = Math.random().toString(36).substring(2, 10) + Math.random().toString(36).substring(2, 10)
+  return maxlen ? guid.substring(0, maxlen) : guid
+}
+
+function getEventProperties(payload: Payload, settings: Settings): LaunchpadEventProperties {
+  const datetime = payload.timestamp
+  const time = datetime && dayjs.utc(datetime).isValid() ? dayjs.utc(datetime).valueOf() : Date.now()
+
+  const integration = payload.context?.integration as Record<string, string>
+  return {
+    time: time,
+    ip: payload.context?.ip,
+    id: payload.event,
+    anonymous_id: payload.anonymousId,
+    distinct_id: payload.userId ? payload.userId : payload.anonymousId,
+    context: payload.context,
+    group_id: payload.groupId,
+    identified_id: payload.userId,
+    properties: payload.properties,
+    traits: payload.traits,
+    messageId: payload.messageId ?? generateGUID(),
+    source: integration?.name == 'Iterable' ? 'Iterable' : 'segment',
+    user_id: payload.userId,
+    segment_source_name: settings.sourceName
+  }
+}
+
+const getEventFromPayload = (payload: Payload, settings: Settings): LaunchpadEvent => {
+  const event: LaunchpadEvent = {
+    event: payload.event,
+    properties: {
+      ...getEventProperties(payload, settings)
+    },
+    api_key: settings.apiSecret
+  }
+  return event
+}
+
+const getBatchFromPayload = (payload: Payload, settings: Settings): LPBatchEvent => {
+  const event: LPBatchEvent = {
+    event: payload.event,
+    properties: {
+      ...getEventProperties(payload, settings)
+    }
+  }
+  return event
+}
+
+const processData = async (request: RequestClient, settings: Settings, payload: Payload[]) => {
+  let events
+  let urlAddendum: string
+
+  if (payload.length === 1) {
+    events = payload.map((value) => getEventFromPayload(value, settings))
+    urlAddendum = 'capture'
+  } else {
+    events = {
+      api_key: settings.apiSecret,
+      batch: payload.map((value) => getBatchFromPayload(value, settings))
+    }
+    urlAddendum = 'batch'
+  }
+
+  const requestURL: string = `${getApiServerUrl(settings.apiRegion)}` + urlAddendum
+
+  return request(requestURL, {
+    method: 'post',
+    json: events
+  })
+}
+
+const trackEvent: ActionDefinition<Settings, Payload> = {
+  title: 'Track Event',
+  description: 'Send an event to Launchpad. [Learn more about Events in Launchpad]',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    event: {
+      label: 'Event Name',
+      type: 'string',
+      description: 'The name of the action being performed.',
+      required: true,
+      default: {
+        '@path': '$.event'
+      }
+    },
+    ...eventProperties
+  },
+
+  perform: async (request, { settings, payload }) => {
+    return processData(request, settings, [payload])
+  },
+  performBatch: async (request, { settings, payload }) => {
+    return processData(request, settings, payload)
+  }
+}
+
+export default trackEvent

--- a/packages/destination-actions/src/destinations/launchpad/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/launchpad/trackEvent/index.ts
@@ -5,7 +5,6 @@ import { LaunchpadEvent } from '../launchpad-types'
 import { getApiServerUrl } from '../utils'
 import { LaunchpadEventProperties } from '../launchpad-types'
 import { eventProperties } from './launchpad-properties'
-import { IntegrationError } from '@segment/actions-core'
 
 function getEventProperties(payload: Payload, settings: Settings): LaunchpadEventProperties {
   const integration = payload.context?.integration as Record<string, string>
@@ -26,8 +25,6 @@ function getEventProperties(payload: Payload, settings: Settings): LaunchpadEven
 }
 
 const getEventFromPayload = (payload: Payload, settings: Settings): LaunchpadEvent => {
-  if (!payload.anonymousId || !payload.userId) throw new IntegrationError('User ID or AnonymousId required', '400')
-
   const event: LaunchpadEvent = {
     event: payload.event,
     properties: {

--- a/packages/destination-actions/src/destinations/launchpad/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/launchpad/trackEvent/index.ts
@@ -1,10 +1,11 @@
 import { ActionDefinition, RequestClient } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { LaunchpadEvent, LPBatchEvent } from '../launchpad-types'
+import { LaunchpadEvent } from '../launchpad-types'
 import { getApiServerUrl } from '../utils'
 import { LaunchpadEventProperties } from '../launchpad-types'
 import { eventProperties } from './launchpad-properties'
+import { IntegrationError } from '@segment/actions-core'
 
 function getEventProperties(payload: Payload, settings: Settings): LaunchpadEventProperties {
   const integration = payload.context?.integration as Record<string, string>
@@ -15,7 +16,6 @@ function getEventProperties(payload: Payload, settings: Settings): LaunchpadEven
     distinct_id: payload.userId ? payload.userId : payload.anonymousId,
     context: payload.context,
     group_id: payload.groupId,
-    identified_id: payload.userId,
     properties: payload.properties,
     traits: payload.traits ? payload.traits : payload.context?.traits,
     messageId: payload.messageId,
@@ -26,6 +26,8 @@ function getEventProperties(payload: Payload, settings: Settings): LaunchpadEven
 }
 
 const getEventFromPayload = (payload: Payload, settings: Settings): LaunchpadEvent => {
+  if (!payload.anonymousId || !payload.userId) throw new IntegrationError('User ID or AnonymousId required', '400')
+
   const event: LaunchpadEvent = {
     event: payload.event,
     properties: {
@@ -36,36 +38,15 @@ const getEventFromPayload = (payload: Payload, settings: Settings): LaunchpadEve
   return event
 }
 
-const getBatchFromPayload = (payload: Payload, settings: Settings): LPBatchEvent => {
-  const event: LPBatchEvent = {
-    event: payload.event,
-    properties: {
-      ...getEventProperties(payload, settings)
-    }
-  }
-  return event
-}
-
-const processData = async (request: RequestClient, settings: Settings, payload: Payload[]) => {
-  let events
-  let urlAddendum: string
-
-  if (payload.length === 1) {
-    events = payload.map((value) => getEventFromPayload(value, settings))
-    urlAddendum = 'capture'
-  } else {
-    events = {
-      api_key: settings.apiSecret,
-      batch: payload.map((value) => getBatchFromPayload(value, settings))
-    }
-    urlAddendum = 'batch'
-  }
+const processData = async (request: RequestClient, settings: Settings, payload: Payload) => {
+  const event = getEventFromPayload(payload, settings)
+  const urlAddendum = 'capture'
 
   const requestURL: string = `${getApiServerUrl(settings.apiRegion)}` + urlAddendum
 
   return request(requestURL, {
     method: 'post',
-    json: events
+    json: event
   })
 }
 
@@ -87,9 +68,6 @@ const trackEvent: ActionDefinition<Settings, Payload> = {
   },
 
   perform: async (request, { settings, payload }) => {
-    return processData(request, settings, [payload])
-  },
-  performBatch: async (request, { settings, payload }) => {
     return processData(request, settings, payload)
   }
 }

--- a/packages/destination-actions/src/destinations/launchpad/trackEvent/launchpad-properties.ts
+++ b/packages/destination-actions/src/destinations/launchpad/trackEvent/launchpad-properties.ts
@@ -1,0 +1,76 @@
+import { InputField } from '@segment/actions-core'
+
+export const eventProperties: Record<string, InputField> = {
+  anonymousId: {
+    label: 'Anonymous ID',
+    type: 'string',
+    description: 'A distinct ID randomly generated prior to calling identify.',
+    default: {
+      '@path': '$.anonymousId'
+    }
+  },
+  userId: {
+    label: 'User ID',
+    type: 'string',
+    description: 'The distinct ID after calling identify.',
+    default: {
+      '@path': '$.userId'
+    }
+  },
+  groupId: {
+    label: 'Group ID',
+    type: 'string',
+    description: 'The unique identifier of the group that performed this event.',
+    default: {
+      '@path': '$.context.groupId'
+    }
+  },
+  messageId: {
+    label: 'Insert ID',
+    type: 'string',
+    description: 'A random id that is unique to an event. Launchpad uses $insert_id to deduplicate events.',
+    default: {
+      '@path': '$.messageId'
+    }
+  },
+  timestamp: {
+    label: 'Timestamp',
+    type: 'datetime',
+    required: false,
+    description:
+      'The timestamp of the event. Launchpad expects epoch timestamp in millisecond or second. Please note, Launchpad only accepts this field as the timestamp. If the field is empty, it will be set to the time Launchpad servers receive it.',
+    default: {
+      '@path': '$.timestamp'
+    }
+  },
+  properties: {
+    label: 'Event Properties',
+    type: 'object',
+    description: 'An object of key-value pairs that represent additional data to be sent along with the event.',
+    default: {
+      '@path': '$.properties'
+    }
+  },
+  traits: {
+    label: 'User Properties',
+    type: 'object',
+    description: 'An object of key-value pairs that represent additional data tied to the user.',
+    default: {
+      '@path': '$.traits'
+    }
+  },
+  context: {
+    label: 'Event context',
+    description: 'An object of key-value pairs that provides useful context about the event.',
+    type: 'object',
+    default: {
+      '@path': '$.context'
+    }
+  },
+  enable_batching: {
+    type: 'boolean',
+    label: 'Batch Data to Launchpad',
+    description: 'Set as true to ensure Segment sends data to Launchpad in batches.',
+    default: true
+  }
+}

--- a/packages/destination-actions/src/destinations/launchpad/trackEvent/launchpad-properties.ts
+++ b/packages/destination-actions/src/destinations/launchpad/trackEvent/launchpad-properties.ts
@@ -4,6 +4,7 @@ export const eventProperties: Record<string, InputField> = {
   anonymousId: {
     label: 'Anonymous ID',
     type: 'string',
+    required: true,
     description: 'A distinct ID randomly generated prior to calling identify.',
     default: {
       '@path': '$.anonymousId'
@@ -12,6 +13,7 @@ export const eventProperties: Record<string, InputField> = {
   userId: {
     label: 'User ID',
     type: 'string',
+    required: false,
     description: 'The distinct ID after calling identify.',
     default: {
       '@path': '$.userId'
@@ -20,6 +22,7 @@ export const eventProperties: Record<string, InputField> = {
   groupId: {
     label: 'Group ID',
     type: 'string',
+    required: false,
     description: 'The unique identifier of the group that performed this event.',
     default: {
       '@path': '$.context.groupId'
@@ -28,6 +31,7 @@ export const eventProperties: Record<string, InputField> = {
   messageId: {
     label: 'Insert ID',
     type: 'string',
+    required: true,
     description: 'A random id that is unique to an event. Launchpad uses $insert_id to deduplicate events.',
     default: {
       '@path': '$.messageId'
@@ -36,7 +40,7 @@ export const eventProperties: Record<string, InputField> = {
   timestamp: {
     label: 'Timestamp',
     type: 'datetime',
-    required: false,
+    required: true,
     description:
       'The timestamp of the event. Launchpad expects epoch timestamp in millisecond or second. Please note, Launchpad only accepts this field as the timestamp. If the field is empty, it will be set to the time Launchpad servers receive it.',
     default: {
@@ -44,6 +48,7 @@ export const eventProperties: Record<string, InputField> = {
     }
   },
   properties: {
+    required: false,
     label: 'Event Properties',
     type: 'object',
     description: 'An object of key-value pairs that represent additional data to be sent along with the event.',
@@ -52,15 +57,22 @@ export const eventProperties: Record<string, InputField> = {
     }
   },
   traits: {
+    required: false,
     label: 'User Properties',
     type: 'object',
-    description: 'An object of key-value pairs that represent additional data tied to the user.',
+    description:
+      'An object of key-value pairs that represent additional data tied to the user. This is used for segmentation within the platform.',
     default: {
-      '@path': '$.traits'
+      '@if': {
+        exists: { '@path': '$.traits' },
+        then: { '@path': '$.traits' },
+        else: { '@path': '$.context.traits' }
+      }
     }
   },
   context: {
     label: 'Event context',
+    required: false,
     description: 'An object of key-value pairs that provides useful context about the event.',
     type: 'object',
     default: {
@@ -68,6 +80,7 @@ export const eventProperties: Record<string, InputField> = {
     }
   },
   enable_batching: {
+    required: false,
     type: 'boolean',
     label: 'Batch Data to Launchpad',
     description: 'Set as true to ensure Segment sends data to Launchpad in batches.',

--- a/packages/destination-actions/src/destinations/launchpad/trackEvent/launchpad-properties.ts
+++ b/packages/destination-actions/src/destinations/launchpad/trackEvent/launchpad-properties.ts
@@ -1,22 +1,22 @@
 import { InputField } from '@segment/actions-core'
 
 export const eventProperties: Record<string, InputField> = {
-  anonymousId: {
-    label: 'Anonymous ID',
-    type: 'string',
-    required: true,
-    description: 'A distinct ID randomly generated prior to calling identify.',
-    default: {
-      '@path': '$.anonymousId'
-    }
-  },
   userId: {
     label: 'User ID',
     type: 'string',
-    required: false,
-    description: 'The distinct ID after calling identify.',
+    description:
+      'A unique ID for a known user. This will be used as the Distinct ID. This field is required if the Anonymous ID field is empty',
     default: {
       '@path': '$.userId'
+    }
+  },
+  anonymousId: {
+    label: 'Anonymous ID',
+    type: 'string',
+    description:
+      'A unique ID for an anonymous user. This will be used as the Distinct ID if the User ID field is empty. This field is required if the User ID field is empty',
+    default: {
+      '@path': '$.anonymousId'
     }
   },
   groupId: {

--- a/packages/destination-actions/src/destinations/launchpad/utils.ts
+++ b/packages/destination-actions/src/destinations/launchpad/utils.ts
@@ -1,0 +1,20 @@
+export enum ApiRegions {
+  US = 'US 🇺🇸',
+  EU = 'EU 🇪🇺'
+}
+
+// export enum StrictMode {
+//   ON = '1',
+//   OFF = '0'
+// }
+
+export function getConcatenatedName(firstName: unknown, lastName: unknown, name: unknown): unknown {
+  return name ?? (firstName && lastName ? `${firstName} ${lastName}` : undefined)
+}
+
+export function getApiServerUrl(apiRegion: string | unknown) {
+  if (apiRegion == ApiRegions.EU) {
+    return 'https://data.launchpad.pm/'
+  }
+  return 'https://data.launchpad.pm/'
+}


### PR DESCRIPTION
_Launchpad <> Segment Integration._


We are now adding the ability to send events from segment into [Launchpad.pm](https://www.launchpad.pm) - the mission control for Product teams at scale.

We are adding the following:
* trackEvent
* groupIdentifyUser
* identifyUser

We have added unit tests and have tested this manually.

It requires the following:
* apiRegion - EU by default. We have added the US as means of future extensibility.
* apiSecret - given by Launchpad.pm while onboarding.
* sourceName - to be added.


## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] confirmed that all events arrive into the Launchpad.pm platform as intended. 
- [ ] [Segmenters] Tested in the staging environment
