### PR TITLE
[Livelike] Removes redundant settings check

### DIFF
--- a/packages/destination-actions/src/destinations/livelike-cloud/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/livelike-cloud/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import nock from 'nock'
 import { createTestIntegration } from '@segment/actions-core'
 import Definition from '../index'
 import { apiBaseUrl } from '../properties'
+import { Settings } from '../generated-types'
 
 const testDestination = createTestIntegration(Definition)
 
@@ -21,6 +22,12 @@ describe('Livelike', () => {
       const authData = { clientId: 'abc', producerToken: '123' }
 
       await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
+    })
+
+    it('should throw error when clientId and producerToken is not configured', async () => {
+      await expect(testDestination.testAuthentication({} as Settings)).rejects.toThrowError(
+        "The root value is missing the required field 'clientId'. The root value is missing the required field 'producerToken'."
+      )
     })
   })
 })

--- a/packages/destination-actions/src/destinations/livelike-cloud/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/livelike-cloud/trackEvent/__tests__/index.test.ts
@@ -18,22 +18,6 @@ const expectedEvent: Payload = {
 }
 
 describe('LiveLike.trackEvent', () => {
-  it('should throw integration error when clientId and producerToken is not configured', async () => {
-    const event = createTestEvent({
-      timestamp,
-      properties: {
-        livelike_profile_id: profile_id
-      }
-    })
-
-    await expect(
-      testDestination.testAction('trackEvent', {
-        event,
-        useDefaultMappings: true
-      })
-    ).rejects.toThrowError(new IntegrationError('Missing client ID or producer token.'))
-  })
-
   it('should throw integration error when livelike_profile_id or user_id or custom_id is not found or null', async () => {
     const event = createTestEvent({
       //Need to set userId as null because `createTestEvent` and `testAction` adds a default userId which will fail the test everytime.

--- a/packages/destination-actions/src/destinations/livelike-cloud/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/livelike-cloud/trackEvent/index.ts
@@ -103,9 +103,6 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: (request, { payload, settings }) => {
-    if (!settings.clientId || !settings.producerToken) {
-      throw new IntegrationError('Missing client ID or producer token.')
-    }
     return processData(request, settings, [payload])
   }
   // Commented batching until the segment team supports rejecting a single event in a batch


### PR DESCRIPTION
This PR removes redundant settings check in Livelike-Cloud destination. `clientId` and `producerToken` are already required fields as per the settings configuration [here](https://github.com/segmentio/action-destinations/blob/b1d3e26e016263e1b9b38fba5ecdbe3065692d2f/packages/destination-actions/src/destinations/livelike-cloud/index.ts#L53). I did an audit to identify destinations throwing errors without status code or error code. Such errors are considered as [internal](https://github.com/segmentio/integrations/blob/1f12a437909bf46cb7f871b263d330a43b69b6fd/Service/cloudevents.js#L879) error by Integrations and are logged in [Sentry](https://github.com/segmentio/integrations/blob/1f12a437909bf46cb7f871b263d330a43b69b6fd/Service/cloudevents.js#L519). These redundant errors were not using error codes or status code. Removing this would help us make the build pass and also enable us to make error code mandatory in future.

This part of 1 of series of PRs to identify and fix such invalid exceptions. I earlier raised a consolidated PR to highlight all such changes [here](https://github.com/segmentio/action-destinations/pull/1137/files#diff-373c5ee4f1cfa3530f3b465453261979f6e9914e757f46d13d52b8d6c3f57534).

As part of this change, I had to remove a test that was specifically added to validate settings. 

## Testing

All unit tests are passing. There is no change in functionality and there is also no need for additional validation because the framework validates the settings before executing the action [here](https://github.com/segmentio/action-destinations/blob/b1d3e26e016263e1b9b38fba5ecdbe3065692d2f/packages/core/src/destination-kit/index.ts#L615).

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
