### PR TITLE
[HGI-378]- Intercom Cloud - Replace the endpoint used for testAuthentication

### DIFF
--- a/packages/destination-actions/src/destinations/intercom/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/intercom/__tests__/index.test.ts
@@ -8,14 +8,14 @@ const endpoint = 'https://api.intercom.io'
 describe('Intercom (actions)', () => {
   describe('testAuthentication', () => {
     it('should validate authentication inputs', async () => {
-      nock(endpoint).get('/admins').reply(200, {})
+      nock(endpoint).get('/me').reply(200, {})
       const authData = {}
 
       await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
     })
 
     it('should fail on authentication failure', async () => {
-      nock(endpoint).get('/admins').reply(404, {})
+      nock(endpoint).get('/me').reply(404, {})
       const authData = {}
 
       await expect(testDestination.testAuthentication(authData)).rejects.toThrowError(

--- a/packages/destination-actions/src/destinations/intercom/index.ts
+++ b/packages/destination-actions/src/destinations/intercom/index.ts
@@ -14,10 +14,10 @@ const destination: DestinationDefinition<Settings> = {
     scheme: 'oauth2',
     fields: {},
     testAuthentication: async (request) => {
-      // Uses the admin route as a stand-in to test authentication creds.
-      // Should be a light request since there most likely won't be many admins
+      // /me returns details of the currently authorized admin
+      // https://developers.intercom.com/intercom-api-reference/reference/identifyadmin
       try {
-        return await request('https://api.intercom.io/admins')
+        return await request('https://api.intercom.io/me')
       } catch (error) {
         throw new Error('Test authentication failed')
       }

--- a/packages/destination-actions/src/destinations/intercom/index.ts
+++ b/packages/destination-actions/src/destinations/intercom/index.ts
@@ -14,8 +14,8 @@ const destination: DestinationDefinition<Settings> = {
     scheme: 'oauth2',
     fields: {},
     testAuthentication: async (request) => {
-      // /me returns details of the currently authorized admin
-      // https://developers.intercom.com/intercom-api-reference/reference/identifyadmin
+      // The me endpoint idenfies the logged in user.
+      // https://developers.intercom.com/intercom-api-reference/reference/identifyadmin.
       try {
         return await request('https://api.intercom.io/me')
       } catch (error) {


### PR DESCRIPTION
A customer reported ([JIRA](https://segment.atlassian.net/browse/HGI-378)) that they were unable to turn on intercom destination because `testAuthentication` was timing out. It turns out that for the customer reporting this error, the List All Admins (`/admins`) endpoint was returning a large response payload > 55kb. We have a well documented issue with action destination handling payloads greater than 16KB in size. ([Reference](https://segment.atlassian.net/browse/ACT-242)).

This PR updates `/admins` with `/me` endpoint instead of setting `skipResponseCloning` option as `/me` always gives a shorter response and it seems more appropriate for `testAuthentication` as it identifies the current user.

## Testing

### Local Actions Tester

https://user-images.githubusercontent.com/109586712/220261406-10396738-5d13-4dfe-bf23-bd085327e7f9.mov


### Stage Validation to confirm testAuthentication is working

https://user-images.githubusercontent.com/109586712/220259105-153f69e5-bfd1-4a13-95f4-0f70c487a981.mov

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
