### PR TITLE
Temp fix vwo

### DIFF
--- a/packages/browser-destinations/src/destinations/vwo/index.ts
+++ b/packages/browser-destinations/src/destinations/vwo/index.ts
@@ -69,7 +69,7 @@ export const destination: BrowserDestinationDefinition<Settings, VWO> = {
       vwoAccountId: settings.vwoAccountId,
       settingsTolerance: settings.settingsTolerance,
       libraryTolerance: settings.libraryTolerance,
-      useExistingJquery: settings.useExistingJquery
+      useExistingJquery: false // temporarily ignore this because of bug that caused window.VWO from ever being present.
     })
     await deps.resolveWhen(() => Object.prototype.hasOwnProperty.call(window, 'VWO'), 100)
     return window.VWO

--- a/packages/browser-destinations/src/destinations/vwo/index.ts
+++ b/packages/browser-destinations/src/destinations/vwo/index.ts
@@ -69,7 +69,7 @@ export const destination: BrowserDestinationDefinition<Settings, VWO> = {
       vwoAccountId: settings.vwoAccountId,
       settingsTolerance: settings.settingsTolerance,
       libraryTolerance: settings.libraryTolerance,
-      useExistingJquery: false // temporarily ignore this because of bug that caused window.VWO from ever being present.
+      useExistingJquery: false // temporarily ignore this because of bug that presented window.VWO from ever being present, causing analytics to completely fail.
     })
     await deps.resolveWhen(() => Object.prototype.hasOwnProperty.call(window, 'VWO'), 100)
     return window.VWO


### PR DESCRIPTION
temporarily ignore `useExistingJquery` setting  because of bug that presented window.VWO from ever being present, causing analytics to completely fail.

loading multiple copies of jquery doesn't usually break things; the other option is to just throw an error for the customers who use this.
