### PR TITLE
[STRATCONN-1895] [Facebook-CAPI] update description for partner_id and partner_name

### DIFF
--- a/packages/destination-actions/src/destinations/emarsys/upsertContact/generated-types.ts
+++ b/packages/destination-actions/src/destinations/emarsys/upsertContact/generated-types.ts
@@ -16,5 +16,6 @@ export interface Payload {
     '1'?: string
     '2'?: string
     '3'?: string
+    [k: string]: unknown
   }
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
@@ -86,11 +86,11 @@ export interface Payload {
      */
     fbLoginID?: number
     /**
-     * The ID issued by Facebook identity partner
+     * The ID issued by Facebook identity partner.
      */
     partner_id?: string
     /**
-     * The name of the Facebook identity partner
+     * The name of the Facebook identity partner.
      */
     partner_name?: string
   }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom/generated-types.ts
@@ -90,11 +90,11 @@ export interface Payload {
      */
     fbLoginID?: number
     /**
-     * The ID issued by Facebook identity partner
+     * The ID issued by Facebook identity partner.
      */
     partner_id?: string
     /**
-     * The name of the Facebook identity partner
+     * The name of the Facebook identity partner.
      */
     partner_name?: string
   }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-user-data.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-user-data.ts
@@ -107,12 +107,12 @@ export const user_data_field: InputField = {
     },
     partner_id: {
       label: 'Partner ID',
-      description: 'The ID issued by Facebook identity partner',
+      description: 'The ID issued by Facebook identity partner.',
       type: 'string'
     },
     partner_name: {
       label: 'Partner Name',
-      description: 'The name of the Facebook identity partner',
+      description: 'The name of the Facebook identity partner.',
       type: 'string'
     }
   },

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
@@ -86,11 +86,11 @@ export interface Payload {
      */
     fbLoginID?: number
     /**
-     * The ID issued by Facebook identity partner
+     * The ID issued by Facebook identity partner.
      */
     partner_id?: string
     /**
-     * The name of the Facebook identity partner
+     * The name of the Facebook identity partner.
      */
     partner_name?: string
   }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
@@ -86,11 +86,11 @@ export interface Payload {
      */
     fbLoginID?: number
     /**
-     * The ID issued by Facebook identity partner
+     * The ID issued by Facebook identity partner.
      */
     partner_id?: string
     /**
-     * The name of the Facebook identity partner
+     * The name of the Facebook identity partner.
      */
     partner_name?: string
   }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
@@ -90,11 +90,11 @@ export interface Payload {
      */
     fbLoginID?: number
     /**
-     * The ID issued by Facebook identity partner
+     * The ID issued by Facebook identity partner.
      */
     partner_id?: string
     /**
-     * The name of the Facebook identity partner
+     * The name of the Facebook identity partner.
      */
     partner_name?: string
   }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
@@ -86,11 +86,11 @@ export interface Payload {
      */
     fbLoginID?: number
     /**
-     * The ID issued by Facebook identity partner
+     * The ID issued by Facebook identity partner.
      */
     partner_id?: string
     /**
-     * The name of the Facebook identity partner
+     * The name of the Facebook identity partner.
      */
     partner_name?: string
   }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
@@ -86,11 +86,11 @@ export interface Payload {
      */
     fbLoginID?: number
     /**
-     * The ID issued by Facebook identity partner
+     * The ID issued by Facebook identity partner.
      */
     partner_id?: string
     /**
-     * The name of the Facebook identity partner
+     * The name of the Facebook identity partner.
      */
     partner_name?: string
   }


### PR DESCRIPTION
This is a small PR to update description for partner_id and partner_name. 

## Testing

Testing not required as this is a description change.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
