### PR TITLE
Introduce APIError class

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -29,13 +29,13 @@ Errors due to invalid access tokens, refresh tokens or api keys are captured as 
 
 The inbuilt error handling should help you with most of the error scenarios you face. In cases where the validation capabilities provided by the framework are not sufficient or the error messages returned by the API you are interacting with are not helpful, you can chose to capture and throw your own custom errors. It is important to adhere to the following guidelines to ensure your errors are structured properly and displayed to your destination users for appropriate action.
 
-- DO NOT throw Javascript `Error` objects. Any error thrown from an action MUST contain a `message` describing the error, an `error code` indicating the type of error and a `status code` indicating the http status of the action. You MUST use predefined error classes defined in [error.ts](../packages/core/src/errors.ts). These classes help in capturing the necessary information in appropriate format. For example, assume that your action needs one of product id or product name. This kind of validation is not currently supported in `Action Definition`. Instead of `throw new Error('One of product id or name is required')`, use `throw new PayloadValidationError('One of product id or name is required')`. 
+- DO NOT throw Javascript `Error` objects. Any error thrown from an action MUST contain a `message` describing the error, an `error code` indicating the type of error and a `status code` indicating the http status of the action. You MUST use predefined error classes defined in [error.ts](../packages/core/src/errors.ts). These classes help in capturing the necessary information in appropriate format. For example, assume that your action needs one of product id or product name. This kind of validation is not currently supported in `Action Definition`. Instead of `throw new Error('One of product id or name is required')`, use `throw new PayloadValidationError('One of product id or name is required')`.
 
-  - Use `PayloadValidationError` for any custom validations. These errors won't be retried.
+  - Use `PayloadValidationError` for any custom event payload validations. These errors won't be retried.
   - Use `InvalidAuthenticationError` for any authentication related errors. These errors won't be retried.
   - Use `RetryableError` in case you want to signal Segment to retry the events. Use this error only for transient errors.
+  - Use `APIError` in case you want to capture HttpErrors and rethrow them with more readable message for special error scenarios. These errors will be retried depending on their status code.
   - For all other scenarios, use the `IntegrationError`.
-
 
 - Use appropriate Error Codes. Error Codes are short representation of the error type and they are shown in [Event Delivery](error-handling.md/#where-are-the-errors-from-destinations-displayed) pane. It is RECOMMENDED to use the predefined error codes as Segment adds additional contexual information for debugging in Event Delivery for these error cdoes.
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -85,6 +85,17 @@ export class PayloadValidationError extends IntegrationError {
 }
 
 /**
+ * Error to indicate HTTP API call to destination field.
+ * Should include a user-friendly message and status code.
+ * Errors will be retried based on status code.
+ */
+export class APIError extends IntegrationError {
+  constructor(message: string, status: number) {
+    super(message, status.toString(), status)
+  }
+}
+
+/**
  * Standard error codes. Use one from this enum whenever possible.
  */
 export enum ErrorCodes {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -85,7 +85,7 @@ export class PayloadValidationError extends IntegrationError {
 }
 
 /**
- * Error to indicate HTTP API call to destination field.
+ * Error to indicate HTTP API call to destination failed.
  * Should include a user-friendly message and status code.
  * Errors will be retried based on status code.
  */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,7 @@ export {
   InvalidAuthenticationError,
   RetryableError,
   PayloadValidationError,
+  APIError,
   ErrorCodes
 } from './errors'
 export { get } from './get'


### PR DESCRIPTION
This PR introduces a new APIError class. APIError class can be used to throw HttpErrors from actions `perform` block. This can be used by builder to augment the response message from Destination API with additional information.  An example usage can be seen in [this](https://github.com/segmentio/action-destinations/pull/1309/files#diff-3c955f0f8d911dbf3b8523f50874b91753fecdf8d4c020087761e2807e895d56) PR. 

`HttpError` class requires request and response object which is generally available in `perform` block and hence the new Error class. 

`APIError` class takes in a message and a status code. The error code is assumed to be same as status code. 

## Testing

Tested using HubSpot.
1. Updated HubSpot to throw APIError
<img width="525" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/55cac7f0-2aee-4e36-a13f-2426dda19948">

2. Sent events. Event Delivery shows 500 errors
<img width="1512" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/d59395c7-8178-45ec-b918-7b2d9df94498">

500s are retried by default

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
