### PR TITLE
Update LCNC CLI tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
       "./bin/run generate:types",
       "git add **/generated-types.ts"
     ],
-    "!(templates)/**/*.ts": [
+    "!(**/templates/**)/*.ts": [
       "eslint --fix --cache",
       "prettier --write"
     ],

--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -129,6 +129,7 @@ export default class Init extends Command {
             field.isTemplate = true
             field.directiveType = '@template'
             const templateValue: string = field.defaultValue['@template']
+            // Replace double curly braces with square brackets so that it can be properly rendered in Mustache template
             field.value = templateValue.replace(/\{\{([^{}]+)\}\}/g, '[[$1]]')
           }
           field.defaultValue = defaultValue
@@ -142,6 +143,8 @@ export default class Init extends Command {
           {
             name: action.name,
             description: action.description,
+            hasDefaultSubscription: action.hasDefaultSubscription,
+            trigger: action.trigger,
             slug,
             destination,
             fields: action.fields,

--- a/packages/cli/templates/actions/empty-action-lowcode/index.ts
+++ b/packages/cli/templates/actions/empty-action-lowcode/index.ts
@@ -5,25 +5,28 @@ import type { Payload } from './generated-types'
 const action: ActionDefinition<Settings, Payload> = {
   title: '{{name}}',
   description: '{{description}}',
+  {{#hasDefaultSubscription}}
+  defaultSubscription: '{{{trigger}}}',
+  {{/hasDefaultSubscription}}
   fields: {
     {{#fields}}
-   {{key}}: {
-     label: '{{label}}',
-     description: '{{description}}',
-     type: '{{type}}',
-     required: {{required}},
-     {{#hasDefault}}
-     {{#isTemplate}}
-     default: {
-      "@template": "{{value}}"
-     }
-     {{/isTemplate}}
-     {{^isTemplate}}
-     default: {{{defaultValue}}}
-     {{/isTemplate}}
-     {{/hasDefault}}
-   },
-   {{/fields}}
+    {{key}}: {
+      label: '{{label}}',
+      description: '{{description}}',
+      type: '{{type}}',
+      required: {{required}},
+      {{#hasDefault}}
+      {{#isTemplate}}
+      default: {
+        "@template": "{{value}}"
+      }
+      {{/isTemplate}}
+      {{^isTemplate}}
+      default: {{{defaultValue}}}
+      {{/isTemplate}}
+      {{/hasDefault}}
+    },
+    {{/fields}}
   },
   perform: (request, { payload }) => {
     return request('{{{apiEndpoint}}}', {


### PR DESCRIPTION
This PR adds a new template file for the `no-auth` authentication scheme and scaffolds an action's default subscription if provided.

<img width="511" alt="Screenshot 2023-06-26 at 12 05 51 PM" src="https://github.com/segmentio/action-destinations/assets/87985289/e35ccbeb-5277-4f53-90a3-a10353e7e95a">


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
