### PR TITLE
Qualtrics - Fixed timezone issue in unit test

### DIFF
--- a/packages/destination-actions/src/destinations/qualtrics/upsertContactTransaction/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/qualtrics/upsertContactTransaction/__tests__/index.test.ts
@@ -1,10 +1,9 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
-import dayjs from 'dayjs'
-import utc from 'dayjs/plugin/utc'
+import dayjs from '../../../../lib/dayjs'
 
-dayjs.extend(utc)
+// Create a date object from the current time
 const dateObj = dayjs()
 
 const testDestination = createTestIntegration(Destination)
@@ -16,7 +15,9 @@ const DIRECTORY_ID = 'POOL_XXXX'
 const CONTACT_ID = 'CID_XXXX'
 const MAILING_LIST_ID = 'CG_XXXX'
 const TRANSACTION_DATA = { Key: 'Value' }
+// Convert the date object to formatted string
 const TRANSACTION_DATE = dateObj.format('YYYY-MM-DD HH:mm:ss')
+// Convert the date object to formatted string in UTC
 const TRANSACTION_DATE_UTC = dateObj.utc().format('YYYY-MM-DD HH:mm:ss')
 const CONTACT_INFO = {
   firstName: 'Jane',

--- a/packages/destination-actions/src/destinations/qualtrics/upsertContactTransaction/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/qualtrics/upsertContactTransaction/__tests__/index.test.ts
@@ -1,6 +1,11 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+
+dayjs.extend(utc)
+const dateObj = dayjs()
 
 const testDestination = createTestIntegration(Destination)
 const SETTINGS = {
@@ -11,7 +16,8 @@ const DIRECTORY_ID = 'POOL_XXXX'
 const CONTACT_ID = 'CID_XXXX'
 const MAILING_LIST_ID = 'CG_XXXX'
 const TRANSACTION_DATA = { Key: 'Value' }
-const TRANSACTION_DATE = '2000-01-01 00:00:00'
+const TRANSACTION_DATE = dateObj.format('YYYY-MM-DD HH:mm:ss')
+const TRANSACTION_DATE_UTC = dateObj.utc().format('YYYY-MM-DD HH:mm:ss')
 const CONTACT_INFO = {
   firstName: 'Jane',
   lastName: 'Doe',
@@ -77,7 +83,7 @@ describe('upsertContactTransaction', () => {
     expect(actualRequest[Object.keys(actualRequest)[0]]).toMatchObject({
       contactId: CONTACT_ID,
       data: TRANSACTION_DATA,
-      transactionDate: TRANSACTION_DATE,
+      transactionDate: TRANSACTION_DATE_UTC,
       mailingListId: MAILING_LIST_ID
     })
   })
@@ -140,7 +146,7 @@ describe('upsertContactTransaction', () => {
     expect(actualCreateTransactionRequest[Object.keys(actualCreateTransactionRequest)[0]]).toMatchObject({
       contactId: 'CID_FOUND',
       data: TRANSACTION_DATA,
-      transactionDate: TRANSACTION_DATE,
+      transactionDate: TRANSACTION_DATE_UTC,
       mailingListId: MAILING_LIST_ID
     })
   })
@@ -232,7 +238,7 @@ describe('upsertContactTransaction', () => {
     expect(actualCreateTransactionRequest[Object.keys(actualCreateTransactionRequest)[0]]).toMatchObject({
       contactId: 'CID_CREATED',
       data: TRANSACTION_DATA,
-      transactionDate: TRANSACTION_DATE,
+      transactionDate: TRANSACTION_DATE_UTC,
       mailingListId: MAILING_LIST_ID
     })
   })


### PR DESCRIPTION
There is a test case that is failing in the main branch due to timezone difference.

Note: The issue can be reproduced from a timezone other than UTC. Our CI servers are already running in UTC which is the reason this was not detected by CI tests.

Steps to reproduce:
- Clone `action-destinations` git repo (if not already done)
- Execute `git pull` on main branch to pull the latest changes
- Execute `yarn cloud test`

![image](https://user-images.githubusercontent.com/109198085/217517547-16410f16-a922-4112-b9e6-8d1f2c27ac5a.png)


This PR fixes the test case.
![image](https://user-images.githubusercontent.com/109198085/217517927-866ea26c-39f6-4bdb-a864-6840cf6775e2.png)


## Testing
Testing not required as this is a minor fix in unit test.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
