### PR TITLE
Update API endpoint used for testing user authN

### DIFF
--- a/packages/destination-actions/src/destinations/sendgrid/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/index.ts
@@ -23,7 +23,7 @@ const destination: DestinationDefinition<Settings> = {
       // Return a request that tests/validates the user's credentials.
       // If you do not have a way to validate the authentication fields safely,
       // you can remove the `testAuthentication` function, though discouraged.
-      return request('https://api.sendgrid.com/v3/marketing/contacts')
+      return request('https://api.sendgrid.com/v3/user/account')
     }
   },
 


### PR DESCRIPTION
## Summary
This PR updates the API endpoint used for testing authentication in the Sendgrid Marketing Campaigns Action Destination.  

### The problem
Previously, `testAuthentication` would call [/v3/marketing/contacts](https://docs.sendgrid.com/api-reference/contacts/get-sample-contacts) to test user authentication.  This endpoint returns the 50 most recently uploaded contacts and has been known to timeout on first request from time to time for customers with large numbers of contacts (1M+ contacts).

### The solution
Because we don't need info about a user's contacts and that API endpoint can potentially timeout, the solution is to use a different API endpoint for `testAuthentication`.  With this PR, we switch the API endpoint to (/v3/user/account
)[https://docs.sendgrid.com/api-reference/users-api/get-a-users-account-information], which returns the user's account details.  This is a more appropriate API endpoint for testing a user's API key works.

## Testing

~- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality~
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
