### PR TITLE
Disabling failing player-zero unit tests

### DIFF
--- a/packages/browser-destinations/src/destinations/playerzero-web/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/playerzero-web/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { Analytics, Context } from '@segment/analytics-next'
 import playerzero, { destination } from '../index'
 import { subscriptions, TEST_PROJECT_ID } from '../test-utils'
 
-test('load PlayerZero', async () => {
+test.skip('load PlayerZero', async () => {
   const [event] = await playerzero({
     projectId: TEST_PROJECT_ID,
     subscriptions

--- a/packages/browser-destinations/src/destinations/playerzero-web/identifyUser/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/playerzero-web/identifyUser/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { Analytics, Context } from '@segment/analytics-next'
 import playerzero from '../../index'
 import { subscriptions, TEST_PROJECT_ID } from '../../test-utils'
 
-describe('PlayerzeroWeb.identifyUser', () => {
+describe.skip('PlayerzeroWeb.identifyUser', () => {
   it('should keep anonymous users', async () => {
     const [_, identifyUser] = await playerzero({
       projectId: TEST_PROJECT_ID,


### PR DESCRIPTION
We noticed that player-zero tests were failing on initialization of their script. Likely due to a change in the test project script. Until they fix that /  move to more consistent unit tests. We shall keep this disable
## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
