### PR TITLE
EXPANSION-352: regionalize Engage SMS sender reference to Profiles API

### DIFF
--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/generated-types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/generated-types.ts
@@ -62,4 +62,8 @@ export interface Payload {
    * Time of when the actual event happened.
    */
   eventOccurredTS?: string
+  /**
+   * The region where the message is originating from
+   */
+  region?: string
 }

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/index.ts
@@ -113,6 +113,12 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.timestamp'
       }
+    },
+    region: {
+      label: 'Region',
+      description: 'The region where the message is originating from',
+      type: 'string',
+      required: false
     }
   },
   perform: async (request, { settings, payload, statsContext }) => {

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/index.ts
@@ -118,6 +118,10 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Region',
       description: 'The region where the message is originating from',
       type: 'string',
+      choices: [
+        { value: 'us-west-2', label: 'US West 2' },
+        { value: 'eu-west-1', label: 'EU West 1' }
+      ],
       required: false
     }
   },

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/sms-sender.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/sms-sender.ts
@@ -6,6 +6,11 @@ import { IntegrationError } from '@segment/actions-core'
 import { StatsClient, StatsContext } from '@segment/actions-core/src/destination-kit'
 import { MessageSender, RequestFn } from '../utils/message-sender'
 
+export enum Region {
+  usWest2 = 'us-west-2',
+  euWest1 = 'eu-west-1'
+}
+
 const Liquid = new LiquidJs()
 
 export class SmsMessageSender extends MessageSender<Payload> {
@@ -63,9 +68,9 @@ export class SmsMessageSender extends MessageSender<Payload> {
       )
     }
     try {
-      const endpoint = `https://profiles.segment.${
-        this.settings.profileApiEnvironment === 'production' ? 'com' : 'build'
-      }`
+      const baseEndpoint =
+        this.payload.region === Region.euWest1 ? 'https://profiles.euw1.segment' : 'https://profiles.segment'
+      const endpoint = `${baseEndpoint}.${this.settings.profileApiEnvironment === 'production' ? 'com' : 'build'}`
       const response = await this.request(
         `${endpoint}/v1/spaces/${this.settings.spaceId}/collections/users/profiles/user_id:${encodeURIComponent(
           this.payload.userId


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR updates the Engage Twilio SMS destination to use the correct, region-specific Profiles API base endpoint to support sending SMS messages through Engage in the EU region.

[Jira Issue](https://segment.atlassian.net/browse/EXPANSION-352)

## Testing

For more details on testing, see the screenshots from [this related PR](https://github.com/segmentio/personas-service/pull/1695).

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
