### PR TITLE
[STRATCONN-1779]Add datadog stats for google ads api version

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -1,8 +1,8 @@
 import { createHash } from 'crypto'
 import { ConversionCustomVariable, PartialErrorResponse, QueryResponse } from './types'
 import { ModifiedResponse, RequestClient, IntegrationError } from '@segment/actions-core'
-import { getUrlByVersion } from './types'
 import { Features } from '@segment/actions-core/src/mapping-kit'
+import { StatsContext } from '@segment/actions-core/src/destination-kit'
 
 export function formatCustomVariables(
   customVariables: object,
@@ -43,9 +43,10 @@ export async function getCustomVariables(
   customerId: string,
   auth: any,
   request: RequestClient,
-  features: Features | undefined
+  features?: Features,
+  statsContext?: StatsContext
 ): Promise<ModifiedResponse<QueryResponse[]>> {
-  return await request(`${getUrlByVersion(features)}/${customerId}/googleAds:searchStream`, {
+  return await request(`${getUrlByVersion(features, statsContext)}/${customerId}/googleAds:searchStream`, {
     method: 'post',
     headers: {
       authorization: `Bearer ${auth?.accessToken}`,
@@ -71,4 +72,15 @@ export function convertTimestamp(timestamp: string | undefined): string | undefi
     return undefined
   }
   return timestamp.replace(/T/, ' ').replace(/\..+/, '+00:00')
+}
+
+// Ticket to remove flagon - https://segment.atlassian.net/browse/STRATCONN-1953
+export function getUrlByVersion(features: Features | undefined, statsContext: StatsContext | undefined): string {
+  const statsClient = statsContext?.statsClient
+  const tags = statsContext?.tags
+
+  const API_VERSION = features && features['google-enhanced-v12'] ? 'v12' : 'v11'
+  tags?.push(`version:${API_VERSION}`)
+  statsClient?.incr(`google_enhanced_conversions`, 1, tags)
+  return `https://googleads.googleapis.com/${API_VERSION}/customers`
 }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -75,7 +75,7 @@ export function convertTimestamp(timestamp: string | undefined): string | undefi
 }
 
 // Ticket to remove flagon - https://segment.atlassian.net/browse/STRATCONN-1953
-export function getUrlByVersion(features: Features | undefined, statsContext: StatsContext | undefined): string {
+export function getUrlByVersion(features?: Features, statsContext?: StatsContext): string {
   const statsClient = statsContext?.statsClient
   const tags = statsContext?.tags
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/types.ts
@@ -1,5 +1,3 @@
-import { Features } from '@segment/actions-core/src/mapping-kit'
-
 export interface CartItem {
   productId?: string
   quantity?: number
@@ -24,11 +22,4 @@ export interface PartialErrorResponse {
     message: string
   }
   results: {}[]
-}
-// https://segment.atlassian.net/browse/STRATCONN-1953
-export function getUrlByVersion(features: Features | undefined): string {
-  if (features && features['google-enhanced-v12']) {
-    return 'https://googleads.googleapis.com/v12/customers'
-  }
-  return 'https://googleads.googleapis.com/v11/customers'
 }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/index.ts
@@ -1,8 +1,14 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { convertTimestamp, formatCustomVariables, getCustomVariables, handleGoogleErrors } from '../functions'
-import { getUrlByVersion, PartialErrorResponse } from '../types'
+import {
+  convertTimestamp,
+  formatCustomVariables,
+  getCustomVariables,
+  getUrlByVersion,
+  handleGoogleErrors
+} from '../functions'
+import { PartialErrorResponse } from '../types'
 import { ModifiedResponse } from '@segment/actions-core'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -65,7 +71,7 @@ const action: ActionDefinition<Settings, Payload> = {
       defaultObjectUI: 'keyvalue:only'
     }
   },
-  perform: async (request, { auth, settings, payload, features }) => {
+  perform: async (request, { auth, settings, payload, features, statsContext }) => {
     /* Enforcing this here since Customer ID is required for the Google Ads API
     but not for the Enhanced Conversions API. */
     if (!settings.customerId) {
@@ -96,7 +102,7 @@ const action: ActionDefinition<Settings, Payload> = {
       )
     }
     const response: ModifiedResponse<PartialErrorResponse> = await request(
-      `${getUrlByVersion(features)}/${settings.customerId}:uploadCallConversions`,
+      `${getUrlByVersion(features, statsContext)}/${settings.customerId}:uploadCallConversions`,
       {
         method: 'post',
         headers: {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/index.ts
@@ -95,7 +95,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
     // Retrieves all of the custom variables that the customer has created in their Google Ads account
     if (payload.custom_variables) {
-      const customVariableIds = await getCustomVariables(settings.customerId, auth, request, features)
+      const customVariableIds = await getCustomVariables(settings.customerId, auth, request, features, statsContext)
       request_object.customVariables = formatCustomVariables(
         payload.custom_variables,
         customVariableIds.data[0].results

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -1,8 +1,15 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { CartItem, getUrlByVersion, PartialErrorResponse } from '../types'
-import { formatCustomVariables, hash, getCustomVariables, handleGoogleErrors, convertTimestamp } from '../functions'
+import { CartItem, PartialErrorResponse } from '../types'
+import {
+  formatCustomVariables,
+  hash,
+  getCustomVariables,
+  handleGoogleErrors,
+  convertTimestamp,
+  getUrlByVersion
+} from '../functions'
 import { ModifiedResponse } from '@segment/actions-core'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -179,7 +186,7 @@ const action: ActionDefinition<Settings, Payload> = {
       defaultObjectUI: 'keyvalue:only'
     }
   },
-  perform: async (request, { auth, settings, payload, features }) => {
+  perform: async (request, { auth, settings, payload, features, statsContext }) => {
     /* Enforcing this here since Customer ID is required for the Google Ads API
     but not for the Enhanced Conversions API. */
     if (!settings.customerId) {
@@ -240,7 +247,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     const response: ModifiedResponse<PartialErrorResponse> = await request(
-      `${getUrlByVersion(features)}/${settings.customerId}:uploadClickConversions`,
+      `${getUrlByVersion(features, statsContext)}/${settings.customerId}:uploadClickConversions`,
       {
         method: 'post',
         headers: {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -231,7 +231,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
     // Retrieves all of the custom variables that the customer has created in their Google Ads account
     if (payload.custom_variables) {
-      const customVariableIds = await getCustomVariables(settings.customerId, auth, request, features)
+      const customVariableIds = await getCustomVariables(settings.customerId, auth, request, features, statsContext)
       request_object.customVariables = formatCustomVariables(
         payload.custom_variables,
         customVariableIds.data[0].results

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
@@ -1,8 +1,8 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
-import { hash, handleGoogleErrors, convertTimestamp } from '../functions'
+import { hash, handleGoogleErrors, convertTimestamp, getUrlByVersion } from '../functions'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { getUrlByVersion, PartialErrorResponse } from '../types'
+import { PartialErrorResponse } from '../types'
 import { ModifiedResponse } from '@segment/actions-core'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -198,7 +198,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
   },
-  perform: async (request, { settings, payload, features }) => {
+  perform: async (request, { settings, payload, features, statsContext }) => {
     /* Enforcing this here since Customer ID is required for the Google Ads API
     but not for the Enhanced Conversions API. */
     if (!settings.customerId) {
@@ -268,7 +268,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     const response: ModifiedResponse<PartialErrorResponse> = await request(
-      `${getUrlByVersion(features)}/${settings.customerId}:uploadConversionAdjustments`,
+      `${getUrlByVersion(features, statsContext)}/${settings.customerId}:uploadConversionAdjustments`,
       {
         method: 'post',
         headers: {


### PR DESCRIPTION
A follow up to PR-https://github.com/segmentio/action-destinations/pull/1018 , this PR
- Moves the getUrlByVersion to functions.ts from types.ts
- add datadog stats for google ads version

## Testing

Testing not required as this change only ads stats. All unit tests are passing.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
