### PR TITLE
Mixpanel destination: use user-agent for browser data

### DIFF
--- a/packages/destination-actions/src/destinations/mixpanel/trackEvent/functions.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackEvent/functions.ts
@@ -14,8 +14,8 @@ export function getEventProperties(payload: Payload, settings: Settings): Mixpan
     const utm = payload.utm_properties || {}
     let browser, browserVersion
     if (payload.userAgent) {
-        browser = getBrowser(payload.userAgent, payload.device_manufacturer)
-        browserVersion = getBrowserVersion(payload.userAgent, payload.device_manufacturer)
+        browser = getBrowser(payload.userAgent)
+        browserVersion = getBrowserVersion(payload.userAgent)
     }
     const integration = payload.context?.integration as Record<string, string>
     return {

--- a/packages/destination-actions/src/destinations/mixpanel/utils.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/utils.ts
@@ -21,8 +21,7 @@ export function getApiServerUrl(apiRegion: string | undefined) {
   return 'https://api.mixpanel.com'
 }
 
-export function getBrowser(userAgent: string, vendor: string | undefined): string {
-  vendor = vendor || '' // vendor is undefined for at least IE9
+export function getBrowser(userAgent: string): string {
   if (userAgent.includes(' OPR/')) {
     if (userAgent.includes('Mini')) {
       return 'Opera Mini'
@@ -47,11 +46,11 @@ export function getBrowser(userAgent: string, vendor: string | undefined): strin
     return 'UC Browser'
   } else if (userAgent.includes('FxiOS')) {
     return 'Firefox iOS'
-  } else if (vendor.includes('Apple')) {
-    if (userAgent.includes('Mobile')) {
-      return 'Mobile Safari'
+  } else if (userAgent.includes('Safari')) {
+    if (userAgent.includes('Macintosh')) {
+      return 'Safari'
     }
-    return 'Safari'
+    return 'Mobile Safari'
   } else if (userAgent.includes('Android')) {
     return 'Android Mobile'
   } else if (userAgent.includes('Konqueror')) {
@@ -67,8 +66,8 @@ export function getBrowser(userAgent: string, vendor: string | undefined): strin
   }
 }
 
-export function getBrowserVersion(userAgent: string, vendor: string | undefined) {
-  const browser = getBrowser(userAgent, vendor)
+export function getBrowserVersion(userAgent: string) {
+  const browser = getBrowser(userAgent)
   const versionRegexs: { [browser: string]: RegExp } = {
     'Internet Explorer Mobile': /rv:(\d+(\.\d+)?)/,
     'Microsoft Edge': /Edge?\/(\d+(\.\d+)?)/,

--- a/packages/destination-actions/src/destinations/mixpanel/utils.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/utils.ts
@@ -9,9 +9,7 @@ export enum StrictMode {
 }
 
 export function getConcatenatedName(firstName: unknown, lastName: unknown, name: unknown): unknown {
-  return (
-    name ?? (firstName && lastName ? `${ firstName } ${ lastName }` : undefined)
-  )
+  return name ?? (firstName && lastName ? `${firstName} ${lastName}` : undefined)
 }
 
 export function getApiServerUrl(apiRegion: string | undefined) {
@@ -47,10 +45,7 @@ export function getBrowser(userAgent: string): string {
   } else if (userAgent.includes('FxiOS')) {
     return 'Firefox iOS'
   } else if (userAgent.includes('Safari')) {
-    if (userAgent.includes('Macintosh')) {
-      return 'Safari'
-    }
-    return 'Mobile Safari'
+    return 'Safari'
   } else if (userAgent.includes('Android')) {
     return 'Android Mobile'
   } else if (userAgent.includes('Konqueror')) {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Previously Mixpanel used `device_manufacturer` for detecting Safari. However, this parameter is no longer passed as part of payload for the current `analysis` APIs. This PR remove dependency on `device_manufacturer` and rely on user-agent to parse browser data.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
