### PR TITLE
update string check in CLI scaffold tool

### DIFF
--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -126,7 +126,7 @@ export default class Init extends Command {
         if (hasDefault) {
           field.hasDefaultValue = field.default.type !== 'directive'
           field.hasDirective = field.default.type === 'directive'
-          field.isString = field.default.type === 'string'
+          field.isString = ['string', 'text', 'datetime', 'password'].includes(field.type)
         }
       })
 

--- a/packages/cli/templates/destinations/lowcode/basic-auth/index.ts
+++ b/packages/cli/templates/destinations/lowcode/basic-auth/index.ts
@@ -27,6 +27,7 @@ const destination: DestinationDefinition<Settings> = {
       }
     },
     testAuthentication: (request) => {
+      // Please update the code here for further customization
       return request('{{{json.oauth.apiEndpoint}}}', {
         method: '{{json.oauth.httpMethod}}'
       })
@@ -34,6 +35,7 @@ const destination: DestinationDefinition<Settings> = {
   },
 
   extendRequest({ settings }) {
+    // Please update the code here to modify the request headers
     return {
       username: settings.username,
       password: settings.password

--- a/packages/cli/templates/destinations/lowcode/custom-auth/index.ts
+++ b/packages/cli/templates/destinations/lowcode/custom-auth/index.ts
@@ -23,6 +23,7 @@ const destination: DestinationDefinition<Settings> = {
       {{/json.oauth.fields}}
     },
     testAuthentication: (request) => {
+      // Please update the code here for further customization
       return request('{{{json.oauth.apiEndpoint}}}', {
         method: '{{json.oauth.httpMethod}}'
       })

--- a/packages/cli/templates/destinations/lowcode/oauth-managed/index.ts
+++ b/packages/cli/templates/destinations/lowcode/oauth-managed/index.ts
@@ -23,7 +23,7 @@ const destination: DestinationDefinition<Settings> = {
       {{/json.oauth.fields}}
     },
     refreshAccessToken: async (request, { auth }) => {
-      // Return a request that refreshes the access_token if the API supports it
+      // Please update the code here to further customize how you refresh the access_token
       const res = await request('{{{json.oauth.apiEndpoint}}}', {
         method: 'POST',
         body: new URLSearchParams({
@@ -38,6 +38,7 @@ const destination: DestinationDefinition<Settings> = {
     }
   },
   extendRequest({ auth }) {
+    // Please update the code here to modify the request headers
     return {
       headers: {
         authorization: `Bearer ${auth?.accessToken}`

--- a/packages/cli/templates/destinations/lowcode/oauth2-auth/index.ts
+++ b/packages/cli/templates/destinations/lowcode/oauth2-auth/index.ts
@@ -23,7 +23,7 @@ const destination: DestinationDefinition<Settings> = {
       {{/json.oauth.fields}}
     },
     refreshAccessToken: async (request, { auth }) => {
-      // Return a request that refreshes the access_token if the API supports it
+      // Please update the code here to further customize how you refresh the access_token
       const res = await request('{{{json.oauth.apiEndpoint}}}', {
         method: 'POST',
         body: new URLSearchParams({
@@ -38,6 +38,7 @@ const destination: DestinationDefinition<Settings> = {
     }
   },
   extendRequest({ auth }) {
+    // Please update the code here to modify the request headers
     return {
       headers: {
         authorization: `Bearer ${auth?.accessToken}`


### PR DESCRIPTION
This PR updates the string check in the CLI scaffold tool to check `field.type` instead of `field.default.type`

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
