### PR TITLE
Group call - Allowing multiple object types with object_type_id as a trait

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/__tests__/createUpdateObject.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/createUpdateObject.test.ts
@@ -30,8 +30,7 @@ describe('CustomerIO', () => {
       const attributes = {
         name: 'Sales',
         industry: 'Technology',
-        created_at: dayjs.utc(timestamp).unix(),
-        object_type_id: '1'
+        created_at: dayjs.utc(timestamp).unix()
       }
       trackObjectService.post(`/api/v2/entity`).reply(200, {}, { 'x-customerio-region': 'US' })
       const event = createTestEvent({
@@ -87,8 +86,7 @@ describe('CustomerIO', () => {
       const attributes = {
         name: 'Sales',
         industry: 'Technology',
-        created_at: dayjs.utc(timestamp).unix(),
-        object_type_id: '1'
+        created_at: dayjs.utc(timestamp).unix()
       }
       trackEUObjectService.post(`/api/v2/entity`).reply(200, {}, { 'x-customerio-region': 'EU' })
       const event = createTestEvent({
@@ -142,8 +140,7 @@ describe('CustomerIO', () => {
       const attributes = {
         name: 'Sales',
         industry: 'Technology',
-        created_at: dayjs.utc(timestamp).unix(),
-        object_type_id: '1'
+        created_at: dayjs.utc(timestamp).unix()
       }
       trackObjectService.post(`/api/v2/entity`).reply(200, {}, { 'x-customerio-region': 'US-fallback' })
       const event = createTestEvent({
@@ -196,8 +193,7 @@ describe('CustomerIO', () => {
 
       const attributes = {
         name: 'Sales',
-        created_at: dayjs.utc(timestamp).unix(),
-        object_type_id: '1'
+        created_at: dayjs.utc(timestamp).unix()
       }
       trackObjectService.post(`/api/v2/entity`).reply(200, {}, { 'x-customerio-region': 'US' })
       const event = createTestEvent({
@@ -230,6 +226,60 @@ describe('CustomerIO', () => {
           object_id: groupId
         },
         cio_relationships: [{ identifiers: { anonymous_id: anonymousId } }]
+      })
+    })
+
+    it('should work with object_type_id given in the traits', async () => {
+      const settings: Settings = {
+        siteId: '12345',
+        apiKey: 'abcde',
+        accountRegion: AccountRegion.US
+      }
+      const userId = 'abc123'
+      const anonymousId = 'unknown_123'
+      const timestamp = dayjs.utc().toISOString()
+      const groupId = 'grp123'
+      const traits = {
+        name: 'Sales',
+        created_at: timestamp,
+        object_type_id: '2'
+      }
+
+      const attributes = {
+        name: 'Sales',
+        created_at: dayjs.utc(timestamp).unix()
+      }
+      trackObjectService.post(`/api/v2/entity`).reply(200, {}, { 'x-customerio-region': 'US' })
+      const event = createTestEvent({
+        userId,
+        anonymousId,
+        timestamp,
+        traits,
+        groupId
+      })
+      const responses = await testDestination.testAction('createUpdateObject', {
+        event,
+        settings,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].headers.toJSON()).toMatchObject({
+        'x-customerio-region': 'US',
+        'content-type': 'application/json'
+      })
+      expect(responses[0].data).toMatchObject({})
+      expect(responses[0].options.json).toMatchObject({
+        attributes: attributes,
+        created_at: dayjs.utc(timestamp).unix(),
+        type: 'object',
+        action: 'identify',
+        identifiers: {
+          object_type_id: '2',
+          object_id: groupId
+        },
+        cio_relationships: [{ identifiers: { id: userId } }]
       })
     })
 
@@ -301,6 +351,10 @@ describe('CustomerIO', () => {
         name: 'Sales',
         object_type_id: '1'
       }
+
+      const attributes = {
+        name: 'Sales'
+      }
       trackObjectService.post(`/api/v2/entity`).reply(200, {}, { 'x-customerio-region': 'US' })
       const event = createTestEvent({
         userId,
@@ -323,7 +377,7 @@ describe('CustomerIO', () => {
       })
       expect(responses[0].data).toMatchObject({})
       expect(responses[0].options.json).toMatchObject({
-        attributes: traits,
+        attributes: attributes,
         type: 'object',
         action: 'identify',
         identifiers: {

--- a/packages/destination-actions/src/destinations/customerio/createUpdateObject/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/createUpdateObject/index.ts
@@ -73,6 +73,7 @@ const action: ActionDefinition<Settings, Payload> = {
   perform: (request, { settings, payload }) => {
     let createdAt: string | number | undefined = payload.created_at
     let customAttributes = payload.custom_attributes
+    let objectTypeIDInTraits = null
     const objectTypeID = payload.object_type_id
     const userID = payload.user_id
     const objectID = payload.id
@@ -84,6 +85,10 @@ const action: ActionDefinition<Settings, Payload> = {
 
       if (customAttributes) {
         customAttributes = convertAttributeTimestamps(customAttributes)
+        if (customAttributes.object_type_id) {
+          objectTypeIDInTraits = customAttributes.object_type_id
+          delete customAttributes.object_type_id
+        }
       }
     }
 
@@ -93,7 +98,7 @@ const action: ActionDefinition<Settings, Payload> = {
       body.created_at = createdAt
     }
     body.type = 'object'
-    body.identifiers = { object_type_id: objectTypeID ?? '1', object_id: objectID }
+    body.identifiers = { object_type_id: objectTypeIDInTraits ?? objectTypeID ?? '1', object_id: objectID }
 
     if (userID) {
       body.action = 'identify'

--- a/packages/destination-actions/src/destinations/customerio/createUpdatePerson/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/createUpdatePerson/index.ts
@@ -85,6 +85,7 @@ const action: ActionDefinition<Settings, Payload> = {
   perform: (request, { settings, payload }) => {
     let createdAt: string | number | undefined = payload.created_at
     let customAttributes = payload.custom_attributes
+    let objectTypeIDInTraits = null
     const objectId = payload.group_id
     const objectTypeId = payload.object_type_id
 
@@ -95,6 +96,10 @@ const action: ActionDefinition<Settings, Payload> = {
 
       if (customAttributes) {
         customAttributes = convertAttributeTimestamps(customAttributes)
+        if (customAttributes.object_type_id && objectId) {
+          objectTypeIDInTraits = customAttributes.object_type_id
+          delete customAttributes.object_type_id
+        }
       }
     }
 
@@ -112,7 +117,9 @@ const action: ActionDefinition<Settings, Payload> = {
     if (objectId) {
       body.cio_relationships = {
         action: 'add_relationships',
-        relationships: [{ identifiers: { object_type_id: objectTypeId ?? '1', object_id: objectId } }]
+        relationships: [
+          { identifiers: { object_type_id: objectTypeIDInTraits ?? objectTypeId ?? '1', object_id: objectId } }
+        ]
       }
     }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._
Customerio is now supporting multiple object types.
These changes are to allow sending information from segment.
The object type is information can be sent using traits.
If the object_type_id property is present in traits it takes precedence.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
