### PR TITLE
Make onTokenRefresh async

### DIFF
--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -206,7 +206,7 @@ export interface DecoratedResponse extends ModifiedResponse {
 }
 
 interface OnEventOptions {
-  onTokenRefresh?: (tokens: RefreshAccessTokenResult) => void
+  onTokenRefresh?: (tokens: RefreshAccessTokenResult) => Promise<void>
   onComplete?: (stats: SubscriptionStats) => void
   features?: Features
   statsContext?: StatsContext
@@ -597,7 +597,7 @@ export class Destination<Settings = JSONObject> {
 
       // Update `settings` with new tokens
       settings = updateOAuthSettings(settings, newTokens)
-      options?.onTokenRefresh?.(newTokens)
+      await options?.onTokenRefresh?.(newTokens)
     }
 
     return await retry(run, { retries: 2, onFailedAttempt })
@@ -649,7 +649,7 @@ export class Destination<Settings = JSONObject> {
 
       // Update `settings` with new tokens
       settings = updateOAuthSettings(settings, newTokens)
-      options?.onTokenRefresh?.(newTokens)
+      await options?.onTokenRefresh?.(newTokens)
     }
 
     return await retry(run, { retries: 2, onFailedAttempt })


### PR DESCRIPTION
As part of the recent redis change,  the `onTokenRefresh` method was changed to async.  Refer [here](https://github.com/segmentio/integrations/blob/5d331af46f84ee6862c5228b1b19b19ee083de2f/createActionDestination/index.js#L193). It was missed to update the onTokenRefresh as async in actions-core. This PR marks onTokenRefresh as async and awaits the response.
Previous PRs - [Integrations](https://github.com/segmentio/integrations/pull/2609) and [Action Destination](https://github.com/segmentio/action-destinations/pull/1239)

This seem to have had no impact in production but it is safe to make this update. The trend for token refresh has been consistent over the past two weeks. Refer datadog [here](https://segment.datadoghq.com/s/A9ih7c/6we-spn-pf7).

Confirmed in local and by testing in production by sending events that the missing await has no impact.

**Local Testing**

<img width="1131" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/c9f5b1e8-e114-492a-9c18-7f78a4a0bd44">


## Testing

Testing completed successfully in local. Update actions-core to integrations and sent an event. New token is set in response context as it was before adding the await.

<img width="1082" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/978aa190-dd14-4c76-8740-5076799b11a9">

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
