### PR TITLE
Introduce API Error Class

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -29,13 +29,13 @@ Errors due to invalid access tokens, refresh tokens or api keys are captured as 
 
 The inbuilt error handling should help you with most of the error scenarios you face. In cases where the validation capabilities provided by the framework are not sufficient or the error messages returned by the API you are interacting with are not helpful, you can chose to capture and throw your own custom errors. It is important to adhere to the following guidelines to ensure your errors are structured properly and displayed to your destination users for appropriate action.
 
-- DO NOT throw Javascript `Error` objects. Any error thrown from an action MUST contain a `message` describing the error, an `error code` indicating the type of error and a `status code` indicating the http status of the action. You MUST use predefined error classes defined in [error.ts](../packages/core/src/errors.ts). These classes help in capturing the necessary information in appropriate format. For example, assume that your action needs one of product id or product name. This kind of validation is not currently supported in `Action Definition`. Instead of `throw new Error('One of product id or name is required')`, use `throw new PayloadValidationError('One of product id or name is required')`. 
+- DO NOT throw Javascript `Error` objects. Any error thrown from an action MUST contain a `message` describing the error, an `error code` indicating the type of error and a `status code` indicating the http status of the action. You MUST use predefined error classes defined in [error.ts](../packages/core/src/errors.ts). These classes help in capturing the necessary information in appropriate format. For example, assume that your action needs one of product id or product name. This kind of validation is not currently supported in `Action Definition`. Instead of `throw new Error('One of product id or name is required')`, use `throw new PayloadValidationError('One of product id or name is required')`.
 
-  - Use `PayloadValidationError` for any custom validations. These errors won't be retried.
+  - Use `PayloadValidationError` for any custom event payload validations. These errors won't be retried.
   - Use `InvalidAuthenticationError` for any authentication related errors. These errors won't be retried.
   - Use `RetryableError` in case you want to signal Segment to retry the events. Use this error only for transient errors.
+  - Use `APIError` in case you want to capture HttpErrors and rethrow them with more readable message for special error scenarios. These errors won't be retried.
   - For all other scenarios, use the `IntegrationError`.
-
 
 - Use appropriate Error Codes. Error Codes are short representation of the error type and they are shown in [Event Delivery](error-handling.md/#where-are-the-errors-from-destinations-displayed) pane. It is RECOMMENDED to use the predefined error codes as Segment adds additional contexual information for debugging in Event Delivery for these error cdoes.
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -85,6 +85,21 @@ export class PayloadValidationError extends IntegrationError {
 }
 
 /**
+ * Error to indicate that an API call to the destination failed with non-retryable error.
+ * Most of the HTTP API Errors are handled automatically by the framework. It is recommended to use this error class
+ * for cases where the destination has to capture HTTPErrors and rethrow them for better error message or for handling special scenarios.
+ * Should include a user-friendly message. These errors will not be retried.
+ */
+export class APIError extends IntegrationError {
+  /**
+   * @param message - a human-friendly message to display to users
+   */
+  constructor(message: string) {
+    super(message, ErrorCodes.API_CALL_FAILED, 400)
+  }
+}
+
+/**
  * Standard error codes. Use one from this enum whenever possible.
  */
 export enum ErrorCodes {
@@ -99,5 +114,7 @@ export enum ErrorCodes {
   // Refresh token has expired
   REFRESH_TOKEN_EXPIRED = 'REFRESH_TOKEN_EXPIRED',
   // OAuth refresh failed
-  OAUTH_REFRESH_FAILED = 'OAUTH_REFRESH_FAILED'
+  OAUTH_REFRESH_FAILED = 'OAUTH_REFRESH_FAILED',
+  // Integration API call failed
+  API_CALL_FAILED = 'API_CALL_FAILED'
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export {
   InvalidAuthenticationError,
   RetryableError,
   PayloadValidationError,
+  APIError,
   ErrorCodes
 } from './errors'
 export { get } from './get'

--- a/packages/destination-actions/src/destinations/emarsys/addToContactList/index.ts
+++ b/packages/destination-actions/src/destinations/emarsys/addToContactList/index.ts
@@ -1,4 +1,4 @@
-import { IntegrationError, RetryableError } from '@segment/actions-core'
+import { RetryableError, PayloadValidationError, APIError } from '@segment/actions-core'
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -46,9 +46,9 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, data) => {
-    if (!data?.payload?.key_field) throw new IntegrationError('Missing key field')
+    if (!data?.payload?.key_field) throw new PayloadValidationError('Missing key field')
 
-    if (!data?.payload?.key_value) throw new IntegrationError('Missing key value')
+    if (!data?.payload?.key_value) throw new PayloadValidationError('Missing key value')
 
     data.payload.contactlistid = parseInt(data.payload.contactlistid.toString().replace(/[^0-9]/g, ''))
 
@@ -68,19 +68,19 @@ const action: ActionDefinition<Settings, Payload> = {
           try {
             const body = await response.json()
             if (body.replyCode === 0) return response
-            else throw new IntegrationError('Something went wrong while adding to contact list')
+            else throw new APIError('Something went wrong while adding to contact list')
           } catch (err) {
-            throw new IntegrationError('Invalid JSON response')
+            throw new APIError('Invalid JSON response')
           }
         case 400:
-          throw new IntegrationError('The contact could not be removed from the contact list')
+          throw new APIError('The contact could not be removed from the contact list')
         case 429:
           throw new RetryableError('Rate limit reached.')
         default:
           throw new RetryableError('There seems to be an API issue.')
       }
     } else {
-      throw new IntegrationError('ContactlistId must be >0')
+      throw new PayloadValidationError('ContactlistId must be >0')
     }
   },
   performBatch: async (request, data) => {

--- a/packages/destination-actions/src/destinations/emarsys/removeFromContactList/index.ts
+++ b/packages/destination-actions/src/destinations/emarsys/removeFromContactList/index.ts
@@ -1,4 +1,4 @@
-import { IntegrationError, RetryableError } from '@segment/actions-core'
+import { APIError, PayloadValidationError, RetryableError } from '@segment/actions-core'
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -46,9 +46,9 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, data) => {
-    if (!data?.payload?.key_field) throw new IntegrationError('Missing key field')
+    if (!data?.payload?.key_field) throw new PayloadValidationError('Missing key field')
 
-    if (!data?.payload?.key_value) throw new IntegrationError('Missing key value')
+    if (!data?.payload?.key_value) throw new PayloadValidationError('Missing key value')
 
     data.payload.contactlistid = parseInt(data.payload.contactlistid.toString().replace(/[^0-9]/g, ''))
 
@@ -70,19 +70,19 @@ const action: ActionDefinition<Settings, Payload> = {
           try {
             const body = await response.json()
             if (body.replyCode === 0) return response
-            else throw new IntegrationError('Something went wrong while removing from contact list')
+            else throw new APIError('Something went wrong while removing from contact list')
           } catch (err) {
-            throw new IntegrationError('Invalid JSON response')
+            throw new APIError('Invalid JSON response')
           }
         case 400:
-          throw new IntegrationError('The contact could not be removed from the contact list')
+          throw new APIError('The contact could not be removed from the contact list')
         case 429:
           throw new RetryableError('Rate limit reached.')
         default:
           throw new RetryableError('There seems to be an API issue.')
       }
     } else {
-      throw new IntegrationError('ContactlistId must be >0')
+      throw new PayloadValidationError('ContactlistId must be >0')
     }
   },
   performBatch: async (request, data) => {

--- a/packages/destination-actions/src/destinations/emarsys/triggerEvent/index.ts
+++ b/packages/destination-actions/src/destinations/emarsys/triggerEvent/index.ts
@@ -1,4 +1,4 @@
-import type { ActionDefinition } from '@segment/actions-core'
+import { APIError, ActionDefinition, PayloadValidationError, RetryableError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import {
@@ -11,8 +11,6 @@ import {
   TriggerEventApiPayload,
   TriggerEventsApiPayload
 } from '../emarsys-helper'
-import { IntegrationError } from '@segment/actions-core'
-import { RetryableError } from '@segment/actions-core'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Trigger Event',
@@ -59,9 +57,9 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, data) => {
-    if (!data?.payload?.key_field) throw new IntegrationError('Missing key field')
+    if (!data?.payload?.key_field) throw new PayloadValidationError('Missing key field')
 
-    if (!data?.payload?.key_value) throw new IntegrationError('Missing key value')
+    if (!data?.payload?.key_value) throw new PayloadValidationError('Missing key value')
 
     data.payload.eventid = parseInt(data.payload.eventid.toString().replace(/[^0-9]/g, ''))
 
@@ -83,19 +81,19 @@ const action: ActionDefinition<Settings, Payload> = {
           try {
             const body = await response.json()
             if (body.replyCode === 0) return response
-            else throw new IntegrationError('Something went wrong while triggering the event')
+            else throw new APIError('Something went wrong while triggering the event')
           } catch (err) {
-            throw new IntegrationError('Invalid JSON response')
+            throw new APIError('Invalid JSON response')
           }
         case 400:
-          throw new IntegrationError('The event could not be triggered')
+          throw new APIError('The event could not be triggered')
         case 429:
           throw new RetryableError('Rate limit reached.')
         default:
           throw new RetryableError('There seems to be an API issue.')
       }
     } else {
-      throw new IntegrationError('eventid must be >0')
+      throw new PayloadValidationError('eventid must be >0')
     }
   },
   performBatch: async (request, data) => {

--- a/packages/destination-actions/src/destinations/emarsys/upsertContact/index.ts
+++ b/packages/destination-actions/src/destinations/emarsys/upsertContact/index.ts
@@ -1,4 +1,4 @@
-import type { ActionDefinition } from '@segment/actions-core'
+import { APIError, ActionDefinition, PayloadValidationError, RetryableError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import {
@@ -9,8 +9,6 @@ import {
   BufferBatchContacts,
   BufferBatchContactItem
 } from '../emarsys-helper'
-import { IntegrationError } from '@segment/actions-core'
-import { RetryableError } from '@segment/actions-core'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Upsert Contact',
@@ -65,9 +63,9 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: async (request, data) => {
     const contact: ContactData = {}
-    if (!data?.payload?.key_field) throw new IntegrationError('Missing key field')
+    if (!data?.payload?.key_field) throw new PayloadValidationError('Missing key field')
 
-    if (!data?.payload?.key_value) throw new IntegrationError('Missing key value')
+    if (!data?.payload?.key_value) throw new PayloadValidationError('Missing key value')
 
     contact[data.payload.key_field] = data.payload.key_value
     Object.assign(contact, data.payload.write_field)
@@ -86,12 +84,12 @@ const action: ActionDefinition<Settings, Payload> = {
         try {
           const body = await response.json()
           if (body.replyCode === 0) return response
-          else throw new IntegrationError('Something went wrong while upserting the contact')
+          else throw new APIError('Something went wrong while upserting the contact')
         } catch (err) {
-          throw new IntegrationError('Invalid JSON response')
+          throw new APIError('Invalid JSON response')
         }
       case 400:
-        throw new IntegrationError('Contact could not be upserted')
+        throw new APIError('Contact could not be upserted')
       case 429:
         throw new RetryableError('Rate limit reached.')
       default:


### PR DESCRIPTION
This PR introduces a new API Error class and new Error Code - API_CALL_FAILED. 

The new error class and code can be used to categorize API errors handled by builders within action code. Builders may decide to capture and rethrow API errors with better contextual error messages or interpret response and decide whether the API call is a failure or a success. **Emarsys** is the only destination that currently seem to need this error class right now. 

The previous implementation of these errors didn't assign an error code or status. Such error are considered as unhandled errors by integrations and show up in Sentry.

Emarsys is a partner build destination and has very low traffic in production. So, there is a chance that we won't see these errors until we see more adoption. These error code changes are safe and seem appropriate. These errors will not be retried.

**Note** 
- We currently don't show error messages in Event delivery page except for **Payload Validation Errors**. The error messages themselves are of no use for Integration Errors or API Error.

## Testing
I don't have an emarsys account. So, i used HubSpot to simulate the new error in staging. This is what they look like in Event delivery. 

<img width="1296" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/748e3fba-e765-461c-8237-dc7766b31a92">

The message shown in this pane can be customized from contentful
<img width="1511" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/e6ba6034-0448-48bc-b45d-81566cc7938e">


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
