### PR TITLE
Add company enrichment to Upollo

### DIFF
--- a/packages/browser-destinations/src/destinations/upollo/enrichUser/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/upollo/enrichUser/__tests__/index.test.ts
@@ -1,0 +1,77 @@
+import { Analytics, Context } from '@segment/analytics-next'
+
+import identify from '..'
+import { UpolloClient } from '../../types'
+import { Payload } from '../generated-types'
+
+it('should enrich', async () => {
+  const client = {
+    checkEmail: jest.fn().mockResolvedValue({ company: { name: 'Bar' } })
+  } as any as UpolloClient
+
+  const context = new Context({
+    type: 'identify',
+    event: 'Signed Up'
+  })
+
+  await identify.perform(client as any as UpolloClient, {
+    settings: { apiKey: '123' },
+    analytics: jest.fn() as any as Analytics,
+    context: context,
+    payload: {
+      user_id: 'u1',
+      email: 'foo@bar.com',
+      phone: '+611231234',
+      name: 'Mr Foo',
+      avatar_image_url: 'http://smile',
+      custom_traits: {
+        DOB: '1990-01-01',
+        Plan: 'Bronze',
+        session: {
+          // session is excluded because its not a string
+          count: 1
+        }
+      }
+    } as Payload
+  })
+
+  expect(client.checkEmail).toHaveBeenCalledWith('foo@bar.com')
+
+  expect(context.event.traits?.company?.name).toEqual('Bar')
+})
+
+it('should not enrich when it gets no result', async () => {
+  const client = {
+    checkEmail: jest.fn().mockResolvedValue({ company: { name: '' } })
+  } as any as UpolloClient
+
+  const context = new Context({
+    type: 'identify',
+    event: 'Signed Up'
+  })
+
+  await identify.perform(client as any as UpolloClient, {
+    settings: { apiKey: '123' },
+    analytics: jest.fn() as any as Analytics,
+    context: context,
+    payload: {
+      user_id: 'u1',
+      email: 'foo@bar.com',
+      phone: '+611231234',
+      name: 'Mr Foo',
+      avatar_image_url: 'http://smile',
+      custom_traits: {
+        DOB: '1990-01-01',
+        Plan: 'Bronze',
+        session: {
+          // session is excluded because its not a string
+          count: 1
+        }
+      }
+    } as Payload
+  })
+
+  expect(client.checkEmail).toHaveBeenCalledWith('foo@bar.com')
+
+  expect(context.event.traits?.company).toBeUndefined()
+})

--- a/packages/browser-destinations/src/destinations/upollo/enrichUser/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/upollo/enrichUser/generated-types.ts
@@ -1,0 +1,30 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID of the user
+   */
+  user_id?: string
+  /**
+   * The user's name.
+   */
+  name?: string
+  /**
+   * The user's email address.
+   */
+  email?: string
+  /**
+   * The user's phone number.
+   */
+  phone?: string
+  /**
+   * The URL for the user's avatar/profile image.
+   */
+  avatar_image_url?: string
+  /**
+   * The user's custom attributes.
+   */
+  custom_traits?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/src/destinations/upollo/enrichUser/index.ts
+++ b/packages/browser-destinations/src/destinations/upollo/enrichUser/index.ts
@@ -1,0 +1,84 @@
+import { BrowserActionDefinition } from 'src/lib/browser-destinations'
+import { UpolloClient } from '../types'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const enrichUser: BrowserActionDefinition<Settings, UpolloClient, Payload> = {
+  title: 'Enrich user',
+  description: 'Enrich the user',
+  defaultSubscription: 'type = "identify"',
+  platform: 'web',
+  lifecycleHook: 'enrichment',
+  fields: {
+    user_id: {
+      type: 'string',
+      required: false,
+      label: 'User ID',
+      description: 'The ID of the user ',
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    name: {
+      description: "The user's name.",
+      label: 'Name',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.traits.name'
+      }
+    },
+    email: {
+      description: "The user's email address.",
+      label: 'Email Address',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.traits.email'
+      }
+    },
+    phone: {
+      description: "The user's phone number.",
+      label: 'Phone Number',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.traits.phone'
+      }
+    },
+    avatar_image_url: {
+      description: "The URL for the user's avatar/profile image.",
+      label: 'Avatar',
+      type: 'string',
+      required: false,
+      default: { '@path': '$.traits.avatar' }
+    },
+    custom_traits: {
+      description: "The user's custom attributes.",
+      label: 'Custom Attributes',
+      type: 'object',
+      required: false,
+      defaultObjectUI: 'keyvalue'
+    }
+  },
+  perform: async (UpClient, { payload, context }) => {
+    if (payload?.email) {
+      const result = await UpClient.checkEmail(payload?.email)
+      if (result && result?.company?.name != '') {
+        const company = result?.company
+        if (company && company?.name != '') {
+          const size = company.companySize
+          const count = size && Math.max(size.employeesMin, size.employeesMax)
+          const companyInfo = {
+            name: company?.name,
+            industry: company?.industry,
+            employee_count: count
+          }
+          context.updateEvent('traits.company', companyInfo)
+        }
+      }
+    }
+  }
+}
+
+export default enrichUser

--- a/packages/browser-destinations/src/destinations/upollo/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/upollo/generated-types.ts
@@ -5,4 +5,8 @@ export interface Settings {
    * The api key of your Upollo project. Get it from the Upollo [dashboard](https://upollo.ai/dashboard)
    */
   apiKey: string
+  /**
+   * Enable enrichment of company details on Segment identify events
+   */
+  companyEnrichment?: boolean
 }

--- a/packages/browser-destinations/src/destinations/upollo/identifyUser/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/upollo/identifyUser/__tests__/index.test.ts
@@ -6,16 +6,18 @@ import { Payload } from '../generated-types'
 
 it('should identify', async () => {
   const client = {
-    track: jest.fn()
+    assess: jest.fn().mockResolvedValue({ emailAnalysis: { company: { name: 'Bar' } } })
   } as any as UpolloClient
 
+  const context = new Context({
+    type: 'identify',
+    event: 'Signed Up'
+  })
+
   await identify.perform(client as any as UpolloClient, {
-    settings: { apiKey: '123' },
+    settings: { apiKey: '123', companyEnrichment: true },
     analytics: jest.fn() as any as Analytics,
-    context: new Context({
-      type: 'identify',
-      event: 'Signed Up'
-    }),
+    context: context,
     payload: {
       user_id: 'u1',
       email: 'foo@bar.com',
@@ -33,7 +35,7 @@ it('should identify', async () => {
     } as Payload
   })
 
-  expect(client.track).toHaveBeenCalledWith({
+  expect(client.assess).toHaveBeenCalledWith({
     userId: 'u1',
     userEmail: 'foo@bar.com',
     userPhone: '+611231234',
@@ -41,4 +43,49 @@ it('should identify', async () => {
     userImage: 'http://smile',
     customerSuppliedValues: { DOB: '1990-01-01', Plan: 'Bronze' }
   })
+
+  expect(context.event.traits?.company?.name).toEqual('Bar')
+})
+
+it('should not enrich when it gets no result', async () => {
+  const client = {
+    assess: jest.fn().mockResolvedValue({ emailAnalysis: { company: { name: '' } } })
+  } as any as UpolloClient
+
+  const context = new Context({
+    type: 'identify',
+    event: 'Signed Up'
+  })
+
+  await identify.perform(client as any as UpolloClient, {
+    settings: { apiKey: '123', companyEnrichment: true },
+    analytics: jest.fn() as any as Analytics,
+    context: context,
+    payload: {
+      user_id: 'u1',
+      email: 'foo@bar.com',
+      phone: '+611231234',
+      name: 'Mr Foo',
+      avatar_image_url: 'http://smile',
+      custom_traits: {
+        DOB: '1990-01-01',
+        Plan: 'Bronze',
+        session: {
+          // session is excluded because its not a string
+          count: 1
+        }
+      }
+    } as Payload
+  })
+
+  expect(client.assess).toHaveBeenCalledWith({
+    userId: 'u1',
+    userEmail: 'foo@bar.com',
+    userPhone: '+611231234',
+    userName: 'Mr Foo',
+    userImage: 'http://smile',
+    customerSuppliedValues: { DOB: '1990-01-01', Plan: 'Bronze' }
+  })
+
+  expect(context.event.traits?.company).toBeUndefined()
 })

--- a/packages/browser-destinations/src/destinations/upollo/identifyUser/__tests__/index.test.ts.rej
+++ b/packages/browser-destinations/src/destinations/upollo/identifyUser/__tests__/index.test.ts.rej
@@ -1,0 +1,67 @@
+diff a/packages/browser-destinations/src/destinations/upollo/identifyUser/__tests__/index.test.ts b/packages/browser-destinations/src/destinations/upollo/identifyUser/__tests__/index.test.ts	(rejected hunks)
+@@ -6,16 +6,61 @@ import { Payload } from '../generated-types'
+ 
+ it('should identify', async () => {
+   const client = {
+-    track: jest.fn()
++    assess: jest.fn().mockResolvedValue({ emailAnalysis: { company: { name: 'Bar' } } })
+   } as any as UpolloClient
+ 
++  const context = new Context({
++    type: 'identify',
++    event: 'Signed Up'
++  })
++
+   await identify.perform(client as any as UpolloClient, {
+-    settings: { apiKey: '123' },
++    settings: { apiKey: '123', companyEnrichment: true },
+     analytics: jest.fn() as any as Analytics,
+-    context: new Context({
++    context: context,
++    payload: {
++      user_id: 'u1',
++      email: 'foo@bar.com',
++      phone: '+611231234',
++      name: 'Mr Foo',
++      avatar_image_url: 'http://smile',
++      custom_traits: {
++        DOB: '1990-01-01',
++        Plan: 'Bronze',
++        session: {
++          // session is excluded because its not a string
++          count: 1
++        }
++      }
++    } as Payload
++  })
++
++  expect(client.assess).toHaveBeenCalledWith({
++    userId: 'u1',
++    userEmail: 'foo@bar.com',
++    userPhone: '+611231234',
++    userName: 'Mr Foo',
++    userImage: 'http://smile',
++    customerSuppliedValues: { DOB: '1990-01-01', Plan: 'Bronze' }
++  })
++
++  expect(context.event.traits?.company?.name).toEqual('Bar')
++})
++
++it('should not enrich when it gets no result', async () => {
++  const client = {
++    assess: jest.fn().mockResolvedValue({ emailAnalysis: { company: { name: '' } } })
++  } as any as UpolloClient
++
++  const context = new Context({
+     type: 'identify',
+     event: 'Signed Up'
+-    }),
++  })
++
++  await identify.perform(client as any as UpolloClient, {
++    settings: { apiKey: '123', companyEnrichment: true },
++    analytics: jest.fn() as any as Analytics,
++    context: context,
+     payload: {
+       user_id: 'u1',
+       email: 'foo@bar.com',

--- a/packages/browser-destinations/src/destinations/upollo/identifyUser/index.ts
+++ b/packages/browser-destinations/src/destinations/upollo/identifyUser/index.ts
@@ -8,6 +8,7 @@ const identifyUser: BrowserActionDefinition<Settings, UpolloClient, Payload> = {
   description: 'Identify the user',
   defaultSubscription: 'type = "identify"',
   platform: 'web',
+  lifecycleHook: 'enrichment',
   fields: {
     user_id: {
       type: 'string',

--- a/packages/browser-destinations/src/destinations/upollo/identifyUser/index.ts
+++ b/packages/browser-destinations/src/destinations/upollo/identifyUser/index.ts
@@ -60,7 +60,7 @@ const identifyUser: BrowserActionDefinition<Settings, UpolloClient, Payload> = {
       defaultObjectUI: 'keyvalue'
     }
   },
-  perform: (UpClient, { payload }) => {
+  perform: async (UpClient, { payload, context, settings }) => {
     const userInfo = {
       userId: payload.user_id,
       userEmail: payload.email,
@@ -70,7 +70,18 @@ const identifyUser: BrowserActionDefinition<Settings, UpolloClient, Payload> = {
       customerSuppliedValues: payload.custom_traits ? toCustomValues(payload.custom_traits) : undefined
     }
 
-    void UpClient.track(userInfo)
+    const result = await UpClient.assess(userInfo)
+    const company = result?.emailAnalysis?.company
+    if (company && company?.name != '' && settings?.companyEnrichment) {
+      const size = company.companySize
+      const count = size && Math.max(size.employeesMin, size.employeesMax)
+      const companyInfo = {
+        name: company?.name,
+        industry: company?.industry,
+        employee_count: count
+      }
+      context.updateEvent('traits.company', companyInfo)
+    }
   }
 }
 

--- a/packages/browser-destinations/src/destinations/upollo/index.ts
+++ b/packages/browser-destinations/src/destinations/upollo/index.ts
@@ -4,6 +4,7 @@ import { browserDestination } from '../../runtime/shim'
 import { UpolloClient } from './types'
 import { defaultValues } from '@segment/actions-core'
 import identifyUser from './identifyUser'
+import enrichUser from './enrichUser'
 
 declare global {
   interface Window {
@@ -24,6 +25,12 @@ export const destination: BrowserDestinationDefinition<Settings, UpolloClient> =
       subscribe: 'type = "identify"',
       partnerAction: 'identifyUser',
       mapping: defaultValues(identifyUser.fields)
+    },
+    {
+      name: 'Enrich',
+      subscribe: 'type = "identify"',
+      partnerAction: 'enrichUser',
+      mapping: defaultValues(enrichUser.fields)
     }
   ],
 
@@ -61,7 +68,8 @@ export const destination: BrowserDestinationDefinition<Settings, UpolloClient> =
   },
 
   actions: {
-    identifyUser
+    identifyUser,
+    enrichUser
   }
 }
 

--- a/packages/browser-destinations/src/destinations/upollo/index.ts
+++ b/packages/browser-destinations/src/destinations/upollo/index.ts
@@ -35,6 +35,13 @@ export const destination: BrowserDestinationDefinition<Settings, UpolloClient> =
       label: 'API Key',
       type: 'string',
       required: true
+    },
+    companyEnrichment: {
+      description: 'Enable enrichment of company details on Segment identify events',
+      label: 'Enable Company Enrichment',
+      type: 'boolean',
+      required: false,
+      default: true
     }
   },
 

--- a/packages/browser-destinations/src/destinations/upollo/types.ts
+++ b/packages/browser-destinations/src/destinations/upollo/types.ts
@@ -13,6 +13,10 @@ export declare class UpolloClient {
       company?: { name: string; industry: string; companySize: { employeesMin: number; employeesMax: number } }
     }
   }>
+  checkEmail(email: string): Promise<{
+    valid: boolean
+    company?: { name: string; industry: string; companySize: { employeesMin: number; employeesMax: number } }
+  }>
 }
 
 export interface UpUser {

--- a/packages/browser-destinations/src/destinations/upollo/types.ts
+++ b/packages/browser-destinations/src/destinations/upollo/types.ts
@@ -5,6 +5,14 @@ export declare class UpolloClient {
     userinfo?: UpUser,
     eventtype?: number // eventtype is a proto enum, but we cant use those types here.
   ): Promise<void>
+  assess(
+    userinfo?: UpUser,
+    eventtype?: number
+  ): Promise<{
+    emailAnalysis?: {
+      company?: { name: string; industry: string; companySize: { employeesMin: number; employeesMax: number } }
+    }
+  }>
 }
 
 export interface UpUser {


### PR DESCRIPTION
This PR optionally adds company information enrichment to Identify requests. This includes company name, industry and employee count. 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
