### PR TITLE
Update index.ts - Added line to clarify Debounce Middleware is not available with Engage and server-side connections

### DIFF
--- a/packages/browser-destinations/src/destinations/braze/debounce/index.ts
+++ b/packages/browser-destinations/src/destinations/braze/debounce/index.ts
@@ -40,7 +40,7 @@ function shouldSendToBraze(event: SegmentEvent) {
 const action: BrowserActionDefinition<Settings, BrazeDestinationClient, Payload> = {
   title: 'Debounce Middleware',
   description:
-    'When enabled, it ensures that only events where at least one changed trait value are sent to Braze, and events with duplicate traits are not sent.',
+    'When enabled, it ensures that only events where at least one changed trait value are sent to Braze, and events with duplicate traits are not sent. Debounce functionality requires a frontend client to work. Therefore, it cannot be used with server-side libraries or with Engage.',
   platform: 'web',
   defaultSubscription: 'type = "identify" or type = "group"',
   fields: {},


### PR DESCRIPTION
Added line to clarify Debounce Middleware is not available with Engage and server-side connections

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Only made a text change to a single line for data around Debounce Middleware. https://segment.com/docs/connections/destinations/catalog/braze-cloud-mode-actions/#debounce-middleware

Per [this Slack thread](https://twilio.slack.com/archives/CC97A542H/p1677700957017759), the Debounce Middleware Action, though possible to add on the Mappings tab, is not available or applicable for destinations connected to Engage. This is because Engage hits the Tracking API directly, and thus no AJS2 to run the debounce middleware against.

This section should say something to include that this Action is not applicable to destinations within Engage.

I'm currently working with our customer (papier) who believed that the Debounce Middleware action was applicable to their Engage Braze destination. I've updated them with the above information and believe that adding this section into our docs will ensure that future customers aren't also confused by this. This has also occurred for a second customer as well.

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

No testing was performed.

Here's the [Docs Issue](https://github.com/segmentio/segment-docs/issues/4333) I created
The [KCS Jira](https://segment.atlassian.net/jira/software/projects/KCS/issues/KCS-158?jql=project%20%3D%20%22KCS%22%20AND%20reporter%20%3D%20currentUser()%20ORDER%20BY%20created%20DESC) I created
And the latest [Slack thread](https://twilio.slack.com/archives/CD3LFFTFZ/p1683824768608609?thread_ts=1683769864.648409&cid=CD3LFFTFZ) pertaining to this update.
