### PR TITLE
committing generated-types for liveramp-audiences

### DIFF
--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEntered/generated-types.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEntered/generated-types.ts
@@ -19,5 +19,8 @@ export interface Payload {
    * Name of the CSV file to upload for LiveRamp ingestion.
    */
   filename: string
+  /**
+   * Receive events in a batch payload. This is required for LiveRamp audiences ingestion.
+   */
   enable_batching: boolean
 }


### PR DESCRIPTION
##Summary 
Committing generated-types for liveramp-audiences, as part of deploy

## Testing

None needed - part of deploy. 