### PR TITLE
Make email field non-required

### DIFF
--- a/packages/destination-actions/src/destinations/outfunnel/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/outfunnel/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -75,7 +75,6 @@ exports[`Testing snapshot for actions-outfunnel destination: forwardTrackEvent a
 Object {
   "action": "@PZgcUszl",
   "anonymous_id": "@PZgcUszl",
-  "email": "ve@kamzucu.lu",
   "event_name": "@PZgcUszl",
   "group_id": "@PZgcUszl",
   "timestamp": "@PZgcUszl",

--- a/packages/destination-actions/src/destinations/outfunnel/forwardTrackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/outfunnel/forwardTrackEvent/generated-types.ts
@@ -24,7 +24,7 @@ export interface Payload {
   /**
    * Email address of the user who performed the event
    */
-  email: string
+  email?: string
   /**
    * The time the event occured in UTC
    */

--- a/packages/destination-actions/src/destinations/outfunnel/forwardTrackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/outfunnel/forwardTrackEvent/index.ts
@@ -50,7 +50,6 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     email: {
       type: 'string',
-      required: true,
       description: 'Email address of the user who performed the event',
       label: 'Email Address',
       default: {


### PR DESCRIPTION
Change the email field to be non-required. Otherwise track events without email field will get dropped.

## Testing

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
