### PR TITLE
[ACT-498] Update alpha script to use lerna version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test-partners": "lerna run test --stream --ignore @segment/actions-core --ignore @segment/actions-cli --ignore @segment/ajv-human-errors",
     "test-browser": "bash scripts/test-browser.sh",
     "typecheck": "lerna run typecheck --stream",
-    "alpha": "lerna publish --canary --preid $(git branch --show-current) --include-merged-tags",
+    "alpha": "lerna version prerelease --allow-branch $(git branch --show-current) --preid $(git branch --show-current) --no-push --no-git-tag-version",
     "prepare": "husky install",
     "clean": "sh scripts/clean.sh"
   },


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

Removes publish step from `yarn alpha` script by moving to `lerna version`.

`lerna publish --skip-npm` is deprecated:
<img width="558" alt="Screen Shot 2023-03-01 at 3 37 34 PM" src="https://user-images.githubusercontent.com/14102504/222291542-8ee5fb41-c260-4f58-a042-3cc69918f6a6.png">


The publish can be removed since the alpha script is used to test in staging and we no longer need published assets to test in stage.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
