### PR TITLE
[Podscribe] Add new destination

### DIFF
--- a/packages/destination-actions/src/destinations/podscribe/generated-types.ts
+++ b/packages/destination-actions/src/destinations/podscribe/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Podscribe advertiser lookup key
+   */
+  advertiser: string
+}

--- a/packages/destination-actions/src/destinations/podscribe/index.ts
+++ b/packages/destination-actions/src/destinations/podscribe/index.ts
@@ -1,11 +1,32 @@
-import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
+import { defaultValues, DestinationDefinition } from '@segment/actions-core'
 
 import track from './track'
 import page from './page'
 
+const presets: DestinationDefinition['presets'] = [
+  {
+    name: 'Order Completed Calls',
+    subscribe: 'type = "track" and event = "Order Completed"',
+    partnerAction: 'track',
+    mapping: {
+      ...defaultValues(track.fields),
+      event_type: 'purchase'
+    }
+  },
+  {
+    name: 'Signed Up Calls',
+    subscribe: 'type = "track" and event = "Signed Up"',
+    partnerAction: 'track',
+    mapping: {
+      ...defaultValues(track.fields),
+      event_type: 'signup'
+    }
+  }
+]
+
 const destination: DestinationDefinition<Settings> = {
-  name: 'Podscribe',
+  name: 'Podscribe (Actions)',
   slug: 'actions-podscribe',
   mode: 'cloud',
 
@@ -20,7 +41,7 @@ const destination: DestinationDefinition<Settings> = {
       }
     }
   },
-
+  presets,
   actions: {
     track,
     page

--- a/packages/destination-actions/src/destinations/podscribe/index.ts
+++ b/packages/destination-actions/src/destinations/podscribe/index.ts
@@ -11,7 +11,7 @@ const presets: DestinationDefinition['presets'] = [
     partnerAction: 'track',
     mapping: {
       ...defaultValues(track.fields),
-      event_type: 'purchase'
+      podscribeEvent: 'purchase'
     }
   },
   {
@@ -20,7 +20,7 @@ const presets: DestinationDefinition['presets'] = [
     partnerAction: 'track',
     mapping: {
       ...defaultValues(track.fields),
-      event_type: 'signup'
+      podscribeEvent: 'signup'
     }
   }
 ]

--- a/packages/destination-actions/src/destinations/podscribe/index.ts
+++ b/packages/destination-actions/src/destinations/podscribe/index.ts
@@ -1,0 +1,30 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import track from './track'
+import page from './page'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Podscribe',
+  slug: 'actions-podscribe',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      advertiser: {
+        label: 'Advertiser',
+        description: 'Podscribe advertiser lookup key',
+        type: 'string',
+        required: true
+      }
+    }
+  },
+
+  actions: {
+    track,
+    page
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/podscribe/index.ts
+++ b/packages/destination-actions/src/destinations/podscribe/index.ts
@@ -22,6 +22,12 @@ const presets: DestinationDefinition['presets'] = [
       ...defaultValues(track.fields),
       podscribeEvent: 'signup'
     }
+  },
+  {
+    name: 'Page Calls',
+    subscribe: 'type = "page"',
+    partnerAction: 'page',
+    mapping: defaultValues(page.fields)
   }
 ]
 

--- a/packages/destination-actions/src/destinations/podscribe/page/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/podscribe/page/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Testing snapshot for Podscribe's page destination action: all fields 1`] = `"https://verifi.podscribe.com/tag?action=view&advertiser=JyC801Hwa%5DRTOeags&timestamp=2070-10-11T07%3A49%3A42.718Z&device_id=JyC801Hwa%5DRTOeags&referrer=JyC801Hwa%5DRTOeags&url=http%3A%2F%2Fkewolbu.mm%2Fcacpo&ip=JyC801Hwa%5DRTOeags&user_agent=JyC801Hwa%5DRTOeags"`;
 
-exports[`Testing snapshot for Podscribe's page destination action: required fields 1`] = `"https://verifi.podscribe.com/tag?action=view&advertiser=JyC801Hwa%5DRTOeags"`;
+exports[`Testing snapshot for Podscribe's page destination action: required fields 1`] = `"https://verifi.podscribe.com/tag?action=view&advertiser=JyC801Hwa%5DRTOeags&timestamp=2070-10-11T07%3A49%3A42.718Z&ip=JyC801Hwa%5DRTOeags"`;
 
 exports[`Testing snapshot for Podscribe's page destination action: required fields 2`] = `
 Headers {

--- a/packages/destination-actions/src/destinations/podscribe/page/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/podscribe/page/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing snapshot for Podscribe's page destination action: all fields 1`] = `"https://verifi.podscribe.com/tag?action=view&advertiser=JyC801Hwa%5DRTOeags&timestamp=2070-10-11T07%3A49%3A42.718Z&device_id=JyC801Hwa%5DRTOeags&referrer=JyC801Hwa%5DRTOeags&url=http%3A%2F%2Fkewolbu.mm%2Fcacpo&ip=JyC801Hwa%5DRTOeags&user_agent=JyC801Hwa%5DRTOeags"`;
+exports[`Testing snapshot for Podscribe's page destination action: all fields 1`] = `"https://verifi.podscribe.com/tag?action=view&advertiser=JyC801Hwa%5DRTOeags&timestamp=FIXED_TIMESTAMP&device_id=JyC801Hwa%5DRTOeags&referrer=JyC801Hwa%5DRTOeags&url=http%3A%2F%2Fkewolbu.mm%2Fcacpo&ip=JyC801Hwa%5DRTOeags&user_agent=JyC801Hwa%5DRTOeags"`;
 
-exports[`Testing snapshot for Podscribe's page destination action: required fields 1`] = `"https://verifi.podscribe.com/tag?action=view&advertiser=JyC801Hwa%5DRTOeags&timestamp=2070-10-11T07%3A49%3A42.718Z&ip=JyC801Hwa%5DRTOeags"`;
+exports[`Testing snapshot for Podscribe's page destination action: required fields 1`] = `"https://verifi.podscribe.com/tag?action=view&advertiser=JyC801Hwa%5DRTOeags&timestamp=FIXED_TIMESTAMP&ip=JyC801Hwa%5DRTOeags"`;
 
 exports[`Testing snapshot for Podscribe's page destination action: required fields 2`] = `
 Headers {

--- a/packages/destination-actions/src/destinations/podscribe/page/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/podscribe/page/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing snapshot for Podscribe's page destination action: all fields 1`] = `""`;
+exports[`Testing snapshot for Podscribe's page destination action: all fields 1`] = `"https://verifi.podscribe.com/tag?action=view&advertiser=JyC801Hwa%5DRTOeags&timestamp=2070-10-11T07%3A49%3A42.718Z&device_id=JyC801Hwa%5DRTOeags&referrer=JyC801Hwa%5DRTOeags&url=http%3A%2F%2Fkewolbu.mm%2Fcacpo&ip=JyC801Hwa%5DRTOeags&user_agent=JyC801Hwa%5DRTOeags"`;
 
-exports[`Testing snapshot for Podscribe's page destination action: required fields 1`] = `""`;
+exports[`Testing snapshot for Podscribe's page destination action: required fields 1`] = `"https://verifi.podscribe.com/tag?action=view&advertiser=JyC801Hwa%5DRTOeags"`;
 
 exports[`Testing snapshot for Podscribe's page destination action: required fields 2`] = `
 Headers {

--- a/packages/destination-actions/src/destinations/podscribe/page/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/podscribe/page/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Podscribe's page destination action: all fields 1`] = `""`;
+
+exports[`Testing snapshot for Podscribe's page destination action: required fields 1`] = `""`;
+
+exports[`Testing snapshot for Podscribe's page destination action: required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;

--- a/packages/destination-actions/src/destinations/podscribe/page/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/podscribe/page/__tests__/index.test.ts
@@ -1,0 +1,26 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Podscribe.page', () => {
+  const TEST_ADVERTISER = 'test-advertiser'
+
+  it('should send view event', async () => {
+    const params = new URLSearchParams({ advertiser: TEST_ADVERTISER, action: 'view' })
+    nock('https://verifi.podscribe.com').get('/tag').query(params).reply(204, {})
+
+    const event = createTestEvent({
+      event: 'Test event'
+    })
+
+    const responses = await testDestination.testAction('page', {
+      mapping: { properties: {}, name: 'page-name' },
+      event,
+      settings: { advertiser: TEST_ADVERTISER }
+    })
+
+    expect(responses[0].status).toBe(204)
+  })
+})

--- a/packages/destination-actions/src/destinations/podscribe/page/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/podscribe/page/__tests__/index.test.ts
@@ -6,9 +6,16 @@ const testDestination = createTestIntegration(Destination)
 
 describe('Podscribe.page', () => {
   const TEST_ADVERTISER = 'test-advertiser'
+  const TEST_IP = '11.111.11.11'
+  const TEST_TIMESTAMP = '2021-07-12T23:02:40.563Z'
 
   it('should send view event', async () => {
-    const params = new URLSearchParams({ advertiser: TEST_ADVERTISER, action: 'view' })
+    const params = new URLSearchParams({
+      advertiser: TEST_ADVERTISER,
+      action: 'view',
+      ip: TEST_IP,
+      timestamp: TEST_TIMESTAMP
+    })
     nock('https://verifi.podscribe.com').get('/tag').query(params).reply(204, {})
 
     const event = createTestEvent({
@@ -16,7 +23,7 @@ describe('Podscribe.page', () => {
     })
 
     const responses = await testDestination.testAction('page', {
-      mapping: { properties: {}, name: 'page-name' },
+      mapping: { properties: {}, name: 'page-name', ip: TEST_IP, timestamp: TEST_TIMESTAMP },
       event,
       settings: { advertiser: TEST_ADVERTISER }
     })

--- a/packages/destination-actions/src/destinations/podscribe/page/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/podscribe/page/__tests__/snapshot.test.ts
@@ -29,16 +29,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     })
 
     const request = responses[0].request
-    const rawBody = await request.text()
-
-    try {
-      const json = JSON.parse(rawBody)
-      expect(json).toMatchSnapshot()
-      return
-    } catch (err) {
-      expect(rawBody).toMatchSnapshot()
-    }
-
+    expect(request.url).toMatchSnapshot()
     expect(request.headers).toMatchSnapshot()
   })
 
@@ -62,14 +53,6 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     })
 
     const request = responses[0].request
-    const rawBody = await request.text()
-
-    try {
-      const json = JSON.parse(rawBody)
-      expect(json).toMatchSnapshot()
-      return
-    } catch (err) {
-      expect(rawBody).toMatchSnapshot()
-    }
+    expect(request.url).toMatchSnapshot()
   })
 })

--- a/packages/destination-actions/src/destinations/podscribe/page/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/podscribe/page/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'page'
+const destinationSlug = 'Podscribe'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/podscribe/page/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/podscribe/page/__tests__/snapshot.test.ts
@@ -29,7 +29,8 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     })
 
     const request = responses[0].request
-    expect(request.url).toMatchSnapshot()
+    const request_url_fixed_timestamp = request.url.replace(/timestamp=[^&]*/g, 'timestamp=FIXED_TIMESTAMP')
+    expect(request_url_fixed_timestamp).toMatchSnapshot()
     expect(request.headers).toMatchSnapshot()
   })
 
@@ -53,6 +54,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     })
 
     const request = responses[0].request
-    expect(request.url).toMatchSnapshot()
+    const request_url_fixed_timestamp = request.url.replace(/timestamp=[^&]*/g, 'timestamp=FIXED_TIMESTAMP')
+    expect(request_url_fixed_timestamp).toMatchSnapshot()
   })
 })

--- a/packages/destination-actions/src/destinations/podscribe/page/generated-types.ts
+++ b/packages/destination-actions/src/destinations/podscribe/page/generated-types.ts
@@ -2,9 +2,9 @@
 
 export interface Payload {
   /**
-   * The ID associated with the user
+   * The anonymous ID associated with the user
    */
-  userId?: string | null
+  anonymousId?: string | null
   /**
    * The timestamp of the event
    */

--- a/packages/destination-actions/src/destinations/podscribe/page/generated-types.ts
+++ b/packages/destination-actions/src/destinations/podscribe/page/generated-types.ts
@@ -8,7 +8,7 @@ export interface Payload {
   /**
    * The timestamp of the event
    */
-  timestamp?: string
+  timestamp: string
   /**
    * The page referrer
    */
@@ -20,7 +20,7 @@ export interface Payload {
   /**
    * The IP address of the device sending the event.
    */
-  ip?: string
+  ip: string
   /**
    * The user agent of the device sending the event.
    */

--- a/packages/destination-actions/src/destinations/podscribe/page/generated-types.ts
+++ b/packages/destination-actions/src/destinations/podscribe/page/generated-types.ts
@@ -18,7 +18,7 @@ export interface Payload {
    */
   url?: string | null
   /**
-   * The if of the device sending the event.
+   * The IP address of the device sending the event.
    */
   ip?: string
   /**

--- a/packages/destination-actions/src/destinations/podscribe/page/generated-types.ts
+++ b/packages/destination-actions/src/destinations/podscribe/page/generated-types.ts
@@ -1,0 +1,28 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID associated with the user
+   */
+  userId?: string | null
+  /**
+   * The timestamp of the event
+   */
+  timestamp?: string
+  /**
+   * The page referrer
+   */
+  referrer?: string | null
+  /**
+   * The page URL
+   */
+  url?: string | null
+  /**
+   * The if of the device sending the event.
+   */
+  ip?: string
+  /**
+   * The user agent of the device sending the event.
+   */
+  userAgent?: string
+}

--- a/packages/destination-actions/src/destinations/podscribe/page/index.ts
+++ b/packages/destination-actions/src/destinations/podscribe/page/index.ts
@@ -1,0 +1,86 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { serializeParams } from '../utils'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Page',
+  description: 'Register page view in Podscribe',
+  defaultSubscription: 'type = "page"',
+  fields: {
+    userId: {
+      type: 'string',
+      allowNull: true,
+      description: 'The ID associated with the user',
+      label: 'User ID',
+      default: { '@path': '$.userId' }
+    },
+    timestamp: {
+      type: 'string',
+      format: 'date-time',
+      required: false,
+      description: 'The timestamp of the event',
+      label: 'Timestamp',
+      default: { '@path': '$.timestamp' }
+    },
+    referrer: {
+      type: 'string',
+      allowNull: true,
+      description: 'The page referrer',
+      label: 'Page Referrer',
+      default: {
+        '@if': {
+          exists: { '@path': '$.context.page.referrer' },
+          then: { '@path': '$.context.page.referrer' },
+          else: { '@path': '$.properties.referrer' }
+        }
+      }
+    },
+    url: {
+      type: 'string',
+      format: 'uri',
+      allowNull: true,
+      description: 'The page URL',
+      label: 'Page URL',
+      default: {
+        '@if': {
+          exists: { '@path': '$.context.page.url' },
+          then: { '@path': '$.context.page.url' },
+          else: { '@path': '$.properties.url' }
+        }
+      }
+    },
+    ip: {
+      label: 'Ip',
+      type: 'string',
+      description: 'The if of the device sending the event.',
+      default: {
+        '@path': '$.context.ip'
+      }
+    },
+    userAgent: {
+      label: 'User Agent',
+      type: 'string',
+      description: 'The user agent of the device sending the event.',
+      default: {
+        '@path': '$.context.userAgent'
+      }
+    }
+  },
+  perform: (request, { settings, payload }) => {
+    const params = serializeParams({
+      action: 'view',
+      advertiser: settings.advertiser,
+      timestamp: payload.timestamp,
+      device_id: payload.userId,
+      referrer: payload.referrer,
+      url: payload.url,
+      ip: payload.ip,
+      user_agent: payload.userAgent
+    })
+
+    return request(`https://verifi.podscribe.com/tag?${params}`)
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/podscribe/page/index.ts
+++ b/packages/destination-actions/src/destinations/podscribe/page/index.ts
@@ -53,7 +53,7 @@ const action: ActionDefinition<Settings, Payload> = {
     ip: {
       label: 'Ip',
       type: 'string',
-      description: 'The if of the device sending the event.',
+      description: 'The IP address of the device sending the event.',
       default: {
         '@path': '$.context.ip'
       }

--- a/packages/destination-actions/src/destinations/podscribe/page/index.ts
+++ b/packages/destination-actions/src/destinations/podscribe/page/index.ts
@@ -18,7 +18,7 @@ const action: ActionDefinition<Settings, Payload> = {
     timestamp: {
       type: 'string',
       format: 'date-time',
-      required: false,
+      required: true,
       description: 'The timestamp of the event',
       label: 'Timestamp',
       default: { '@path': '$.timestamp' }
@@ -51,8 +51,9 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     ip: {
-      label: 'Ip',
+      label: 'User IP address',
       type: 'string',
+      required: true,
       description: 'The IP address of the device sending the event.',
       default: {
         '@path': '$.context.ip'

--- a/packages/destination-actions/src/destinations/podscribe/page/index.ts
+++ b/packages/destination-actions/src/destinations/podscribe/page/index.ts
@@ -8,12 +8,12 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Register page view in Podscribe',
   defaultSubscription: 'type = "page"',
   fields: {
-    userId: {
+    anonymousId: {
       type: 'string',
       allowNull: true,
-      description: 'The ID associated with the user',
-      label: 'User ID',
-      default: { '@path': '$.userId' }
+      description: 'The anonymous ID associated with the user',
+      label: 'Anonymous ID',
+      default: { '@path': '$.anonymousId' }
     },
     timestamp: {
       type: 'string',
@@ -72,7 +72,7 @@ const action: ActionDefinition<Settings, Payload> = {
       action: 'view',
       advertiser: settings.advertiser,
       timestamp: payload.timestamp,
-      device_id: payload.userId,
+      device_id: payload.anonymousId,
       referrer: payload.referrer,
       url: payload.url,
       ip: payload.ip,

--- a/packages/destination-actions/src/destinations/podscribe/track/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/podscribe/track/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing snapshot for Podscribe's track destination action: all fields 1`] = `"https://verifi.podscribe.com/tag?action=a%40LzYSjmA%5D5%5B%298qPK%5E&advertiser=a%40LzYSjmA%5D5%5B%298qPK%5E&timestamp=2023-10-27T10%3A20%3A40.603Z&device_id=a%40LzYSjmA%5D5%5B%298qPK%5E&referrer=a%40LzYSjmA%5D5%5B%298qPK%5E&url=http%3A%2F%2Femvofe.za%2Futeputre&ip=a%40LzYSjmA%5D5%5B%298qPK%5E&user_agent=a%40LzYSjmA%5D5%5B%298qPK%5E&order_value=59632032384286.72&order_number=a%40LzYSjmA%5D5%5B%298qPK%5E&currency=SLL&discount_code=a%40LzYSjmA%5D5%5B%298qPK%5E&hashed_email=ditcem%40im.pm&num_items_purchased=5963203238428672"`;
+exports[`Testing snapshot for Podscribe's track destination action: all fields 1`] = `"https://verifi.podscribe.com/tag?action=a%40LzYSjmA%5D5%5B%298qPK%5E&advertiser=a%40LzYSjmA%5D5%5B%298qPK%5E&timestamp=FIXED_TIMESTAMP&device_id=a%40LzYSjmA%5D5%5B%298qPK%5E&referrer=a%40LzYSjmA%5D5%5B%298qPK%5E&url=http%3A%2F%2Femvofe.za%2Futeputre&ip=a%40LzYSjmA%5D5%5B%298qPK%5E&user_agent=a%40LzYSjmA%5D5%5B%298qPK%5E&order_value=59632032384286.72&order_number=a%40LzYSjmA%5D5%5B%298qPK%5E&currency=SLL&discount_code=a%40LzYSjmA%5D5%5B%298qPK%5E&hashed_email=ditcem%40im.pm&num_items_purchased=5963203238428672"`;
 
-exports[`Testing snapshot for Podscribe's track destination action: required fields 1`] = `"https://verifi.podscribe.com/tag?action=a%40LzYSjmA%5D5%5B%298qPK%5E&advertiser=a%40LzYSjmA%5D5%5B%298qPK%5E&timestamp=2023-10-27T10%3A20%3A40.603Z&ip=a%40LzYSjmA%5D5%5B%298qPK%5E"`;
+exports[`Testing snapshot for Podscribe's track destination action: required fields 1`] = `"https://verifi.podscribe.com/tag?action=a%40LzYSjmA%5D5%5B%298qPK%5E&advertiser=a%40LzYSjmA%5D5%5B%298qPK%5E&timestamp=FIXED_TIMESTAMP&ip=a%40LzYSjmA%5D5%5B%298qPK%5E"`;
 
 exports[`Testing snapshot for Podscribe's track destination action: required fields 2`] = `
 Headers {

--- a/packages/destination-actions/src/destinations/podscribe/track/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/podscribe/track/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing snapshot for Podscribe's track destination action: all fields 1`] = `"https://verifi.podscribe.com/tag?action=a%40LzYSjmA%5D5%5B%298qPK%5E&advertiser=a%40LzYSjmA%5D5%5B%298qPK%5E&timestamp=2023-10-27T10%3A20%3A40.603Z&device_id=a%40LzYSjmA%5D5%5B%298qPK%5E&referrer=a%40LzYSjmA%5D5%5B%298qPK%5E&url=http%3A%2F%2Femvofe.za%2Futeputre&ip=a%40LzYSjmA%5D5%5B%298qPK%5E&user_agent=a%40LzYSjmA%5D5%5B%298qPK%5E&hashed_email=ditcem%40im.pm"`;
+exports[`Testing snapshot for Podscribe's track destination action: all fields 1`] = `"https://verifi.podscribe.com/tag?action=a%40LzYSjmA%5D5%5B%298qPK%5E&advertiser=a%40LzYSjmA%5D5%5B%298qPK%5E&timestamp=2023-10-27T10%3A20%3A40.603Z&device_id=a%40LzYSjmA%5D5%5B%298qPK%5E&referrer=a%40LzYSjmA%5D5%5B%298qPK%5E&url=http%3A%2F%2Femvofe.za%2Futeputre&ip=a%40LzYSjmA%5D5%5B%298qPK%5E&user_agent=a%40LzYSjmA%5D5%5B%298qPK%5E&order_value=59632032384286.72&order_number=a%40LzYSjmA%5D5%5B%298qPK%5E&currency=SLL&discount_code=a%40LzYSjmA%5D5%5B%298qPK%5E&hashed_email=ditcem%40im.pm&num_items_purchased=5963203238428672"`;
 
-exports[`Testing snapshot for Podscribe's track destination action: required fields 1`] = `"https://verifi.podscribe.com/tag?action=a%40LzYSjmA%5D5%5B%298qPK%5E&advertiser=a%40LzYSjmA%5D5%5B%298qPK%5E&ip=a%40LzYSjmA%5D5%5B%298qPK%5E"`;
+exports[`Testing snapshot for Podscribe's track destination action: required fields 1`] = `"https://verifi.podscribe.com/tag?action=a%40LzYSjmA%5D5%5B%298qPK%5E&advertiser=a%40LzYSjmA%5D5%5B%298qPK%5E&timestamp=2023-10-27T10%3A20%3A40.603Z&ip=a%40LzYSjmA%5D5%5B%298qPK%5E"`;
 
 exports[`Testing snapshot for Podscribe's track destination action: required fields 2`] = `
 Headers {

--- a/packages/destination-actions/src/destinations/podscribe/track/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/podscribe/track/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing snapshot for Podscribe's track destination action: all fields 1`] = `""`;
+exports[`Testing snapshot for Podscribe's track destination action: all fields 1`] = `"https://verifi.podscribe.com/tag?action=view&advertiser=a%40LzYSjmA%5D5%5B%298qPK%5E&timestamp=2023-10-27T10%3A20%3A40.603Z&device_id=a%40LzYSjmA%5D5%5B%298qPK%5E&referrer=a%40LzYSjmA%5D5%5B%298qPK%5E&url=http%3A%2F%2Femvofe.za%2Futeputre&ip=a%40LzYSjmA%5D5%5B%298qPK%5E&user_agent=a%40LzYSjmA%5D5%5B%298qPK%5E"`;
 
-exports[`Testing snapshot for Podscribe's track destination action: required fields 1`] = `""`;
+exports[`Testing snapshot for Podscribe's track destination action: required fields 1`] = `"https://verifi.podscribe.com/tag?action=view&advertiser=a%40LzYSjmA%5D5%5B%298qPK%5E"`;
 
 exports[`Testing snapshot for Podscribe's track destination action: required fields 2`] = `
 Headers {

--- a/packages/destination-actions/src/destinations/podscribe/track/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/podscribe/track/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Podscribe's track destination action: all fields 1`] = `""`;
+
+exports[`Testing snapshot for Podscribe's track destination action: required fields 1`] = `""`;
+
+exports[`Testing snapshot for Podscribe's track destination action: required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;

--- a/packages/destination-actions/src/destinations/podscribe/track/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/podscribe/track/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing snapshot for Podscribe's track destination action: all fields 1`] = `"https://verifi.podscribe.com/tag?action=view&advertiser=a%40LzYSjmA%5D5%5B%298qPK%5E&timestamp=2023-10-27T10%3A20%3A40.603Z&device_id=a%40LzYSjmA%5D5%5B%298qPK%5E&referrer=a%40LzYSjmA%5D5%5B%298qPK%5E&url=http%3A%2F%2Femvofe.za%2Futeputre&ip=a%40LzYSjmA%5D5%5B%298qPK%5E&user_agent=a%40LzYSjmA%5D5%5B%298qPK%5E"`;
+exports[`Testing snapshot for Podscribe's track destination action: all fields 1`] = `"https://verifi.podscribe.com/tag?action=a%40LzYSjmA%5D5%5B%298qPK%5E&advertiser=a%40LzYSjmA%5D5%5B%298qPK%5E&timestamp=2023-10-27T10%3A20%3A40.603Z&device_id=a%40LzYSjmA%5D5%5B%298qPK%5E&referrer=a%40LzYSjmA%5D5%5B%298qPK%5E&url=http%3A%2F%2Femvofe.za%2Futeputre&ip=a%40LzYSjmA%5D5%5B%298qPK%5E&user_agent=a%40LzYSjmA%5D5%5B%298qPK%5E"`;
 
-exports[`Testing snapshot for Podscribe's track destination action: required fields 1`] = `"https://verifi.podscribe.com/tag?action=view&advertiser=a%40LzYSjmA%5D5%5B%298qPK%5E"`;
+exports[`Testing snapshot for Podscribe's track destination action: required fields 1`] = `"https://verifi.podscribe.com/tag?action=a%40LzYSjmA%5D5%5B%298qPK%5E&advertiser=a%40LzYSjmA%5D5%5B%298qPK%5E"`;
 
 exports[`Testing snapshot for Podscribe's track destination action: required fields 2`] = `
 Headers {

--- a/packages/destination-actions/src/destinations/podscribe/track/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/podscribe/track/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing snapshot for Podscribe's track destination action: all fields 1`] = `"https://verifi.podscribe.com/tag?action=a%40LzYSjmA%5D5%5B%298qPK%5E&advertiser=a%40LzYSjmA%5D5%5B%298qPK%5E&timestamp=2023-10-27T10%3A20%3A40.603Z&device_id=a%40LzYSjmA%5D5%5B%298qPK%5E&referrer=a%40LzYSjmA%5D5%5B%298qPK%5E&url=http%3A%2F%2Femvofe.za%2Futeputre&ip=a%40LzYSjmA%5D5%5B%298qPK%5E&user_agent=a%40LzYSjmA%5D5%5B%298qPK%5E"`;
+exports[`Testing snapshot for Podscribe's track destination action: all fields 1`] = `"https://verifi.podscribe.com/tag?action=a%40LzYSjmA%5D5%5B%298qPK%5E&advertiser=a%40LzYSjmA%5D5%5B%298qPK%5E&timestamp=2023-10-27T10%3A20%3A40.603Z&device_id=a%40LzYSjmA%5D5%5B%298qPK%5E&referrer=a%40LzYSjmA%5D5%5B%298qPK%5E&url=http%3A%2F%2Femvofe.za%2Futeputre&ip=a%40LzYSjmA%5D5%5B%298qPK%5E&user_agent=a%40LzYSjmA%5D5%5B%298qPK%5E&hashed_email=ditcem%40im.pm"`;
 
-exports[`Testing snapshot for Podscribe's track destination action: required fields 1`] = `"https://verifi.podscribe.com/tag?action=a%40LzYSjmA%5D5%5B%298qPK%5E&advertiser=a%40LzYSjmA%5D5%5B%298qPK%5E"`;
+exports[`Testing snapshot for Podscribe's track destination action: required fields 1`] = `"https://verifi.podscribe.com/tag?action=a%40LzYSjmA%5D5%5B%298qPK%5E&advertiser=a%40LzYSjmA%5D5%5B%298qPK%5E&ip=a%40LzYSjmA%5D5%5B%298qPK%5E"`;
 
 exports[`Testing snapshot for Podscribe's track destination action: required fields 2`] = `
 Headers {

--- a/packages/destination-actions/src/destinations/podscribe/track/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/podscribe/track/__tests__/index.test.ts
@@ -1,0 +1,43 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Podscribe.track', () => {
+  const TEST_ADVERTISER = 'test-advertiser'
+
+  it('should send signup event', async () => {
+    const params = new URLSearchParams({ advertiser: TEST_ADVERTISER, action: 'signup' })
+    nock('https://verifi.podscribe.com').get('/tag').query(params).reply(204, {})
+
+    const event = createTestEvent({
+      event: 'Signed Up'
+    })
+
+    const responses = await testDestination.testAction('track', {
+      event,
+      mapping: { event: 'Signed Up' },
+      settings: { advertiser: TEST_ADVERTISER }
+    })
+
+    expect(responses[0].status).toBe(204)
+  })
+
+  it('should send purchase event', async () => {
+    const params = new URLSearchParams({ advertiser: TEST_ADVERTISER, action: 'purchase' })
+    nock('https://verifi.podscribe.com').get('/tag').query(params).reply(204, {})
+
+    const event = createTestEvent({
+      event: 'Order Completed'
+    })
+
+    const responses = await testDestination.testAction('track', {
+      event,
+      mapping: { event: 'Order Completed' },
+      settings: { advertiser: TEST_ADVERTISER }
+    })
+
+    expect(responses[0].status).toBe(204)
+  })
+})

--- a/packages/destination-actions/src/destinations/podscribe/track/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/podscribe/track/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
-import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration, defaultValues } from '@segment/actions-core'
 import Destination from '../../index'
+import track from '../../track'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -8,16 +9,19 @@ describe('Podscribe.track', () => {
   const TEST_ADVERTISER = 'test-advertiser'
 
   it('should send signup event', async () => {
-    const params = new URLSearchParams({ advertiser: TEST_ADVERTISER, action: 'signup' })
-    nock('https://verifi.podscribe.com').get('/tag').query(params).reply(204, {})
+    nock('https://verifi.podscribe.com').get('/tag').query(true).reply(204, {})
 
     const event = createTestEvent({
-      event: 'Signed Up'
+      event: 'Signed Up',
+      type: 'track'
     })
 
     const responses = await testDestination.testAction('track', {
       event,
-      mapping: { event: 'Signed Up' },
+      mapping: {
+        ...defaultValues(track.fields),
+        event_type: 'signup'
+      },
       settings: { advertiser: TEST_ADVERTISER }
     })
 
@@ -25,16 +29,19 @@ describe('Podscribe.track', () => {
   })
 
   it('should send purchase event', async () => {
-    const params = new URLSearchParams({ advertiser: TEST_ADVERTISER, action: 'purchase' })
-    nock('https://verifi.podscribe.com').get('/tag').query(params).reply(204, {})
+    nock('https://verifi.podscribe.com').get('/tag').query(true).reply(204, {})
 
     const event = createTestEvent({
-      event: 'Order Completed'
+      event: 'Order Completed',
+      type: 'track'
     })
 
     const responses = await testDestination.testAction('track', {
       event,
-      mapping: { event: 'Order Completed' },
+      mapping: {
+        ...defaultValues(track.fields),
+        event_type: 'purchase'
+      },
       settings: { advertiser: TEST_ADVERTISER }
     })
 

--- a/packages/destination-actions/src/destinations/podscribe/track/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/podscribe/track/__tests__/index.test.ts
@@ -20,7 +20,7 @@ describe('Podscribe.track', () => {
       event,
       mapping: {
         ...defaultValues(track.fields),
-        event_type: 'signup'
+        podscribeEvent: 'signup'
       },
       settings: { advertiser: TEST_ADVERTISER }
     })
@@ -40,7 +40,7 @@ describe('Podscribe.track', () => {
       event,
       mapping: {
         ...defaultValues(track.fields),
-        event_type: 'purchase'
+        podscribeEvent: 'purchase'
       },
       settings: { advertiser: TEST_ADVERTISER }
     })

--- a/packages/destination-actions/src/destinations/podscribe/track/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/podscribe/track/__tests__/index.test.ts
@@ -7,6 +7,8 @@ const testDestination = createTestIntegration(Destination)
 
 describe('Podscribe.track', () => {
   const TEST_ADVERTISER = 'test-advertiser'
+  const TEST_IP = '11.111.11.11'
+  const TEST_TIMESTAMP = '2021-07-12T23:02:40.563Z'
 
   it('should send signup event', async () => {
     nock('https://verifi.podscribe.com').get('/tag').query(true).reply(204, {})
@@ -20,7 +22,9 @@ describe('Podscribe.track', () => {
       event,
       mapping: {
         ...defaultValues(track.fields),
-        podscribeEvent: 'signup'
+        podscribeEvent: 'signup',
+        ip: TEST_IP,
+        timestamp: TEST_TIMESTAMP
       },
       settings: { advertiser: TEST_ADVERTISER }
     })

--- a/packages/destination-actions/src/destinations/podscribe/track/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/podscribe/track/__tests__/snapshot.test.ts
@@ -29,7 +29,10 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     })
 
     const request = responses[0].request
-    expect(request.url).toMatchSnapshot()
+
+    const request_url_fixed_timestamp = request.url.replace(/timestamp=[^&]*/g, 'timestamp=FIXED_TIMESTAMP')
+
+    expect(request_url_fixed_timestamp).toMatchSnapshot()
 
     expect(request.headers).toMatchSnapshot()
   })
@@ -54,6 +57,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     })
 
     const request = responses[0].request
-    expect(request.url).toMatchSnapshot()
+    const request_url_fixed_timestamp = request.url.replace(/timestamp=[^&]*/g, 'timestamp=FIXED_TIMESTAMP')
+    expect(request_url_fixed_timestamp).toMatchSnapshot()
   })
 })

--- a/packages/destination-actions/src/destinations/podscribe/track/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/podscribe/track/__tests__/snapshot.test.ts
@@ -29,15 +29,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     })
 
     const request = responses[0].request
-    const rawBody = await request.text()
-
-    try {
-      const json = JSON.parse(rawBody)
-      expect(json).toMatchSnapshot()
-      return
-    } catch (err) {
-      expect(rawBody).toMatchSnapshot()
-    }
+    expect(request.url).toMatchSnapshot()
 
     expect(request.headers).toMatchSnapshot()
   })
@@ -62,14 +54,6 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     })
 
     const request = responses[0].request
-    const rawBody = await request.text()
-
-    try {
-      const json = JSON.parse(rawBody)
-      expect(json).toMatchSnapshot()
-      return
-    } catch (err) {
-      expect(rawBody).toMatchSnapshot()
-    }
+    expect(request.url).toMatchSnapshot()
   })
 })

--- a/packages/destination-actions/src/destinations/podscribe/track/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/podscribe/track/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'track'
+const destinationSlug = 'Podscribe'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/podscribe/track/generated-types.ts
+++ b/packages/destination-actions/src/destinations/podscribe/track/generated-types.ts
@@ -2,9 +2,9 @@
 
 export interface Payload {
   /**
-   * The ID associated with the user
+   * The anonymous ID associated with the user
    */
-  userId?: string | null
+  anonymousId?: string | null
   /**
    * The timestamp of the event
    */
@@ -20,15 +20,15 @@ export interface Payload {
   /**
    * The IP address of the device sending the event.
    */
-  ip?: string
+  ip: string
   /**
    * The user agent of the device sending the event.
    */
   userAgent?: string
   /**
-   * The event name
+   * Email address of the user
    */
-  event: string
+  email?: string | null
   /**
    * Properties to send with the event
    */
@@ -36,7 +36,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * Type of event to send
+   * Podscribe type of event to send
    */
-  event_type: string
+  podscribeEvent: string
 }

--- a/packages/destination-actions/src/destinations/podscribe/track/generated-types.ts
+++ b/packages/destination-actions/src/destinations/podscribe/track/generated-types.ts
@@ -54,11 +54,11 @@ export interface Payload {
      */
     num_items_purchased?: number
     /**
-     * true value Indicates if the user is a new customer
+     * true value indicates if the user is a new customer
      */
     is_new_customer?: boolean
     /**
-     * true value Indicates a subscription
+     * true value indicates a subscription
      */
     is_subscription?: boolean
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/podscribe/track/generated-types.ts
+++ b/packages/destination-actions/src/destinations/podscribe/track/generated-types.ts
@@ -8,7 +8,7 @@ export interface Payload {
   /**
    * The timestamp of the event
    */
-  timestamp?: string
+  timestamp: string
   /**
    * The page referrer
    */
@@ -33,6 +33,34 @@ export interface Payload {
    * Properties to send with the event
    */
   properties?: {
+    /**
+     * The total value of the order
+     */
+    total?: number
+    /**
+     * The order ID. A unique identifier for the order
+     */
+    order_id?: string
+    /**
+     * Currency code. e.g. USD for US dollar, EUR for Euro
+     */
+    currency?: string
+    /**
+     * Coupon Code. A Discount code for the purchase
+     */
+    coupon?: string
+    /**
+     * The number of items purchased in this order
+     */
+    num_items_purchased?: number
+    /**
+     * true value Indicates if the user is a new customer
+     */
+    is_new_customer?: boolean
+    /**
+     * true value Indicates a subscription
+     */
+    is_subscription?: boolean
     [k: string]: unknown
   }
   /**

--- a/packages/destination-actions/src/destinations/podscribe/track/generated-types.ts
+++ b/packages/destination-actions/src/destinations/podscribe/track/generated-types.ts
@@ -1,0 +1,38 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID associated with the user
+   */
+  userId?: string | null
+  /**
+   * The timestamp of the event
+   */
+  timestamp?: string
+  /**
+   * The page referrer
+   */
+  referrer?: string | null
+  /**
+   * The page URL
+   */
+  url?: string | null
+  /**
+   * The if of the device sending the event.
+   */
+  ip?: string
+  /**
+   * The user agent of the device sending the event.
+   */
+  userAgent?: string
+  /**
+   * The event name
+   */
+  event: string
+  /**
+   * Properties to send with the event
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/podscribe/track/generated-types.ts
+++ b/packages/destination-actions/src/destinations/podscribe/track/generated-types.ts
@@ -18,7 +18,7 @@ export interface Payload {
    */
   url?: string | null
   /**
-   * The if of the device sending the event.
+   * The IP address of the device sending the event.
    */
   ip?: string
   /**
@@ -35,4 +35,8 @@ export interface Payload {
   properties?: {
     [k: string]: unknown
   }
+  /**
+   * Type of event to send
+   */
+  event_type: string
 }

--- a/packages/destination-actions/src/destinations/podscribe/track/index.ts
+++ b/packages/destination-actions/src/destinations/podscribe/track/index.ts
@@ -18,7 +18,7 @@ const action: ActionDefinition<Settings, Payload> = {
     timestamp: {
       type: 'string',
       format: 'date-time',
-      required: false,
+      required: true,
       description: 'The timestamp of the event',
       label: 'Timestamp',
       default: { '@path': '$.timestamp' }
@@ -51,7 +51,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     ip: {
-      label: 'Ip',
+      label: 'User IP address',
       type: 'string',
       required: true,
       description: 'The IP address of the device sending the event.',
@@ -82,11 +82,56 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     properties: {
-      type: 'object',
-      required: false,
-      description: 'Properties to send with the event',
       label: 'Event properties',
-      default: { '@path': '$.properties' }
+      description: 'Properties to send with the event',
+      type: 'object',
+      additionalProperties: true,
+      properties: {
+        total: {
+          label: 'Total Value',
+          type: 'number',
+          description: 'The total value of the order'
+        },
+        order_id: {
+          label: 'Order id',
+          type: 'string',
+          description: 'The order ID. A unique identifier for the order'
+        },
+        currency: {
+          label: 'Currency',
+          type: 'string',
+          description: 'Currency code. e.g. USD for US dollar, EUR for Euro'
+        },
+        coupon: {
+          label: 'Coupon',
+          type: 'string',
+          description: 'Coupon Code. A Discount code for the purchase'
+        },
+        num_items_purchased: {
+          label: 'Number of Items Purchased',
+          type: 'integer',
+          description: 'The number of items purchased in this order'
+        },
+        is_new_customer: {
+          label: 'Is New Customer',
+          type: 'boolean',
+          description: 'true value Indicates if the user is a new customer'
+        },
+        is_subscription: {
+          label: 'Is Subscription',
+          type: 'boolean',
+          description: 'true value Indicates a subscription'
+        }
+      },
+      default: {
+        total: { '@path': '$.properties.total' },
+        order_id: { '@path': '$.properties.order_id' },
+        currency: { '@path': '$.properties.currency' },
+        coupon: { '@path': '$.properties.coupon' },
+        num_items_purchased: { '@path': '$.properties.num_items_purchased' },
+        is_new_customer: { '@path': '$.properties.is_new_customer' },
+        is_subscription: { '@path': '$.properties.is_subscription' }
+      }
     },
     podscribeEvent: {
       type: 'string',

--- a/packages/destination-actions/src/destinations/podscribe/track/index.ts
+++ b/packages/destination-actions/src/destinations/podscribe/track/index.ts
@@ -115,12 +115,12 @@ const action: ActionDefinition<Settings, Payload> = {
         is_new_customer: {
           label: 'Is New Customer',
           type: 'boolean',
-          description: 'true value Indicates if the user is a new customer'
+          description: 'true value indicates if the user is a new customer'
         },
         is_subscription: {
           label: 'Is Subscription',
           type: 'boolean',
-          description: 'true value Indicates a subscription'
+          description: 'true value indicates a subscription'
         }
       },
       default: {

--- a/packages/destination-actions/src/destinations/podscribe/track/index.ts
+++ b/packages/destination-actions/src/destinations/podscribe/track/index.ts
@@ -1,0 +1,118 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import { serializeParams } from '../utils'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Track',
+  description: 'Send user events to Podscribe',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    userId: {
+      type: 'string',
+      allowNull: true,
+      description: 'The ID associated with the user',
+      label: 'User ID',
+      default: { '@path': '$.userId' }
+    },
+    timestamp: {
+      type: 'string',
+      format: 'date-time',
+      required: false,
+      description: 'The timestamp of the event',
+      label: 'Timestamp',
+      default: { '@path': '$.timestamp' }
+    },
+    referrer: {
+      type: 'string',
+      allowNull: true,
+      description: 'The page referrer',
+      label: 'Page Referrer',
+      default: {
+        '@if': {
+          exists: { '@path': '$.context.page.referrer' },
+          then: { '@path': '$.context.page.referrer' },
+          else: { '@path': '$.properties.referrer' }
+        }
+      }
+    },
+    url: {
+      type: 'string',
+      format: 'uri',
+      allowNull: true,
+      description: 'The page URL',
+      label: 'Page URL',
+      default: {
+        '@if': {
+          exists: { '@path': '$.context.page.url' },
+          then: { '@path': '$.context.page.url' },
+          else: { '@path': '$.properties.url' }
+        }
+      }
+    },
+    ip: {
+      label: 'Ip',
+      type: 'string',
+      description: 'The if of the device sending the event.',
+      default: {
+        '@path': '$.context.ip'
+      }
+    },
+    userAgent: {
+      label: 'User Agent',
+      type: 'string',
+      description: 'The user agent of the device sending the event.',
+      default: {
+        '@path': '$.context.userAgent'
+      }
+    },
+    event: {
+      type: 'string',
+      required: true,
+      description: 'The event name',
+      label: 'Event Name',
+      default: { '@path': '$.event' }
+    },
+    properties: {
+      type: 'object',
+      required: false,
+      description: 'Properties to send with the event',
+      label: 'Event properties',
+      default: { '@path': '$.properties' }
+    }
+  },
+  perform: (request, { settings, payload }) => {
+    let action = 'view'
+
+    if (payload.event === 'Order Completed') {
+      action = 'purchase'
+    }
+
+    if (payload.event === 'Signed Up') {
+      action = 'signup'
+    }
+
+    const params = serializeParams({
+      action,
+      advertiser: settings.advertiser,
+      timestamp: payload.timestamp,
+      device_id: payload.userId,
+      referrer: payload.referrer,
+      url: payload.url,
+      ip: payload.ip,
+      user_agent: payload.userAgent,
+      order_value: payload.properties?.total,
+      order_number: payload.properties?.order_id,
+      currency: payload.properties?.currency,
+      discount_code: payload.properties?.coupon,
+      hashed_email: payload.properties?.email,
+      num_items_purchased: payload.properties?.num_items_purchased,
+      is_new_customer: payload.properties?.is_new_customer,
+      is_subscription: payload.properties?.is_subscription
+    })
+
+    return request(`https://verifi.podscribe.com/tag?${params}`)
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/podscribe/track/index.ts
+++ b/packages/destination-actions/src/destinations/podscribe/track/index.ts
@@ -53,7 +53,7 @@ const action: ActionDefinition<Settings, Payload> = {
     ip: {
       label: 'Ip',
       type: 'string',
-      description: 'The if of the device sending the event.',
+      description: 'The IP address of the device sending the event.',
       default: {
         '@path': '$.context.ip'
       }
@@ -79,21 +79,18 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'Properties to send with the event',
       label: 'Event properties',
       default: { '@path': '$.properties' }
+    },
+    event_type: {
+      type: 'string',
+      required: true,
+      description: 'Type of event to send',
+      label: 'Event type',
+      default: { '@path': '$.event_type' }
     }
   },
   perform: (request, { settings, payload }) => {
-    let action = 'view'
-
-    if (payload.event === 'Order Completed') {
-      action = 'purchase'
-    }
-
-    if (payload.event === 'Signed Up') {
-      action = 'signup'
-    }
-
     const params = serializeParams({
-      action,
+      action: payload.event_type,
       advertiser: settings.advertiser,
       timestamp: payload.timestamp,
       device_id: payload.userId,

--- a/packages/destination-actions/src/destinations/podscribe/track/index.ts
+++ b/packages/destination-actions/src/destinations/podscribe/track/index.ts
@@ -92,8 +92,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: true,
       description: 'Podscribe type of event to send',
-      label: 'Podscribe event type',
-      default: { '@path': '$.podscribeEvent' }
+      label: 'Podscribe event type'
     }
   },
   perform: (request, { settings, payload }) => {

--- a/packages/destination-actions/src/destinations/podscribe/track/index.ts
+++ b/packages/destination-actions/src/destinations/podscribe/track/index.ts
@@ -92,7 +92,8 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: true,
       description: 'Podscribe type of event to send',
-      label: 'Podscribe event type'
+      label: 'Podscribe event type',
+      default: { '@path': '$.properties.podscribeEvent' }
     }
   },
   perform: (request, { settings, payload }) => {

--- a/packages/destination-actions/src/destinations/podscribe/utils.ts
+++ b/packages/destination-actions/src/destinations/podscribe/utils.ts
@@ -1,0 +1,16 @@
+export const serializeParams = (params: any) => {
+  return Object.entries(params)
+    .reduce((acc, [k, v]: any[]) => {
+      if (Array.isArray(v)) {
+        for (const val of v) {
+          acc.append(k, val)
+        }
+        return acc
+      }
+      if (v) {
+        acc.append(k, v)
+      }
+      return acc
+    }, new URLSearchParams())
+    .toString()
+}


### PR DESCRIPTION
This PR adds Podscribe as a new destination.
[Podscribe](https://podscribe.com) is a verification and measurement company for advertising in podcasts 
For now, we would handle the destination for 3 user actions _view_, _signup_, _purchase_


## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
