### PR TITLE
Ccp 204

### DIFF
--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/generated-types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/generated-types.ts
@@ -54,17 +54,9 @@ export interface Payload {
    */
   subject: string
   /**
-   * The message body
-   */
-  body?: string
-  /**
    * URL to the message body
    */
   bodyUrl?: string
-  /**
-   * The type of body which is used generally html | design
-   */
-  bodyType: string
   /**
    * The HTML content of the body
    */

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
@@ -208,7 +208,7 @@ const attemptEmailDelivery = async (
   }
 
   // only include preview text in design editor templates
-  if (payload.bodyType === 'design' && payload.previewText) {
+  if (payload.previewText) {
     const parsedPreviewText = await parseTemplating(
       payload.previewText,
       profile,


### PR DESCRIPTION
- Removing unlayer support from the send email AD
- Removing bodyType support, as only HTML is supported now

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
