### PR TITLE
Fixed a typo in actions-tiktok-offline-conversions preset

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions/index.ts
@@ -50,7 +50,7 @@ const destination: DestinationDefinition<Settings> = {
     {
       name: 'Complete Payment',
       subscribe: 'type = "track" and event = "Order Completed"',
-      partnerAction: 'trackOfflinePaymentConversion',
+      partnerAction: 'trackPaymentOfflineConversion',
       mapping: {
         ...defaultValues(trackPaymentOfflineConversion.fields),
         event: 'CompletePayment'


### PR DESCRIPTION
This PR fixes an error in`actions-tiktok-offline-conversions` preset which was referencing a non-existent partner action (typo).

## Testing
Tested locally using `yarn validate`

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
