### PR TITLE
fixing Mixpanel broken test pe-63

### DIFF
--- a/packages/destination-actions/src/destinations/mixpanel/trackPurchase/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackPurchase/__tests__/index.test.ts
@@ -55,7 +55,7 @@ const orderCompletedEvent: Partial<SegmentEvent> = {
 }
 
 const expectedOrderCompleted = {
-  ...omit(orderCompletedEvent, ['anonymousId', 'messageId', 'timestamp', 'type', 'userId']),
+  ...omit(orderCompletedEvent, ['anonymousId', 'messageId', 'timestamp', 'type', 'userId'])
 }
 
 const mapping = {
@@ -75,7 +75,6 @@ describe('Mixpanel.trackPurchase', () => {
     const event = createTestEvent(orderCompletedEvent)
 
     nock('https://api.mixpanel.com').post('/import?strict=1').reply(200, {})
-
 
     const responses = await testDestination.testAction('trackPurchase', {
       event,
@@ -183,7 +182,7 @@ describe('Mixpanel.trackPurchase', () => {
       settings: {
         projectToken: MIXPANEL_PROJECT_TOKEN,
         apiSecret: MIXPANEL_API_SECRET,
-        apiRegion: ApiRegions.US,
+        apiRegion: ApiRegions.US
       }
     })
     expect(responses.length).toBe(1)
@@ -285,7 +284,7 @@ describe('Mixpanel.trackPurchase', () => {
           ip: '8.8.8.8',
           id: 'abc123',
           distinct_id: 'abc123',
-          $browser: 'Mozilla',
+          $browser: 'Safari',
           $current_url: 'https://segment.com/academy/',
           $insert_id: '112c2a3c-7242-4327-9090-48a89de6a4110',
           $lib_version: '2.11.1',
@@ -336,7 +335,7 @@ describe('Mixpanel.trackPurchase', () => {
           ip: '8.8.8.8',
           id: 'abc123',
           distinct_id: 'abc123',
-          $browser: 'Mozilla',
+          $browser: 'Safari',
           $current_url: 'https://segment.com/academy/',
           $insert_id: '0112c2a3c-7242-4327-9090-48a89de6a4110',
           $lib_version: '2.11.1',
@@ -367,7 +366,7 @@ describe('Mixpanel.trackPurchase', () => {
           ip: '8.8.8.8',
           id: 'abc123',
           distinct_id: 'abc123',
-          $browser: 'Mozilla',
+          $browser: 'Safari',
           $current_url: 'https://segment.com/academy/',
           $insert_id: '1112c2a3c-7242-4327-9090-48a89de6a4110',
           $lib_version: '2.11.1',
@@ -405,7 +404,7 @@ describe('Mixpanel.trackPurchase', () => {
     expect(responses.length).toBe(1)
     expect(responses[0].status).toBe(200)
     expect(responses[0].options.body).toMatchInlineSnapshot(
-      `"[{\\"event\\":\\"Order Completed\\",\\"properties\\":{\\"time\\":1629213675449,\\"ip\\":\\"8.8.8.8\\",\\"id\\":\\"abc123\\",\\"$anon_id\\":\\"anon-2134\\",\\"distinct_id\\":\\"abc123\\",\\"$browser\\":\\"Mozilla\\",\\"$current_url\\":\\"https://segment.com/academy/\\",\\"$identified_id\\":\\"abc123\\",\\"$insert_id\\":\\"112c2a3c-7242-4327-9090-48a89de6a4110\\",\\"$lib_version\\":\\"2.11.1\\",\\"$locale\\":\\"en-US\\",\\"$source\\":\\"segment\\",\\"$user_id\\":\\"abc123\\",\\"mp_country_code\\":\\"United States\\",\\"mp_lib\\":\\"Segment Actions: analytics.js\\",\\"affiliation\\":\\"Super Online Store\\",\\"order_id\\":\\"order-id-123\\",\\"checkout_id\\":\\"checkout-id-123\\",\\"coupon\\":\\"Mixpanel Day\\",\\"currency\\":\\"USD\\",\\"products\\":[{\\"product_id\\":\\"507f1f77bcf86cd799439011\\",\\"sku\\":\\"45790-32\\",\\"name\\":\\"Monopoly: 3rd Edition\\",\\"price\\":19,\\"position\\":1,\\"quantity\\":2,\\"coupon\\":\\"MOUNTAIN\\",\\"brand\\":\\"Unknown\\",\\"category\\":\\"Games\\",\\"variant\\":\\"Black\\",\\"url\\":\\"https://www.example.com/product/path\\",\\"image_url\\":\\"https://www.example.com/product/path.jpg\\"},{\\"product_id\\":\\"505bd76785ebb509fc183733\\",\\"sku\\":\\"46493-32\\",\\"name\\":\\"Uno Card Game\\",\\"price\\":3,\\"position\\":2,\\"category\\":\\"Games\\",\\"custom\\":\\"xyz\\"}],\\"revenue\\":5.99,\\"shipping\\":1.5,\\"tax\\":3,\\"total\\":24.48}}]"`
+      `"[{\\"event\\":\\"Order Completed\\",\\"properties\\":{\\"time\\":1629213675449,\\"ip\\":\\"8.8.8.8\\",\\"id\\":\\"abc123\\",\\"$anon_id\\":\\"anon-2134\\",\\"distinct_id\\":\\"abc123\\",\\"$browser\\":\\"Safari\\",\\"$browser_version\\":\\"9.0\\",\\"$current_url\\":\\"https://segment.com/academy/\\",\\"$identified_id\\":\\"abc123\\",\\"$insert_id\\":\\"112c2a3c-7242-4327-9090-48a89de6a4110\\",\\"$lib_version\\":\\"2.11.1\\",\\"$locale\\":\\"en-US\\",\\"$source\\":\\"segment\\",\\"$user_id\\":\\"abc123\\",\\"mp_country_code\\":\\"United States\\",\\"mp_lib\\":\\"Segment Actions: analytics.js\\",\\"affiliation\\":\\"Super Online Store\\",\\"order_id\\":\\"order-id-123\\",\\"checkout_id\\":\\"checkout-id-123\\",\\"coupon\\":\\"Mixpanel Day\\",\\"currency\\":\\"USD\\",\\"products\\":[{\\"product_id\\":\\"507f1f77bcf86cd799439011\\",\\"sku\\":\\"45790-32\\",\\"name\\":\\"Monopoly: 3rd Edition\\",\\"price\\":19,\\"position\\":1,\\"quantity\\":2,\\"coupon\\":\\"MOUNTAIN\\",\\"brand\\":\\"Unknown\\",\\"category\\":\\"Games\\",\\"variant\\":\\"Black\\",\\"url\\":\\"https://www.example.com/product/path\\",\\"image_url\\":\\"https://www.example.com/product/path.jpg\\"},{\\"product_id\\":\\"505bd76785ebb509fc183733\\",\\"sku\\":\\"46493-32\\",\\"name\\":\\"Uno Card Game\\",\\"price\\":3,\\"position\\":2,\\"category\\":\\"Games\\",\\"custom\\":\\"xyz\\"}],\\"revenue\\":5.99,\\"shipping\\":1.5,\\"tax\\":3,\\"total\\":24.48}}]"`
     )
   })
 
@@ -422,7 +421,7 @@ describe('Mixpanel.trackPurchase', () => {
     expect(responses.length).toBe(1)
     expect(responses[0].status).toBe(200)
     expect(responses[0].options.body).toMatchInlineSnapshot(
-      `"[{\\"event\\":\\"Order Completed\\",\\"properties\\":{\\"time\\":1629213675449,\\"ip\\":\\"8.8.8.8\\",\\"id\\":\\"abc123\\",\\"$anon_id\\":\\"anon-2134\\",\\"distinct_id\\":\\"abc123\\",\\"$browser\\":\\"Mozilla\\",\\"$current_url\\":\\"https://segment.com/academy/\\",\\"$identified_id\\":\\"abc123\\",\\"$insert_id\\":\\"112c2a3c-7242-4327-9090-48a89de6a4110\\",\\"$lib_version\\":\\"2.11.1\\",\\"$locale\\":\\"en-US\\",\\"$source\\":\\"segment\\",\\"$user_id\\":\\"abc123\\",\\"mp_country_code\\":\\"United States\\",\\"mp_lib\\":\\"Segment Actions: analytics.js\\",\\"affiliation\\":\\"Super Online Store\\",\\"order_id\\":\\"order-id-123\\",\\"checkout_id\\":\\"checkout-id-123\\",\\"coupon\\":\\"Mixpanel Day\\",\\"currency\\":\\"USD\\",\\"products\\":[{\\"product_id\\":\\"507f1f77bcf86cd799439011\\",\\"sku\\":\\"45790-32\\",\\"name\\":\\"Monopoly: 3rd Edition\\",\\"price\\":19,\\"position\\":1,\\"quantity\\":2,\\"coupon\\":\\"MOUNTAIN\\",\\"brand\\":\\"Unknown\\",\\"category\\":\\"Games\\",\\"variant\\":\\"Black\\",\\"url\\":\\"https://www.example.com/product/path\\",\\"image_url\\":\\"https://www.example.com/product/path.jpg\\"},{\\"product_id\\":\\"505bd76785ebb509fc183733\\",\\"sku\\":\\"46493-32\\",\\"name\\":\\"Uno Card Game\\",\\"price\\":3,\\"position\\":2,\\"category\\":\\"Games\\",\\"custom\\":\\"xyz\\"}],\\"revenue\\":5.99,\\"shipping\\":1.5,\\"tax\\":3,\\"total\\":24.48}},{\\"event\\":\\"Product Purchased\\",\\"properties\\":{\\"time\\":1629213675448,\\"ip\\":\\"8.8.8.8\\",\\"id\\":\\"abc123\\",\\"$anon_id\\":\\"anon-2134\\",\\"distinct_id\\":\\"abc123\\",\\"$browser\\":\\"Mozilla\\",\\"$current_url\\":\\"https://segment.com/academy/\\",\\"$identified_id\\":\\"abc123\\",\\"$insert_id\\":\\"0112c2a3c-7242-4327-9090-48a89de6a4110\\",\\"$lib_version\\":\\"2.11.1\\",\\"$locale\\":\\"en-US\\",\\"$source\\":\\"segment\\",\\"$user_id\\":\\"abc123\\",\\"mp_country_code\\":\\"United States\\",\\"mp_lib\\":\\"Segment Actions: analytics.js\\",\\"order_id\\":\\"order-id-123\\",\\"checkout_id\\":\\"checkout-id-123\\",\\"product_id\\":\\"507f1f77bcf86cd799439011\\",\\"sku\\":\\"45790-32\\",\\"category\\":\\"Games\\",\\"name\\":\\"Monopoly: 3rd Edition\\",\\"brand\\":\\"Unknown\\",\\"variant\\":\\"Black\\",\\"price\\":19,\\"quantity\\":2,\\"coupon\\":\\"MOUNTAIN\\",\\"position\\":1,\\"url\\":\\"https://www.example.com/product/path\\",\\"image_url\\":\\"https://www.example.com/product/path.jpg\\"}},{\\"event\\":\\"Product Purchased\\",\\"properties\\":{\\"time\\":1629213675447,\\"ip\\":\\"8.8.8.8\\",\\"id\\":\\"abc123\\",\\"$anon_id\\":\\"anon-2134\\",\\"distinct_id\\":\\"abc123\\",\\"$browser\\":\\"Mozilla\\",\\"$current_url\\":\\"https://segment.com/academy/\\",\\"$identified_id\\":\\"abc123\\",\\"$insert_id\\":\\"1112c2a3c-7242-4327-9090-48a89de6a4110\\",\\"$lib_version\\":\\"2.11.1\\",\\"$locale\\":\\"en-US\\",\\"$source\\":\\"segment\\",\\"$user_id\\":\\"abc123\\",\\"mp_country_code\\":\\"United States\\",\\"mp_lib\\":\\"Segment Actions: analytics.js\\",\\"order_id\\":\\"order-id-123\\",\\"checkout_id\\":\\"checkout-id-123\\",\\"product_id\\":\\"505bd76785ebb509fc183733\\",\\"sku\\":\\"46493-32\\",\\"category\\":\\"Games\\",\\"name\\":\\"Uno Card Game\\",\\"price\\":3,\\"position\\":2}}]"`
+      `"[{\\"event\\":\\"Order Completed\\",\\"properties\\":{\\"time\\":1629213675449,\\"ip\\":\\"8.8.8.8\\",\\"id\\":\\"abc123\\",\\"$anon_id\\":\\"anon-2134\\",\\"distinct_id\\":\\"abc123\\",\\"$browser\\":\\"Safari\\",\\"$browser_version\\":\\"9.0\\",\\"$current_url\\":\\"https://segment.com/academy/\\",\\"$identified_id\\":\\"abc123\\",\\"$insert_id\\":\\"112c2a3c-7242-4327-9090-48a89de6a4110\\",\\"$lib_version\\":\\"2.11.1\\",\\"$locale\\":\\"en-US\\",\\"$source\\":\\"segment\\",\\"$user_id\\":\\"abc123\\",\\"mp_country_code\\":\\"United States\\",\\"mp_lib\\":\\"Segment Actions: analytics.js\\",\\"affiliation\\":\\"Super Online Store\\",\\"order_id\\":\\"order-id-123\\",\\"checkout_id\\":\\"checkout-id-123\\",\\"coupon\\":\\"Mixpanel Day\\",\\"currency\\":\\"USD\\",\\"products\\":[{\\"product_id\\":\\"507f1f77bcf86cd799439011\\",\\"sku\\":\\"45790-32\\",\\"name\\":\\"Monopoly: 3rd Edition\\",\\"price\\":19,\\"position\\":1,\\"quantity\\":2,\\"coupon\\":\\"MOUNTAIN\\",\\"brand\\":\\"Unknown\\",\\"category\\":\\"Games\\",\\"variant\\":\\"Black\\",\\"url\\":\\"https://www.example.com/product/path\\",\\"image_url\\":\\"https://www.example.com/product/path.jpg\\"},{\\"product_id\\":\\"505bd76785ebb509fc183733\\",\\"sku\\":\\"46493-32\\",\\"name\\":\\"Uno Card Game\\",\\"price\\":3,\\"position\\":2,\\"category\\":\\"Games\\",\\"custom\\":\\"xyz\\"}],\\"revenue\\":5.99,\\"shipping\\":1.5,\\"tax\\":3,\\"total\\":24.48}},{\\"event\\":\\"Product Purchased\\",\\"properties\\":{\\"time\\":1629213675448,\\"ip\\":\\"8.8.8.8\\",\\"id\\":\\"abc123\\",\\"$anon_id\\":\\"anon-2134\\",\\"distinct_id\\":\\"abc123\\",\\"$browser\\":\\"Safari\\",\\"$browser_version\\":\\"9.0\\",\\"$current_url\\":\\"https://segment.com/academy/\\",\\"$identified_id\\":\\"abc123\\",\\"$insert_id\\":\\"0112c2a3c-7242-4327-9090-48a89de6a4110\\",\\"$lib_version\\":\\"2.11.1\\",\\"$locale\\":\\"en-US\\",\\"$source\\":\\"segment\\",\\"$user_id\\":\\"abc123\\",\\"mp_country_code\\":\\"United States\\",\\"mp_lib\\":\\"Segment Actions: analytics.js\\",\\"order_id\\":\\"order-id-123\\",\\"checkout_id\\":\\"checkout-id-123\\",\\"product_id\\":\\"507f1f77bcf86cd799439011\\",\\"sku\\":\\"45790-32\\",\\"category\\":\\"Games\\",\\"name\\":\\"Monopoly: 3rd Edition\\",\\"brand\\":\\"Unknown\\",\\"variant\\":\\"Black\\",\\"price\\":19,\\"quantity\\":2,\\"coupon\\":\\"MOUNTAIN\\",\\"position\\":1,\\"url\\":\\"https://www.example.com/product/path\\",\\"image_url\\":\\"https://www.example.com/product/path.jpg\\"}},{\\"event\\":\\"Product Purchased\\",\\"properties\\":{\\"time\\":1629213675447,\\"ip\\":\\"8.8.8.8\\",\\"id\\":\\"abc123\\",\\"$anon_id\\":\\"anon-2134\\",\\"distinct_id\\":\\"abc123\\",\\"$browser\\":\\"Safari\\",\\"$browser_version\\":\\"9.0\\",\\"$current_url\\":\\"https://segment.com/academy/\\",\\"$identified_id\\":\\"abc123\\",\\"$insert_id\\":\\"1112c2a3c-7242-4327-9090-48a89de6a4110\\",\\"$lib_version\\":\\"2.11.1\\",\\"$locale\\":\\"en-US\\",\\"$source\\":\\"segment\\",\\"$user_id\\":\\"abc123\\",\\"mp_country_code\\":\\"United States\\",\\"mp_lib\\":\\"Segment Actions: analytics.js\\",\\"order_id\\":\\"order-id-123\\",\\"checkout_id\\":\\"checkout-id-123\\",\\"product_id\\":\\"505bd76785ebb509fc183733\\",\\"sku\\":\\"46493-32\\",\\"category\\":\\"Games\\",\\"name\\":\\"Uno Card Game\\",\\"price\\":3,\\"position\\":2}}]"`
     )
   })
 })


### PR DESCRIPTION
## Summary
 - Fixing breaking tests caused by a PR [submitted](https://github.com/segmentio/action-destinations/pull/1035).  

## Testing

Ran local unit tests to verity they passed. No other testing necessary. I'll message the Partner to have them validate that they don't need to update their tests or implementation logic. 