### PR TITLE
Increase ci timeout of test-and-build and install-and-test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test-and-build:
     runs-on: ubuntu-20.04
 
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     strategy:
       matrix:

--- a/.github/workflows/ext.yml
+++ b/.github/workflows/ext.yml
@@ -10,7 +10,7 @@ jobs:
   install-and-test:
     runs-on: ubuntu-20.04
 
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     strategy:
       matrix:


### PR DESCRIPTION
Recently, we have been seeing a lot of CI timeouts with CI workflow and Test External workflow as we are hitting the 15 minute time out mark with test-and-build job and 10 min timeout mark with install-and-test jobs. This PR is to bump the CI timeout of test and build step to 20 minutes.

<img width="1160" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/bb248662-8a59-4885-8fd6-5e690a722ce5">

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
