### PR TITLE
Stratconn 2612 - Removed duplicate page events calls in GA4-WEB

### DIFF
--- a/packages/browser-destinations/src/destinations/google-analytics-4-web/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/google-analytics-4-web/generated-types.ts
@@ -6,10 +6,6 @@ export interface Settings {
    */
   measurementID: string
   /**
-   * Set to false to prevent the default snippet from sending page views. Enabled by default.
-   */
-  pageView?: boolean
-  /**
    * Set to false to disable all advertising features. Set to true by default.
    */
   allowGoogleSignals?: boolean

--- a/packages/browser-destinations/src/destinations/google-analytics-4-web/index.ts
+++ b/packages/browser-destinations/src/destinations/google-analytics-4-web/index.ts
@@ -137,7 +137,10 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
   },
 
   initialize: async ({ settings }, deps) => {
+    console.log({ settings: settings })
+
     const config = {
+      send_page_view: false,
       cookie_update: settings.cookieUpdate,
       cookie_domain: settings.cookieDomain,
       cookie_prefix: settings.cookiePrefix,

--- a/packages/browser-destinations/src/destinations/google-analytics-4-web/index.ts
+++ b/packages/browser-destinations/src/destinations/google-analytics-4-web/index.ts
@@ -137,8 +137,6 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
   },
 
   initialize: async ({ settings }, deps) => {
-    console.log({ settings: settings })
-
     const config = {
       send_page_view: false,
       cookie_update: settings.cookieUpdate,

--- a/packages/browser-destinations/src/destinations/google-analytics-4-web/index.ts
+++ b/packages/browser-destinations/src/destinations/google-analytics-4-web/index.ts
@@ -138,7 +138,6 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
 
   initialize: async ({ settings }, deps) => {
     const config = {
-      send_page_view: settings.pageView,
       cookie_update: settings.cookieUpdate,
       cookie_domain: settings.cookieDomain,
       cookie_prefix: settings.cookiePrefix,

--- a/packages/browser-destinations/src/destinations/google-analytics-4-web/index.ts
+++ b/packages/browser-destinations/src/destinations/google-analytics-4-web/index.ts
@@ -52,12 +52,6 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
       type: 'string',
       required: true
     },
-    pageView: {
-      description: 'Set to false to prevent the default snippet from sending page views. Enabled by default.',
-      label: 'Page Views',
-      type: 'boolean',
-      default: true
-    },
     allowGoogleSignals: {
       description: 'Set to false to disable all advertising features. Set to true by default.',
       label: 'Allow Google Signals',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

In this ticket removed duplicate page events calls in GA4 web. Removed page view options from Advance settings and configured manually. 

Jira tickets: https://segment.atlassian.net/browse/STRATCONN-2612?atlOrigin=eyJpIjoiYzM0YWM2YzBjMGIwNGQwMzk1NGZhMTBlZTA0OTFhMmYiLCJwIjoiaiJ9

Testing img
<img width="1136" alt="Screenshot 2023-05-24 at 12 56 53 PM" src="https://github.com/segmentio/action-destinations/assets/117071411/507b4e5c-ab78-4dd5-a0cd-be346b3747cf">

Mappings of setConfigurationFields
<img width="861" alt="Screenshot 2023-05-24 at 12 57 31 PM" src="https://github.com/segmentio/action-destinations/assets/117071411/11d92666-38b3-47b9-9f28-73a0730929d7">

Mappings data of setConfigurationFields in GA4-web
<img width="417" alt="Screenshot 2023-05-24 at 12 58 25 PM" src="https://github.com/segmentio/action-destinations/assets/117071411/a138248e-cc49-4b40-969f-0fe31c79133a">


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [X] [Segmenters] Tested in the staging environment
