### PR TITLE
Revert "Allow installation for node14 or greater (#1257)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     ]
   },
   "engines": {
-    "node": ">=14"
+    "node": "14 || ^18.12"
   },
   "scripts": {
     "browser": "yarn workspace @segment/browser-destinations",


### PR DESCRIPTION
## Description

This reverts commit 78228c4a0c728ed99408e6ecd8b583cda28cc5e5.

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Reverting the repo wide change to allow node14 or greater, as `app` just needs actions-core

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
