### PR TITLE
[sev-4403] re-add BE to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,27 +1,37 @@
 # These owners will be the default owners for everything in
+
 # the repo. Unless a later match takes precedence, these users
+
 # will be requested for review when someone opens a pull request.
 
 # Actions common lib folder
+
 actions-shared/ @segmentio/build-experience-team
 
 # AJV utils
+
 ajv-human-errors/ @segmentio/build-experience-team
 
 # Browser destinations
+
 browser-destinations/ @segmentio/libraries-web-team @segmentio/strategic-connections-team @segmentio/build-experience-team
 
 # CLI private libs
+
 cli-internal/ @segmentio/build-experience-team
 
 # CLI binary
+
 cli/ @segmentio/build-experience-team
 
 # Core actions runtime
+
 core/ @segmentio/build-experience-team
 
 # Destination definitions and their actions
-destination-actions/ @segmentio/strategic-connections-team
+
+destination-actions/ @segmentio/strategic-connections-team @segmentio/build-experience-team
 
 # Utilities for event payload validation against an action's subscription AST.
+
 destination-subscriptions/ @segmentio/build-experience-team


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Recent sev has shown that having a broader approver pool is beneficial:

- less annoying to teams not directly involved in the sev
- faster review SLO

## Testing

n/a codeowners only

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
