### PR TITLE
Allow installation for node14 or greater

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     ]
   },
   "engines": {
-    "node": "14 || ^18.12"
+    "node": ">=14"
   },
   "scripts": {
     "browser": "yarn workspace @segment/browser-destinations",


### PR DESCRIPTION
Makes the required node version a bit more flexible since some of the consumers are running on node versions greater than 18 even.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
