### PR TITLE
bugfix: make queryID optional in Algolia insights destination action

### DIFF
--- a/packages/destination-actions/src/destinations/algolia-insights/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -38,7 +38,6 @@ Object {
           "product_id": "U[ABpE$k",
         },
       ],
-      "queryID": "U[ABpE$k",
       "userToken": "U[ABpE$k",
     },
   ],
@@ -83,7 +82,6 @@ Object {
       "positions": Array [
         -1912532923056128,
       ],
-      "queryID": "LLjxSD^^GnH",
       "userToken": "LLjxSD^^GnH",
     },
   ],
@@ -120,7 +118,6 @@ Object {
       "objectIDs": Array [
         "BLFCPcmz",
       ],
-      "queryID": "BLFCPcmz",
       "userToken": "BLFCPcmz",
     },
   ],

--- a/packages/destination-actions/src/destinations/algolia-insights/algolia-insight-api.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/algolia-insight-api.ts
@@ -10,6 +10,7 @@ type EventCommon = {
   userToken: string
   objectIDs: string[]
   timestamp?: number
+  queryID?: string
 }
 
 export type AlgoliaProductViewedEvent = EventCommon & {
@@ -18,7 +19,6 @@ export type AlgoliaProductViewedEvent = EventCommon & {
 
 export type AlgoliaProductClickedEvent = EventCommon & {
   eventType: 'click'
-  queryID: string
   positions: number[]
 }
 

--- a/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -38,7 +38,6 @@ Object {
           "product_id": ")j)vR5%1AP*epuo8A%R",
         },
       ],
-      "queryID": ")j)vR5%1AP*epuo8A%R",
       "timestamp": 1674843786677,
       "userToken": ")j)vR5%1AP*epuo8A%R",
     },

--- a/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/__tests__/index.test.ts
@@ -64,7 +64,6 @@ describe('AlgoliaInsights.conversionEvents', () => {
       type: 'track',
       event: 'Order Completed',
       properties: {
-        query_id: '1234',
         search_index: 'fashion_1',
         products: [
           {
@@ -80,5 +79,28 @@ describe('AlgoliaInsights.conversionEvents', () => {
     })
     const algoliaEvent = await testAlgoliaDestination(event)
     expect(algoliaEvent.timestamp).toBe(new Date(event.timestamp as string).valueOf())
+  })
+
+  it('should pass queryID if present', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      event: 'Order Completed',
+      properties: {
+        query_id: '1234',
+        search_index: 'fashion_1',
+        products: [
+          {
+            product_id: '9876',
+            product_name: 'skirt 1'
+          },
+          {
+            product_id: '5432',
+            product_name: 'skirt 2'
+          }
+        ]
+      }
+    })
+    const algoliaEvent = await testAlgoliaDestination(event)
+    expect(algoliaEvent.queryID).toBe(event.properties?.query_id)
   })
 })

--- a/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/generated-types.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/generated-types.ts
@@ -12,9 +12,9 @@ export interface Payload {
    */
   index: string
   /**
-   * Query ID of the list on which the item was clicked.
+   * Query ID of the list on which the item was purchased.
    */
-  queryID: string
+  queryID?: string
   /**
    * The ID associated with the user.
    */

--- a/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/index.ts
@@ -31,9 +31,9 @@ export const conversionEvents: ActionDefinition<Settings, Payload> = {
     },
     queryID: {
       label: 'Query ID',
-      description: 'Query ID of the list on which the item was clicked.',
+      description: 'Query ID of the list on which the item was purchased.',
       type: 'string',
-      required: true,
+      required: false,
       default: {
         '@path': '$.properties.query_id'
       }

--- a/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -38,7 +38,6 @@ Object {
       "positions": Array [
         -8127732168785920,
       ],
-      "queryID": "tTO6#",
       "timestamp": 1674843786677,
       "userToken": "tTO6#",
     },

--- a/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/__tests__/index.test.ts
@@ -56,7 +56,6 @@ describe('AlgoliaInsights.productClickedEvents', () => {
       type: 'track',
       event: 'Product Clicked',
       properties: {
-        query_id: '1234',
         search_index: 'fashion_1',
         product_id: '9876',
         position: 5
@@ -64,5 +63,20 @@ describe('AlgoliaInsights.productClickedEvents', () => {
     })
     const algoliaEvent = await testAlgoliaDestination(event)
     expect(algoliaEvent.timestamp).toBe(new Date(event.timestamp as string).valueOf())
+  })
+
+  it('should pass queryID if present', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      event: 'Product Clicked',
+      properties: {
+        query_id: '1234',
+        search_index: 'fashion_1',
+        product_id: '9876',
+        position: 5
+      }
+    })
+    const algoliaEvent = await testAlgoliaDestination(event)
+    expect(algoliaEvent.queryID).toBe(event.properties?.query_id)
   })
 })

--- a/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/generated-types.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/generated-types.ts
@@ -12,7 +12,7 @@ export interface Payload {
   /**
    * Query ID of the list on which the item was clicked.
    */
-  queryID: string
+  queryID?: string
   /**
    * Position of the click in the list of Algolia search results.
    */

--- a/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/index.ts
@@ -30,7 +30,7 @@ export const productClickedEvents: ActionDefinition<Settings, Payload> = {
       label: 'Query ID',
       description: 'Query ID of the list on which the item was clicked.',
       type: 'string',
-      required: true,
+      required: false,
       default: {
         '@path': '$.properties.query_id'
       }

--- a/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -30,7 +30,6 @@ Object {
       "objectIDs": Array [
         "og&DCP)aINw@qxe)",
       ],
-      "queryID": "og&DCP)aINw@qxe)",
       "timestamp": 1674843786677,
       "userToken": "og&DCP)aINw@qxe)",
     },

--- a/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/__tests__/index.test.ts
@@ -53,7 +53,6 @@ describe('AlgoliaInsights.productViewedEvents', () => {
       type: 'track',
       event: 'Product Viewed',
       properties: {
-        query_id: '1234',
         search_index: 'fashion_1',
         product_id: '9876'
       },
@@ -61,5 +60,20 @@ describe('AlgoliaInsights.productViewedEvents', () => {
     })
     const algoliaEvent = await testAlgoliaDestination(event)
     expect(algoliaEvent.timestamp).toBe(new Date(event.timestamp as string).valueOf())
+  })
+
+  it('should pass queryId if present', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      event: 'Product Viewed',
+      properties: {
+        query_id: '1234',
+        search_index: 'fashion_1',
+        product_id: '9876'
+      },
+      userId: undefined
+    })
+    const algoliaEvent = await testAlgoliaDestination(event)
+    expect(algoliaEvent.queryID).toBe(event.properties?.query_id)
   })
 })

--- a/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/generated-types.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/generated-types.ts
@@ -10,9 +10,9 @@ export interface Payload {
    */
   index: string
   /**
-   * Query ID of the list on which the item was clicked.
+   * Query ID of the list on which the item was viewed.
    */
-  queryID: string
+  queryID?: string
   /**
    * The ID associated with the user.
    */

--- a/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/index.ts
@@ -28,9 +28,9 @@ export const productViewedEvents: ActionDefinition<Settings, Payload> = {
     },
     queryID: {
       label: 'Query ID',
-      description: 'Query ID of the list on which the item was clicked.',
+      description: 'Query ID of the list on which the item was viewed.',
       type: 'string',
-      required: true,
+      required: false,
       default: {
         '@path': '$.properties.query_id'
       }


### PR DESCRIPTION
Algolia Insights destination was added here: https://github.com/segmentio/action-destinations/pull/975 and merged here: https://github.com/segmentio/action-destinations/pull/1027.

In those additional, queryID was mistakenly made required which is not the case in the downstream API (Algolia Insights). This PR fixes that problem.

## Testing

The snapshot tests seem to test this without a query ID. I've added additional unit tests that ensure the queryID is forwarded as expected when it is present.

I've booted up my local environment and tested this manually as well. 👍 

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
