### PR TITLE
Add new CLI command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -96,7 +96,8 @@
       }
     },
     "hooks": {
-      "init": "./src/hooks/init.ts"
+      "init": "./src/hooks/init.ts",
+      "lowcode": "./src/hooks/lowcode.ts"
     }
   },
   "jest": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -97,7 +97,7 @@
     },
     "hooks": {
       "init": "./src/hooks/init.ts",
-      "lowcode": "./src/hooks/lowcode.ts"
+      "scaffold": "./src/hooks/scaffold.ts"
     }
   },
   "jest": {

--- a/packages/cli/src/commands/lowcode.ts
+++ b/packages/cli/src/commands/lowcode.ts
@@ -21,11 +21,10 @@ const pretterOptions = prettier.resolveConfig.sync(process.cwd())
 export default class Init extends Command {
   private spinner: ora.Ora = ora()
 
-  static description = `Scaffolds a new integration with a template. This does not register or deploy the integration.`
+  static description = `Scaffolds a new integration given a JSON configuration`
 
   static examples = [
-    `$ ./bin/run init my-integration`,
-    `$ ./bin/run init my-integration --directory packages/destination-actions --template basic-auth`
+    `$ ./bin/run lowcode`
   ]
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -136,7 +135,7 @@ export default class Init extends Command {
             httpMethod: action.httpMethod,
             performJSON: action.mappings
           },
-          flags.force
+          true
         )
         this.spinner.succeed(chalk`Scaffold action {magenta ${action.name}}`)
       } catch (err) {

--- a/packages/cli/src/commands/lowcode.ts
+++ b/packages/cli/src/commands/lowcode.ts
@@ -23,9 +23,7 @@ export default class Init extends Command {
 
   static description = `Scaffolds a new integration given a JSON configuration`
 
-  static examples = [
-    `$ ./bin/run lowcode`
-  ]
+  static examples = [`$ ./bin/run lowcode`]
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static flags: flags.Input<any> = {
@@ -118,7 +116,7 @@ export default class Init extends Command {
       this.exit()
     }
 
-    for (let action of actions) {
+    for (const action of actions) {
       const actionsTargetDirectory = `${targetDirectory}/${action.name}`
 
       try {
@@ -142,7 +140,7 @@ export default class Init extends Command {
         this.spinner.fail(chalk`Scaffold action {magenta ${action.name}}: ${chalk.red(err.message)}`)
         this.exit()
       }
-      
+
       try {
         this.spinner.start(`Creating snapshot tests for ${chalk.bold(`${destination}'s ${slug}`)} destination action`)
         renderTemplates(

--- a/packages/cli/src/commands/lowcode.ts
+++ b/packages/cli/src/commands/lowcode.ts
@@ -1,0 +1,217 @@
+import { Command, flags } from '@oclif/command'
+import chalk from 'chalk'
+import ora from 'ora'
+import path from 'path'
+import { autoPrompt } from '../lib/prompt'
+import globby from 'globby'
+import { renderTemplates } from '../lib/templates'
+import GenerateTypes from './generate/types'
+import fs from 'fs-extra'
+import { camelCase, startCase } from 'lodash'
+import { addKeyToExport } from '../lib/codemods'
+
+export default class Init extends Command {
+  private spinner: ora.Ora = ora()
+
+  static description = `Scaffolds a new integration with a template. This does not register or deploy the integration.`
+
+  static examples = [
+    `$ ./bin/run init my-integration`,
+    `$ ./bin/run init my-integration --directory packages/destination-actions --template basic-auth`
+  ]
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static flags: flags.Input<any> = {
+    help: flags.help({ char: 'h' }),
+    directory: flags.string({
+      char: 'd',
+      description: 'target directory to scaffold the integration',
+      default: './packages/destination-actions/src/destinations'
+    }),
+    name: flags.string({ char: 'n', description: 'name of the integration' }),
+    slug: flags.string({ char: 's', description: 'url-friendly slug of the integration' }),
+    template: flags.enum({
+      char: 't',
+      options: ['basic-auth', 'custom-auth', 'oauth2-auth', 'minimal'],
+      description: 'the template to use to scaffold your integration'
+    })
+  }
+
+  static args = [
+    {
+      name: 'path',
+      description: 'path to scaffold the integration'
+    }
+  ]
+
+  async integrationDirs(glob: string) {
+    const integrationDirs = await globby(glob, {
+      expandDirectories: false,
+      onlyDirectories: true,
+      gitignore: true,
+      ignore: ['node_modules']
+    })
+
+    return integrationDirs
+  }
+
+  parseFlags() {
+    return this.parse(Init)
+  }
+
+  async run() {
+    const { args, flags } = this.parseFlags()
+    const answers = await autoPrompt(flags, [
+      {
+        type: 'text',
+        name: 'json',
+        message: 'JSON: ',
+        format: (val) => JSON.parse(val)
+      }
+    ])
+
+    const name = answers.json.name
+    const slug = answers.json.slug
+    const authenticationScheme = answers.json.authenticationScheme
+    const actions = answers.json.actions
+
+    console.log('actions: ', actions)
+
+    const directory = answers.directory
+
+    // For now, include the slug in the path, but when we support external repos, we'll have to change this
+    const slugWithoutActions = String(slug).replace('actions-', '')
+    const relativePath = path.join(directory, args.path || slugWithoutActions)
+    const targetDirectory = path.join(process.cwd(), relativePath)
+    const templatePath = path.join(__dirname, '../../templates/destinations/lowcode', authenticationScheme)
+    const snapshotPath = path.join(__dirname, '../../templates/actions/snapshot')
+
+    const destinationFolder = path.parse(directory).base
+    const destination = startCase(camelCase(destinationFolder)).replace(/ /g, '')
+    const actionsSnapshotPath = path.join(__dirname, '../../templates/actions/action-snapshot')
+
+    let actionsTemplatePath = path.join(__dirname, '../../templates/actions/empty-action-lowcode')
+
+    try {
+      this.spinner.start(`Creating ${chalk.bold(name)}`)
+      renderTemplates(templatePath, targetDirectory, answers)
+      this.spinner.succeed(`Scaffold integration`)
+    } catch (err) {
+      this.spinner.fail(`Scaffold integration: ${chalk.red(err.message)}`)
+      this.exit()
+    }
+
+    try {
+      this.spinner.start(chalk`Generating types for {magenta ${slug}} destination`)
+      await GenerateTypes.run(['--path', `${relativePath}/index.ts`])
+      this.spinner.succeed()
+    } catch (err) {
+      this.spinner.fail(chalk`Generating types for {magenta ${slug}} destination: ${err.message}`)
+    }
+
+    try {
+      this.spinner.start(`Creating snapshot tests for ${chalk.bold(slug)} destination`)
+      renderTemplates(
+        snapshotPath,
+        targetDirectory,
+        {
+          destination: slug,
+          // json: JSON.parse(answers.json)
+        },
+        true
+      )
+      this.spinner.succeed(`Created snapshot tests for ${slug} destination`)
+    } catch (err) {
+      this.spinner.fail(`Snapshot test creation failed: ${chalk.red(err.message)}`)
+      this.exit()
+    }
+
+    for (let action of actions) {
+
+      console.log('action: ', action)
+      const actionsTargetDirectory = `${targetDirectory}/${action.name}`
+      console.log('actionsTargetDirectory: ', targetDirectory)
+
+
+      
+      try {
+        renderTemplates(
+          actionsTemplatePath,
+          actionsTargetDirectory,
+          {
+            name: action.name,
+            description: action.description,
+            slug,
+            destination,
+            fields: action.fields,
+            apiEndpoint: action.apiEndpoint,
+            httpMethod: action.httpMethod
+          },
+          flags.force
+        )
+        this.spinner.succeed(`Scaffold action`)
+      } catch (err) {
+        this.spinner.fail(`Scaffold action: ${chalk.red(err.message)}`)
+        this.exit()
+      }
+      
+      try {
+        this.spinner.start(`Creating snapshot tests for ${chalk.bold(`${destination}'s ${slug}`)} destination action`)
+        renderTemplates(
+          actionsSnapshotPath,
+          actionsTargetDirectory,
+          {
+            destination: destination,
+            actionSlug: slug
+          },
+          true
+        )
+        this.spinner.succeed(`Creating snapshot tests for ${chalk.bold(`${destination}'s ${slug}`)} destination action`)
+      } catch (err) {
+        this.spinner.fail(`Snapshot test creation failed: ${chalk.red(err.message)}`)
+        this.exit()
+      }
+  
+      // Update destination with action
+      const entryFile = require.resolve(path.relative(__dirname, path.join(process.cwd(), actionsTargetDirectory)))
+      try {
+        this.spinner.start(chalk`Updating destination definition`)
+        const destinationStr = fs.readFileSync(entryFile, 'utf8')
+        const exportName = 'default'
+        const updatedCode = addKeyToExport(destinationStr, exportName, 'actions', slug)
+        fs.writeFileSync(entryFile, updatedCode, 'utf8')
+        this.spinner.succeed()
+      } catch (err) {
+        this.spinner.fail(chalk`Failed to update your destination imports: ${err.message}`)
+        this.exit()
+      }
+  
+      try {
+        this.spinner.start(chalk`Generating types for {magenta ${slug}} action`)
+        await GenerateTypes.run(['--path', entryFile])
+        this.spinner.succeed()
+      } catch (err) {
+        this.spinner.fail(chalk`Generating types for {magenta ${slug}} action: ${err.message}`)
+        this.exit()
+      }
+    }
+
+    this.log(chalk.green(`Done creating "${name}" 🎉`))
+    this.log(chalk.green(`Start coding! cd ${actionsTargetDirectory}`))
+  }
+
+  async catch(error: unknown) {
+    if (this.spinner?.isSpinning) {
+      this.spinner.fail()
+    }
+    throw error
+  }
+}
+
+
+
+
+
+
+
+

--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -92,6 +92,8 @@ export default class Init extends Command {
     const actionsSnapshotPath = path.join(__dirname, '../../templates/actions/action-snapshot')
     const actionsTemplatePath = path.join(__dirname, '../../templates/actions/empty-action-lowcode')
 
+    const overwriteExisting = true
+
     try {
       this.spinner.start(`Creating ${chalk.bold(name)}`)
       renderTemplates(templatePath, targetDirectory, answers)
@@ -108,7 +110,7 @@ export default class Init extends Command {
         {
           destination: slug
         },
-        true
+        overwriteExisting
       )
       this.spinner.succeed(chalk`Created snapshot tests for {magenta ${slug}} destination`)
     } catch (err) {
@@ -133,7 +135,7 @@ export default class Init extends Command {
             httpMethod: action.httpMethod,
             performJSON: action.mappings
           },
-          true
+          overwriteExisting
         )
         this.spinner.succeed(chalk`Scaffold action {magenta ${action.name}}`)
       } catch (err) {
@@ -150,7 +152,7 @@ export default class Init extends Command {
             destination: destination,
             actionSlug: slug
           },
-          true
+          overwriteExisting
         )
         this.spinner.succeed(chalk`Creating snapshot tests for action {magenta ${action.name}}`)
       } catch (err) {

--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -117,7 +117,7 @@ export default class Init extends Command {
     }
 
     for (const action of actions) {
-      const actionsTargetDirectory = `${targetDirectory}/${action.name}`
+      const actionsTargetDirectory = `${targetDirectory}/${action.key}`
 
       try {
         renderTemplates(

--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -23,7 +23,7 @@ export default class Init extends Command {
 
   static description = `Scaffolds a new integration given a JSON configuration`
 
-  static examples = [`$ ./bin/run lowcode`]
+  static examples = [`$ ./bin/run scaffold`]
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static flags: flags.Input<any> = {

--- a/packages/cli/templates/actions/empty-action-lowcode/index.ts
+++ b/packages/cli/templates/actions/empty-action-lowcode/index.ts
@@ -7,11 +7,14 @@ const action: ActionDefinition<Settings, Payload> = {
   description: '{{description}}',
   fields: {
     {{#fields}}
-   {{name}}: {
+   {{key}}: {
      label: '{{label}}',
      description: '{{description}}',
      type: '{{type}}',
-     required: {{required}}
+     required: {{required}},
+     {{#default}}
+     default: {{{value}}}
+     {{/default}}
    },
    {{/fields}}
   },
@@ -20,7 +23,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: '{{httpMethod}}',
       json: {
         {{ #fields }}
-        {{name}}: {{mapping}},
+        {{key}}: {{mapping}},
         {{/fields}}
       }
     })

--- a/packages/cli/templates/actions/empty-action-lowcode/index.ts
+++ b/packages/cli/templates/actions/empty-action-lowcode/index.ts
@@ -18,7 +18,11 @@ const action: ActionDefinition<Settings, Payload> = {
   perform: (request, { payload }) => {
     return request('{{{apiEndpoint}}}', {
       method: '{{httpMethod}}',
-      json: '{{ performJSON }}'
+      json: {
+        {{ #fields }}
+        {{name}}: {{mapping}},
+        {{/fields}}
+      }
     })
   }
 }

--- a/packages/cli/templates/actions/empty-action-lowcode/index.ts
+++ b/packages/cli/templates/actions/empty-action-lowcode/index.ts
@@ -1,0 +1,26 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: '{{name}}',
+  description: '{{description}}',
+  fields: {
+    {{#fields}}
+   {{name}}: {
+     label: '{{label}}',
+     description: '{{description}}',
+     type: '{{type}}',
+     required: {{required}}
+   },
+   {{/fields}}
+  },
+  perform: (request, { payload }) => {
+    return request('{{{apiEndpoint}}}', {
+      method: '{{httpMethod}}',
+      json: '{{ performJSON }}'
+    })
+  }
+}
+
+export default action

--- a/packages/cli/templates/destinations/lowcode/basic-auth/index.ts
+++ b/packages/cli/templates/destinations/lowcode/basic-auth/index.ts
@@ -1,0 +1,50 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+{{#json.actions}}
+import {{name}} from './{{name}}'
+{{/json.actions}}
+
+const destination: DestinationDefinition<Settings> = {
+  name: '{{json.name}}',
+  slug: '{{json.slug}}',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'basic',
+    fields: {
+      username: {
+        label: 'Username',
+        description: 'Your {{json.name}} username',
+        type: 'string',
+        required: true
+      },
+      password: {
+        label: 'password',
+        description: 'Your {{json.name}} password.',
+        type: 'string',
+        required: true
+      }
+    },
+    testAuthentication: (request) => {
+      return request('{{{json.oauth.apiEndpoint}}}', {
+        method: '{{json.oauth.httpMethod}}'
+      })
+    }
+  },
+
+  extendRequest({ settings }) {
+    return {
+      username: settings.username,
+      password: settings.password
+    }
+  },
+
+  actions: {
+    {{#json.actions}}
+    {{name}},
+    {{/json.actions}}
+  }
+}
+
+export default destination

--- a/packages/cli/templates/destinations/lowcode/custom-auth/index.ts
+++ b/packages/cli/templates/destinations/lowcode/custom-auth/index.ts
@@ -1,0 +1,39 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+{{#json.actions}}
+import {{name}} from './{{name}}'
+{{/json.actions}}
+
+const destination: DestinationDefinition<Settings> = {
+  name: '{{name}}',
+  slug: '{{slug}}',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      {{#json.oauth.fields}}
+      {{name}}: {
+        label: '{{label}}',
+        description: '{{description}}',
+        type: '{{type}}',
+        required: {{required}}
+      },
+      {{/json.oauth.fields}}
+    },
+    testAuthentication: (request) => {
+      return request('{{{json.oauth.apiEndpoint}}}', {
+        method: '{{json.oauth.httpMethod}}'
+      })
+    }
+  },
+
+  actions: {
+    {{#json.actions}}
+    {{name}},
+    {{/json.actions}}
+  }
+}
+
+export default destination

--- a/packages/cli/templates/destinations/lowcode/oauth-managed/index.ts
+++ b/packages/cli/templates/destinations/lowcode/oauth-managed/index.ts
@@ -1,0 +1,59 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+{{#json.actions}}
+import {{name}} from './{{name}}'
+{{/json.actions}}
+
+const destination: DestinationDefinition<Settings> = {
+  name: '{{json.name}}',
+  slug: '{{json.slug}}',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'oauth-managed',
+    fields: {
+      username: {
+        label: 'Username',
+        description: 'Your {{json.name}} username',
+        type: 'string',
+        required: true
+      },
+      password: {
+        label: 'password',
+        description: 'Your {{json.name}} password.',
+        type: 'string',
+        required: true
+      }
+    },
+    refreshAccessToken: async (request, { auth }) => {
+      // Return a request that refreshes the access_token if the API supports it
+      const res = await request('{{{json.oauth.apiEndpoint}}}', {
+        method: 'POST',
+        body: new URLSearchParams({
+          refresh_token: auth.refreshToken,
+          client_id: auth.clientId,
+          client_secret: auth.clientSecret,
+          grant_type: 'refresh_token'
+        })
+      })
+
+      return { accessToken: res.data.access_token }
+    }
+  },
+  extendRequest({ auth }) {
+    return {
+      headers: {
+        authorization: `Bearer ${auth?.accessToken}`
+      }
+    }
+  },
+
+  actions: {
+    {{#json.actions}}
+    {{name}},
+    {{/json.actions}}
+  }
+}
+
+export default destination

--- a/packages/cli/templates/destinations/lowcode/oauth2-auth/index.ts
+++ b/packages/cli/templates/destinations/lowcode/oauth2-auth/index.ts
@@ -1,0 +1,55 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+{{#json.actions}}
+import {{name}} from './{{name}}'
+{{/json.actions}}
+
+const destination: DestinationDefinition<Settings> = {
+  name: '{{name}}',
+  slug: '{{slug}}',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'oauth2',
+    fields: {
+      {{#json.oauth.fields}}
+      {{name}}: {
+        label: '{{label}}',
+        description: '{{description}}',
+        type: '{{type}}',
+        required: {{required}}
+      },
+      {{/json.oauth.fields}}
+    },
+    refreshAccessToken: async (request, { auth }) => {
+      // Return a request that refreshes the access_token if the API supports it
+      const res = await request('{{{json.oauth.apiEndpoint}}}', {
+        method: 'POST',
+        body: new URLSearchParams({
+          refresh_token: auth.refreshToken,
+          client_id: auth.clientId,
+          client_secret: auth.clientSecret,
+          grant_type: 'refresh_token'
+        })
+      })
+
+      return { accessToken: res.data.access_token }
+    }
+  },
+  extendRequest({ auth }) {
+    return {
+      headers: {
+        authorization: `Bearer ${auth?.accessToken}`
+      }
+    }
+  },
+
+  actions: {
+    {{#json.actions}}
+    {{name}},
+    {{/json.actions}}
+  }
+}
+
+export default destination


### PR DESCRIPTION
This PR adds a new cli command, `./bin/run scaffold`, which takes in a JSON and based on the JSON provided, scaffolds the necessarily files/folders and generates the types.

Schema for JSON in [SDD](https://docs.google.com/document/d/171eaRLeGSrgCT9hNJVS4pQO4Sc6OsbPPD4Q36Exm4bc/edit#heading=h.ki319sb0388)

Click [here](https://docs.google.com/document/d/1vvcD9kBYvJbakYlZ2u_-Uzrj0htMC4VtWLDvD7EjrB4/edit) to access Loom of CLI command.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
