### PR TITLE
[EXPANSION-352] regionalize profile api for sms

### DIFF
--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/generated-types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/generated-types.ts
@@ -41,4 +41,8 @@ export interface Settings {
    * Connection overrides are configuration supported by twilio webhook services. Must be passed as fragments on the callback url
    */
   connectionOverrides?: string
+  /**
+   * The region where the message is originating from
+   */
+  region?: string
 }

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/index.ts
@@ -152,6 +152,17 @@ const destination: DestinationDefinition<Settings> = {
         required: false,
         default: 'rp=all&rc=5',
         properties: ConnectionOverridesProperties
+      },
+      region: {
+        label: 'Region',
+        description: 'The region where the message is originating from',
+        type: 'string',
+        choices: [
+          { value: 'us-west-2', label: 'US West 2' },
+          { value: 'eu-west-1', label: 'EU West 1' }
+        ],
+        default: 'us-west-2',
+        required: false
       }
     },
     testAuthentication: (request, options) => {

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/index.ts
@@ -117,9 +117,11 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: async (request, { settings, payload, statsContext }) => {
     const statsClient = statsContext?.statsClient
-    const tags = statsContext?.tags
-    tags?.push(`space_id:${settings.spaceId}`, `projectid:${settings.sourceId}`)
-
+    const tags = statsContext?.tags || []
+    if (!settings.region) {
+      settings.region = 'us-west-1'
+    }
+    tags.push(`space_id:${settings.spaceId}`, `projectid:${settings.sourceId}`, `region:${settings.region}`)
     return new SmsMessageSender(request, payload, settings, statsClient, tags).send()
   }
 }

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/sms-sender.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/sms-sender.ts
@@ -14,7 +14,7 @@ export class SmsMessageSender extends MessageSender<Payload> {
     readonly payload: Payload,
     readonly settings: Settings,
     readonly statsClient: StatsClient | undefined,
-    readonly tags: StatsContext['tags'] | undefined
+    readonly tags: StatsContext['tags']
   ) {
     super(request, payload, settings, statsClient, tags)
   }
@@ -63,21 +63,21 @@ export class SmsMessageSender extends MessageSender<Payload> {
       )
     }
     try {
-      const endpoint = `https://profiles.segment.${
-        this.settings.profileApiEnvironment === 'production' ? 'com' : 'build'
-      }`
+      const { region, profileApiEnvironment, spaceId, profileApiAccessToken } = this.settings
+      const domainName = region === 'eu-west-1' ? 'profiles.euw1.segment' : 'profiles.segment'
+      const topLevelName = profileApiEnvironment === 'production' ? 'com' : 'build'
       const response = await this.request(
-        `${endpoint}/v1/spaces/${this.settings.spaceId}/collections/users/profiles/user_id:${encodeURIComponent(
+        `https://${domainName}.${topLevelName}/v1/spaces/${spaceId}/collections/users/profiles/user_id:${encodeURIComponent(
           this.payload.userId
         )}/traits?limit=200`,
         {
           headers: {
-            authorization: `Basic ${Buffer.from(this.settings.profileApiAccessToken + ':').toString('base64')}`,
+            authorization: `Basic ${Buffer.from(profileApiAccessToken + ':').toString('base64')}`,
             'content-type': 'application/json'
           }
         }
       )
-      this.tags?.push(`profile_status_code:${response.status}`)
+      this.tags.push(`profile_status_code:${response.status}`)
       this.statsClient?.incr('actions-personas-messaging-twilio.profile_invoked', 1, this.tags)
       const body = await response.json()
       return body.traits

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendWhatsApp/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendWhatsApp/index.ts
@@ -125,8 +125,11 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: async (request, { settings, payload, statsContext }) => {
     const statsClient = statsContext?.statsClient
-    const tags = statsContext?.tags
-    tags?.push(`space_id:${settings.spaceId}`, `projectid:${settings.sourceId}`)
+    const tags = statsContext?.tags || []
+    if (!settings.region) {
+      settings.region = 'us-west-1'
+    }
+    tags.push(`space_id:${settings.spaceId}`, `projectid:${settings.sourceId}`, `region:${settings.region}`)
 
     return new WhatsAppMessageSender(request, payload, settings, statsClient, tags).send()
   }

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendWhatsApp/whatsapp-sender.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendWhatsApp/whatsapp-sender.ts
@@ -16,7 +16,7 @@ export class WhatsAppMessageSender extends MessageSender<Payload> {
     readonly payload: Payload,
     readonly settings: Settings,
     readonly statsClient: StatsClient | undefined,
-    readonly tags: StatsContext['tags'] | undefined
+    readonly tags: StatsContext['tags']
   ) {
     super(request, payload, settings, statsClient, tags)
   }
@@ -37,7 +37,7 @@ export class WhatsAppMessageSender extends MessageSender<Payload> {
       parsedPhone = phoneUtil.format(parsedPhone, PhoneNumberFormat.E164)
       parsedPhone = `whatsapp:${parsedPhone}`
     } catch (error: unknown) {
-      this.tags?.push('type:invalid_phone_e164')
+      this.tags.push('type:invalid_phone_e164')
       this.statsClient?.incr('actions-personas-messaging-twilio.error', 1, this.tags)
       throw new IntegrationError(
         'The string supplied did not seem to be a phone number. Phone number must be able to be formatted to e164 for whatsapp.',

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/utils/message-sender.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/utils/message-sender.ts
@@ -32,7 +32,7 @@ export abstract class MessageSender<SmsPayload extends MinimalPayload> {
     readonly payload: SmsPayload,
     readonly settings: Settings,
     readonly statsClient: StatsClient | undefined,
-    readonly tags: StatsContext['tags'] | undefined
+    readonly tags: StatsContext['tags']
   ) {}
 
   abstract getBody: (phone: string) => Promise<URLSearchParams>
@@ -66,7 +66,7 @@ export abstract class MessageSender<SmsPayload extends MinimalPayload> {
         body
       }
     )
-    this.tags?.push(`twilio_status_code:${response.status}`)
+    this.tags.push(`twilio_status_code:${response.status}`)
     this.statsClient?.incr('actions-personas-messaging-twilio.response', 1, this.tags)
 
     if (this.payload.eventOccurredTS != undefined) {


### PR DESCRIPTION
## Description

- add a new optional choice to setting `region`
- if the region is eu-west-1, use profiles.euw1.segment

[EXPANSION-352](https://segment.atlassian.net/browse/EXPANSION-352)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment


Related to https://github.com/segmentio/personas-service/pull/1706


[EXPANSION-352]: https://segment.atlassian.net/browse/EXPANSION-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ