### PR TITLE
Use correct defaultPath for messageId in Ripe Cloud Mode

### DIFF
--- a/packages/destination-actions/src/destinations/ripe/group/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/ripe/group/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Testing snapshot for Ripe's group destination action: all fields 1`] = 
 Object {
   "anonymousId": "DY&TUQqmpg2I",
   "groupId": "DY&TUQqmpg2I",
-  "messageId": "2159444d-cdb6-52df-84de-11853deccb7e",
+  "messageId": Any<String>,
   "timestamp": Any<String>,
   "traits": Object {
     "testType": "DY&TUQqmpg2I",
@@ -17,6 +17,7 @@ exports[`Testing snapshot for Ripe's group destination action: required fields 1
 Object {
   "anonymousId": "anonId1234",
   "groupId": "DY&TUQqmpg2I",
+  "messageId": Any<String>,
   "timestamp": Any<String>,
   "traits": Object {},
   "userId": "user1234",

--- a/packages/destination-actions/src/destinations/ripe/group/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/ripe/group/__tests__/snapshot.test.ts
@@ -35,6 +35,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     try {
       const json = JSON.parse(rawBody)
       expect(json).toMatchSnapshot({
+        messageId: expect.any(String),
         timestamp: expect.any(String)
       })
       return
@@ -70,6 +71,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     try {
       const json = JSON.parse(rawBody)
       expect(json).toMatchSnapshot({
+        messageId: expect.any(String),
         timestamp: expect.any(String)
       })
       return

--- a/packages/destination-actions/src/destinations/ripe/group/index.ts
+++ b/packages/destination-actions/src/destinations/ripe/group/index.ts
@@ -49,7 +49,7 @@ const action: ActionDefinition<Settings, Payload> = {
       required: false,
       description: 'The Segment messageId',
       label: 'MessageId',
-      default: { '@path': '$messageId' }
+      default: { '@path': '$.messageId' }
     }
   },
   perform: (request, { payload, settings }) => {

--- a/packages/destination-actions/src/destinations/ripe/identify/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/ripe/identify/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -6,7 +6,7 @@ Object {
   "context": Object {
     "groupId": "ojywl7GMKZU*opR%8",
   },
-  "messageId": "7dbfec72-3264-59dd-8983-99027cd3e162",
+  "messageId": Any<String>,
   "timestamp": Any<String>,
   "traits": Object {
     "testType": "ojywl7GMKZU*opR%8",
@@ -19,6 +19,7 @@ exports[`Testing snapshot for Ripe's identify destination action: required field
 Object {
   "anonymousId": "anonId1234",
   "context": Object {},
+  "messageId": Any<String>,
   "timestamp": Any<String>,
   "traits": Object {},
   "userId": "user1234",

--- a/packages/destination-actions/src/destinations/ripe/identify/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/ripe/identify/__tests__/snapshot.test.ts
@@ -35,6 +35,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     try {
       const json = JSON.parse(rawBody)
       expect(json).toMatchSnapshot({
+        messageId: expect.any(String),
         timestamp: expect.any(String)
       })
       return
@@ -70,6 +71,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     try {
       const json = JSON.parse(rawBody)
       expect(json).toMatchSnapshot({
+        messageId: expect.any(String),
         timestamp: expect.any(String)
       })
       return

--- a/packages/destination-actions/src/destinations/ripe/identify/index.ts
+++ b/packages/destination-actions/src/destinations/ripe/identify/index.ts
@@ -49,7 +49,7 @@ const action: ActionDefinition<Settings, Payload> = {
       required: false,
       description: 'The Segment messageId',
       label: 'MessageId',
-      default: { '@path': '$messageId' }
+      default: { '@path': '$.messageId' }
     }
   },
   perform: (request, { payload, settings }) => {

--- a/packages/destination-actions/src/destinations/ripe/page/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/ripe/page/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -13,7 +13,7 @@ Object {
       "url": "http://fujav.cx/ef",
     },
   },
-  "messageId": "22c96ec8-da18-5ccf-90bb-f92dfd44a98e",
+  "messageId": Any<String>,
   "name": "Gm^2vj@raF9m",
   "properties": Object {
     "testType": "Gm^2vj@raF9m",
@@ -33,6 +33,7 @@ Object {
       "url": "https://segment.com/academy/",
     },
   },
+  "messageId": Any<String>,
   "properties": Object {},
   "timestamp": Any<String>,
   "userId": "user1234",

--- a/packages/destination-actions/src/destinations/ripe/page/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/ripe/page/__tests__/snapshot.test.ts
@@ -35,6 +35,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     try {
       const json = JSON.parse(rawBody)
       expect(json).toMatchSnapshot({
+        messageId: expect.any(String),
         timestamp: expect.any(String)
       })
       return
@@ -71,6 +72,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     try {
       const json = JSON.parse(rawBody)
       expect(json).toMatchSnapshot({
+        messageId: expect.any(String),
         timestamp: expect.any(String)
       })
       return

--- a/packages/destination-actions/src/destinations/ripe/page/index.ts
+++ b/packages/destination-actions/src/destinations/ripe/page/index.ts
@@ -124,7 +124,7 @@ const action: ActionDefinition<Settings, Payload> = {
       required: false,
       description: 'The Segment messageId',
       label: 'MessageId',
-      default: { '@path': '$messageId' }
+      default: { '@path': '$.messageId' }
     }
   },
   perform: (request, { payload, settings }) => {

--- a/packages/destination-actions/src/destinations/ripe/track/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/ripe/track/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -7,7 +7,7 @@ Object {
     "groupId": "f6t8rQsKdU^N",
   },
   "event": "f6t8rQsKdU^N",
-  "messageId": "2b7e8d4e-2a59-53b3-b51a-8830d6a1ceea",
+  "messageId": Any<String>,
   "name": "f6t8rQsKdU^N",
   "properties": Object {
     "testType": "f6t8rQsKdU^N",
@@ -22,6 +22,7 @@ Object {
   "anonymousId": "anonId1234",
   "context": Object {},
   "event": "f6t8rQsKdU^N",
+  "messageId": Any<String>,
   "name": "f6t8rQsKdU^N",
   "properties": Object {
     "event": "f6t8rQsKdU^N",

--- a/packages/destination-actions/src/destinations/ripe/track/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/ripe/track/__tests__/snapshot.test.ts
@@ -35,6 +35,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     try {
       const json = JSON.parse(rawBody)
       expect(json).toMatchSnapshot({
+        messageId: expect.any(String),
         timestamp: expect.any(String)
       })
       return
@@ -70,6 +71,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     try {
       const json = JSON.parse(rawBody)
       expect(json).toMatchSnapshot({
+        messageId: expect.any(String),
         timestamp: expect.any(String)
       })
       return

--- a/packages/destination-actions/src/destinations/ripe/track/index.ts
+++ b/packages/destination-actions/src/destinations/ripe/track/index.ts
@@ -56,7 +56,7 @@ const action: ActionDefinition<Settings, Payload> = {
       required: false,
       description: 'The Segment messageId',
       label: 'MessageId',
-      default: { '@path': '$messageId' }
+      default: { '@path': '$.messageId' }
     }
   },
   perform: (request, { payload, settings }) => {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

Correct the default path for messageId for all events from `$messageId` to `$.messageId`.

## Testing

Updated the snapshot test accordingly.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
