### PR TITLE
Prevent trapping calls to `then` on returning CommandBar's SDK object

### DIFF
--- a/packages/browser-destinations/src/destinations/commandbar/index.ts
+++ b/packages/browser-destinations/src/destinations/commandbar/index.ts
@@ -58,8 +58,9 @@ export const destination: BrowserDestinationDefinition<Settings, CommandBarClien
 
     await deps.resolveWhen(() => Object.prototype.hasOwnProperty.call(window, 'CommandBar'), 100)
 
-    // Older CommandBar snippets initialize a proxy that will trap calls to `then` recursively
-    // `then` is called implicitly on the return value of a Promise, so we need to remove that behavior
+    // Older CommandBar snippets initialize a proxy that traps all field access including `then`
+    // `then` is called implicitly on the return value of an async function on await
+    // So, we need to remove that behavior for the promise to resolve
     Object.assign(window.CommandBar, { then: undefined })
 
     return window.CommandBar

--- a/packages/browser-destinations/src/destinations/commandbar/index.ts
+++ b/packages/browser-destinations/src/destinations/commandbar/index.ts
@@ -58,6 +58,10 @@ export const destination: BrowserDestinationDefinition<Settings, CommandBarClien
 
     await deps.resolveWhen(() => Object.prototype.hasOwnProperty.call(window, 'CommandBar'), 100)
 
+    // Older CommandBar snippets initialize a proxy that will trap calls to `then` recursively
+    // `then` is called implicitly on the return value of a Promise, so we need to remove that behavior
+    Object.assign(window.CommandBar, { then: undefined })
+
     return window.CommandBar
   },
 


### PR DESCRIPTION
## Change description
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Unfortunately, our earlier PR #1009 does not fix all cases of problems with initializing our browser destination that we have seen during private beta.

The problem is that some customers do not initialize CommandBar with the snippet that is included in the destination but use an older version of the CommandBar SDK initialization snippet. Back then, we initialized a `Proxy` that trapped all field access. This is a problem when the SDK object is the return value of a promise, as that will implicitly access the object's `then` field and cause the Promise to never resolve. 

The implemented solution is to explicitly set `then` to `undefined` on the returned SDK object.

## Testing


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
