### PR TITLE
[STRATCONN-2049] FBCAPI - Update Marketing API from v14 to v16

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-conversions-api/constants.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/constants.ts
@@ -1,5 +1,5 @@
 export const API_VERSION = '14.0'
-export const CANARY_API_VERSION = '14.0'
+export const CANARY_API_VERSION = '16.0'
 export const CURRENCY_ISO_CODES = new Set([
   'AED',
   'AFN',


### PR DESCRIPTION
Update the FB Marketing API version to V16. More info regarding the change can be available upon private message request.

The analysis of the update determined that there are no breaking changes to this destination when updating the API.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
