### PR TITLE
[Cli Push] - Fixes `TypeError: Cannot read property 'hidden' of undefined`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,6 +39,17 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Run CLI Push",
+      "program": "${workspaceFolder}/bin/run",
+      "restart": true,
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "port": 47082,
+      "args": ["push"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Run CLI",
       "program": "${workspaceFolder}/bin/run",
       "args": [

--- a/packages/cli-internal/src/commands/push.ts
+++ b/packages/cli-internal/src/commands/push.ts
@@ -433,7 +433,7 @@ export function getOptions(
       default: schema.default ?? defaultValues[schema.type],
       description: schema.description,
       encrypt: schema.type === 'password',
-      hidden: existing['hidden'] ?? false,
+      hidden: existing?.hidden ?? false,
       label: schema.label,
       private: isPrivateSetting,
       scope: 'event_destination',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

When a new destination is registered, but before it's first `push`, the `existing` object being referenced will be undefined. This causes a `TypeError: Cannot read property 'hidden' of undefined`
This was reported here: https://github.com/segmentio/action-destinations/pull/1219/files#r1221927012

This PR safely references the `existing` object when pushing options. 
I also included a VS code launch option for the push command to support debugging.

## Testing
Since this issue occurs after a new destination is registered and before it's first push I reproduced by manually setting the object: `existing = undefined`. This is to avoid actually registering a new dummy integration in our stage DB.

Repro:
<img width="1066" alt="Screenshot 2023-06-09 at 4 29 37 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/c962d74e-cec4-4fb9-a8db-3501991000a3">

With fix, the push command doesn't error:
<img width="1073" alt="Screenshot 2023-06-09 at 4 30 43 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/bc119d6c-e266-4f1a-b39a-c4f0037bfed6">

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
