### PR TITLE
[Webhooks] Throwing payload validation error for invalid headers

### DIFF
--- a/packages/destination-actions/src/destinations/webhook/send/index.ts
+++ b/packages/destination-actions/src/destinations/webhook/send/index.ts
@@ -1,4 +1,4 @@
-import { ActionDefinition } from '@segment/actions-core'
+import { ActionDefinition, PayloadValidationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
@@ -48,21 +48,30 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: (request, { payload }) => {
-    return request(payload.url, {
-      method: payload.method as RequestMethod,
-      headers: payload.headers as Record<string, string>,
-      json: payload.data
-    })
+    try {
+      return request(payload.url, {
+        method: payload.method as RequestMethod,
+        headers: payload.headers as Record<string, string>,
+        json: payload.data
+      })
+    } catch (error) {
+      if (error instanceof TypeError) throw new PayloadValidationError(error.message)
+      throw error
+    }
   },
   performBatch: (request, { payload }) => {
     // Expect these to be the same across the payloads
     const { url, method, headers } = payload[0]
-
-    return request(url, {
-      method: method as RequestMethod,
-      headers: headers as Record<string, string>,
-      json: payload.map(({ data }) => data)
-    })
+    try {
+      return request(url, {
+        method: method as RequestMethod,
+        headers: headers as Record<string, string>,
+        json: payload.map(({ data }) => data)
+      })
+    } catch (error) {
+      if (error instanceof TypeError) throw new PayloadValidationError(error.message)
+      throw error
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR resolves STRATCONN-2366: عبدالله is not a legal HTTP header value.
Throwing payload validation error if invalid header is received.

JIRA Ticket : [STRATCONN-2366](https://segment.atlassian.net/browse/STRATCONN-2366)
## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment

### Local Testing
<img width="1790" alt="Screenshot 2023-04-19 at 11 24 55 AM" src="https://user-images.githubusercontent.com/129737395/233010575-9799d897-64fd-4c14-9fda-4add0188a747.png">

### Stage Testing
<img width="1790" alt="Screenshot 2023-04-19 at 1 17 53 PM" src="https://user-images.githubusercontent.com/129737395/233010740-8866746c-940b-4128-8eca-b3c9b0cbed40.png">

