### PR TITLE
Passes NODE_OPTIONS=--openssl-legacy-provider to yarn browser dev command

### DIFF
--- a/packages/browser-destinations/package.json
+++ b/packages/browser-destinations/package.json
@@ -32,7 +32,7 @@
     "prepublishOnly": "yarn build",
     "test": "jest",
     "typecheck": "tsc -p tsconfig.build.json --noEmit",
-    "dev": "NODE_ENV=development concurrently \"webpack serve\" \"webpack -c webpack.config.js --watch\""
+    "dev": "NODE_ENV=development NODE_OPTIONS=--openssl-legacy-provider concurrently \"webpack serve\" \"webpack -c webpack.config.js --watch\""
   },
   "dependencies": {
     "@braze/web-sdk": "npm:@braze/web-sdk@^4.1.0",


### PR DESCRIPTION
The local actions web tester was failing due to openssl issues as a result of Node 18 upgrade. This PR passes `NODE_OPTIONS=--openssl-legacy-provider` to the webpack command to avoid the failure. We already pass this option in the [build scripts](https://github.com/segmentio/action-destinations/blob/56d86d9a45732fe342379fa0b9b6f7c9a2b45c17/packages/browser-destinations/scripts/build-web.sh#L6).

This command was failing silently when running the serve command for browser destinations` ./bin/run serve --directory ./packages/browser-destinations/src/destinations --browser` and as a result we were seeing `ERR:CONNECTION_REFUSED` error

A customer also reported the same and has raised a [PR](https://github.com/segmentio/action-destinations/pull/1051) to update the documentation with instructions to run webpack server separately but adding this option should fix their query.

**Note** - This option fails with node versions 16 and below but i guess we want all our developers to use Node 18.

![Screenshot 2023-05-12 at 10 39 08 AM](https://github.com/segmentio/action-destinations/assets/109586712/e6064578-7608-452c-b7f4-8c93045cbc3d)


## Testing

Testing completed successfully.

**Before**
<img width="1494" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/d751bfa1-30f6-489d-9cdf-913fef40585e">

**After**
<img width="1490" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/6b28c6bd-2792-4b2b-90d2-c06e8bdea0b3">


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
