### PR TITLE
update default scaffolding for LCNC destinations

### DIFF
--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -129,7 +129,7 @@ export default class Init extends Command {
             field.isTemplate = true
             field.directiveType = '@template'
             const templateValue: string = field.defaultValue['@template']
-            field.value = templateValue.replace(/[}]/g, "]").replace(/[{]/g, "[")
+            field.value = templateValue.replace(/\{\{([^{}]+)\}\}/g, '[[$1]]')
           }
           field.defaultValue = defaultValue
         }
@@ -179,7 +179,7 @@ export default class Init extends Command {
       try {
         this.spinner.start(chalk`Updating action field templates for action: ${action.name}`)
         const actionsStr = fs.readFileSync(entryFile, 'utf8')
-        const result = actionsStr.replace(/\]/g, '}').replace(/\[/g, '{')
+        const result = actionsStr.replace(/\[\[([^[\]]+)\]\]/g, '{{$1}}')
         fs.writeFileSync(entryFile, result, 'utf8')
         this.spinner.succeed()
       } catch (err) {

--- a/packages/cli/templates/actions/empty-action-lowcode/index.ts
+++ b/packages/cli/templates/actions/empty-action-lowcode/index.ts
@@ -12,36 +12,23 @@ const action: ActionDefinition<Settings, Payload> = {
      description: '{{description}}',
      type: '{{type}}',
      required: {{required}},
-     {{#hasDefaultValue}}
-     {{#isString}}
-     {{#default}}
-     default: "{{value}}",
-     {{/default}}
-     {{/isString}}
-     {{/hasDefaultValue}}
-     {{#hasDefaultValue}}
-     {{^isString}}
-     {{#default}}
-     default: {{value}},
-     {{/default}}
-     {{/isString}}
-     {{/hasDefaultValue}}
-     {{#hasDirective}}
-     {{#default}}
-     default: { "{{{directiveType}}}": "{{{value}}}" },
-     {{/default}}
-     {{/hasDirective}}
+     {{#hasDefault}}
+     {{#isTemplate}}
+     default: {
+      "@template": "{{value}}"
+     }
+     {{/isTemplate}}
+     {{^isTemplate}}
+     default: {{{defaultValue}}}
+     {{/isTemplate}}
+     {{/hasDefault}}
    },
    {{/fields}}
   },
   perform: (request, { payload }) => {
     return request('{{{apiEndpoint}}}', {
       method: '{{httpMethod}}',
-      json: {
-        {{ #fields }}
-        {{key}}: {{mapping}},
-        {{/fields}}
-      }
+      json: payload
     })
   }
 }


### PR DESCRIPTION
This PR updates the LCNC template files to properly generate files with default action fields.

<img width="1053" alt="Screen Shot 2023-05-25 at 4 35 30 PM" src="https://github.com/segmentio/action-destinations/assets/87985289/1d5617e5-38fe-46a5-8082-0941407dd325">

<img width="514" alt="Screen Shot 2023-05-25 at 4 35 39 PM" src="https://github.com/segmentio/action-destinations/assets/87985289/2c15b523-e03e-4183-b342-88160b7abecc">

<img width="868" alt="Screen Shot 2023-05-25 at 4 43 39 PM" src="https://github.com/segmentio/action-destinations/assets/87985289/8f65f31d-1f6b-4fbd-a3c7-8e1b36dcf07d">


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
