### PR TITLE
SEV-4480/adding-logging

### DIFF
--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/generated-types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/generated-types.ts
@@ -66,4 +66,9 @@ export interface Payload {
    * Time of when the actual event happened.
    */
   eventOccurredTS?: string
+
+  /**
+   * Message ID from segment event
+   */
+  messageId?: string
 }

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/index.ts
@@ -119,6 +119,13 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.timestamp'
       }
+    },
+    messageId: {
+      type: 'string',
+      required: false,
+      description: 'The Segment messageId',
+      label: 'MessageId',
+      default: { '@path': '$.messageId' }
     }
   },
   perform: async (request, { settings, payload, statsContext, logger }) => {
@@ -128,7 +135,20 @@ const action: ActionDefinition<Settings, Payload> = {
       settings.region = 'us-west-1'
     }
     tags.push(`space_id:${settings.spaceId}`, `projectid:${settings.sourceId}`, `region:${settings.region}`)
-    return new SmsMessageSender(request, payload, settings, statsClient, tags, logger).send()
+    const logDetails={
+      userId: payload.userId,
+      subscriptionStatus: payload.externalIds?.map(eid=>({type: eid.type, subscriptionStatus: eid.subscriptionStatus})),
+      shouldSend: payload.send,
+      contentSid: payload.contentSid,
+      sourceId: settings.sourceId,
+      spaceId : settings.spaceId,
+      twilioApiKeySID : settings.twilioApiKeySID,
+      region : settings.region,
+      messageId: payload.messageId
+    }
+    logger?.info("TE Messaging: SMS Destination Action Performing...", JSON.stringify(logDetails))
+
+    return new SmsMessageSender(request, payload, settings, statsClient, tags, logger, logDetails).send()
   }
 }
 

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/sms-sender.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/sms-sender.ts
@@ -32,7 +32,7 @@ export class SmsMessageSender extends MessageSender<Payload> {
     readonly tags: StatsContext['tags'],
     readonly logger: Logger | undefined,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    readonly logDetails: {[key:string]: any}
+    readonly logDetails: {[key:string]: any} = {}
   ) {
     super(request, payload, settings, statsClient, tags, logger, logDetails)
   }

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/sms-sender.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendSms/sms-sender.ts
@@ -30,9 +30,11 @@ export class SmsMessageSender extends MessageSender<Payload> {
     readonly settings: Settings,
     readonly statsClient: StatsClient | undefined,
     readonly tags: StatsContext['tags'],
-    readonly logger: Logger | undefined
+    readonly logger: Logger | undefined,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    readonly logDetails: {[key:string]: any}
   ) {
-    super(request, payload, settings, statsClient, tags, logger)
+    super(request, payload, settings, statsClient, tags, logger, logDetails)
   }
 
   getExternalId = () => this.payload.externalIds?.find(({ type }) => type === 'phone')
@@ -129,6 +131,8 @@ export class SmsMessageSender extends MessageSender<Payload> {
     )
 
     try {
+      this.logger?.info("TE Messaging: Get content template from Twilio by ContentSID", JSON.stringify(this.logDetails))
+
       const response = await this.request(`https://content.twilio.com/v1/Content/${this.payload.contentSid}`, {
         method: 'GET',
         headers: {
@@ -141,7 +145,8 @@ export class SmsMessageSender extends MessageSender<Payload> {
       this.tags.push('reason:get_content_template')
       this.statsClient?.incr('actions-personas-messaging-twilio.error', 1, this.tags)
       this.logger?.error(
-        `TE Messaging: SMS failed request to fetch content template from Twilio Content API - ${this.settings.spaceId} - [${error}]`
+        `TE Messaging: SMS failed request to fetch content template from Twilio Content API - ${this.settings.spaceId}, ${JSON.stringify(error)})}`,
+        JSON.stringify(this.logDetails)
       )
       throw new IntegrationError('Unable to fetch content template', 'Twilio Content API request failure', 500)
     }

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/utils/message-sender.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/utils/message-sender.ts
@@ -49,7 +49,7 @@ export abstract class MessageSender<SmsPayload extends MinimalPayload> {
     readonly tags: StatsContext['tags'],
     readonly logger: Logger | undefined,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    readonly logDetails: {[key:string]: any}
+    readonly logDetails: {[key:string]: any} = {}
   ) {
   }
 


### PR DESCRIPTION
Improvements for sev #inc-sev3-4480-engage-sms-channel-not-being-triggered-2023-05-08 adds more logging into integrations

## Testing

- [x] Fixed [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for updated logging
