### PR TITLE
[STRATCONN-1950] Init new destination `Pinterest Conversions API`

### DIFF
--- a/packages/destination-actions/src/destinations/pinterest-conversions/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/__tests__/index.test.ts
@@ -1,0 +1,22 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+import { Settings } from '../generated-types'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Pinterest Conversions Api', () => {
+  describe('testAuthentication', () => {
+    it('should validate authentication inputs', async () => {
+      nock('https://your.destination.endpoint').get('*').reply(200, {})
+
+      // This should match your authentication.fields
+      const authData: Settings = {
+        ad_account_id: 'ad_account_id',
+        conversion_token: 'test_token'
+      }
+
+      await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/pinterest-conversions/generated-types.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/generated-types.ts
@@ -1,0 +1,12 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Unique identifier of an ad account. This can be found in the Pinterest UI by following the steps mentioned [here](https://developers.pinterest.com/docs/conversions/conversion-management/#Finding%20your%20%2Cad_account_id).
+   */
+  ad_account_id: string
+  /**
+   * The conversion token for your Pinterest account. This can be found in the Pinterest UI by following the steps mentioned [here](https://developers.pinterest.com/docs/conversions/conversion-management/#Authenticating%20for%20the%20send%20conversion%20events%20endpoint).
+   */
+  conversion_token: string
+}

--- a/packages/destination-actions/src/destinations/pinterest-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/index.ts
@@ -1,0 +1,37 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Pinterest Conversions Api',
+  slug: 'actions-pinterest-conversions',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      ad_account_id: {
+        label: 'Ad Account ID',
+        description:
+          'Unique identifier of an ad account. This can be found in the Pinterest UI by following the steps mentioned [here](https://developers.pinterest.com/docs/conversions/conversion-management/#Finding%20your%20%2Cad_account_id).',
+        type: 'string',
+        required: true
+      },
+      conversion_token: {
+        label: 'Conversion Token',
+        description:
+          'The conversion token for your Pinterest account. This can be found in the Pinterest UI by following the steps mentioned [here](https://developers.pinterest.com/docs/conversions/conversion-management/#Authenticating%20for%20the%20send%20conversion%20events%20endpoint).',
+        type: 'password',
+        required: true
+      }
+    },
+    testAuthentication: (_request) => {
+      // Return a request that tests/validates the user's credentials.
+      // If you do not have a way to validate the authentication fields safely,
+      // you can remove the `testAuthentication` function, though discouraged.
+    }
+  },
+
+  actions: {}
+}
+
+export default destination


### PR DESCRIPTION
This PR Boorstraps `Pinterest Conversions API` in Actions Destination.
There is currently no actions or test cases in this destination and will be added later.

## Testing
Testing not required this registers a new destination to kick-off the development.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
