### PR TITLE
[STRATCONN-2041] Add synchronization support for refresh access token

### DIFF
--- a/packages/core/src/__tests__/destination-kit.test.ts
+++ b/packages/core/src/__tests__/destination-kit.test.ts
@@ -316,6 +316,60 @@ describe('destination kit', () => {
 
       expect(res).toEqual({ accessToken: 'fresh-token' })
     })
+
+    test('should invoke synchronizeRefreshAccessToken if defined', async () => {
+      const destinationTest = new Destination(destinationOAuth2)
+
+      const testSettings = {
+        apiSecret: 'test_key',
+        subscription: {
+          subscribe: 'type = "track"',
+          partnerAction: 'customEvent',
+          mapping: {
+            clientId: '23455343467',
+            name: 'fancy_event',
+            parameters: { field_one: 'rogue one' }
+          }
+        }
+      }
+
+      const acquireLockMock = jest.fn(() => Promise.resolve())
+
+      await expect(
+        destinationTest.refreshAccessToken(
+          testSettings,
+          { clientId: '', clientSecret: '', accessToken: '', refreshToken: '' },
+          acquireLockMock
+        )
+      ).resolves.not.toThrowError()
+      expect(acquireLockMock).toHaveBeenCalledTimes(1)
+    })
+
+    test('should succeed if synchronizeRefreshAccessToken handler is not passed in event options', async () => {
+      const destinationTest = new Destination(destinationOAuth2)
+
+      const testSettings = {
+        apiSecret: 'test_key',
+        subscription: {
+          subscribe: 'type = "track"',
+          partnerAction: 'customEvent',
+          mapping: {
+            clientId: '23455343467',
+            name: 'fancy_event',
+            parameters: { field_one: 'rogue one' }
+          }
+        }
+      }
+
+      await expect(
+        destinationTest.refreshAccessToken(testSettings, {
+          clientId: '',
+          clientSecret: '',
+          accessToken: '',
+          refreshToken: ''
+        })
+      ).resolves.not.toThrowError()
+    })
   })
 
   describe('features', () => {

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -364,8 +364,8 @@ export class Destination<Settings = JSONObject> {
       return undefined
     }
 
-    // Acquire Lock if acquireLock option is passed. Acquire Lock is to required to perform synchronized token refresh
-    // for destinations that invalidate previous tokens
+    // Invoke synchronizeRefreshAccessToken handler if synchronizeRefreshAccessToken option is passed.
+    // This will ensure that there is only one active refresh happening at a time.
     await synchronizeRefreshAccessToken?.()
     return this.authentication.refreshAccessToken(requestClient, { settings, auth: oauthData })
   }

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -213,7 +213,8 @@ interface OnEventOptions {
   logger?: Logger
   transactionContext?: TransactionContext
   stateContext?: StateContext
-  /** Handler to perform synchronization. If set, refresh access token action will be synchronized across all events*/
+  /** Handler to perform synchronization. If set, the refresh access token method will be synchronized across
+   * all events across multiple instances of the destination using the same account for a given source*/
   synchronizeRefreshAccessToken?: () => Promise<void>
 }
 

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -365,7 +365,7 @@ export class Destination<Settings = JSONObject> {
     }
 
     // Acquire Lock if acquireLock option is passed. Acquire Lock is to required to perform synchronized token refresh
-    // for destinations that invalidate previoius tokens
+    // for destinations that invalidate previous tokens
     await synchronizeRefreshAccessToken?.()
     return this.authentication.refreshAccessToken(requestClient, { settings, auth: oauthData })
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,11 +35,14 @@ export type {
   BasicAuthentication,
   CustomAuthentication,
   OAuth2Authentication,
+  OAuthManagedAuthentication,
   OAuth2ClientCredentials,
   RefreshAccessTokenResult,
   RequestFn,
   DecoratedResponse,
-  MinimalInputField
+  MinimalInputField,
+  StateContext,
+  StatsContext
 } from './destination-kit'
 
 export type {


### PR DESCRIPTION
For action-destinations like Blackbaud,  previous access tokens are invalidated on each refresh. Since access tokens are stored in memory of Centrifuge director and not shared across multiple service instances, we are running it endless cycle of access token refreshes and also permanent failure of events if refreshToken is invalidated. 

Until we figure out a permanent solution for the problem and to enable the affected destinations, we’ll be using redis as a token store and also as the distributed lock store like some of the classic destinations do.

A more detailed note on the impact of this change, the reasoning behind the change and the test results for review are available in this doc- [Redis as token store and lock store for Action Destinations requiring synchronization](https://docs.google.com/document/d/1nfeFyR9AQ1YJ8csrtdYyGxIIWAOgsPZTzsTbMOWzgSM/edit#)

This PR accompanies this integration PR. The following are the changes made to actions-core as part of this PR:

- onTokenRefresh is now an async method to allow storing of tokens in redis
- passes a synchronization handler to be executed to acquire lock before token refresh. This will be passed in only for destinations that require it. Only [Blackbaud](https://app.segment.com/partner-portal/integration/actions-blackbaud-raisers-edge-nxt/profile) is meant to use it initially. This handler will only acquire the lock and not release the lock. The lock will auto-expire after 15s which is greater than the default timeout for cloudevent calls. The events that reach retry with refreshAccessToken stage will get a RESOURCE_LOCKED_ERROR that will be retried by Centrifuge. Therefore, i have left the release lock portion out of it for simplicity.

## Testing

Testing completed successfully in staging with HubSpot. There is a challenge with testing this change with Blackbaud in staging as we don't have proper test account and also the oauth setup is incomplete. But test results with HubSpot and datadog stats point that this should be safe to move to production.

[Test Results](https://docs.google.com/document/d/1o1YrZW4Dlb9agy_Trup4nZQu2giQFmhvHBjzbS03J_0/edit#
)
- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
