### PR TITLE
Ripe Cloud: Use group fields as default mappings for group call

### DIFF
--- a/packages/destination-actions/src/destinations/ripe/index.ts
+++ b/packages/destination-actions/src/destinations/ripe/index.ts
@@ -62,7 +62,7 @@ const destination: DestinationDefinition<Settings> = {
       name: 'Group user',
       subscribe: 'type = "group"',
       partnerAction: 'group',
-      mapping: defaultValues(identify.fields)
+      mapping: defaultValues(group.fields)
     },
     {
       name: 'Identify user',


### PR DESCRIPTION
Noticed that we were using the default mappings for the identify call in group.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
