### PR TITLE
HGI 372 - Fix Segment Profiles Destination

### DIFF
--- a/packages/destination-actions/src/destinations/segment-profiles/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,6 +4,9 @@ exports[`Testing snapshot for actions-segment-profiles destination: sendGroup ac
 Object {
   "anonymousId": "cZE8HyAL0!BF#)WQb^",
   "groupId": "cZE8HyAL0!BF#)WQb^",
+  "integrations": Object {
+    "All": false,
+  },
   "traits": Object {
     "testType": "cZE8HyAL0!BF#)WQb^",
   },
@@ -15,6 +18,9 @@ exports[`Testing snapshot for actions-segment-profiles destination: sendGroup ac
 Object {
   "anonymousId": "cZE8HyAL0!BF#)WQb^",
   "groupId": "cZE8HyAL0!BF#)WQb^",
+  "integrations": Object {
+    "All": false,
+  },
   "traits": Object {},
   "userId": "cZE8HyAL0!BF#)WQb^",
 }
@@ -24,6 +30,9 @@ exports[`Testing snapshot for actions-segment-profiles destination: sendIdentify
 Object {
   "anonymousId": "hIC1OAmWa[Q!&d%o",
   "groupId": "hIC1OAmWa[Q!&d%o",
+  "integrations": Object {
+    "All": false,
+  },
   "traits": Object {
     "testType": "hIC1OAmWa[Q!&d%o",
   },
@@ -35,6 +44,9 @@ exports[`Testing snapshot for actions-segment-profiles destination: sendIdentify
 Object {
   "anonymousId": "hIC1OAmWa[Q!&d%o",
   "groupId": "hIC1OAmWa[Q!&d%o",
+  "integrations": Object {
+    "All": false,
+  },
   "traits": Object {},
   "userId": "hIC1OAmWa[Q!&d%o",
 }

--- a/packages/destination-actions/src/destinations/segment-profiles/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/index.ts
@@ -17,7 +17,7 @@ const destination: DestinationDefinition<Settings> = {
         label: 'Segment Public API Token',
         description:
           'The Segment Public API requires that you have an authentication token before you send requests. [This document](https://docs.segmentapis.com/tag/Getting-Started#section/Get-an-API-token) explains how to setup a token.',
-        type: 'string',
+        type: 'password',
         required: true
       },
       endpoint: {

--- a/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
@@ -28,9 +28,9 @@ export const traits: InputField = {
 }
 
 export const engage_space: InputField = {
-  label: 'Engage Space',
+  label: 'Profile Space',
   description:
-    'The Engage Space to use for creating a record. *Note: This field shows list of internal sources associated with your Engaged Spaces. Changes made to the Engage Space name in **Settings** will not reflect in this list unless the source associated with the Engage Space is renamed explicitly.*',
+    'The Profile Space to use for creating a record. *Note: This field shows list of internal sources associated with your Engaged Spaces. Changes made to the Engage Space name in **Settings** will not reflect in this list unless the source associated with the Engage Space is renamed explicitly.*',
   type: 'string',
   required: true,
   dynamic: true

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/__snapshots__/index.test.ts.snap
@@ -17,6 +17,9 @@ exports[`SegmentProfiles.sendGroup Should send an group event to Segment 2`] = `
 Object {
   "anonymousId": "arky4h2sh7k",
   "groupId": "test-group-ks2i7e",
+  "integrations": Object {
+    "All": false,
+  },
   "traits": Object {
     "industry": "Technology",
     "name": "Example Corp",

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,6 +4,9 @@ exports[`Testing snapshot for SegmentProfiles's sendGroup destination action: al
 Object {
   "anonymousId": "tKaa(2A",
   "groupId": "tKaa(2A",
+  "integrations": Object {
+    "All": false,
+  },
   "traits": Object {
     "testType": "tKaa(2A",
   },
@@ -15,6 +18,9 @@ exports[`Testing snapshot for SegmentProfiles's sendGroup destination action: re
 Object {
   "anonymousId": "tKaa(2A",
   "groupId": "tKaa(2A",
+  "integrations": Object {
+    "All": false,
+  },
   "traits": Object {},
   "userId": "tKaa(2A",
 }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * The Engage Space to use for creating a record. *Note: This field shows list of internal sources associated with your Engaged Spaces. Changes made to the Engage Space name in **Settings** will not reflect in this list unless the source associated with the Engage Space is renamed explicitly.*
+   * The Profile Space to use for creating a record. *Note: This field shows list of internal sources associated with your Engaged Spaces. Changes made to the Engage Space name in **Settings** will not reflect in this list unless the source associated with the Engage Space is renamed explicitly.*
    */
   engage_space: string
   /**

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/index.ts
@@ -35,6 +35,11 @@ const action: ActionDefinition<Settings, Payload> = {
       groupId: payload?.group_id,
       traits: {
         ...payload?.traits
+      },
+      integrations: {
+        // Setting 'integrations.All' to false will ensure that we don't send events
+        // to any destinations which is connected to the Segment Profiles space.
+        All: false
       }
     }
 

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/index.test.ts.snap
@@ -17,6 +17,9 @@ exports[`Segment.sendIdentify Should send an identify event to Segment 2`] = `
 Object {
   "anonymousId": "arky4h2sh7k",
   "groupId": undefined,
+  "integrations": Object {
+    "All": false,
+  },
   "traits": Object {
     "email": "test-user@test-company.com",
     "name": "Test User",

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,6 +4,9 @@ exports[`Testing snapshot for SegmentProfiles's sendIdentify destination action:
 Object {
   "anonymousId": "mV[ZQcEVgZO$MX",
   "groupId": "mV[ZQcEVgZO$MX",
+  "integrations": Object {
+    "All": false,
+  },
   "traits": Object {
     "testType": "mV[ZQcEVgZO$MX",
   },
@@ -15,6 +18,9 @@ exports[`Testing snapshot for SegmentProfiles's sendIdentify destination action:
 Object {
   "anonymousId": "mV[ZQcEVgZO$MX",
   "groupId": "mV[ZQcEVgZO$MX",
+  "integrations": Object {
+    "All": false,
+  },
   "traits": Object {},
   "userId": "mV[ZQcEVgZO$MX",
 }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * The Engage Space to use for creating a record. *Note: This field shows list of internal sources associated with your Engaged Spaces. Changes made to the Engage Space name in **Settings** will not reflect in this list unless the source associated with the Engage Space is renamed explicitly.*
+   * The Profile Space to use for creating a record. *Note: This field shows list of internal sources associated with your Engaged Spaces. Changes made to the Engage Space name in **Settings** will not reflect in this list unless the source associated with the Engage Space is renamed explicitly.*
    */
   engage_space: string
   /**

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
@@ -36,6 +36,11 @@ const action: ActionDefinition<Settings, Payload> = {
       groupId: payload?.group_id,
       traits: {
         ...payload?.traits
+      },
+      integrations: {
+        // Setting 'integrations.All' to false will ensure that we don't send events
+        // to any destinations which is connected to the Segment Profiles space.
+        All: false
       }
     }
 


### PR DESCRIPTION
This PR resolves [HGI-372](https://segment.atlassian.net/browse/HGI-372) and includes some minor fixes.

Changes are as follows

1. Sets `All: false` in the `integration` property so that events are not propagated to destinations connected to Profiles Space.
2. Updates to snapshot test to test the above criteria
3. **Segment Public API Token Key** field is being changed from `string` to `password`
4. Changes to a field label and description from `Engage Space` to `Profile Space`

## Testing
Testing completed successfully in local server.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment


[HGI-372]: https://segment.atlassian.net/browse/HGI-372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ