### PR TITLE
[GA4] Remove fully rolled out feature flags

### DIFF
--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
@@ -623,7 +623,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-verify-params-feature': true },
         mapping: {
           client_id: {
             '@path': '$.userId'
@@ -678,7 +677,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.userId'
@@ -733,7 +731,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.userId'
@@ -788,7 +785,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.userId'
@@ -847,7 +843,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -917,7 +912,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
@@ -58,7 +58,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -288,7 +287,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           currency: {
             '@path': '$.properties.currency'
@@ -980,7 +978,8 @@ describe('GA4', () => {
                 engagement_time_msec: 1
               }
             }
-          ]
+          ],
+          timestamp_micros: 1655936458905000
         })
         .reply(201, {})
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
@@ -430,7 +430,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-verify-params-feature': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -513,7 +512,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -596,7 +594,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -679,7 +676,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -757,7 +753,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToCart.test.ts
@@ -50,7 +50,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -102,7 +101,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -202,7 +200,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -380,7 +377,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -798,7 +794,8 @@ describe('GA4', () => {
                 engagement_time_msec: 1
               }
             }
-          ]
+          ],
+          timestamp_micros: 1655936458905000
         })
         .reply(201, {})
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
@@ -50,7 +50,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -99,7 +98,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -488,7 +486,8 @@ describe('GA4', () => {
                 engagement_time_msec: 1
               }
             }
-          ]
+          ],
+          timestamp_micros: 1655936458905000
         })
         .reply(201, {})
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addToWishlist.test.ts
@@ -395,7 +395,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.userId'
@@ -450,7 +449,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
@@ -74,7 +74,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -426,7 +425,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -608,7 +606,8 @@ describe('GA4', () => {
                 engagement_time_msec: 1
               }
             }
-          ]
+          ],
+          timestamp_micros: 1655936458905000
         })
         .reply(201, {})
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/beginCheckout.test.ts
@@ -481,7 +481,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -553,7 +552,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
@@ -348,7 +348,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -392,7 +391,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/customEvent.test.ts
@@ -50,7 +50,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -106,7 +105,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           name: 'this_is_a_test'
         },
@@ -151,7 +149,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           name: 'this_is_a_test'
         },
@@ -257,7 +254,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -300,7 +296,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           lowercase: true
         },
@@ -423,7 +418,8 @@ describe('GA4', () => {
       nock('https://www.google-analytics.com/mp/collect')
         .post(`?api_secret=${apiSecret}&firebase_app_id=${firebaseAppId}`, {
           app_instance_id: 'anon-2134',
-          events: [{ name: 'Some_Event_Here', params: { engagement_time_msec: 1 } }]
+          events: [{ name: 'Some_Event_Here', params: { engagement_time_msec: 1 } }],
+          timestamp_micros: 1655936458905000
         })
         .reply(201, {})
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
@@ -291,7 +291,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -335,7 +334,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/generateLead.test.ts
@@ -50,7 +50,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -91,7 +90,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.userId'
@@ -360,7 +358,8 @@ describe('GA4', () => {
       nock('https://www.google-analytics.com/mp/collect')
         .post(`?api_secret=${apiSecret}&firebase_app_id=${firebaseAppId}`, {
           app_instance_id: 'anon-2134',
-          events: [{ name: 'generate_lead', params: { currency: 'USD', engagement_time_msec: 1 } }]
+          events: [{ name: 'generate_lead', params: { currency: 'USD', engagement_time_msec: 1 } }],
+          timestamp_micros: 1655936458905000
         })
         .reply(201, {})
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
@@ -148,7 +148,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -192,7 +191,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/login.test.ts
@@ -49,7 +49,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -89,7 +88,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.userId'
@@ -220,7 +218,8 @@ describe('GA4', () => {
       nock('https://www.google-analytics.com/mp/collect')
         .post(`?api_secret=${apiSecret}&firebase_app_id=${firebaseAppId}`, {
           app_instance_id: 'anon-2134',
-          events: [{ name: 'login', params: { engagement_time_msec: 1 } }]
+          events: [{ name: 'login', params: { engagement_time_msec: 1 } }],
+          timestamp_micros: 1655936458905000
         })
         .reply(201, {})
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
@@ -50,7 +50,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -101,7 +100,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -175,7 +173,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -301,7 +298,8 @@ describe('GA4', () => {
                 engagement_time_msec: 1
               }
             }
-          ]
+          ],
+          timestamp_micros: 1655936458905000
         })
         .reply(201, {})
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/pageView.test.ts
@@ -222,7 +222,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -266,7 +265,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
@@ -599,7 +599,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             transaction_id: {
               '@path': '$.properties.order_number'
@@ -690,7 +689,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             transaction_id: {
               '@path': '$.properties.order_number'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/purchase.test.ts
@@ -81,7 +81,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           transaction_id: {
             '@path': '$.properties.order_number'
@@ -535,7 +534,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -775,7 +773,8 @@ describe('GA4', () => {
                 engagement_time_msec: 1
               }
             }
-          ]
+          ],
+          timestamp_micros: 1655936458905000
         })
         .reply(201, {})
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
@@ -49,7 +49,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           transaction_id: {
             '@path': '$.properties.order_number'
@@ -183,7 +182,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           currency: {
             '@path': '$.properties.currency'
@@ -259,7 +257,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           currency: {
             '@path': '$.properties.currency'
@@ -558,7 +555,8 @@ describe('GA4', () => {
               name: 'refund',
               params: { currency: 'USD', transaction_id: '12345abcde', items: [], engagement_time_msec: 1 }
             }
-          ]
+          ],
+          timestamp_micros: 1655936458905000
         })
         .reply(201, {})
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/refund.test.ts
@@ -474,7 +474,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             transaction_id: {
               '@path': '$.properties.order_number'
@@ -521,7 +520,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             transaction_id: {
               '@path': '$.properties.order_number'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
@@ -391,7 +391,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -435,7 +434,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/removeFromCart.test.ts
@@ -50,7 +50,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -473,7 +472,8 @@ describe('GA4', () => {
                 engagement_time_msec: 1
               }
             }
-          ]
+          ],
+          timestamp_micros: 1655936458905000
         })
         .reply(201, {})
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
@@ -50,7 +50,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -97,7 +96,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -231,7 +229,10 @@ describe('GA4', () => {
       nock('https://www.google-analytics.com/mp/collect')
         .post(`?api_secret=${apiSecret}&firebase_app_id=${firebaseAppId}`, {
           app_instance_id: 'anon-2134',
-          events: [{ name: 'search', params: { search_term: 'Quadruple Stack Oreos, 52 ct', engagement_time_msec: 1 } }]
+          events: [
+            { name: 'search', params: { search_term: 'Quadruple Stack Oreos, 52 ct', engagement_time_msec: 1 } }
+          ],
+          timestamp_micros: 1655936458905000
         })
         .reply(201, {})
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/search.test.ts
@@ -157,7 +157,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -202,7 +201,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
@@ -49,7 +49,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -100,7 +99,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -196,7 +194,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -292,7 +289,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -475,7 +471,8 @@ describe('GA4', () => {
                 engagement_time_msec: 1
               }
             }
-          ]
+          ],
+          timestamp_micros: 1655936458905000
         })
         .reply(201, {})
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectItem.test.ts
@@ -391,7 +391,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -435,7 +434,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
@@ -479,7 +479,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -531,7 +530,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/selectPromotion.test.ts
@@ -49,7 +49,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -101,7 +100,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.userId'
@@ -197,7 +195,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -288,7 +285,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -578,7 +574,8 @@ describe('GA4', () => {
                 engagement_time_msec: 1
               }
             }
-          ]
+          ],
+          timestamp_micros: 1655936458905000
         })
         .reply(201, {})
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
@@ -184,7 +184,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -228,7 +227,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/signUp.test.ts
@@ -45,7 +45,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -85,7 +84,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -256,7 +254,8 @@ describe('GA4', () => {
       nock('https://www.google-analytics.com/mp/collect')
         .post(`?api_secret=${apiSecret}&firebase_app_id=${firebaseAppId}`, {
           app_instance_id: 'anonId1234',
-          events: [{ name: 'sign_up', params: { method: 'Google', engagement_time_msec: 1 } }]
+          events: [{ name: 'sign_up', params: { method: 'Google', engagement_time_msec: 1 } }],
+          timestamp_micros: 1655936458905000
         })
         .reply(201, {})
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
@@ -440,7 +440,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -499,7 +498,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewCart.test.ts
@@ -79,7 +79,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -128,7 +127,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -544,7 +542,8 @@ describe('GA4', () => {
                 engagement_time_msec: 1
               }
             }
-          ]
+          ],
+          timestamp_micros: 1655936458905000
         })
         .reply(201, {})
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
@@ -327,7 +327,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -371,7 +370,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItem.test.ts
@@ -49,7 +49,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -102,7 +101,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -182,7 +180,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -240,7 +237,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -411,7 +407,8 @@ describe('GA4', () => {
                 engagement_time_msec: 1
               }
             }
-          ]
+          ],
+          timestamp_micros: 1655936458905000
         })
         .reply(201, {})
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
@@ -58,7 +58,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -544,7 +543,8 @@ describe('GA4', () => {
                 engagement_time_msec: 1
               }
             }
-          ]
+          ],
+          timestamp_micros: 1655936458905000
         })
         .reply(201, {})
 
@@ -592,7 +592,6 @@ describe('GA4', () => {
             apiSecret,
             firebaseAppId
           },
-          features: { 'actions-google-analytics-4-add-timestamp': true },
           mapping: {
             data_stream_type: DataStreamType.MobileApp
           },
@@ -608,7 +607,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-add-timestamp': true },
           useDefaultMappings: true
         })
       ).rejects.toThrowError('Measurement ID is required for web streams')
@@ -622,7 +620,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-add-timestamp': true },
           mapping: {
             client_id: {
               '@path': '$.traits.dummy'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewItemList.test.ts
@@ -419,7 +419,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -487,7 +486,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
@@ -511,7 +511,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             params: {
               test_value: null
@@ -593,7 +592,6 @@ describe('GA4', () => {
             apiSecret,
             measurementId
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             user_properties: {
               hello: ['World', 'world'],

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/viewPromotion.test.ts
@@ -75,7 +75,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.userId'
@@ -181,7 +180,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -431,7 +429,6 @@ describe('GA4', () => {
           apiSecret,
           measurementId
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           user_properties: {
             hello: 'world',
@@ -659,7 +656,8 @@ describe('GA4', () => {
                 engagement_time_msec: 1
               }
             }
-          ]
+          ],
+          timestamp_micros: 1655936458905000
         })
         .reply(201, {})
 

--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
@@ -50,7 +50,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features, settings }) => {
+  perform: (request, { payload, settings }) => {
     const data_stream_type = payload.data_stream_type ?? DataStreamType.Web
     const stream_params: DataStreamParams =
       data_stream_type === DataStreamType.MobileApp
@@ -99,10 +99,8 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
 
     const request_object: { [key: string]: unknown } = {
       ...stream_params.identifier,

--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
@@ -121,11 +121,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return sendData(request, stream_params.search_params, request_object)

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
@@ -95,11 +95,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return sendData(request, stream_params.search_params, request_object)

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
@@ -46,7 +46,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features, settings }) => {
+  perform: (request, { payload, settings }) => {
     const data_stream_type = payload.data_stream_type ?? DataStreamType.Web
     const stream_params: DataStreamParams =
       data_stream_type === DataStreamType.MobileApp
@@ -75,10 +75,8 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
 
     const request_object: { [key: string]: unknown } = {
       ...stream_params.identifier,

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
@@ -46,7 +46,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features, settings }) => {
+  perform: (request, { payload, settings }) => {
     const data_stream_type = payload.data_stream_type ?? DataStreamType.Web
     const stream_params: DataStreamParams =
       data_stream_type === DataStreamType.MobileApp
@@ -88,10 +88,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: unknown } = {
       ...stream_params.identifier,
       user_id: payload.user_id,

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
@@ -107,11 +107,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return sendData(request, stream_params.search_params, request_object)

--- a/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
@@ -100,11 +100,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return sendData(request, stream_params.search_params, request_object)

--- a/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
@@ -50,7 +50,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features, settings }) => {
+  perform: (request, { payload, settings }) => {
     const data_stream_type = payload.data_stream_type ?? DataStreamType.Web
     const stream_params: DataStreamParams =
       data_stream_type === DataStreamType.MobileApp
@@ -79,10 +79,8 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
 
     const request_object: { [key: string]: unknown } = {
       ...stream_params.identifier,

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
@@ -64,7 +64,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: { ...params }
   },
-  perform: (request, { payload, features, settings }) => {
+  perform: (request, { payload, settings }) => {
     const data_stream_type = payload.data_stream_type ?? DataStreamType.Web
     const stream_params: DataStreamParams =
       data_stream_type === DataStreamType.MobileApp
@@ -73,10 +73,8 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const event_name = normalizeEventName(payload.name, payload.lowercase)
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
 
     const request_object: { [key: string]: unknown } = {
       ...stream_params.identifier,

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
@@ -90,11 +90,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return sendData(request, stream_params.search_params, request_object)

--- a/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
@@ -76,11 +76,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return sendData(request, stream_params.search_params, request_object)

--- a/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
@@ -41,7 +41,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features, settings }) => {
+  perform: (request, { payload, settings }) => {
     const data_stream_type = payload.data_stream_type ?? DataStreamType.Web
     const stream_params: DataStreamParams =
       data_stream_type === DataStreamType.MobileApp
@@ -57,10 +57,8 @@ const action: ActionDefinition<Settings, Payload> = {
       throw new IntegrationError('Currency is required if value is set.', ErrorCodes.INVALID_CURRENCY_CODE, 400)
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
 
     const request_object: { [key: string]: unknown } = {
       ...stream_params.identifier,

--- a/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
@@ -42,17 +42,15 @@ const action: ActionDefinition<Settings, Payload> = {
     params: params
   },
 
-  perform: (request, { payload, features, settings }) => {
+  perform: (request, { payload, settings }) => {
     const data_stream_type = payload.data_stream_type ?? DataStreamType.Web
     const stream_params: DataStreamParams =
       data_stream_type === DataStreamType.MobileApp
         ? getMobileStreamParams(settings.apiSecret, settings.firebaseAppId, payload.app_instance_id)
         : getWebStreamParams(settings.apiSecret, settings.measurementId, payload.client_id)
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
 
     const request_object: { [key: string]: unknown } = {
       ...stream_params.identifier,

--- a/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
@@ -67,11 +67,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return sendData(request, stream_params.search_params, request_object)

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
@@ -86,12 +86,10 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
-    }
     return sendData(request, stream_params.search_params, request_object)
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
@@ -60,17 +60,16 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features, settings }) => {
+  perform: (request, { payload, settings }) => {
     const data_stream_type = payload.data_stream_type ?? DataStreamType.Web
     const stream_params: DataStreamParams =
       data_stream_type === DataStreamType.MobileApp
         ? getMobileStreamParams(settings.apiSecret, settings.firebaseAppId, payload.app_instance_id)
         : getWebStreamParams(settings.apiSecret, settings.measurementId, payload.clientId)
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: unknown } = {
       ...stream_params.identifier,
       user_id: payload.user_id,

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
@@ -60,7 +60,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features, settings }) => {
+  perform: (request, { payload, settings }) => {
     const data_stream_type = payload.data_stream_type ?? DataStreamType.Web
     const stream_params: DataStreamParams =
       data_stream_type === DataStreamType.MobileApp
@@ -87,10 +87,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: unknown } = {
       ...stream_params.identifier,
       user_id: payload.user_id,

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
@@ -111,11 +111,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return sendData(request, stream_params.search_params, request_object)

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
@@ -58,7 +58,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features, settings }) => {
+  perform: (request, { payload, settings }) => {
     const data_stream_type = payload.data_stream_type ?? DataStreamType.Web
     const stream_params: DataStreamParams =
       data_stream_type === DataStreamType.MobileApp
@@ -101,10 +101,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: unknown } = {
       ...stream_params.identifier,
       user_id: payload.user_id,

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
@@ -125,11 +125,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return sendData(request, stream_params.search_params, request_object)

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
@@ -46,7 +46,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features, settings }) => {
+  perform: (request, { payload, settings }) => {
     const data_stream_type = payload.data_stream_type ?? DataStreamType.Web
     const stream_params: DataStreamParams =
       data_stream_type === DataStreamType.MobileApp
@@ -89,10 +89,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: unknown } = {
       ...stream_params.identifier,
       user_id: payload.user_id,

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
@@ -108,11 +108,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return sendData(request, stream_params.search_params, request_object)

--- a/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
@@ -69,11 +69,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return sendData(request, stream_params.search_params, request_object)

--- a/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
@@ -45,17 +45,16 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features, settings }) => {
+  perform: (request, { payload, settings }) => {
     const data_stream_type = payload.data_stream_type ?? DataStreamType.Web
     const stream_params: DataStreamParams =
       data_stream_type === DataStreamType.MobileApp
         ? getMobileStreamParams(settings.apiSecret, settings.firebaseAppId, payload.app_instance_id)
         : getWebStreamParams(settings.apiSecret, settings.measurementId, payload.client_id)
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: unknown } = {
       ...stream_params.identifier,
       user_id: payload.user_id,

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
@@ -52,7 +52,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features, settings }) => {
+  perform: (request, { payload, settings }) => {
     const data_stream_type = payload.data_stream_type ?? DataStreamType.Web
     const stream_params: DataStreamParams =
       data_stream_type === DataStreamType.MobileApp
@@ -77,10 +77,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: unknown } = {
       ...stream_params.identifier,
       user_id: payload.user_id,

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
@@ -96,11 +96,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return sendData(request, stream_params.search_params, request_object)

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
@@ -70,7 +70,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features, settings }) => {
+  perform: (request, { payload, settings }) => {
     const data_stream_type = payload.data_stream_type ?? DataStreamType.Web
     const stream_params: DataStreamParams =
       data_stream_type === DataStreamType.MobileApp
@@ -95,10 +95,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: unknown } = {
       ...stream_params.identifier,
       user_id: payload.user_id,

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
@@ -117,11 +117,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return sendData(request, stream_params.search_params, request_object)

--- a/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
@@ -44,17 +44,16 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features, settings }) => {
+  perform: (request, { payload, settings }) => {
     const data_stream_type = payload.data_stream_type ?? DataStreamType.Web
     const stream_params: DataStreamParams =
       data_stream_type === DataStreamType.MobileApp
         ? getMobileStreamParams(settings.apiSecret, settings.firebaseAppId, payload.app_instance_id)
         : getWebStreamParams(settings.apiSecret, settings.measurementId, payload.client_id)
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: unknown } = {
       ...stream_params.identifier,
       user_id: payload.user_id,

--- a/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
@@ -68,11 +68,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return sendData(request, stream_params.search_params, request_object)

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
@@ -103,11 +103,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return sendData(request, stream_params.search_params, request_object)

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
@@ -46,7 +46,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features, settings }) => {
+  perform: (request, { payload, settings }) => {
     const data_stream_type = payload.data_stream_type ?? DataStreamType.Web
     const stream_params: DataStreamParams =
       data_stream_type === DataStreamType.MobileApp
@@ -84,10 +84,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: unknown } = {
       ...stream_params.identifier,
       user_id: payload.user_id,

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
@@ -46,7 +46,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features, settings }) => {
+  perform: (request, { payload, settings }) => {
     const data_stream_type = payload.data_stream_type ?? DataStreamType.Web
     const stream_params: DataStreamParams =
       data_stream_type === DataStreamType.MobileApp
@@ -75,10 +75,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: unknown } = {
       ...stream_params.identifier,
       user_id: payload.user_id,

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
@@ -94,11 +94,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return sendData(request, stream_params.search_params, request_object)

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
@@ -62,7 +62,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features, settings }) => {
+  perform: (request, { payload, settings }) => {
     const data_stream_type = payload.data_stream_type ?? DataStreamType.Web
     const stream_params: DataStreamParams =
       data_stream_type === DataStreamType.MobileApp
@@ -87,10 +87,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: unknown } = {
       ...stream_params.identifier,
       user_id: payload.user_id,

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
@@ -106,12 +106,10 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
-    }
     return sendData(request, stream_params.search_params, request_object)
   }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
@@ -79,7 +79,7 @@ const action: ActionDefinition<Settings, Payload> = {
     params: params
   },
 
-  perform: (request, { payload, features, settings }) => {
+  perform: (request, { payload, settings }) => {
     const data_stream_type = payload.data_stream_type ?? DataStreamType.Web
     const stream_params: DataStreamParams =
       data_stream_type === DataStreamType.MobileApp
@@ -102,10 +102,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: unknown } = {
       ...stream_params.identifier,
       user_id: payload.user_id,

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
@@ -124,11 +124,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return sendData(request, stream_params.search_params, request_object)


### PR DESCRIPTION
These 2 feature flags, [add-timestamp](https://flagon.segment.com/families/centrifuge-destinations/gates/actions-google-analytics-4-add-timestamp) & [verify-params](https://flagon.segment.com/families/centrifuge-destinations/gates/actions-google-analytics-4-verify-params-feature) have been fully rolled out for a while now. This PR is to do some cleanup of these flags.

## Testing
Sent tests for all 19 actions and see them downstream in GA4 Dashboard
![Screenshot 2023-04-03 at 1 33 52 PM](https://user-images.githubusercontent.com/99763167/229622079-61c03077-a2b5-4415-902f-bcad43b462ca.png)

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
