### PR TITLE
SalesWings: fix non-default environment handling in testAuthentication

### DIFF
--- a/packages/destination-actions/src/destinations/saleswings/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/saleswings/__tests__/index.test.ts
@@ -15,6 +15,14 @@ describe('Saleswings', () => {
       ).resolves.not.toThrowError()
     })
 
+    it('should support non-default environment', async () => {
+      const otherEnv = 'ozone'
+      nock(getAccountUrl(otherEnv)).get('').matchHeader('authorization', 'Bearer myApiKey').reply(200, {})
+      await expect(
+        testDestination.testAuthentication({ apiKey: 'myApiKey', environment: otherEnv })
+      ).resolves.not.toThrowError()
+    })
+
     it('should reject invalid API key', async () => {
       nock(getAccountUrl(env)).get('').matchHeader('authorization', 'Bearer myApiKey').reply(200, {})
       nock(getAccountUrl(env)).get('').reply(401, {})

--- a/packages/destination-actions/src/destinations/saleswings/index.ts
+++ b/packages/destination-actions/src/destinations/saleswings/index.ts
@@ -34,7 +34,7 @@ const destination: DestinationDefinition<Settings> = {
       }
     },
     testAuthentication: async (request, { settings }) => {
-      return request(getAccountUrl('helium'), {
+      return request(getAccountUrl(settings.environment), {
         headers: { Authorization: `Bearer ${settings.apiKey}` }
       })
     }


### PR DESCRIPTION
This is a direct follow-up to https://github.com/segmentio/action-destinations/pull/1039. 

Unfortunately, there was an oversight in https://github.com/segmentio/action-destinations/pull/1039: a default SalesWings environment (`helium`) was always used in `testAuthentication` function. It went unnoticed during the testing, because the unit test also used only the default environment value and because `testAuthentication` is not invoked by the action tester during the end-to-end testing. 

I've fixed the bug and added the missing unit test.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
