### PR TITLE
[STRATCONN-1799] Update GA4 Cloud Mode name

### DIFF
--- a/packages/destination-actions/src/destinations/google-analytics-4/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/index.ts
@@ -21,9 +21,7 @@ import refund from './refund'
 import removeFromCart from './removeFromCart'
 
 const destination: DestinationDefinition<Settings> = {
-  // NOTE: We need to match the name with the creation name in DB.
-  // This is not the value used in the UI.
-  name: 'Actions Google Analytic 4',
+  name: 'Google Analytics 4 Cloud Mode',
   slug: 'actions-google-analytics-4',
   mode: 'cloud',
   authentication: {

--- a/packages/destination-actions/src/destinations/google-analytics-4/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/index.ts
@@ -21,7 +21,7 @@ import refund from './refund'
 import removeFromCart from './removeFromCart'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Google Analytics 4 Cloud Mode',
+  name: 'Google Analytics 4 Cloud',
   slug: 'actions-google-analytics-4',
   mode: 'cloud',
   authentication: {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_This PR updates the current GA4 cloud mode destination from `Google Analytics 4` to `Google Analytics 4 Cloud Mode` to avoid any confusion with the new GA4 browser destination going to public beta._

## Testing

Stage Testing: 

Confirmed none of the previous names were `Google Analytics 4 Cloud Mode`: 

![image](https://user-images.githubusercontent.com/89420099/217665243-419b6f71-f8e8-44c8-ad45-60fa284b8b63.png)


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
