### PR TITLE
Add first and last name support to Upollo action

### DIFF
--- a/packages/browser-destinations/src/destinations/upollo/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/upollo/generated-types.ts
@@ -5,8 +5,4 @@ export interface Settings {
    * The api key of your Upollo project. Get it from the Upollo [dashboard](https://upollo.ai/dashboard)
    */
   apiKey: string
-  /**
-   * Enable enrichment of company details on Segment identify events
-   */
-  companyEnrichment?: boolean
 }

--- a/packages/browser-destinations/src/destinations/upollo/identifyUser/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/upollo/identifyUser/__tests__/index.test.ts
@@ -45,7 +45,7 @@ it('should identify', async () => {
   })
 })
 
-it('should not enrich when it gets no result', async () => {
+it('should combine first and last if no full name is provided', async () => {
   const client = {
     track: jest.fn().mockResolvedValue({ emailAnalysis: { company: { name: '' } } })
   } as any as UpolloClient
@@ -63,7 +63,9 @@ it('should not enrich when it gets no result', async () => {
       user_id: 'u1',
       email: 'foo@bar.com',
       phone: '+611231234',
-      name: 'Mr Foo',
+      name: '',
+      firstName: 'test',
+      lastName: 'test',
       avatar_image_url: 'http://smile',
       custom_traits: {
         DOB: '1990-01-01',
@@ -80,7 +82,50 @@ it('should not enrich when it gets no result', async () => {
     userId: 'u1',
     userEmail: 'foo@bar.com',
     userPhone: '+611231234',
-    userName: 'Mr Foo',
+    userName: 'test test',
+    userImage: 'http://smile',
+    customerSuppliedValues: { DOB: '1990-01-01', Plan: 'Bronze' }
+  })
+})
+
+it('should have an empty string for name if no name is provided', async () => {
+  const client = {
+    track: jest.fn().mockResolvedValue({ emailAnalysis: { company: { name: '' } } })
+  } as any as UpolloClient
+
+  const context = new Context({
+    type: 'identify',
+    event: 'Signed Up'
+  })
+
+  await identify.perform(client as any as UpolloClient, {
+    settings: { apiKey: '123' },
+    analytics: jest.fn() as any as Analytics,
+    context: context,
+    payload: {
+      user_id: 'u1',
+      email: 'foo@bar.com',
+      phone: '+611231234',
+      name: '',
+      firstName: '',
+      lastName: '',
+      avatar_image_url: 'http://smile',
+      custom_traits: {
+        DOB: '1990-01-01',
+        Plan: 'Bronze',
+        session: {
+          // session is excluded because its not a string
+          count: 1
+        }
+      }
+    } as Payload
+  })
+
+  expect(client.track).toHaveBeenCalledWith({
+    userId: 'u1',
+    userEmail: 'foo@bar.com',
+    userPhone: '+611231234',
+    userName: '',
     userImage: 'http://smile',
     customerSuppliedValues: { DOB: '1990-01-01', Plan: 'Bronze' }
   })

--- a/packages/browser-destinations/src/destinations/upollo/identifyUser/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/upollo/identifyUser/__tests__/index.test.ts
@@ -6,7 +6,7 @@ import { Payload } from '../generated-types'
 
 it('should identify', async () => {
   const client = {
-    assess: jest.fn().mockResolvedValue({ emailAnalysis: { company: { name: 'Bar' } } })
+    assess: jest.fn()
   } as any as UpolloClient
 
   const context = new Context({
@@ -15,7 +15,7 @@ it('should identify', async () => {
   })
 
   await identify.perform(client as any as UpolloClient, {
-    settings: { apiKey: '123', companyEnrichment: true },
+    settings: { apiKey: '123' },
     analytics: jest.fn() as any as Analytics,
     context: context,
     payload: {
@@ -35,7 +35,7 @@ it('should identify', async () => {
     } as Payload
   })
 
-  expect(client.assess).toHaveBeenCalledWith({
+  expect(client.track).toHaveBeenCalledWith({
     userId: 'u1',
     userEmail: 'foo@bar.com',
     userPhone: '+611231234',
@@ -43,8 +43,6 @@ it('should identify', async () => {
     userImage: 'http://smile',
     customerSuppliedValues: { DOB: '1990-01-01', Plan: 'Bronze' }
   })
-
-  expect(context.event.traits?.company?.name).toEqual('Bar')
 })
 
 it('should not enrich when it gets no result', async () => {
@@ -58,7 +56,7 @@ it('should not enrich when it gets no result', async () => {
   })
 
   await identify.perform(client as any as UpolloClient, {
-    settings: { apiKey: '123', companyEnrichment: true },
+    settings: { apiKey: '123' },
     analytics: jest.fn() as any as Analytics,
     context: context,
     payload: {
@@ -78,7 +76,7 @@ it('should not enrich when it gets no result', async () => {
     } as Payload
   })
 
-  expect(client.assess).toHaveBeenCalledWith({
+  expect(client.track).toHaveBeenCalledWith({
     userId: 'u1',
     userEmail: 'foo@bar.com',
     userPhone: '+611231234',
@@ -86,6 +84,4 @@ it('should not enrich when it gets no result', async () => {
     userImage: 'http://smile',
     customerSuppliedValues: { DOB: '1990-01-01', Plan: 'Bronze' }
   })
-
-  expect(context.event.traits?.company).toBeUndefined()
 })

--- a/packages/browser-destinations/src/destinations/upollo/identifyUser/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/upollo/identifyUser/__tests__/index.test.ts
@@ -6,7 +6,7 @@ import { Payload } from '../generated-types'
 
 it('should identify', async () => {
   const client = {
-    assess: jest.fn()
+    track: jest.fn()
   } as any as UpolloClient
 
   const context = new Context({
@@ -47,7 +47,7 @@ it('should identify', async () => {
 
 it('should not enrich when it gets no result', async () => {
   const client = {
-    assess: jest.fn().mockResolvedValue({ emailAnalysis: { company: { name: '' } } })
+    track: jest.fn().mockResolvedValue({ emailAnalysis: { company: { name: '' } } })
   } as any as UpolloClient
 
   const context = new Context({

--- a/packages/browser-destinations/src/destinations/upollo/identifyUser/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/upollo/identifyUser/__tests__/index.test.ts
@@ -125,7 +125,7 @@ it('should have an empty string for name if no name is provided', async () => {
     userId: 'u1',
     userEmail: 'foo@bar.com',
     userPhone: '+611231234',
-    userName: '',
+    userName: undefined,
     userImage: 'http://smile',
     customerSuppliedValues: { DOB: '1990-01-01', Plan: 'Bronze' }
   })

--- a/packages/browser-destinations/src/destinations/upollo/identifyUser/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/upollo/identifyUser/generated-types.ts
@@ -10,6 +10,14 @@ export interface Payload {
    */
   name?: string
   /**
+   * The user's given name.
+   */
+  firstName?: string
+  /**
+   * The user's surname.
+   */
+  lastName?: string
+  /**
    * The user's email address.
    */
   email?: string

--- a/packages/browser-destinations/src/destinations/upollo/identifyUser/index.ts
+++ b/packages/browser-destinations/src/destinations/upollo/identifyUser/index.ts
@@ -80,7 +80,7 @@ const identifyUser: BrowserActionDefinition<Settings, UpolloClient, Payload> = {
       userId: payload.user_id,
       userEmail: payload.email,
       userPhone: payload.phone,
-      userName: payload.name ? payload.name : payload.firstName + ' ' + payload.lastName,
+      userName: payload.name ? payload.name : (payload.firstName + ' ' + payload.lastName).trim(),
       userImage: payload.avatar_image_url,
       customerSuppliedValues: payload.custom_traits ? toCustomValues(payload.custom_traits) : undefined
     }

--- a/packages/browser-destinations/src/destinations/upollo/identifyUser/index.ts
+++ b/packages/browser-destinations/src/destinations/upollo/identifyUser/index.ts
@@ -80,7 +80,7 @@ const identifyUser: BrowserActionDefinition<Settings, UpolloClient, Payload> = {
       userId: payload.user_id,
       userEmail: payload.email,
       userPhone: payload.phone,
-      userName: payload.name ? payload.name : (payload.firstName + ' ' + payload.lastName).trim(),
+      userName: payload.name ? payload.name : (payload.firstName || payload.lasteName) ? (payload.firstName + ' ' + payload.lastName).trim(): undefined,
       userImage: payload.avatar_image_url,
       customerSuppliedValues: payload.custom_traits ? toCustomValues(payload.custom_traits) : undefined
     }

--- a/packages/browser-destinations/src/destinations/upollo/identifyUser/index.ts
+++ b/packages/browser-destinations/src/destinations/upollo/identifyUser/index.ts
@@ -28,6 +28,20 @@ const identifyUser: BrowserActionDefinition<Settings, UpolloClient, Payload> = {
         '@path': '$.traits.name'
       }
     },
+    firstName: {
+      label: 'First Name',
+      description: "The user's given name.",
+      type: 'string',
+      required: false,
+      default: { '@path': '$.traits.firstName' }
+    },
+    lastName: {
+      label: 'Last Name',
+      description: "The user's surname.",
+      type: 'string',
+      required: false,
+      default: { '@path': '$.traits.lastName' }
+    },
     email: {
       description: "The user's email address.",
       label: 'Email Address',
@@ -61,28 +75,17 @@ const identifyUser: BrowserActionDefinition<Settings, UpolloClient, Payload> = {
       defaultObjectUI: 'keyvalue'
     }
   },
-  perform: async (UpClient, { payload, context, settings }) => {
+  perform: async (UpClient, { payload }) => {
     const userInfo = {
       userId: payload.user_id,
       userEmail: payload.email,
       userPhone: payload.phone,
-      userName: payload.name,
+      userName: payload.name ? payload.name : payload.firstName + ' ' + payload.lastName,
       userImage: payload.avatar_image_url,
       customerSuppliedValues: payload.custom_traits ? toCustomValues(payload.custom_traits) : undefined
     }
 
-    const result = await UpClient.assess(userInfo)
-    const company = result?.emailAnalysis?.company
-    if (company && company?.name != '' && settings?.companyEnrichment) {
-      const size = company.companySize
-      const count = size && Math.max(size.employeesMin, size.employeesMax)
-      const companyInfo = {
-        name: company?.name,
-        industry: company?.industry,
-        employee_count: count
-      }
-      context.updateEvent('traits.company', companyInfo)
-    }
+    void UpClient.track(userInfo)
   }
 }
 

--- a/packages/browser-destinations/src/destinations/upollo/identifyUser/index.ts
+++ b/packages/browser-destinations/src/destinations/upollo/identifyUser/index.ts
@@ -80,7 +80,11 @@ const identifyUser: BrowserActionDefinition<Settings, UpolloClient, Payload> = {
       userId: payload.user_id,
       userEmail: payload.email,
       userPhone: payload.phone,
-      userName: payload.name ? payload.name : (payload.firstName || payload.lasteName) ? (payload.firstName + ' ' + payload.lastName).trim(): undefined,
+      userName: payload.name
+        ? payload.name
+        : payload.firstName || payload.lastName
+        ? (payload.firstName + ' ' + payload.lastName).trim()
+        : undefined,
       userImage: payload.avatar_image_url,
       customerSuppliedValues: payload.custom_traits ? toCustomValues(payload.custom_traits) : undefined
     }

--- a/packages/browser-destinations/src/destinations/upollo/index.ts
+++ b/packages/browser-destinations/src/destinations/upollo/index.ts
@@ -42,13 +42,6 @@ export const destination: BrowserDestinationDefinition<Settings, UpolloClient> =
       label: 'API Key',
       type: 'string',
       required: true
-    },
-    companyEnrichment: {
-      description: 'Enable enrichment of company details on Segment identify events',
-      label: 'Enable Company Enrichment',
-      type: 'boolean',
-      required: false,
-      default: true
     }
   },
 


### PR DESCRIPTION
Adding support for first and last name to the Upollo action based on user feedback. 

## Testing

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
