### PR TITLE
TikTok Audiences Post PROD updates

### DIFF
--- a/packages/destination-actions/package.json
+++ b/packages/destination-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/action-destinations",
   "description": "Destination Actions engine and definitions.",
-  "version": "3.145.0",
+  "version": "3.145.1-add-create-audience.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",

--- a/packages/destination-actions/package.json
+++ b/packages/destination-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/action-destinations",
   "description": "Destination Actions engine and definitions.",
-  "version": "3.145.1-add-create-audience.0",
+  "version": "3.145.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",

--- a/packages/destination-actions/src/destinations/tiktok-audiences/addUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addUser/__tests__/index.test.ts
@@ -62,7 +62,7 @@ describe('TiktokAudiences.addUser', () => {
         auth,
         mapping: {
           selected_advertiser_id: '123',
-          custom_audience_id: '1234345'
+          audience_id: '1234345'
         }
       })
     ).resolves.not.toThrowError()

--- a/packages/destination-actions/src/destinations/tiktok-audiences/addUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addUser/__tests__/index.test.ts
@@ -31,12 +31,6 @@ const event = createTestEvent({
   }
 })
 
-const urlParams = {
-  advertiser_id: '123',
-  page: 1,
-  page_size: 100
-}
-
 const updateUsersRequestBody = {
   advertiser_ids: ['123'],
   action: 'add',
@@ -56,34 +50,8 @@ const updateUsersRequestBody = {
 }
 
 describe('TiktokAudiences.addUser', () => {
-  it('should fail if `personas_audience_key` field does not match the `custom_audience_name` field', async () => {
-    await expect(
-      testDestination.testAction('addUser', {
-        event,
-        settings: {
-          advertiser_ids: ['123']
-        },
-        useDefaultMappings: true,
-        auth,
-        mapping: {
-          personas_audience_key: 'mismatched_audience',
-          selected_advertiser_id: '123'
-        }
-      })
-    ).rejects.toThrow('The value of `custom_audience_name` and `personas_audience_key` must match.')
-  })
-
-  it('should succeed if an exisiting audience is found', async () => {
-    nock(`${BASE_URL}${TIKTOK_API_VERSION}/dmp/custom_audience/list/`)
-      .get(/.*/)
-      .query(urlParams)
-      .reply(200, {
-        code: 0,
-        message: 'OK',
-        data: { page_info: { total_number: 1 }, list: [{ name: 'personas_test_audience', audience_id: '1234345' }] }
-      })
+  it('should succeed if audience id is valid', async () => {
     nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`).post(/.*/, updateUsersRequestBody).reply(200)
-
     await expect(
       testDestination.testAction('addUser', {
         event,
@@ -94,21 +62,14 @@ describe('TiktokAudiences.addUser', () => {
         auth,
         mapping: {
           selected_advertiser_id: '123',
-          personas_audience_key: 'personas_test_audience'
+          custom_audience_id: '1234345'
         }
       })
     ).resolves.not.toThrowError()
   })
 
-  it('should fail if an audience is not found', async () => {
-    nock(`${BASE_URL}${TIKTOK_API_VERSION}/dmp/custom_audience/list/`)
-      .get(/.*/)
-      .query(urlParams)
-      .reply(200, {
-        code: 0,
-        message: 'OK',
-        data: { page_info: { total_number: 1 }, list: [{ name: 'another_audience', audience_id: '1234345' }] }
-      })
+  it('should fail if an audience id is invalid', async () => {
+    nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`).post(/.*/, updateUsersRequestBody).reply(400)
 
     await expect(
       testDestination.testAction('addUser', {
@@ -123,21 +84,10 @@ describe('TiktokAudiences.addUser', () => {
           personas_audience_key: 'personas_test_audience'
         }
       })
-    ).rejects.toThrow(
-      'No audience with name personas_test_audience found. Please ensure that you create the audience before syncing.'
-    )
+    ).rejects.toThrowError()
   })
 
   it('should fail if all the send fields are false', async () => {
-    nock(`${BASE_URL}${TIKTOK_API_VERSION}/dmp/custom_audience/list/`)
-      .get(/.*/)
-      .query(urlParams)
-      .reply(200, {
-        code: 0,
-        message: 'OK',
-        data: { page_info: { total_number: 1 }, list: [{ name: 'another_audience', audience_id: '1234345' }] }
-      })
-
     nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`).post(/.*/, updateUsersRequestBody).reply(200)
 
     await expect(

--- a/packages/destination-actions/src/destinations/tiktok-audiences/addUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addUser/generated-types.ts
@@ -6,9 +6,9 @@ export interface Payload {
    */
   selected_advertiser_id: string
   /**
-   * Custom audience name of audience to be synced. This audience must already exist in your TikTok Advertising account
+   * Audience ID for the TikTok Audience you want to sync your Engage audience to. This is returned after you create an audience and can also be found in the TikTok Audiences dashboard.
    */
-  custom_audience_name: string
+  custom_audience_id: string
   /**
    * The user's email address to send to TikTok.
    */
@@ -33,8 +33,4 @@ export interface Payload {
    * Enable batching of requests to the TikTok Audiences.
    */
   enable_batching?: boolean
-  /**
-   * The `audience_key` of the Engage audience you want to sync to TikTok. This value must be a hard-coded string variable, e.g. `personas_test_audience`, in order for batching to work properly.
-   */
-  personas_audience_key?: string
 }

--- a/packages/destination-actions/src/destinations/tiktok-audiences/addUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addUser/generated-types.ts
@@ -8,7 +8,7 @@ export interface Payload {
   /**
    * Audience ID for the TikTok Audience you want to sync your Engage audience to. This is returned after you create an audience and can also be found in the TikTok Audiences dashboard.
    */
-  custom_audience_id: string
+  audience_id: string
   /**
    * The user's email address to send to TikTok.
    */

--- a/packages/destination-actions/src/destinations/tiktok-audiences/addUser/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addUser/index.ts
@@ -4,14 +4,13 @@ import type { Payload } from './generated-types'
 import { processPayload } from '../functions'
 import {
   selected_advertiser_id,
-  custom_audience_name,
+  custom_audience_id,
   email,
   advertising_id,
   send_email,
   send_advertising_id,
   event_name,
-  enable_batching,
-  personas_audience_key
+  enable_batching
 } from '../properties'
 import { TikTokAudiences } from '../api'
 
@@ -21,14 +20,13 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'event = "Audience Entered"',
   fields: {
     selected_advertiser_id: { ...selected_advertiser_id },
-    custom_audience_name: { ...custom_audience_name },
+    custom_audience_id: { ...custom_audience_id },
     email: { ...email },
     advertising_id: { ...advertising_id },
     send_email: { ...send_email },
     send_advertising_id: { ...send_advertising_id },
     event_name: { ...event_name },
-    enable_batching: { ...enable_batching },
-    personas_audience_key: { ...personas_audience_key }
+    enable_batching: { ...enable_batching }
   },
   dynamicFields: {
     selected_advertiser_id: async (request, { settings }) => {

--- a/packages/destination-actions/src/destinations/tiktok-audiences/addUser/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addUser/index.ts
@@ -4,7 +4,7 @@ import type { Payload } from './generated-types'
 import { processPayload } from '../functions'
 import {
   selected_advertiser_id,
-  custom_audience_id,
+  audience_id,
   email,
   advertising_id,
   send_email,
@@ -20,7 +20,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'event = "Audience Entered"',
   fields: {
     selected_advertiser_id: { ...selected_advertiser_id },
-    custom_audience_id: { ...custom_audience_id },
+    audience_id: { ...audience_id },
     email: { ...email },
     advertising_id: { ...advertising_id },
     send_email: { ...send_email },

--- a/packages/destination-actions/src/destinations/tiktok-audiences/api/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/api/index.ts
@@ -1,5 +1,5 @@
 import type { RequestClient, ModifiedResponse } from '@segment/actions-core'
-import type { Payload } from '../addUser/generated-types'
+import type { Payload } from '../createAudience/generated-types'
 import { BASE_URL, TIKTOK_API_VERSION } from '../constants'
 import type { GetAudienceAPIResponse, CreateAudienceAPIResponse, APIResponse } from '../types'
 import { DynamicFieldResponse } from '@segment/actions-core'
@@ -63,6 +63,7 @@ export class TikTokAudiences {
       json: {
         custom_audience_name: payload.custom_audience_name,
         advertiser_id: this.selectedAdvertiserID,
+        id_type: payload.id_type,
         action: 'create'
       }
     })

--- a/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/__tests__/index.test.ts
@@ -1,0 +1,176 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { BASE_URL, TIKTOK_API_VERSION } from '../../constants'
+
+const testDestination = createTestIntegration(Destination)
+
+interface AuthTokens {
+  accessToken: string
+  refreshToken: string
+}
+
+const auth: AuthTokens = {
+  accessToken: 'test',
+  refreshToken: 'test'
+}
+
+const event = createTestEvent({
+  event: 'Audience Entered',
+  type: 'track',
+  properties: {
+    audience_key: 'personas_test_audience'
+  },
+  context: {
+    device: {
+      advertisingId: '123'
+    },
+    traits: {
+      email: 'testing@testing.com'
+    }
+  }
+})
+
+const urlParams = {
+  advertiser_id: '123',
+  page: 1,
+  page_size: 100
+}
+
+const updateUsersRequestBody = {
+  advertiser_ids: ['123'],
+  action: 'add',
+  id_schema: ['EMAIL_SHA256', 'IDFA_SHA256'],
+  batch_data: [
+    [
+      {
+        id: '44d206f60172cd898051a9fb2174750aee1eca00f6f63f12801b90644321e342',
+        audience_ids: ['1234345']
+      },
+      {
+        id: 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3',
+        audience_ids: ['1234345']
+      }
+    ]
+  ]
+}
+
+const createAudienceRequestBody = {
+  custom_audience_name: 'personas_test_audience',
+  advertiser_id: '123',
+  id_type: 'EMAIL_SHA256',
+  action: 'create'
+}
+
+describe('TiktokAudiences.addUser', () => {
+  // it('should fail if `personas_audience_key` field does not match the `custom_audience_name` field', async () => {
+  //   await expect(
+  //     testDestination.testAction('addUser', {
+  //       event,
+  //       settings: {
+  //         advertiser_ids: ['123']
+  //       },
+  //       useDefaultMappings: true,
+  //       auth,
+  //       mapping: {
+  //         personas_audience_key: 'mismatched_audience',
+  //         id_type: 'EMAIL_SHA256',
+  //         selected_advertiser_id: '123'
+  //       }
+  //     })
+  //   ).rejects.toThrow('The value of `custom_audience_name` and `personas_audience_key` must match.')
+  // })
+
+  it('should succeed if an exisiting audience is found', async () => {
+    // nock(`${BASE_URL}${TIKTOK_API_VERSION}/dmp/custom_audience/list/`)
+    //   .get(/.*/)
+    //   .query(urlParams)
+    //   .reply(200, {
+    //     code: 0,
+    //     message: 'OK',
+    //     data: { page_info: { total_number: 1 }, list: [{ name: 'personas_test_audience', audience_id: '1234345' }] }
+    //   })
+    nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`).post(/.*/, updateUsersRequestBody).reply(200)
+
+    await expect(
+      testDestination.testAction('addUser', {
+        event,
+        settings: {
+          advertiser_ids: ['123']
+        },
+        useDefaultMappings: true,
+        auth,
+        mapping: {
+          selected_advertiser_id: '123',
+          custom_audience_id: '1234345'
+        }
+      })
+    ).resolves.not.toThrowError()
+  })
+
+  // it('should successfully create a new audience if one is not found', async () => {
+  //   nock(`${BASE_URL}${TIKTOK_API_VERSION}/dmp/custom_audience/list/`)
+  //     .get(/.*/)
+  //     .query(urlParams)
+  //     .reply(200, {
+  //       code: 0,
+  //       message: 'OK',
+  //       data: { page_info: { total_number: 1 }, list: [{ name: 'another_audience', audience_id: '1234345' }] }
+  //     })
+
+  //   nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/audience/`)
+  //     .post(/.*/, createAudienceRequestBody)
+  //     .reply(200, { data: { audience_id: '1234345' } })
+  //   nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`).post(/.*/, updateUsersRequestBody).reply(200)
+
+  //   await expect(
+  //     testDestination.testAction('addUser', {
+  //       event,
+  //       settings: {
+  //         advertiser_ids: ['123']
+  //       },
+  //       useDefaultMappings: true,
+  //       auth,
+  //       mapping: {
+  //         selected_advertiser_id: '123',
+  //         personas_audience_key: 'personas_test_audience',
+  //         id_type: 'EMAIL_SHA256'
+  //       }
+  //     })
+  //   ).resolves.not.toThrowError()
+  // })
+
+  it('should fail if all the send fields are false', async () => {
+    nock(`${BASE_URL}${TIKTOK_API_VERSION}/dmp/custom_audience/list/`)
+      .get(/.*/)
+      .query(urlParams)
+      .reply(200, {
+        code: 0,
+        message: 'OK',
+        data: { page_info: { total_number: 1 }, list: [{ name: 'another_audience', audience_id: '1234345' }] }
+      })
+
+    nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/audience/`)
+      .post(/.*/, createAudienceRequestBody)
+      .reply(200, { data: { audience_id: '1234345' } })
+    nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`).post(/.*/, updateUsersRequestBody).reply(200)
+
+    await expect(
+      testDestination.testAction('addUser', {
+        event,
+        settings: {
+          advertiser_ids: ['123']
+        },
+        useDefaultMappings: true,
+        auth,
+        mapping: {
+          selected_advertiser_id: '123',
+          personas_audience_key: 'personas_test_audience',
+          id_type: 'EMAIL_SHA256',
+          send_email: false,
+          send_advertising_id: false
+        }
+      })
+    ).rejects.toThrow('At least one of `Send Email`, or `Send Advertising ID` must be set to `true`.')
+  })
+})

--- a/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/__tests__/index.test.ts
@@ -16,44 +16,9 @@ const auth: AuthTokens = {
 }
 
 const event = createTestEvent({
-  event: 'Audience Entered',
-  type: 'track',
-  properties: {
-    audience_key: 'personas_test_audience'
-  },
-  context: {
-    device: {
-      advertisingId: '123'
-    },
-    traits: {
-      email: 'testing@testing.com'
-    }
-  }
+  event: 'Create Audience',
+  type: 'track'
 })
-
-const urlParams = {
-  advertiser_id: '123',
-  page: 1,
-  page_size: 100
-}
-
-const updateUsersRequestBody = {
-  advertiser_ids: ['123'],
-  action: 'add',
-  id_schema: ['EMAIL_SHA256', 'IDFA_SHA256'],
-  batch_data: [
-    [
-      {
-        id: '44d206f60172cd898051a9fb2174750aee1eca00f6f63f12801b90644321e342',
-        audience_ids: ['1234345']
-      },
-      {
-        id: 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3',
-        audience_ids: ['1234345']
-      }
-    ]
-  ]
-}
 
 const createAudienceRequestBody = {
   custom_audience_name: 'personas_test_audience',
@@ -62,101 +27,14 @@ const createAudienceRequestBody = {
   action: 'create'
 }
 
-describe('TiktokAudiences.addUser', () => {
-  // it('should fail if `personas_audience_key` field does not match the `custom_audience_name` field', async () => {
-  //   await expect(
-  //     testDestination.testAction('addUser', {
-  //       event,
-  //       settings: {
-  //         advertiser_ids: ['123']
-  //       },
-  //       useDefaultMappings: true,
-  //       auth,
-  //       mapping: {
-  //         personas_audience_key: 'mismatched_audience',
-  //         id_type: 'EMAIL_SHA256',
-  //         selected_advertiser_id: '123'
-  //       }
-  //     })
-  //   ).rejects.toThrow('The value of `custom_audience_name` and `personas_audience_key` must match.')
-  // })
-
-  it('should succeed if an exisiting audience is found', async () => {
-    // nock(`${BASE_URL}${TIKTOK_API_VERSION}/dmp/custom_audience/list/`)
-    //   .get(/.*/)
-    //   .query(urlParams)
-    //   .reply(200, {
-    //     code: 0,
-    //     message: 'OK',
-    //     data: { page_info: { total_number: 1 }, list: [{ name: 'personas_test_audience', audience_id: '1234345' }] }
-    //   })
-    nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`).post(/.*/, updateUsersRequestBody).reply(200)
-
-    await expect(
-      testDestination.testAction('addUser', {
-        event,
-        settings: {
-          advertiser_ids: ['123']
-        },
-        useDefaultMappings: true,
-        auth,
-        mapping: {
-          selected_advertiser_id: '123',
-          custom_audience_id: '1234345'
-        }
-      })
-    ).resolves.not.toThrowError()
-  })
-
-  // it('should successfully create a new audience if one is not found', async () => {
-  //   nock(`${BASE_URL}${TIKTOK_API_VERSION}/dmp/custom_audience/list/`)
-  //     .get(/.*/)
-  //     .query(urlParams)
-  //     .reply(200, {
-  //       code: 0,
-  //       message: 'OK',
-  //       data: { page_info: { total_number: 1 }, list: [{ name: 'another_audience', audience_id: '1234345' }] }
-  //     })
-
-  //   nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/audience/`)
-  //     .post(/.*/, createAudienceRequestBody)
-  //     .reply(200, { data: { audience_id: '1234345' } })
-  //   nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`).post(/.*/, updateUsersRequestBody).reply(200)
-
-  //   await expect(
-  //     testDestination.testAction('addUser', {
-  //       event,
-  //       settings: {
-  //         advertiser_ids: ['123']
-  //       },
-  //       useDefaultMappings: true,
-  //       auth,
-  //       mapping: {
-  //         selected_advertiser_id: '123',
-  //         personas_audience_key: 'personas_test_audience',
-  //         id_type: 'EMAIL_SHA256'
-  //       }
-  //     })
-  //   ).resolves.not.toThrowError()
-  // })
-
-  it('should fail if all the send fields are false', async () => {
-    nock(`${BASE_URL}${TIKTOK_API_VERSION}/dmp/custom_audience/list/`)
-      .get(/.*/)
-      .query(urlParams)
-      .reply(200, {
-        code: 0,
-        message: 'OK',
-        data: { page_info: { total_number: 1 }, list: [{ name: 'another_audience', audience_id: '1234345' }] }
-      })
-
+describe('TiktokAudiences.createAudience', () => {
+  it('should successfully create a new audience', async () => {
     nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/audience/`)
       .post(/.*/, createAudienceRequestBody)
       .reply(200, { data: { audience_id: '1234345' } })
-    nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`).post(/.*/, updateUsersRequestBody).reply(200)
 
     await expect(
-      testDestination.testAction('addUser', {
+      testDestination.testAction('createAudience', {
         event,
         settings: {
           advertiser_ids: ['123']
@@ -165,12 +43,10 @@ describe('TiktokAudiences.addUser', () => {
         auth,
         mapping: {
           selected_advertiser_id: '123',
-          personas_audience_key: 'personas_test_audience',
-          id_type: 'EMAIL_SHA256',
-          send_email: false,
-          send_advertising_id: false
+          custom_audience_name: 'personas_test_audience',
+          id_type: 'EMAIL_SHA256'
         }
       })
-    ).rejects.toThrow('At least one of `Send Email`, or `Send Advertising ID` must be set to `true`.')
+    ).resolves.not.toThrowError()
   })
 })

--- a/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/generated-types.ts
@@ -1,0 +1,16 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Custom audience name of audience to be synced. This audience must already exist in your TikTok Advertising account
+   */
+  custom_audience_name: string
+  /**
+   * The advertiser ID to use when syncing audiences.
+   */
+  selected_advertiser_id: string
+  /**
+   * Encryption type to be used for populating the audience. This field is set only when Segment creates a new audience.
+   */
+  id_type: string
+}

--- a/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * Custom audience name of audience to be synced. This audience must already exist in your TikTok Advertising account
+   * Custom audience name of audience to be created. Please note that names over 70 characters will be truncated to 67 characters with "..." appended.
    */
   custom_audience_name: string
   /**

--- a/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/index.ts
@@ -8,6 +8,7 @@ import { createAudience } from '../functions'
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Create Audience',
   description: 'Creates a TikTok Audience Segment.',
+  defaultSubscription: 'event = "Audience Entered"',
   fields: {
     custom_audience_name: { ...custom_audience_name },
     selected_advertiser_id: { ...selected_advertiser_id },

--- a/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/index.ts
@@ -1,0 +1,38 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { id_type, custom_audience_name, selected_advertiser_id } from '../properties'
+import { TikTokAudiences } from '../api'
+import { createAudience } from '../functions'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Create Audience',
+  description: 'Creates a TikTok Audience Segment.',
+  fields: {
+    custom_audience_name: { ...custom_audience_name },
+    selected_advertiser_id: { ...selected_advertiser_id },
+    id_type: { ...id_type }
+  },
+  dynamicFields: {
+    selected_advertiser_id: async (request, { settings }) => {
+      try {
+        const tiktok = new TikTokAudiences(request)
+
+        return tiktok.fetchAdvertisers(settings.advertiser_ids)
+      } catch (err) {
+        return {
+          choices: [],
+          error: {
+            message: JSON.stringify(err),
+            code: '500'
+          }
+        }
+      }
+    }
+  },
+  perform: (request, { payload }) => {
+    return createAudience(request, payload)
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/tiktok-audiences/functions.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/functions.ts
@@ -1,9 +1,10 @@
-import { IntegrationError, RequestClient, RetryableError } from '@segment/actions-core'
-import { Audiences } from './types'
+import { IntegrationError, RequestClient, RetryableError, ModifiedResponse } from '@segment/actions-core'
+import { Audiences, CreateAudienceAPIResponse } from './types'
 import { createHash } from 'crypto'
 import { TikTokAudiences } from './api'
 import { Payload as AddUserPayload } from './addUser/generated-types'
 import { Payload as RemoveUserPayload } from './removeUser/generated-types'
+import { Payload as CreateAudiencePayload } from './createAudience/generated-types'
 import { Settings } from './generated-types'
 
 type GenericPayload = AddUserPayload | RemoveUserPayload
@@ -158,4 +159,13 @@ export function extractUsers(payloads: GenericPayload[], audienceID: string): {}
     batch_data.push(user_ids)
   })
   return batch_data
+}
+
+export async function createAudience(
+  request: RequestClient,
+  payload: CreateAudiencePayload
+): Promise<ModifiedResponse<CreateAudienceAPIResponse>> {
+  const TikTokApiClient: TikTokAudiences = new TikTokAudiences(request, payload.selected_advertiser_id)
+
+  return TikTokApiClient.createAudience(payload)
 }

--- a/packages/destination-actions/src/destinations/tiktok-audiences/functions.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/functions.ts
@@ -84,7 +84,7 @@ export function extractUsers(payloads: GenericPayload[]): {}[][] {
         payload.email = payload.email.replace(/\+.*@/, '@').replace(/\./g, '').toLowerCase()
         email_id = {
           id: createHash('sha256').update(payload.email).digest('hex'),
-          audience_ids: [payload.custom_audience_id]
+          audience_ids: [payload.audience_id]
         }
       }
       user_ids.push(email_id)
@@ -95,7 +95,7 @@ export function extractUsers(payloads: GenericPayload[]): {}[][] {
       if (payload.advertising_id) {
         advertising_id = {
           id: createHash('sha256').update(payload.advertising_id).digest('hex'),
-          audience_ids: [payload.custom_audience_id]
+          audience_ids: [payload.audience_id]
         }
       }
       user_ids.push(advertising_id)

--- a/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
@@ -6,6 +6,7 @@ import removeUser from './removeUser'
 import { TikTokAudiences } from './api'
 import { ModifiedResponse } from '@segment/actions-core'
 import { APIResponse } from './types'
+import createAudience from './createAudience'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'TikTok Audiences',
@@ -55,7 +56,8 @@ const destination: DestinationDefinition<Settings> = {
 
   actions: {
     addUser,
-    removeUser
+    removeUser,
+    createAudience
   }
 }
 

--- a/packages/destination-actions/src/destinations/tiktok-audiences/properties.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/properties.ts
@@ -22,8 +22,8 @@ export const id_type: InputField = {
   required: true
 }
 
-export const custom_audience_id: InputField = {
-  label: 'Custom Audience ID',
+export const audience_id: InputField = {
+  label: 'Audience ID',
   description:
     'Audience ID for the TikTok Audience you want to sync your Engage audience to. This is returned after you create an audience and can also be found in the TikTok Audiences dashboard.',
   type: 'string',

--- a/packages/destination-actions/src/destinations/tiktok-audiences/properties.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/properties.ts
@@ -8,6 +8,20 @@ export const selected_advertiser_id: InputField = {
   required: true
 }
 
+export const id_type: InputField = {
+  label: 'ID Type',
+  description:
+    'Encryption type to be used for populating the audience. This field is set only when Segment creates a new audience.',
+  type: 'string',
+  choices: [
+    { label: 'Email', value: 'EMAIL_SHA256' },
+    { label: 'Google Advertising ID', value: 'GAID_SHA256' },
+    { label: 'Android Advertising ID', value: 'AAID_SHA256' },
+    { label: 'iOS Advertising ID', value: 'IDFA_SHA256' }
+  ],
+  required: true
+}
+
 export const custom_audience_name: InputField = {
   label: 'Custom Audience Name',
   description:

--- a/packages/destination-actions/src/destinations/tiktok-audiences/properties.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/properties.ts
@@ -27,9 +27,6 @@ export const custom_audience_id: InputField = {
   description:
     'Audience ID for the TikTok Audience you want to sync your Engage audience to. This is returned after you create an audience and can also be found in the TikTok Audiences dashboard.',
   type: 'string',
-  default: {
-    '@path': '$.properties.audience_key'
-  },
   required: true
 }
 
@@ -38,9 +35,6 @@ export const custom_audience_name: InputField = {
   description:
     'Custom audience name of audience to be created. Please note that names over 70 characters will be truncated to 67 characters with "..." appended.',
   type: 'string',
-  default: {
-    '@path': '$.properties.audience_key'
-  },
   required: true
 }
 

--- a/packages/destination-actions/src/destinations/tiktok-audiences/properties.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/properties.ts
@@ -22,10 +22,21 @@ export const id_type: InputField = {
   required: true
 }
 
+export const custom_audience_id: InputField = {
+  label: 'Custom Audience ID',
+  description:
+    'Audience ID for the TikTok Audience you want to sync your Engage audience to. This is returned after you create an audience and can also be found in the TikTok Audiences dashboard.',
+  type: 'string',
+  default: {
+    '@path': '$.properties.audience_key'
+  },
+  required: true
+}
+
 export const custom_audience_name: InputField = {
   label: 'Custom Audience Name',
   description:
-    'Custom audience name of audience to be synced. This audience must already exist in your TikTok Advertising account',
+    'Custom audience name of audience to be created. Please note that names over 70 characters will be truncated to 67 characters with "..." appended.',
   type: 'string',
   default: {
     '@path': '$.properties.audience_key'
@@ -80,11 +91,4 @@ export const enable_batching: InputField = {
   description: 'Enable batching of requests to the TikTok Audiences.',
   type: 'boolean',
   default: true
-}
-
-export const personas_audience_key: InputField = {
-  label: 'Segment Engage Audience Key',
-  description:
-    'The `audience_key` of the Engage audience you want to sync to TikTok. This value must be a hard-coded string variable, e.g. `personas_test_audience`, in order for batching to work properly.',
-  type: 'string'
 }

--- a/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/__tests__/index.test.ts
@@ -63,7 +63,7 @@ describe('TiktokAudiences.removeUser', () => {
         auth,
         mapping: {
           selected_advertiser_id: '123',
-          custom_audience_id: '1234345'
+          audience_id: '1234345'
         }
       })
     ).resolves.not.toThrowError()
@@ -101,7 +101,7 @@ describe('TiktokAudiences.removeUser', () => {
         auth,
         mapping: {
           selected_advertiser_id: '123',
-          custom_audience_id: '123456',
+          audience_id: '123456',
           send_email: false,
           send_advertising_id: false
         }

--- a/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/__tests__/index.test.ts
@@ -31,12 +31,6 @@ const event = createTestEvent({
   }
 })
 
-const urlParams = {
-  advertiser_id: '123',
-  page: 1,
-  page_size: 100
-}
-
 const updateUsersRequestBody = {
   advertiser_ids: ['123'],
   action: 'delete',
@@ -56,32 +50,7 @@ const updateUsersRequestBody = {
 }
 
 describe('TiktokAudiences.removeUser', () => {
-  it('should fail if `personas_audience_key` field does not match the `custom_audience_name` field', async () => {
-    await expect(
-      testDestination.testAction('removeUser', {
-        event,
-        settings: {
-          advertiser_ids: ['123']
-        },
-        useDefaultMappings: true,
-        auth,
-        mapping: {
-          selected_advertiser_id: '123',
-          personas_audience_key: 'mismatched_audience'
-        }
-      })
-    ).rejects.toThrow('The value of `custom_audience_name` and `personas_audience_key` must match.')
-  })
-
-  it('should succeed if an exisiting audience is found', async () => {
-    nock(`${BASE_URL}${TIKTOK_API_VERSION}/dmp/custom_audience/list/`)
-      .get(/.*/)
-      .query(urlParams)
-      .reply(200, {
-        code: 0,
-        message: 'OK',
-        data: { page_info: { total_number: 1 }, list: [{ name: 'personas_test_audience', audience_id: '1234345' }] }
-      })
+  it('should succeed if audience id is valid', async () => {
     nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`).post(/.*/, updateUsersRequestBody).reply(200)
 
     await expect(
@@ -94,21 +63,14 @@ describe('TiktokAudiences.removeUser', () => {
         auth,
         mapping: {
           selected_advertiser_id: '123',
-          personas_audience_key: 'personas_test_audience'
+          custom_audience_id: '1234345'
         }
       })
     ).resolves.not.toThrowError()
   })
 
-  it('should fail if audience is not found', async () => {
-    nock(`${BASE_URL}${TIKTOK_API_VERSION}/dmp/custom_audience/list/`)
-      .get(/.*/)
-      .query(urlParams)
-      .reply(200, {
-        code: 0,
-        message: 'OK',
-        data: { page_info: { total_number: 1 }, list: [{ name: 'another_audience', audience_id: '1234345' }] }
-      })
+  it('should fail if audienceid is invalid', async () => {
+    nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`).post(/.*/, updateUsersRequestBody).reply(400)
 
     await expect(
       testDestination.testAction('removeUser', {
@@ -123,21 +85,10 @@ describe('TiktokAudiences.removeUser', () => {
           personas_audience_key: 'personas_test_audience'
         }
       })
-    ).rejects.toThrow(
-      'No audience with name personas_test_audience found. Please ensure that you create the audience before syncing.'
-    )
+    ).rejects.toThrowError()
   })
 
   it('should fail if all the send fields are false', async () => {
-    nock(`${BASE_URL}${TIKTOK_API_VERSION}/dmp/custom_audience/list/`)
-      .get(/.*/)
-      .query(urlParams)
-      .reply(200, {
-        code: 0,
-        message: 'OK',
-        data: { page_info: { total_number: 1 }, list: [{ name: 'another_audience', audience_id: '1234345' }] }
-      })
-
     nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`).post(/.*/, updateUsersRequestBody).reply(200)
 
     await expect(
@@ -150,7 +101,7 @@ describe('TiktokAudiences.removeUser', () => {
         auth,
         mapping: {
           selected_advertiser_id: '123',
-          personas_audience_key: 'personas_test_audience',
+          custom_audience_id: '123456',
           send_email: false,
           send_advertising_id: false
         }

--- a/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/generated-types.ts
@@ -6,9 +6,9 @@ export interface Payload {
    */
   selected_advertiser_id: string
   /**
-   * Custom audience name of audience to be synced. This audience must already exist in your TikTok Advertising account
+   * Audience ID for the TikTok Audience you want to sync your Engage audience to. This is returned after you create an audience and can also be found in the TikTok Audiences dashboard.
    */
-  custom_audience_name: string
+  custom_audience_id: string
   /**
    * The user's email address to send to TikTok.
    */
@@ -33,8 +33,4 @@ export interface Payload {
    * Enable batching of requests to the TikTok Audiences.
    */
   enable_batching?: boolean
-  /**
-   * The `audience_key` of the Engage audience you want to sync to TikTok. This value must be a hard-coded string variable, e.g. `personas_test_audience`, in order for batching to work properly.
-   */
-  personas_audience_key?: string
 }

--- a/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/generated-types.ts
@@ -8,7 +8,7 @@ export interface Payload {
   /**
    * Audience ID for the TikTok Audience you want to sync your Engage audience to. This is returned after you create an audience and can also be found in the TikTok Audiences dashboard.
    */
-  custom_audience_id: string
+  audience_id: string
   /**
    * The user's email address to send to TikTok.
    */

--- a/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/index.ts
@@ -4,7 +4,7 @@ import type { Payload } from './generated-types'
 import { processPayload } from '../functions'
 import {
   selected_advertiser_id,
-  custom_audience_id,
+  audience_id,
   email,
   send_email,
   send_advertising_id,
@@ -20,7 +20,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'event = "Audience Exited"',
   fields: {
     selected_advertiser_id: { ...selected_advertiser_id },
-    custom_audience_id: { ...custom_audience_id },
+    audience_id: { ...audience_id },
     email: { ...email },
     advertising_id: { ...advertising_id },
     send_email: { ...send_email },

--- a/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/index.ts
@@ -4,14 +4,13 @@ import type { Payload } from './generated-types'
 import { processPayload } from '../functions'
 import {
   selected_advertiser_id,
-  custom_audience_name,
+  custom_audience_id,
   email,
   send_email,
   send_advertising_id,
   advertising_id,
   event_name,
-  enable_batching,
-  personas_audience_key
+  enable_batching
 } from '../properties'
 import { TikTokAudiences } from '../api'
 
@@ -21,14 +20,13 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'event = "Audience Exited"',
   fields: {
     selected_advertiser_id: { ...selected_advertiser_id },
-    custom_audience_name: { ...custom_audience_name },
+    custom_audience_id: { ...custom_audience_id },
     email: { ...email },
     advertising_id: { ...advertising_id },
     send_email: { ...send_email },
     send_advertising_id: { ...send_advertising_id },
     event_name: { ...event_name },
-    enable_batching: { ...enable_batching },
-    personas_audience_key: { ...personas_audience_key }
+    enable_batching: { ...enable_batching }
   },
   dynamicFields: {
     selected_advertiser_id: async (request, { settings }) => {


### PR DESCRIPTION
This PR changes 2 things with the new TikTok Audiences destination.
1. It requires users to input `audience id` to update audiences in TikTok instead of the `audience name` so we don't have to get all audiences and filter through them to match which audience to send users to. 
2. It adds a `createAudience` action to provide users a way to create their audience.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
