### PR TITLE
Use default mappings in action tester if mappings are not provider

### DIFF
--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -1,7 +1,7 @@
 import express from 'express'
 import cors from 'cors'
 import http from 'http'
-import { once } from 'lodash'
+import { isEmpty, isNil, mapValues, omitBy, once } from 'lodash'
 import logger from './logger'
 import path from 'path'
 import { loadDestination } from './destinations'
@@ -10,7 +10,8 @@ import {
   Destination,
   DestinationDefinition as CloudDestinationDefinition,
   HTTPError,
-  ModifiedResponse
+  ModifiedResponse,
+  JSONObject
 } from '@segment/actions-core'
 import asyncHandler from './async-handler'
 import getExchanges from './summarize-http'
@@ -215,16 +216,22 @@ function setupRoutes(def: DestinationDefinition | null): void {
             return res.status(400).send(msg)
           }
 
+          let mapping = req.body.mapping || {}
+          const fields = action.definition.fields
+          const defaultMappings = omitBy(mapValues(fields, 'default'), isNil)
+          mapping = { ...defaultMappings, ...mapping } as JSONObject
+          if (isEmpty(mapping)) mapping = null
+
           const eventParams = {
             data: req.body.payload || {},
             settings: req.body.settings || {},
-            mapping: req.body.mapping || req.body.payload || {},
+            mapping: mapping || req.body.payload || {},
             auth: req.body.auth || {}
           }
 
           if (Array.isArray(eventParams.data)) {
-            // If no mapping is provided default to using the first payload across all events.
-            eventParams.mapping = req.body.mapping ?? eventParams.data[0] ?? {}
+            // If no mapping or default mapping is provided, default to using the first payload across all events.
+            eventParams.mapping = mapping || eventParams.data[0] || {}
             await action.executeBatch(eventParams)
           } else {
             await action.execute(eventParams)


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

Updated the action tester to use default mappings when mappings are not provided in the request body.
JIRA -> [STRATCONN-2195](https://segment.atlassian.net/browse/STRATCONN-2195)

<img width="1792" alt="Screenshot 2023-05-16 at 4 41 02 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/c7edfb22-b617-4e05-8112-f306641062da">


## Testing

Tested locally via postman

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment


[STRATCONN-2195]: https://segment.atlassian.net/browse/STRATCONN-2195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ