### PR TITLE
[external] add new segement destination for rokt custom audiences

### DIFF
--- a/packages/destination-actions/src/destinations/rokt-audiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/__tests__/index.test.ts
@@ -1,0 +1,29 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+
+const testDestination = createTestIntegration(Definition)
+
+const VALID_SETTINGS = {
+  apiKey: 'key'
+}
+
+const MOCK_TOKEN_RESPONSE = {
+  success: true
+}
+
+describe('Rokt Audiences', () => {
+  describe('testAuthentication', () => {
+    it('should validate valid auth token', async () => {
+      nock('https://data.stage.rokt.com/').get('/api/1.0/auth-check').reply(200, MOCK_TOKEN_RESPONSE)
+      const settings = VALID_SETTINGS
+      await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()
+    })
+
+    it('should test that authentication fails', async () => {
+      nock('https://data.stage.rokt.com/').get('/api/1.0/auth-check').reply(401)
+      const settings = VALID_SETTINGS
+      await expect(testDestination.testAuthentication(settings)).rejects.toThrowError('')
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/rokt-audiences/constants.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/constants.ts
@@ -1,0 +1,11 @@
+export const CONSTANTS = {
+  // rokt
+  INCLUDE: 'include',
+  EXCLUDE: 'exclude',
+  ROKT_API_BASE_URL: 'https://data.stage.rokt.com/api/1.0',
+  ROKT_API_CUSTOM_AUDIENCE_ENDPOINT: '/import/suppression',
+  ROKT_API_AUTH_ENDPOINT: '/auth-check',
+
+  // segment
+  SUPPORTED_SEGMENT_COMPUTATION_ACTION: 'audience'
+}

--- a/packages/destination-actions/src/destinations/rokt-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * APIKey used for Rokt API authorization before sending custom audiences data
+   */
+  apiKey: string
+}

--- a/packages/destination-actions/src/destinations/rokt-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/index.ts
@@ -12,7 +12,7 @@ const destination: DestinationDefinition<Settings> = {
   description: `
   This destination allows user to engage audiences using Rokt public API.
   User can connect Rokt Audiences (Actions) as a destination to their Engage Audience in segment,
-  if they intend to create/update custom audiences in Rokt data platform.  
+  which will create/update custom audiences in the Rokt data platform.  
   `,
   authentication: {
     scheme: 'custom',

--- a/packages/destination-actions/src/destinations/rokt-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/index.ts
@@ -11,7 +11,7 @@ const destination: DestinationDefinition<Settings> = {
   mode: 'cloud',
   description: `
   This destination allows user to engage audiences using Rokt public API.
-  User can select actions-rokt-audiences as destination when creating engage->audience in segment,
+  User can connect Rokt Audiences (Actions) as a destination to their Engage Audience in segment,
   if they intend to create/update custom audiences in Rokt data platform.  
   `,
   authentication: {

--- a/packages/destination-actions/src/destinations/rokt-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/index.ts
@@ -1,4 +1,4 @@
-import { RetryableError } from '@segment/actions-core'
+import { InvalidAuthenticationError } from '@segment/actions-core'
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
@@ -33,7 +33,7 @@ const destination: DestinationDefinition<Settings> = {
         }
       })
 
-      if (res.status !== 200) throw new RetryableError(`Rokt API key authentication check failed`)
+      if (res.status !== 200) throw new InvalidAuthenticationError('Authentication using Rokt ApiKey failed')
     }
   },
 

--- a/packages/destination-actions/src/destinations/rokt-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/index.ts
@@ -1,0 +1,50 @@
+import { RetryableError } from '@segment/actions-core'
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import upsertCustomAudiences from './upsertCustomAudiences'
+import { CONSTANTS } from './constants'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Rokt Audiences',
+  slug: 'actions-rokt-audiences',
+  mode: 'cloud',
+  description: `
+  This destination allows user to engage audiences using Rokt public API.
+  User can select actions-rokt-audiences as destination when creating engage->audience in segment,
+  if they intend to create/update custom audiences in Rokt data platform.  
+  `,
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      apiKey: {
+        label: 'API Key provided by Rokt integration',
+        description: 'APIKey used for Rokt API authorization before sending custom audiences data',
+        type: 'password',
+        required: true
+      }
+    },
+
+    testAuthentication: async (request, { settings }) => {
+      const res = await request(CONSTANTS.ROKT_API_BASE_URL + CONSTANTS.ROKT_API_AUTH_ENDPOINT, {
+        method: 'GET',
+        headers: {
+          Authorization: `${settings.apiKey}`
+        }
+      })
+
+      if (res.status !== 200) throw new RetryableError(`Rokt API key authentication check failed`)
+    }
+  },
+
+  extendRequest({ settings }) {
+    return {
+      headers: { Authorization: `${settings.apiKey}` }
+    }
+  },
+  actions: {
+    upsertCustomAudiences
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/rokt-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/index.ts
@@ -6,7 +6,7 @@ import upsertCustomAudiences from './upsertCustomAudiences'
 import { CONSTANTS } from './constants'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Rokt Audiences',
+  name: 'Rokt Audiences (Actions)',
   slug: 'actions-rokt-audiences',
   mode: 'cloud',
   description: `

--- a/packages/destination-actions/src/destinations/rokt-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/index.ts
@@ -1,5 +1,5 @@
 import { InvalidAuthenticationError } from '@segment/actions-core'
-import type { DestinationDefinition } from '@segment/actions-core'
+import { defaultValues, DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
 import upsertCustomAudiences from './upsertCustomAudiences'
@@ -44,7 +44,15 @@ const destination: DestinationDefinition<Settings> = {
   },
   actions: {
     upsertCustomAudiences
-  }
+  },
+  presets: [
+    {
+      name: 'Sync Engage Audience to Rokt',
+      subscribe: 'type = "track" or type = "identify"',
+      partnerAction: 'upsertCustomAudiences',
+      mapping: defaultValues(upsertCustomAudiences.fields)
+    }
+  ]
 }
 
 export default destination

--- a/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/__tests__/index.test.ts
@@ -1,0 +1,89 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+import { CONSTANTS } from '../../constants'
+
+const testDestination = createTestIntegration(Destination)
+const goodEvent = createTestEvent({
+  context: {
+    personas: {
+      computation_class: 'audience',
+      computation_key: 'aval_test_two_track_only'
+    },
+    traits: {
+      email: 'test.email@test.com'
+    }
+  },
+  traits: {
+    email: 'test.email@test.com',
+    aval_test_audience_for_chewy: true
+  },
+  properties: {
+    audience_key: 'aval_test_two_track_only',
+    aval_test_two_track_only: true
+  }
+})
+
+const badEvent = createTestEvent({
+  context: {
+    personas: {
+      computation_key: 'aval_test_two_track_only'
+    },
+    traits: {
+      email: 'test.email@test.com'
+    }
+  },
+  traits: {
+    email: 'test.email@test.com',
+    aval_test_audience_for_chewy: true
+  },
+  properties: {
+    audience_key: 'aval_test_two_track_only',
+    aval_test_two_track_only: true
+  }
+})
+
+describe('RoktAudiences.upsertCustomAudiences', () => {
+  it('should not throw an error if the audience creation succeed', async () => {
+    nock(CONSTANTS.ROKT_API_BASE_URL).persist().post(CONSTANTS.ROKT_API_CUSTOM_AUDIENCE_ENDPOINT).reply(201)
+
+    await expect(
+      testDestination.testAction('upsertCustomAudiences', {
+        event: goodEvent,
+        useDefaultMappings: true
+      })
+    ).resolves.not.toThrowError()
+  })
+
+  it('should throw an error if the audience creation failed, bad body', async () => {
+    nock(CONSTANTS.ROKT_API_BASE_URL).persist().post(CONSTANTS.ROKT_API_CUSTOM_AUDIENCE_ENDPOINT).reply(400)
+
+    await expect(
+      testDestination.testAction('upsertCustomAudiences', {
+        event: goodEvent,
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError('Bad Request')
+  })
+
+  it('should throw an error if the audience creation failed, wrong api key auth', async () => {
+    nock(CONSTANTS.ROKT_API_BASE_URL).persist().post(CONSTANTS.ROKT_API_CUSTOM_AUDIENCE_ENDPOINT).reply(401)
+
+    await expect(
+      testDestination.testAction('upsertCustomAudiences', {
+        event: goodEvent,
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError('Unauthorized')
+  })
+
+  it('should throw an error if audience creation event missing mandatory field', async () => {
+    await expect(
+      testDestination.testAction('upsertCustomAudiences', {
+        event: badEvent,
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError("The root value is missing the required field 'segment_computation_action'.")
+  })
+})

--- a/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/__tests__/index.test.ts
@@ -46,7 +46,7 @@ const badEvent = createTestEvent({
 
 describe('RoktAudiences.upsertCustomAudiences', () => {
   it('should not throw an error if the audience creation succeed', async () => {
-    nock(CONSTANTS.ROKT_API_BASE_URL).persist().post(CONSTANTS.ROKT_API_CUSTOM_AUDIENCE_ENDPOINT).reply(201)
+    nock(CONSTANTS.ROKT_API_BASE_URL).post(CONSTANTS.ROKT_API_CUSTOM_AUDIENCE_ENDPOINT).reply(201)
 
     await expect(
       testDestination.testAction('upsertCustomAudiences', {
@@ -57,7 +57,7 @@ describe('RoktAudiences.upsertCustomAudiences', () => {
   })
 
   it('should throw an error if the audience creation failed, bad body', async () => {
-    nock(CONSTANTS.ROKT_API_BASE_URL).persist().post(CONSTANTS.ROKT_API_CUSTOM_AUDIENCE_ENDPOINT).reply(400)
+    nock(CONSTANTS.ROKT_API_BASE_URL).post(CONSTANTS.ROKT_API_CUSTOM_AUDIENCE_ENDPOINT).reply(400)
 
     await expect(
       testDestination.testAction('upsertCustomAudiences', {
@@ -68,7 +68,7 @@ describe('RoktAudiences.upsertCustomAudiences', () => {
   })
 
   it('should throw an error if the audience creation failed, wrong api key auth', async () => {
-    nock(CONSTANTS.ROKT_API_BASE_URL).persist().post(CONSTANTS.ROKT_API_CUSTOM_AUDIENCE_ENDPOINT).reply(401)
+    nock(CONSTANTS.ROKT_API_BASE_URL).post(CONSTANTS.ROKT_API_CUSTOM_AUDIENCE_ENDPOINT).reply(401)
 
     await expect(
       testDestination.testAction('upsertCustomAudiences', {

--- a/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/custom-audience-operations.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/custom-audience-operations.ts
@@ -3,7 +3,7 @@ import type { Payload } from './generated-types'
 
 import { CONSTANTS } from '../constants'
 /**
- * CustomAudienceOperation is a custom type to encapsulates the request body params
+ * CustomAudienceOperation is a custom type to encapsulate the request body params
  * for inserting/updating custom audience list in rokt data platform
  * @action [include, exclude]
  * @list custom audience name ( or list ) in rokt data platform

--- a/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/custom-audience-operations.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/custom-audience-operations.ts
@@ -1,0 +1,96 @@
+import type { RequestClient } from '@segment/actions-core'
+import type { Payload } from './generated-types'
+
+import { CONSTANTS } from '../constants'
+/**
+ * CustomAudienceOperation is a custom type to encapsulates the request body params
+ * for inserting/updating custom audience list in rokt data platform
+ * @action [include, exclude]
+ * @list custome audience name ( or list ) in rokt data platform
+ * @emails list of user emails to be included/excluded from custom audience list
+ */
+type CustomAudienceOperation = {
+  action: string
+  list: string
+  emails: string[]
+}
+
+/**
+ * getCustomAudienceOperations parses event payloads from segment to convert to request object for rokt api
+ * @payload payload of events
+ */
+
+const getCustomAudienceOperations = (payload: Payload[]): CustomAudienceOperation[] => {
+  let custom_audience_list = ''
+  const action_map = new Map<string, string[]>([
+    [CONSTANTS.INCLUDE, []],
+    [CONSTANTS.EXCLUDE, []]
+  ])
+
+  for (const p of payload) {
+    if (p.segment_computation_action != CONSTANTS.SUPPORTED_SEGMENT_COMPUTATION_ACTION) {
+      // ignore event
+      continue
+    }
+    if (!custom_audience_list) {
+      // set audience name to be processed for sending to rokt
+      custom_audience_list = p.custom_audience_name
+    }
+    if (p.custom_audience_name != custom_audience_list) {
+      // this is edge case where a batch contains more than 1 audiences
+      // for the 1st iteration we don't to handle the case of multiple audiences in same batch
+      // so we have decided to ignore other audience name in the batch, once we have picked one to process
+      continue
+    }
+
+    if (p.traits_or_props[custom_audience_list]) {
+      // audience entered true, include email to list
+      action_map.get(CONSTANTS.INCLUDE)?.push(p.email)
+    } else {
+      // exclude email from list
+      action_map.get(CONSTANTS.EXCLUDE)?.push(p.email)
+    }
+  }
+
+  // build operation request to be sent to rokt api
+  const custom_audience_ops: CustomAudienceOperation[] = []
+  action_map.forEach((value: string[], key: string) => {
+    // key will include or exclude
+    // vaulue will be emails to be included or excluded
+    const custom_audience_op: CustomAudienceOperation = {
+      list: custom_audience_list,
+      action: key,
+      emails: value
+    }
+    custom_audience_ops.push(custom_audience_op)
+  })
+  return custom_audience_ops
+}
+
+/**
+ * Takes an array of events of type Payload, decides whether event is meant for include/exclude action of rokt api
+ * and then pushes the event to proper list to build request body.
+ * @param request request object used to perform HTTP calls
+ * @param events array of events containing Rokt custom audience details
+ */
+async function processPayload(request: RequestClient, events: Payload[]) {
+  const custom_audience_ops: CustomAudienceOperation[] = getCustomAudienceOperations(events)
+  const promises = []
+
+  for (const op of custom_audience_ops) {
+    if (op.emails.length > 0) {
+      // if emails are present for action, send to rokt. Push to list of promises
+      // There will be max 2 promies for 2 http reuests ( include & exclude actions )
+      promises.push(
+        request(CONSTANTS.ROKT_API_BASE_URL + CONSTANTS.ROKT_API_CUSTOM_AUDIENCE_ENDPOINT, {
+          method: 'POST',
+          json: op
+        })
+      )
+    }
+  }
+
+  return await Promise.all(promises)
+}
+
+export { processPayload }

--- a/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/custom-audience-operations.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/custom-audience-operations.ts
@@ -6,7 +6,7 @@ import { CONSTANTS } from '../constants'
  * CustomAudienceOperation is a custom type to encapsulates the request body params
  * for inserting/updating custom audience list in rokt data platform
  * @action [include, exclude]
- * @list custome audience name ( or list ) in rokt data platform
+ * @list custom audience name ( or list ) in rokt data platform
  * @emails list of user emails to be included/excluded from custom audience list
  */
 type CustomAudienceOperation = {

--- a/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/generated-types.ts
@@ -1,0 +1,26 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Name of custom audience list to which emails should added/removed
+   */
+  custom_audience_name: string
+  /**
+   * Segment computation class used to determine if action is 'Engage-Aduience'
+   */
+  segment_computation_action: string
+  /**
+   * User's email address for including/excluding from custom audience
+   */
+  email: string
+  /**
+   * Object which will be computed differently for track and identify events
+   */
+  traits_or_props: {
+    [k: string]: unknown
+  }
+  /**
+   * Set as true to ensure Segment infrastructure uses batching when required.
+   */
+  enable_batching?: boolean
+}

--- a/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   custom_audience_name: string
   /**
-   * Segment computation class used to determine if action is 'Engage-Aduience'
+   * Segment computation class used to determine if action is an 'Engage-Audience'
    */
   segment_computation_action: string
   /**
@@ -20,7 +20,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * Set as true to ensure Segment infrastructure uses batching when required.
+   * Set as true to ensure Segment infrastructure uses batching when possible.
    */
   enable_batching?: boolean
 }

--- a/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/index.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/index.ts
@@ -20,7 +20,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     segment_computation_action: {
       label: 'Segment Computation Action',
-      description: "Segment computation class used to determine if action is 'Engage-Aduience'",
+      description: "Segment computation class used to determine if action is an 'Engage-Audience'",
       type: 'string',
       required: true,
       default: {

--- a/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/index.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/index.ts
@@ -6,7 +6,7 @@ import { processPayload } from './custom-audience-operations'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'ROKT build custom audience',
-  description: 'Add/Remove users from ROKT custom audience list by consuming Segment Events and invoking ROKT API',
+  description: 'Add/Remove users from ROKT custom audience list. Both identify() and track() calls are supported',
   defaultSubscription: 'type = "track" or type = "identify"',
   fields: {
     custom_audience_name: {

--- a/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/index.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/index.ts
@@ -1,0 +1,74 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+import { processPayload } from './custom-audience-operations'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'ROKT build custom audience',
+  description: 'Add/Remove users from ROKT custom audience list by consuming Segment Events and invoking ROKT API',
+  defaultSubscription: 'type = "track" or type = "identify"',
+  fields: {
+    custom_audience_name: {
+      label: 'Custom Audience Name',
+      description: 'Name of custom audience list to which emails should added/removed',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.context.personas.computation_key'
+      }
+    },
+    segment_computation_action: {
+      label: 'Segment Computation Action',
+      description: "Segment computation class used to determine if action is 'Engage-Aduience'",
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.context.personas.computation_class'
+      }
+    },
+    email: {
+      label: 'Email',
+      description: "User's email address for including/excluding from custom audience",
+      type: 'string',
+      format: 'email',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.context.traits.email' },
+          then: { '@path': '$.context.traits.email' },
+          else: { '@path': '$.traits.email' }
+        }
+      }
+    },
+    traits_or_props: {
+      label: 'traits or properties object',
+      description: 'Object which will be computed differently for track and identify events',
+      type: 'object',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.properties' },
+          then: { '@path': '$.properties' },
+          else: { '@path': '$.traits' }
+        }
+      }
+    },
+    enable_batching: {
+      type: 'boolean',
+      label: 'enable batching to rokt api',
+      description: 'Set as true to ensure Segment infrastructure uses batching when required.',
+      default: true
+    }
+  },
+
+  perform: (request, { payload }) => {
+    return processPayload(request, [payload])
+  },
+
+  performBatch: (request, { payload }) => {
+    return processPayload(request, payload)
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/index.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/index.ts
@@ -5,8 +5,8 @@ import type { Payload } from './generated-types'
 import { processPayload } from './custom-audience-operations'
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'ROKT build custom audience',
-  description: 'Add/Remove users from ROKT custom audience list. Both identify() and track() calls are supported',
+  title: 'Sync Engage Audience to Rokt',
+  description: 'Add/Remove users from Rokt custom audience list. Both identify() and track() calls are supported',
   defaultSubscription: 'type = "track" or type = "identify"',
   fields: {
     custom_audience_name: {

--- a/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/index.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/upsertCustomAudiences/index.ts
@@ -57,7 +57,7 @@ const action: ActionDefinition<Settings, Payload> = {
     enable_batching: {
       type: 'boolean',
       label: 'enable batching to rokt api',
-      description: 'Set as true to ensure Segment infrastructure uses batching when required.',
+      description: 'Set as true to ensure Segment infrastructure uses batching when possible.',
       default: true
     }
   },


### PR DESCRIPTION
_A summary of your pull request, including the what change you're making and why._

We want to allow ROKT customers ( currently only one ) to send attribution events to ROKT using segment platform & our custom action destination. We would like that batching is used where felt required by segment infrastructure.

- We have added a new destination 'rokt-audiences'
- We are using 'CUSTOM' authentication using API_KEY. So for authentication client needs to provide a valid API_KEY ( ROKT provided ), this is a mandatory field used in auth header for invoking ROKT APIs
- We currently only have one _action_ 'upsertCustomAudiences' for this destination. This action will subscribe to 'track' & 'identify' segment events. This action makes a POST request to ROKT API import suppression endpoint to include/exclude emails to ROKT custom audience list.
- We expect below fields to be present as the part of event payload
    - .context.personas.computation_class ( This always needs to be 'audience' for handling Engage->Audience )
    - .context.personas.computation_key ( name of the audience )
    - .context.traits.email OR .traits.email ( user email )
    - .properties OR .traits 
 - We have support for both single & batched events, we parse through the list of events and build a list of (emails & action) to send to ROKT via API


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
