### PR TITLE
[HEAP-41596]: Add Identity and traits to track event

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -280,6 +280,12 @@ Once the actions under a new destination are complete, developers can run the fo
 yarn jest --testPathPattern='./packages/destination-actions/src/destinations/<DESTINATION SLUG>' --updateSnapshot
 ```
 
+Ensure your NODE_ENV environment variable is set to test.
+
+```
+export NODE_ENV=test
+```
+
 ## Code Coverage
 
 Code coverage is automatically collected upon completion of `yarn test`. Results may be inspected by examining the HTML report found at `coverage/lcov-report/index.html`, or directly in your IDE if _lcov_ is supported.

--- a/packages/browser-destinations/src/destinations/heap/test-utilities.ts
+++ b/packages/browser-destinations/src/destinations/heap/test-utilities.ts
@@ -28,6 +28,15 @@ export const trackEventSubscription: Subscription = {
     },
     properties: {
       '@path': '$.properties'
+    },
+    identity: {
+      '@path': '$.userId'
+    },
+    anonymousId: {
+      '@path': '$.anonymousId'
+    },
+    traits: {
+      '@path': '$.context.traits'
     }
   }
 }

--- a/packages/browser-destinations/src/destinations/heap/trackEvent/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/heap/trackEvent/__tests__/index.test.ts
@@ -9,19 +9,28 @@ import {
 import { HEAP_SEGMENT_BROWSER_LIBRARY_NAME } from '../../constants'
 
 describe('#trackEvent', () => {
-  const createHeapDestinationAndSpy = async (): Promise<[Plugin, jest.SpyInstance]> => {
+  let event: Plugin
+  let heapTrackSpy: jest.SpyInstance
+  let addUserPropertiesSpy: jest.SpyInstance
+  let identifySpy: jest.SpyInstance
+
+  beforeAll(async () => {
     mockHeapJsHttpRequest()
     window.heap = createMockedHeapJsSdk()
 
-    const [event] = await heapDestination({ appId: HEAP_TEST_ENV_ID, subscriptions: [trackEventSubscription] })
+    event = (await heapDestination({ appId: HEAP_TEST_ENV_ID, subscriptions: [trackEventSubscription] }))[0]
 
     await event.load(Context.system(), {} as Analytics)
-    const heapTrackSpy = jest.spyOn(window.heap, 'track')
+    heapTrackSpy = jest.spyOn(window.heap, 'track')
+    addUserPropertiesSpy = jest.spyOn(window.heap, 'addUserProperties')
+    identifySpy = jest.spyOn(window.heap, 'identify')
+  })
 
-    return [event, heapTrackSpy]
-  }
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
   it('sends events to heap', async () => {
-    const [event, heapTrackSpy] = await createHeapDestinationAndSpy()
     await event.track?.(
       new Context({
         type: 'track',
@@ -36,10 +45,11 @@ describe('#trackEvent', () => {
       banana: '📞',
       segment_library: HEAP_SEGMENT_BROWSER_LIBRARY_NAME
     })
+    expect(addUserPropertiesSpy).toHaveBeenCalledTimes(0)
+    expect(identifySpy).toHaveBeenCalledTimes(0)
   })
 
   it('should send segment_library property if no other properties were provided', async () => {
-    const [event, heapTrackSpy] = await createHeapDestinationAndSpy()
     await event.track?.(
       new Context({
         type: 'track',
@@ -50,23 +60,58 @@ describe('#trackEvent', () => {
     expect(heapTrackSpy).toHaveBeenCalledWith('hello!', {
       segment_library: HEAP_SEGMENT_BROWSER_LIBRARY_NAME
     })
+    expect(addUserPropertiesSpy).toHaveBeenCalledTimes(0)
+    expect(identifySpy).toHaveBeenCalledTimes(0)
   })
 
   it('should not override segment_library property value if provided by user', async () => {
-    const [event, heapTrackSpy] = await createHeapDestinationAndSpy()
     const segmentLibraryValue = 'user-provided-value'
+    const userId = 'TEST_ID77'
     await event.track?.(
       new Context({
         type: 'track',
         name: 'hello!',
         properties: {
           segment_library: segmentLibraryValue
-        }
+        },
+        userId
       })
     )
 
     expect(heapTrackSpy).toHaveBeenCalledWith('hello!', {
       segment_library: HEAP_SEGMENT_BROWSER_LIBRARY_NAME
     })
+    expect(identifySpy).toHaveBeenCalledWith(userId)
+    expect(addUserPropertiesSpy).toHaveBeenCalledTimes(0)
+  })
+
+  it('should add traits', async () => {
+    const segmentLibraryValue = 'test123'
+    const anonymous_id = 'ANON1'
+    const name = 'Grace Hopper'
+    await event.track?.(
+      new Context({
+        type: 'track',
+        name: 'hello!',
+        properties: {
+          segment_library: segmentLibraryValue
+        },
+        context: {
+          traits: {
+            name
+          }
+        },
+        anonymousId: anonymous_id
+      })
+    )
+
+    expect(heapTrackSpy).toHaveBeenCalledWith('hello!', {
+      segment_library: HEAP_SEGMENT_BROWSER_LIBRARY_NAME
+    })
+    expect(addUserPropertiesSpy).toHaveBeenCalledWith({
+      anonymous_id,
+      name
+    })
+    expect(identifySpy).toHaveBeenCalledTimes(0)
   })
 })

--- a/packages/browser-destinations/src/destinations/heap/trackEvent/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/heap/trackEvent/generated-types.ts
@@ -12,6 +12,10 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
+   * a string that uniquely identifies a user, such as an email, handle, or username. This means no two users in one environment may share the same identity. More on identify: https://developers.heap.io/docs/using-identify
+   */
+  identity?: string
+  /**
    * The segment anonymous identifier for the user
    */
   anonymousId?: string

--- a/packages/browser-destinations/src/destinations/heap/trackEvent/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/heap/trackEvent/generated-types.ts
@@ -19,4 +19,10 @@ export interface Payload {
    * The segment anonymous identifier for the user
    */
   anonymousId?: string
+  /**
+   * An object with key-value properties you want associated with the user. Each property must either be a number or string with fewer than 1024 characters.
+   */
+  traits?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
@@ -3,8 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { HeapApi } from '../types'
 import { HEAP_SEGMENT_BROWSER_LIBRARY_NAME } from '../constants'
-import { isDefined } from '../utils'
-import { flat } from '@segment/action-destinations/dist/destinations/heap/flat'
+import { isDefined, flat } from '../utils'
 
 const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
   title: 'Track Event',
@@ -57,12 +56,7 @@ const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
     }
   },
   perform: (heap, event) => {
-    const eventProperties = Object.assign(
-      {
-        ...(isDefined(event.payload.anonymousId) && { anonymous_id: event.payload.anonymousId })
-      },
-      event.payload.properties ?? {}
-    )
+    const eventProperties = Object.assign({}, event.payload.properties)
     eventProperties.segment_library = HEAP_SEGMENT_BROWSER_LIBRARY_NAME
     if (event.payload.anonymousId || isDefined(event.payload?.traits)) {
       const traits = flat(event.payload?.traits)

--- a/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
@@ -57,7 +57,12 @@ const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
     }
   },
   perform: (heap, event) => {
-    const eventProperties = Object.assign({}, event.payload.properties ?? {})
+    const eventProperties = Object.assign(
+      {
+        ...(isDefined(event.payload.anonymousId) && { anonymous_id: event.payload.anonymousId })
+      },
+      event.payload.properties ?? {}
+    )
     eventProperties.segment_library = HEAP_SEGMENT_BROWSER_LIBRARY_NAME
     if (event.payload.anonymousId || isDefined(event.payload?.traits)) {
       const traits = flat(event.payload?.traits)

--- a/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
@@ -28,6 +28,13 @@ const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
         '@path': '$.properties'
       }
     },
+    identity: {
+      type: 'string',
+      required: false,
+      label: 'Identity',
+      description:
+        'a string that uniquely identifies a user, such as an email, handle, or username. This means no two users in one environment may share the same identity. More on identify: https://developers.heap.io/docs/using-identify'
+    },
     anonymousId: {
       type: 'string',
       required: false,
@@ -41,10 +48,13 @@ const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
   perform: (heap, event) => {
     const eventProperties = Object.assign({}, event.payload.properties ?? {})
     eventProperties.segment_library = HEAP_SEGMENT_BROWSER_LIBRARY_NAME
-    heap.track(event.payload.name, eventProperties)
     if (event.payload.anonymousId) {
       heap.addUserProperties({ anonymous_id: event.payload.anonymousId })
     }
+    if (event.payload?.identity) {
+      heap.identify(event.payload.identity)
+    }
+    heap.track(event.payload.name, eventProperties)
   }
 }
 

--- a/packages/browser-destinations/src/destinations/heap/utils.ts
+++ b/packages/browser-destinations/src/destinations/heap/utils.ts
@@ -1,0 +1,6 @@
+export function isDefined(value: string | undefined | null | number | object): boolean {
+  if (typeof value === 'object') {
+    return !!value && Object.keys(value).length !== 0
+  }
+  return !(value === undefined || value === null || value === '' || value === 0 || value === '0')
+}

--- a/packages/browser-destinations/src/destinations/heap/utils.ts
+++ b/packages/browser-destinations/src/destinations/heap/utils.ts
@@ -4,6 +4,7 @@ export function isDefined(value: string | undefined | null | number | object): b
   }
   return !(value === undefined || value === null || value === '' || value === 0 || value === '0')
 }
+
 export type Properties = {
   [k: string]: unknown
 }

--- a/packages/browser-destinations/src/destinations/heap/utils.ts
+++ b/packages/browser-destinations/src/destinations/heap/utils.ts
@@ -4,3 +4,37 @@ export function isDefined(value: string | undefined | null | number | object): b
   }
   return !(value === undefined || value === null || value === '' || value === 0 || value === '0')
 }
+export type Properties = {
+  [k: string]: unknown
+}
+
+type FlattenProperties = object & {
+  [k: string]: string
+}
+
+export function flat(data?: Properties, prefix = ''): FlattenProperties | undefined {
+  if (!isDefined(data)) {
+    return undefined
+  }
+  let result: FlattenProperties = {}
+  for (const key in data) {
+    if (typeof data[key] == 'object' && data[key] !== null) {
+      const flatten = flat(data[key] as Properties, prefix + '.' + key)
+      result = { ...result, ...flatten }
+    } else {
+      const stringifiedValue = stringify(data[key])
+      result[(prefix + '.' + key).replace(/^\./, '')] = stringifiedValue
+    }
+  }
+  return result
+}
+
+function stringify(value: unknown): string {
+  if (typeof value === 'string') {
+    return value
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value.toString()
+  }
+  return JSON.stringify(value)
+}

--- a/packages/destination-actions/src/destinations/heap/flat.ts
+++ b/packages/destination-actions/src/destinations/heap/flat.ts
@@ -1,5 +1,3 @@
-import { isDefined } from './heapUtils'
-
 export type Properties = {
   [k: string]: unknown
 }
@@ -8,10 +6,7 @@ type FlattenProperties = object & {
   [k: string]: string
 }
 
-export function flat(data?: Properties, prefix = ''): FlattenProperties | undefined {
-  if (!isDefined(data)) {
-    return undefined
-  }
+export function flat(data: Properties, prefix = ''): FlattenProperties {
   let result: FlattenProperties = {}
   for (const key in data) {
     if (typeof data[key] == 'object' && data[key] !== null) {

--- a/packages/destination-actions/src/destinations/heap/flat.ts
+++ b/packages/destination-actions/src/destinations/heap/flat.ts
@@ -1,3 +1,5 @@
+import { isDefined } from './heapUtils'
+
 export type Properties = {
   [k: string]: unknown
 }
@@ -6,7 +8,10 @@ type FlattenProperties = object & {
   [k: string]: string
 }
 
-export function flat(data: Properties, prefix = ''): FlattenProperties {
+export function flat(data?: Properties, prefix = ''): FlattenProperties | undefined {
+  if (!isDefined(data)) {
+    return undefined
+  }
   let result: FlattenProperties = {}
   for (const key in data) {
     if (typeof data[key] == 'object' && data[key] !== null) {


### PR DESCRIPTION
I've added support for user properties and identity to the track event. Now if the event has the userId or context.traits they will be sent to heap. We explicitly check for 0 values in the identity field because one of out customers sends in a 0 for failed logins. We don't want to identify the user in this case. 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
