### PR TITLE
resolveWhen bug

### DIFF
--- a/packages/browser-destinations/src/runtime/__tests__/resolve-when.test.ts
+++ b/packages/browser-destinations/src/runtime/__tests__/resolve-when.test.ts
@@ -1,0 +1,42 @@
+import { resolveWhen } from '../resolve-when'
+
+// jest.useFakeTimers was hard to use
+const sleep = (time: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, time)
+  })
+
+describe(resolveWhen, () => {
+  it('should resolve immediately', async () => {
+    const resolveCb = jest.fn()
+    const errorCb = jest.fn()
+
+    await resolveWhen(() => true, 100)
+      .then(resolveCb)
+      .catch(errorCb)
+    expect(errorCb).not.toHaveBeenCalled()
+    expect(resolveCb).toHaveBeenCalled()
+  })
+
+  it('should reject after some time', async () => {
+    const errorCb = jest.fn()
+    await resolveWhen(() => false, 200, 300).catch(errorCb)
+    expect(errorCb).toHaveBeenCalled()
+  })
+
+  it('should wait the correct amount of time before rejecting', async () => {
+    const errorCb = jest.fn()
+    void resolveWhen(() => false, 100, 500).catch(errorCb)
+    await sleep(100)
+    expect(errorCb).not.toHaveBeenCalled()
+    await sleep(400)
+    expect(errorCb).toHaveBeenCalled()
+  })
+
+  it('should still resolve if timeout is smaller than flush interval', async () => {
+    const cb = jest.fn()
+    await resolveWhen(() => true, 100, 50).then(cb)
+    await sleep(100)
+    expect(cb).toHaveBeenCalled()
+  })
+})

--- a/packages/browser-destinations/src/runtime/promise-timeout.ts
+++ b/packages/browser-destinations/src/runtime/promise-timeout.ts
@@ -1,0 +1,14 @@
+export function pTimeout<T>(promise: Promise<T>, timeout: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(`Failed to resolve before ${timeout} ms`))
+    }, timeout)
+
+    promise
+      .then((val) => {
+        clearTimeout(timeoutId)
+        return resolve(val)
+      })
+      .catch(reject)
+  })
+}

--- a/packages/browser-destinations/src/runtime/resolve-when.ts
+++ b/packages/browser-destinations/src/runtime/resolve-when.ts
@@ -1,19 +1,29 @@
-export async function resolveWhen(condition: () => boolean, timeout?: number): Promise<void> {
-  return new Promise((resolve, _reject) => {
+import { pTimeout } from './promise-timeout'
+
+/**
+ * Will reject if error
+ *
+ * @param condition - condition after which function will resolve
+ * @param checkInterval - how often to check the condition
+ * @param timeout - max timeout - should be very generous to allow for slower connections.
+ */
+export async function resolveWhen(condition: () => boolean, checkInterval: number, timeout = 10000): Promise<void> {
+  const p = new Promise((resolve) => {
     if (condition()) {
-      resolve()
+      resolve(undefined)
       return
     }
 
     const check = () =>
       setTimeout(() => {
         if (condition()) {
-          resolve()
+          resolve(undefined)
         } else {
           check()
         }
-      }, timeout)
+      }, checkInterval)
 
     check()
   })
+  await pTimeout(p, timeout)
 }


### PR DESCRIPTION
force reject / do not load destination after 3 seconds -- this is maybe too short? Just an example. 

Assumption is that if a single plugin rejects, we just don't load that plugin.

This is a long term fix 

TODO: 
fix vwo specifically