### PR TITLE
[GA4] Modify params check to allow for items array

### DIFF
--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
@@ -17,7 +17,7 @@ export function verifyParams(params: object | undefined): void {
 
   Object.entries(params).forEach(([key, value]) => {
     // Google will allow array objects for an items list
-    if (key == 'items') return
+    if (key == 'items' && value instanceof Array) return
     if (value instanceof Array) {
       throw new PayloadValidationError(
         `Param [${key}] has unsupported value of type [Array]. GA4 does not accept null, array, or object values for event parameters and item parameters.`

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-functions.ts
@@ -16,6 +16,8 @@ export function verifyParams(params: object | undefined): void {
   }
 
   Object.entries(params).forEach(([key, value]) => {
+    // Google will allow array objects for an items list
+    if (key == 'items') return
     if (value instanceof Array) {
       throw new PayloadValidationError(
         `Param [${key}] has unsupported value of type [Array]. GA4 does not accept null, array, or object values for event parameters and item parameters.`


### PR DESCRIPTION
This PR addresses [STRATCONN-2025](https://segment.atlassian.net/browse/STRATCONN-2025). Although google normally restricts parameters that are of array type it allows for a parameter to be an array if the name is `items`. 

Used the debugger to verify this:

If we had a param that was named "stuff" we got an error.
<img width="1145" alt="Screenshot 2023-04-17 at 5 33 07 PM" src="https://user-images.githubusercontent.com/99763167/232623256-aa7145ad-47d7-4e39-a6d5-6c24578c6d67.png">

Same payload just changed the name to "items" and now we don't get an error.
<img width="1151" alt="Screenshot 2023-04-17 at 5 33 17 PM" src="https://user-images.githubusercontent.com/99763167/232623433-2546cb66-598e-4b0c-84f8-7170058b9a83.png">

This PR changes the check we implemented before to allow for arrays that are named "items".

## Testing
Mapping an array with "items" as key succeeds.
![Screenshot 2023-04-17 at 6 28 07 PM](https://user-images.githubusercontent.com/99763167/232624112-c0a51fc3-59d5-4a5e-8e78-ec8bb492d6da.png)

Mapping an array with random key still throws an error.
![Screenshot 2023-04-17 at 6 08 55 PM](https://user-images.githubusercontent.com/99763167/232623745-007aa379-10b6-4e22-aaaa-1728cc2a54ae.png)

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
