### PR TITLE
decouple logger

### DIFF
--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/__tests__/send-sms.test.ts
@@ -7,9 +7,13 @@ import { Logger } from '@segment/actions-core/src/destination-kit'
 const twilio = createTestIntegration(Twilio)
 const timestamp = new Date().toISOString()
 
-function createLoggerMock()
-{
-  return { level: 'error', name: 'test', error: jest.fn() as Logger['error'], info: jest.fn() as Logger['info'] } as Logger
+function createLoggerMock() {
+  return {
+    level: 'error',
+    name: 'test',
+    error: jest.fn() as Logger['error'],
+    info: jest.fn() as Logger['info']
+  } as Logger
 }
 
 describe.each(['stage', 'production'])('%s environment', (environment) => {
@@ -67,7 +71,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         settings,
         mapping: getDefaultMapping({
           externalIds: [{ type: 'email', id: 'test@twilio.com', subscriptionStatus: 'subscribed' }]
-        })
+        }),
+        logger: createLoggerMock()
       })
 
       expect(responses.length).toEqual(0)
@@ -313,7 +318,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           userId: 'jane'
         }),
         settings,
-        mapping: getDefaultMapping()
+        mapping: getDefaultMapping(),
+        logger: createLoggerMock()
       }
 
       const responses = await twilio.testAction('sendSms', actionInputData)
@@ -352,7 +358,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
             contentSid
           }),
           ['body']
-        )
+        ),
+        logger: createLoggerMock()
       }
 
       await twilio.testAction('sendSms', actionInputData)
@@ -382,7 +389,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         settings,
         mapping: getDefaultMapping({
           media: ['http://myimg.com']
-        })
+        }),
+        logger: createLoggerMock()
       }
 
       const responses = await twilio.testAction('sendSms', actionInputData)
@@ -433,7 +441,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
             contentSid
           }),
           ['body']
-        )
+        ),
+        logger: createLoggerMock()
       }
 
       const responses = await twilio.testAction('sendSms', actionInputData)
@@ -469,7 +478,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           ...settings,
           twilioHostname
         },
-        mapping: getDefaultMapping()
+        mapping: getDefaultMapping(),
+        logger: createLoggerMock()
       }
 
       const responses = await twilio.testAction('sendSms', actionInputData)
@@ -503,7 +513,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           webhookUrl: 'http://localhost',
           connectionOverrides: 'rp=all&rc=5'
         },
-        mapping: getDefaultMapping({ customArgs: { foo: 'bar' } })
+        mapping: getDefaultMapping({ customArgs: { foo: 'bar' } }),
+        logger: createLoggerMock()
       }
 
       const responses = await twilio.testAction('sendSms', actionInputData)
@@ -525,7 +536,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           ...settings,
           webhookUrl: 'foo'
         },
-        mapping: getDefaultMapping({ customArgs: { foo: 'bar' } })
+        mapping: getDefaultMapping({ customArgs: { foo: 'bar' } }),
+        logger: createLoggerMock()
       }
       await expect(twilio.testAction('sendSms', actionInputData)).rejects.toHaveProperty('code', 'ERR_INVALID_URL')
     })
@@ -569,7 +581,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         },
         mapping: getDefaultMapping({
           traitEnrichment: false
-        })
+        }),
+        logger: createLoggerMock()
       }
 
       const responses = await twilio.testAction('sendSms', actionInputData)
@@ -613,7 +626,10 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           userId: 'jane'
         }),
         settings,
-        mapping: getDefaultMapping({ externalIds: [{ type: 'phone', id: '+1234567891', subscriptionStatus, channelType: 'sms' }] })
+        mapping: getDefaultMapping({
+          externalIds: [{ type: 'phone', id: '+1234567891', subscriptionStatus, channelType: 'sms' }]
+        }),
+        logger: createLoggerMock()
       }
 
       const responses = await twilio.testAction('sendSms', actionInputData)
@@ -644,7 +660,10 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
             userId: 'jane'
           }),
           settings,
-          mapping: getDefaultMapping({ externalIds: [{ type: 'phone', id: '+1234567891', subscriptionStatus, channelType: 'sms' }] })
+          mapping: getDefaultMapping({
+            externalIds: [{ type: 'phone', id: '+1234567891', subscriptionStatus, channelType: 'sms' }]
+          }),
+          logger: createLoggerMock()
         }
 
         const responses = await twilio.testAction('sendSms', actionInputData)
@@ -652,7 +671,6 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         expect(twilioRequest.isDone()).toEqual(false)
       }
     )
-
   })
 
   it('Unrecognized subscriptionStatus treated as Unsubscribed"', async () => {
@@ -685,11 +703,11 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
     const responses = await twilio.testAction('sendSms', actionInputData)
     expect(responses).toHaveLength(0)
     expect(actionInputData.logger.info).toHaveBeenCalledWith(
-      expect.stringContaining("TE Messaging: Invalid subscription statuses found in externalIds"),
+      expect.stringContaining('TE Messaging: Invalid subscription statuses found in externalIds'),
       expect.anything()
     )
     expect(actionInputData.logger.info).toHaveBeenCalledWith(
-      expect.stringContaining("TE Messaging: Not sending message, because sendabilityStatus"),
+      expect.stringContaining('TE Messaging: Not sending message, because sendabilityStatus'),
       expect.anything()
     )
   })
@@ -741,7 +759,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           userId: 'jane'
         }),
         settings,
-        mapping: getDefaultMapping()
+        mapping: getDefaultMapping(),
+        logger: createLoggerMock()
       }
 
       await expect(twilio.testAction('sendSms', actionInputData)).resolves.not.toThrowError()

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/__tests__/send-whatsapp.test.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/__tests__/send-whatsapp.test.ts
@@ -9,11 +9,14 @@ const timestamp = new Date().toISOString()
 const defaultTemplateSid = 'my_template'
 const defaultTo = 'whatsapp:+1234567891'
 
-function createLoggerMock()
-{
-  return { level: 'error', name: 'test', error: jest.fn() as Logger['error'], info: jest.fn() as Logger['info'] } as Logger
+function createLoggerMock() {
+  return {
+    level: 'error',
+    name: 'test',
+    error: jest.fn() as Logger['error'],
+    info: jest.fn() as Logger['info']
+  } as Logger
 }
-
 
 describe.each(['stage', 'production'])('%s environment', (environment) => {
   const spaceId = 'd'
@@ -57,7 +60,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         settings,
         mapping: getDefaultMapping({
           externalIds: [{ type: 'email', id: 'test@twilio.com', subscriptionStatus: 'subscribed' }]
-        })
+        }),
+        logger: createLoggerMock()
       })
 
       expect(responses.length).toEqual(0)
@@ -73,7 +77,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         settings,
         mapping: getDefaultMapping({
           externalIds: [{ type: 'phone', id: '+1234567891', subscriptionStatus: 'subscribed' }]
-        })
+        }),
+        logger: createLoggerMock()
       })
 
       expect(responses.length).toEqual(0)
@@ -97,7 +102,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           userId: 'jane'
         }),
         settings,
-        mapping: getDefaultMapping()
+        mapping: getDefaultMapping(),
+        logger: createLoggerMock()
       }
 
       const responses = await twilio.testAction('sendWhatsApp', actionInputData)
@@ -130,7 +136,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           ...settings,
           twilioHostname
         },
-        mapping: getDefaultMapping()
+        mapping: getDefaultMapping(),
+        logger: createLoggerMock()
       }
 
       const responses = await twilio.testAction('sendWhatsApp', actionInputData)
@@ -163,7 +170,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           webhookUrl: 'http://localhost',
           connectionOverrides: 'rp=all&rc=5'
         },
-        mapping: getDefaultMapping({ customArgs: { foo: 'bar' } })
+        mapping: getDefaultMapping({ customArgs: { foo: 'bar' } }),
+        logger: createLoggerMock()
       }
 
       const responses = await twilio.testAction('sendWhatsApp', actionInputData)
@@ -185,7 +193,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           ...settings,
           webhookUrl: 'foo'
         },
-        mapping: getDefaultMapping({ customArgs: { foo: 'bar' } })
+        mapping: getDefaultMapping({ customArgs: { foo: 'bar' } }),
+        logger: createLoggerMock()
       }
       await expect(twilio.testAction('sendWhatsApp', actionInputData)).rejects.toHaveProperty('code', 'ERR_INVALID_URL')
     })
@@ -211,7 +220,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         settings,
         mapping: getDefaultMapping({
           externalIds: [{ type: 'phone', id: '+1234567891', subscriptionStatus, channelType: 'whatsapp' }]
-        })
+        }),
+        logger: createLoggerMock()
       }
 
       const responses = await twilio.testAction('sendWhatsApp', actionInputData)
@@ -243,7 +253,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           settings,
           mapping: getDefaultMapping({
             externalIds: [{ type: 'phone', id: '+1234567891', subscriptionStatus, channelType: 'whatsapp' }]
-          })
+          }),
+          logger: createLoggerMock()
         }
 
         const responses = await twilio.testAction('sendWhatsApp', actionInputData)
@@ -288,14 +299,13 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       const responses = await twilio.testAction('sendWhatsApp', actionInputData)
       expect(responses).toHaveLength(0)
       expect(actionInputData.logger.info).toHaveBeenCalledWith(
-        expect.stringContaining("TE Messaging: Invalid subscription statuses found in externalIds"),
+        expect.stringContaining('TE Messaging: Invalid subscription statuses found in externalIds'),
         expect.anything()
       )
       expect(actionInputData.logger.info).toHaveBeenCalledWith(
-        expect.stringContaining("TE Messaging: Not sending message, because sendabilityStatus"),
+        expect.stringContaining('TE Messaging: Not sending message, because sendabilityStatus'),
         expect.anything()
       )
-  
     })
 
     it('formats the to number correctly for whatsapp', async () => {
@@ -321,7 +331,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           from: from,
           contentSid: defaultTemplateSid,
           externalIds: [{ type: 'phone', id: '(919) 555 1234', subscriptionStatus: true, channelType: 'whatsapp' }]
-        })
+        }),
+        logger: createLoggerMock()
       }
 
       const responses = await twilio.testAction('sendWhatsApp', actionInputData)
@@ -447,7 +458,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
               street: '360 Scope St'
             }
           }
-        })
+        }),
+        logger: createLoggerMock()
       }
 
       const responses = await twilio.testAction('sendWhatsApp', actionInputData)
@@ -484,7 +496,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
               street: '360 Scope St'
             }
           }
-        })
+        }),
+        logger: createLoggerMock()
       }
 
       const responses = await twilio.testAction('sendWhatsApp', actionInputData)
@@ -516,7 +529,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         mapping: getDefaultMapping({
           contentVariables: { '1': 'Soap', '2': '360 Scope St' },
           traitEnrichment: false
-        })
+        }),
+        logger: createLoggerMock()
       }
 
       const responses = await twilio.testAction('sendWhatsApp', actionInputData)

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendWhatsApp/whatsapp-sender.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendWhatsApp/whatsapp-sender.ts
@@ -9,12 +9,11 @@ const phoneUtil = PhoneNumberUtil.getInstance()
 const Liquid = new LiquidJs()
 
 export class WhatsAppMessageSender extends MessageSender<Payload> {
-
-  getChannelType(){
+  getChannelType() {
     return 'whatsapp'
   }
 
-  async getBody(phone: string){
+  async getBody(phone: string) {
     let parsedPhone
 
     try {
@@ -26,7 +25,7 @@ export class WhatsAppMessageSender extends MessageSender<Payload> {
       parsedPhone = `whatsapp:${parsedPhone}`
     } catch (error: unknown) {
       this.tags.push('type:invalid_phone_e164')
-      this.logError(`WhatsApp invalid phone number - ${this.settings.spaceId} - [${error}]`)
+      this.messagingLogger.logError(`WhatsApp invalid phone number - ${this.settings.spaceId} - [${error}]`)
       this.statsClient?.incr('actions-personas-messaging-twilio.error', 1, this.tags)
       throw new IntegrationError(
         'The string supplied did not seem to be a phone number. Phone number must be able to be formatted to e164 for whatsapp.',
@@ -36,7 +35,7 @@ export class WhatsAppMessageSender extends MessageSender<Payload> {
     }
 
     if (!this.payload.contentSid) {
-      this.logError(`A valid WhatsApp Content SID was not provided - ${this.settings.spaceId}`)
+      this.messagingLogger.logError(`A valid WhatsApp Content SID was not provided - ${this.settings.spaceId}`)
       throw new IntegrationError('A valid whatsApp Content SID was not provided.', `INVALID_CONTENT_SID`, 400)
     }
 
@@ -77,7 +76,7 @@ export class WhatsAppMessageSender extends MessageSender<Payload> {
 
       return JSON.stringify(mapping)
     } catch (error: unknown) {
-      this.logError(
+      this.messagingLogger.logError(
         `Failed to parse WhatsApp template with content variables - ${this.settings.spaceId} - [${error}]`
       )
       throw new IntegrationError(

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/utils/message-sender.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/utils/message-sender.ts
@@ -6,6 +6,7 @@ import type { Payload as WhatsappPayload } from '../sendWhatsApp/generated-types
 import { IntegrationError } from '@segment/actions-core'
 import { Logger, StatsClient, StatsContext } from '@segment/actions-core/src/destination-kit'
 import { ExecuteInput } from '@segment/actions-core'
+import { MessagingLogger } from './messaging-logger'
 
 enum SendabilityStatus {
   NoSenderPhone = 'no_sender_phone',
@@ -22,9 +23,9 @@ interface TwilioApiError extends Error {
       message: string
       more_info: string
       status: number
-    },
-    headers?: Response['headers'],
-  },
+    }
+    headers?: Response['headers']
+  }
   code?: number
   status?: number
   statusCode?: number
@@ -38,6 +39,7 @@ export abstract class MessageSender<MessagePayload extends SmsPayload | Whatsapp
   private readonly EXTERNAL_ID_KEY = 'phone'
   private readonly DEFAULT_HOSTNAME = 'api.twilio.com'
   private readonly DEFAULT_CONNECTION_OVERRIDES = 'rp=all&rc=5'
+  protected readonly messagingLogger: MessagingLogger
 
   constructor(
     readonly request: RequestFn,
@@ -46,126 +48,60 @@ export abstract class MessageSender<MessagePayload extends SmsPayload | Whatsapp
     readonly statsClient: StatsClient | undefined,
     readonly tags: StatsContext['tags'],
     readonly logger: Logger | undefined,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    readonly executeInput: ExecuteInput<Settings, MessagePayload>,
-    readonly logDetails: Record<string, unknown> = {}
-  )
-  {
+    readonly executeInput: ExecuteInput<Settings, MessagePayload>
+  ) {
+    this.messagingLogger = new MessagingLogger(logger)
   }
 
   abstract getBody(phone: string): Promise<URLSearchParams>
 
-  abstract getChannelType():string
+  abstract getChannelType(): string
 
   /**
    * check if the externalId object is supported for sending a message
-   * @param externalId 
-   * @returns 
+   * @param externalId
+   * @returns
    */
   isValidExternalId(externalId: NonNullable<MessagePayload['externalIds']>[number]): boolean {
     return externalId.type === 'phone' && this.getChannelType() === externalId.channelType?.toLowerCase()
   }
 
-  redactPii(pii: string | undefined) {
-    if(!pii) {
-      return pii
-    }
-    
-    if(pii.length <= 8) {
-      return '***'
-     }
-    return pii.substring(0, 3) + '***' + pii.substring(pii.length - 3)
-  }
-  
-  logInfo(...msgs:string[]) {
-    const [firstMsg, ...rest] = msgs
-    this.logger?.info(`TE Messaging: ${firstMsg}`, ...rest, JSON.stringify(this.logDetails))
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  logError(error?: any, ...msgs:string[]) {
-    const [firstMsg, ...rest] = msgs
-    if(typeof error === 'string' )
-    {
-      this.logger?.error(`TE Messaging: ${error}`, ...msgs, JSON.stringify(this.logDetails))
-    }
-    else 
-    {
-      this.logger?.error(`TE Messaging: ${firstMsg}`, ...rest, error instanceof Error? error.message: error?.toString(), JSON.stringify(this.logDetails))
-    }
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private static isPromise<T=unknown>(obj: unknown): obj is Promise<T> {
-    // `obj instanceof Promise` is not reliable since it can be a custom promise object from fetch lib
-    //https://stackoverflow.com/questions/27746304/how-to-check-if-an-object-is-a-promise
-    
-    // for whatever reason it gave me error "Property 'then' does not exist on type 'never'." so i have to use ts-ignore
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    return obj instanceof Object && 'then' in obj && typeof obj.then === 'function'
-  }
-
-  logWrap<R=void>(messages:string[], fn: ()=>R):R {
-    this.logInfo("Starting: ", ...messages)
-    try{
-      const res = fn()
-      if(MessageSender.isPromise(res)){
-        return (async()=>{
-          try{
-            const promisedRes = await res
-            this.logInfo("Success: ", ...messages)
-            return promisedRes
-          } catch(error:unknown){
-            this.logError(error, "Failed: ", ...messages)
-            throw error
-          }
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        })() as any as R // cast to R otherwise ts is not happy
-      }
-      this.logInfo("Success: ", ...messages)
-      return res
-    }
-    catch(error:unknown){
-      this.logError(error, "Failed: ", ...messages)
-      throw error
-    }
-  }
-
   /**
    * populate the logDetails object with the data that should be logged for every message
    */
-  initLogDetails()//overrideable
-  {
-    Object.assign(this.logDetails,{
-      externalIds: this.payload.externalIds?.map(eid=>({...eid, id: this.redactPii(eid.id)})),
+  initLogDetails() {
+    const logDetails: Record<string, unknown> = {
+      externalIds: this.payload.externalIds?.map((eid) => ({ ...eid, id: this.messagingLogger.redactPii(eid.id) })),
       shouldSend: this.payload.send,
       contentSid: this.payload.contentSid,
       sourceId: this.settings.sourceId,
-      spaceId : this.settings.spaceId,
-      twilioApiKeySID : this.settings.twilioApiKeySID,
-      region : this.settings.region,
+      spaceId: this.settings.spaceId,
+      twilioApiKeySID: this.settings.twilioApiKeySID,
+      region: this.settings.region,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       messageId: (this.executeInput as any)['rawData']?.messageId, // undocumented, not recommended way used here for tracing retries in logs https://github.com/segmentio/action-destinations/blob/main/packages/core/src/destination-kit/action.ts#L141
-      channelType: this.getChannelType(),
-    })
-    if('userId' in this.payload)
-      this.logDetails.userId = this.payload.userId
+      channelType: this.getChannelType()
+    }
+    if ('userId' in this.payload) logDetails.userId = this.payload.userId
+    this.messagingLogger.appendLogDetails(logDetails)
   }
 
   async send() {
-
     this.initLogDetails()
 
-    return this.logWrap([`Destination Action ${this.getChannelType()}`], async ()=>{
+    return this.messagingLogger.logWrap([`Destination Action ${this.getChannelType()}`], async () => {
       const { phone, sendabilityStatus } = this.getSendabilityPayload()
 
       if (sendabilityStatus !== SendabilityStatus.ShouldSend || !phone) {
-        this.logInfo(`Not sending message, because sendabilityStatus: ${sendabilityStatus}, phone: ${this.redactPii(phone)}`)
+        this.messagingLogger.logInfo(
+          `Not sending message, because sendabilityStatus: ${sendabilityStatus}, phone: ${this.messagingLogger.redactPii(
+            phone
+          )}`
+        )
         return
       }
 
-      this.logInfo("Getting content Body")
+      this.messagingLogger.logInfo('Getting content Body')
       const body = await this.getBody(phone)
 
       const webhookUrlWithParams = this.getWebhookUrlWithParams(phone)
@@ -177,14 +113,10 @@ export abstract class MessageSender<MessagePayload extends SmsPayload | Whatsapp
         'base64'
       )
 
-      this.statsClient?.set(
-        'actions_personas_messaging_twilio.message_body_size',
-        body?.toString().length,
-        this.tags
-      )
+      this.statsClient?.set('actions_personas_messaging_twilio.message_body_size', body?.toString().length, this.tags)
 
       try {
-        this.logInfo("Sending message to Twilio API")
+        this.messagingLogger.logInfo('Sending message to Twilio API')
 
         const response = await this.request(
           `https://${twilioHostname}/2010-04-01/Accounts/${this.settings.twilioAccountSID}/Messages.json`,
@@ -207,31 +139,29 @@ export abstract class MessageSender<MessagePayload extends SmsPayload | Whatsapp
           )
         }
 
-        this.logDetails['twilio-request-id'] = response.headers?.get('twilio-request-id')
-
-        this.logInfo("Message sent successfully")
+        this.messagingLogger.appendLogDetails({ 'twilio-request-id': response.headers?.get('twilio-request-id') })
+        this.messagingLogger.logInfo('Message sent successfully')
 
         return response
       } catch (errorOrig: unknown) {
         let errorToRethrow = errorOrig
         if (errorOrig instanceof Object) {
           const twilioApiError = errorOrig as TwilioApiError
-          this.logDetails['twilioApiError_response_data'] = twilioApiError.response?.data
-          this.logDetails['twilio-request-id'] = twilioApiError.response?.headers?.get('twilio-request-id')
-          this.logDetails['error'] = twilioApiError.response
-
-          this.logError(
-            `Twilio Programmable API error - ${this.settings.spaceId}`
-          )
+          this.messagingLogger.appendLogDetails({
+            twilioApiError_response_data: twilioApiError.response?.data,
+            'twilio-request-id': twilioApiError.response?.headers?.get('twilio-request-id'),
+            error: twilioApiError.response
+          })
+          this.messagingLogger.logError(`Twilio Programmable API error - ${this.settings.spaceId}`)
           const statusCode = twilioApiError.status || twilioApiError.response?.data?.status
           this.tags.push(`twilio_status_code:${statusCode}`)
           this.statsClient?.incr('actions_personas_messaging_twilio.response', 1, this.tags)
-  
-          if(!twilioApiError.status) //to handle error properly by Centrifuge
-          {
+
+          if (!twilioApiError.status) {
+            //to handle error properly by Centrifuge
             errorToRethrow = new IntegrationError(
               twilioApiError.response?.data?.message || twilioApiError.message,
-              (twilioApiError.response?.data?.code || statusCode)?.toString() || "Twilio Api Request Error",
+              (twilioApiError.response?.data?.code || statusCode)?.toString() || 'Twilio Api Request Error',
               statusCode
             )
           }
@@ -251,31 +181,38 @@ export abstract class MessageSender<MessagePayload extends SmsPayload | Whatsapp
   static nonSendableStatuses = ['unsubscribed', 'did not subscribed', 'false'] // do we need that??
   static sendableStatuses = ['subscribed', 'true']
   private getSendabilityPayload(): SendabilityPayload {
-
     if (!this.payload.send) {
       this.statsClient?.incr('actions-personas-messaging-twilio.send-disabled', 1, this.tags)
       return { sendabilityStatus: SendabilityStatus.SendDisabled, phone: undefined }
     }
 
     // list of extenalIds that are supported by this Channel
-    const validExtIds = this.payload.externalIds?.filter(extId => this.isValidExternalId(extId))
-    
+    const validExtIds = this.payload.externalIds?.filter((extId) => this.isValidExternalId(extId))
+
     // finding first that isSubscribed
-    const firstSubscribedExtId = validExtIds?.find(extId => extId.subscriptionStatus
-      && MessageSender.sendableStatuses.includes(extId.subscriptionStatus?.toString()?.toLowerCase())
+    const firstSubscribedExtId = validExtIds?.find(
+      (extId) =>
+        extId.subscriptionStatus &&
+        MessageSender.sendableStatuses.includes(extId.subscriptionStatus?.toString()?.toLowerCase())
     )
 
-    const invalidStatuses = validExtIds?.filter(extId=>{
+    const invalidStatuses = validExtIds?.filter((extId) => {
       const subStatus = extId.subscriptionStatus?.toString()?.toLowerCase()
-      if(!subStatus) return false // falsy status is valid and considered to be Not Subscribed, so return false
+      if (!subStatus) return false // falsy status is valid and considered to be Not Subscribed, so return false
       // if subStatus is not in any of the lists of valid statuses, then return true
-      return !(MessageSender.nonSendableStatuses.includes(subStatus) || MessageSender.sendableStatuses.includes(subStatus))
+      return !(
+        MessageSender.nonSendableStatuses.includes(subStatus) || MessageSender.sendableStatuses.includes(subStatus)
+      )
     })
-    
+
     const hasInvalidStatuses = invalidStatuses && invalidStatuses.length > 0
-    if(hasInvalidStatuses){
+    if (hasInvalidStatuses) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.logInfo(`Invalid subscription statuses found in externalIds: ${invalidStatuses!.map(extId=>extId.subscriptionStatus).join(', ')}`)
+      this.messagingLogger.logInfo(
+        `Invalid subscription statuses found in externalIds: ${invalidStatuses!
+          .map((extId) => extId.subscriptionStatus)
+          .join(', ')}`
+      )
     }
 
     let status: SendabilityStatus = SendabilityStatus.DoNotSend
@@ -285,13 +222,13 @@ export abstract class MessageSender<MessagePayload extends SmsPayload | Whatsapp
     if (firstSubscribedExtId) {
       this.statsClient?.incr('actions_personas_messaging_twilio.subscribed', 1, this.tags)
       status = phone ? SendabilityStatus.ShouldSend : SendabilityStatus.NoSenderPhone
-    } else if(hasInvalidStatuses) {
+    } else if (hasInvalidStatuses) {
       this.statsClient?.incr('actions_personas_messaging_twilio.invalid_subscription_status', 1, this.tags)
       status = SendabilityStatus.InvalidSubscriptionStatus
     } else if (validExtIds && validExtIds.length > 0) {
       this.statsClient?.incr('actions_personas_messaging_twilio.notsubscribed', 1, this.tags)
       status = SendabilityStatus.DoNotSend
-    } else{
+    } else {
       status = SendabilityStatus.NoSenderPhone
     }
 

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/utils/messaging-logger.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/utils/messaging-logger.ts
@@ -1,0 +1,82 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+import { Logger } from '@segment/actions-core/src/destination-kit'
+
+export class MessagingLogger {
+  private readonly logDetails: Record<string, unknown> = {}
+
+  constructor(readonly logger?: Logger) {}
+
+  /**
+   * populate the logDetails object with the data that should be logged for every message
+   */
+  appendLogDetails(details: Record<string, unknown>) {
+    Object.assign(this.logDetails, details)
+  }
+
+  redactPii(pii: string | undefined) {
+    if (!pii) {
+      return pii
+    }
+
+    if (pii.length <= 8) {
+      return '***'
+    }
+    return pii.substring(0, 3) + '***' + pii.substring(pii.length - 3)
+  }
+
+  logInfo(...msgs: string[]) {
+    const [firstMsg, ...rest] = msgs
+    this.logger?.info(`TE Messaging: ${firstMsg}`, ...rest, JSON.stringify(this.logDetails))
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  logError(error?: any, ...msgs: string[]) {
+    const [firstMsg, ...rest] = msgs
+    if (typeof error === 'string') {
+      this.logger?.error(`TE Messaging: ${error}`, ...msgs, JSON.stringify(this.logDetails))
+    } else {
+      this.logger?.error(
+        `TE Messaging: ${firstMsg}`,
+        ...rest,
+        error instanceof Error ? error.message : error?.toString(),
+        JSON.stringify(this.logDetails)
+      )
+    }
+  }
+
+  logWrap<R = void>(messages: string[], fn: () => R): R {
+    this.logInfo('Starting: ', ...messages)
+    try {
+      const res = fn()
+      if (this.isPromise(res)) {
+        return (async () => {
+          try {
+            const promisedRes = await res
+            this.logInfo('Success: ', ...messages)
+            return promisedRes
+          } catch (error: unknown) {
+            this.logError(error, 'Failed: ', ...messages)
+            throw error
+          }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        })() as any as R // cast to R otherwise ts is not happy
+      }
+      this.logInfo('Success: ', ...messages)
+      return res
+    } catch (error: unknown) {
+      this.logError(error, 'Failed: ', ...messages)
+      throw error
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private isPromise<T = unknown>(obj: unknown): obj is Promise<T> {
+    // `obj instanceof Promise` is not reliable since it can be a custom promise object from fetch lib
+    //https://stackoverflow.com/questions/27746304/how-to-check-if-an-object-is-a-promise
+
+    // for whatever reason it gave me error "Property 'then' does not exist on type 'never'." so i have to use ts-ignore
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    return obj instanceof Object && 'then' in obj && typeof obj.then === 'function'
+  }
+}


### PR DESCRIPTION
This PR decouples the logger from the engage message sender into it's own entity. We will need to utilize this logger in the upcoming sendPush action and potentially for sendgrid.

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
