### PR TITLE
[WIP] Add support for array value in @path directive

### DIFF
--- a/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
@@ -506,6 +506,50 @@ describe('@path', () => {
     }).toThrowError()
   })
 
+  test('accepts path value as an array', () => {
+    const output = transform(
+      { neat: { '@path': ['integrations', 'Company.Billing', 'chicken'] } },
+      {
+        integrations: {
+          'Company.Billing': {
+            chicken: 'noodle'
+          }
+        }
+      }
+    )
+    expect(output).toStrictEqual({ neat: 'noodle' })
+  })
+
+  test('throws an error for invalid path value: boolean', () => {
+    expect(() =>
+      transform(
+        { neat: { '@path': false } },
+        {
+          integrations: {
+            'Company.Billing': {
+              chicken: 'noodle'
+            }
+          }
+        }
+      )
+    ).toThrowError()
+  })
+
+  test('throws an error for invalid path value: number', () => {
+    expect(() =>
+      transform(
+        { neat: { '@path': 123 } },
+        {
+          integrations: {
+            'Company.Billing': {
+              chicken: 'noodle'
+            }
+          }
+        }
+      )
+    ).toThrowError()
+  })
+
   test('spaced nested value', () => {
     const output = transform(
       { neat: { '@path': '$.integrations.Actions Amplitude.session_id' } },

--- a/packages/core/src/mapping-kit/validate.ts
+++ b/packages/core/src/mapping-kit/validate.ts
@@ -107,11 +107,29 @@ function validateDirectiveOrString(v: unknown, stack: string[] = []) {
 }
 
 type validator = (v: unknown, stack: string[]) => void
-function chain(...validators: validator[]) {
+function allOf(...validators: validator[]) {
   return (v: unknown, stack: string[] = []) => {
     validators.forEach((validate) => {
       validate(v, stack)
     })
+  }
+}
+
+function oneOf(...validators: validator[]) {
+  return (v: unknown, stack: string[] = []) => {
+    const errors: Error[] = []
+    validators.forEach((validate) => {
+      try {
+        validate(v, stack)
+      } catch (e) {
+        errors.push(e)
+      }
+    })
+    if (errors.length < validators.length) {
+      return
+    } else {
+      throw new AggregateError(flatAggregate(errors))
+    }
   }
 }
 
@@ -264,8 +282,8 @@ directive('@replace', (v, stack) => {
   validateObjectWithFields(
     v,
     {
-      pattern: { required: chain(validateString, validateStringLength(1, MAX_PATTERN_LENGTH)) },
-      replacement: { optional: chain(validateString, validateStringLength(0, MAX_REPLACEMENT_LENGTH)) },
+      pattern: { required: allOf(validateString, validateStringLength(1, MAX_PATTERN_LENGTH)) },
+      replacement: { optional: allOf(validateString, validateStringLength(0, MAX_REPLACEMENT_LENGTH)) },
       value: { required: validateDirectiveOrString },
       ignorecase: { optional: validateBoolean },
       global: { optional: validateBoolean }
@@ -282,7 +300,8 @@ directive('@arrayPath', (v, stack) => {
 })
 
 directive('@path', (v, stack) => {
-  validateDirectiveOrString(v, stack)
+  const validatePath = oneOf(validateDirectiveOrString, validateArray)
+  validatePath(v, stack)
 })
 
 directive('@template', (v, stack) => {


### PR DESCRIPTION
Users are unable to map properties that include a dot character in the key. This PR is an attempt to fix that problem by using an array value for specifying the path. On the app side, we'd need to detect the presence of a dot in the key and then construct/pass an array value.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
