### PR TITLE
Stratconn 2625 add error when no users are extracted

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-audiences/addUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addUser/__tests__/index.test.ts
@@ -107,4 +107,27 @@ describe('TiktokAudiences.addUser', () => {
       })
     ).rejects.toThrow('At least one of `Send Email`, or `Send Advertising ID` must be set to `true`.')
   })
+  it('should fail if email and/or advertising_id is not in the payload', async () => {
+    nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`).post(/.*/, updateUsersRequestBody).reply(400)
+
+    delete event?.context?.device
+    delete event?.context?.traits
+
+    await expect(
+      testDestination.testAction('addUser', {
+        event,
+        settings: {
+          advertiser_ids: ['123']
+        },
+        useDefaultMappings: true,
+        auth,
+        mapping: {
+          selected_advertiser_id: '123',
+          audience_id: 'personas_test_audience',
+          send_email: true,
+          send_advertising_id: true
+        }
+      })
+    ).rejects.toThrowError('At least one of Email Id or Advertising ID must be provided.')
+  })
 })

--- a/packages/destination-actions/src/destinations/tiktok-audiences/functions.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/functions.ts
@@ -73,8 +73,6 @@ export function extractUsers(payloads: GenericPayload[]): {}[][] {
 
   payloads.forEach((payload: GenericPayload) => {
     if (!payload.email && !payload.advertising_id) {
-      console.log('dswe')
-
       return
     }
 

--- a/packages/destination-actions/src/destinations/tiktok-audiences/functions.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/functions.ts
@@ -1,4 +1,4 @@
-import { IntegrationError, RequestClient, RetryableError } from '@segment/actions-core'
+import { IntegrationError, RequestClient, RetryableError, PayloadValidationError } from '@segment/actions-core'
 import { createHash } from 'crypto'
 import { TikTokAudiences } from './api'
 import { Payload as AddUserPayload } from './addUser/generated-types'
@@ -39,6 +39,8 @@ export async function processPayload(
     if (res.status !== 200) {
       throw new RetryableError('Error while attempting to update TikTok Audience. This batch will be retried.')
     }
+  } else {
+    throw new PayloadValidationError('At least one of Email Id or Advertising ID must be provided.')
   }
 
   return res
@@ -71,6 +73,8 @@ export function extractUsers(payloads: GenericPayload[]): {}[][] {
 
   payloads.forEach((payload: GenericPayload) => {
     if (!payload.email && !payload.advertising_id) {
+      console.log('dswe')
+
       return
     }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pull request is to handle the case when email and/or advertising_id is not in the payload for TikTok audiences,  then don't extract any users and no request is sent however it just return a "successful" response for the events.  So, in this case now an error will thrown.

## Testing

- [x] [Segmenters] Tested in the staging environment
