### PR TITLE
[Revend] Remove fully rolled out feature flags

### DIFF
--- a/packages/destination-actions/src/destinations/revend/__tests__/addPaymentInfo.test.ts
+++ b/packages/destination-actions/src/destinations/revend/__tests__/addPaymentInfo.test.ts
@@ -39,7 +39,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -283,7 +282,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           currency: {
             '@path': '$.properties.currency'
@@ -641,7 +639,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-verify-params-feature': true },
         mapping: {
           client_id: {
             '@path': '$.userId'
@@ -698,7 +695,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.userId'
@@ -755,7 +751,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.userId'
@@ -812,7 +807,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.userId'
@@ -873,7 +867,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -946,7 +939,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/revend/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/revend/__tests__/addToCart.test.ts
@@ -35,7 +35,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -90,7 +89,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -194,7 +192,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -379,7 +376,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -439,7 +435,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-verify-params-feature': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -525,7 +520,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -611,7 +605,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -697,7 +690,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -778,7 +770,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/revend/__tests__/addToWishlist.test.ts
+++ b/packages/destination-actions/src/destinations/revend/__tests__/addToWishlist.test.ts
@@ -35,7 +35,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -87,7 +86,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -403,7 +401,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.userId'
@@ -460,7 +457,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/revend/__tests__/beginCheckout.test.ts
+++ b/packages/destination-actions/src/destinations/revend/__tests__/beginCheckout.test.ts
@@ -47,7 +47,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -417,7 +416,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -480,7 +478,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -555,7 +552,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/revend/__tests__/customEvent.test.ts
+++ b/packages/destination-actions/src/destinations/revend/__tests__/customEvent.test.ts
@@ -35,7 +35,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -94,7 +93,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           name: 'this_is_a_test'
         },
@@ -145,7 +143,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           name: 'this_is_a_test'
         },
@@ -263,7 +260,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -312,7 +308,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           lowercase: true
         },
@@ -371,7 +366,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -418,7 +412,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/revend/__tests__/generateLead.test.ts
+++ b/packages/destination-actions/src/destinations/revend/__tests__/generateLead.test.ts
@@ -35,7 +35,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -79,7 +78,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.userId'
@@ -299,7 +297,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -346,7 +343,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/revend/__tests__/login.test.ts
+++ b/packages/destination-actions/src/destinations/revend/__tests__/login.test.ts
@@ -35,7 +35,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -78,7 +77,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.userId'
@@ -145,7 +143,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -192,7 +189,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/revend/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/revend/__tests__/pageView.test.ts
@@ -35,7 +35,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -89,7 +88,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -163,7 +161,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -219,7 +216,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -266,7 +262,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/revend/__tests__/purchase.test.ts
+++ b/packages/destination-actions/src/destinations/revend/__tests__/purchase.test.ts
@@ -51,7 +51,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           transaction_id: {
             '@path': '$.properties.order_number'
@@ -521,7 +520,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -593,7 +591,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             transaction_id: {
               '@path': '$.properties.order_number'
@@ -687,7 +684,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             transaction_id: {
               '@path': '$.properties.order_number'

--- a/packages/destination-actions/src/destinations/revend/__tests__/refund.test.ts
+++ b/packages/destination-actions/src/destinations/revend/__tests__/refund.test.ts
@@ -35,7 +35,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           transaction_id: {
             '@path': '$.properties.order_number'
@@ -178,7 +177,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           currency: {
             '@path': '$.properties.currency'
@@ -260,7 +258,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           currency: {
             '@path': '$.properties.currency'
@@ -493,7 +490,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             transaction_id: {
               '@path': '$.properties.order_number'
@@ -543,7 +539,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             transaction_id: {
               '@path': '$.properties.order_number'

--- a/packages/destination-actions/src/destinations/revend/__tests__/removeFromCart.test.ts
+++ b/packages/destination-actions/src/destinations/revend/__tests__/removeFromCart.test.ts
@@ -35,7 +35,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -398,7 +397,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -445,7 +443,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/revend/__tests__/search.test.ts
+++ b/packages/destination-actions/src/destinations/revend/__tests__/search.test.ts
@@ -35,7 +35,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -79,7 +78,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -147,7 +145,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -195,7 +192,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/revend/__tests__/selectItem.test.ts
+++ b/packages/destination-actions/src/destinations/revend/__tests__/selectItem.test.ts
@@ -35,7 +35,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -89,7 +88,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -189,7 +187,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -291,7 +288,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -401,7 +397,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -448,7 +443,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/revend/__tests__/selectPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/revend/__tests__/selectPromotion.test.ts
@@ -35,7 +35,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -90,7 +89,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -181,7 +179,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -278,7 +275,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -483,7 +479,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -538,7 +533,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/revend/__tests__/signUp.test.ts
+++ b/packages/destination-actions/src/destinations/revend/__tests__/signUp.test.ts
@@ -35,7 +35,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -78,7 +77,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -191,7 +189,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -238,7 +235,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/revend/__tests__/viewCart.test.ts
+++ b/packages/destination-actions/src/destinations/revend/__tests__/viewCart.test.ts
@@ -50,7 +50,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -102,7 +101,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -433,7 +431,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -495,7 +492,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/revend/__tests__/viewItem.test.ts
+++ b/packages/destination-actions/src/destinations/revend/__tests__/viewItem.test.ts
@@ -35,7 +35,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -91,7 +90,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -174,7 +172,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -238,7 +235,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         useDefaultMappings: true
       })
 
@@ -338,7 +334,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -385,7 +380,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/revend/__tests__/viewItemList.test.ts
+++ b/packages/destination-actions/src/destinations/revend/__tests__/viewItemList.test.ts
@@ -39,7 +39,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           client_id: {
             '@path': '$.anonymousId'
@@ -343,7 +342,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'
@@ -413,7 +411,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             client_id: {
               '@path': '$.anonymousId'

--- a/packages/destination-actions/src/destinations/revend/__tests__/viewPromotion.test.ts
+++ b/packages/destination-actions/src/destinations/revend/__tests__/viewPromotion.test.ts
@@ -47,7 +47,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -150,7 +149,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           clientId: {
             '@path': '$.anonymousId'
@@ -414,7 +412,6 @@ describe('GA4', () => {
         settings: {
           apiSecret
         },
-        features: { 'actions-google-analytics-4-add-timestamp': true },
         mapping: {
           user_properties: {
             hello: 'world',
@@ -500,7 +497,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             params: {
               test_value: null
@@ -585,7 +581,6 @@ describe('GA4', () => {
           settings: {
             apiSecret
           },
-          features: { 'actions-google-analytics-4-verify-params-feature': true },
           mapping: {
             user_properties: {
               hello: ['World', 'world'],

--- a/packages/destination-actions/src/destinations/revend/addPaymentInfo/index.ts
+++ b/packages/destination-actions/src/destinations/revend/addPaymentInfo/index.ts
@@ -38,7 +38,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features }) => {
+  perform: (request, { payload }) => {
     // Google requires that `add_payment_info` events include an array of products: https://developers.google.com/analytics/devguides/collection/ga4/reference/events
     // This differs from the Segment spec, which doesn't require a products array: https://segment.com/docs/connections/spec/ecommerce/v2/#payment-info-entered
     if (payload.items && !payload.items.length) {
@@ -91,10 +91,8 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
 
     const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
@@ -113,11 +111,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://gtmadapter-node-cbjg5cz5hq-ew.a.run.app/v2/consolidated-data', {

--- a/packages/destination-actions/src/destinations/revend/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/revend/addToCart/index.ts
@@ -34,7 +34,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features }) => {
+  perform: (request, { payload }) => {
     let googleItems: ProductItem[] = []
 
     if (payload.currency) {
@@ -59,10 +59,8 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
 
     const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
@@ -79,11 +77,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://gtmadapter-node-cbjg5cz5hq-ew.a.run.app/v2/consolidated-data', {

--- a/packages/destination-actions/src/destinations/revend/addToWishlist/index.ts
+++ b/packages/destination-actions/src/destinations/revend/addToWishlist/index.ts
@@ -34,7 +34,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features }) => {
+  perform: (request, { payload }) => {
     if (payload.currency) {
       verifyCurrency(payload.currency)
     }
@@ -76,10 +76,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
@@ -95,11 +94,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://gtmadapter-node-cbjg5cz5hq-ew.a.run.app/v2/consolidated-data', {

--- a/packages/destination-actions/src/destinations/revend/beginCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/revend/beginCheckout/index.ts
@@ -38,7 +38,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features }) => {
+  perform: (request, { payload }) => {
     if (payload.currency) {
       verifyCurrency(payload.currency)
     }
@@ -63,10 +63,8 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
 
     const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
@@ -84,11 +82,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://gtmadapter-node-cbjg5cz5hq-ew.a.run.app/v2/consolidated-data', {

--- a/packages/destination-actions/src/destinations/revend/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/revend/customEvent/index.ts
@@ -52,13 +52,11 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: { ...params }
   },
-  perform: (request, { payload, features }) => {
+  perform: (request, { payload }) => {
     const event_name = normalizeEventName(payload.name, payload.lowercase)
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
 
     const request_object: { [key: string]: any } = {
       client_id: payload.clientId,
@@ -72,11 +70,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://gtmadapter-node-cbjg5cz5hq-ew.a.run.app/v2/consolidated-data', {

--- a/packages/destination-actions/src/destinations/revend/generateLead/index.ts
+++ b/packages/destination-actions/src/destinations/revend/generateLead/index.ts
@@ -28,7 +28,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features }) => {
+  perform: (request, { payload }) => {
     if (payload.currency) {
       verifyCurrency(payload.currency)
     }
@@ -38,10 +38,8 @@ const action: ActionDefinition<Settings, Payload> = {
       throw new IntegrationError('Currency is required if value is set.', 'Misconfigured required field', 400)
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
 
     const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
@@ -57,11 +55,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://gtmadapter-node-cbjg5cz5hq-ew.a.run.app/v2/consolidated-data', {

--- a/packages/destination-actions/src/destinations/revend/login/index.ts
+++ b/packages/destination-actions/src/destinations/revend/login/index.ts
@@ -30,11 +30,9 @@ const action: ActionDefinition<Settings, Payload> = {
     params: params
   },
 
-  perform: (request, { payload, features }) => {
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+  perform: (request, { payload }) => {
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
 
     const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
@@ -49,11 +47,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://gtmadapter-node-cbjg5cz5hq-ew.a.run.app/v2/consolidated-data', {

--- a/packages/destination-actions/src/destinations/revend/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/revend/pageView/index.ts
@@ -48,11 +48,10 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features }) => {
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+  perform: (request, { payload }) => {
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: any } = {
       client_id: payload.clientId,
       user_id: payload.user_id,
@@ -68,12 +67,10 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
-    }
     return request('https://gtmadapter-node-cbjg5cz5hq-ew.a.run.app/v2/consolidated-data', {
       method: 'POST',
       json: request_object

--- a/packages/destination-actions/src/destinations/revend/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/revend/purchase/index.ts
@@ -48,7 +48,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features }) => {
+  perform: (request, { payload }) => {
     verifyCurrency(payload.currency)
 
     let googleItems: ProductItem[] = []
@@ -71,10 +71,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
@@ -95,11 +94,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://gtmadapter-node-cbjg5cz5hq-ew.a.run.app/v2/consolidated-data', {

--- a/packages/destination-actions/src/destinations/revend/refund/index.ts
+++ b/packages/destination-actions/src/destinations/revend/refund/index.ts
@@ -46,7 +46,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features }) => {
+  perform: (request, { payload }) => {
     if (payload.currency) {
       verifyCurrency(payload.currency)
     }
@@ -89,10 +89,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
@@ -113,11 +112,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://gtmadapter-node-cbjg5cz5hq-ew.a.run.app/v2/consolidated-data', {

--- a/packages/destination-actions/src/destinations/revend/removeFromCart/index.ts
+++ b/packages/destination-actions/src/destinations/revend/removeFromCart/index.ts
@@ -34,7 +34,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features }) => {
+  perform: (request, { payload }) => {
     if (payload.currency) {
       verifyCurrency(payload.currency)
     }
@@ -77,10 +77,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
@@ -96,11 +95,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://gtmadapter-node-cbjg5cz5hq-ew.a.run.app/v2/consolidated-data', {

--- a/packages/destination-actions/src/destinations/revend/search/index.ts
+++ b/packages/destination-actions/src/destinations/revend/search/index.ts
@@ -33,11 +33,10 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features }) => {
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+  perform: (request, { payload }) => {
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
@@ -51,11 +50,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://gtmadapter-node-cbjg5cz5hq-ew.a.run.app/v2/consolidated-data', {

--- a/packages/destination-actions/src/destinations/revend/selectItem/index.ts
+++ b/packages/destination-actions/src/destinations/revend/selectItem/index.ts
@@ -40,7 +40,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features }) => {
+  perform: (request, { payload }) => {
     let googleItems: ProductItem[] = []
 
     if (payload.items) {
@@ -61,10 +61,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
@@ -80,11 +79,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://gtmadapter-node-cbjg5cz5hq-ew.a.run.app/v2/consolidated-data', {

--- a/packages/destination-actions/src/destinations/revend/selectPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/revend/selectPromotion/index.ts
@@ -58,7 +58,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features }) => {
+  perform: (request, { payload }) => {
     let googleItems: PromotionProductItem[] = []
 
     if (payload.items) {
@@ -79,10 +79,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
@@ -101,11 +100,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://gtmadapter-node-cbjg5cz5hq-ew.a.run.app/v2/consolidated-data', {

--- a/packages/destination-actions/src/destinations/revend/signUp/index.ts
+++ b/packages/destination-actions/src/destinations/revend/signUp/index.ts
@@ -32,11 +32,10 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features }) => {
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+  perform: (request, { payload }) => {
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
@@ -50,11 +49,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://gtmadapter-node-cbjg5cz5hq-ew.a.run.app/v2/consolidated-data', {

--- a/packages/destination-actions/src/destinations/revend/viewCart/index.ts
+++ b/packages/destination-actions/src/destinations/revend/viewCart/index.ts
@@ -34,7 +34,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features }) => {
+  perform: (request, { payload }) => {
     if (payload.currency) {
       verifyCurrency(payload.currency)
     }
@@ -72,10 +72,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
@@ -91,11 +90,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://gtmadapter-node-cbjg5cz5hq-ew.a.run.app/v2/consolidated-data', {

--- a/packages/destination-actions/src/destinations/revend/viewItem/index.ts
+++ b/packages/destination-actions/src/destinations/revend/viewItem/index.ts
@@ -34,7 +34,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features }) => {
+  perform: (request, { payload }) => {
     if (payload.currency) {
       verifyCurrency(payload.currency)
     }
@@ -59,10 +59,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
@@ -78,11 +77,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://gtmadapter-node-cbjg5cz5hq-ew.a.run.app/v2/consolidated-data', {

--- a/packages/destination-actions/src/destinations/revend/viewItemList/index.ts
+++ b/packages/destination-actions/src/destinations/revend/viewItemList/index.ts
@@ -50,7 +50,7 @@ const action: ActionDefinition<Settings, Payload> = {
     engagement_time_msec: engagement_time_msec,
     params: params
   },
-  perform: (request, { payload, features }) => {
+  perform: (request, { payload }) => {
     let googleItems: ProductItem[] = []
 
     if (payload.items) {
@@ -71,10 +71,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
@@ -90,11 +89,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://gtmadapter-node-cbjg5cz5hq-ew.a.run.app/v2/consolidated-data', {

--- a/packages/destination-actions/src/destinations/revend/viewPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/revend/viewPromotion/index.ts
@@ -67,7 +67,7 @@ const action: ActionDefinition<Settings, Payload> = {
     params: params
   },
 
-  perform: (request, { payload, features }) => {
+  perform: (request, { payload }) => {
     let googleItems: PromotionProductItem[] = []
 
     if (payload.items) {
@@ -84,10 +84,9 @@ const action: ActionDefinition<Settings, Payload> = {
       })
     }
 
-    if (features && features['actions-google-analytics-4-verify-params-feature']) {
-      verifyParams(payload.params)
-      verifyUserProps(payload.user_properties)
-    }
+    verifyParams(payload.params)
+    verifyUserProps(payload.user_properties)
+
     const request_object: { [key: string]: any } = {
       client_id: payload.client_id,
       user_id: payload.user_id,
@@ -106,11 +105,8 @@ const action: ActionDefinition<Settings, Payload> = {
           }
         }
       ],
-      ...formatUserProperties(payload.user_properties)
-    }
-
-    if (features && features['actions-google-analytics-4-add-timestamp']) {
-      request_object.timestamp_micros = convertTimestamp(payload.timestamp_micros)
+      ...formatUserProperties(payload.user_properties),
+      timestamp_micros: convertTimestamp(payload.timestamp_micros)
     }
 
     return request('https://gtmadapter-node-cbjg5cz5hq-ew.a.run.app/v2/consolidated-data', {


### PR DESCRIPTION
This PR mimics this one for [GA4](https://github.com/segmentio/action-destinations/pull/1136) to remove two feature flags, [add-timestamp](https://flagon.segment.com/families/centrifuge-destinations/gates/actions-google-analytics-4-add-timestamp) & [verify-params](https://flagon.segment.com/families/centrifuge-destinations/gates/actions-google-analytics-4-verify-params-feature) that have been fully rolled out for a while now. 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
