### PR TITLE
[EXPANSION-366] fix:regionalize Sendgrid sender reference to Profiles

### DIFF
--- a/packages/destination-actions/package.json
+++ b/packages/destination-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/action-destinations",
   "description": "Destination Actions engine and definitions.",
-  "version": "3.150.0",
+  "version": "3.150.1-expansion-366.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/__tests__/send-email.test.ts
@@ -6,14 +6,36 @@ import Sendgrid from '..'
 const sendgrid = createTestIntegration(Sendgrid)
 const timestamp = new Date().toISOString()
 
-describe.each(['stage', 'production'])('%s environment', (environment) => {
+describe.each([
+  {
+    environment: 'production',
+    region: 'us-west-2',
+    endpoint: 'https://profiles.segment.com'
+  },
+  {
+    environment: 'staging',
+    region: 'us-west-2',
+    endpoint: 'https://profiles.segment.build'
+  },
+  {
+    environment: 'production',
+    region: 'eu-west-1',
+    endpoint: 'https://profiles.euw1.segment.com'
+  },
+  {
+    environment: 'staging',
+    region: 'eu-west-1',
+    endpoint: 'https://profiles.euw1.segment.build'
+  }
+])('%s', ({ environment, region, endpoint }) => {
   const settings = {
     unlayerApiKey: 'unlayerApiKey',
     sendGridApiKey: 'sendGridApiKey',
     profileApiEnvironment: environment,
     profileApiAccessToken: 'c',
     spaceId: 'spaceId',
-    sourceId: 'sourceId'
+    sourceId: 'sourceId',
+    region
   }
 
   const userData = {
@@ -23,8 +45,6 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
     phone: '+11235554657',
     email: 'test@example.com'
   }
-
-  const endpoint = `https://profiles.segment.${environment === 'production' ? 'com' : 'build'}`
 
   const sendgridRequestBody = {
     personalizations: [

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/generated-types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/generated-types.ts
@@ -25,4 +25,8 @@ export interface Settings {
    * Source ID
    */
   sourceId: string
+  /**
+   * The region where the email is originating from
+   */
+  region?: string
 }

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/index.ts
@@ -44,6 +44,12 @@ const destination: DestinationDefinition<Settings> = {
         description: 'Source ID',
         type: 'string',
         required: true
+      },
+      region: {
+        label: 'Region',
+        description: 'The region where the email is originating from',
+        type: 'string',
+        required: false
       }
     },
     testAuthentication: (request) => {

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/index.ts
@@ -49,6 +49,10 @@ const destination: DestinationDefinition<Settings> = {
         label: 'Region',
         description: 'The region where the email is originating from',
         type: 'string',
+        choices: [
+          { value: 'us-west-2', label: 'US West 2' },
+          { value: 'eu-west-1', label: 'EU West 1' }
+        ],
         required: false
       }
     },

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
@@ -327,7 +327,10 @@ const action: ActionDefinition<Settings, Payload> = {
   perform: async (request, { settings, payload, statsContext }) => {
     const statsClient = statsContext?.statsClient
     const tags = statsContext?.tags
-    tags?.push(`space_id:${settings.spaceId}`, `projectid:${settings.sourceId}`)
+    if (!settings.region) {
+      settings.region = 'us-west-2'
+    }
+    tags?.push(`space_id:${settings.spaceId}`, `projectid:${settings.sourceId}`, `region:${settings.region}`)
     if (!payload.send) {
       statsClient?.incr('actions-personas-messaging-sendgrid.send-disabled', 1, tags)
       return

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/__tests__/send-sms.test.ts
@@ -2,7 +2,6 @@ import nock from 'nock'
 import { createTestIntegration } from '@segment/actions-core'
 import { createMessagingTestEvent } from '../../../lib/engage-test-data/create-messaging-test-event'
 import Twilio from '..'
-import { Region } from '../sendSms/sms-sender'
 
 const twilio = createTestIntegration(Twilio)
 const timestamp = new Date().toISOString()
@@ -32,10 +31,9 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
     }
   }
 
-  const getProfilesEndpoint = (environment: string, region: Region = Region.usWest2) => {
-    const baseEndpoint = region === Region.euWest1 ? 'https://profiles.euw1.segment' : 'https://profiles.segment'
-
-    return `${baseEndpoint}.${environment === 'production' ? 'com' : 'build'}`
+  const getProfilesEndpoint = (environment: string) => {
+    const topLevelName = environment === 'production' ? 'com' : 'build'
+    return `https://profiles.segment.${topLevelName}`
   }
 
   beforeEach(() => {
@@ -197,55 +195,55 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       await expect(twilio.testAction('sendSms', actionInputData)).rejects.toHaveProperty('code', 'ERR_INVALID_URL')
     })
 
-    it.each([Region.euWest1, Region.usWest2])(
-      'should retrieve profiles from expected endpoint based upon region',
-      async (region) => {
-        nock.cleanAll()
-        // mock the correct endpoint
-        const usProfilesApiMock = nock(
-          `${getProfilesEndpoint(environment, Region.usWest2)}/v1/spaces/d/collections/users/profiles/user_id:jane`
-        )
-          .get('/traits?limit=200')
-          .optionally(region === Region.usWest2)
-          .reply(200, { traits: {} })
-
-        const euProfilesApiMock = nock(
-          `${getProfilesEndpoint(environment, Region.euWest1)}/v1/spaces/d/collections/users/profiles/user_id:jane`
-        )
-          .get('/traits?limit=200')
-          .optionally(region === Region.euWest1)
-          .reply(200, { traits: {} })
-
-        const expectedTwilioRequest = new URLSearchParams({
-          Body: 'Hello world, jane!',
-          From: 'MG1111222233334444',
-          To: '+1234567891'
-        })
-
-        const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
-          .post('/Messages.json', expectedTwilioRequest.toString())
-          .reply(201, {})
-
-        const actionInputData = {
-          event: createMessagingTestEvent({
-            timestamp,
-            event: 'Audience Entered',
-            userId: 'jane'
-          }),
-          settings,
-          mapping: { ...getDefaultMapping(), region }
-        }
-
-        const responses = await twilio.testAction('sendSms', actionInputData)
-
-        expect(responses.map((response) => response.url)).toStrictEqual([
-          'https://api.twilio.com/2010-04-01/Accounts/a/Messages.json'
-        ])
-        expect(twilioRequest.isDone()).toBe(true)
-        expect(euProfilesApiMock.isDone()).toBe(region === Region.euWest1)
-        expect(usProfilesApiMock.isDone()).toBe(region === Region.usWest2)
+    it.each([
+      {
+        region: 'us-west-2',
+        endpoint: 'https://profiles.segment'
+      },
+      {
+        region: 'eu-west-1',
+        endpoint: 'https://profiles.euw1.segment'
       }
-    )
+    ])('%s', async ({ region, endpoint }) => {
+      nock.cleanAll()
+      // mock the correct endpoint
+      const topLevelName = environment === 'production' ? 'com' : 'build'
+      const profilesApiMock = nock(`${endpoint}.${topLevelName}/v1/spaces/d/collections/users/profiles/user_id:jane`)
+        .get('/traits?limit=200')
+        .optionally(true)
+        .reply(200, { traits: {} })
+
+      const expectedTwilioRequest = new URLSearchParams({
+        Body: 'Hello world, jane!',
+        From: 'MG1111222233334444',
+        To: '+1234567891'
+      })
+
+      const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
+        .post('/Messages.json', expectedTwilioRequest.toString())
+        .reply(201, {})
+
+      const actionInputData = {
+        event: createMessagingTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          userId: 'jane'
+        }),
+        settings: {
+          ...settings,
+          region
+        },
+        mapping: getDefaultMapping()
+      }
+
+      const responses = await twilio.testAction('sendSms', actionInputData)
+
+      expect(responses.map((response) => response.url)).toStrictEqual([
+        'https://api.twilio.com/2010-04-01/Accounts/a/Messages.json'
+      ])
+      expect(twilioRequest.isDone()).toBe(true)
+      expect(profilesApiMock.isDone()).toBe(true)
+    })
   })
 
   describe('subscription handling', () => {

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/generated-types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/generated-types.ts
@@ -41,4 +41,8 @@ export interface Settings {
    * Connection overrides are configuration supported by twilio webhook services. Must be passed as fragments on the callback url
    */
   connectionOverrides?: string
+  /**
+   * The region where the message is originating from
+   */
+  region?: string
 }

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/index.ts
@@ -152,6 +152,16 @@ const destination: DestinationDefinition<Settings> = {
         required: false,
         default: 'rp=all&rc=5',
         properties: ConnectionOverridesProperties
+      },
+      region: {
+        label: 'Region',
+        description: 'The region where the message is originating from',
+        type: 'string',
+        choices: [
+          { value: 'us-west-2', label: 'US West 2' },
+          { value: 'eu-west-1', label: 'EU West 1' }
+        ],
+        required: false
       }
     },
     testAuthentication: (request, options) => {

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/generated-types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/generated-types.ts
@@ -62,4 +62,8 @@ export interface Payload {
    * Time of when the actual event happened.
    */
   eventOccurredTS?: string
+  /**
+   * The region where the message is originating from
+   */
+  region?: string
 }

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/generated-types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/generated-types.ts
@@ -62,8 +62,4 @@ export interface Payload {
    * Time of when the actual event happened.
    */
   eventOccurredTS?: string
-  /**
-   * The region where the message is originating from
-   */
-  region?: string
 }

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/index.ts
@@ -113,6 +113,16 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.timestamp'
       }
+    },
+    region: {
+      label: 'Region',
+      description: 'The region where the message is originating from',
+      type: 'string',
+      choices: [
+        { value: 'us-west-2', label: 'US West 2' },
+        { value: 'eu-west-1', label: 'EU West 1' }
+      ],
+      required: false
     }
   },
   perform: async (request, { settings, payload, statsContext }) => {

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/index.ts
@@ -113,23 +113,15 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.timestamp'
       }
-    },
-    region: {
-      label: 'Region',
-      description: 'The region where the message is originating from',
-      type: 'string',
-      choices: [
-        { value: 'us-west-2', label: 'US West 2' },
-        { value: 'eu-west-1', label: 'EU West 1' }
-      ],
-      required: false
     }
   },
   perform: async (request, { settings, payload, statsContext }) => {
     const statsClient = statsContext?.statsClient
     const tags = statsContext?.tags
-    tags?.push(`space_id:${settings.spaceId}`, `projectid:${settings.sourceId}`)
-
+    if (!settings.region) {
+      settings.region = 'us-west-1'
+    }
+    tags?.push(`space_id:${settings.spaceId}`, `projectid:${settings.sourceId}`, `region:${settings.region}`)
     return new SmsMessageSender(request, payload, settings, statsClient, tags).send()
   }
 }

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/sms-sender.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/sms-sender.ts
@@ -6,6 +6,11 @@ import { IntegrationError } from '@segment/actions-core'
 import { StatsClient, StatsContext } from '@segment/actions-core/src/destination-kit'
 import { MessageSender, RequestFn } from '../utils/message-sender'
 
+export enum Region {
+  usWest2 = 'us-west-2',
+  euWest1 = 'eu-west-1'
+}
+
 const Liquid = new LiquidJs()
 
 export class SmsMessageSender extends MessageSender<Payload> {
@@ -63,9 +68,9 @@ export class SmsMessageSender extends MessageSender<Payload> {
       )
     }
     try {
-      const endpoint = `https://profiles.segment.${
-        this.settings.profileApiEnvironment === 'production' ? 'com' : 'build'
-      }`
+      const baseEndpoint =
+        this.payload.region === Region.euWest1 ? 'https://profiles.euw1.segment' : 'https://profiles.segment'
+      const endpoint = `${baseEndpoint}.${this.settings.profileApiEnvironment === 'production' ? 'com' : 'build'}`
       const response = await this.request(
         `${endpoint}/v1/spaces/${this.settings.spaceId}/collections/users/profiles/user_id:${encodeURIComponent(
           this.payload.userId

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/sms-sender.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/sms-sender.ts
@@ -68,16 +68,16 @@ export class SmsMessageSender extends MessageSender<Payload> {
       )
     }
     try {
-      const baseEndpoint =
-        this.payload.region === Region.euWest1 ? 'https://profiles.euw1.segment' : 'https://profiles.segment'
-      const endpoint = `${baseEndpoint}.${this.settings.profileApiEnvironment === 'production' ? 'com' : 'build'}`
+      const { region, profileApiEnvironment, spaceId, profileApiAccessToken } = this.settings
+      const domainName = region === 'eu-west-1' ? 'profiles.euw1.segment' : 'profiles.segment'
+      const topLevelName = profileApiEnvironment === 'production' ? 'com' : 'build'
       const response = await this.request(
-        `${endpoint}/v1/spaces/${this.settings.spaceId}/collections/users/profiles/user_id:${encodeURIComponent(
+        `https://${domainName}.${topLevelName}/v1/spaces/${spaceId}/collections/users/profiles/user_id:${encodeURIComponent(
           this.payload.userId
         )}/traits?limit=200`,
         {
           headers: {
-            authorization: `Basic ${Buffer.from(this.settings.profileApiAccessToken + ':').toString('base64')}`,
+            authorization: `Basic ${Buffer.from(profileApiAccessToken + ':').toString('base64')}`,
             'content-type': 'application/json'
           }
         }


### PR DESCRIPTION
## Description

- add a new field to setting for engage-messaging-sendgrid, it's an optional string
- when the value is eu-west-1, the profiles api is profile.euw1.segment.[build|com]

jira:EXPANSION-366


## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
