### PR TITLE
[Mixpanel] Remove unused mapping in /track

### DIFF
--- a/packages/destination-actions/src/destinations/mixpanel/mixpanel-properties.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/mixpanel-properties.ts
@@ -40,8 +40,7 @@ export const eventProperties: Record<string, InputField> = {
   insert_id: {
     label: 'Insert ID',
     type: 'string',
-    description:
-      'A random id that is unique to an event. Mixpanel uses $insert_id to deduplicate events.',
+    description: 'A random id that is unique to an event. Mixpanel uses $insert_id to deduplicate events.',
     default: {
       '@path': '$.messageId'
     }
@@ -292,23 +291,6 @@ export const eventProperties: Record<string, InputField> = {
       '@path': '$.properties'
     }
   },
-  user_properties: {
-    label: 'User Properties',
-    type: 'object',
-    description: 'An object of key-value pairs that represent additional data tied to the user.',
-    default: {
-      '@path': '$.traits'
-    }
-  },
-  context: {
-    label: 'Event context',
-    description:
-      'An object of key-value pairs that provides useful context about the event.',
-    type: 'object',
-    default: {
-      '@path': '$.context'
-    }
-  },
   utm_properties: {
     label: 'UTM Properties',
     type: 'object',
@@ -362,44 +344,37 @@ export const productsProperties: Record<string, InputField> = {
       product_id: {
         label: 'Product Id',
         type: 'string',
-        description:
-          'Database id of the product being viewed.'
+        description: 'Database id of the product being viewed.'
       },
       sku: {
         label: 'SKU',
         type: 'string',
-        description:
-          'Sku of the product being viewed.'
+        description: 'Sku of the product being viewed.'
       },
       category: {
         label: 'Category',
         type: 'string',
-        description:
-          'Product category being viewed.'
+        description: 'Product category being viewed.'
       },
       name: {
         label: 'Name',
         type: 'string',
-        description:
-          'Name of the product being viewed.'
+        description: 'Name of the product being viewed.'
       },
       brand: {
         label: 'Brand',
         type: 'string',
-        description:
-          'Brand associated with the product.'
+        description: 'Brand associated with the product.'
       },
       variant: {
         label: 'Variant',
         type: 'string',
-        description:
-          'Variant of the product.'
+        description: 'Variant of the product.'
       },
       price: {
         label: 'Price',
         type: 'number',
-        description:
-          'Price ($) of the product being viewed.'
+        description: 'Price ($) of the product being viewed.'
       },
       quantity: {
         label: 'Quantity',
@@ -409,26 +384,22 @@ export const productsProperties: Record<string, InputField> = {
       coupon: {
         label: 'Coupon',
         type: 'string',
-        description:
-          'Coupon code associated with a product (for example, MAY_DEALS_3).'
+        description: 'Coupon code associated with a product (for example, MAY_DEALS_3).'
       },
       position: {
         label: 'position',
         type: 'number',
-        description:
-          'Position in the product list (ex. 3).'
+        description: 'Position in the product list (ex. 3).'
       },
       url: {
         label: 'url',
         type: 'string',
-        description:
-          'URL of the product page.'
+        description: 'URL of the product page.'
       },
       image_url: {
         label: 'Image url',
         type: 'string',
-        description:
-          'Image url of the product.'
+        description: 'Image url of the product.'
       }
     },
     default: {

--- a/packages/destination-actions/src/destinations/mixpanel/mixpanel-properties.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/mixpanel-properties.ts
@@ -291,6 +291,14 @@ export const eventProperties: Record<string, InputField> = {
       '@path': '$.properties'
     }
   },
+  context: {
+    label: 'Event context',
+    description: 'An object of key-value pairs that provides useful context about the event.',
+    type: 'object',
+    default: {
+      '@path': '$.context'
+    }
+  },
   utm_properties: {
     label: 'UTM Properties',
     type: 'object',

--- a/packages/destination-actions/src/destinations/mixpanel/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackEvent/generated-types.ts
@@ -148,18 +148,6 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * An object of key-value pairs that represent additional data tied to the user.
-   */
-  user_properties?: {
-    [k: string]: unknown
-  }
-  /**
-   * An object of key-value pairs that provides useful context about the event.
-   */
-  context?: {
-    [k: string]: unknown
-  }
-  /**
    * UTM Tracking Properties
    */
   utm_properties?: {

--- a/packages/destination-actions/src/destinations/mixpanel/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackEvent/generated-types.ts
@@ -148,6 +148,12 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
+   * An object of key-value pairs that provides useful context about the event.
+   */
+  context?: {
+    [k: string]: unknown
+  }
+  /**
    * UTM Tracking Properties
    */
   utm_properties?: {

--- a/packages/destination-actions/src/destinations/mixpanel/trackPurchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackPurchase/generated-types.ts
@@ -148,18 +148,6 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * An object of key-value pairs that represent additional data tied to the user.
-   */
-  user_properties?: {
-    [k: string]: unknown
-  }
-  /**
-   * An object of key-value pairs that provides useful context about the event.
-   */
-  context?: {
-    [k: string]: unknown
-  }
-  /**
    * UTM Tracking Properties
    */
   utm_properties?: {

--- a/packages/destination-actions/src/destinations/mixpanel/trackPurchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackPurchase/generated-types.ts
@@ -148,6 +148,12 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
+   * An object of key-value pairs that provides useful context about the event.
+   */
+  context?: {
+    [k: string]: unknown
+  }
+  /**
    * UTM Tracking Properties
    */
   utm_properties?: {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR removes `user_properties` from mixpanel properties. This property is not used in `/track` and causes user confusion. Since this field was essentially a no-op, no unit test was broken; there is no change in user experience either, except that `user_properties` won't show up in mapping UI.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
