### PR TITLE
Update Wisepops loader URL

### DIFF
--- a/packages/browser-destinations/src/destinations/wisepops/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/wisepops/__tests__/index.test.ts
@@ -17,7 +17,7 @@ describe('Wisepops', () => {
   test('initialize Wisepops with a website hash', async () => {
     const startTime = Date.now();
     jest.spyOn(destination, 'initialize')
-    nock('https://loader.wisepops.com').get('/get-loader.js?v=1&site=1234567890').reply(200, {})
+    nock('https://loader.wisepops.com').get('/get-loader.js?plugin=segment&v=1&site=1234567890').reply(200, {})
 
     const [event] = await wisepopsDestination({
       websiteId: '1234567890',
@@ -35,7 +35,7 @@ describe('Wisepops', () => {
     expect(scripts).toMatchInlineSnapshot(`
       NodeList [
         <script
-          src="https://loader.wisepops.com/get-loader.js?v=1&site=1234567890"
+          src="https://loader.wisepops.com/get-loader.js?plugin=segment&v=1&site=1234567890"
           status="loading"
           type="text/javascript"
         />,

--- a/packages/browser-destinations/src/destinations/wisepops/index.ts
+++ b/packages/browser-destinations/src/destinations/wisepops/index.ts
@@ -80,7 +80,7 @@ export const destination: BrowserDestinationDefinition<Settings, Wisepops> = {
     window.wisepops.l = Date.now()
     window.wisepops('options', { autoPageview: false })
     // Can load asynchronously, no need to wait
-    void deps.loadScript(`https://loader.wisepops.com/get-loader.js?v=1&site=${settings.websiteId}`)
+    void deps.loadScript(`https://loader.wisepops.com/get-loader.js?plugin=segment&v=1&site=${settings.websiteId}`)
     return window.wisepops
   },
 


### PR DESCRIPTION
Add a parameter `plugin=segment` in the URL.
This is for internal analytics, to measure the adoption of our Segment destination.

From this Slack question:

![image](https://user-images.githubusercontent.com/1969355/221897283-574dd90e-40b1-4de7-b070-85e1b40b8957.png)


## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
