### PR TITLE
[STRATCONN-2524] FB Marketing API Cleanup

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-conversions-api/constants.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/constants.ts
@@ -1,4 +1,4 @@
-export const API_VERSION = '14.0'
+export const API_VERSION = '16.0'
 export const CANARY_API_VERSION = '16.0'
 export const CURRENCY_ISO_CODES = new Set([
   'AED',


### PR DESCRIPTION
## Summary

This PR brings the API default version to be on pair with Canary as that's been rolled out for a while now.

## Testing

Testing not required because Canary is already running this API version and we haven't seen any issues.
