### PR TITLE
Add GWEN destination, sendEvent and identifyUser actions

### DIFF
--- a/packages/destination-actions/src/destinations/gwen/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/gwen/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -10,7 +10,7 @@ Object {
         }",
   "variables": Object {
     "session": Object {
-      "ip": "35.240.202.232",
+      "ip": "*6^p&3X",
       "userAgent": "*6^p&3X",
     },
     "userId": "c079d975-3cc4-58c4-85ab-1f5974b54aa0",

--- a/packages/destination-actions/src/destinations/gwen/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/gwen/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-gwen destination: identifyUser action - all fields 1`] = `
+Object {
+  "operationName": "UserSession",
+  "query": "mutation UserSession($userId: UUID!, $session: UserSessionInput) {
+          userSession(userId: $userId, data: $session) {
+            timestamp
+          }
+        }",
+  "variables": Object {
+    "session": Object {
+      "ip": "35.240.202.232",
+      "userAgent": "*6^p&3X",
+    },
+    "userId": "c079d975-3cc4-58c4-85ab-1f5974b54aa0",
+  },
+}
+`;
+
+exports[`Testing snapshot for actions-gwen destination: identifyUser action - required fields 1`] = `
+Object {
+  "operationName": "UserSession",
+  "query": "mutation UserSession($userId: UUID!, $session: UserSessionInput) {
+          userSession(userId: $userId, data: $session) {
+            timestamp
+          }
+        }",
+  "variables": Object {
+    "session": Object {},
+    "userId": "c079d975-3cc4-58c4-85ab-1f5974b54aa0",
+  },
+}
+`;
+
+exports[`Testing snapshot for actions-gwen destination: sendEvent action - all fields 1`] = `
+Object {
+  "operationName": "SendEvent",
+  "query": "mutation SendEvent($userId: UUID!, $type: String!, $data: JSONObject) {
+ event(userId: $userId, type: $type, data: $data)
+}",
+  "variables": Object {
+    "data": Object {
+      "testType": "EWjG!^JdXSHmwRNuelph",
+    },
+    "type": "EWjG!^JdXSHmwRNuelph",
+    "userId": "015b2892-a542-5ce4-8ebc-db8e2f622781",
+  },
+}
+`;
+
+exports[`Testing snapshot for actions-gwen destination: sendEvent action - required fields 1`] = `
+Object {
+  "operationName": "SendEvent",
+  "query": "mutation SendEvent($userId: UUID!, $type: String!, $data: JSONObject) {
+ event(userId: $userId, type: $type, data: $data)
+}",
+  "variables": Object {
+    "data": Object {},
+    "type": "EWjG!^JdXSHmwRNuelph",
+    "userId": "015b2892-a542-5ce4-8ebc-db8e2f622781",
+  },
+}
+`;

--- a/packages/destination-actions/src/destinations/gwen/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gwen/__tests__/index.test.ts
@@ -1,0 +1,32 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+import { baseURL } from '../request-params'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Gwen', () => {
+  describe('testAuthentication', () => {
+    it('should validate authentication inputs', async () => {
+      nock(baseURL).post('').reply(200, { data: {} })
+
+      const authData = {
+        apiKey: 'my-api-key'
+      }
+
+      await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
+    })
+
+    it('invalid api token', async () => {
+      nock(baseURL)
+        .post('')
+        .reply(200, { data: { errors: [{ message: "Access Denied!  You don't have permission for this action!" }] } })
+
+      const authData = {
+        apiKey: 'no-api-key'
+      }
+
+      await expect(testDestination.testAuthentication(authData)).rejects.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/gwen/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/gwen/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-gwen'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/gwen/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gwen/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * GWEN API key. Can be found [here](http://gwen.insertcoin.se/iam/api-token)
+   */
+  apiKey: string
+}

--- a/packages/destination-actions/src/destinations/gwen/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/gwen/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -10,7 +10,7 @@ Object {
         }",
   "variables": Object {
     "session": Object {
-      "ip": "229.244.252.222",
+      "ip": "(]#(3SU!l74R3T[DbfD",
       "userAgent": "(]#(3SU!l74R3T[DbfD",
     },
     "userId": "90080745-8c77-5474-91ab-117f7fd5cf5d",

--- a/packages/destination-actions/src/destinations/gwen/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/gwen/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Gwen's identifyUser destination action: all fields 1`] = `
+Object {
+  "operationName": "UserSession",
+  "query": "mutation UserSession($userId: UUID!, $session: UserSessionInput) {
+          userSession(userId: $userId, data: $session) {
+            timestamp
+          }
+        }",
+  "variables": Object {
+    "session": Object {
+      "ip": "229.244.252.222",
+      "userAgent": "(]#(3SU!l74R3T[DbfD",
+    },
+    "userId": "90080745-8c77-5474-91ab-117f7fd5cf5d",
+  },
+}
+`;
+
+exports[`Testing snapshot for Gwen's identifyUser destination action: required fields 1`] = `
+Object {
+  "operationName": "UserSession",
+  "query": "mutation UserSession($userId: UUID!, $session: UserSessionInput) {
+          userSession(userId: $userId, data: $session) {
+            timestamp
+          }
+        }",
+  "variables": Object {
+    "session": Object {},
+    "userId": "90080745-8c77-5474-91ab-117f7fd5cf5d",
+  },
+}
+`;

--- a/packages/destination-actions/src/destinations/gwen/identifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gwen/identifyUser/__tests__/index.test.ts
@@ -45,19 +45,6 @@ describe('Gwen.identifyUser', () => {
     expect(t[0].options.body).toEqual(JSON.stringify(query))
   })
 
-  it('IP must be a valid IP address', async () => {
-    let event = createTestEvent({ userId: '2d947e75-de80-4776-8e0e-4d645977d3df' })
-    event = createTestEvent({ ...event, context: { ...event.context, ip: '127.0.0.256' } })
-
-    await expect(
-      testDestination.testAction('identifyUser', {
-        event,
-        useDefaultMappings: true,
-        settings: { apiKey: 'my-api-key' }
-      })
-    ).rejects.toThrow('User IP Address must be a valid IPv4 address string but it was not.')
-  })
-
   it('User ID must be a UUID', async () => {
     await expect(
       testDestination.testAction('identifyUser', {

--- a/packages/destination-actions/src/destinations/gwen/identifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gwen/identifyUser/__tests__/index.test.ts
@@ -1,0 +1,72 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { baseURL } from '../../request-params'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Gwen.identifyUser', () => {
+  it('should start a user session', async () => {
+    const event = createTestEvent({ userId: '2d947e75-de80-4776-8e0e-4d645977d3df' })
+    nock(baseURL)
+      .post('')
+      .reply(200, {
+        data: {
+          userSession: {
+            timestamp: Date.now()
+          }
+        }
+      })
+
+    const t = await testDestination.testAction('identifyUser', {
+      event,
+      useDefaultMappings: true,
+      settings: { apiKey: 'my-api-key' }
+    })
+
+    expect(t[0].status).toBe(200)
+
+    const query = {
+      operationName: 'UserSession',
+      query: `mutation UserSession($userId: UUID!, $session: UserSessionInput) {
+          userSession(userId: $userId, data: $session) {
+            timestamp
+          }
+        }`,
+      variables: {
+        userId: event.userId,
+        session: {
+          ip: event.context?.ip,
+          userAgent: event.context?.userAgent
+        }
+      }
+    }
+
+    expect(t[0].options.body).toEqual(JSON.stringify(query))
+  })
+
+  it('IP must be a valid IP address', async () => {
+    let event = createTestEvent({ userId: '2d947e75-de80-4776-8e0e-4d645977d3df' })
+    event = createTestEvent({ ...event, context: { ...event.context, ip: '127.0.0.256' } })
+
+    await expect(
+      testDestination.testAction('identifyUser', {
+        event,
+        useDefaultMappings: true,
+        settings: { apiKey: 'my-api-key' }
+      })
+    ).rejects.toThrow('User IP Address must be a valid IPv4 address string but it was not.')
+  })
+
+  it('User ID must be a UUID', async () => {
+    await expect(
+      testDestination.testAction('identifyUser', {
+        event: createTestEvent({
+          userId: 'user-id-123'
+        }),
+        useDefaultMappings: true,
+        settings: { apiKey: 'my-api-key' }
+      })
+    ).rejects.toThrow('User ID must be a valid uuid string but it was not.')
+  })
+})

--- a/packages/destination-actions/src/destinations/gwen/identifyUser/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/gwen/identifyUser/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'identifyUser'
+const destinationSlug = 'Gwen'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/gwen/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gwen/identifyUser/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * The user's id
+   * The user's id. (Format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
    */
   userId: string
   /**

--- a/packages/destination-actions/src/destinations/gwen/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gwen/identifyUser/generated-types.ts
@@ -1,0 +1,16 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The user's id
+   */
+  userId: string
+  /**
+   * The IP address of the user
+   */
+  ip?: string
+  /**
+   * The userAgent string of the user
+   */
+  userAgent?: string
+}

--- a/packages/destination-actions/src/destinations/gwen/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/gwen/identifyUser/index.ts
@@ -1,0 +1,66 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import { baseURL, defaultRequestParams } from '../request-params'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Identify User',
+  description: 'Starts a new GWEN user session. Provide the users IP and userAgent to improve the GWEN experience',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    userId: {
+      label: 'User ID',
+      description: "The user's id",
+      type: 'string',
+      format: 'uuid',
+      required: true,
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    ip: {
+      label: 'User IP Address',
+      description: 'The IP address of the user',
+      type: 'string',
+      format: 'ipv4',
+      required: false,
+      default: {
+        '@path': '$.context.ip'
+      }
+    },
+    userAgent: {
+      label: 'User Agent',
+      description: 'The userAgent string of the user',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.context.userAgent'
+      }
+    }
+  },
+  perform: async (request, { payload }) => {
+    // Make your partner api request here!
+    const { userId, ip, userAgent } = payload
+
+    await request(baseURL, {
+      ...defaultRequestParams,
+      body: JSON.stringify({
+        operationName: 'UserSession',
+        query: `mutation UserSession($userId: UUID!, $session: UserSessionInput) {
+          userSession(userId: $userId, data: $session) {
+            timestamp
+          }
+        }`,
+        variables: {
+          userId,
+          session: {
+            ip,
+            userAgent
+          }
+        }
+      })
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/gwen/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/gwen/identifyUser/index.ts
@@ -10,7 +10,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     userId: {
       label: 'User ID',
-      description: "The user's id",
+      description: "The user's id. (Format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)",
       type: 'string',
       format: 'uuid',
       required: true,
@@ -22,7 +22,6 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'User IP Address',
       description: 'The IP address of the user',
       type: 'string',
-      format: 'ipv4',
       required: false,
       default: {
         '@path': '$.context.ip'
@@ -39,7 +38,6 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, { payload }) => {
-    // Make your partner api request here!
     const { userId, ip, userAgent } = payload
 
     await request(baseURL, {

--- a/packages/destination-actions/src/destinations/gwen/index.ts
+++ b/packages/destination-actions/src/destinations/gwen/index.ts
@@ -1,4 +1,4 @@
-import type { DestinationDefinition } from '@segment/actions-core'
+import { defaultValues, DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import sendEvent from './sendEvent'
 
@@ -7,8 +7,8 @@ import { baseURL, defaultRequestParams } from './request-params'
 import identifyUser from './identifyUser'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Gwen',
-  slug: 'actions-gwen',
+  name: 'GWEN (Actions)',
+  slug: 'actions-cloud-gwen',
   mode: 'cloud',
 
   authentication: {
@@ -46,17 +46,24 @@ const destination: DestinationDefinition<Settings> = {
       }
     }
   },
-
-  // onDelete: async (request, { settings, payload }) => {
-  //   // Return a request that performs a GDPR delete for the provided Segment userId or anonymousId
-  //   // provided in the payload. If your destination does not support GDPR deletion you should not
-  //   // implement this function and should remove it completely.
-  // },
-
   actions: {
     sendEvent,
     identifyUser
-  }
+  },
+  presets: [
+    {
+      name: 'Send an event to GWEN',
+      subscribe: 'type = "track"',
+      partnerAction: 'sendEvent',
+      mapping: defaultValues(sendEvent.fields)
+    },
+    {
+      name: 'Identify a user',
+      subscribe: 'type = "identify"',
+      partnerAction: 'identifyUser',
+      mapping: defaultValues(identifyUser.fields)
+    }
+  ]
 }
 
 export default destination

--- a/packages/destination-actions/src/destinations/gwen/index.ts
+++ b/packages/destination-actions/src/destinations/gwen/index.ts
@@ -1,0 +1,62 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+import sendEvent from './sendEvent'
+
+import { baseURL, defaultRequestParams } from './request-params'
+
+import identifyUser from './identifyUser'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Gwen',
+  slug: 'actions-gwen',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      apiKey: {
+        label: 'API Key',
+        description: 'GWEN API key. Can be found [here](http://gwen.insertcoin.se/iam/api-token)',
+        type: 'password',
+        required: true
+      }
+    },
+    testAuthentication: (request) => {
+      return request(baseURL, {
+        ...defaultRequestParams,
+        json: {
+          operationName: 'ValidateAPIKey',
+          query: `query ValidateAPIKey {
+                validateApiKey
+              }`
+        }
+      }).then(async (response) => {
+        const { errors } = (await response.json()).data
+        if (errors && errors.length > 0) {
+          throw new Error('Invalid API key')
+        }
+      })
+    }
+  },
+  extendRequest: ({ settings }) => {
+    return {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: settings.apiKey
+      }
+    }
+  },
+
+  // onDelete: async (request, { settings, payload }) => {
+  //   // Return a request that performs a GDPR delete for the provided Segment userId or anonymousId
+  //   // provided in the payload. If your destination does not support GDPR deletion you should not
+  //   // implement this function and should remove it completely.
+  // },
+
+  actions: {
+    sendEvent,
+    identifyUser
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/gwen/request-params.ts
+++ b/packages/destination-actions/src/destinations/gwen/request-params.ts
@@ -1,0 +1,8 @@
+import { RequestOptions } from '@segment/actions-core'
+
+export const baseURL =
+  process.env.NODE_ENV === 'prod' ? 'https://gwen.insertcoin.se/graphql' : 'http://localhost:4000/graphql'
+
+export const defaultRequestParams: RequestOptions = {
+  method: 'POST'
+}

--- a/packages/destination-actions/src/destinations/gwen/request-params.ts
+++ b/packages/destination-actions/src/destinations/gwen/request-params.ts
@@ -1,7 +1,6 @@
 import { RequestOptions } from '@segment/actions-core'
 
-export const baseURL =
-  process.env.NODE_ENV === 'prod' ? 'https://gwen.insertcoin.se/graphql' : 'http://localhost:4000/graphql'
+export const baseURL = 'https://gwen.insertcoin.se/graphql'
 
 export const defaultRequestParams: RequestOptions = {
   method: 'POST'

--- a/packages/destination-actions/src/destinations/gwen/sendEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/gwen/sendEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Gwen's sendEvent destination action: all fields 1`] = `
+Object {
+  "operationName": "SendEvent",
+  "query": "mutation SendEvent($userId: UUID!, $type: String!, $data: JSONObject) {
+ event(userId: $userId, type: $type, data: $data)
+}",
+  "variables": Object {
+    "data": Object {
+      "testType": "czPOuvItQ@bFuB",
+    },
+    "type": "czPOuvItQ@bFuB",
+    "userId": "4af33ee2-e48a-51e1-948d-7175e99b381b",
+  },
+}
+`;
+
+exports[`Testing snapshot for Gwen's sendEvent destination action: required fields 1`] = `
+Object {
+  "operationName": "SendEvent",
+  "query": "mutation SendEvent($userId: UUID!, $type: String!, $data: JSONObject) {
+ event(userId: $userId, type: $type, data: $data)
+}",
+  "variables": Object {
+    "data": Object {},
+    "type": "czPOuvItQ@bFuB",
+    "userId": "4af33ee2-e48a-51e1-948d-7175e99b381b",
+  },
+}
+`;

--- a/packages/destination-actions/src/destinations/gwen/sendEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gwen/sendEvent/__tests__/index.test.ts
@@ -1,0 +1,58 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { baseURL } from '../../request-params'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Gwen.sendEvent', () => {
+  it('should send an event', async () => {
+    const event = createTestEvent({
+      userId: '2d947e75-de80-4776-8e0e-4d645977d3df'
+    })
+    nock(baseURL)
+      .post('')
+      .reply(200, {
+        data: {
+          sendEvent: true
+        }
+      })
+
+    const t = await testDestination.testAction('sendEvent', {
+      event,
+      useDefaultMappings: true,
+      mapping: {
+        data: {
+          '@path': '$.'
+        }
+      },
+      settings: { apiKey: 'my-api-key' }
+    })
+
+    expect(t[0].status).toBe(200)
+
+    const query = {
+      operationName: 'SendEvent',
+      query: `mutation SendEvent($userId: UUID!, $type: String!, $data: JSONObject) {\n event(userId: $userId, type: $type, data: $data)\n}`,
+      variables: {
+        userId: event.userId,
+        type: event.type,
+        data: event
+      }
+    }
+
+    expect(t[0].options.body).toEqual(JSON.stringify(query))
+  })
+
+  it('userId must be UUID', async () => {
+    await expect(
+      testDestination.testAction('sendEvent', {
+        event: createTestEvent({
+          userId: 'user-id-123'
+        }),
+        useDefaultMappings: true,
+        settings: { apiKey: 'my-api-key' }
+      })
+    ).rejects.toThrow('User ID must be a valid uuid string but it was not.')
+  })
+})

--- a/packages/destination-actions/src/destinations/gwen/sendEvent/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/gwen/sendEvent/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'sendEvent'
+const destinationSlug = 'Gwen'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/gwen/sendEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gwen/sendEvent/generated-types.ts
@@ -1,0 +1,18 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The user's id
+   */
+  userId: string
+  /**
+   * The type of the event
+   */
+  type: string
+  /**
+   * The data to be sent to GWEN
+   */
+  data?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/gwen/sendEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gwen/sendEvent/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * The user's id
+   * The user's id. (Format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
    */
   userId: string
   /**

--- a/packages/destination-actions/src/destinations/gwen/sendEvent/index.ts
+++ b/packages/destination-actions/src/destinations/gwen/sendEvent/index.ts
@@ -12,7 +12,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       format: 'uuid',
       required: true,
-      description: "The user's id",
+      description: "The user's id. (Format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)",
       label: 'User ID',
       default: {
         '@path': '$.userId'
@@ -31,7 +31,10 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Data',
       type: 'object',
       required: false,
-      description: 'The data to be sent to GWEN'
+      description: 'The data to be sent to GWEN',
+      default: {
+        '@path': '$.properties'
+      }
     }
   },
   perform: async (request, { payload }) => {

--- a/packages/destination-actions/src/destinations/gwen/sendEvent/index.ts
+++ b/packages/destination-actions/src/destinations/gwen/sendEvent/index.ts
@@ -1,0 +1,55 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import { baseURL, defaultRequestParams } from '../request-params'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Send Event',
+  description: 'Send a user event to GWEN',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    userId: {
+      type: 'string',
+      format: 'uuid',
+      required: true,
+      description: "The user's id",
+      label: 'User ID',
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    type: {
+      label: 'Event Type',
+      description: 'The type of the event',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.type'
+      }
+    },
+    data: {
+      label: 'Data',
+      type: 'object',
+      required: false,
+      description: 'The data to be sent to GWEN'
+    }
+  },
+  perform: async (request, { payload }) => {
+    const { userId, type, data } = payload
+
+    await request(baseURL, {
+      ...defaultRequestParams,
+      body: JSON.stringify({
+        operationName: 'SendEvent',
+        query: `mutation SendEvent($userId: UUID!, $type: String!, $data: JSONObject) {\n event(userId: $userId, type: $type, data: $data)\n}`,
+        variables: {
+          userId,
+          type,
+          data: data || {}
+        }
+      })
+    })
+  }
+}
+
+export default action


### PR DESCRIPTION
This PR adds the GWEN (Gamify the World ENgine) destination as well as the `sendEvent` action for passing events to GWEN and the `identifyUser` action which (optionally) provides GWEN with user insights

## Testing

Unit tests should cover basic use cases and errors. 
End-to-end testing has been performed locally with no issues.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
