### PR TITLE
Add Null Check in Google Invalid OAuth Error

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/google-enhanced-conversions.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/google-enhanced-conversions.test.ts
@@ -229,6 +229,7 @@ describe('GoogleEnhancedConversions', () => {
           url: 'https://www.google.com/ads/event/api/v1?conversion_tracking_id=699373583',
           status: 400,
           statusText: 'Unauthorized',
+          // @ts-ignore Headers don't matter for this test. Only need status 400 and type to be HTTPError
           headers: []
         },
         {},

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/google-enhanced-conversions.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/google-enhanced-conversions.test.ts
@@ -237,7 +237,7 @@ describe('GoogleEnhancedConversions', () => {
             conversionTrackingId
           }
         })
-      ).rejects.toThrow()
+      ).rejects.toHaveProperty('response.status', 400)
     })
   })
 })

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/google-enhanced-conversions.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/google-enhanced-conversions.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { HTTPError, createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import GoogleEnhancedConversions from '../index'
 
 const testDestination = createTestIntegration(GoogleEnhancedConversions)
@@ -224,21 +224,9 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      const error = new HTTPError(
-        {
-          url: 'https://www.google.com/ads/event/api/v1?conversion_tracking_id=699373583',
-          status: 400,
-          statusText: 'Unauthorized',
-          // @ts-ignore Headers don't matter for this test. Only need status 400 and type to be HTTPError
-          headers: []
-        },
-        {},
-        {}
-      )
-
       nock('https://www.google.com/ads/event/api/v1')
         .post(`?conversion_tracking_id=${conversionTrackingId}`)
-        .reply(400, error)
+        .reply(400, {})
 
       await expect(
         testDestination.testAction('postConversion', {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
@@ -269,7 +269,7 @@ const action: ActionDefinition<Settings, Payload> = {
         const statusCode = err.response.status
         if (statusCode === 400) {
           const data = (err.response as ModifiedResponse).data as GoogleError
-          const invalidOAuth = data.error_statuses.find((es) => es.error_code === 'INVALID_OAUTH_TOKEN')
+          const invalidOAuth = data?.error_statuses?.find((es) => es.error_code === 'INVALID_OAUTH_TOKEN')
           if (invalidOAuth) {
             throw new IntegrationError('The OAuth token is missing or invalid.', 'INVALID_OAUTH_TOKEN', 401)
           }


### PR DESCRIPTION
This PR is to fix Google Enhanced Conversions - Cannot read property 'find' of undefined.
The original error will be thrown if `invalidOAuth` is undefined.
JIRA -> [STRATCONN-2589](https://segment.atlassian.net/browse/STRATCONN-2589) 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment


[STRATCONN-2589]: https://segment.atlassian.net/browse/STRATCONN-2589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ