### PR TITLE
[STRATCONN-2144][Adobe Target] Refactor IntegrationError to APIError

### DIFF
--- a/packages/destination-actions/src/destinations/adobe-target/adobeTarget_operations.ts
+++ b/packages/destination-actions/src/destinations/adobe-target/adobeTarget_operations.ts
@@ -1,4 +1,4 @@
-import { RequestClient, IntegrationError } from '@segment/actions-core'
+import { RequestClient, IntegrationError, APIError } from '@segment/actions-core'
 import { StatsContext } from '@segment/actions-core/src/destination-kit'
 
 function getNestedObjects(obj: { [x: string]: any }, objectPath = '', attributes: { [x: string]: string } = {}) {
@@ -68,14 +68,14 @@ export default class AdobeTarget {
         // If we throw a 404, Centrifuge will discard the job and it will never be retried. Thereforce, we are throwing a 500.
         // Unless the API is failing, errors from this endpoint will reference that the user profile does not exist.
         // The 500 error code also works in Centrifuge in the scenario where the API is down. Hence, its choice as a trigger for a retry.
-        const errorCode = error.message == 'Forbidden' ? '403' : '500'
+        const errorCode = error.message == 'Forbidden' ? 403 : 500
 
-        if (errorCode == '500') {
+        if (errorCode == 500) {
           // For now, we will keep track of the number of times we run this flow.
           statsContext?.statsClient.incr('actions-adobe-target.profile-not-found', 1, statsContext.tags)
         }
 
-        throw new IntegrationError(error.message, errorCode)
+        throw new APIError(error.message, errorCode)
       }
     }
 


### PR DESCRIPTION
Refactors Integration Error to API Error. No expected change in retries or functionality as the status code and error code stay the same.

APIError was introduced in this [PR](https://github.com/segmentio/action-destinations/pull/1310).

Reason for this change – I am working on a different [PR](https://github.com/segmentio/action-destinations/pull/1322) for enforcing error code and status code mandatory. This is to ensure errors don't show up in Sentry and also builders take time providing good error codes and descriptions for easier debugging. 

## Testing
No testing required as it only changes the error class

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
