### PR TITLE
Revert: Capture and re-throw refresh token failures as authentication failures

### DIFF
--- a/packages/core/src/__tests__/destination-kit.test.ts
+++ b/packages/core/src/__tests__/destination-kit.test.ts
@@ -1,4 +1,3 @@
-import { InvalidAuthenticationError, ErrorCodes } from '../errors'
 import {
   StateContext,
   Destination,
@@ -6,8 +5,7 @@ import {
   Logger,
   StatsClient,
   StatsContext,
-  TransactionContext,
-  OAuth2Authentication
+  TransactionContext
 } from '../destination-kit'
 import { JSONObject } from '../json-object'
 import { SegmentEvent } from '../segment-event'
@@ -317,37 +315,6 @@ describe('destination kit', () => {
       const res = await destinationTest.refreshAccessToken(testSettings, oauthData)
 
       expect(res).toEqual({ accessToken: 'fresh-token' })
-    })
-
-    test('should capture and rethrow refreshAccessToken errors as AuthenticationError', async () => {
-      const destination = {
-        ...destinationOAuth2,
-        authentication: {
-          ...destinationOAuth2.authentication,
-          refreshAccessToken: () => {
-            return new Promise((_resolve, reject) => {
-              reject(new Error('Invalid Refresh Token'))
-            })
-          }
-        } as OAuth2Authentication<any>
-      }
-      const destinationTest = new Destination(destination)
-      const testSettings = {
-        subscription: { subscribe: 'type = "track"', partnerAction: 'customEvent' }
-      }
-      const oauthData = {
-        accessToken: 'test-access-token',
-        refreshToken: 'refresh-token',
-        clientId: 'test-clientid',
-        clientSecret: 'test-clientsecret',
-        refreshTokenUrl: 'abc123.xyz'
-      }
-      await expect(destinationTest.refreshAccessToken(testSettings, oauthData)).rejects.toThrowError(
-        new InvalidAuthenticationError(
-          'Failed to refresh access token. Reason:Invalid Refresh Token',
-          ErrorCodes.OAUTH_REFRESH_FAILED
-        )
-      )
     })
   })
 

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -361,13 +361,7 @@ export class Destination<Settings = JSONObject> {
       return undefined
     }
 
-    return this.authentication.refreshAccessToken(requestClient, { settings, auth: oauthData }).catch((err) => {
-      const message = (err as Error).message ?? 'UNKNOWN'
-      throw new InvalidAuthenticationError(
-        `Failed to refresh access token. Reason:${message}`,
-        ErrorCodes.OAUTH_REFRESH_FAILED
-      )
-    })
+    return this.authentication.refreshAccessToken(requestClient, { settings, auth: oauthData })
   }
 
   private partnerAction(slug: string, definition: ActionDefinition<Settings>): Destination<Settings> {


### PR DESCRIPTION
This PR reverts the changes made in this [PR](https://github.com/segmentio/action-destinations/pull/1143). The new error code is flagging timeouts for authentication as refresh failed. Reverting this until I figure out a better approach to capture refresh token failure. 
Relevant Slack Conversation - https://twilio.slack.com/archives/CC97A542H/p1681889525553499

## Testing

Testing not required as this PR reverts the changes to the previously stable state.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
