### PR TITLE
[Salesforce] Delete operation

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/__tests__/account.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/account.test.ts
@@ -60,6 +60,67 @@ describe('Salesforce', () => {
       expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"Name\\":\\"John's Test Acccount\\"}"`)
     })
 
+    it('should delete an account record given an Id', async () => {
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).delete('/Account/123').reply(204, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Delete',
+        userId: '123'
+      })
+
+      const responses = await testDestination.testAction('account', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          operation: 'delete',
+          traits: {
+            Id: { '@path': '$.userId' }
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(204)
+    })
+
+    it('should delete an account record given some lookup traits', async () => {
+      const query = encodeURIComponent(`SELECT Id FROM Account WHERE Email = 'bob@bobsburgers.net'`)
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/query`)
+        .get(`/?q=${query}`)
+        .reply(201, {
+          totalSize: 1,
+          records: [{ Id: 'abc123' }]
+        })
+
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).delete('/Account/abc123').reply(201, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Delete',
+        properties: {
+          email: 'bob@bobsburgers.net'
+        }
+      })
+
+      const responses = await testDestination.testAction('account', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          operation: 'delete',
+          traits: {
+            Email: { '@path': '$.properties.email' }
+          }
+        }
+      })
+
+      expect(responses.length).toBe(2)
+      expect(responses[0].status).toBe(201)
+      expect(responses[1].status).toBe(201)
+    })
+
     it('should create a account record with default mappings', async () => {
       nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).post('/Account').reply(201, {})
 

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/contact.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/contact.test.ts
@@ -179,6 +179,67 @@ describe('Salesforce', () => {
       )
     })
 
+    it('should delete a contact record given an Id', async () => {
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).delete('/Contact/123').reply(204, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Delete',
+        userId: '123'
+      })
+
+      const responses = await testDestination.testAction('contact', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          operation: 'delete',
+          traits: {
+            Id: { '@path': '$.userId' }
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(204)
+    })
+
+    it('should delete a contact record given some lookup traits', async () => {
+      const query = encodeURIComponent(`SELECT Id FROM Contact WHERE Email = 'bob@bobsburgers.net'`)
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/query`)
+        .get(`/?q=${query}`)
+        .reply(201, {
+          totalSize: 1,
+          records: [{ Id: 'abc123' }]
+        })
+
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).delete('/Contact/abc123').reply(201, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Delete',
+        properties: {
+          email: 'bob@bobsburgers.net'
+        }
+      })
+
+      const responses = await testDestination.testAction('contact', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          operation: 'delete',
+          traits: {
+            Email: { '@path': '$.properties.email' }
+          }
+        }
+      })
+
+      expect(responses.length).toBe(2)
+      expect(responses[0].status).toBe(201)
+      expect(responses[1].status).toBe(201)
+    })
+
     it('should update a contact record', async () => {
       const event = createTestEvent({
         type: 'track',

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/customObject.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/customObject.test.ts
@@ -66,6 +66,87 @@ describe('Salesforce', () => {
       )
     })
 
+    it('should error out when custom fields are not passed for create operation', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Create Custom Object',
+        properties: {
+          email: 'sponge@seamail.com',
+          company: 'Krusty Krab',
+          last_name: 'Squarepants'
+        }
+      })
+
+      await expect(
+        testDestination.testAction('customObject', {
+          event,
+          settings,
+          auth,
+          mapping: {
+            operation: 'create',
+            customObjectName: 'TestCustom__c',
+            traits: {
+              Id: { '@path': '$.userId' }
+            }
+          }
+        })
+      ).rejects.toThrow('Custom fields are required for this operation.')
+    })
+
+    it('should error out when custom fields are not passed for update operation', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Create Custom Object',
+        properties: {
+          email: 'sponge@seamail.com',
+          company: 'Krusty Krab',
+          last_name: 'Squarepants'
+        }
+      })
+
+      await expect(
+        testDestination.testAction('customObject', {
+          event,
+          settings,
+          auth,
+          mapping: {
+            operation: 'update',
+            customObjectName: 'TestCustom__c',
+            traits: {
+              Id: { '@path': '$.userId' }
+            }
+          }
+        })
+      ).rejects.toThrow('Custom fields are required for this operation.')
+    })
+
+    it('should error out when custom fields are not passed for upsert operation', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Create Custom Object',
+        properties: {
+          email: 'sponge@seamail.com',
+          company: 'Krusty Krab',
+          last_name: 'Squarepants'
+        }
+      })
+
+      await expect(
+        testDestination.testAction('customObject', {
+          event,
+          settings,
+          auth,
+          mapping: {
+            operation: 'upsert',
+            customObjectName: 'TestCustom__c',
+            traits: {
+              Id: { '@path': '$.userId' }
+            }
+          }
+        })
+      ).rejects.toThrow('Custom fields are required for this operation.')
+    })
+
     it('should delete a custom record given an Id', async () => {
       nock(`${settings.instanceUrl}/services/data/${API_VERSION}/sobjects`).delete('/TestCustom__c/123').reply(201, {})
 
@@ -84,9 +165,6 @@ describe('Salesforce', () => {
           customObjectName: 'TestCustom__c',
           traits: {
             Id: { '@path': '$.userId' }
-          },
-          customFields: {
-            '@path': '$.properties'
           }
         }
       })

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/customObject.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/customObject.test.ts
@@ -66,6 +66,35 @@ describe('Salesforce', () => {
       )
     })
 
+    it('should delete a custom record given an Id', async () => {
+      nock(`${settings.instanceUrl}/services/data/${API_VERSION}/sobjects`).delete('/TestCustom__c/123').reply(201, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Delete',
+        userId: '123'
+      })
+
+      const responses = await testDestination.testAction('customObject', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          operation: 'delete',
+          customObjectName: 'TestCustom__c',
+          traits: {
+            Id: { '@path': '$.userId' }
+          },
+          customFields: {
+            '@path': '$.properties'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
     it('should dynamically fetch customObjectName', async () => {
       nock(`${settings.instanceUrl}/services/data/${API_VERSION}`)
         .get('/sobjects')

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/lead.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/lead.test.ts
@@ -70,6 +70,67 @@ describe('Salesforce', () => {
       )
     })
 
+    it('should delete a lead record given an Id', async () => {
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).delete('/Lead/123').reply(204, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Delete',
+        userId: '123'
+      })
+
+      const responses = await testDestination.testAction('lead', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          operation: 'delete',
+          traits: {
+            Id: { '@path': '$.userId' }
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(204)
+    })
+
+    it('should delete a lead record given some lookup traits', async () => {
+      const query = encodeURIComponent(`SELECT Id FROM Lead WHERE Email = 'bob@bobsburgers.net'`)
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/query`)
+        .get(`/?q=${query}`)
+        .reply(201, {
+          totalSize: 1,
+          records: [{ Id: 'abc123' }]
+        })
+
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).delete('/Lead/abc123').reply(201, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Delete',
+        properties: {
+          email: 'bob@bobsburgers.net'
+        }
+      })
+
+      const responses = await testDestination.testAction('lead', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          operation: 'delete',
+          traits: {
+            Email: { '@path': '$.properties.email' }
+          }
+        }
+      })
+
+      expect(responses.length).toBe(2)
+      expect(responses[0].status).toBe(201)
+      expect(responses[1].status).toBe(201)
+    })
+
     it('should create a lead record with default mappings', async () => {
       nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).post('/Lead').reply(201, {})
 

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/opportunity.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/opportunity.test.ts
@@ -131,7 +131,7 @@ describe('Salesforce', () => {
       )
     })
 
-    it('should delete an opprotunity record given an Id', async () => {
+    it('should delete an opportunity record given an Id', async () => {
       nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).delete('/Opportunity/123').reply(204, {})
 
       const event = createTestEvent({
@@ -156,7 +156,7 @@ describe('Salesforce', () => {
       expect(responses[0].status).toBe(204)
     })
 
-    it('should delete an opprotunity record given some lookup traits', async () => {
+    it('should delete an opportunity record given some lookup traits', async () => {
       const query = encodeURIComponent(`SELECT Id FROM Opportunity WHERE Email = 'bob@bobsburgers.net'`)
       nock(`${settings.instanceUrl}services/data/${API_VERSION}/query`)
         .get(`/?q=${query}`)

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/opportunity.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/opportunity.test.ts
@@ -131,6 +131,67 @@ describe('Salesforce', () => {
       )
     })
 
+    it('should delete an opprotunity record given an Id', async () => {
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).delete('/Opportunity/123').reply(204, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Delete',
+        userId: '123'
+      })
+
+      const responses = await testDestination.testAction('opportunity', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          operation: 'delete',
+          traits: {
+            Id: { '@path': '$.userId' }
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(204)
+    })
+
+    it('should delete an opprotunity record given some lookup traits', async () => {
+      const query = encodeURIComponent(`SELECT Id FROM Opportunity WHERE Email = 'bob@bobsburgers.net'`)
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/query`)
+        .get(`/?q=${query}`)
+        .reply(201, {
+          totalSize: 1,
+          records: [{ Id: 'abc123' }]
+        })
+
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).delete('/Opportunity/abc123').reply(201, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Delete',
+        properties: {
+          email: 'bob@bobsburgers.net'
+        }
+      })
+
+      const responses = await testDestination.testAction('opportunity', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          operation: 'delete',
+          traits: {
+            Email: { '@path': '$.properties.email' }
+          }
+        }
+      })
+
+      expect(responses.length).toBe(2)
+      expect(responses[0].status).toBe(201)
+      expect(responses[1].status).toBe(201)
+    })
+
     it('should update a opportunity record', async () => {
       const event = createTestEvent({
         type: 'track',

--- a/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * The Salesforce operation performed. The available operations are Create, Update or Upsert records in Salesforce.
+   * The Salesforce operation performed. The available operations are Create, Delete, Update or Upsert records in Salesforce.
    */
   operation: string
   /**
@@ -14,11 +14,11 @@ export interface Payload {
    */
   recordMatcherOperator?: string
   /**
-   * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
+   * The fields used to find Salesforce records for updates. **This is required if the operation is Delete, Update or Upsert.**
    *
    *   Any field can function as a matcher, including Record ID, External IDs, standard fields and custom fields. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.
    *
-   *   If multiple records are found, no updates will be made. **Please use fields that result in unique records.**
+   *   If multiple records are found, no changes will be made. **Please use fields that result in unique records.**
    *
    *   ---
    *

--- a/packages/destination-actions/src/destinations/salesforce/account/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account/index.ts
@@ -200,6 +200,10 @@ const action: ActionDefinition<Settings, Payload> = {
       }
       return await sf.upsertRecord(payload, OBJECT_NAME)
     }
+
+    if (payload.operation === 'delete') {
+      return await sf.deleteRecord(payload, OBJECT_NAME)
+    }
   },
   performBatch: async (request, { settings, payload }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)

--- a/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * The Salesforce operation performed. The available operations are Create, Update or Upsert records in Salesforce.
+   * The Salesforce operation performed. The available operations are Create, Delete, Update or Upsert records in Salesforce.
    */
   operation: string
   /**
@@ -14,11 +14,11 @@ export interface Payload {
    */
   enable_batching?: boolean
   /**
-   * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
+   * The fields used to find Salesforce records for updates. **This is required if the operation is Delete, Update or Upsert.**
    *
    *   Any field can function as a matcher, including Record ID, External IDs, standard fields and custom fields. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.
    *
-   *   If multiple records are found, no updates will be made. **Please use fields that result in unique records.**
+   *   If multiple records are found, no changes will be made. **Please use fields that result in unique records.**
    *
    *   ---
    *

--- a/packages/destination-actions/src/destinations/salesforce/cases/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases/index.ts
@@ -48,6 +48,10 @@ const action: ActionDefinition<Settings, Payload> = {
     if (payload.operation === 'upsert') {
       return await sf.upsertRecord(payload, OBJECT_NAME)
     }
+
+    if (payload.operation === 'delete') {
+      return await sf.deleteRecord(payload, OBJECT_NAME)
+    }
   },
   performBatch: async (request, { settings, payload }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)

--- a/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * The Salesforce operation performed. The available operations are Create, Update or Upsert records in Salesforce.
+   * The Salesforce operation performed. The available operations are Create, Delete, Update or Upsert records in Salesforce.
    */
   operation: string
   /**
@@ -14,11 +14,11 @@ export interface Payload {
    */
   enable_batching?: boolean
   /**
-   * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
+   * The fields used to find Salesforce records for updates. **This is required if the operation is Delete, Update or Upsert.**
    *
    *   Any field can function as a matcher, including Record ID, External IDs, standard fields and custom fields. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.
    *
-   *   If multiple records are found, no updates will be made. **Please use fields that result in unique records.**
+   *   If multiple records are found, no changes will be made. **Please use fields that result in unique records.**
    *
    *   ---
    *

--- a/packages/destination-actions/src/destinations/salesforce/contact/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact/index.ts
@@ -151,6 +151,10 @@ const action: ActionDefinition<Settings, Payload> = {
       }
       return await sf.upsertRecord(payload, OBJECT_NAME)
     }
+
+    if (payload.operation === 'delete') {
+      return await sf.deleteRecord(payload, OBJECT_NAME)
+    }
   },
   performBatch: async (request, { settings, payload }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)

--- a/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * The Salesforce operation performed. The available operations are Create, Update or Upsert records in Salesforce.
+   * The Salesforce operation performed. The available operations are Create, Delete, Update or Upsert records in Salesforce.
    */
   operation: string
   /**
@@ -14,11 +14,11 @@ export interface Payload {
    */
   enable_batching?: boolean
   /**
-   * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
+   * The fields used to find Salesforce records for updates. **This is required if the operation is Delete, Update or Upsert.**
    *
    *   Any field can function as a matcher, including Record ID, External IDs, standard fields and custom fields. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.
    *
-   *   If multiple records are found, no updates will be made. **Please use fields that result in unique records.**
+   *   If multiple records are found, no changes will be made. **Please use fields that result in unique records.**
    *
    *   ---
    *

--- a/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
@@ -58,7 +58,7 @@ export interface Payload {
    *
    *
    */
-  customFields: {
+  customFields?: {
     [k: string]: unknown
   }
 }

--- a/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
@@ -12,7 +12,7 @@ import {
   recordMatcherOperator
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
-
+import { IntegrationError } from '@segment/actions-core'
 const OPERATIONS_WITH_CUSTOM_FIELDS = ['create', 'update', 'upsert']
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -44,7 +44,7 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: async (request, { settings, payload }) => {
     if (OPERATIONS_WITH_CUSTOM_FIELDS.includes(payload.operation) && !payload.customFields) {
-      throw new Error('Custom fields are required for this operation.')
+      throw new IntegrationError('Custom fields are required for this operation.')
     }
 
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)
@@ -69,7 +69,7 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   performBatch: async (request, { settings, payload }) => {
     if (OPERATIONS_WITH_CUSTOM_FIELDS.includes(payload[0].operation) && !payload[0].customFields) {
-      throw new Error('Custom fields are required for this operation.')
+      throw new IntegrationError('Custom fields are required for this operation.')
     }
 
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)

--- a/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
@@ -12,7 +12,7 @@ import {
   recordMatcherOperator
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
-import { IntegrationError } from '@segment/actions-core'
+import { PayloadValidationError } from '@segment/actions-core'
 const OPERATIONS_WITH_CUSTOM_FIELDS = ['create', 'update', 'upsert']
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -44,7 +44,7 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: async (request, { settings, payload }) => {
     if (OPERATIONS_WITH_CUSTOM_FIELDS.includes(payload.operation) && !payload.customFields) {
-      throw new IntegrationError('Custom fields are required for this operation.')
+      throw new PayloadValidationError('Custom fields are required for this operation.')
     }
 
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)
@@ -69,7 +69,7 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   performBatch: async (request, { settings, payload }) => {
     if (OPERATIONS_WITH_CUSTOM_FIELDS.includes(payload[0].operation) && !payload[0].customFields) {
-      throw new IntegrationError('Custom fields are required for this operation.')
+      throw new PayloadValidationError('Custom fields are required for this operation.')
     }
 
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)

--- a/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
@@ -13,6 +13,8 @@ import {
 } from '../sf-properties'
 import Salesforce from '../sf-operations'
 
+const OPERATIONS_WITH_CUSTOM_FIELDS = ['create', 'update', 'upsert']
+
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Custom Object',
   description: 'Create, update, or upsert records in any custom or standard object in Salesforce.',
@@ -31,7 +33,7 @@ const action: ActionDefinition<Settings, Payload> = {
       required: true,
       dynamic: true
     },
-    customFields: { ...customFields, required: true }
+    customFields: customFields
   },
   dynamicFields: {
     customObjectName: async (request, data) => {
@@ -41,6 +43,10 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, { settings, payload }) => {
+    if (OPERATIONS_WITH_CUSTOM_FIELDS.includes(payload.operation) && !payload.customFields) {
+      throw new Error('Custom fields are required for this operation.')
+    }
+
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)
 
     if (payload.operation === 'create') {
@@ -62,6 +68,10 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   performBatch: async (request, { settings, payload }) => {
+    if (OPERATIONS_WITH_CUSTOM_FIELDS.includes(payload[0].operation) && !payload[0].customFields) {
+      throw new Error('Custom fields are required for this operation.')
+    }
+
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)
 
     return sf.bulkHandler(payload, payload[0].customObjectName)

--- a/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
@@ -56,6 +56,10 @@ const action: ActionDefinition<Settings, Payload> = {
     if (payload.operation === 'upsert') {
       return await sf.upsertRecord(payload, payload.customObjectName)
     }
+
+    if (payload.operation === 'delete') {
+      return await sf.deleteRecord(payload, payload.customObjectName)
+    }
   },
   performBatch: async (request, { settings, payload }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)

--- a/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * The Salesforce operation performed. The available operations are Create, Update or Upsert records in Salesforce.
+   * The Salesforce operation performed. The available operations are Create, Delete, Update or Upsert records in Salesforce.
    */
   operation: string
   /**
@@ -14,11 +14,11 @@ export interface Payload {
    */
   enable_batching?: boolean
   /**
-   * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
+   * The fields used to find Salesforce records for updates. **This is required if the operation is Delete, Update or Upsert.**
    *
    *   Any field can function as a matcher, including Record ID, External IDs, standard fields and custom fields. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.
    *
-   *   If multiple records are found, no updates will be made. **Please use fields that result in unique records.**
+   *   If multiple records are found, no changes will be made. **Please use fields that result in unique records.**
    *
    *   ---
    *

--- a/packages/destination-actions/src/destinations/salesforce/lead/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/index.ts
@@ -158,6 +158,10 @@ const action: ActionDefinition<Settings, Payload> = {
       }
       return await sf.upsertRecord(payload, OBJECT_NAME)
     }
+
+    if (payload.operation === 'delete') {
+      return await sf.deleteRecord(payload, OBJECT_NAME)
+    }
   },
   performBatch: async (request, { settings, payload }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)

--- a/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * The Salesforce operation performed. The available operations are Create, Update or Upsert records in Salesforce.
+   * The Salesforce operation performed. The available operations are Create, Delete, Update or Upsert records in Salesforce.
    */
   operation: string
   /**
@@ -14,11 +14,11 @@ export interface Payload {
    */
   enable_batching?: boolean
   /**
-   * The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
+   * The fields used to find Salesforce records for updates. **This is required if the operation is Delete, Update or Upsert.**
    *
    *   Any field can function as a matcher, including Record ID, External IDs, standard fields and custom fields. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.
    *
-   *   If multiple records are found, no updates will be made. **Please use fields that result in unique records.**
+   *   If multiple records are found, no changes will be made. **Please use fields that result in unique records.**
    *
    *   ---
    *

--- a/packages/destination-actions/src/destinations/salesforce/opportunity/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity/index.ts
@@ -75,6 +75,10 @@ const action: ActionDefinition<Settings, Payload> = {
       }
       return await sf.upsertRecord(payload, OBJECT_NAME)
     }
+
+    if (payload.operation === 'delete') {
+      return await sf.deleteRecord(payload, OBJECT_NAME)
+    }
   },
   performBatch: async (request, { settings, payload }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)

--- a/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
@@ -123,6 +123,25 @@ export default class Salesforce {
     return await this.baseUpdate(recordId, sobject, payload)
   }
 
+  deleteRecord = async (payload: GenericPayload, sobject: string) => {
+    if (!payload.traits || Object.keys(payload.traits).length === 0) {
+      throw new IntegrationError('Undefined Traits when using delete operation', 'Undefined Traits', 400)
+    }
+
+    if (Object.keys(payload.traits).includes('Id') && payload.traits['Id']) {
+      return await this.baseDelete(payload.traits['Id'] as string, sobject)
+    }
+
+    const soqlOperator: SOQLOperator = validateSOQLOperator(payload.recordMatcherOperator)
+    const [recordId, err] = await this.lookupTraits(payload.traits, sobject, soqlOperator)
+
+    if (err) {
+      throw err
+    }
+
+    return await this.baseDelete(recordId, sobject)
+  }
+
   bulkHandler = async (payloads: GenericPayload[], sobject: string) => {
     if (!payloads[0].enable_batching) {
       throwBulkMismatchError()
@@ -132,6 +151,14 @@ export default class Salesforce {
       return await this.bulkUpsert(payloads, sobject)
     } else if (payloads[0].operation === 'update') {
       return await this.bulkUpdate(payloads, sobject)
+    }
+
+    if (payloads[0].operation === 'delete') {
+      throw new IntegrationError(
+        `Unsupported operation: Bulk API does not support the delete operation`,
+        'Unsupported operation',
+        400
+      )
     }
 
     throw new IntegrationError(
@@ -260,6 +287,12 @@ export default class Salesforce {
     return this.request(`${this.instanceUrl}services/data/${API_VERSION}/sobjects/${sobject}/${recordId}`, {
       method: 'patch',
       json: json
+    })
+  }
+
+  private baseDelete = async (recordId: string, sobject: string) => {
+    return this.request(`${this.instanceUrl}services/data/${API_VERSION}/sobjects/${sobject}/${recordId}`, {
+      method: 'delete'
     })
   }
 

--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -4,7 +4,7 @@ import { IntegrationError } from '@segment/actions-core'
 export const operation: InputField = {
   label: 'Operation',
   description:
-    'The Salesforce operation performed. The available operations are Create, Update or Upsert records in Salesforce.',
+    'The Salesforce operation performed. The available operations are Create, Delete, Update or Upsert records in Salesforce.',
   type: 'string',
   required: true,
   choices: [
@@ -65,11 +65,11 @@ export const recordMatcherOperator: InputField = {
 
 export const traits: InputField = {
   label: 'Record Matchers',
-  description: `The fields used to find Salesforce records for updates. **This is required if the operation is Update or Upsert.**
+  description: `The fields used to find Salesforce records for updates. **This is required if the operation is Delete, Update or Upsert.**
 
   Any field can function as a matcher, including Record ID, External IDs, standard fields and custom fields. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.  
   
-  If multiple records are found, no updates will be made. **Please use fields that result in unique records.**
+  If multiple records are found, no changes will be made. **Please use fields that result in unique records.**
   
   ---
 

--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -10,7 +10,8 @@ export const operation: InputField = {
   choices: [
     { label: 'Create new record', value: 'create' },
     { label: 'Update existing record', value: 'update' },
-    { label: `Update or create a record if one doesn't exist`, value: 'upsert' }
+    { label: `Update or create a record if one doesn't exist`, value: 'upsert' },
+    { label: 'Delete existing record', value: 'delete' }
   ]
 }
 
@@ -97,7 +98,7 @@ interface Payload {
 }
 
 export const validateLookup = (payload: Payload) => {
-  if (payload.operation === 'update' || payload.operation === 'upsert') {
+  if (payload.operation === 'update' || payload.operation === 'upsert' || payload.operation === 'delete') {
     if (!payload.traits) {
       throw new IntegrationError(
         'Undefined lookup traits for update or upsert operation',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR implements the Salesforce delete operation for every action. The operation will lookup a record given some traits and if that record exists, call the delete endpoint using it's Id. This is being added to reach feature parity with the Salesforce (Classic) integration, which allows deletions.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment

The Delete operation being triggered:
<img width="1576" alt="Screenshot 2023-04-05 at 3 31 13 PM" src="https://user-images.githubusercontent.com/27820201/230226697-2754fe13-72d8-4ea8-a9c6-328cc9a0de0f.png">

The record being looked up for deletion:
<img width="1165" alt="Screenshot 2023-04-05 at 3 30 43 PM" src="https://user-images.githubusercontent.com/27820201/230226871-999d8ef5-fb83-49e8-9cd5-a4c8673be674.png">

The record is deleted:
<img width="1169" alt="Screenshot 2023-04-05 at 3 31 24 PM" src="https://user-images.githubusercontent.com/27820201/230226829-29fcc47a-0acb-4770-9949-6a8625860879.png">
 