### PR TITLE
Add Screeb browser destination

### DIFF
--- a/packages/browser-destinations/src/destinations/screeb/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/screeb/__tests__/index.test.ts
@@ -21,6 +21,9 @@ describe('Screeb initialization', () => {
     jest.mock('../../../runtime/load-script', () => ({
       loadScript: (_src: any, _attributes: any) => {}
     }))
+    jest.mock('../../../runtime/resolve-when', () => ({
+      resolveWhen: (_fn: any, _timeout: any) => {}
+    }))
   })
   test('can load Screeb', async () => {
     const [event] = await screebDestination({

--- a/packages/browser-destinations/src/destinations/screeb/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/screeb/__tests__/index.test.ts
@@ -1,0 +1,38 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import screebDestination, { destination } from '../index'
+import { Subscription } from '../../../lib/browser-destinations'
+
+const subscriptions: Subscription[] = [
+  {
+    partnerAction: 'track',
+    name: 'Track',
+    enabled: true,
+    subscribe: 'type = "track"',
+    mapping: {
+      name: {
+        '@path': '$.name'
+      }
+    }
+  }
+]
+
+describe('Screeb initialization', () => {
+  beforeAll(() => {
+    jest.mock('../../../runtime/load-script', () => ({
+      loadScript: (_src: any, _attributes: any) => {}
+    }))
+  })
+  test('can load Screeb', async () => {
+    const [event] = await screebDestination({
+      websiteId: 'fake-website-id',
+      subscriptions
+    })
+
+    jest.spyOn(destination, 'initialize')
+
+    await event.load(Context.system(), {} as Analytics)
+    expect(destination.initialize).toHaveBeenCalled()
+
+    expect(window.$screeb.q).toStrictEqual([['init', 'fake-website-id']])
+  })
+})

--- a/packages/browser-destinations/src/destinations/screeb/alias.types.ts
+++ b/packages/browser-destinations/src/destinations/screeb/alias.types.ts
@@ -1,0 +1,18 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The group id
+   */
+  groupId: string
+  /**
+   * The group type
+   */
+  groupType: string
+  /**
+   * Traits to associate with the group
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/src/destinations/screeb/alias/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/screeb/alias/__tests__/index.test.ts
@@ -24,6 +24,9 @@ describe('alias', () => {
     jest.mock('../../../../runtime/load-script', () => ({
       loadScript: (_src: any, _attributes: any) => {}
     }))
+    jest.mock('../../../../runtime/resolve-when', () => ({
+      resolveWhen: (_fn: any, _timeout: any) => {}
+    }))
   })
   test('it maps event parameters correctly to alias function', async () => {
     const [alias] = await screebDestination({

--- a/packages/browser-destinations/src/destinations/screeb/alias/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/screeb/alias/__tests__/index.test.ts
@@ -1,0 +1,90 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import screebDestination, { destination } from '../../index'
+import { Subscription } from '../../../../lib/browser-destinations'
+
+const subscriptions: Subscription[] = [
+  {
+    partnerAction: 'alias',
+    name: 'Alias',
+    enabled: true,
+    subscribe: 'type = "alias"',
+    mapping: {
+      userId: {
+        '@path': '$.userId'
+      },
+      anonymousId: {
+        '@path': '$.anonymousId'
+      }
+    }
+  }
+]
+
+describe('alias', () => {
+  beforeAll(() => {
+    jest.mock('../../../../runtime/load-script', () => ({
+      loadScript: (_src: any, _attributes: any) => {}
+    }))
+  })
+  test('it maps event parameters correctly to alias function', async () => {
+    const [alias] = await screebDestination({
+      websiteId: 'fake-website-id',
+      subscriptions
+    })
+
+    jest.spyOn(destination.actions.alias, 'perform')
+    await alias.load(Context.system(), {} as Analytics)
+
+    await alias.alias?.(
+      new Context({
+        type: 'alias',
+        userId: 'user-id',
+        anonymousId: 'anonymous-id'
+      })
+    )
+
+    expect(destination.actions.alias.perform).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        payload: {
+          userId: 'user-id',
+          anonymousId: 'anonymous-id'
+        }
+      })
+    )
+
+    expect(window.$screeb.q).toStrictEqual([
+      ['init', 'fake-website-id'],
+      ['identity', 'user-id']
+    ])
+  })
+  test('it maps event parameters correctly to alias function without user id but anonymous id', async () => {
+    const [alias] = await screebDestination({
+      websiteId: 'fake-website-id',
+      subscriptions
+    })
+
+    jest.spyOn(destination.actions.alias, 'perform')
+    await alias.load(Context.system(), {} as Analytics)
+
+    await alias.alias?.(
+      new Context({
+        type: 'alias',
+        anonymousId: 'anonymous-id'
+      })
+    )
+
+    expect(destination.actions.alias.perform).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        payload: {
+          anonymousId: 'anonymous-id'
+        }
+      })
+    )
+
+    expect(window.$screeb.q).toStrictEqual([
+      ['init', 'fake-website-id'],
+      ['identity', 'anonymous-id']
+    ])
+  })
+})

--- a/packages/browser-destinations/src/destinations/screeb/alias/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/screeb/alias/generated-types.ts
@@ -1,0 +1,12 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * New unique identifier for the user
+   */
+  userId?: string
+  /**
+   * New anonymous identifier for the user
+   */
+  anonymousId?: string
+}

--- a/packages/browser-destinations/src/destinations/screeb/alias/index.ts
+++ b/packages/browser-destinations/src/destinations/screeb/alias/index.ts
@@ -1,0 +1,45 @@
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import type { Screeb } from '../types'
+
+const action: BrowserActionDefinition<Settings, Screeb, Payload> = {
+  title: 'Alias',
+  description: 'Update user identity with new user ID.',
+  platform: 'web',
+  defaultSubscription: 'type = "alias"',
+  fields: {
+    userId: {
+      type: 'string',
+      required: false,
+      description: 'New unique identifier for the user',
+      label: 'User ID',
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    anonymousId: {
+      type: 'string',
+      required: false,
+      description: 'New anonymous identifier for the user',
+      label: 'Anonymous ID',
+      default: {
+        '@path': '$.anonymousId'
+      }
+    }
+  },
+  perform: (Screeb, event) => {
+    const payload = event.payload
+    if (!payload || typeof payload !== 'object' || !payload.userId || !payload.anonymousId) {
+      console.warn(
+        '[Screeb] received invalid payload (expected userId or anonymousId to be present); skipping alias',
+        payload
+      )
+      return
+    }
+
+    Screeb('identity', payload.userId ?? payload.anonymousId)
+  }
+}
+
+export default action

--- a/packages/browser-destinations/src/destinations/screeb/alias/index.ts
+++ b/packages/browser-destinations/src/destinations/screeb/alias/index.ts
@@ -30,7 +30,7 @@ const action: BrowserActionDefinition<Settings, Screeb, Payload> = {
   },
   perform: (Screeb, event) => {
     const payload = event.payload
-    if (!payload || typeof payload !== 'object' || !payload.userId || !payload.anonymousId) {
+    if (!payload || typeof payload !== 'object' || !(payload.userId || payload.anonymousId)) {
       console.warn(
         '[Screeb] received invalid payload (expected userId or anonymousId to be present); skipping alias',
         payload

--- a/packages/browser-destinations/src/destinations/screeb/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/screeb/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your website ID (given in Screeb app).
+   */
+  websiteId: string
+}

--- a/packages/browser-destinations/src/destinations/screeb/group/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/screeb/group/__tests__/index.test.ts
@@ -1,0 +1,106 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import screebDestination, { destination } from '../../index'
+import { Subscription } from '../../../../lib/browser-destinations'
+
+const subscriptions: Subscription[] = [
+  {
+    partnerAction: 'group',
+    name: 'Group',
+    enabled: true,
+    subscribe: 'type = "group"',
+    mapping: {
+      groupId: {
+        '@path': '$.groupId'
+      },
+      groupType: {
+        '@path': '$.traits.group_type'
+      },
+      properties: {
+        '@path': '$.traits'
+      }
+    }
+  }
+]
+
+describe('group', () => {
+  beforeAll(() => {
+    jest.mock('../../../../runtime/load-script', () => ({
+      loadScript: (_src: any, _attributes: any) => {}
+    }))
+  })
+  test('it maps event parameters correctly to group function ', async () => {
+    const [group] = await screebDestination({
+      websiteId: 'fake-website-id',
+      subscriptions
+    })
+
+    jest.spyOn(destination.actions.group, 'perform')
+    await group.load(Context.system(), {} as Analytics)
+
+    await group.group?.(
+      new Context({
+        type: 'group',
+        groupId: 'group-name',
+        traits: {
+          plan: 'free'
+        }
+      })
+    )
+
+    expect(destination.actions.group.perform).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        payload: {
+          groupId: 'group-name',
+          properties: {
+            plan: 'free'
+          }
+        }
+      })
+    )
+
+    expect(window.$screeb.q).toStrictEqual([
+      ['init', 'fake-website-id'],
+      ['identity.group.assign', undefined, 'group-name', { plan: 'free' }]
+    ])
+  })
+  test('it maps event parameters correctly to group function with group type', async () => {
+    const [group] = await screebDestination({
+      websiteId: 'fake-website-id',
+      subscriptions
+    })
+
+    jest.spyOn(destination.actions.group, 'perform')
+    await group.load(Context.system(), {} as Analytics)
+
+    await group.group?.(
+      new Context({
+        type: 'group',
+        groupId: 'group-name',
+        traits: {
+          plan: 'free',
+          group_type: 'cohort'
+        }
+      })
+    )
+
+    expect(destination.actions.group.perform).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        payload: {
+          groupId: 'group-name',
+          groupType: 'cohort',
+          properties: {
+            plan: 'free',
+            group_type: 'cohort'
+          }
+        }
+      })
+    )
+
+    expect(window.$screeb.q).toStrictEqual([
+      ['init', 'fake-website-id'],
+      ['identity.group.assign', 'cohort', 'group-name', { plan: 'free', group_type: 'cohort' }]
+    ])
+  })
+})

--- a/packages/browser-destinations/src/destinations/screeb/group/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/screeb/group/__tests__/index.test.ts
@@ -27,6 +27,9 @@ describe('group', () => {
     jest.mock('../../../../runtime/load-script', () => ({
       loadScript: (_src: any, _attributes: any) => {}
     }))
+    jest.mock('../../../../runtime/resolve-when', () => ({
+      resolveWhen: (_fn: any, _timeout: any) => {}
+    }))
   })
   test('it maps event parameters correctly to group function ', async () => {
     const [group] = await screebDestination({

--- a/packages/browser-destinations/src/destinations/screeb/group/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/screeb/group/generated-types.ts
@@ -1,0 +1,18 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The group id
+   */
+  groupId: string
+  /**
+   * The group type
+   */
+  groupType: string
+  /**
+   * Traits to associate with the group
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/src/destinations/screeb/group/index.ts
+++ b/packages/browser-destinations/src/destinations/screeb/group/index.ts
@@ -1,0 +1,49 @@
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import type { Screeb } from '../types'
+
+const action: BrowserActionDefinition<Settings, Screeb, Payload> = {
+  title: 'Group',
+  description: 'Set user group and/or attributes.',
+  platform: 'web',
+  defaultSubscription: 'type = "group"',
+  fields: {
+    groupId: {
+      type: 'string',
+      description: 'The group id',
+      label: 'Group ID',
+      required: true,
+      default: { '@path': '$.groupId' }
+    },
+    groupType: {
+      type: 'string',
+      description: 'The group type',
+      label: 'Group type',
+      required: true,
+      default: { '@path': '$.traits.group_type' }
+    },
+    properties: {
+      type: 'object',
+      label: 'Traits',
+      description: 'Traits to associate with the group',
+      default: { '@path': '$.traits' }
+    }
+  },
+  perform: (Screeb, event) => {
+    const payload = event.payload
+    if (!payload || typeof payload !== 'object' || !(payload.groupId || payload.properties)) {
+      console.warn(
+        '[Screeb] received invalid payload (expected userId, anonymousId, or properties to be present); skipping identify',
+        payload
+      )
+      return
+    }
+
+    const properties = payload.properties && Object.keys(payload.properties).length > 0 ? payload.properties : undefined
+
+    Screeb('identity.group.assign', payload.groupType, payload.groupId, properties)
+  }
+}
+
+export default action

--- a/packages/browser-destinations/src/destinations/screeb/identify/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/screeb/identify/__tests__/index.test.ts
@@ -1,0 +1,113 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import screebDestination, { destination } from '../../index'
+import { Subscription } from '../../../../lib/browser-destinations'
+
+const subscriptions: Subscription[] = [
+  {
+    partnerAction: 'identify',
+    name: 'Identify',
+    enabled: true,
+    subscribe: 'type = "identify"',
+    mapping: {
+      userId: {
+        '@path': '$.userId'
+      },
+      anonymousId: {
+        '@path': '$.anonymousId'
+      },
+      properties: {
+        '@path': '$.traits'
+      }
+    }
+  }
+]
+
+describe('identify', () => {
+  beforeAll(() => {
+    jest.mock('../../../../runtime/load-script', () => ({
+      loadScript: (_src: any, _attributes: any) => {}
+    }))
+  })
+  test('it maps event parameters correctly to identify function without user id but anonymous id', async () => {
+    const [identify] = await screebDestination({
+      websiteId: 'fake-website-id',
+      subscriptions
+    })
+
+    jest.spyOn(destination.actions.identify, 'perform')
+    await identify.load(Context.system(), {} as Analytics)
+
+    await identify.identify?.(
+      new Context({
+        type: 'identify',
+        userId: 'user-id',
+        anonymousId: 'anonymous-id',
+        traits: {
+          firstname: 'Frida',
+          lastname: 'Khalo',
+          email: 'frida.khalo@screeb.app'
+        }
+      })
+    )
+
+    expect(destination.actions.identify.perform).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        payload: {
+          userId: 'user-id',
+          anonymousId: 'anonymous-id',
+          properties: {
+            firstname: 'Frida',
+            lastname: 'Khalo',
+            email: 'frida.khalo@screeb.app'
+          }
+        }
+      })
+    )
+
+    expect(window.$screeb.q).toStrictEqual([
+      ['init', 'fake-website-id'],
+      ['identity', 'user-id', { firstname: 'Frida', lastname: 'Khalo', email: 'frida.khalo@screeb.app' }]
+    ])
+  })
+  test('it maps event parameters correctly to identify function ', async () => {
+    const [identify] = await screebDestination({
+      websiteId: 'fake-website-id',
+      subscriptions
+    })
+
+    jest.spyOn(destination.actions.identify, 'perform')
+    await identify.load(Context.system(), {} as Analytics)
+
+    await identify.identify?.(
+      new Context({
+        type: 'identify',
+        anonymousId: 'anonymous-id',
+        traits: {
+          firstname: 'Frida',
+          lastname: 'Khalo',
+          email: 'frida.khalo@screeb.app'
+        }
+      })
+    )
+
+    expect(destination.actions.identify.perform).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        payload: {
+          anonymousId: 'anonymous-id',
+          properties: {
+            firstname: 'Frida',
+            lastname: 'Khalo',
+            email: 'frida.khalo@screeb.app'
+          }
+        }
+      })
+    )
+
+    expect(window.$screeb.q).toStrictEqual([
+      ['init', 'fake-website-id'],
+      ['identity', 'anonymous-id', { firstname: 'Frida', lastname: 'Khalo', email: 'frida.khalo@screeb.app' }]
+    ])
+  })
+})

--- a/packages/browser-destinations/src/destinations/screeb/identify/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/screeb/identify/__tests__/index.test.ts
@@ -27,6 +27,9 @@ describe('identify', () => {
     jest.mock('../../../../runtime/load-script', () => ({
       loadScript: (_src: any, _attributes: any) => {}
     }))
+    jest.mock('../../../../runtime/resolve-when', () => ({
+      resolveWhen: (_fn: any, _timeout: any) => {}
+    }))
   })
   test('it maps event parameters correctly to identify function without user id but anonymous id', async () => {
     const [identify] = await screebDestination({

--- a/packages/browser-destinations/src/destinations/screeb/identify/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/screeb/identify/generated-types.ts
@@ -1,0 +1,18 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Unique identifier for the user
+   */
+  userId?: string
+  /**
+   * Anonymous identifier for the user
+   */
+  anonymousId?: string
+  /**
+   * The Segment user traits to be forwarded to Screeb and set as attributes
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/src/destinations/screeb/identify/index.ts
+++ b/packages/browser-destinations/src/destinations/screeb/identify/index.ts
@@ -1,0 +1,56 @@
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import type { Screeb } from '../types'
+
+const action: BrowserActionDefinition<Settings, Screeb, Payload> = {
+  title: 'Identify',
+  description: 'Set user ID and/or attributes.',
+  platform: 'web',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    userId: {
+      type: 'string',
+      required: false,
+      description: 'Unique identifier for the user',
+      label: 'User ID',
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    anonymousId: {
+      type: 'string',
+      required: false,
+      description: 'Anonymous identifier for the user',
+      label: 'Anonymous ID',
+      default: {
+        '@path': '$.anonymousId'
+      }
+    },
+    properties: {
+      type: 'object',
+      required: false,
+      description: 'The Segment user traits to be forwarded to Screeb and set as attributes',
+      label: 'User Attributes',
+      default: {
+        '@path': '$.traits'
+      }
+    }
+  },
+  perform: (Screeb, event) => {
+    const payload = event.payload
+    if (!payload || typeof payload !== 'object' || !(payload.userId || payload.anonymousId || payload.properties)) {
+      console.warn(
+        '[Screeb] received invalid payload (expected userId, anonymousId, or properties to be present); skipping identify',
+        payload
+      )
+      return
+    }
+
+    const properties = payload.properties && Object.keys(payload.properties).length > 0 ? payload.properties : undefined
+
+    Screeb('identity', payload.userId ?? payload.anonymousId, properties)
+  }
+}
+
+export default action

--- a/packages/browser-destinations/src/destinations/screeb/index.ts
+++ b/packages/browser-destinations/src/destinations/screeb/index.ts
@@ -1,0 +1,83 @@
+import type { Settings } from './generated-types'
+import type { BrowserDestinationDefinition } from '../../lib/browser-destinations'
+import { browserDestination } from '../../runtime/shim'
+import { Screeb } from './types'
+import { defaultValues } from '@segment/actions-core'
+import identify from './identify'
+import track from './track'
+import group from './group'
+import alias from './alias'
+
+declare global {
+  interface Window {
+    $screeb: Screeb
+  }
+}
+
+export const destination: BrowserDestinationDefinition<Settings, Screeb> = {
+  name: 'Screeb',
+  slug: 'actions-screeb',
+  mode: 'device',
+
+  settings: {
+    websiteId: {
+      description: 'Your website ID (given in Screeb app).',
+      label: 'Website ID',
+      type: 'string',
+      required: true
+    }
+  },
+
+  presets: [
+    {
+      name: 'Identify',
+      subscribe: 'type = "identify"',
+      partnerAction: 'identify',
+      mapping: defaultValues(identify.fields)
+    },
+    {
+      name: 'Track',
+      subscribe: 'type = "track"',
+      partnerAction: 'track',
+      mapping: defaultValues(track.fields)
+    },
+    {
+      name: 'Group',
+      subscribe: 'type = "group"',
+      partnerAction: 'group',
+      mapping: defaultValues(group.fields)
+    },
+    {
+      name: 'Alias',
+      subscribe: 'type = "alias"',
+      partnerAction: 'alias',
+      mapping: defaultValues(alias.fields)
+    }
+  ],
+
+  initialize: async ({ settings }, deps) => {
+    const preloadFunction = function (...args: unknown[]) {
+      if (window.$screeb.q) {
+        window.$screeb.q.push(args)
+      }
+    }
+    window.$screeb = preloadFunction
+    window.$screeb.q = []
+
+    await deps.loadScript('https://t.screeb.app/tag.js')
+    await deps.resolveWhen(() => window.$screeb !== preloadFunction, 500)
+
+    window.$screeb('init', settings.websiteId)
+
+    return window.$screeb
+  },
+
+  actions: {
+    identify,
+    track,
+    group,
+    alias
+  }
+}
+
+export default browserDestination(destination)

--- a/packages/browser-destinations/src/destinations/screeb/index.ts
+++ b/packages/browser-destinations/src/destinations/screeb/index.ts
@@ -65,7 +65,10 @@ export const destination: BrowserDestinationDefinition<Settings, Screeb> = {
     window.$screeb.q = []
 
     await deps.loadScript('https://t.screeb.app/tag.js')
-    await deps.resolveWhen(() => window.$screeb !== preloadFunction, 500)
+
+    if (process.env.NODE_ENV !== 'test') {
+      await deps.resolveWhen(() => window.$screeb !== preloadFunction, 500)
+    }
 
     window.$screeb('init', settings.websiteId)
 

--- a/packages/browser-destinations/src/destinations/screeb/index.ts
+++ b/packages/browser-destinations/src/destinations/screeb/index.ts
@@ -65,10 +65,7 @@ export const destination: BrowserDestinationDefinition<Settings, Screeb> = {
     window.$screeb.q = []
 
     await deps.loadScript('https://t.screeb.app/tag.js')
-
-    if (process.env.NODE_ENV !== 'test') {
-      await deps.resolveWhen(() => window.$screeb !== preloadFunction, 500)
-    }
+    await deps.resolveWhen(() => window.$screeb !== preloadFunction, 500)
 
     window.$screeb('init', settings.websiteId)
 

--- a/packages/browser-destinations/src/destinations/screeb/track/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/screeb/track/__tests__/index.test.ts
@@ -1,0 +1,66 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import screebDestination, { destination } from '../../index'
+import { Subscription } from '../../../../lib/browser-destinations'
+
+const subscriptions: Subscription[] = [
+  {
+    partnerAction: 'track',
+    name: 'Track',
+    enabled: true,
+    subscribe: 'type = "track"',
+    mapping: {
+      name: {
+        '@path': '$.event'
+      },
+      properties: {
+        '@path': '$.properties'
+      }
+    }
+  }
+]
+
+describe('track', () => {
+  beforeAll(() => {
+    jest.mock('../../../../runtime/load-script', () => ({
+      loadScript: (_src: any, _attributes: any) => {}
+    }))
+  })
+  test('it maps event parameters correctly to track function', async () => {
+    const [track] = await screebDestination({
+      websiteId: 'fake-website-id',
+      subscriptions
+    })
+
+    jest.spyOn(destination.actions.track, 'perform')
+    await track.load(Context.system(), {} as Analytics)
+
+    await track.track?.(
+      new Context({
+        type: 'track',
+        event: 'event-name',
+        properties: {
+          prop1: 1,
+          prop2: 'pickle sandwish'
+        }
+      })
+    )
+
+    expect(destination.actions.track.perform).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        payload: {
+          name: 'event-name',
+          properties: {
+            prop1: 1,
+            prop2: 'pickle sandwish'
+          }
+        }
+      })
+    )
+
+    expect(window.$screeb.q).toStrictEqual([
+      ['init', 'fake-website-id'],
+      ['event.track', 'event-name', { prop1: 1, prop2: 'pickle sandwish' }]
+    ])
+  })
+})

--- a/packages/browser-destinations/src/destinations/screeb/track/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/screeb/track/__tests__/index.test.ts
@@ -24,6 +24,9 @@ describe('track', () => {
     jest.mock('../../../../runtime/load-script', () => ({
       loadScript: (_src: any, _attributes: any) => {}
     }))
+    jest.mock('../../../../runtime/resolve-when', () => ({
+      resolveWhen: (_fn: any, _timeout: any) => {}
+    }))
   })
   test('it maps event parameters correctly to track function', async () => {
     const [track] = await screebDestination({

--- a/packages/browser-destinations/src/destinations/screeb/track/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/screeb/track/generated-types.ts
@@ -1,0 +1,14 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The event name that will be shown on Screeb's dashboard
+   */
+  name: string
+  /**
+   * Object containing the properties of the event
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/src/destinations/screeb/track/index.ts
+++ b/packages/browser-destinations/src/destinations/screeb/track/index.ts
@@ -1,0 +1,42 @@
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import type { Screeb } from '../types'
+
+const action: BrowserActionDefinition<Settings, Screeb, Payload> = {
+  title: 'Track',
+  description: 'Track event to potentially filter user studies (microsurveys) later, or trigger a study now.',
+  platform: 'web',
+  defaultSubscription: 'type = "track" and event != "Signed Out"',
+  fields: {
+    name: {
+      description: "The event name that will be shown on Screeb's dashboard",
+      label: 'Event name',
+      required: true,
+      type: 'string',
+      default: {
+        '@path': '$.event'
+      }
+    },
+    properties: {
+      type: 'object',
+      required: false,
+      description: 'Object containing the properties of the event',
+      label: 'Event Properties',
+      default: {
+        '@path': '$.properties'
+      }
+    }
+  },
+  perform: (Screeb, event) => {
+    const payload = event.payload
+    if (!payload || typeof payload !== 'object' || !payload.name) {
+      console.warn('[Screeb] received invalid payload (expected name to be present); skipping track', payload)
+      return
+    }
+
+    Screeb('event.track', payload.name, payload.properties)
+  }
+}
+
+export default action

--- a/packages/browser-destinations/src/destinations/screeb/types.ts
+++ b/packages/browser-destinations/src/destinations/screeb/types.ts
@@ -1,0 +1,4 @@
+export interface Screeb {
+  (...args: unknown[]): unknown
+  q?: unknown[]
+}


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

Add Screeb browser destination with handling for identify, track, group, and alias.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
  - Tested with the [browser action tester](https://segment.com/docs/partners/destinations/testing/#getting-started/)
- [ ] [Segmenters] Tested in the staging environment
  - N/A for browser destinations

