### PR TITLE
Improve docs about starting the actions tester for browser destinations

### DIFF
--- a/packages/browser-destinations/README.md
+++ b/packages/browser-destinations/README.md
@@ -28,6 +28,15 @@ bin/run generate:types
 
 You can use our Action Tester environment to test your browser actions:
 
+First start webpack in destinations.
+
+```
+cd packages/browser-destinations
+yarn dev
+```
+
+Then start the Action Test environment
+
 ```
 ./bin/run serve --directory ./packages/browser-destinations/src/destinations --browser
 ```


### PR DESCRIPTION
Hi, this PR just tweaks some of the developer documentation about running the actions tester for browser destinations.

I dont know if im doing something wrong, but the actions tester would always crash loading a destination If I didnt run `yarn dev` in `packages/browser-destinations`. It would be nice if this happened automatically but it didnt seem to.

Heres a screenshot of me running the actions tester without running `yarn dev`. After I click "Send Test Event" I tries to load `http://localhost:9001/dist/web/adobe-target.js` and fails.
![image](https://user-images.githubusercontent.com/727013/219268917-51179cc0-ea0d-422c-a68a-a0d9774f766e.png)

Anyway, this PR just mentions that you need to start `yarn dev`. 
Thanks