### PR TITLE
[FullStory] Refactor Integration error to PayloadValidationError

### DIFF
--- a/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
@@ -160,7 +160,7 @@ describe('FullStory', () => {
     })
 
     falsyUserIds.forEach((falsyUserId) => {
-      it(`it throws IntegrationError given falsy user id ${falsyUserId}`, async () => {
+      it(`it throws PayloadValidationError given falsy user id ${falsyUserId}`, async () => {
         await expect(testDestination.onDelete!({ type: 'delete', userId: falsyUserId }, settings)).rejects.toThrowError(
           new IntegrationError('User Id is required for user deletion.')
         )

--- a/packages/destination-actions/src/destinations/fullstory/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/index.ts
@@ -1,5 +1,5 @@
-import type { DestinationDefinition } from '@segment/actions-core'
-import { defaultValues, IntegrationError } from '@segment/actions-core'
+import { DestinationDefinition, PayloadValidationError } from '@segment/actions-core'
+import { defaultValues } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import identifyUser from './identifyUser'
 import trackEvent from './trackEvent'
@@ -42,7 +42,7 @@ const destination: DestinationDefinition<Settings> = {
 
   onDelete: async (request, { settings, payload }) => {
     if (!payload.userId) {
-      throw new IntegrationError('User Id is required for user deletion.')
+      throw new PayloadValidationError('User Id is required for user deletion.')
     }
     const { url, options } = deleteUserRequestParams(settings, payload.userId)
     return request(url, options)

--- a/packages/destination-actions/src/destinations/fullstory/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/index.ts
@@ -1,5 +1,5 @@
-import { DestinationDefinition, PayloadValidationError } from '@segment/actions-core'
-import { defaultValues } from '@segment/actions-core'
+import type { DestinationDefinition } from '@segment/actions-core'
+import { defaultValues, PayloadValidationError } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import identifyUser from './identifyUser'
 import trackEvent from './trackEvent'


### PR DESCRIPTION
This PR changes the Integration Error to Payload Validation Error when user ID is not found in `onDelete` payload. The Integration Error previously thrown from onDelete didn't contain status code and would hinder making status code mandatory for all destinations.
The reason for making status code mandatory is to ensure that they are not classified as Internal Errors and are shown with proper descriptions in Event Delivery screen. This part of a series of PRs to identify and fix such invalid exceptions. I earlier raised a consolidated PR to highlight all such changes [here](https://github.com/segmentio/action-destinations/pull/1137/files#diff-373c5ee4f1cfa3530f3b465453261979f6e9914e757f46d13d52b8d6c3f57534).

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
