### PR TITLE
Criteo Audiences: Added hash_emails field to actions + API version update

### DIFF
--- a/packages/destination-actions/src/destinations/criteo-audiences/addUserToAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/criteo-audiences/addUserToAudience/generated-types.ts
@@ -13,4 +13,8 @@ export interface Payload {
    * The user's email
    */
   email?: string
+  /**
+   * Hash emails before sending them to Criteo (may lower your audience's match rate). If deactivated, emails will be sent unhashed to Criteo's API and will be hashed upon reception at Criteo's server.
+   */
+  hash_emails?: boolean
 }

--- a/packages/destination-actions/src/destinations/criteo-audiences/addUserToAudience/index.ts
+++ b/packages/destination-actions/src/destinations/criteo-audiences/addUserToAudience/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition } from '@segment/actions-core'
-import { getAudienceId, patchAudience } from '../criteo-audiences'
+import { getAudienceId, patchAudience, hash } from '../criteo-audiences'
 import type { Operation, ClientCredentials } from '../criteo-audiences'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -20,10 +20,13 @@ const getOperationFromPayload = async (
   */
 
   for (const event of payload) {
+    let email = undefined
+
     if (!audience_key && event.audience_key)
       audience_key = event.audience_key
-    if (event.email)
-      add_user_list.push(event.email)
+
+    email = event.hash_emails ? hash(event.email) : event.email
+    if (email) add_user_list.push(email)
   }
 
   const audience_id = await getAudienceId(request, advertiser_id, audience_key, credentials)
@@ -77,6 +80,13 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.context.traits.email'
       }
+    },
+    hash_emails: {
+      label: 'Hash Emails',
+      description: "Hash emails before sending them to Criteo (may lower your audience's match rate). If deactivated, emails will be sent unhashed to Criteo's API and will be hashed upon reception at Criteo's server.",
+      type: 'boolean',
+      default: false,
+      required: false
     },
   },
   perform: async (request, { settings, payload }) => {

--- a/packages/destination-actions/src/destinations/criteo-audiences/criteo-audiences.ts
+++ b/packages/destination-actions/src/destinations/criteo-audiences/criteo-audiences.ts
@@ -1,7 +1,16 @@
+import { createHash } from 'crypto'
 import { IntegrationError, RetryableError } from '@segment/actions-core'
 import type { RequestClient } from '@segment/actions-core'
 
 const BASE_API_URL = 'https://api.criteo.com/2022-01'
+
+export const hash = (value: string | undefined): string | undefined => {
+  if (value === undefined) return
+
+  const hash = createHash('sha256')
+  hash.update(value)
+  return hash.digest('hex')
+}
 
 class CriteoAPIError extends IntegrationError {
   readonly error?: Record<string, string>

--- a/packages/destination-actions/src/destinations/criteo-audiences/criteo-audiences.ts
+++ b/packages/destination-actions/src/destinations/criteo-audiences/criteo-audiences.ts
@@ -2,7 +2,7 @@ import { createHash } from 'crypto'
 import { IntegrationError, RetryableError } from '@segment/actions-core'
 import type { RequestClient } from '@segment/actions-core'
 
-const BASE_API_URL = 'https://api.criteo.com/2022-01'
+const BASE_API_URL = 'https://api.criteo.com/2023-01'
 
 export const hash = (value: string | undefined): string | undefined => {
   if (value === undefined) return

--- a/packages/destination-actions/src/destinations/criteo-audiences/removeUserFromAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/criteo-audiences/removeUserFromAudience/generated-types.ts
@@ -13,4 +13,8 @@ export interface Payload {
    * The user's email
    */
   email?: string
+  /**
+   * Hash emails before sending them to Criteo (may lower your audience's match rate). If deactivated, emails will be sent unhashed to Criteo's API and will be hashed upon reception at Criteo's server.
+   */
+  hash_emails?: boolean
 }


### PR DESCRIPTION
- Added a hash_emails field to both Criteo's actions to allow advertisers to hash emails before sending them to the Criteo API
- Update the Criteo API version from 2022-01 to 2023-01

## Testing

- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
