### PR TITLE
[Expansion-366] chord: regionalize emails channels

### DIFF
--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/__tests__/send-email.test.ts
@@ -6,14 +6,36 @@ import Sendgrid from '..'
 const sendgrid = createTestIntegration(Sendgrid)
 const timestamp = new Date().toISOString()
 
-describe.each(['stage', 'production'])('%s environment', (environment) => {
+describe.each([
+  {
+    environment: 'production',
+    region: 'us-west-2',
+    endpoint: 'https://profiles.segment.com'
+  },
+  {
+    environment: 'staging',
+    region: 'us-west-2',
+    endpoint: 'https://profiles.segment.build'
+  },
+  {
+    environment: 'production',
+    region: 'eu-west-1',
+    endpoint: 'https://profiles.euw1.segment.com'
+  },
+  {
+    environment: 'staging',
+    region: 'eu-west-1',
+    endpoint: 'https://profiles.euw1.segment.build'
+  }
+])('%s', ({ environment, region, endpoint }) => {
   const settings = {
     unlayerApiKey: 'unlayerApiKey',
     sendGridApiKey: 'sendGridApiKey',
     profileApiEnvironment: environment,
     profileApiAccessToken: 'c',
     spaceId: 'spaceId',
-    sourceId: 'sourceId'
+    sourceId: 'sourceId',
+    region
   }
 
   const userData = {
@@ -23,8 +45,6 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
     phone: '+11235554657',
     email: 'test@example.com'
   }
-
-  const endpoint = `https://profiles.segment.${environment === 'production' ? 'com' : 'build'}`
 
   const sendgridRequestBody = {
     personalizations: [

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/generated-types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/generated-types.ts
@@ -25,4 +25,8 @@ export interface Settings {
    * Source ID
    */
   sourceId: string
+  /**
+   * The region where the email is originating from
+   */
+  region?: string
 }

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/index.ts
@@ -44,6 +44,17 @@ const destination: DestinationDefinition<Settings> = {
         description: 'Source ID',
         type: 'string',
         required: true
+      },
+      region: {
+        label: 'Region',
+        description: 'The region where the email is originating from',
+        type: 'string',
+        choices: [
+          { value: 'us-west-2', label: 'US West 2' },
+          { value: 'eu-west-1', label: 'EU West 1' }
+        ],
+        default: 'us-west-2',
+        required: false
       }
     },
     testAuthentication: (request) => {


### PR DESCRIPTION
## Description

This PR updates the Engage Twilio Sendgrid destination to use the correct, region-specific Profiles API base endpoint to support sending Sendgrid emails through Engage in the EU region.

Another PR: #1186 

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) (yes, using insomnia and send payloads to action destination service)
- [x] [Segmenters] Tested in the staging environment (see the screenshot [EXPANSION-321](https://segment.atlassian.net/browse/EXPANSION-321), [EXPANSION-322](https://segment.atlassian.net/browse/EXPANSION-322) and [EXPANSION-367](https://segment.atlassian.net/browse/EXPANSION-367), the version is v3.150.1-EXPANSION-366.4)


[EXPANSION-321]: https://segment.atlassian.net/browse/EXPANSION-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EXPANSION-322]: https://segment.atlassian.net/browse/EXPANSION-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EXPANSION-367]: https://segment.atlassian.net/browse/EXPANSION-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Related to https://github.com/segmentio/personas-service/pull/1706 