### PR TITLE
IQM Destination

### DIFF
--- a/packages/destination-actions/src/destinations/iqm/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/iqm/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-iqm destination: postEvent action - all fields 1`] = `
+Object {
+  "data": Object {
+    "testType": "&V4U(!rZ6u7Zsevzgp",
+  },
+}
+`;
+
+exports[`Testing snapshot for actions-iqm destination: postEvent action - required fields 1`] = `Object {}`;

--- a/packages/destination-actions/src/destinations/iqm/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/iqm/__tests__/index.test.ts
@@ -1,0 +1,19 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+import { BASE_URL } from '../index'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Iqm', () => {
+  describe('testAuthentication', () => {
+    it('should validate authentication inputs', async () => {
+      nock(`${BASE_URL}`).post('').reply(200, {})
+
+      // This should match your authentication.fields
+      const authData = { pixel_id: 'my-pixel-id' }
+
+      await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/iqm/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/iqm/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-iqm'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/iqm/generated-types.ts
+++ b/packages/destination-actions/src/destinations/iqm/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * The Pixel ID for your IQM Conversion.
+   */
+  pixel_id: string
+}

--- a/packages/destination-actions/src/destinations/iqm/index.ts
+++ b/packages/destination-actions/src/destinations/iqm/index.ts
@@ -1,5 +1,5 @@
 import type { DestinationDefinition } from '@segment/actions-core'
-import { IntegrationError, defaultValues } from '@segment/actions-core'
+import { defaultValues } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
 import postEvent from './postEvent'
@@ -20,12 +20,6 @@ const destination: DestinationDefinition<Settings> = {
         type: 'string',
         required: true
       }
-    },
-    testAuthentication: async (_, { settings }) => {
-      if (!settings.pixel_id) {
-        throw new IntegrationError('PixelID is required', 'Misconfigured field', 400)
-      }
-      return {}
     }
   },
 

--- a/packages/destination-actions/src/destinations/iqm/index.ts
+++ b/packages/destination-actions/src/destinations/iqm/index.ts
@@ -1,0 +1,55 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import { IntegrationError, defaultValues } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import postEvent from './postEvent'
+
+export const BASE_URL = 'https://postback.iqm.com/open?pid=segment'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Iqm',
+  slug: 'actions-iqm',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      pixel_id: {
+        label: 'Pixel ID',
+        description: 'The Pixel ID for your IQM Conversion.',
+        type: 'string',
+        required: true
+      }
+    },
+    testAuthentication: async (_, { settings }) => {
+      if (!settings.pixel_id) {
+        throw new IntegrationError('PixelID is required', 'Misconfigured field', 400)
+      }
+      return {}
+    }
+  },
+
+  onDelete: async (request, { settings, payload }) => {
+    const { pixel_id } = settings
+    await request(`${BASE_URL}&pixel_id=${pixel_id}`, {
+      method: 'delete',
+      headers: { HOST: 'postback.iqm.com', 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+  },
+
+  actions: {
+    postEvent
+  },
+
+  presets: [
+    {
+      name: 'Send an event to IQM',
+      subscribe: 'type = "track"',
+      partnerAction: 'sendEvent',
+      mapping: defaultValues(postEvent.fields)
+    }
+  ]
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/iqm/postEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/iqm/postEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Iqm's postEvent destination action: all fields 1`] = `
+Object {
+  "data": Object {
+    "testType": "[7TV!",
+  },
+}
+`;
+
+exports[`Testing snapshot for Iqm's postEvent destination action: required fields 1`] = `Object {}`;

--- a/packages/destination-actions/src/destinations/iqm/postEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/iqm/postEvent/__tests__/index.test.ts
@@ -1,0 +1,34 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination, { BASE_URL } from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Iqm.postEvent', () => {
+  it('should send an event', async () => {
+    const event = createTestEvent({
+      userId: '2d947e75-de80-4776-8e0e-4d645977d3df'
+    })
+    nock(`${BASE_URL}`)
+      .post('')
+      .query(true)
+      .reply(200, {
+        data: {
+          postEvent: true
+        }
+      })
+
+    const t = await testDestination.testAction('postEvent', {
+      event,
+      useDefaultMappings: false,
+      mapping: {
+        data: {
+          '@path': '$.'
+        }
+      },
+      settings: { pixel_id: 'my-pixel-id' }
+    })
+
+    expect(t[0].status).toBe(200)
+  })
+})

--- a/packages/destination-actions/src/destinations/iqm/postEvent/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/iqm/postEvent/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'postEvent'
+const destinationSlug = 'Iqm'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/iqm/postEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/iqm/postEvent/generated-types.ts
@@ -1,0 +1,10 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The data to be sent to IQM
+   */
+  data?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/iqm/postEvent/index.ts
+++ b/packages/destination-actions/src/destinations/iqm/postEvent/index.ts
@@ -1,0 +1,34 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import { IntegrationError } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { BASE_URL } from '..'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Post Event',
+  description: 'Post a user event to IQM',
+  fields: {
+    data: {
+      label: 'Data',
+      type: 'object',
+      required: false,
+      description: 'The data to be sent to IQM',
+      default: {
+        '@path': '$.'
+      }
+    }
+  },
+  perform: (request, { settings, payload }) => {
+    const { pixel_id } = settings
+    if (!pixel_id) {
+      throw new IntegrationError('PixelID is required', 'Misconfigured field', 400)
+    }
+    return request(`${BASE_URL}&pixel_id=${pixel_id}`, {
+      method: 'post',
+      headers: { HOST: 'postback.iqm.com', 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/iqm/postEvent/index.ts
+++ b/packages/destination-actions/src/destinations/iqm/postEvent/index.ts
@@ -1,5 +1,4 @@
 import type { ActionDefinition } from '@segment/actions-core'
-import { IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { BASE_URL } from '..'
@@ -7,6 +6,7 @@ import { BASE_URL } from '..'
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Post Event',
   description: 'Post a user event to IQM',
+  defaultSubscription: 'type = "track"',
   fields: {
     data: {
       label: 'Data',
@@ -20,9 +20,6 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: (request, { settings, payload }) => {
     const { pixel_id } = settings
-    if (!pixel_id) {
-      throw new IntegrationError('PixelID is required', 'Misconfigured field', 400)
-    }
     return request(`${BASE_URL}&pixel_id=${pixel_id}`, {
       method: 'post',
       headers: { HOST: 'postback.iqm.com', 'Content-Type': 'application/json' },


### PR DESCRIPTION
IQM Destination for Segment.io

A new destination for segment.io for the IQM platform for conversion tracking.

## Testing

Tested all the endpoints using local Segment CLI, and tested all the IQM endpoints.

- [ x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ x] [Segmenters] Tested in the staging environment
