### PR TITLE
GA4 Web Updates

### DIFF
--- a/packages/browser-destinations/src/destinations/google-analytics-4-web/setConfigurationFields/index.ts
+++ b/packages/browser-destinations/src/destinations/google-analytics-4-web/setConfigurationFields/index.ts
@@ -136,7 +136,6 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     if (payload.campaign_content) {
       gtag('set', { campaign_content: payload.campaign_content })
     }
-    gtag('set', { page_view: false })
     gtag('event', 'page_view')
   }
 }

--- a/packages/browser-destinations/src/destinations/google-analytics-4-web/setConfigurationFields/index.ts
+++ b/packages/browser-destinations/src/destinations/google-analytics-4-web/setConfigurationFields/index.ts
@@ -136,7 +136,7 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     if (payload.campaign_content) {
       gtag('set', { campaign_content: payload.campaign_content })
     }
-    updateUser(payload.user_id, payload.user_properties, gtag)
+    gtag('set', { page_view: false })
     gtag('event', 'page_view')
   }
 }

--- a/packages/browser-destinations/src/destinations/google-analytics-4-web/setConfigurationFields/index.ts
+++ b/packages/browser-destinations/src/destinations/google-analytics-4-web/setConfigurationFields/index.ts
@@ -93,6 +93,7 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     }
   },
   perform: (gtag, { payload, settings }) => {
+    updateUser(payload.user_id, payload.user_properties, gtag)
     if (settings.enableConsentMode) {
       window.gtag('consent', 'update', {
         ad_storage: payload.ads_storage_consent_state,
@@ -136,6 +137,7 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
       gtag('set', { campaign_content: payload.campaign_content })
     }
     updateUser(payload.user_id, payload.user_properties, gtag)
+    gtag('event', 'page_view')
   }
 }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_This PR updates the `setConfigurationFields` Action to send a page view event to ensure all the values being set with the gtag are not dropped._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
