### PR TITLE
changing name of new Algolia Insights Integration

### DIFF
--- a/packages/destination-actions/src/destinations/algolia-insights/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/index.ts
@@ -11,7 +11,7 @@ import { AlgoliaApiPermissions, algoliaApiPermissionsUrl } from './algolia-insig
 export const ALGOLIA_INSIGHTS_USER_AGENT = 'algolia-segment-action-destination: 0.1'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Algolia Insights',
+  name: 'Algolia Insights (Actions)',
   slug: 'actions-algolia-insights',
   mode: 'cloud',
 


### PR DESCRIPTION
## Summary
Changing name for algolia-insights Integration to so that it can be registered. 
Currently the name of this new Inetgration clashes with the Classic Destination. 

## Testing

None required. 
