### PR TITLE
Return intercom response when calling group identify

### DIFF
--- a/packages/destination-actions/src/destinations/intercom/groupIdentifyContact/index.ts
+++ b/packages/destination-actions/src/destinations/intercom/groupIdentifyContact/index.ts
@@ -127,6 +127,7 @@ const action: ActionDefinition<Settings, Payload> = {
       const companyId = response.data.id
       return attachContactToIntercomCompany(request, contact.id, companyId)
     }
+    return response
   }
 }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

## Description

Customers have noticed that, for Actions Intercom Cloud, when running a "test event" on app.segment.com for the group-identify action, it gives an `unexpected error`. After debugging, I realized that it was because we do not pass on responses on company creation when no user is associated. Fixing here!

Warning: While this is technically a valid action, intercom warns that: 

```Companies will be only visible in Intercom when there is at least one associated user.``` [URL](https://developers.intercom.com/intercom-api-reference/reference/createorupdatecompany)

<img src="https://user-images.githubusercontent.com/1487616/222590797-44b148b4-f8ff-428d-a4ea-c67dbb3040f6.png" width="600" height="500">

## Testing

Tested locally using staging resources and confirmed that the response is now properly passed through.

Unfortunately, we can't actually unit-test if a response is [returned in the perform block](https://github.com/segmentio/action-destinations/blob/97228ca8315cc8ba2f63a917b8568db014844b04/packages/core/src/create-test-integration.ts#L81-L94), as the testing pattern just checks if a response has been stored inside `this.responses`

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
