### PR TITLE
[HubSpot]- Enable object editor for properties fields

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
@@ -64,7 +64,7 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'Default or custom properties that describe the event. On the left-hand side, input the internal name of the property as seen in your HubSpot account. On the right-hand side, map the Segment field that contains the value. See more information in [HubSpot’s documentation](https://knowledge.hubspot.com/analytics-tools/create-custom-behavioral-events#add-and-manage-event-properties).',
       type: 'object',
-      defaultObjectUI: 'keyvalue:only'
+      defaultObjectUI: 'keyvalue'
     }
   },
   perform: (request, { payload }) => {

--- a/packages/destination-actions/src/destinations/hubspot/upsertCompany/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCompany/index.ts
@@ -251,7 +251,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Other Properties',
       description: `Any other default or custom company properties. On the left-hand side, input the internal name of the property as seen in your HubSpot account. On the right-hand side, map the Segment field that contains the value. Custom properties must be predefined in HubSpot. See more information in [HubSpot’s documentation](https://knowledge.hubspot.com/crm-setup/manage-your-properties#create-custom-properties). Important: Do not use ’${SEGMENT_UNIQUE_IDENTIFIER}’ here as it is an internal property and will result in an an error.`,
       type: 'object',
-      defaultObjectUI: 'keyvalue:only',
+      defaultObjectUI: 'keyvalue',
       allowNull: false
     }
   },

--- a/packages/destination-actions/src/destinations/hubspot/upsertContact/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertContact/index.ts
@@ -129,7 +129,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'object',
       description:
         'Any other default or custom contact properties. On the left-hand side, input the internal name of the property as seen in your HubSpot account. On the right-hand side, map the Segment field that contains the value. Custom properties must be predefined in HubSpot. See more information in [HubSpot’s documentation](https://knowledge.hubspot.com/crm-setup/manage-your-properties#create-custom-properties).',
-      defaultObjectUI: 'keyvalue:only'
+      defaultObjectUI: 'keyvalue'
     }
   },
   perform: async (request, { payload, transactionContext }) => {

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
@@ -35,7 +35,7 @@ const action: ActionDefinition<Settings, Payload> = {
         'Properties to send to HubSpot. On the left-hand side, input the internal name of the property as seen in your HubSpot account. On the right-hand side, map the Segment field that contains the value. Please make sure to include the object’s required properties. Any custom properties must be predefined in HubSpot. More information in [HubSpot documentation](https://knowledge.hubspot.com/crm-setup/manage-your-properties#create-custom-properties).',
       type: 'object',
       required: true,
-      defaultObjectUI: 'keyvalue:only',
+      defaultObjectUI: 'keyvalue',
       allowNull: false
     }
   },


### PR DESCRIPTION

## Testing

**Upsert Company**
<img width="1500" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/5cd170fb-783c-4a77-b504-4c3c2cb1535e">


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
