### PR TITLE
[Actions Braze Cloud] Updated batch failure logic

### DIFF
--- a/packages/destination-actions/src/destinations/braze/__tests__/__snapshots__/braze.test.ts.snap
+++ b/packages/destination-actions/src/destinations/braze/__tests__/__snapshots__/braze.test.ts.snap
@@ -1,0 +1,133 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Braze Cloud Mode (Actions) trackEvent should require one of braze_id, user_alias, or external_id 1`] = `"One of \\"external_id\\" or \\"user_alias\\" or \\"braze_id\\" is required."`;
+
+exports[`Braze Cloud Mode (Actions) trackEvent should work with batched events 1`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer my-api-key",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+    "x-braze-batch": Array [
+      "true",
+    ],
+  },
+}
+`;
+
+exports[`Braze Cloud Mode (Actions) trackEvent should work with batched events with single element 1`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer my-api-key",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Braze Cloud Mode (Actions) trackEvent should work with default mappings 1`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer my-api-key",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+    "x-braze-batch": Array [
+      "true",
+    ],
+  },
+}
+`;
+
+exports[`Braze Cloud Mode (Actions) trackEvent should work with default mappings 2`] = `
+Object {
+  "events": Array [
+    Object {
+      "_update_existing_only": false,
+      "app_id": "my-app-id",
+      "braze_id": undefined,
+      "external_id": "user1234",
+      "name": "Test Event",
+      "properties": Object {},
+      "time": "2021-08-03T17:40:04.055Z",
+      "user_alias": undefined,
+    },
+  ],
+}
+`;
+
+exports[`Braze Cloud Mode (Actions) trackPurchase should require one of braze_id, user_alias, or external_id 1`] = `"One of \\"external_id\\" or \\"user_alias\\" or \\"braze_id\\" is required."`;
+
+exports[`Braze Cloud Mode (Actions) trackPurchase should work with default mappings 1`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer my-api-key",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Braze Cloud Mode (Actions) updateUserProfile should require one of braze_id, user_alias, or external_id 1`] = `"One of \\"external_id\\" or \\"user_alias\\" or \\"braze_id\\" is required."`;
+
+exports[`Braze Cloud Mode (Actions) updateUserProfile should work with default mappings 1`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer my-api-key",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Braze Cloud Mode (Actions) updateUserProfile should work with default mappings 2`] = `
+Object {
+  "attributes": Array [
+    Object {
+      "_update_existing_only": false,
+      "braze_id": undefined,
+      "country": "United States",
+      "current_location": Object {
+        "latitude": 40.2964197,
+        "longitude": -76.9411617,
+      },
+      "date_of_first_session": undefined,
+      "date_of_last_session": undefined,
+      "dob": undefined,
+      "email": undefined,
+      "email_click_tracking_disabled": undefined,
+      "email_open_tracking_disabled": undefined,
+      "email_subscribe": undefined,
+      "external_id": "user1234",
+      "facebook": undefined,
+      "first_name": undefined,
+      "gender": undefined,
+      "home_city": undefined,
+      "image_url": undefined,
+      "language": undefined,
+      "last_name": undefined,
+      "marked_email_as_spam_at": undefined,
+      "phone": undefined,
+      "push_subscribe": undefined,
+      "push_tokens": undefined,
+      "time_zone": undefined,
+      "twitter": undefined,
+      "user_alias": undefined,
+    },
+  ],
+}
+`;

--- a/packages/destination-actions/src/destinations/braze/__tests__/__snapshots__/braze.test.ts.snap
+++ b/packages/destination-actions/src/destinations/braze/__tests__/__snapshots__/braze.test.ts.snap
@@ -40,9 +40,6 @@ Headers {
     "user-agent": Array [
       "Segment (Actions)",
     ],
-    "x-braze-batch": Array [
-      "true",
-    ],
   },
 }
 `;

--- a/packages/destination-actions/src/destinations/braze/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/braze/trackEvent/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { sendTrackEvent } from '../utils'
+import { sendTrackEvent, sendBatchedTrackEvent } from '../utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track Event',
@@ -83,10 +83,10 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: (request, { settings, payload }) => {
-    return sendTrackEvent(request, settings, [payload])
+    return sendTrackEvent(request, settings, payload)
   },
   performBatch: (request, { settings, payload }) => {
-    return sendTrackEvent(request, settings, payload)
+    return sendBatchedTrackEvent(request, settings, payload)
   }
 }
 

--- a/packages/destination-actions/src/destinations/braze/utils.ts
+++ b/packages/destination-actions/src/destinations/braze/utils.ts
@@ -32,7 +32,6 @@ export function sendTrackEvent(request: RequestClient, settings: Settings, paylo
 
   return request(`${settings.endpoint}/users/track`, {
     method: 'post',
-    headers: { 'X-Braze-Batch': 'true' },
     json: {
       events: [
         {

--- a/packages/destination-actions/src/destinations/braze/utils.ts
+++ b/packages/destination-actions/src/destinations/braze/utils.ts
@@ -18,19 +18,52 @@ function toISO8601(date: DateInput): DateOutput {
   return d.isValid() ? d.toISOString() : undefined
 }
 
-export function sendTrackEvent(request: RequestClient, settings: Settings, payloads: TrackEventPayload[]) {
+export function sendTrackEvent(request: RequestClient, settings: Settings, payload: TrackEventPayload) {
+  const { braze_id, external_id } = payload
+  const user_alias = getUserAlias(payload.user_alias)
+
+  if (!braze_id && !user_alias && !external_id) {
+    throw new IntegrationError(
+      'One of "external_id" or "user_alias" or "braze_id" is required.',
+      'Missing required fields',
+      400
+    )
+  }
+
+  return request(`${settings.endpoint}/users/track`, {
+    method: 'post',
+    headers: { 'X-Braze-Batch': 'true' },
+    json: {
+      events: [
+        {
+          braze_id,
+          external_id,
+          user_alias,
+          app_id: settings.app_id,
+          name: payload.name,
+          time: toISO8601(payload.time),
+          properties: payload.properties,
+          _update_existing_only: payload._update_existing_only
+        }
+      ]
+    }
+  })
+}
+
+export function sendBatchedTrackEvent(request: RequestClient, settings: Settings, payloads: TrackEventPayload[]) {
   const payload = payloads.map((payload) => {
     const { braze_id, external_id } = payload
     // Extract valid user_alias shape. Since it is optional (oneOf braze_id, external_id) we need to only include it if fully formed.
     const user_alias = getUserAlias(payload.user_alias)
 
-    if (!braze_id && !user_alias && !external_id) {
-      throw new IntegrationError(
-        'One of "external_id" or "user_alias" or "braze_id" is required.',
-        'Missing required fields',
-        400
-      )
-    }
+    // Disable errors until Actions Framework has a multistatus support
+    // if (!braze_id && !user_alias && !external_id) {
+    //   throw new IntegrationError(
+    //     'One of "external_id" or "user_alias" or "braze_id" is required.',
+    //     'Missing required fields',
+    //     400
+    //   )
+    // }
 
     return {
       braze_id,


### PR DESCRIPTION
This PR addresses [HGI-402](https://segment.atlassian.net/browse/HGI-402) and [HGI-405](https://segment.atlassian.net/browse/HGI-405)

The current logic for batched events to `trackEvent` discards the entire batch if a single event is invalid. This PR removes this check sending all events to Braze API and let it discard invalid events. This would enable partial batch failures.

## Testing
Tested in local environment.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment


[HGI-402]: https://segment.atlassian.net/browse/HGI-402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HGI-405]: https://segment.atlassian.net/browse/HGI-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ