### PR TITLE
New integration - ambee destination

### DIFF
--- a/packages/destination-actions/src/destinations/ambee/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/ambee/__tests__/index.test.ts
@@ -1,0 +1,23 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Ambee', () => {
+  describe('testAuthentication', () => {
+    it('should validate authentication inputs', async () => {
+      nock('https://segment-api.ambeedata.com').post('/v1/company-info').reply(200, {})
+
+      const settings = {
+        companyName: 'test_company_name',
+        apiKey: 'test_api_key',
+        email: 'test@test.com',
+        segmentRegion: 'US',
+        segmentWriteKey: '123456789'
+      }
+
+      await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/ambee/generated-types.ts
+++ b/packages/destination-actions/src/destinations/ambee/generated-types.ts
@@ -1,0 +1,24 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Enter your company’s name
+   */
+  companyName: string
+  /**
+   * The API Key is available via Ambee’s API Dashboard: https://api-dashboard.getambee.com. Paste the API key generated on the homepage. For bulk use, subscribe to enterprise plan on the dashboard
+   */
+  apiKey: string
+  /**
+   * Enter the email address you used to sign up for Ambee’s API Key.
+   */
+  email: string
+  /**
+   * ...
+   */
+  segmentRegion?: string
+  /**
+   * This is your Segment Source WriteKey. Use this WriteKey to send data from Ambee to your destination
+   */
+  segmentWriteKey: string
+}

--- a/packages/destination-actions/src/destinations/ambee/generated-types.ts
+++ b/packages/destination-actions/src/destinations/ambee/generated-types.ts
@@ -14,7 +14,7 @@ export interface Settings {
    */
   email: string
   /**
-   * ...
+   * Your Segment Workspace is hosted in either the US or EU Region. Select which Segment Region Ambee should send notifications to. The default is US
    */
   segmentRegion?: string
   /**

--- a/packages/destination-actions/src/destinations/ambee/index.ts
+++ b/packages/destination-actions/src/destinations/ambee/index.ts
@@ -1,0 +1,68 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import subscribeUserToCampaign from './subscribeUserToCampaign'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Ambee (Actions)',
+  slug: 'actions-ambee',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      companyName: {
+        label: 'Company Name',
+        description: 'Enter your company’s name',
+        type: 'string',
+        required: true
+      },
+      apiKey: {
+        label: 'API Key',
+        description:
+          'The API Key is available via Ambee’s API Dashboard: https://api-dashboard.getambee.com. Paste the API key generated on the homepage. For bulk use, subscribe to enterprise plan on the dashboard',
+        type: 'string',
+        required: true
+      },
+      email: {
+        label: 'Email',
+        description: 'Enter the email address you used to sign up for Ambee’s API Key.',
+        type: 'string',
+        required: true
+      },
+      segmentRegion: {
+        label: 'Segment Region For Notifications',
+        description: '...',
+        type: 'string',
+        choices: [
+          { label: 'US', value: 'US' },
+          { label: 'EU', value: 'EU' }
+        ],
+        default: 'US',
+        required: false
+      },
+      segmentWriteKey: {
+        label: 'Segment WriteKey For Notifications',
+        description:
+          'This is your Segment Source WriteKey. Use this WriteKey to send data from Ambee to your destination',
+        type: 'string',
+        required: true
+      }
+    },
+    testAuthentication: (request, { settings }) => {
+      return request('https://segment-api.ambeedata.com/v1/company-info', {
+        method: 'post',
+        json: settings
+      })
+      // Return a request that tests/validates the user's credentials.
+      // If you do not have a way to validate the authentication fields safely,
+      // you can remove the `testAuthentication` function, though discouraged.
+    }
+  },
+
+  actions: {
+    subscribeUserToCampaign
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/ambee/index.ts
+++ b/packages/destination-actions/src/destinations/ambee/index.ts
@@ -32,7 +32,8 @@ const destination: DestinationDefinition<Settings> = {
       },
       segmentRegion: {
         label: 'Segment Region For Notifications',
-        description: '...',
+        description:
+          'Your Segment Workspace is hosted in either the US or EU Region. Select which Segment Region Ambee should send notifications to. The default is US',
         type: 'string',
         choices: [
           { label: 'US', value: 'US' },

--- a/packages/destination-actions/src/destinations/ambee/subscribeUserToCampaign/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/ambee/subscribeUserToCampaign/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-ambee's subscribeUserToCampaign destination action: all fields 1`] = `
+Object {
+  "airQualitySubscription": "hazardous",
+  "campaignId": "^XXUmeaMilBog0fn5MdS",
+  "email": "^XXUmeaMilBog0fn5MdS",
+  "ipAddress": "^XXUmeaMilBog0fn5MdS",
+  "platform": "^XXUmeaMilBog0fn5MdS",
+  "pollenSubscription": "very_high",
+  "segmentLibrary": "analytics.js",
+  "userId": "^XXUmeaMilBog0fn5MdS",
+}
+`;
+
+exports[`Testing snapshot for actions-ambee's subscribeUserToCampaign destination action: required fields 1`] = `
+Object {
+  "email": "^XXUmeaMilBog0fn5MdS",
+  "ipAddress": "^XXUmeaMilBog0fn5MdS",
+  "segmentLibrary": "analytics.js",
+  "userId": "^XXUmeaMilBog0fn5MdS",
+}
+`;

--- a/packages/destination-actions/src/destinations/ambee/subscribeUserToCampaign/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/ambee/subscribeUserToCampaign/__tests__/index.test.ts
@@ -1,0 +1,63 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+const email = 'test@test.com'
+const companyName = 'test_company'
+const apiKey = 'test_api_key'
+const segmentRegion = 'US'
+const segmentWriteKey = 'test_segment_write_key'
+
+describe('Ambee.subscribeUserToCampaign', () => {
+  it('should work', async () => {
+    nock('https://segment-api.ambeedata.com').post('/v1/campaign-info').reply(200, {})
+
+    const event = createTestEvent({
+      userId: 'user123',
+      context: {
+        library: {
+          name: 'analytics.js',
+          version: '123'
+        },
+        device: {
+          type: 'device'
+        },
+        ip: '1.1.1.1'
+      },
+      properties: {
+        campaignId: 'test_campaign_id',
+        airQualitySubscription: 'hazardous',
+        pollenSubscription: 'very_high'
+      }
+    })
+
+    const responses = await testDestination.testAction('subscribeUserToCampaign', {
+      event,
+      settings: {
+        email,
+        companyName,
+        apiKey,
+        segmentRegion,
+        segmentWriteKey
+      },
+      mapping: {
+        campaignId: {
+          '@path': '$.properties.campaignId'
+        },
+        airQualitySubscription: {
+          '@path': '$.properties.hazardous'
+        },
+        pollenSubscription: {
+          '@path': '$.properties.very_high'
+        }
+      },
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+  })
+})

--- a/packages/destination-actions/src/destinations/ambee/subscribeUserToCampaign/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/ambee/subscribeUserToCampaign/__tests__/snapshot.test.ts
@@ -1,0 +1,87 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'subscribeUserToCampaign'
+const destinationSlug = 'actions-ambee'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData,
+      context: {
+        library: {
+          name: 'analytics.js',
+          version: '1234'
+        }
+      }
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: { ...event.properties, segmentLibrary: { '@path': 'context.library.name' } },
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData,
+      context: {
+        library: {
+          name: 'analytics.js',
+          version: '1234'
+        }
+      }
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: { ...event.properties, segmentLibrary: { '@path': 'context.library.name' } },
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/ambee/subscribeUserToCampaign/generated-types.ts
+++ b/packages/destination-actions/src/destinations/ambee/subscribeUserToCampaign/generated-types.ts
@@ -1,0 +1,32 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The Segment library used when the event was triggered. This Integration will only work with analytics.js or Mobile Segment libraries
+   */
+  segmentLibrary?: string
+  /**
+   * The platform of the device which generated the event e.g. "Android" or "iOS"
+   */
+  platform?: string
+  /**
+   * ...
+   */
+  campaignId?: string
+  /**
+   * The main user identifier to be sent to Ambee
+   */
+  userId: string
+  /**
+   * Subscribe to Air quality notifications from Ambee. Please select the Air Quality (AQI) risk level you would like to receive notifications for
+   */
+  airQualitySubscription?: string
+  /**
+   * Subscribe to Pollen level notifications from Ambee. Please select the Pollen risk level you would like to receive notifications for
+   */
+  pollenSubscription?: string
+  /**
+   * The IP address assocated with the user, ...
+   */
+  ipAddress: string
+}

--- a/packages/destination-actions/src/destinations/ambee/subscribeUserToCampaign/generated-types.ts
+++ b/packages/destination-actions/src/destinations/ambee/subscribeUserToCampaign/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   platform?: string
   /**
-   * ...
+   * Create an ID for your campaign. For every campaign you activate using Ambee’s pollen and/or air quality action, you need to create a new ID. Note: a campaign ID must not contain spaces. Example:“companyabc_ambeepollen” is valid while “companyabc ambeepollen” is not valid
    */
   campaignId?: string
   /**
@@ -26,7 +26,7 @@ export interface Payload {
    */
   pollenSubscription?: string
   /**
-   * The IP address assocated with the user, ...
+   * Ambee uses the user’s IP address when determining who to send air quality and/or pollen notifications to.
    */
   ipAddress: string
 }

--- a/packages/destination-actions/src/destinations/ambee/subscribeUserToCampaign/index.ts
+++ b/packages/destination-actions/src/destinations/ambee/subscribeUserToCampaign/index.ts
@@ -21,7 +21,8 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     campaignId: {
       label: 'Campaign ID',
-      description: '...',
+      description:
+        'Create an ID for your campaign. For every campaign you activate using Ambee’s pollen and/or air quality action, you need to create a new ID. Note: a campaign ID must not contain spaces. Example:“companyabc_ambeepollen” is valid while “companyabc ambeepollen” is not valid',
       type: 'string'
     },
     userId: {
@@ -67,7 +68,8 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     ipAddress: {
       label: 'User IP Address',
-      description: 'The IP address assocated with the user, ...',
+      description:
+        'Ambee uses the user’s IP address when determining who to send air quality and/or pollen notifications to.',
       type: 'string',
       default: { '@path': '$.context.ip' },
       required: true

--- a/packages/destination-actions/src/destinations/ambee/subscribeUserToCampaign/index.ts
+++ b/packages/destination-actions/src/destinations/ambee/subscribeUserToCampaign/index.ts
@@ -1,0 +1,96 @@
+import { ActionDefinition, PayloadValidationError } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Subscribe to Campaign',
+  description: 'Subscribes a user to notifications',
+  fields: {
+    segmentLibrary: {
+      label: 'Segment Library',
+      description:
+        'The Segment library used when the event was triggered. This Integration will only work with analytics.js or Mobile Segment libraries',
+      type: 'hidden',
+      default: { '@path': '$.context.library.name' }
+    },
+    platform: {
+      label: 'User Device Platform',
+      description: 'The platform of the device which generated the event e.g. "Android" or "iOS"',
+      type: 'hidden',
+      default: { '@path': '$.context.device.type' }
+    },
+    campaignId: {
+      label: 'Campaign ID',
+      description: '...',
+      type: 'string'
+    },
+    userId: {
+      label: 'User ID',
+      description: 'The main user identifier to be sent to Ambee',
+      type: 'string',
+      default: {
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      },
+      required: true
+    },
+    airQualitySubscription: {
+      label: 'Air Quality Subscription',
+      description:
+        'Subscribe to Air quality notifications from Ambee. Please select the Air Quality (AQI) risk level you would like to receive notifications for',
+      type: 'string',
+      choices: [
+        { label: 'Good', value: 'good' },
+        { label: 'Moderate', value: 'moderate' },
+        { label: 'Unhealthy for sensitive group', value: 'unhealthy_sensitive_group' },
+        { label: 'Unhealthy', value: 'unhealthy' },
+        { label: 'Very unhealthy', value: 'very_unhealthy' },
+        { label: 'Hazardous', value: 'hazardous' }
+      ],
+      required: false
+    },
+    pollenSubscription: {
+      label: 'Pollen Subscription',
+      description:
+        'Subscribe to Pollen level notifications from Ambee. Please select the Pollen risk level you would like to receive notifications for',
+      type: 'string',
+      choices: [
+        { label: 'Low', value: 'low' },
+        { label: 'Moderate', value: 'moderate' },
+        { label: 'High', value: 'high' },
+        { label: 'Very high', value: 'very_high' }
+      ],
+      required: false
+    },
+    ipAddress: {
+      label: 'User IP Address',
+      description: 'The IP address assocated with the user, ...',
+      type: 'string',
+      default: { '@path': '$.context.ip' },
+      required: true
+    }
+  },
+  perform: (request, { settings, payload }) => {
+    const platform = payload?.platform?.toLowerCase() ?? ''
+    const library = payload?.segmentLibrary ?? ''
+
+    if (library != 'analytics.js' && platform != 'ios' && platform != 'android')
+      throw new PayloadValidationError(
+        `Payload must be sent from the Segment analytics.js library or from a Segment Mobile library`
+      )
+
+    if (payload.segmentLibrary)
+      return request('https://segment-api.ambeedata.com/v1/campaign-info', {
+        method: 'post',
+        json: {
+          ...payload,
+          email: settings.email
+        }
+      })
+  }
+}
+
+export default action


### PR DESCRIPTION
Raising this PR on behalf of Partner Ambee
This is a new Integration with a single Action. 

This Integration is a little unorthodox. 
Its purpose is to capture the user's IP addresses which get sent to Ambee. Along with this the user's preference for Air Quality and Pollen notifications is captured. 

Once Ambee's servers have this data, if there is an air quality or pollen event in the location of the user (determined using ip address), an event will be sent from Ambee's servers to Segment (using the writeKey in settings). 


## Testing
Tested using Actions Tester. 
Unit tests added. 
