### PR TITLE
Bring back autopublish on main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,8 +63,6 @@ jobs:
             --canary \
             --preid \
             $(git branch --show-current) \
-            --pre-dist-tag canary \
-            --no-verify-access \
             --yes \
             2>&1 | tee)
           RESPONSE="${RESPONSE//$'\n'/'\r\n'}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,4 +58,4 @@ jobs:
           npm whoami
 
       - name: Publish
-        run: yarn alpha --no-verify-access --yes
+        run: yarn alpha

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,61 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  push:
+    branches:
+      - npm_auto_publish
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-20.04
+
+    timeout-minutes: 15
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Use Github Personal Access Token
+        run: git config --global url."https://${{ secrets.GH_PAT }}@github.com/".insteadOf ssh://git@github.com/
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Build
+        run: NODE_ENV=production yarn build
+
+      - name: Set NPM Token
+        run: |
+          npm set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_PUBLISH_TOKEN }}
+          npm whoami
+
+      - name: Publish
+        run: yarn alpha --no-verify-access --yes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,4 +58,17 @@ jobs:
           npm whoami
 
       - name: Publish
-        run: yarn alpha
+        run: |
+          RESPONSE=$(lerna publish prerelease \
+            --canary \
+            --preid \
+            $(git branch --show-current) \
+            --pre-dist-tag canary \
+            --no-verify-access \
+            --yes \
+            2>&1 | tee)
+          RESPONSE="${RESPONSE//$'\n'/'\r\n'}"
+          echo 'LERNA_RESPONSE<<EOF' >> $GITHUB_ENV
+          echo $RESPONSE >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+          echo $RESPONSE


### PR DESCRIPTION
We want to bring back autopublish on our npm packages. Let's see if we can do it?
## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
