### PR TITLE
renaming noop Destination as the slug clashes with an existing Integration - weekly deploy 30-May-2023

### DIFF
--- a/packages/destination-actions/src/destinations/noop/index.ts
+++ b/packages/destination-actions/src/destinations/noop/index.ts
@@ -13,8 +13,8 @@ const presets: Subscription[] = [
 ]
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'NOOP',
-  slug: 'actions-noop',
+  name: 'NOOP (Actions)',
+  slug: 'actions-noop-cloud',
   mode: 'cloud',
   description: 'A NOOP destination used for private internal services.',
   presets: presets,


### PR DESCRIPTION
## Summary

Need to rename a new Integration as the slug clashes with an existing Integration. 
![image](https://github.com/segmentio/action-destinations/assets/45374896/ec28afe2-bac0-42a7-8f29-e824be5caba5)

![image](https://github.com/segmentio/action-destinations/assets/45374896/2bafe709-788d-44d3-a51c-1a849098fc07)

![image](https://github.com/segmentio/action-destinations/assets/45374896/4015561a-43cc-4f6b-9f38-28b9e265acd9)

## Testing

No testing needed. This change is for a new Integration. 
