### PR TITLE
Add batch_size config to webhook action

### DIFF
--- a/packages/destination-actions/src/destinations/webhook/send/generated-types.ts
+++ b/packages/destination-actions/src/destinations/webhook/send/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   method: string
   /**
+   * The target number of events to batch together in a single request, max size 4000.
+   */
+  batch_size?: number
+  /**
    * HTTP headers to send with each request.
    */
   headers?: {

--- a/packages/destination-actions/src/destinations/webhook/send/index.ts
+++ b/packages/destination-actions/src/destinations/webhook/send/index.ts
@@ -27,6 +27,13 @@ const action: ActionDefinition<Settings, Payload> = {
       default: 'POST',
       required: true
     },
+    batch_size: {
+      label: 'Batch Size',
+      description: 'The target number of events to batch together in a single request, max size 4000.',
+      type: 'number',
+      required: false,
+      default: 0
+    },
     headers: {
       label: 'Headers',
       description: 'HTTP headers to send with each request.',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This change adds the `batch_size` to the webhook destination so it can be adjusted depending on the capabilities of the webhook service.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
