### PR TITLE
livelike-cloud action destination PE-41

### DIFF
--- a/packages/destination-actions/src/destinations/livelike-cloud/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/livelike-cloud/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-livelike-cloud destination: trackEvent action - all fields 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "action_description": "n]C0wig#f82f0li1(A",
+      "action_key": "n]C0wig#f82f0li1(A",
+      "action_name": "n]C0wig#f82f0li1(A",
+      "livelike_profile_id": "n]C0wig#f82f0li1(A",
+      "properties": Object {
+        "testType": "n]C0wig#f82f0li1(A",
+      },
+      "timestamp": "2021-02-01T00:00:00.000Z",
+      "user_id": "n]C0wig#f82f0li1(A",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for actions-livelike-cloud destination: trackEvent action - required fields 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "action_key": "n]C0wig#f82f0li1(A",
+      "livelike_profile_id": "n]C0wig#f82f0li1(A",
+      "timestamp": "2021-02-01T00:00:00.000Z",
+      "user_id": "n]C0wig#f82f0li1(A",
+    },
+  ],
+}
+`;

--- a/packages/destination-actions/src/destinations/livelike-cloud/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/livelike-cloud/__tests__/index.test.ts
@@ -1,0 +1,26 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+import { apiBaseUrl } from '../properties'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Livelike', () => {
+  describe('testAuthentication', () => {
+    it('should throw an error in case of invalid inputs', async () => {
+      nock(apiBaseUrl).get('/applications/abc/validate-app/').matchHeader('authorization', `Bearer 123`).reply(401, {})
+
+      const authData = { clientId: 'abc', producerToken: '123' }
+
+      await expect(testDestination.testAuthentication(authData)).rejects.toThrowError()
+    })
+
+    it('should validate authentication inputs', async () => {
+      nock(apiBaseUrl).get('/applications/abc/validate-app/').matchHeader('authorization', `Bearer 123`).reply(200, {})
+
+      const authData = { clientId: 'abc', producerToken: '123' }
+
+      await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/livelike-cloud/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/livelike-cloud/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-livelike-cloud'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/livelike-cloud/generated-types.ts
+++ b/packages/destination-actions/src/destinations/livelike-cloud/generated-types.ts
@@ -1,0 +1,12 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your LiveLike Application Client ID.
+   */
+  clientId: string
+  /**
+   * Your LiveLike Producer token.
+   */
+  producerToken: string
+}

--- a/packages/destination-actions/src/destinations/livelike-cloud/index.ts
+++ b/packages/destination-actions/src/destinations/livelike-cloud/index.ts
@@ -1,0 +1,84 @@
+import { defaultValues, DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+import { apiBaseUrl } from './properties'
+
+import trackEvent from './trackEvent'
+
+const presets: DestinationDefinition['presets'] = [
+  {
+    name: 'Track User Actions',
+    subscribe: 'type = "track"',
+    partnerAction: 'trackEvent',
+    mapping: defaultValues(trackEvent.fields)
+  },
+  {
+    name: 'Page Calls',
+    subscribe: 'type = "page"',
+    partnerAction: 'trackEvent',
+    mapping: {
+      ...defaultValues(trackEvent.fields),
+      action_name: {
+        '@if': {
+          exists: { '@path': '$.properties.action_name' },
+          then: { '@path': '$.properties.action_name' },
+          else: { '@path': '$.properties.title' }
+        }
+      }
+    }
+  },
+  {
+    name: 'Screen Calls',
+    subscribe: 'type = "screen"',
+    partnerAction: 'trackEvent',
+    mapping: {
+      ...defaultValues(trackEvent.fields),
+      action_name: {
+        '@if': {
+          exists: { '@path': '$.properties.action_name' },
+          then: { '@path': '$.properties.action_name' },
+          else: { '@path': '$.properties.title' }
+        }
+      }
+    }
+  }
+]
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'LiveLike',
+  slug: 'actions-livelike-cloud',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      clientId: {
+        label: 'Client ID',
+        description: 'Your LiveLike Application Client ID.',
+        type: 'string',
+        required: true
+      },
+      producerToken: {
+        label: 'Producer Token',
+        description: 'Your LiveLike Producer token.',
+        type: 'password',
+        required: true
+      }
+    },
+    testAuthentication: async (request, { settings }) => {
+      return request(`${apiBaseUrl}/applications/${settings.clientId}/validate-app/`, {
+        method: 'get'
+      })
+    }
+  },
+  extendRequest: ({ settings }) => {
+    return {
+      headers: { Authorization: `Bearer ${settings.producerToken}` }
+    }
+  },
+  presets,
+  actions: {
+    trackEvent
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/livelike-cloud/properties.ts
+++ b/packages/destination-actions/src/destinations/livelike-cloud/properties.ts
@@ -1,0 +1,1 @@
+export const apiBaseUrl = 'https://cf-blast-iconic.livelikecdn.com/api/v1'

--- a/packages/destination-actions/src/destinations/livelike-cloud/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/livelike-cloud/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for LivelikeCloud's trackEvent destination action: all fields 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "action_description": "&Lu]rW[@yx2%6aWnTgQ",
+      "action_key": "&Lu]rW[@yx2%6aWnTgQ",
+      "action_name": "&Lu]rW[@yx2%6aWnTgQ",
+      "livelike_profile_id": "&Lu]rW[@yx2%6aWnTgQ",
+      "properties": Object {
+        "testType": "&Lu]rW[@yx2%6aWnTgQ",
+      },
+      "timestamp": "2021-02-01T00:00:00.000Z",
+      "user_id": "&Lu]rW[@yx2%6aWnTgQ",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for LivelikeCloud's trackEvent destination action: required fields 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "action_key": "&Lu]rW[@yx2%6aWnTgQ",
+      "livelike_profile_id": "&Lu]rW[@yx2%6aWnTgQ",
+      "timestamp": "2021-02-01T00:00:00.000Z",
+      "user_id": "&Lu]rW[@yx2%6aWnTgQ",
+    },
+  ],
+}
+`;

--- a/packages/destination-actions/src/destinations/livelike-cloud/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/livelike-cloud/trackEvent/__tests__/index.test.ts
@@ -1,0 +1,250 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration, IntegrationError } from '@segment/actions-core'
+import Destination from '../../index'
+import { Payload } from '../generated-types'
+import { apiBaseUrl } from '../../properties'
+
+const testDestination = createTestIntegration(Destination)
+const LIVELIKE_CLIENT_ID = 'test-client-id'
+const LIVELIKE_PRODUCER_TOKEN = 'test-producer-token'
+const timestamp = '2021-08-17T15:21:15.449Z'
+const livelike_profile_id = 'user123'
+
+const expectedEvent: Payload = {
+  action_key: 'test-event',
+  properties: {},
+  timestamp: timestamp
+}
+
+describe('LiveLike.trackEvent', () => {
+  it('should throw integration error when clientId and producerToken is not configured', async () => {
+    const event = createTestEvent({
+      timestamp,
+      properties: {
+        action_key: 'test-event',
+        livelike_profile_id: livelike_profile_id
+      }
+    })
+
+    await expect(
+      testDestination.testAction('trackEvent', {
+        event,
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError(new IntegrationError('Missing client ID or producer token.'))
+  })
+
+  it('should throw integration error when livelike_profile_id or user_id is not found or null', async () => {
+    const event = createTestEvent({
+      //Need to set userId as null because `createTestEvent` and `testAction` adds a default userId which will fail the test everytime.
+      userId: null,
+      timestamp,
+      properties: {
+        action_key: 'test-event'
+      }
+    })
+
+    await expect(
+      testDestination.testAction('trackEvent', {
+        event,
+        useDefaultMappings: true,
+        settings: {
+          clientId: LIVELIKE_CLIENT_ID,
+          producerToken: LIVELIKE_PRODUCER_TOKEN
+        }
+      })
+    ).rejects.toThrowError(
+      new IntegrationError('`livelike_profile_id` or `user_id` is required.', 'Missing required fields', 400)
+    )
+  })
+
+  it('should throw integration error when action_key is not found', async () => {
+    const event = createTestEvent({
+      timestamp,
+      properties: {
+        livelike_profile_id: livelike_profile_id
+      }
+    })
+
+    await expect(
+      testDestination.testAction('trackEvent', {
+        event,
+        useDefaultMappings: true,
+        settings: {
+          clientId: LIVELIKE_CLIENT_ID,
+          producerToken: LIVELIKE_PRODUCER_TOKEN
+        }
+      })
+    ).rejects.toThrowError(new IntegrationError("The root value is missing the required field 'action_key'."))
+  })
+
+  it('should validate action fields when userId is found and not livelike_profile_id ', async () => {
+    const event = createTestEvent({
+      userId: livelike_profile_id,
+      timestamp,
+      properties: {
+        action_key: 'test-event'
+      }
+    })
+
+    nock(apiBaseUrl)
+      .post(`/applications/${LIVELIKE_CLIENT_ID}/segment-events/`)
+      .matchHeader('authorization', `Bearer ${LIVELIKE_PRODUCER_TOKEN}`)
+      .reply(202, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        clientId: LIVELIKE_CLIENT_ID,
+        producerToken: LIVELIKE_PRODUCER_TOKEN
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(202)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.json).toMatchObject({
+      events: [
+        {
+          ...expectedEvent,
+          user_id: livelike_profile_id
+        }
+      ]
+    })
+  })
+
+  it('should validate action fields when livelike_profile_id is found and not user_id ', async () => {
+    const event = createTestEvent({
+      timestamp,
+      properties: {
+        action_key: 'test-event',
+        livelike_profile_id: livelike_profile_id
+      }
+    })
+
+    nock(apiBaseUrl)
+      .post(`/applications/${LIVELIKE_CLIENT_ID}/segment-events/`)
+      .matchHeader('authorization', `Bearer ${LIVELIKE_PRODUCER_TOKEN}`)
+      .reply(202, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        clientId: LIVELIKE_CLIENT_ID,
+        producerToken: LIVELIKE_PRODUCER_TOKEN
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(202)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.json).toMatchObject({
+      events: [
+        {
+          ...expectedEvent,
+          livelike_profile_id: livelike_profile_id
+        }
+      ]
+    })
+  })
+
+  it('should invoke performBatch for batches', async () => {
+    const events = [
+      createTestEvent({
+        timestamp,
+        properties: {
+          action_key: 'test-event',
+          livelike_profile_id: livelike_profile_id
+        }
+      }),
+      createTestEvent({
+        timestamp,
+        properties: {
+          action_key: 'test-event',
+          livelike_profile_id: livelike_profile_id
+        }
+      })
+    ]
+
+    nock(apiBaseUrl)
+      .post(`/applications/${LIVELIKE_CLIENT_ID}/segment-events/`)
+      .matchHeader('authorization', `Bearer ${LIVELIKE_PRODUCER_TOKEN}`)
+      .reply(202, {})
+
+    const responses = await testDestination.testBatchAction('trackEvent', {
+      events,
+      useDefaultMappings: true,
+      settings: {
+        clientId: LIVELIKE_CLIENT_ID,
+        producerToken: LIVELIKE_PRODUCER_TOKEN
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(202)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.json).toMatchObject({
+      events: [
+        {
+          ...expectedEvent,
+          livelike_profile_id: livelike_profile_id
+        },
+        {
+          ...expectedEvent,
+          livelike_profile_id: livelike_profile_id
+        }
+      ]
+    })
+  })
+
+  it('should validate action fields when event type is page or screen(presets) ', async () => {
+    const event = createTestEvent({
+      type: 'page',
+      timestamp,
+      properties: {
+        name: 'Home Page',
+        action_key: 'test-event',
+        livelike_profile_id: livelike_profile_id
+      }
+    })
+
+    nock(apiBaseUrl)
+      .post(`/applications/${LIVELIKE_CLIENT_ID}/segment-events/`)
+      .matchHeader('authorization', `Bearer ${LIVELIKE_PRODUCER_TOKEN}`)
+      .reply(202, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      // Using the mapping of presets with event type 'page' and 'screen'
+      mapping: {
+        action_name: {
+          '@if': {
+            exists: { '@path': '$.properties.action_name' },
+            then: { '@path': '$.properties.action_name' },
+            else: { '@path': '$.properties.name' }
+          }
+        }
+      },
+      useDefaultMappings: true,
+      settings: {
+        clientId: LIVELIKE_CLIENT_ID,
+        producerToken: LIVELIKE_PRODUCER_TOKEN
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(202)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.json).toMatchObject({
+      events: [
+        {
+          ...expectedEvent,
+          livelike_profile_id: livelike_profile_id,
+          action_name: 'Home Page'
+        }
+      ]
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/livelike-cloud/trackEvent/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/livelike-cloud/trackEvent/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'trackEvent'
+const destinationSlug = 'LivelikeCloud'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/livelike-cloud/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/livelike-cloud/trackEvent/generated-types.ts
@@ -1,0 +1,34 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The unique key of Action. LiveLike will uniquely identify any event by this key.
+   */
+  action_key: string
+  /**
+   * The name of the action being performed.
+   */
+  action_name?: string
+  /**
+   * The description of the Action.
+   */
+  action_description?: string
+  /**
+   * A unique identifier for a user. Atleast one of `User ID` or `LiveLike User Profile ID` is mandatory.
+   */
+  user_id?: string
+  /**
+   * The unique LiveLike user identifier. Atleast one of `LiveLike User Profile ID` or `User ID` is mandatory.
+   */
+  livelike_profile_id?: string
+  /**
+   * The timestamp of the event.
+   */
+  timestamp: string | number
+  /**
+   * Properties of the event.
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/livelike-cloud/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/livelike-cloud/trackEvent/index.ts
@@ -57,7 +57,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'User ID',
       type: 'string',
       description:
-        'A unique identifier for a user. Atleast one of `User ID` or `LiveLike User Profile ID` is mandatory.',
+        'A unique identifier for a user. At least one of `User ID` or `LiveLike User Profile ID` is mandatory.',
       default: {
         '@path': '$.userId'
       }

--- a/packages/destination-actions/src/destinations/livelike-cloud/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/livelike-cloud/trackEvent/index.ts
@@ -1,0 +1,107 @@
+import { ActionDefinition, IntegrationError, RequestClient } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import { apiBaseUrl } from '../properties'
+import type { Payload } from './generated-types'
+
+const processData = async (request: RequestClient, settings: Settings, payloads: Payload[]) => {
+  const events = payloads.map((payload) => {
+    if (!payload.livelike_profile_id && !payload.user_id) {
+      throw new IntegrationError('`livelike_profile_id` or `user_id` is required.', 'Missing required fields', 400)
+    }
+    return payload
+  })
+
+  return request(`${apiBaseUrl}/applications/${settings.clientId}/segment-events/`, {
+    method: 'post',
+    json: {
+      events
+    }
+  })
+}
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Track Event',
+  description: 'Send an event to LiveLike.',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    action_key: {
+      label: 'Action Key',
+      description: 'The unique key of Action. LiveLike will uniquely identify any event by this key.',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.properties.action_key'
+      }
+    },
+    action_name: {
+      label: 'Action Name',
+      description: 'The name of the action being performed.',
+      type: 'string',
+      default: {
+        '@if': {
+          exists: { '@path': '$.properties.action_name' },
+          then: { '@path': '$.properties.action_name' },
+          else: { '@path': '$.event' }
+        }
+      }
+    },
+    action_description: {
+      label: 'Action Description',
+      description: 'The description of the Action.',
+      type: 'string',
+      default: {
+        '@path': '$.properties.action_description'
+      }
+    },
+    user_id: {
+      label: 'User ID',
+      type: 'string',
+      description:
+        'A unique identifier for a user. Atleast one of `User ID` or `LiveLike User Profile ID` is mandatory.',
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    livelike_profile_id: {
+      label: 'LiveLike User Profile ID',
+      description:
+        'The unique LiveLike user identifier. Atleast one of `LiveLike User Profile ID` or `User ID` is mandatory.',
+      type: 'string',
+      default: {
+        '@path': '$.properties.livelike_profile_id'
+      }
+    },
+    timestamp: {
+      label: 'Timestamp',
+      description: 'The timestamp of the event.',
+      type: 'datetime',
+      required: true,
+      default: {
+        '@path': '$.timestamp'
+      }
+    },
+    properties: {
+      label: 'Event Properties',
+      description: 'Properties of the event.',
+      type: 'object',
+      default: {
+        '@path': '$.properties'
+      }
+    }
+  },
+  perform: (request, { payload, settings }) => {
+    if (!settings.clientId || !settings.producerToken) {
+      throw new IntegrationError('Missing client ID or producer token.')
+    }
+    return processData(request, settings, [payload])
+  },
+
+  performBatch: async (request, { settings, payload }) => {
+    if (!settings.clientId || !settings.producerToken) {
+      throw new IntegrationError('Missing client ID or producer token.')
+    }
+    return processData(request, settings, payload)
+  }
+}
+
+export default action


### PR DESCRIPTION
This is the initial livelike-cloud destination.
This includes an action for tracking events and 3 presets for `track`, `page` and `screen` event types.

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [✓] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
