### PR TITLE
Add type suffixes to nested FullStory cloud mode properties

### DIFF
--- a/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
@@ -1,22 +1,21 @@
 import { normalizePropertyNames } from '../vars'
 
-const suffixToExampleValuesMap: Record<string, any[]> = {
-  str: ['some string'],
-  bool: [true, false],
+const suffixToExampleValuesMap: Record<string, any> = {
+  str: 'some string',
+  strs: ['string 1', 'string 2'],
+  bool: true,
+  bools: [true, false],
+  real: 1.23,
   // We include an int value with real example values since real will always be preferred when inferring
   // custom var types from values.
-  real: [1, 1.23],
-  int: [1],
-  date: [new Date()],
-  obj: [{}, { secondLevelProp: 'some value' }]
+  reals: [1, 4.56],
+  int: 1,
+  ints: [2, 3],
+  date: new Date(2000, 1),
+  dates: [new Date(2000, 2), new Date(2000, 3)],
+  obj: {},
+  objs: [{}, { nested_string_str: 'nested string' }]
 }
-
-suffixToExampleValuesMap.strs = [suffixToExampleValuesMap.str]
-suffixToExampleValuesMap.bools = [suffixToExampleValuesMap.bool]
-suffixToExampleValuesMap.reals = [suffixToExampleValuesMap.real]
-suffixToExampleValuesMap.ints = [suffixToExampleValuesMap.int]
-suffixToExampleValuesMap.dates = [suffixToExampleValuesMap.date]
-suffixToExampleValuesMap.objs = [suffixToExampleValuesMap.obj]
 
 describe('normalizePropertyNames', () => {
   it('does not add type suffix for undefined values', () => {
@@ -33,54 +32,50 @@ describe('normalizePropertyNames', () => {
 
   it('does not add type suffix if known type suffix is present', () => {
     const obj: Record<string, unknown> = {}
-    Object.entries(suffixToExampleValuesMap).forEach(([suffix, values]) => {
-      values.forEach((value, index) => {
-        obj[`prop${index}_${suffix}`] = value
-      })
+    Object.entries(suffixToExampleValuesMap).forEach(([suffix, value]) => {
+      obj[`${suffix}_prop_${suffix}`] = value
     })
     const normalizedObj = normalizePropertyNames(obj)
     expect(normalizedObj).toEqual(obj)
   })
 
   it('adds type suffixes when type can be inferred and known type suffix is absent', () => {
-    const obj = {
-      string_prop: suffixToExampleValuesMap.str[0],
-      bool_prop1: suffixToExampleValuesMap.bool[0],
-      bool_prop2: suffixToExampleValuesMap.bool[1],
-      real_prop1: suffixToExampleValuesMap.real[0],
-      real_prop2: suffixToExampleValuesMap.real[1],
-      int_prop: suffixToExampleValuesMap.int[0],
-      date_prop: suffixToExampleValuesMap.date[0],
-      obj_prop1: suffixToExampleValuesMap.obj[0],
-      obj_prop2: suffixToExampleValuesMap.obj[1],
-      strs_prop: suffixToExampleValuesMap.strs[0],
-      bools_prop: suffixToExampleValuesMap.bools[0],
-      reals_prop: suffixToExampleValuesMap.reals[0],
-      ints_prop: suffixToExampleValuesMap.ints[0],
-      dates_prop: suffixToExampleValuesMap.dates[0],
-      objs_prop: suffixToExampleValuesMap.objs[0]
+    const originalPayload = {
+      str_prop: suffixToExampleValuesMap.str,
+      strs_prop: suffixToExampleValuesMap.strs,
+      bool_prop1: suffixToExampleValuesMap.bool,
+      bool_prop2: !suffixToExampleValuesMap.bool,
+      bools_prop: suffixToExampleValuesMap.bools,
+      real_prop: suffixToExampleValuesMap.real,
+      reals_prop: suffixToExampleValuesMap.reals,
+      int_prop: suffixToExampleValuesMap.int,
+      ints_prop: suffixToExampleValuesMap.ints,
+      date_prop: suffixToExampleValuesMap.date,
+      dates_prop: suffixToExampleValuesMap.dates,
+      obj_prop: suffixToExampleValuesMap.obj,
+      objs_prop: suffixToExampleValuesMap.objs
     }
-    const expected = {
-      string_prop_str: obj.string_prop,
-      bool_prop1_bool: obj.bool_prop1,
-      bool_prop2_bool: obj.bool_prop2,
-      real_prop1_real: obj.real_prop1,
-      real_prop2_real: obj.real_prop2,
+
+    const expectedPayload = {
+      str_prop_str: originalPayload.str_prop,
+      strs_prop_strs: originalPayload.strs_prop,
+      bool_prop1_bool: originalPayload.bool_prop1,
+      bool_prop2_bool: originalPayload.bool_prop2,
+      bools_prop_bools: originalPayload.bools_prop,
+      real_prop_real: originalPayload.real_prop,
+      reals_prop_reals: originalPayload.reals_prop,
       // This may seem counter-intuitive, but this matches the FullStory client API behavior which prefers
       // reals over ints to avoid inconsistent type inference.
-      int_prop_real: obj.int_prop,
-      date_prop_date: obj.date_prop,
-      obj_prop1_obj: obj.obj_prop1,
-      obj_prop2_obj: obj.obj_prop2,
-      strs_prop_strs: obj.strs_prop,
-      bools_prop_bools: obj.bools_prop,
-      reals_prop_reals: obj.reals_prop,
-      ints_prop_reals: obj.ints_prop,
-      dates_prop_dates: obj.dates_prop,
-      objs_prop_objs: obj.objs_prop
+      int_prop_real: originalPayload.int_prop,
+      ints_prop_reals: originalPayload.ints_prop,
+      date_prop_date: originalPayload.date_prop,
+      dates_prop_dates: originalPayload.dates_prop,
+      obj_prop_obj: originalPayload.obj_prop,
+      objs_prop_objs: originalPayload.objs_prop
     }
-    const actual = normalizePropertyNames(obj)
-    expect(actual).toEqual(expected)
+
+    const transformedPayload = normalizePropertyNames(originalPayload)
+    expect(transformedPayload).toEqual(expectedPayload)
   })
 
   it('camel cases when specified', () => {
@@ -102,6 +97,39 @@ describe('normalizePropertyNames', () => {
     }
     const actual = normalizePropertyNames(obj, { camelCase: true })
     expect(actual).toEqual(expected)
+  })
+
+  it('type suffixes and camel cases nested properties up to max depth', () => {
+    const originalPayload = {
+      first: {
+        second: {
+          third: {
+            fourth: {
+              fourth_nested: 'some string',
+              fifth: {
+                fifth_nested: 'some other string'
+              }
+            }
+          }
+        }
+      }
+    }
+    const expectedPayload = {
+      first_obj: {
+        second_obj: {
+          third_obj: {
+            fourth_obj: {
+              fourthNested_str: 'some string',
+              fifth_obj: {
+                fifth_nested: 'some other string'
+              }
+            }
+          }
+        }
+      }
+    }
+    const transformedPayload = normalizePropertyNames(originalPayload, { camelCase: true })
+    expect(transformedPayload).toEqual(expectedPayload)
   })
 
   const unsupportedPropertyNameChars = [' ', '.', '-', ':']

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
@@ -70,7 +70,8 @@ describe('normalizePropertyNames', () => {
       ints_prop_reals: originalPayload.ints_prop,
       date_prop_date: originalPayload.date_prop,
       dates_prop_dates: originalPayload.dates_prop,
-      obj_prop_obj: originalPayload.obj_prop,
+      // We don't add _obj type suffixes to object properties. This matches FullStory client API behavior.
+      obj_prop: originalPayload.obj_prop,
       objs_prop_objs: originalPayload.objs_prop
     }
 
@@ -115,12 +116,12 @@ describe('normalizePropertyNames', () => {
       }
     }
     const expectedPayload = {
-      first_obj: {
-        second_obj: {
-          third_obj: {
-            fourth_obj: {
+      first: {
+        second: {
+          third: {
+            fourth: {
               fourthNested_str: 'some string',
-              fifth_obj: {
+              fifth: {
                 fifth_nested: 'some other string'
               }
             }

--- a/packages/destination-actions/src/destinations/fullstory/vars.ts
+++ b/packages/destination-actions/src/destinations/fullstory/vars.ts
@@ -100,8 +100,9 @@ const typeSuffixPropertyName = (name: string, value: unknown) => {
   if (lastUnderscore === -1 || !isKnownTypeSuffix(name.substring(lastUnderscore + 1))) {
     // Either no type suffix or the name contains an underscore with an unknown suffix.
     const maybeType = inferType(value)
-    if (maybeType === null) {
-      // We can't infer the type. Don't change the property name.
+    if (maybeType === null || maybeType === 'obj') {
+      // If we can't infer the type or if the type is a single object, don't change the property name.
+      // The FullStory client API doesn't add _obj type suffixes to inferred object propery names.
       return name
     }
 


### PR DESCRIPTION
Before this PR, FullStory custom event and custom user properties were type suffixed as required by FullStory's v1 events and users APIs. However, type suffixing was only applied to root level track properties and identify traits. In practice, mutual Segment and FullStory customers often pass in track properties or identify traits which are complex objects containing nested properties. Since these nested properties were not type suffixed, these track and identify events would fail to be processed by FullStory's server APIs.

This PR:
- Expands type suffixing for FullStory cloud mode properties up to 5 levels deep -- a depth which appears sufficient for the majority of FullStory customer custom event and custom user properties.
- Stops adding an `_obj` type suffix to inferred object properties. This matches type suffixing behavior with FullStory browser API behavior and isn't expected to negatively impact mutual FullStory and Segment customers already using the FullStory Segment cloud mode destination.

## Testing

Unit tests were run, and full integration tests were carried out against FullStory production server APIs.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment