### PR TITLE
[Heap] Remove redundant appID settings check

### DIFF
--- a/packages/destination-actions/src/destinations/heap/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/heap/identifyUser/index.ts
@@ -48,10 +48,6 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, { payload, settings }) => {
-    if (!settings.appId) {
-      throw new IntegrationError('Missing Heap app ID.', 'Missing required field', 400)
-    }
-
     if (!payload.user_id || !isDefined(payload.user_id)) {
       throw new IntegrationError(
         'Missing identity, cannot add user properties without identity',

--- a/packages/destination-actions/src/destinations/heap/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/heap/trackEvent/index.ts
@@ -111,9 +111,6 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: (request, { payload, settings }) => {
     const requests = []
-    if (!settings.appId) {
-      throw new IntegrationError('Missing app ID')
-    }
 
     if (!payload.anonymous_id && !payload.identity) {
       throw new IntegrationError('Either Anonymous id or Identity should be specified.', 'MISSING_REQUIRED_FIELD', 400)


### PR DESCRIPTION
This PR removes redundant settings check in Heap destination. appID is already a required field as per the settings configuration [here](https://github.com/segmentio/action-destinations/blob/b1d3e26e016263e1b9b38fba5ecdbe3065692d2f/packages/destination-actions/src/destinations/heap/index.ts#L34). I did an audit to identify destinations throwing errors without status code or error code. Such errors are considered as [internal](https://github.com/segmentio/integrations/blob/1f12a437909bf46cb7f871b263d330a43b69b6fd/Service/cloudevents.js#L879) error by Integrations and are logged in [Sentry](https://github.com/segmentio/integrations/blob/1f12a437909bf46cb7f871b263d330a43b69b6fd/Service/cloudevents.js#L519). These redundant errors were not using error codes or status code. Removing this would help us make the build pass and also enable us to make error code mandatory in future.

**No impact to retries** as the code will never hit this point and fail with 400 before

This part of a series of PRs to identify and fix such invalid exceptions. I earlier raised a consolidated PR to highlight all such changes [here](https://github.com/segmentio/action-destinations/pull/1137/files#diff-373c5ee4f1cfa3530f3b465453261979f6e9914e757f46d13d52b8d6c3f57534).

## Testing

There is no need for additional validation because the framework validates the settings before executing the action [here](https://github.com/segmentio/action-destinations/blob/b1d3e26e016263e1b9b38fba5ecdbe3065692d2f/packages/core/src/destination-kit/index.ts#L615).

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
