### PR TITLE
change api url from stage to prod

### DIFF
--- a/packages/destination-actions/src/destinations/rokt-audiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestIntegration } from '@segment/actions-core'
 import Definition from '../index'
+import { CONSTANTS } from '../constants'
 
 const testDestination = createTestIntegration(Definition)
 
@@ -15,13 +16,13 @@ const MOCK_TOKEN_RESPONSE = {
 describe('Rokt Audiences', () => {
   describe('testAuthentication', () => {
     it('should validate valid auth token', async () => {
-      nock('https://data.stage.rokt.com/').get('/api/1.0/auth-check').reply(200, MOCK_TOKEN_RESPONSE)
+      nock(CONSTANTS.ROKT_API_BASE_URL).get(CONSTANTS.ROKT_API_AUTH_ENDPOINT).reply(200, MOCK_TOKEN_RESPONSE)
       const settings = VALID_SETTINGS
       await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()
     })
 
     it('should test that authentication fails', async () => {
-      nock('https://data.stage.rokt.com/').get('/api/1.0/auth-check').reply(401)
+      nock(CONSTANTS.ROKT_API_BASE_URL).get(CONSTANTS.ROKT_API_AUTH_ENDPOINT).reply(401)
       const settings = VALID_SETTINGS
       await expect(testDestination.testAuthentication(settings)).rejects.toThrowError('')
     })

--- a/packages/destination-actions/src/destinations/rokt-audiences/constants.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/constants.ts
@@ -2,7 +2,7 @@ export const CONSTANTS = {
   // rokt
   INCLUDE: 'include',
   EXCLUDE: 'exclude',
-  ROKT_API_BASE_URL: 'https://data.stage.rokt.com/api/1.0',
+  ROKT_API_BASE_URL: 'https://data.rokt.com/api/1.0',
   ROKT_API_CUSTOM_AUDIENCE_ENDPOINT: '/import/suppression',
   ROKT_API_AUTH_ENDPOINT: '/auth-check',
 

--- a/packages/destination-actions/src/destinations/rokt-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/rokt-audiences/index.ts
@@ -1,4 +1,3 @@
-import { InvalidAuthenticationError } from '@segment/actions-core'
 import { defaultValues, DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
@@ -26,14 +25,12 @@ const destination: DestinationDefinition<Settings> = {
     },
 
     testAuthentication: async (request, { settings }) => {
-      const res = await request(CONSTANTS.ROKT_API_BASE_URL + CONSTANTS.ROKT_API_AUTH_ENDPOINT, {
+      return request(CONSTANTS.ROKT_API_BASE_URL + CONSTANTS.ROKT_API_AUTH_ENDPOINT, {
         method: 'GET',
         headers: {
           Authorization: `${settings.apiKey}`
         }
       })
-
-      if (res.status !== 200) throw new InvalidAuthenticationError('Authentication using Rokt ApiKey failed')
     }
   },
 


### PR DESCRIPTION
- Change the API URL to our `prod` env to allow first customer to start using private-beta.
- Modify Auth check method

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
