### PR TITLE
HGI-368 | Fixed the missing x-signature in request header when batching is enabled 

### DIFF
--- a/packages/destination-actions/src/destinations/webhook/index.ts
+++ b/packages/destination-actions/src/destinations/webhook/index.ts
@@ -20,10 +20,9 @@ const destination: DestinationDefinition<Settings> = {
     }
   },
   extendRequest: ({ settings, payload }) => {
-    if (settings.sharedSecret && payload?.data) {
-      const digest = createHmac('sha1', settings.sharedSecret)
-        .update(JSON.stringify(payload.data), 'utf8')
-        .digest('hex')
+    const payloadData = payload.length ? payload[0]['data'] : payload['data']
+    if (settings.sharedSecret && payloadData) {
+      const digest = createHmac('sha1', settings.sharedSecret).update(JSON.stringify(payloadData), 'utf8').digest('hex')
       return { headers: { 'X-Signature': digest } }
     }
     return {}


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pr is to fix the missing x-signature in request header when batching is enabled.
[Jira Ticket](https://docs.google.com/document/d/1fJ4LhQK-nwSB2hm6YYNcbUbkkzLzolw5rSttZOH-RU0/edit#)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment

Please click [here](https://docs.google.com/document/d/1fJ4LhQK-nwSB2hm6YYNcbUbkkzLzolw5rSttZOH-RU0/edit#) to see the results of staging testing.
