### PR TITLE
Add Support for Canary API Version in Google Enhanced Conversions API

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadCallConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadCallConversion.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import GoogleEnhancedConversions from '../index'
+import { API_VERSION } from '../functions'
 
 const testDestination = createTestIntegration(GoogleEnhancedConversions)
 const timestamp = new Date('Thu Jun 10 2021 11:08:04 GMT-0700 (Pacific Daylight Time)').toISOString()
@@ -20,7 +21,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}:uploadCallConversions`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadCallConversions`)
         .post('')
         .reply(201, { results: [{}] })
 
@@ -53,7 +54,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}/googleAds:searchStream`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}/googleAds:searchStream`)
         .post('')
         .reply(200, [
           {
@@ -69,7 +70,7 @@ describe('GoogleEnhancedConversions', () => {
           }
         ])
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}:uploadCallConversions`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadCallConversions`)
         .post('')
         .reply(201, { results: [{}] })
 
@@ -107,7 +108,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}:uploadCallConversions`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadCallConversions`)
         .post('')
         .reply(201, { results: [{}] })
 
@@ -135,7 +136,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}:uploadCallConversions`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadCallConversions`)
         .post('')
         .reply(201, { results: [{}] })
 
@@ -168,7 +169,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}:uploadCallConversions`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadCallConversions`)
         .post('')
         .reply(201, { results: [{}] })
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import GoogleEnhancedConversions from '../index'
+import { API_VERSION } from '../functions'
 
 const testDestination = createTestIntegration(GoogleEnhancedConversions)
 const timestamp = new Date('Thu Jun 10 2021 11:08:04 GMT-0700 (Pacific Daylight Time)').toISOString()
@@ -28,7 +29,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}:uploadClickConversions`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
         .post('')
         .reply(201, { results: [{}] })
 
@@ -70,7 +71,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}:uploadClickConversions`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
         .post('')
         .reply(201, { results: [{}] })
 
@@ -110,7 +111,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}/googleAds:searchStream`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}/googleAds:searchStream`)
         .post('')
         .reply(200, [
           {
@@ -126,7 +127,7 @@ describe('GoogleEnhancedConversions', () => {
           }
         ])
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}:uploadClickConversions`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
         .post('')
         .reply(201, { results: [{}] })
 
@@ -167,7 +168,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}:uploadClickConversions`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
         .post('')
         .reply(201, {})
 
@@ -203,7 +204,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}:uploadClickConversions`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
         .post('')
         .reply(201, { results: [{}] })
 
@@ -246,7 +247,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}:uploadClickConversions`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
         .post('')
         .reply(201, { results: [{}] })
 
@@ -287,7 +288,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}:uploadClickConversions`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
         .post('')
         .reply(201, {})
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadConversionAdjustment.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadConversionAdjustment.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import GoogleEnhancedConversions from '../index'
+import { API_VERSION } from '../functions'
 
 const testDestination = createTestIntegration(GoogleEnhancedConversions)
 const timestamp = new Date('Thu Jun 10 2021 11:08:04 GMT-0700 (Pacific Daylight Time)').toISOString()
@@ -30,7 +31,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}:uploadConversionAdjustments`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
         .post('')
         .reply(201, { results: [{}] })
 
@@ -77,7 +78,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}:uploadConversionAdjustments`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
         .post('')
         .reply(201, { results: [{}] })
 
@@ -106,7 +107,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}:uploadConversionAdjustments`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
         .post('')
         .reply(201, { results: [{}] })
 
@@ -150,7 +151,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}:uploadConversionAdjustments`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
         .post('')
         .reply(201, { results: [{}] })
 
@@ -187,7 +188,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}:uploadConversionAdjustments`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
         .post('')
         .reply(201, { results: [{}] })
 
@@ -217,7 +218,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}:uploadConversionAdjustments`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
         .post('')
         .reply(201, { results: [{}] })
 
@@ -262,7 +263,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      nock(`https://googleads.googleapis.com/v12/customers/${customerId}:uploadConversionAdjustments`)
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
         .post('')
         .reply(201, { results: [{}] })
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -1,6 +1,12 @@
 import { createHash } from 'crypto'
 import { ConversionCustomVariable, PartialErrorResponse, QueryResponse } from './types'
 import { ModifiedResponse, RequestClient, IntegrationError } from '@segment/actions-core'
+import { StatsContext } from '@segment/actions-core/src/destination-kit'
+import { Features } from '@segment/actions-core/src/mapping-kit'
+
+export const API_VERSION = 'v12'
+const CANARY_API_VERSION = 'v13'
+const FLAGON_NAME = 'google-enhanced-canary-version'
 
 export function formatCustomVariables(
   customVariables: object,
@@ -40,18 +46,26 @@ export const hash = (value: string | undefined): string | undefined => {
 export async function getCustomVariables(
   customerId: string,
   auth: any,
-  request: RequestClient
+  request: RequestClient,
+  features: Features | undefined,
+  statsContext: StatsContext | undefined
 ): Promise<ModifiedResponse<QueryResponse[]>> {
-  return await request(`https://googleads.googleapis.com/v12/customers/${customerId}/googleAds:searchStream`, {
-    method: 'post',
-    headers: {
-      authorization: `Bearer ${auth?.accessToken}`,
-      'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
-    },
-    json: {
-      query: `SELECT conversion_custom_variable.id, conversion_custom_variable.name FROM conversion_custom_variable`
+  return await request(
+    `https://googleads.googleapis.com/${get_api_version(
+      features,
+      statsContext
+    )}/customers/${customerId}/googleAds:searchStream`,
+    {
+      method: 'post',
+      headers: {
+        authorization: `Bearer ${auth?.accessToken}`,
+        'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
+      },
+      json: {
+        query: `SELECT conversion_custom_variable.id, conversion_custom_variable.name FROM conversion_custom_variable`
+      }
     }
-  })
+  )
 }
 
 /* Ensures there is no error when using Google's partialFailure mode
@@ -68,4 +82,19 @@ export function convertTimestamp(timestamp: string | undefined): string | undefi
     return undefined
   }
   return timestamp.replace(/T/, ' ').replace(/\..+/, '+00:00')
+}
+
+export function get_api_version(features: Features | undefined, statsContext: StatsContext | undefined): string {
+  const statsClient = statsContext?.statsClient
+  const tags = statsContext?.tags
+
+  if (features && features[FLAGON_NAME]) {
+    tags?.push(`version:${CANARY_API_VERSION}`)
+    statsClient?.incr(`google_api_version`, 1, tags)
+    return CANARY_API_VERSION
+  }
+
+  tags?.push(`version:${API_VERSION}`)
+  statsClient?.incr(`google_api_version`, 1, tags)
+  return API_VERSION
 }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, PayloadValidationError } from '@segment/actions-core'
-import { hash, handleGoogleErrors, convertTimestamp } from '../functions'
+import { hash, handleGoogleErrors, convertTimestamp, get_api_version } from '../functions'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { PartialErrorResponse } from '../types'
@@ -198,7 +198,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
   },
-  perform: async (request, { settings, payload }) => {
+  perform: async (request, { settings, payload, features, statsContext }) => {
     /* Enforcing this here since Customer ID is required for the Google Ads API
     but not for the Enhanced Conversions API. */
     if (!settings.customerId) {
@@ -266,7 +266,9 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     const response: ModifiedResponse<PartialErrorResponse> = await request(
-      `https://googleads.googleapis.com/v12/customers/${settings.customerId}:uploadConversionAdjustments`,
+      `https://googleads.googleapis.com/${get_api_version(features, statsContext)}/customers/${
+        settings.customerId
+      }:uploadConversionAdjustments`,
       {
         method: 'post',
         headers: {


### PR DESCRIPTION
This PR is to upgrade API version for google enhanced conversions.

JIRA - [STRATCONN-2568](https://segment.atlassian.net/browse/STRATCONN-2568)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment

### Stage Testing

#### Click Conversion
<img width="1790" alt="upload click - v13" src="https://user-images.githubusercontent.com/129737395/233921056-fd860c48-db63-45c2-bc46-dbdaf9311148.png">

#### Call Conversion
<img width="1790" alt="call - v13" src="https://user-images.githubusercontent.com/129737395/233921134-0d5ef23d-9147-44a4-8e15-143250f6ab46.png">

#### Conversion Adjustment
<img width="1790" alt="adjustment - v13" src="https://user-images.githubusercontent.com/129737395/233921216-c4efc92f-e266-45b3-858f-202e91a4f909.png">


