### PR TITLE
[Facebook-Conversions-API] Adds support for App Events

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
@@ -483,5 +483,70 @@ describe('FacebookConversionsApi', () => {
         `"{\\"data\\":[{\\"event_name\\":\\"AddToCart\\",\\"event_time\\":\\"1631210000\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"city\\":\\"Gotham\\",\\"country\\":\\"United States\\",\\"last_name\\":\\"Wayne\\",\\"currency\\":\\"USD\\",\\"value\\":12.12}}],\\"test_event_code\\":\\"1234567890\\"}"`
       )
     })
+
+    it('should send app events correctly', async () => {
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Product Added',
+        userId: 'abc123',
+        timestamp: '1631210000',
+        properties: {
+          action_source: 'email',
+          currency: 'USD',
+          value: 12.12,
+          email: 'nicholas.aguilar@segment.com',
+          traits: {
+            city: 'Gotham',
+            country: 'United States',
+            last_name: 'Wayne'
+          }
+        },
+        context: {
+          app: {
+            build: '2',
+            name: 'Krusty Krab ToGo',
+            namespace: 'com.krusty.krab.ios-prod',
+            version: '2.0.1'
+          },
+          device: {
+            id: '1234-5678',
+            manufacturer: 'Apple',
+            model: 'iPhone10,5',
+            name: 'iPhone X',
+            type: 'ios'
+          },
+          locale: 'en-US',
+          timezone: 'America/Los Angeles',
+          screen: {
+            height: 736,
+            width: 414
+          },
+          network: {
+            carrier: 'AT&T',
+            cellular: true,
+            wifi: true
+          },
+          os: {
+            name: 'iOS',
+            version: '16.3.1'
+          }
+        }
+      })
+
+      const responses = await testDestination.testAction('addToCart', {
+        event,
+        settings,
+        mapping: {
+          action_source: { '@path': '$.properties.action_source' }
+        },
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot()
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
@@ -484,7 +484,7 @@ describe('FacebookConversionsApi', () => {
       )
     })
 
-    it('should send app events correctly', async () => {
+    it('should send app events using default mappings correctly', async () => {
       nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({
@@ -496,6 +496,7 @@ describe('FacebookConversionsApi', () => {
           currency: 'USD',
           value: 12.12,
           email: 'nicholas.aguilar@segment.com',
+          product_id: 'abc12345',
           traits: {
             city: 'Gotham',
             country: 'United States',
@@ -538,7 +539,10 @@ describe('FacebookConversionsApi', () => {
         event,
         settings,
         mapping: {
-          action_source: { '@path': '$.properties.action_source' }
+          action_source: { '@path': '$.properties.action_source' },
+          app_data_field: {
+            use_app_data: true
+          }
         },
         useDefaultMappings: true
       })
@@ -546,7 +550,9 @@ describe('FacebookConversionsApi', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
 
-      expect(responses[0].options.body).toMatchInlineSnapshot()
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"AddToCart\\",\\"event_time\\":\\"1631210000\\",\\"event_id\\":\\"f696c0af-f775-4962-af7d-cc2f67f8e998\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"external_id\\":\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"contents\\":[{\\"id\\":\\"abc12345\\"}]},\\"app_data\\":{\\"extinfo\\":\\",com.krusty.krab.ios-prod,,2.0.1,16.3.1,iPhone10,5,en-US,,AT&T,414,736,,,\\"}}]}"`
+      )
     })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/app-data.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/app-data.test.ts
@@ -1,0 +1,80 @@
+import { generate_app_data, AppData, GeneratedAppData } from '../fb-capi-app-data'
+
+describe('FacebookConversionsApi', () => {
+  describe('AppData', () => {
+    const sampleAppDataComplete: AppData = {
+      use_app_data: true,
+      advertiser_tracking_enabled: true,
+      application_tracking_enabled: true,
+      version: 'i2',
+      packageName: 'com.segment.app',
+      shortVersion: '1.0.0',
+      longVersion: '1.0.0',
+      osVersion: '19.5',
+      deviceName: 'iPhone 19,1',
+      locale: 'en_US',
+      timezone: 'America/Los_Angeles',
+      carrier: 'T-Mobile',
+      width: '1920',
+      height: '1080',
+      density: '2.0',
+      cpuCores: '8',
+      storageSize: '128',
+      freeStorage: '64',
+      deviceTimezone: 'America/Los_Angeles'
+    }
+    const sampleAppDataIncomplete: AppData = {
+      ...sampleAppDataComplete
+    }
+    delete sampleAppDataIncomplete.timezone
+    delete sampleAppDataIncomplete.carrier
+    delete sampleAppDataIncomplete.deviceTimezone
+
+    it('generated app data should always have a length 16 exinfo array', () => {
+      let appData: GeneratedAppData | undefined = generate_app_data(sampleAppDataComplete)
+      if (appData) {
+        expect(appData.extinfo.length).toBe(16)
+      }
+      expect(appData).toBeDefined()
+
+      appData = generate_app_data(sampleAppDataIncomplete)
+      if (appData) {
+        expect(appData.extinfo.length).toBe(16)
+      }
+      expect(appData).toBeDefined()
+    })
+
+    it('generated app data should be undefined if use_app_data is false', () => {
+      const appData = generate_app_data({
+        use_app_data: false
+      })
+      expect(appData).toBeUndefined()
+    })
+
+    it('generated app data should include empty strings if fields are missing from extinfo', () => {
+      const appData = generate_app_data(sampleAppDataIncomplete)
+      if (appData) {
+        expect(appData.advertiser_tracking_enabled).toBe(1)
+        expect(appData.application_tracking_enabled).toBe(1)
+
+        expect(appData.extinfo[0]).toBe(sampleAppDataIncomplete.version)
+        expect(appData.extinfo[1]).toBe(sampleAppDataIncomplete.packageName)
+        expect(appData.extinfo[2]).toBe(sampleAppDataIncomplete.shortVersion)
+        expect(appData.extinfo[3]).toBe(sampleAppDataIncomplete.longVersion)
+        expect(appData.extinfo[4]).toBe(sampleAppDataIncomplete.osVersion)
+        expect(appData.extinfo[5]).toBe(sampleAppDataIncomplete.deviceName)
+        expect(appData.extinfo[6]).toBe(sampleAppDataIncomplete.locale)
+        expect(appData.extinfo[7]).toBe('')
+        expect(appData.extinfo[8]).toBe('')
+        expect(appData.extinfo[9]).toBe(sampleAppDataIncomplete.width)
+        expect(appData.extinfo[10]).toBe(sampleAppDataIncomplete.height)
+        expect(appData.extinfo[11]).toBe(sampleAppDataIncomplete.density)
+        expect(appData.extinfo[12]).toBe(sampleAppDataIncomplete.cpuCores)
+        expect(appData.extinfo[13]).toBe(sampleAppDataIncomplete.storageSize)
+        expect(appData.extinfo[14]).toBe(sampleAppDataIncomplete.freeStorage)
+        expect(appData.extinfo[15]).toBe('')
+      }
+      expect(appData).toBeDefined()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
@@ -95,6 +95,85 @@ export interface Payload {
     partner_name?: string
   }
   /**
+   * TODO
+   */
+  app_data_field?: {
+    /**
+     * *Required for app events*
+     *             Use this field to specify ATT permission on an iOS 14.5+ device. Set to 0 for disabled or 1 for enabled.
+     */
+    advertiser_tracking_enabled?: boolean
+    /**
+     * *Required for app events*
+     *             A person can choose to enable ad tracking on an app level. Your SDK should allow an app developer to put an opt-out setting into their app. Use this field to specify the person's choice. Use 0 for disabled, 1 for enabled.
+     */
+    application_tracking_enabled?: boolean
+    /**
+     * *Required for app events* Example: i2
+     */
+    version?: string
+    /**
+     * Example: com.facebook.sdk.samples.hellofacebook
+     */
+    packageName?: string
+    /**
+     * Example: 1.0
+     */
+    shortVersion?: string
+    /**
+     * Example: 1.0 long
+     */
+    longVersion?: string
+    /**
+     * Example: 13.4.1
+     */
+    osVersion?: string
+    /**
+     * Example: iPhone5,1
+     */
+    deviceName?: string
+    /**
+     * Example: En_US
+     */
+    locale?: string
+    /**
+     * Example: 'PST'
+     */
+    timezone?: string
+    /**
+     * Example: AT&T
+     */
+    carrier?: string
+    /**
+     * Example: 1080
+     */
+    width?: string
+    /**
+     * Example: 1920
+     */
+    height?: string
+    /**
+     * Example: 2.0
+     */
+    density?: string
+    /**
+     * Example: 8
+     */
+    cpuCores?: string
+    /**
+     * Example: 64
+     */
+    storageSize?: string
+    /**
+     * Example: 32
+     */
+    freeStorage?: string
+    /**
+     * Example: USA/New York
+     */
+    deviceTimezone?: string
+  }
+  /**
    * The content IDs associated with the event, such as product SKUs.
    */
   content_ids?: string[]

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
@@ -95,11 +95,14 @@ export interface Payload {
     partner_name?: string
   }
   /**
-   * TODO
+   * These fields support sending app events to Facebook through the Conversions API. For more information about app events support in the Conversions API, see the Facebook docs [here](https://developers.facebook.com/docs/marketing-api/conversions-api/app-events).
+   *   App events sent through the Conversions API must be associated with a dataset.
+   *   Instructions for creating a dataset can be found [here](https://www.facebook.com/business/help/750785952855662?id=490360542427371). Once a dataset is created, the dataset ID
+   *   can be substituted for the pixel ID in the destination settings.
    */
   app_data_field?: {
     /**
-     * Send app data to Facebook?
+     * Segment will not send app events to Facebook by default. Enable this once you have created a dataset in Facebook and are ready to begin sending app events.
      */
     use_app_data?: boolean
     /**

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
@@ -116,67 +116,67 @@ export interface Payload {
      */
     application_tracking_enabled?: boolean
     /**
-     * *Required for app events* Example: i2
+     * *Required for app events* Example: 'i2'.
      */
     version?: string
     /**
-     * Example: com.facebook.sdk.samples.hellofacebook
+     * Example: 'com.facebook.sdk.samples.hellofacebook'.
      */
     packageName?: string
     /**
-     * Example: 1.0
+     * Example: '1.0'.
      */
     shortVersion?: string
     /**
-     * Example: 1.0 long
+     * Example: '1.0 long'.
      */
     longVersion?: string
     /**
-     * Example: 13.4.1
+     * Example: '13.4.1'.
      */
     osVersion?: string
     /**
-     * Example: iPhone5,1
+     * Example: 'iPhone5,1'.
      */
     deviceName?: string
     /**
-     * Example: En_US
+     * Example: 'En_US'.
      */
     locale?: string
     /**
-     * Example: 'PST'
+     * Example: 'PST'.
      */
     timezone?: string
     /**
-     * Example: AT&T
+     * Example: 'AT&T'.
      */
     carrier?: string
     /**
-     * Example: 1080
+     * Example: '1080'.
      */
     width?: string
     /**
-     * Example: 1920
+     * Example: '1920'.
      */
     height?: string
     /**
-     * Example: 2.0
+     * Example: '2.0'.
      */
     density?: string
     /**
-     * Example: 8
+     * Example: '8'.
      */
     cpuCores?: string
     /**
-     * Example: 64
+     * Example: '64'.
      */
     storageSize?: string
     /**
-     * Example: 32
+     * Example: '32'.
      */
     freeStorage?: string
     /**
-     * Example: USA/New York
+     * Example: 'USA/New York'.
      */
     deviceTimezone?: string
   }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
@@ -99,6 +99,10 @@ export interface Payload {
    */
   app_data_field?: {
     /**
+     * Send app data to Facebook?
+     */
+    use_app_data?: boolean
+    /**
      * *Required for app events*
      *             Use this field to specify ATT permission on an iOS 14.5+ device. Set to 0 for disabled or 1 for enabled.
      */

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
@@ -67,6 +67,7 @@ const action: ActionDefinition<Settings, Payload> = {
   },
 
   perform: (request, { payload, settings, features, statsContext }) => {
+    console.log('payload', payload)
     if (payload.currency && !CURRENCY_ISO_CODES.has(payload.currency)) {
       throw new IntegrationError(
         `${payload.currency} is not a valid currency code.`,

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
@@ -100,7 +100,7 @@ const action: ActionDefinition<Settings, Payload> = {
     )
 
     return request(
-      `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
+      `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events?debug=all`,
       {
         method: 'POST',
         json: {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
@@ -99,7 +99,7 @@ const action: ActionDefinition<Settings, Payload> = {
     )
 
     return request(
-      `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events?debug=all`,
+      `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
       {
         method: 'POST',
         json: {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
@@ -67,7 +67,6 @@ const action: ActionDefinition<Settings, Payload> = {
   },
 
   perform: (request, { payload, settings, features, statsContext }) => {
-    console.log('payload', payload)
     if (payload.currency && !CURRENCY_ISO_CODES.has(payload.currency)) {
       throw new IntegrationError(
         `${payload.currency} is not a valid currency code.`,

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
@@ -22,6 +22,7 @@ import {
 import { CURRENCY_ISO_CODES } from '../constants'
 import { hash_user_data, user_data_field } from '../fb-capi-user-data'
 import { get_api_version } from '../utils'
+import { generate_app_data, app_data_field } from '../fb-capi-app-data'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Add to Cart',
@@ -31,6 +32,7 @@ const action: ActionDefinition<Settings, Payload> = {
     action_source: { ...action_source, required: true },
     event_time: { ...event_time, required: true },
     user_data: user_data_field,
+    app_data_field: app_data_field,
     content_ids: content_ids,
     content_name: content_name,
     content_type: content_type,
@@ -118,6 +120,7 @@ const action: ActionDefinition<Settings, Payload> = {
                 contents: payload.contents,
                 content_type: payload.content_type
               },
+              app_data: generate_app_data(payload.app_data_field),
               data_processing_options: data_options,
               data_processing_options_country: country_code,
               data_processing_options_state: state_code

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom/generated-types.ts
@@ -120,67 +120,67 @@ export interface Payload {
      */
     application_tracking_enabled?: boolean
     /**
-     * *Required for app events* Example: i2
+     * *Required for app events* Example: 'i2'.
      */
     version?: string
     /**
-     * Example: com.facebook.sdk.samples.hellofacebook
+     * Example: 'com.facebook.sdk.samples.hellofacebook'.
      */
     packageName?: string
     /**
-     * Example: 1.0
+     * Example: '1.0'.
      */
     shortVersion?: string
     /**
-     * Example: 1.0 long
+     * Example: '1.0 long'.
      */
     longVersion?: string
     /**
-     * Example: 13.4.1
+     * Example: '13.4.1'.
      */
     osVersion?: string
     /**
-     * Example: iPhone5,1
+     * Example: 'iPhone5,1'.
      */
     deviceName?: string
     /**
-     * Example: En_US
+     * Example: 'En_US'.
      */
     locale?: string
     /**
-     * Example: 'PST'
+     * Example: 'PST'.
      */
     timezone?: string
     /**
-     * Example: AT&T
+     * Example: 'AT&T'.
      */
     carrier?: string
     /**
-     * Example: 1080
+     * Example: '1080'.
      */
     width?: string
     /**
-     * Example: 1920
+     * Example: '1920'.
      */
     height?: string
     /**
-     * Example: 2.0
+     * Example: '2.0'.
      */
     density?: string
     /**
-     * Example: 8
+     * Example: '8'.
      */
     cpuCores?: string
     /**
-     * Example: 64
+     * Example: '64'.
      */
     storageSize?: string
     /**
-     * Example: 32
+     * Example: '32'.
      */
     freeStorage?: string
     /**
-     * Example: USA/New York
+     * Example: 'USA/New York'.
      */
     deviceTimezone?: string
   }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom/generated-types.ts
@@ -99,6 +99,89 @@ export interface Payload {
     partner_name?: string
   }
   /**
+   * TODO
+   */
+  app_data_field?: {
+    /**
+     * Send app data to Facebook?
+     */
+    use_app_data?: boolean
+    /**
+     * *Required for app events*
+     *             Use this field to specify ATT permission on an iOS 14.5+ device. Set to 0 for disabled or 1 for enabled.
+     */
+    advertiser_tracking_enabled?: boolean
+    /**
+     * *Required for app events*
+     *             A person can choose to enable ad tracking on an app level. Your SDK should allow an app developer to put an opt-out setting into their app. Use this field to specify the person's choice. Use 0 for disabled, 1 for enabled.
+     */
+    application_tracking_enabled?: boolean
+    /**
+     * *Required for app events* Example: i2
+     */
+    version?: string
+    /**
+     * Example: com.facebook.sdk.samples.hellofacebook
+     */
+    packageName?: string
+    /**
+     * Example: 1.0
+     */
+    shortVersion?: string
+    /**
+     * Example: 1.0 long
+     */
+    longVersion?: string
+    /**
+     * Example: 13.4.1
+     */
+    osVersion?: string
+    /**
+     * Example: iPhone5,1
+     */
+    deviceName?: string
+    /**
+     * Example: En_US
+     */
+    locale?: string
+    /**
+     * Example: 'PST'
+     */
+    timezone?: string
+    /**
+     * Example: AT&T
+     */
+    carrier?: string
+    /**
+     * Example: 1080
+     */
+    width?: string
+    /**
+     * Example: 1920
+     */
+    height?: string
+    /**
+     * Example: 2.0
+     */
+    density?: string
+    /**
+     * Example: 8
+     */
+    cpuCores?: string
+    /**
+     * Example: 64
+     */
+    storageSize?: string
+    /**
+     * Example: 32
+     */
+    freeStorage?: string
+    /**
+     * Example: USA/New York
+     */
+    deviceTimezone?: string
+  }
+  /**
    * The custom data object can be used to pass custom properties. See [Facebook documentation](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/custom-data#custom-properties) for more information.
    */
   custom_data?: {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom/generated-types.ts
@@ -99,11 +99,14 @@ export interface Payload {
     partner_name?: string
   }
   /**
-   * TODO
+   * These fields support sending app events to Facebook through the Conversions API. For more information about app events support in the Conversions API, see the Facebook docs [here](https://developers.facebook.com/docs/marketing-api/conversions-api/app-events).
+   *   App events sent through the Conversions API must be associated with a dataset.
+   *   Instructions for creating a dataset can be found [here](https://www.facebook.com/business/help/750785952855662?id=490360542427371). Once a dataset is created, the dataset ID
+   *   can be substituted for the pixel ID in the destination settings.
    */
   app_data_field?: {
     /**
-     * Send app data to Facebook?
+     * Segment will not send app events to Facebook by default. Enable this once you have created a dataset in Facebook and are ready to begin sending app events.
      */
     use_app_data?: boolean
     /**

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
@@ -14,6 +14,7 @@ import { hash_user_data, user_data_field } from '../fb-capi-user-data'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { get_api_version } from '../utils'
+import { generate_app_data, app_data_field } from '../fb-capi-app-data'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Custom Event',
@@ -32,6 +33,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     event_time: { ...event_time, required: true },
     user_data: user_data_field,
+    app_data_field: app_data_field,
     custom_data: custom_data,
     event_id: event_id,
     event_source_url: event_source_url,
@@ -64,6 +66,7 @@ const action: ActionDefinition<Settings, Payload> = {
               event_source_url: payload.event_source_url,
               user_data: hash_user_data({ user_data: payload.user_data }),
               custom_data: payload.custom_data,
+              app_data: generate_app_data(payload.app_data_field),
               data_processing_options: data_options,
               data_processing_options_country: country_code,
               data_processing_options_state: state_code

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
@@ -1,8 +1,14 @@
 import { InputField } from '@segment/actions-core'
 import { Payload } from './addToCart/generated-types'
 
-type AppData = Payload['app_data_field']
-export const generate_app_data = (app_data: AppData): Object | undefined => {
+//exported for unit test
+export type AppData = Payload['app_data_field']
+export type GeneratedAppData = {
+  advertiser_tracking_enabled: 1 | 0
+  application_tracking_enabled: 1 | 0
+  extinfo: string[]
+}
+export const generate_app_data = (app_data: AppData): GeneratedAppData | undefined => {
   if (!app_data || !app_data.use_app_data) {
     return undefined
   }
@@ -24,8 +30,10 @@ export const generate_app_data = (app_data: AppData): Object | undefined => {
       app_data?.height ?? '',
       app_data?.density ?? '',
       app_data?.cpuCores ?? '',
-      app_data?.storageSize ?? ''
-    ].join(',')
+      app_data?.storageSize ?? '',
+      app_data?.freeStorage ?? '',
+      app_data?.deviceTimezone ?? ''
+    ]
   }
 }
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
@@ -2,7 +2,11 @@ import { InputField } from '@segment/actions-core'
 import { Payload } from './addToCart/generated-types'
 
 type AppData = Payload['app_data_field']
-export const generate_app_data = (app_data: AppData) => {
+export const generate_app_data = (app_data: AppData): Object | undefined => {
+  if (!app_data || !app_data.use_app_data) {
+    return undefined
+  }
+
   return {
     advertiser_tracking_enabled: app_data?.advertiser_tracking_enabled,
     application_tracking_enabled: app_data?.application_tracking_enabled,
@@ -30,6 +34,12 @@ export const app_data_field: InputField = {
   description: 'TODO',
   type: 'object',
   properties: {
+    use_app_data: {
+      label: 'Use App Data?',
+      description: 'Send app data to Facebook?',
+      type: 'boolean',
+      default: false
+    },
     advertiser_tracking_enabled: {
       label: 'Advertiser Tracking Enabled',
       description: `*Required for app events*
@@ -40,8 +50,7 @@ export const app_data_field: InputField = {
       label: 'Application Tracking Enabled',
       type: 'boolean',
       description: `*Required for app events*
-            A person can choose to enable ad tracking on an app level. Your SDK should allow an app developer to put an opt-out setting into their app. Use this field to specify the person's choice. Use 0 for disabled, 1 for enabled. `,
-      default: { '@path': '$.context.device.adTrackingEnabled' }
+            A person can choose to enable ad tracking on an app level. Your SDK should allow an app developer to put an opt-out setting into their app. Use this field to specify the person's choice. Use 0 for disabled, 1 for enabled. `
     },
     version: {
       label: 'ExtInfo Version',
@@ -55,8 +64,7 @@ export const app_data_field: InputField = {
     packageName: {
       label: 'Package Name',
       description: `Example: com.facebook.sdk.samples.hellofacebook`,
-      type: 'string',
-      default: { '@path': '$.context.app.namespace' }
+      type: 'string'
     },
     shortVersion: {
       label: 'Short Version',
@@ -66,26 +74,22 @@ export const app_data_field: InputField = {
     longVersion: {
       label: 'Long Version',
       description: `Example: 1.0 long`,
-      type: 'string',
-      default: { '@path': '$.context.app.version' }
+      type: 'string'
     },
     osVersion: {
       label: 'OS Version',
       description: `Example: 13.4.1`,
-      type: 'string',
-      default: { '@path': '$.context.device.os.version' }
+      type: 'string'
     },
     deviceName: {
       label: 'Device Model Name',
       description: `Example: iPhone5,1`,
-      type: 'string',
-      default: { '@path': '$.context.device.model' }
+      type: 'string'
     },
     locale: {
       label: 'Locale',
       description: `Example: En_US`,
-      type: 'string',
-      default: { '@path': '$.context.locale' }
+      type: 'string'
     },
     timezone: {
       label: 'Timezone Abbreviation',
@@ -95,26 +99,22 @@ export const app_data_field: InputField = {
     carrier: {
       label: 'Carrier Name',
       description: 'Example: AT&T',
-      type: 'string',
-      default: { '@path': '$.context.network.carrier' }
+      type: 'string'
     },
     width: {
       label: 'Screen Width',
       description: 'Example: 1080',
-      type: 'string',
-      default: { '@path': '$.context.screen.width' }
+      type: 'string'
     },
     height: {
       label: 'Screen Height',
       description: 'Example: 1920',
-      type: 'string',
-      default: { '@path': '$.context.screen.height' }
+      type: 'string'
     },
     density: {
       label: 'Screen Density',
       description: 'Example: 2.0',
-      type: 'string',
-      default: { '@path': '$.context.screen.density' }
+      type: 'string'
     },
     cpuCores: {
       label: 'CPU Cores',
@@ -134,8 +134,42 @@ export const app_data_field: InputField = {
     deviceTimezone: {
       label: 'Device Timezone',
       description: 'Example: USA/New York',
-      type: 'string',
-      default: { '@path': '$.context.timezone' }
+      type: 'string'
+    }
+  },
+  default: {
+    application_tracking_enabled: {
+      '@path': '$.context.device.adTrackingEnabled'
+    },
+    packageName: {
+      '@path': '$.context.app.namespace'
+    },
+    longVersion: {
+      '@path': '$.context.app.version'
+    },
+    osVersion: {
+      '@path': '$.context.os.version'
+    },
+    deviceName: {
+      '@path': '$.context.device.model'
+    },
+    locale: {
+      '@path': '$.context.locale'
+    },
+    carrier: {
+      '@path': '$.context.network.carrier'
+    },
+    width: {
+      '@path': '$.context.screen.width'
+    },
+    height: {
+      '@path': '$.context.screen.height'
+    },
+    density: {
+      '@path': '$.context.screen.density'
+    },
+    deviceTimezone: {
+      '@path': '$.context.timezone'
     }
   }
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
@@ -8,6 +8,7 @@ export type GeneratedAppData = {
   application_tracking_enabled: 1 | 0
   extinfo: string[]
 }
+
 export const generate_app_data = (app_data: AppData): GeneratedAppData | undefined => {
   if (!app_data || !app_data.use_app_data) {
     return undefined
@@ -62,11 +63,11 @@ export const app_data_field: InputField = {
       label: 'Application Tracking Enabled',
       type: 'boolean',
       description: `*Required for app events*
-            A person can choose to enable ad tracking on an app level. Your SDK should allow an app developer to put an opt-out setting into their app. Use this field to specify the person's choice. Use 0 for disabled, 1 for enabled. `
+            A person can choose to enable ad tracking on an app level. Your SDK should allow an app developer to put an opt-out setting into their app. Use this field to specify the person's choice. Use 0 for disabled, 1 for enabled.`
     },
     version: {
       label: 'ExtInfo Version',
-      description: `*Required for app events* Example: i2`,
+      description: `*Required for app events* Example: 'i2'.`,
       type: 'string',
       choices: [
         { label: 'iOS', value: 'i2' },
@@ -75,77 +76,77 @@ export const app_data_field: InputField = {
     },
     packageName: {
       label: 'Package Name',
-      description: `Example: com.facebook.sdk.samples.hellofacebook`,
+      description: `Example: 'com.facebook.sdk.samples.hellofacebook'.`,
       type: 'string'
     },
     shortVersion: {
       label: 'Short Version',
-      description: `Example: 1.0`,
+      description: `Example: '1.0'.`,
       type: 'string'
     },
     longVersion: {
       label: 'Long Version',
-      description: `Example: 1.0 long`,
+      description: `Example: '1.0 long'.`,
       type: 'string'
     },
     osVersion: {
       label: '*Required for app events* OS Version',
-      description: `Example: 13.4.1`,
+      description: `Example: '13.4.1'.`,
       type: 'string'
     },
     deviceName: {
       label: 'Device Model Name',
-      description: `Example: iPhone5,1`,
+      description: `Example: 'iPhone5,1'.`,
       type: 'string'
     },
     locale: {
       label: 'Locale',
-      description: `Example: En_US`,
+      description: `Example: 'En_US'.`,
       type: 'string'
     },
     timezone: {
       label: 'Timezone Abbreviation',
-      description: "Example: 'PST'",
+      description: `Example: 'PST'.`,
       type: 'string'
     },
     carrier: {
       label: 'Carrier Name',
-      description: 'Example: AT&T',
+      description: `Example: 'AT&T'.`,
       type: 'string'
     },
     width: {
       label: 'Screen Width',
-      description: 'Example: 1080',
+      description: `Example: '1080'.`,
       type: 'string'
     },
     height: {
       label: 'Screen Height',
-      description: 'Example: 1920',
+      description: `Example: '1920'.`,
       type: 'string'
     },
     density: {
       label: 'Screen Density',
-      description: 'Example: 2.0',
+      description: `Example: '2.0'.`,
       type: 'string'
     },
     cpuCores: {
       label: 'CPU Cores',
-      description: 'Example: 8',
+      description: `Example: '8'.`,
       type: 'string'
     },
     storageSize: {
       label: 'Storage Size in GBs',
-      description: 'Example: 64',
+      description: `Example: '64'.`,
       type: 'string'
     },
     freeStorage: {
       label: 'Free Storage in GBs',
-      description: 'Example: 32',
+      description: `Example: '32'.`,
       type: 'string'
     },
     deviceTimezone: {
       label: 'Device Timezone',
-      description: 'Example: USA/New York',
+      description: `Example: 'USA/New York'.`,
       type: 'string'
     }
   },

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
@@ -1,0 +1,141 @@
+import { InputField } from '@segment/actions-core'
+import { Payload } from './addToCart/generated-types'
+
+type AppData = Payload['app_data_field']
+export const generate_app_data = (app_data: AppData) => {
+  return {
+    advertiser_tracking_enabled: app_data?.advertiser_tracking_enabled,
+    application_tracking_enabled: app_data?.application_tracking_enabled,
+    extinfo: [
+      app_data?.version ?? '',
+      app_data?.packageName ?? '',
+      app_data?.shortVersion ?? '',
+      app_data?.longVersion ?? '',
+      app_data?.osVersion ?? '',
+      app_data?.deviceName ?? '',
+      app_data?.locale ?? '',
+      app_data?.timezone ?? '',
+      app_data?.carrier ?? '',
+      app_data?.width ?? '',
+      app_data?.height ?? '',
+      app_data?.density ?? '',
+      app_data?.cpuCores ?? '',
+      app_data?.storageSize ?? ''
+    ].join(',')
+  }
+}
+
+export const app_data_field: InputField = {
+  label: 'App Data',
+  description: 'TODO',
+  type: 'object',
+  properties: {
+    advertiser_tracking_enabled: {
+      label: 'Advertiser Tracking Enabled',
+      description: `*Required for app events*
+            Use this field to specify ATT permission on an iOS 14.5+ device. Set to 0 for disabled or 1 for enabled.`,
+      type: 'boolean'
+    },
+    application_tracking_enabled: {
+      label: 'Application Tracking Enabled',
+      type: 'boolean',
+      description: `*Required for app events*
+            A person can choose to enable ad tracking on an app level. Your SDK should allow an app developer to put an opt-out setting into their app. Use this field to specify the person's choice. Use 0 for disabled, 1 for enabled. `,
+      default: { '@path': '$.context.device.adTrackingEnabled' }
+    },
+    version: {
+      label: 'ExtInfo Version',
+      description: `*Required for app events* Example: i2`,
+      type: 'string',
+      choices: [
+        { label: 'iOS', value: 'i2' },
+        { label: 'Android', value: 'a2' }
+      ]
+    },
+    packageName: {
+      label: 'Package Name',
+      description: `Example: com.facebook.sdk.samples.hellofacebook`,
+      type: 'string',
+      default: { '@path': '$.context.app.namespace' }
+    },
+    shortVersion: {
+      label: 'Short Version',
+      description: `Example: 1.0`,
+      type: 'string'
+    },
+    longVersion: {
+      label: 'Long Version',
+      description: `Example: 1.0 long`,
+      type: 'string',
+      default: { '@path': '$.context.app.version' }
+    },
+    osVersion: {
+      label: 'OS Version',
+      description: `Example: 13.4.1`,
+      type: 'string',
+      default: { '@path': '$.context.device.os.version' }
+    },
+    deviceName: {
+      label: 'Device Model Name',
+      description: `Example: iPhone5,1`,
+      type: 'string',
+      default: { '@path': '$.context.device.model' }
+    },
+    locale: {
+      label: 'Locale',
+      description: `Example: En_US`,
+      type: 'string',
+      default: { '@path': '$.context.locale' }
+    },
+    timezone: {
+      label: 'Timezone Abbreviation',
+      description: "Example: 'PST'",
+      type: 'string'
+    },
+    carrier: {
+      label: 'Carrier Name',
+      description: 'Example: AT&T',
+      type: 'string',
+      default: { '@path': '$.context.network.carrier' }
+    },
+    width: {
+      label: 'Screen Width',
+      description: 'Example: 1080',
+      type: 'string',
+      default: { '@path': '$.context.screen.width' }
+    },
+    height: {
+      label: 'Screen Height',
+      description: 'Example: 1920',
+      type: 'string',
+      default: { '@path': '$.context.screen.height' }
+    },
+    density: {
+      label: 'Screen Density',
+      description: 'Example: 2.0',
+      type: 'string',
+      default: { '@path': '$.context.screen.density' }
+    },
+    cpuCores: {
+      label: 'CPU Cores',
+      description: 'Example: 8',
+      type: 'string'
+    },
+    storageSize: {
+      label: 'Storage Size in GBs',
+      description: 'Example: 64',
+      type: 'string'
+    },
+    freeStorage: {
+      label: 'Free Storage in GBs',
+      description: 'Example: 32',
+      type: 'string'
+    },
+    deviceTimezone: {
+      label: 'Device Timezone',
+      description: 'Example: USA/New York',
+      type: 'string',
+      default: { '@path': '$.context.timezone' }
+    }
+  }
+}

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
@@ -8,8 +8,8 @@ export const generate_app_data = (app_data: AppData): Object | undefined => {
   }
 
   return {
-    advertiser_tracking_enabled: app_data?.advertiser_tracking_enabled,
-    application_tracking_enabled: app_data?.application_tracking_enabled,
+    advertiser_tracking_enabled: app_data?.advertiser_tracking_enabled ? 1 : 0,
+    application_tracking_enabled: app_data?.application_tracking_enabled ? 1 : 0,
     extinfo: [
       app_data?.version ?? '',
       app_data?.packageName ?? '',
@@ -77,7 +77,7 @@ export const app_data_field: InputField = {
       type: 'string'
     },
     osVersion: {
-      label: 'OS Version',
+      label: '*Required for app events* OS Version',
       description: `Example: 13.4.1`,
       type: 'string'
     },

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
@@ -38,13 +38,17 @@ export const generate_app_data = (app_data: AppData): GeneratedAppData | undefin
 }
 
 export const app_data_field: InputField = {
-  label: 'App Data',
-  description: 'TODO',
+  label: 'App Events Fields',
+  description: `These fields support sending app events to Facebook through the Conversions API. For more information about app events support in the Conversions API, see the Facebook docs [here](https://developers.facebook.com/docs/marketing-api/conversions-api/app-events).
+  App events sent through the Conversions API must be associated with a dataset. 
+  Instructions for creating a dataset can be found [here](https://www.facebook.com/business/help/750785952855662?id=490360542427371). Once a dataset is created, the dataset ID
+  can be substituted for the pixel ID in the destination settings.`,
   type: 'object',
   properties: {
     use_app_data: {
-      label: 'Use App Data?',
-      description: 'Send app data to Facebook?',
+      label: 'Send App Events?',
+      description:
+        'Segment will not send app events to Facebook by default. Enable this once you have created a dataset in Facebook and are ready to begin sending app events.',
       type: 'boolean',
       default: false
     },

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Settings {
   /**
-   * Your Facebook Pixel ID
+   * Your Facebook Pixel ID. Note: You may also use a dataset ID here if you have configured a dataset in your Facebook Events Manager.
    */
   pixelId: string
   /**

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/index.ts
@@ -29,9 +29,6 @@ const destination: DestinationDefinition<Settings> = {
           'Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. You\'ll want to remove your Test Event Code when sending real traffic through this integration.',
         required: false
       }
-    },
-    testAuthentication: () => {
-      return true
     }
   },
   extendRequest: () => {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/index.ts
@@ -29,6 +29,9 @@ const destination: DestinationDefinition<Settings> = {
           'Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. You\'ll want to remove your Test Event Code when sending real traffic through this integration.',
         required: false
       }
+    },
+    testAuthentication: () => {
+      return true
     }
   },
   extendRequest: () => {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/index.ts
@@ -18,7 +18,8 @@ const destination: DestinationDefinition<Settings> = {
     fields: {
       pixelId: {
         label: 'Pixel ID',
-        description: 'Your Facebook Pixel ID',
+        description:
+          'Your Facebook Pixel ID. Note: You may also use a dataset ID here if you have configured a dataset in your Facebook Events Manager.',
         type: 'string',
         required: true
       },

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
@@ -95,6 +95,89 @@ export interface Payload {
     partner_name?: string
   }
   /**
+   * TODO
+   */
+  app_data_field?: {
+    /**
+     * Send app data to Facebook?
+     */
+    use_app_data?: boolean
+    /**
+     * *Required for app events*
+     *             Use this field to specify ATT permission on an iOS 14.5+ device. Set to 0 for disabled or 1 for enabled.
+     */
+    advertiser_tracking_enabled?: boolean
+    /**
+     * *Required for app events*
+     *             A person can choose to enable ad tracking on an app level. Your SDK should allow an app developer to put an opt-out setting into their app. Use this field to specify the person's choice. Use 0 for disabled, 1 for enabled.
+     */
+    application_tracking_enabled?: boolean
+    /**
+     * *Required for app events* Example: i2
+     */
+    version?: string
+    /**
+     * Example: com.facebook.sdk.samples.hellofacebook
+     */
+    packageName?: string
+    /**
+     * Example: 1.0
+     */
+    shortVersion?: string
+    /**
+     * Example: 1.0 long
+     */
+    longVersion?: string
+    /**
+     * Example: 13.4.1
+     */
+    osVersion?: string
+    /**
+     * Example: iPhone5,1
+     */
+    deviceName?: string
+    /**
+     * Example: En_US
+     */
+    locale?: string
+    /**
+     * Example: 'PST'
+     */
+    timezone?: string
+    /**
+     * Example: AT&T
+     */
+    carrier?: string
+    /**
+     * Example: 1080
+     */
+    width?: string
+    /**
+     * Example: 1920
+     */
+    height?: string
+    /**
+     * Example: 2.0
+     */
+    density?: string
+    /**
+     * Example: 8
+     */
+    cpuCores?: string
+    /**
+     * Example: 64
+     */
+    storageSize?: string
+    /**
+     * Example: 32
+     */
+    freeStorage?: string
+    /**
+     * Example: USA/New York
+     */
+    deviceTimezone?: string
+  }
+  /**
    * The category of the content associated with the event.
    */
   content_category?: string

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
@@ -95,11 +95,14 @@ export interface Payload {
     partner_name?: string
   }
   /**
-   * TODO
+   * These fields support sending app events to Facebook through the Conversions API. For more information about app events support in the Conversions API, see the Facebook docs [here](https://developers.facebook.com/docs/marketing-api/conversions-api/app-events).
+   *   App events sent through the Conversions API must be associated with a dataset.
+   *   Instructions for creating a dataset can be found [here](https://www.facebook.com/business/help/750785952855662?id=490360542427371). Once a dataset is created, the dataset ID
+   *   can be substituted for the pixel ID in the destination settings.
    */
   app_data_field?: {
     /**
-     * Send app data to Facebook?
+     * Segment will not send app events to Facebook by default. Enable this once you have created a dataset in Facebook and are ready to begin sending app events.
      */
     use_app_data?: boolean
     /**

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
@@ -116,67 +116,67 @@ export interface Payload {
      */
     application_tracking_enabled?: boolean
     /**
-     * *Required for app events* Example: i2
+     * *Required for app events* Example: 'i2'.
      */
     version?: string
     /**
-     * Example: com.facebook.sdk.samples.hellofacebook
+     * Example: 'com.facebook.sdk.samples.hellofacebook'.
      */
     packageName?: string
     /**
-     * Example: 1.0
+     * Example: '1.0'.
      */
     shortVersion?: string
     /**
-     * Example: 1.0 long
+     * Example: '1.0 long'.
      */
     longVersion?: string
     /**
-     * Example: 13.4.1
+     * Example: '13.4.1'.
      */
     osVersion?: string
     /**
-     * Example: iPhone5,1
+     * Example: 'iPhone5,1'.
      */
     deviceName?: string
     /**
-     * Example: En_US
+     * Example: 'En_US'.
      */
     locale?: string
     /**
-     * Example: 'PST'
+     * Example: 'PST'.
      */
     timezone?: string
     /**
-     * Example: AT&T
+     * Example: 'AT&T'.
      */
     carrier?: string
     /**
-     * Example: 1080
+     * Example: '1080'.
      */
     width?: string
     /**
-     * Example: 1920
+     * Example: '1920'.
      */
     height?: string
     /**
-     * Example: 2.0
+     * Example: '2.0'.
      */
     density?: string
     /**
-     * Example: 8
+     * Example: '8'.
      */
     cpuCores?: string
     /**
-     * Example: 64
+     * Example: '64'.
      */
     storageSize?: string
     /**
-     * Example: 32
+     * Example: '32'.
      */
     freeStorage?: string
     /**
-     * Example: USA/New York
+     * Example: 'USA/New York'.
      */
     deviceTimezone?: string
   }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
@@ -22,6 +22,7 @@ import {
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import { get_api_version } from '../utils'
+import { generate_app_data, app_data_field } from '../fb-capi-app-data'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Initiate Checkout',
@@ -31,6 +32,7 @@ const action: ActionDefinition<Settings, Payload> = {
     action_source: { ...action_source, required: true },
     event_time: { ...event_time, required: true },
     user_data: user_data_field,
+    app_data_field: app_data_field,
     content_category: content_category,
     content_ids: content_ids,
     contents: {
@@ -120,6 +122,7 @@ const action: ActionDefinition<Settings, Payload> = {
                 num_items: payload.num_items,
                 content_category: payload.content_category
               },
+              app_data: generate_app_data(payload.app_data_field),
               data_processing_options: data_options,
               data_processing_options_country: country_code,
               data_processing_options_state: state_code

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
@@ -95,6 +95,89 @@ export interface Payload {
     partner_name?: string
   }
   /**
+   * TODO
+   */
+  app_data_field?: {
+    /**
+     * Send app data to Facebook?
+     */
+    use_app_data?: boolean
+    /**
+     * *Required for app events*
+     *             Use this field to specify ATT permission on an iOS 14.5+ device. Set to 0 for disabled or 1 for enabled.
+     */
+    advertiser_tracking_enabled?: boolean
+    /**
+     * *Required for app events*
+     *             A person can choose to enable ad tracking on an app level. Your SDK should allow an app developer to put an opt-out setting into their app. Use this field to specify the person's choice. Use 0 for disabled, 1 for enabled.
+     */
+    application_tracking_enabled?: boolean
+    /**
+     * *Required for app events* Example: i2
+     */
+    version?: string
+    /**
+     * Example: com.facebook.sdk.samples.hellofacebook
+     */
+    packageName?: string
+    /**
+     * Example: 1.0
+     */
+    shortVersion?: string
+    /**
+     * Example: 1.0 long
+     */
+    longVersion?: string
+    /**
+     * Example: 13.4.1
+     */
+    osVersion?: string
+    /**
+     * Example: iPhone5,1
+     */
+    deviceName?: string
+    /**
+     * Example: En_US
+     */
+    locale?: string
+    /**
+     * Example: 'PST'
+     */
+    timezone?: string
+    /**
+     * Example: AT&T
+     */
+    carrier?: string
+    /**
+     * Example: 1080
+     */
+    width?: string
+    /**
+     * Example: 1920
+     */
+    height?: string
+    /**
+     * Example: 2.0
+     */
+    density?: string
+    /**
+     * Example: 8
+     */
+    cpuCores?: string
+    /**
+     * Example: 64
+     */
+    storageSize?: string
+    /**
+     * Example: 32
+     */
+    freeStorage?: string
+    /**
+     * Example: USA/New York
+     */
+    deviceTimezone?: string
+  }
+  /**
    * This ID can be any unique string. Event ID is used to deduplicate events sent by both Facebook Pixel and Conversions API.
    */
   event_id?: string

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
@@ -95,11 +95,14 @@ export interface Payload {
     partner_name?: string
   }
   /**
-   * TODO
+   * These fields support sending app events to Facebook through the Conversions API. For more information about app events support in the Conversions API, see the Facebook docs [here](https://developers.facebook.com/docs/marketing-api/conversions-api/app-events).
+   *   App events sent through the Conversions API must be associated with a dataset.
+   *   Instructions for creating a dataset can be found [here](https://www.facebook.com/business/help/750785952855662?id=490360542427371). Once a dataset is created, the dataset ID
+   *   can be substituted for the pixel ID in the destination settings.
    */
   app_data_field?: {
     /**
-     * Send app data to Facebook?
+     * Segment will not send app events to Facebook by default. Enable this once you have created a dataset in Facebook and are ready to begin sending app events.
      */
     use_app_data?: boolean
     /**

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
@@ -116,67 +116,67 @@ export interface Payload {
      */
     application_tracking_enabled?: boolean
     /**
-     * *Required for app events* Example: i2
+     * *Required for app events* Example: 'i2'.
      */
     version?: string
     /**
-     * Example: com.facebook.sdk.samples.hellofacebook
+     * Example: 'com.facebook.sdk.samples.hellofacebook'.
      */
     packageName?: string
     /**
-     * Example: 1.0
+     * Example: '1.0'.
      */
     shortVersion?: string
     /**
-     * Example: 1.0 long
+     * Example: '1.0 long'.
      */
     longVersion?: string
     /**
-     * Example: 13.4.1
+     * Example: '13.4.1'.
      */
     osVersion?: string
     /**
-     * Example: iPhone5,1
+     * Example: 'iPhone5,1'.
      */
     deviceName?: string
     /**
-     * Example: En_US
+     * Example: 'En_US'.
      */
     locale?: string
     /**
-     * Example: 'PST'
+     * Example: 'PST'.
      */
     timezone?: string
     /**
-     * Example: AT&T
+     * Example: 'AT&T'.
      */
     carrier?: string
     /**
-     * Example: 1080
+     * Example: '1080'.
      */
     width?: string
     /**
-     * Example: 1920
+     * Example: '1920'.
      */
     height?: string
     /**
-     * Example: 2.0
+     * Example: '2.0'.
      */
     density?: string
     /**
-     * Example: 8
+     * Example: '8'.
      */
     cpuCores?: string
     /**
-     * Example: 64
+     * Example: '64'.
      */
     storageSize?: string
     /**
-     * Example: 32
+     * Example: '32'.
      */
     freeStorage?: string
     /**
-     * Example: USA/New York
+     * Example: 'USA/New York'.
      */
     deviceTimezone?: string
   }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/index.ts
@@ -14,6 +14,8 @@ import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { get_api_version } from '../utils'
+import { generate_app_data, app_data_field } from '../fb-capi-app-data'
+
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Page View',
   description: 'Send a page view event when a user lands on a page',
@@ -22,6 +24,7 @@ const action: ActionDefinition<Settings, Payload> = {
     action_source: { ...action_source, required: true },
     event_time: { ...event_time, required: true },
     user_data: user_data_field,
+    app_data_field: app_data_field,
     event_id: event_id,
     event_source_url: event_source_url,
     custom_data: custom_data,
@@ -61,6 +64,7 @@ const action: ActionDefinition<Settings, Payload> = {
               event_source_url: payload.event_source_url,
               event_id: payload.event_id,
               user_data: hash_user_data({ user_data: payload.user_data }),
+              app_data: generate_app_data(payload.app_data_field),
               data_processing_options: data_options,
               data_processing_options_country: country_code,
               data_processing_options_state: state_code

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
@@ -120,67 +120,67 @@ export interface Payload {
      */
     application_tracking_enabled?: boolean
     /**
-     * *Required for app events* Example: i2
+     * *Required for app events* Example: 'i2'.
      */
     version?: string
     /**
-     * Example: com.facebook.sdk.samples.hellofacebook
+     * Example: 'com.facebook.sdk.samples.hellofacebook'.
      */
     packageName?: string
     /**
-     * Example: 1.0
+     * Example: '1.0'.
      */
     shortVersion?: string
     /**
-     * Example: 1.0 long
+     * Example: '1.0 long'.
      */
     longVersion?: string
     /**
-     * Example: 13.4.1
+     * Example: '13.4.1'.
      */
     osVersion?: string
     /**
-     * Example: iPhone5,1
+     * Example: 'iPhone5,1'.
      */
     deviceName?: string
     /**
-     * Example: En_US
+     * Example: 'En_US'.
      */
     locale?: string
     /**
-     * Example: 'PST'
+     * Example: 'PST'.
      */
     timezone?: string
     /**
-     * Example: AT&T
+     * Example: 'AT&T'.
      */
     carrier?: string
     /**
-     * Example: 1080
+     * Example: '1080'.
      */
     width?: string
     /**
-     * Example: 1920
+     * Example: '1920'.
      */
     height?: string
     /**
-     * Example: 2.0
+     * Example: '2.0'.
      */
     density?: string
     /**
-     * Example: 8
+     * Example: '8'.
      */
     cpuCores?: string
     /**
-     * Example: 64
+     * Example: '64'.
      */
     storageSize?: string
     /**
-     * Example: 32
+     * Example: '32'.
      */
     freeStorage?: string
     /**
-     * Example: USA/New York
+     * Example: 'USA/New York'.
      */
     deviceTimezone?: string
   }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
@@ -99,11 +99,14 @@ export interface Payload {
     partner_name?: string
   }
   /**
-   * TODO
+   * These fields support sending app events to Facebook through the Conversions API. For more information about app events support in the Conversions API, see the Facebook docs [here](https://developers.facebook.com/docs/marketing-api/conversions-api/app-events).
+   *   App events sent through the Conversions API must be associated with a dataset.
+   *   Instructions for creating a dataset can be found [here](https://www.facebook.com/business/help/750785952855662?id=490360542427371). Once a dataset is created, the dataset ID
+   *   can be substituted for the pixel ID in the destination settings.
    */
   app_data_field?: {
     /**
-     * Send app data to Facebook?
+     * Segment will not send app events to Facebook by default. Enable this once you have created a dataset in Facebook and are ready to begin sending app events.
      */
     use_app_data?: boolean
     /**

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
@@ -99,6 +99,89 @@ export interface Payload {
     partner_name?: string
   }
   /**
+   * TODO
+   */
+  app_data_field?: {
+    /**
+     * Send app data to Facebook?
+     */
+    use_app_data?: boolean
+    /**
+     * *Required for app events*
+     *             Use this field to specify ATT permission on an iOS 14.5+ device. Set to 0 for disabled or 1 for enabled.
+     */
+    advertiser_tracking_enabled?: boolean
+    /**
+     * *Required for app events*
+     *             A person can choose to enable ad tracking on an app level. Your SDK should allow an app developer to put an opt-out setting into their app. Use this field to specify the person's choice. Use 0 for disabled, 1 for enabled.
+     */
+    application_tracking_enabled?: boolean
+    /**
+     * *Required for app events* Example: i2
+     */
+    version?: string
+    /**
+     * Example: com.facebook.sdk.samples.hellofacebook
+     */
+    packageName?: string
+    /**
+     * Example: 1.0
+     */
+    shortVersion?: string
+    /**
+     * Example: 1.0 long
+     */
+    longVersion?: string
+    /**
+     * Example: 13.4.1
+     */
+    osVersion?: string
+    /**
+     * Example: iPhone5,1
+     */
+    deviceName?: string
+    /**
+     * Example: En_US
+     */
+    locale?: string
+    /**
+     * Example: 'PST'
+     */
+    timezone?: string
+    /**
+     * Example: AT&T
+     */
+    carrier?: string
+    /**
+     * Example: 1080
+     */
+    width?: string
+    /**
+     * Example: 1920
+     */
+    height?: string
+    /**
+     * Example: 2.0
+     */
+    density?: string
+    /**
+     * Example: 8
+     */
+    cpuCores?: string
+    /**
+     * Example: 64
+     */
+    storageSize?: string
+    /**
+     * Example: 32
+     */
+    freeStorage?: string
+    /**
+     * Example: USA/New York
+     */
+    deviceTimezone?: string
+  }
+  /**
    * A numeric value associated with this event. This could be a monetary value or a value in some other metric.
    */
   value: number

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
@@ -23,6 +23,7 @@ import {
   dataProcessingOptions
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
+import { generate_app_data, app_data_field } from '../fb-capi-app-data'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Purchase',
@@ -33,6 +34,7 @@ const action: ActionDefinition<Settings, Payload> = {
     currency: { ...currency, required: true },
     event_time: { ...event_time, required: true },
     user_data: user_data_field,
+    app_data_field: app_data_field,
     value: {
       ...value,
       required: true,
@@ -120,6 +122,7 @@ const action: ActionDefinition<Settings, Payload> = {
                 contents: payload.contents,
                 num_items: payload.num_items
               },
+              app_data: generate_app_data(payload.app_data_field),
               data_processing_options: data_options,
               data_processing_options_country: country_code,
               data_processing_options_state: state_code

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
@@ -95,6 +95,89 @@ export interface Payload {
     partner_name?: string
   }
   /**
+   * TODO
+   */
+  app_data_field?: {
+    /**
+     * Send app data to Facebook?
+     */
+    use_app_data?: boolean
+    /**
+     * *Required for app events*
+     *             Use this field to specify ATT permission on an iOS 14.5+ device. Set to 0 for disabled or 1 for enabled.
+     */
+    advertiser_tracking_enabled?: boolean
+    /**
+     * *Required for app events*
+     *             A person can choose to enable ad tracking on an app level. Your SDK should allow an app developer to put an opt-out setting into their app. Use this field to specify the person's choice. Use 0 for disabled, 1 for enabled.
+     */
+    application_tracking_enabled?: boolean
+    /**
+     * *Required for app events* Example: i2
+     */
+    version?: string
+    /**
+     * Example: com.facebook.sdk.samples.hellofacebook
+     */
+    packageName?: string
+    /**
+     * Example: 1.0
+     */
+    shortVersion?: string
+    /**
+     * Example: 1.0 long
+     */
+    longVersion?: string
+    /**
+     * Example: 13.4.1
+     */
+    osVersion?: string
+    /**
+     * Example: iPhone5,1
+     */
+    deviceName?: string
+    /**
+     * Example: En_US
+     */
+    locale?: string
+    /**
+     * Example: 'PST'
+     */
+    timezone?: string
+    /**
+     * Example: AT&T
+     */
+    carrier?: string
+    /**
+     * Example: 1080
+     */
+    width?: string
+    /**
+     * Example: 1920
+     */
+    height?: string
+    /**
+     * Example: 2.0
+     */
+    density?: string
+    /**
+     * Example: 8
+     */
+    cpuCores?: string
+    /**
+     * Example: 64
+     */
+    storageSize?: string
+    /**
+     * Example: 32
+     */
+    freeStorage?: string
+    /**
+     * Example: USA/New York
+     */
+    deviceTimezone?: string
+  }
+  /**
    * The category of the content associated with the event.
    */
   content_category?: string

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
@@ -95,11 +95,14 @@ export interface Payload {
     partner_name?: string
   }
   /**
-   * TODO
+   * These fields support sending app events to Facebook through the Conversions API. For more information about app events support in the Conversions API, see the Facebook docs [here](https://developers.facebook.com/docs/marketing-api/conversions-api/app-events).
+   *   App events sent through the Conversions API must be associated with a dataset.
+   *   Instructions for creating a dataset can be found [here](https://www.facebook.com/business/help/750785952855662?id=490360542427371). Once a dataset is created, the dataset ID
+   *   can be substituted for the pixel ID in the destination settings.
    */
   app_data_field?: {
     /**
-     * Send app data to Facebook?
+     * Segment will not send app events to Facebook by default. Enable this once you have created a dataset in Facebook and are ready to begin sending app events.
      */
     use_app_data?: boolean
     /**

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
@@ -116,67 +116,67 @@ export interface Payload {
      */
     application_tracking_enabled?: boolean
     /**
-     * *Required for app events* Example: i2
+     * *Required for app events* Example: 'i2'.
      */
     version?: string
     /**
-     * Example: com.facebook.sdk.samples.hellofacebook
+     * Example: 'com.facebook.sdk.samples.hellofacebook'.
      */
     packageName?: string
     /**
-     * Example: 1.0
+     * Example: '1.0'.
      */
     shortVersion?: string
     /**
-     * Example: 1.0 long
+     * Example: '1.0 long'.
      */
     longVersion?: string
     /**
-     * Example: 13.4.1
+     * Example: '13.4.1'.
      */
     osVersion?: string
     /**
-     * Example: iPhone5,1
+     * Example: 'iPhone5,1'.
      */
     deviceName?: string
     /**
-     * Example: En_US
+     * Example: 'En_US'.
      */
     locale?: string
     /**
-     * Example: 'PST'
+     * Example: 'PST'.
      */
     timezone?: string
     /**
-     * Example: AT&T
+     * Example: 'AT&T'.
      */
     carrier?: string
     /**
-     * Example: 1080
+     * Example: '1080'.
      */
     width?: string
     /**
-     * Example: 1920
+     * Example: '1920'.
      */
     height?: string
     /**
-     * Example: 2.0
+     * Example: '2.0'.
      */
     density?: string
     /**
-     * Example: 8
+     * Example: '8'.
      */
     cpuCores?: string
     /**
-     * Example: 64
+     * Example: '64'.
      */
     storageSize?: string
     /**
-     * Example: 32
+     * Example: '32'.
      */
     freeStorage?: string
     /**
-     * Example: USA/New York
+     * Example: 'USA/New York'.
      */
     deviceTimezone?: string
   }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
@@ -21,6 +21,7 @@ import {
   dataProcessingOptions
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
+import { generate_app_data, app_data_field } from '../fb-capi-app-data'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Search',
@@ -30,6 +31,7 @@ const action: ActionDefinition<Settings, Payload> = {
     action_source: { ...action_source, required: true },
     event_time: { ...event_time, required: true },
     user_data: user_data_field,
+    app_data_field: app_data_field,
     content_category: content_category,
     content_ids: content_ids,
     contents: {
@@ -123,6 +125,7 @@ const action: ActionDefinition<Settings, Payload> = {
                 value: payload.value,
                 search_string: payload.search_string
               },
+              app_data: generate_app_data(payload.app_data_field),
               data_processing_options: data_options,
               data_processing_options_country: country_code,
               data_processing_options_state: state_code

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
@@ -95,6 +95,89 @@ export interface Payload {
     partner_name?: string
   }
   /**
+   * TODO
+   */
+  app_data_field?: {
+    /**
+     * Send app data to Facebook?
+     */
+    use_app_data?: boolean
+    /**
+     * *Required for app events*
+     *             Use this field to specify ATT permission on an iOS 14.5+ device. Set to 0 for disabled or 1 for enabled.
+     */
+    advertiser_tracking_enabled?: boolean
+    /**
+     * *Required for app events*
+     *             A person can choose to enable ad tracking on an app level. Your SDK should allow an app developer to put an opt-out setting into their app. Use this field to specify the person's choice. Use 0 for disabled, 1 for enabled.
+     */
+    application_tracking_enabled?: boolean
+    /**
+     * *Required for app events* Example: i2
+     */
+    version?: string
+    /**
+     * Example: com.facebook.sdk.samples.hellofacebook
+     */
+    packageName?: string
+    /**
+     * Example: 1.0
+     */
+    shortVersion?: string
+    /**
+     * Example: 1.0 long
+     */
+    longVersion?: string
+    /**
+     * Example: 13.4.1
+     */
+    osVersion?: string
+    /**
+     * Example: iPhone5,1
+     */
+    deviceName?: string
+    /**
+     * Example: En_US
+     */
+    locale?: string
+    /**
+     * Example: 'PST'
+     */
+    timezone?: string
+    /**
+     * Example: AT&T
+     */
+    carrier?: string
+    /**
+     * Example: 1080
+     */
+    width?: string
+    /**
+     * Example: 1920
+     */
+    height?: string
+    /**
+     * Example: 2.0
+     */
+    density?: string
+    /**
+     * Example: 8
+     */
+    cpuCores?: string
+    /**
+     * Example: 64
+     */
+    storageSize?: string
+    /**
+     * Example: 32
+     */
+    freeStorage?: string
+    /**
+     * Example: USA/New York
+     */
+    deviceTimezone?: string
+  }
+  /**
    * The category of the content associated with the event.
    */
   content_category?: string

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
@@ -95,11 +95,14 @@ export interface Payload {
     partner_name?: string
   }
   /**
-   * TODO
+   * These fields support sending app events to Facebook through the Conversions API. For more information about app events support in the Conversions API, see the Facebook docs [here](https://developers.facebook.com/docs/marketing-api/conversions-api/app-events).
+   *   App events sent through the Conversions API must be associated with a dataset.
+   *   Instructions for creating a dataset can be found [here](https://www.facebook.com/business/help/750785952855662?id=490360542427371). Once a dataset is created, the dataset ID
+   *   can be substituted for the pixel ID in the destination settings.
    */
   app_data_field?: {
     /**
-     * Send app data to Facebook?
+     * Segment will not send app events to Facebook by default. Enable this once you have created a dataset in Facebook and are ready to begin sending app events.
      */
     use_app_data?: boolean
     /**

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
@@ -116,67 +116,67 @@ export interface Payload {
      */
     application_tracking_enabled?: boolean
     /**
-     * *Required for app events* Example: i2
+     * *Required for app events* Example: 'i2'.
      */
     version?: string
     /**
-     * Example: com.facebook.sdk.samples.hellofacebook
+     * Example: 'com.facebook.sdk.samples.hellofacebook'.
      */
     packageName?: string
     /**
-     * Example: 1.0
+     * Example: '1.0'.
      */
     shortVersion?: string
     /**
-     * Example: 1.0 long
+     * Example: '1.0 long'.
      */
     longVersion?: string
     /**
-     * Example: 13.4.1
+     * Example: '13.4.1'.
      */
     osVersion?: string
     /**
-     * Example: iPhone5,1
+     * Example: 'iPhone5,1'.
      */
     deviceName?: string
     /**
-     * Example: En_US
+     * Example: 'En_US'.
      */
     locale?: string
     /**
-     * Example: 'PST'
+     * Example: 'PST'.
      */
     timezone?: string
     /**
-     * Example: AT&T
+     * Example: 'AT&T'.
      */
     carrier?: string
     /**
-     * Example: 1080
+     * Example: '1080'.
      */
     width?: string
     /**
-     * Example: 1920
+     * Example: '1920'.
      */
     height?: string
     /**
-     * Example: 2.0
+     * Example: '2.0'.
      */
     density?: string
     /**
-     * Example: 8
+     * Example: '8'.
      */
     cpuCores?: string
     /**
-     * Example: 64
+     * Example: '64'.
      */
     storageSize?: string
     /**
-     * Example: 32
+     * Example: '32'.
      */
     freeStorage?: string
     /**
-     * Example: USA/New York
+     * Example: 'USA/New York'.
      */
     deviceTimezone?: string
   }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
@@ -23,6 +23,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { CURRENCY_ISO_CODES } from '../constants'
 import { get_api_version } from '../utils'
+import { generate_app_data, app_data_field } from '../fb-capi-app-data'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'View Content',
@@ -32,6 +33,7 @@ const action: ActionDefinition<Settings, Payload> = {
     action_source: { ...action_source, required: true },
     event_time: { ...event_time, required: true },
     user_data: user_data_field,
+    app_data_field: app_data_field,
     content_category: content_category,
     content_ids: { ...content_ids, default: { '@path': '$.properties.product_id' } },
     content_name: content_name,
@@ -120,6 +122,7 @@ const action: ActionDefinition<Settings, Payload> = {
                 contents: payload.contents,
                 content_category: payload.content_category
               },
+              app_data: generate_app_data(payload.app_data_field),
               data_processing_options: data_options,
               data_processing_options_country: country_code,
               data_processing_options_state: state_code


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Facebook [now recommends](https://developers.facebook.com/docs/marketing-api/app-event-api/) that users send their app events through the Conversions API, rather than through the existing App Events API. 
This PR updates the Conversions API with a new `App Events Fields` object across all actions. This mapping allows users to configure delivery of app events.

An investigation of this feature is described in [this doc](https://docs.google.com/document/d/1UUc25Ch-vZgxaIngbV4Div0zgM2xACgHkyFlk6rV0FI/edit?usp=sharing). 

## Testing

Tested successfully in local and staging:

### Local
<img width="1480" alt="Screenshot 2023-05-19 at 1 38 56 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/79bd858a-a3dc-40fc-a3b4-8dfc437d54d6">

### Staging
<img width="1571" alt="Screenshot 2023-05-23 at 4 07 04 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/4c8a2ad1-c2af-4277-9d15-82e52a86beaf">

### Downstream Delivery
All events correctly delivered downstream to Facebook:
<img width="1373" alt="Screenshot 2023-05-19 at 3 01 43 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/3df281bc-2833-4b29-884d-b0c3f8741b1c">
FB shows that the OS Version from `extinfo` is being picked up:
<img width="1205" alt="Screenshot 2023-05-22 at 11 13 25 AM" src="https://github.com/segmentio/action-destinations/assets/27820201/6b6f9c4e-009d-4969-9aac-20565d064ff8">


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
