### PR TITLE
Initialize new NOOP internal destination

### DIFF
--- a/packages/destination-actions/src/destinations/noop/generated-types.ts
+++ b/packages/destination-actions/src/destinations/noop/generated-types.ts
@@ -1,0 +1,3 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {}

--- a/packages/destination-actions/src/destinations/noop/index.ts
+++ b/packages/destination-actions/src/destinations/noop/index.ts
@@ -1,0 +1,26 @@
+import { defaultValues, DestinationDefinition, Subscription } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import noop from './noop'
+
+const presets: Subscription[] = [
+  {
+    name: 'Track Event',
+    subscribe: 'type = "track"',
+    partnerAction: 'trackEvent',
+    mapping: defaultValues(noop.fields)
+  }
+]
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Test',
+  slug: 'actions-noop',
+  mode: 'cloud',
+  description: 'A NOOP destination used for private internal services.',
+  presets: presets,
+  actions: {
+    noop
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/noop/index.ts
+++ b/packages/destination-actions/src/destinations/noop/index.ts
@@ -13,7 +13,7 @@ const presets: Subscription[] = [
 ]
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Test',
+  name: 'Noop',
   slug: 'actions-noop',
   mode: 'cloud',
   description: 'A NOOP destination used for private internal services.',

--- a/packages/destination-actions/src/destinations/noop/index.ts
+++ b/packages/destination-actions/src/destinations/noop/index.ts
@@ -13,7 +13,7 @@ const presets: Subscription[] = [
 ]
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Noop',
+  name: 'NOOP',
   slug: 'actions-noop',
   mode: 'cloud',
   description: 'A NOOP destination used for private internal services.',

--- a/packages/destination-actions/src/destinations/noop/noop/generated-types.ts
+++ b/packages/destination-actions/src/destinations/noop/noop/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * A single NOOP field
+   */
+  noop?: string
+}

--- a/packages/destination-actions/src/destinations/noop/noop/index.ts
+++ b/packages/destination-actions/src/destinations/noop/noop/index.ts
@@ -1,0 +1,24 @@
+import { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Noop',
+  description: 'A NOOP Action used for private internal services',
+  fields: {
+    noop: {
+      label: 'NOOP',
+      description: 'A single NOOP field',
+      type: 'string',
+      default: {
+        '@path': '$.event'
+      }
+    }
+  },
+  perform: (_, { statsContext }) => {
+    statsContext?.statsClient.incr('actions_noop_perform_hit', 1)
+    return undefined
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/noop/noop/index.ts
+++ b/packages/destination-actions/src/destinations/noop/noop/index.ts
@@ -9,10 +9,7 @@ const action: ActionDefinition<Settings, Payload> = {
     noop: {
       label: 'NOOP',
       description: 'A single NOOP field',
-      type: 'string',
-      default: {
-        '@path': '$.event'
-      }
+      type: 'string'
     }
   },
   perform: (_, { statsContext }) => {


### PR DESCRIPTION
This PR addresses JIRA [EN-102](https://segment.atlassian.net/browse/EN-102)

In it, we create an empty action-destination for an unnamed internal service.

## Testing

Testing not needed because it is an empty destination used for an internal service.


[EN-102]: https://segment.atlassian.net/browse/EN-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ