### PR TITLE
Register noop destination

### DIFF
--- a/packages/destination-actions/src/destinations/index.ts
+++ b/packages/destination-actions/src/destinations/index.ts
@@ -101,6 +101,7 @@ register('645babd9362d97b777391325', './iterable')
 register('644ad6c6c4a87a3290450602', './liveramp-audiences')
 register('6464ef424ac5c5f47f5f3968', './revx')
 register('646ce31d67ac1735b1846052', './calliper')
+register('6470d73d82dfbc7129fc5975', './noop')
 
 function register(id: MetadataId, destinationPath: string) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/destination-actions/src/destinations/noop/index.ts
+++ b/packages/destination-actions/src/destinations/noop/index.ts
@@ -7,7 +7,7 @@ const presets: Subscription[] = [
   {
     name: 'Track Event',
     subscribe: 'type = "track"',
-    partnerAction: 'trackEvent',
+    partnerAction: 'noop',
     mapping: defaultValues(noop.fields)
   }
 ]


### PR DESCRIPTION
This PR registers the new NOOP internal destination from [this](https://github.com/segmentio/action-destinations/pull/1301) PR.

Confirmed id in [partner portal](https://app.segment.com/partner-portal/integration/actions-noop/profile) to be correct 

![Screenshot 2023-05-26 at 11 45 54 AM](https://github.com/segmentio/action-destinations/assets/98849774/13df0601-6024-4941-80e1-e8791aac074d)


## Testing

Testing not required because internal destination.
