### PR TITLE
STRATCONN-2679 - Add required Sync and Batching settings to LiveRamp

### DIFF
--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEntered/generated-types.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEntered/generated-types.ts
@@ -19,4 +19,5 @@ export interface Payload {
    * Name of the CSV file to upload for LiveRamp ingestion.
    */
   filename: string
+  enable_batching: boolean
 }

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEntered/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEntered/index.ts
@@ -42,7 +42,7 @@ const action: ActionDefinition<Settings, Payload> = {
     enable_batching: {
       type: 'boolean',
       label: 'Batch data',
-      description: '',
+      description: 'Receive events in a batch payload. This is required for LiveRamp audiences ingestion.ß',
       required: true,
       default: true
     }

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEntered/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEntered/index.ts
@@ -42,7 +42,7 @@ const action: ActionDefinition<Settings, Payload> = {
     enable_batching: {
       type: 'boolean',
       label: 'Batch data',
-      description: 'Receive events in a batch payload. This is required for LiveRamp audiences ingestion.ß',
+      description: 'Receive events in a batch payload. This is required for LiveRamp audiences ingestion.',
       required: true,
       default: true
     }

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEntered/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEntered/index.ts
@@ -38,6 +38,13 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: true,
       default: { '@template': '{{properties.audience_key}}_PII_{{receivedAt}}.csv' }
+    },
+    enable_batching: {
+      type: 'boolean',
+      label: 'Batch data',
+      description: '',
+      required: true,
+      default: true
     }
   },
   perform: async (request, { settings, payload }) => {

--- a/packages/destination-actions/src/destinations/liveramp-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/generated-types.ts
@@ -33,4 +33,7 @@ export interface Settings {
    * Path within the LiveRamp SFTP server to upload the files to. This path must exist and all subfolders must be pre-created.
    */
   sftp_folder_path?: string
+  __segment_internal_engage_force_full_sync: boolean
+  __segment_internal_engage_batch_sync: boolean
+  enable_batching: boolean
 }

--- a/packages/destination-actions/src/destinations/liveramp-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/generated-types.ts
@@ -35,5 +35,4 @@ export interface Settings {
   sftp_folder_path?: string
   __segment_internal_engage_force_full_sync: boolean
   __segment_internal_engage_batch_sync: boolean
-  enable_batching: boolean
 }

--- a/packages/destination-actions/src/destinations/liveramp-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/index.ts
@@ -59,6 +59,27 @@ const destination: DestinationDefinition<Settings> = {
           'Path within the LiveRamp SFTP server to upload the files to. This path must exist and all subfolders must be pre-created.',
         type: 'string',
         format: 'uri-reference'
+      },
+      __segment_internal_engage_force_full_sync: {
+        label: 'Force Full Sync',
+        description: '',
+        type: 'boolean',
+        required: true,
+        default: true
+      },
+      __segment_internal_engage_batch_sync: {
+        label: 'Supports batch sync via ADS',
+        description: '',
+        type: 'boolean',
+        required: true,
+        default: true
+      },
+      enable_batching: {
+        type: 'boolean',
+        label: 'Batch data',
+        description: '',
+        required: true,
+        default: true
       }
     },
     testAuthentication: async (_, { settings }) => {

--- a/packages/destination-actions/src/destinations/liveramp-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/index.ts
@@ -73,13 +73,6 @@ const destination: DestinationDefinition<Settings> = {
         type: 'boolean',
         required: true,
         default: true
-      },
-      enable_batching: {
-        type: 'boolean',
-        label: 'Batch data',
-        description: '',
-        required: true,
-        default: true
       }
     },
     testAuthentication: async (_, { settings }) => {


### PR DESCRIPTION
This PR adds the [required hidden settings](https://docs.google.com/document/d/1epQsldyZXGHzlhOIKiGzi0nrGWt5L0KvwV91tdCes3Y) for Audiences and Batching to work according to LiveRamp's specifications.

These settings will be hidden using the Partner Portal after pushing.


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
