### PR TITLE
Properly retrieve email

### DIFF
--- a/packages/destination-actions/src/destinations/encharge/common-definitions.ts
+++ b/packages/destination-actions/src/destinations/encharge/common-definitions.ts
@@ -14,7 +14,13 @@ export const commonFields: ActionDefinition<Settings>['fields'] = {
     required: false,
     description: 'The email address of the user.',
     label: 'Email',
-    default: { '@path': '$.email' }
+    default: {
+      '@if': {
+        exists: { '@path': '$.context.traits.email' },
+        then: { '@path': '$.context.traits.email' },
+        else: { '@path': '$.properties.email' }
+      }
+    }
   },
   segmentAnonymousId: {
     type: 'string',

--- a/packages/destination-actions/src/destinations/encharge/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/encharge/identifyUser/generated-types.ts
@@ -8,13 +8,13 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * The type of event.
-   */
-  type: string
-  /**
    * The email address of the user.
    */
   email?: string
+  /**
+   * The type of event.
+   */
+  type: string
   /**
    * An anonymous identifier for this user.
    */

--- a/packages/destination-actions/src/destinations/encharge/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/encharge/identifyUser/index.ts
@@ -18,7 +18,20 @@ const action: ActionDefinition<Settings, Payload> = {
       required: false,
       default: { '@path': '$.traits' }
     },
-    ...commonFields
+    email: {
+      type: 'string',
+      required: false,
+      description: 'The email address of the user.',
+      label: 'Email',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.email' },
+          then: { '@path': '$.traits.email' },
+          else: { '@path': '$.context.traits.email' }
+        }
+      }
+    },
+    ...omit(commonFields, 'email')
   },
   defaultSubscription: 'type = "identify"',
   perform: (request, data) => {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Hello, this PR is updating the paths where the user's email can be found.

For "identify" events, first look in `traits.email`, then in `context.traits.email`.

For "track" and "pageview" events, first check `context.traits.email` and then `properties.email`.

Does this make sense?

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
