### PR TITLE
Update Braze Merge Attributes

### DIFF
--- a/packages/destination-actions/src/destinations/braze/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/braze/identifyUser/index.ts
@@ -42,7 +42,8 @@ const action: ActionDefinition<Settings, Payload> = {
             external_id: payload.external_id,
             user_alias: payload.user_alias
           }
-        ]
+        ],
+          "merge_behavior": "merge" //update to braze attribute handling
       }
     })
   }


### PR DESCRIPTION
New update from Braze this year where if merge_behavior is not defined as "merge" it would leave orphan attributes from the user alias actions

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
