### PR TITLE
Attempt at fixing sprig web tests

### DIFF
--- a/packages/browser-destinations/src/destinations/sprig-web/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/browser-destinations/src/destinations/sprig-web/__tests__/__snapshots__/index.test.ts.snap
@@ -11,11 +11,6 @@ exports[`Sprig initialization can load Sprig:
         </script>,
      1`] = `
 NodeList [
-  <script
-    src="https://cdn.sprig.com/shim.js?id=testEnvId"
-    status="loaded"
-    type="text/javascript"
-  />,
   <script>
     // the emptiness
   </script>,

--- a/packages/browser-destinations/src/destinations/sprig-web/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/sprig-web/__tests__/index.test.ts
@@ -17,6 +17,11 @@ const subscriptions: Subscription[] = [
 ]
 
 describe('Sprig initialization', () => {
+  beforeAll(() => {
+    jest.mock('../../../runtime/load-script', () => ({
+      loadScript: (_src: any, _attributes: any) => {}
+    }))
+  })
   test('can load Sprig', async () => {
     const [event] = await sprigWebDestination({
       envId: 'testEnvId',

--- a/packages/browser-destinations/src/destinations/sprig-web/identifyUser/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/sprig-web/identifyUser/__tests__/index.test.ts
@@ -23,6 +23,11 @@ const subscriptions: Subscription[] = [
 ]
 
 describe('identifyUser', () => {
+  beforeAll(() => {
+    jest.mock('../../../../runtime/load-script', () => ({
+      loadScript: (_src: any, _attributes: any) => {}
+    }))
+  })
   test('it maps event parameters correctly to identify function ', async () => {
     const [identifyEvent] = await sprigWebDestination({
       envId: 'testEnvId',

--- a/packages/browser-destinations/src/destinations/sprig-web/trackEvent/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/sprig-web/trackEvent/__tests__/index.test.ts
@@ -26,6 +26,11 @@ const subscriptions: Subscription[] = [
 ]
 
 describe('trackEvent', () => {
+  beforeAll(() => {
+    jest.mock('../../../../runtime/load-script', () => ({
+      loadScript: (_src: any, _attributes: any) => {}
+    }))
+  })
   test('it maps event parameters correctly to track function ', async () => {
     const [trackEvent] = await sprigWebDestination({
       envId: 'testEnvId',

--- a/packages/browser-destinations/src/destinations/sprig-web/updateUserId/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/sprig-web/updateUserId/__tests__/index.test.ts
@@ -20,6 +20,11 @@ const subscriptions: Subscription[] = [
 ]
 
 describe('updateUserId', () => {
+  beforeAll(() => {
+    jest.mock('../../../../runtime/load-script', () => ({
+      loadScript: (_src: any, _attributes: any) => {}
+    }))
+  })
   test('it maps event parameters correctly to alias function with user id', async () => {
     const [aliasEvent] = await sprigWebDestination({
       envId: 'testEnvId',


### PR DESCRIPTION
Looks like these tests are failing because sprig relies on some things (like `fetch` and `indexedDB`) being there by default. This PR attempts to bypass all that by just not loading the script at all. 🤷 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
