### PR TITLE
GRAMA-1249: [Sendgrid/Twilio data Exposing Sources] - Update payload to add user id

### DIFF
--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/__tests__/send-sms.test.ts
@@ -368,7 +368,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         To: '+1234567891',
         ShortenUrls: 'true',
         StatusCallback:
-          'http://localhost/?foo=bar&space_id=d&__segment_internal_external_id_key__=phone&__segment_internal_external_id_value__=%2B1234567891#rp=all&rc=5'
+          'http://localhost/?foo=bar&space_id=d&__segment_internal_external_id_key__=phone&__segment_internal_external_id_value__=%2B1234567891&user_id=jane#rp=all&rc=5'
       })
       const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
         .post('/Messages.json', expectedTwilioRequest.toString())

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/utils/message-sender.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/utils/message-sender.ts
@@ -243,6 +243,10 @@ export abstract class MessageSender<MessagePayload extends SmsPayload | Whatsapp
       __segment_internal_external_id_value__: externalIdValue
     }
 
+    if ('userId' in this.payload) {
+      customArgs.user_id = this.payload.userId || ''
+    }
+
     if (webhookUrl && customArgs) {
       // Webhook URL parsing has a potential of failing. I think it's better that
       // we fail out of any invocation than silently not getting analytics


### PR DESCRIPTION


<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR is to add segment userid to sms and email send. 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
