### PR TITLE
[Cordial] Added missing test snapshots

### DIFF
--- a/packages/destination-actions/src/destinations/cordial/mergeContacts/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/cordial/mergeContacts/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Cordial's mergeContacts destination action: all fields 1`] = `
+Object {
+  "anonymousId": "H2XHqn[RN5(Rq",
+  "previousId": "H2XHqn[RN5(Rq",
+  "segmentId": "H2XHqn[RN5(Rq",
+  "segmentIdKey": "H2XHqn[RN5(Rq",
+}
+`;
+
+exports[`Testing snapshot for Cordial's mergeContacts destination action: required fields 1`] = `
+Object {
+  "previousId": "H2XHqn[RN5(Rq",
+  "segmentIdKey": "H2XHqn[RN5(Rq",
+}
+`;


### PR DESCRIPTION
This PR adds missing snapshots for Cordial Actions Destination.

## Testing

Testing not required as it adds missing test snapshots.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
