### PR TITLE
Add a new @replace directive

### DIFF
--- a/packages/core/src/mapping-kit/README.md
+++ b/packages/core/src/mapping-kit/README.md
@@ -64,6 +64,7 @@ Output:
   - [@literal](#literal)
   - [@arrayPath](#array-path)
   - [@case](#case)
+  - [@replace](#replace)
 
 <!-- tocstop -->
 
@@ -544,3 +545,45 @@ Result:
 ```json
 "this is a string in all caps"
 ```
+
+### @replace
+
+The @replace directive replaces to the given pattern value with a replacement string. Both "pattern" and "replacement"
+fields are required but replacement can be an empty string.
+
+````json
+Input:
+
+{
+  "a": "cool-story",
+}
+
+Mappings:
+
+{
+  "@replace": {
+    "pattern": "-",
+    "replacement": ""
+  }
+}
+=>
+"coolstory"
+
+```json
+Input:
+
+{
+  "a": "cool-story",
+}
+
+Mappings:
+
+{
+  "@replace": {
+    "pattern": "-",
+    "replacement": "nice"
+  }
+}
+=>
+"coolnicestory"
+````

--- a/packages/core/src/mapping-kit/README.md
+++ b/packages/core/src/mapping-kit/README.md
@@ -587,3 +587,43 @@ Mappings:
 =>
 "coolnicestory"
 ````
+
+```json
+Input:
+
+{
+  "a": "cWWl-story-ww",
+}
+
+Mappings:
+
+{
+  "@replace": {
+    "pattern": "WW",
+    "replacement": "oo",
+    "ignorecase": false
+  }
+}
+=>
+"cool-story-ww"
+```
+
+```json
+Input:
+
+{
+  "a": "just-the-first",
+}
+
+Mappings:
+
+{
+  "@replace": {
+    "pattern": "-",
+    "replacement": "@",
+    "global": false
+  }
+}
+=>
+"just@the-first"
+```

--- a/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
@@ -548,6 +548,89 @@ describe('@template', () => {
   })
 })
 
+describe('@replace', () => {
+  test('replace on empty string', () => {
+    const payload = {
+      a: ''
+    }
+    const output = transform(
+      {
+        '@replace': {
+          pattern: '_',
+          replacement: 'rrrrr',
+          value: { '@path': '$.a' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual('')
+  })
+  test('replace with empty string', () => {
+    const payload = {
+      a: 'nomore_underscore'
+    }
+    const output = transform(
+      {
+        '@replace': {
+          pattern: '_',
+          replacement: '',
+          value: { '@path': '$.a' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual('nomoreunderscore')
+  })
+  test('replace with non-empty string', () => {
+    const payload = {
+      a: 'nomore_underscore'
+    }
+    const output = transform(
+      {
+        '@replace': {
+          pattern: '_',
+          replacement: 'weird',
+          value: { '@path': '$.a' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual('nomoreweirdunderscore')
+  })
+  test('replace multi-char pattern with non-empty string', () => {
+    const payload = {
+      a: 'Well Hello there LOL'
+    }
+    const output = transform(
+      {
+        '@replace': {
+          pattern: 'LOL',
+          replacement: 'YAY',
+          value: { '@path': '$.a' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual('Well Hello there YAY')
+  })
+  test('replace multiple occurrences', () => {
+    const payload = {
+      a: 'many+different+things'
+    }
+    const output = transform(
+      {
+        '@replace': {
+          pattern: '+',
+          replacement: '_',
+          value: { '@path': '$.a' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual('many_different_things')
+  })
+})
+
 describe('remove undefined values in objects', () => {
   test('simple', () => {
     expect(transform({ x: undefined }, {})).toEqual({})

--- a/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
@@ -645,6 +645,21 @@ describe('@replace', () => {
     )
     expect(output).toStrictEqual('')
   })
+  test('should still work without replacement key', () => {
+    const payload = {
+      a: 'many+different+things'
+    }
+    const output = transform(
+      {
+        '@replace': {
+          pattern: 'many+',
+          value: { '@path': '$.a' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual('different+things')
+  })
 })
 
 describe('remove undefined values in objects', () => {

--- a/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
@@ -565,6 +565,40 @@ describe('@replace', () => {
     )
     expect(output).toStrictEqual('')
   })
+  test('replace on case sensitive string', () => {
+    const payload = {
+      a: 'cWWl-story-ww'
+    }
+    const output = transform(
+      {
+        '@replace': {
+          pattern: 'WW',
+          replacement: 'oo',
+          value: { '@path': '$.a' },
+          ignorecase: false // true by default but just showing here
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual('cool-story-ww')
+  })
+  test('replace on case insensitive string', () => {
+    const payload = {
+      a: 'aab-----AaB---aab'
+    }
+    const output = transform(
+      {
+        '@replace': {
+          pattern: 'AaB',
+          replacement: 'nice',
+          value: { '@path': '$.a' },
+          ignorecase: true
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual('nice-----nice---nice')
+  })
   test('replace with empty string', () => {
     const payload = {
       a: 'nomore_underscore'
@@ -574,7 +608,8 @@ describe('@replace', () => {
         '@replace': {
           pattern: '_',
           replacement: '',
-          value: { '@path': '$.a' }
+          value: { '@path': '$.a' },
+          ignorecase: false
         }
       },
       payload
@@ -622,12 +657,30 @@ describe('@replace', () => {
         '@replace': {
           pattern: '+',
           replacement: '_',
-          value: { '@path': '$.a' }
+          value: { '@path': '$.a' },
+          global: true // true by default but just to demo
         }
       },
       payload
     )
     expect(output).toStrictEqual('many_different_things')
+  })
+  test('replace first occurrence', () => {
+    const payload = {
+      a: 'many+different+things'
+    }
+    const output = transform(
+      {
+        '@replace': {
+          pattern: '+',
+          replacement: '_',
+          value: { '@path': '$.a' },
+          global: false // true by default but just to demo
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual('many_different+things')
   })
   test('replace entire value', () => {
     const payload = {

--- a/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
@@ -629,6 +629,22 @@ describe('@replace', () => {
     )
     expect(output).toStrictEqual('many_different_things')
   })
+  test('replace entire value', () => {
+    const payload = {
+      a: 'many+different+things'
+    }
+    const output = transform(
+      {
+        '@replace': {
+          pattern: 'many+different+things',
+          replacement: '',
+          value: { '@path': '$.a' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual('')
+  })
 })
 
 describe('remove undefined values in objects', () => {

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -109,9 +109,10 @@ registerDirective('@replace', (opts, payload) => {
     throw new Error('@replace requires a "pattern" key')
   }
 
-  // Empty replacement string is ok
+  // Assume null/missing replacement means empty
   if (opts.replacement == null) {
-    throw new Error('@replace requires a "replacement" key')
+    // Empty replacement string is ok
+    opts.replacement = ''
   }
 
   let pattern = opts.pattern

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -115,15 +115,40 @@ registerDirective('@replace', (opts, payload) => {
     opts.replacement = ''
   }
 
+  // case sensitive by default if this key is missing
+  if (opts.ignorecase == null) {
+    opts.ignorecase = false
+  }
+
+  // global by default if this key is missing
+  if (opts.global == null) {
+    opts.global = true
+  }
+
   let pattern = opts.pattern
   const replacement = opts.replacement
+  const ignorecase = opts.ignorecase
+  const isGlobal = opts.global
   if (opts.value) {
     const value = resolve(opts.value, payload)
-    if (typeof value === 'string' && typeof pattern === 'string' && typeof replacement === 'string') {
+    if (
+      typeof value === 'string' &&
+      typeof pattern === 'string' &&
+      typeof replacement === 'string' &&
+      typeof ignorecase === 'boolean' &&
+      typeof isGlobal === 'boolean'
+    ) {
       // We don't want users providing regular expressions for the pattern (for now)
       // https://stackoverflow.com/questions/F3115150/how-to-escape-regular-expression-special-characters-using-javascript
       pattern = pattern.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
-      return value.replace(new RegExp(pattern, 'g'), replacement)
+      let flags = ''
+      if (isGlobal) {
+        flags += 'g'
+      }
+      if (ignorecase) {
+        flags += 'i'
+      }
+      return value.replace(new RegExp(pattern, flags), replacement)
     }
   }
 })

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -102,7 +102,7 @@ registerDirective('@case', (opts, payload) => {
 
 registerDirective('@replace', (opts, payload) => {
   if (!isObject(opts)) {
-    throw new Error('@replace requires an object with a "operator" key')
+    throw new Error('@replace requires an object with a "pattern" key')
   }
 
   if (!opts.pattern) {

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -100,6 +100,33 @@ registerDirective('@case', (opts, payload) => {
   }
 })
 
+registerDirective('@replace', (opts, payload) => {
+  if (!isObject(opts)) {
+    throw new Error('@replace requires an object with a "operator" key')
+  }
+
+  if (!opts.pattern) {
+    throw new Error('@replace requires a "pattern" key')
+  }
+
+  // Empty replacement string is ok
+  if (opts.replacement == null) {
+    throw new Error('@replace requires a "replacement" key')
+  }
+
+  let pattern = opts.pattern
+  const replacement = opts.replacement
+  if (opts.value) {
+    const value = resolve(opts.value, payload)
+    if (typeof value === 'string' && typeof pattern === 'string' && typeof replacement === 'string') {
+      // We don't want users providing regular expressions for the pattern (for now)
+      // https://stackoverflow.com/questions/F3115150/how-to-escape-regular-expression-special-characters-using-javascript
+      pattern = pattern.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
+      return value.replace(new RegExp(pattern, 'g'), replacement)
+    }
+  }
+})
+
 registerDirective('@arrayPath', (data, payload) => {
   if (!Array.isArray(data)) {
     throw new Error(`@arrayPath expected array, got ${realTypeOf(data)}`)

--- a/packages/core/src/mapping-kit/schema-fixtures/invalid/@replace-no-pattern.json
+++ b/packages/core/src/mapping-kit/schema-fixtures/invalid/@replace-no-pattern.json
@@ -1,0 +1,8 @@
+{
+  "mapping": {
+    "@replace": {
+      "value": { "@path": "$.a" }
+    }
+  },
+  "expectError": "/@replace should have field \"pattern\" but it doesn't."
+}

--- a/packages/core/src/mapping-kit/schema-fixtures/invalid/@replace-no-value.json
+++ b/packages/core/src/mapping-kit/schema-fixtures/invalid/@replace-no-value.json
@@ -1,0 +1,8 @@
+{
+  "mapping": {
+    "@replace": {
+      "pattern": "bla"
+    }
+  },
+  "expectError": "/@replace should have field \"value\" but it doesn't."
+}

--- a/packages/core/src/mapping-kit/schema-fixtures/invalid/@replace-wrong-global-value.json
+++ b/packages/core/src/mapping-kit/schema-fixtures/invalid/@replace-wrong-global-value.json
@@ -1,0 +1,11 @@
+{
+  "mapping": {
+    "@replace": {
+      "pattern": "+",
+      "replacement": "-",
+      "value": { "@path": "$.a" },
+      "global": "bla"
+    }
+  },
+  "expectError": "/@replace/global should be a boolean but it is a string."
+}

--- a/packages/core/src/mapping-kit/schema-fixtures/invalid/@replace-wrong-ignore-value.json
+++ b/packages/core/src/mapping-kit/schema-fixtures/invalid/@replace-wrong-ignore-value.json
@@ -1,0 +1,11 @@
+{
+  "mapping": {
+    "@replace": {
+      "pattern": "+",
+      "replacement": "-",
+      "value": { "@path": "$.a" },
+      "ignorecase": "bla"
+    }
+  },
+  "expectError": "/@replace/ignorecase should be a boolean but it is a string."
+}

--- a/packages/core/src/mapping-kit/schema-fixtures/valid/@replace-case-insensitive.json
+++ b/packages/core/src/mapping-kit/schema-fixtures/valid/@replace-case-insensitive.json
@@ -1,0 +1,10 @@
+{
+  "mapping": {
+    "@replace": {
+      "pattern": "+",
+      "replacement": "-",
+      "value": { "@path": "$.a" },
+      "ignorecase": true
+    }
+  }
+}

--- a/packages/core/src/mapping-kit/schema-fixtures/valid/@replace-no-replacement.json
+++ b/packages/core/src/mapping-kit/schema-fixtures/valid/@replace-no-replacement.json
@@ -1,0 +1,8 @@
+{
+  "mapping": {
+    "@replace": {
+      "pattern": "+",
+      "value": { "@path": "$.a" }
+    }
+  }
+}

--- a/packages/core/src/mapping-kit/schema-fixtures/valid/@replace-simple.json
+++ b/packages/core/src/mapping-kit/schema-fixtures/valid/@replace-simple.json
@@ -1,0 +1,9 @@
+{
+  "mapping": {
+    "@replace": {
+      "pattern": "+",
+      "replacement": "-",
+      "value": { "@path": "$.a" }
+    }
+  }
+}

--- a/packages/core/src/mapping-kit/validate.ts
+++ b/packages/core/src/mapping-kit/validate.ts
@@ -113,6 +113,14 @@ function validateString(v: unknown, stack: string[] = []) {
   return
 }
 
+function validateBoolean(v: unknown, stack: string[] = []) {
+  const type = realTypeOrDirective(v)
+  if (type !== 'boolean') {
+    throw new ValidationError(`should be a boolean but it is ${indefiniteArticle(type)} ${type}`, stack)
+  }
+  return
+}
+
 function validateObject(value: unknown, stack: string[] = []) {
   const type = realTypeOrDirective(value)
   if (type !== 'object') {
@@ -235,7 +243,9 @@ directive('@replace', (v, stack) => {
     {
       pattern: { required: validateString },
       replacement: { optional: validateString },
-      value: { required: validateDirectiveOrString }
+      value: { required: validateDirectiveOrString },
+      ignorecase: { optional: validateBoolean },
+      global: { optional: validateBoolean }
     },
     stack
   )

--- a/packages/core/src/mapping-kit/validate.ts
+++ b/packages/core/src/mapping-kit/validate.ts
@@ -233,9 +233,9 @@ directive('@replace', (v, stack) => {
   validateObjectWithFields(
     v,
     {
-      pattern: { optional: validateString },
+      pattern: { required: validateString },
       replacement: { optional: validateString },
-      value: { optional: validateDirectiveOrString }
+      value: { required: validateDirectiveOrString }
     },
     stack
   )

--- a/packages/core/src/mapping-kit/validate.ts
+++ b/packages/core/src/mapping-kit/validate.ts
@@ -229,6 +229,18 @@ directive('@case', (v, stack) => {
   )
 })
 
+directive('@replace', (v, stack) => {
+  validateObjectWithFields(
+    v,
+    {
+      pattern: { optional: validateString },
+      replacement: { optional: validateString },
+      value: { optional: validateDirectiveOrString }
+    },
+    stack
+  )
+})
+
 directive('@arrayPath', (v, stack) => {
   const data = v as [unknown, unknown]
   validateArray(data, stack)


### PR DESCRIPTION
Add ability to replace values in fields

## Testing

Tested in stage via webhook action:

Example mapping:

```json
      {
        "fieldKey": "data",
        "value": {
          "userIdReplaced": {
            "@replace": {
              "pattern": "@",
              "replacement": "Weeee",
              "value": {
                "@path": "$.userId"
              }
            }
          },
          "everything": {
            "@path": "$."
          }
        }
      },
```
      
  Example output:
  
```json
  {
  "everything": {
    "channel": "server",
    "context": {
      "library": {
        "name": "unknown",
        "version": "unknown"
      }
    },
    "event": "Example Event",
    "integrations": {},
    "messageId": "api-2NyLfjD8lzVtfkLt2pKsnt8wMU0",
    "projectId": "ah35UczHuHeRK8p3qxd6nE",
    "properties": {},
    "receivedAt": "2023-04-04T18:04:39.926Z",
    "timestamp": "2023-04-04T18:04:39.926Z",
    "type": "track",
    "userId": "wasi@haider@segment.com",
    "version": 2
  },
  "userIdReplaced": "wasiWeeeehaiderWeeeesegment.com"
}
```



- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [X] [Segmenters] Tested in the staging environment
