### PR TITLE
update LCNC templates

### DIFF
--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -122,11 +122,12 @@ export default class Init extends Command {
       const actionsTargetDirectory = `${targetDirectory}/${action.key}`
 
       action.fields.forEach((field: any) => {
-        const hasDirective = field.hasDefault && field.default && field.default.type === 'directive'
-        const hasDefaultValue = field.hasDefault && field.default && field.default.type !== 'directive'
-        field.hasDefaultValue = hasDefaultValue
-        field.isString = field.default?.type === 'string'
-        field.hasDirective = hasDirective
+        const hasDefault = field.hasDefault && field.default
+        if (hasDefault) {
+          field.hasDefaultValue = field.default.type !== 'directive'
+          field.hasDirective = field.default.type === 'directive'
+          field.isString = field.default.type === 'string'
+        }
       })
 
       try {

--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -98,7 +98,7 @@ export default class Init extends Command {
       this.spinner.start(`Creating ${chalk.bold(name)}`)
       renderTemplates(templatePath, targetDirectory, answers)
       this.spinner.succeed(`Scaffold integration`)
-    } catch (err) {
+    } catch (err: any) {
       this.spinner.fail(`Scaffold integration: ${chalk.red(err.message)}`)
       this.exit()
     }
@@ -113,13 +113,21 @@ export default class Init extends Command {
         overwriteExisting
       )
       this.spinner.succeed(chalk`Created snapshot tests for {magenta ${slug}} destination`)
-    } catch (err) {
+    } catch (err: any) {
       this.spinner.fail(`Snapshot test creation failed: ${chalk.red(err.message)}`)
       this.exit()
     }
 
     for (const action of actions) {
       const actionsTargetDirectory = `${targetDirectory}/${action.key}`
+
+      action.fields.forEach((field: any) => {
+        const hasDirective = field.hasDefault && field.default && field.default.type === 'directive'
+        const hasDefaultValue = field.hasDefault && field.default && field.default.type !== 'directive'
+        field.hasDefaultValue = hasDefaultValue
+        field.isString = field.default?.type === 'string'
+        field.hasDirective = hasDirective
+      })
 
       try {
         renderTemplates(
@@ -138,7 +146,7 @@ export default class Init extends Command {
           overwriteExisting
         )
         this.spinner.succeed(chalk`Scaffold action {magenta ${action.name}}`)
-      } catch (err) {
+      } catch (err: any) {
         this.spinner.fail(chalk`Scaffold action {magenta ${action.name}}: ${chalk.red(err.message)}`)
         this.exit()
       }
@@ -155,7 +163,7 @@ export default class Init extends Command {
           overwriteExisting
         )
         this.spinner.succeed(chalk`Creating snapshot tests for action {magenta ${action.name}}`)
-      } catch (err) {
+      } catch (err: any) {
         this.spinner.fail(chalk`Snapshot test creation failed {magenta ${action.name}}: ${chalk.red(err.message)}`)
         this.exit()
       }

--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -96,7 +96,7 @@ export default class Init extends Command {
 
     try {
       this.spinner.start(`Creating ${chalk.bold(name)}`)
-      renderTemplates(templatePath, targetDirectory, answers)
+      renderTemplates(templatePath, targetDirectory, answers, overwriteExisting)
       this.spinner.succeed(`Scaffold integration`)
     } catch (err: any) {
       this.spinner.fail(`Scaffold integration: ${chalk.red(err.message)}`)

--- a/packages/cli/templates/actions/empty-action-lowcode/index.ts
+++ b/packages/cli/templates/actions/empty-action-lowcode/index.ts
@@ -12,9 +12,25 @@ const action: ActionDefinition<Settings, Payload> = {
      description: '{{description}}',
      type: '{{type}}',
      required: {{required}},
+     {{#hasDefaultValue}}
+     {{#isString}}
      {{#default}}
-     default: {{{value}}}
+     default: "{{value}}",
      {{/default}}
+     {{/isString}}
+     {{/hasDefaultValue}}
+     {{#hasDefaultValue}}
+     {{^isString}}
+     {{#default}}
+     default: {{value}},
+     {{/default}}
+     {{/isString}}
+     {{/hasDefaultValue}}
+     {{#hasDirective}}
+     {{#default}}
+     default: { "{{{directiveType}}}": "{{{value}}}" },
+     {{/default}}
+     {{/hasDirective}}
    },
    {{/fields}}
   },

--- a/packages/cli/templates/destinations/lowcode/basic-auth/index.ts
+++ b/packages/cli/templates/destinations/lowcode/basic-auth/index.ts
@@ -2,7 +2,7 @@ import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
 {{#json.actions}}
-import {{name}} from './{{name}}'
+import {{key}} from './{{key}}'
 {{/json.actions}}
 
 const destination: DestinationDefinition<Settings> = {
@@ -42,7 +42,7 @@ const destination: DestinationDefinition<Settings> = {
 
   actions: {
     {{#json.actions}}
-    {{name}},
+    {{key}},
     {{/json.actions}}
   }
 }

--- a/packages/cli/templates/destinations/lowcode/custom-auth/index.ts
+++ b/packages/cli/templates/destinations/lowcode/custom-auth/index.ts
@@ -2,7 +2,7 @@ import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
 {{#json.actions}}
-import {{name}} from './{{name}}'
+import {{key}} from './{{key}}'
 {{/json.actions}}
 
 const destination: DestinationDefinition<Settings> = {
@@ -31,7 +31,7 @@ const destination: DestinationDefinition<Settings> = {
 
   actions: {
     {{#json.actions}}
-    {{name}},
+    {{key}},
     {{/json.actions}}
   }
 }

--- a/packages/cli/templates/destinations/lowcode/oauth-managed/index.ts
+++ b/packages/cli/templates/destinations/lowcode/oauth-managed/index.ts
@@ -2,7 +2,7 @@ import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
 {{#json.actions}}
-import {{name}} from './{{name}}'
+import {{key}} from './{{key}}'
 {{/json.actions}}
 
 const destination: DestinationDefinition<Settings> = {
@@ -51,7 +51,7 @@ const destination: DestinationDefinition<Settings> = {
 
   actions: {
     {{#json.actions}}
-    {{name}},
+    {{key}},
     {{/json.actions}}
   }
 }

--- a/packages/cli/templates/destinations/lowcode/oauth2-auth/index.ts
+++ b/packages/cli/templates/destinations/lowcode/oauth2-auth/index.ts
@@ -2,7 +2,7 @@ import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
 {{#json.actions}}
-import {{name}} from './{{name}}'
+import {{key}} from './{{key}}'
 {{/json.actions}}
 
 const destination: DestinationDefinition<Settings> = {
@@ -47,7 +47,7 @@ const destination: DestinationDefinition<Settings> = {
 
   actions: {
     {{#json.actions}}
-    {{name}},
+    {{key}},
     {{/json.actions}}
   }
 }


### PR DESCRIPTION
This PR updates low-code, no-code templates to use the proper fields and accommodate different default values.

Testing successfully via CLI:
<img width="451" alt="Screenshot 2023-05-05 at 3 20 28 PM" src="https://user-images.githubusercontent.com/87985289/236552311-d5165a84-c48a-489a-9ae1-6e4e59866d3c.png">


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
