### PR TITLE
fixing june presets

### DIFF
--- a/packages/destination-actions/src/destinations/june/index.ts
+++ b/packages/destination-actions/src/destinations/june/index.ts
@@ -1,5 +1,6 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
+import { defaultValues } from '@segment/actions-core'
 import track from './track'
 import page from './page'
 import identify from './identify'
@@ -9,22 +10,26 @@ const presets: DestinationDefinition['presets'] = [
   {
     name: 'Track Calls',
     subscribe: 'type = "track"',
-    partnerAction: 'track'
+    partnerAction: 'track',
+    mapping: defaultValues(track.fields)
   },
   {
     name: 'Page Calls',
     subscribe: 'type = "page"',
-    partnerAction: 'page'
+    partnerAction: 'page',
+    mapping: defaultValues(page.fields)
   },
   {
     name: 'Identify Calls',
     subscribe: 'type = "identify"',
-    partnerAction: 'identify'
+    partnerAction: 'identify',
+    mapping: defaultValues(identify.fields)
   },
   {
     name: 'Group Calls',
     subscribe: 'type = "group"',
-    partnerAction: 'group'
+    partnerAction: 'group',
+    mapping: defaultValues(group.fields)
   }
 ]
 


### PR DESCRIPTION
## Summary

Fixing June Integration presets. 

## Testing

None needed. This integration won't run in the app because presets are incorrectly configured.  
Preset objects require a mapping attribute. This isn't enforced in the action-destination repo, but is required at runtime (by Integrations). 
