### PR TITLE
Allow MMS to be sent through sendSms action

### DIFF
--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/sms-sender.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/sms-sender.ts
@@ -12,8 +12,15 @@ interface ContentTemplateResponse {
   types: {
     [type: string]: {
       body: string
+      media?: string[]
     }
   }
+}
+
+type Profile = {
+  user_id: string | undefined
+  phone: string
+  traits: Payload['traits']
 }
 
 export class SmsMessageSender extends MessageSender<Payload> {
@@ -53,21 +60,16 @@ export class SmsMessageSender extends MessageSender<Payload> {
       traits
     }
 
-    let unparsedBody
+    let parsedBody: string
+    let parsedMedia: string[] | undefined = []
+
     if (this.payload.contentSid) {
       const data = await this.getContentTemplate()
-      unparsedBody = this.getUnparsedContentBody(data)
+      const parsed = await this.parseContent(this.getUnparsedContent(data), profile)
+      parsedBody = parsed.body
+      parsedMedia = parsed.media
     } else {
-      unparsedBody = this.payload.body ?? ''
-    }
-
-    let parsedBody
-
-    try {
-      parsedBody = await Liquid.parseAndRender(unparsedBody, { profile })
-    } catch (error: unknown) {
-      this.logger?.error(`TE Messaging: SMS templating parse failure - ${this.settings.spaceId} - [${error}]`)
-      throw new IntegrationError(`Unable to parse templating in SMS`, `SMS templating parse failure`, 400)
+      parsedBody = (await this.parseContent({ body: this.payload.body ?? '' }, profile)).body
     }
 
     const body = new URLSearchParams({
@@ -77,6 +79,10 @@ export class SmsMessageSender extends MessageSender<Payload> {
       ShortenUrls: 'true'
     })
 
+    parsedMedia?.forEach((media) => {
+      body.append('MediaUrl', media)
+    })
+    console.error(body)
     return body
   }
 
@@ -141,7 +147,7 @@ export class SmsMessageSender extends MessageSender<Payload> {
     }
   }
 
-  private getUnparsedContentBody = (data: ContentTemplateResponse): string => {
+  private getUnparsedContent = (data: ContentTemplateResponse): ContentTemplateResponse['types'][string] => {
     if (!data.types) {
       this.logger?.error(
         `TE Messaging: SMS template from Twilio Content API does not contain a template type - ${
@@ -155,8 +161,8 @@ export class SmsMessageSender extends MessageSender<Payload> {
       )
     }
     const type = Object.keys(data.types)[0] // eg 'twilio/text', 'twilio/media', etc
-    if (type === 'twilio/text') {
-      return data.types[type].body
+    if (type === 'twilio/text' || type === 'twilio/media') {
+      return { body: data.types[type].body, media: data.types[type].media }
     } else {
       this.logger?.error(`TE Messaging: SMS unsupported content template type '${type}' - ${this.settings.spaceId}`)
       throw new IntegrationError(
@@ -164,6 +170,21 @@ export class SmsMessageSender extends MessageSender<Payload> {
         `Sending templates with '${type}' content type is not supported by SMS`,
         400
       )
+    }
+  }
+
+  private async parseContent(
+    content: ContentTemplateResponse['types'][string],
+    profile: Profile
+  ): Promise<ContentTemplateResponse['types'][string]> {
+    try {
+      return {
+        body: await Liquid.parseAndRender(content.body, { profile }),
+        media: await Promise.all(content.media?.map((media) => Liquid.parseAndRender(media, { profile })) || [])
+      }
+    } catch (error: unknown) {
+      this.logger?.error(`TE Messaging: SMS templating parse failure - ${this.settings.spaceId} - [${error}]`)
+      throw new IntegrationError(`Unable to parse templating in SMS`, `SMS templating parse failure`, 400)
     }
   }
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

[CHANNELS-612](https://segment.atlassian.net/browse/CHANNELS-612)

This PR adds the ability for MMS to be sent through the sendSms action.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment


[CHANNELS-612]: https://segment.atlassian.net/browse/CHANNELS-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ