### PR TITLE
Dont run tests for node14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 18.x]
+        node-version: [18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ext.yml
+++ b/.github/workflows/ext.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Node 18 is out, should we stop running tests for 14?

## Before

![Screen Shot 2023-05-11 at 1 11 00 PM](https://github.com/segmentio/action-destinations/assets/316711/ecfce65c-956f-4127-8c24-716c870d55c6)

## After

![Screen Shot 2023-05-11 at 1 38 55 PM](https://github.com/segmentio/action-destinations/assets/316711/81d455fa-0d1c-4991-95a9-32e00749f174)


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
