### PR TITLE
Added condition for event name in hubspot

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,19 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing snapshot for actions-hubspot-cloud destination: sendCustomBehavioralEvent action - all fields 1`] = `
-Object {
-  "email": "geoli@sekuki.mg",
-  "eventName": "NTxWtuPi(z!bOHmgT^*3",
-  "objectId": "NTxWtuPi(z!bOHmgT^*3",
-  "occurredAt": "2021-02-01T00:00:00.000Z",
-  "properties": Object {
-    "testType": "NTxWtuPi(z!bOHmgT^*3",
-  },
-  "utk": "NTxWtuPi(z!bOHmgT^*3",
-}
-`;
+exports[`Testing snapshot for actions-hubspot-cloud destination: sendCustomBehavioralEvent action - all fields 1`] = `[PayloadValidationError: EventName should begin with peNTxWtuPi(z!bOHmgT^*3_]`;
 
 exports[`Testing snapshot for actions-hubspot-cloud destination: sendCustomBehavioralEvent action - required fields 1`] = `[PayloadValidationError: One of the following parameters: email, user token, or objectId is required]`;
+
+exports[`Testing snapshot for actions-hubspot-cloud destination: sendCustomBehavioralEvent action - required fields 1`] = `[PayloadValidationError: EventName should begin with peNTxWtuPi(z!bOHmgT^*3_]`;
 
 exports[`Testing snapshot for actions-hubspot-cloud destination: upsertCompany action - all fields 1`] = `
 Object {

--- a/packages/destination-actions/src/destinations/hubspot/generated-types.ts
+++ b/packages/destination-actions/src/destinations/hubspot/generated-types.ts
@@ -1,3 +1,8 @@
 // Generated file. DO NOT MODIFY IT BY HAND.
 
-export interface Settings {}
+export interface Settings {
+  /**
+   * The Hub ID of your HubSpot account.
+   */
+  portalId?: string
+}

--- a/packages/destination-actions/src/destinations/hubspot/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/index.ts
@@ -17,7 +17,13 @@ const destination: DestinationDefinition<Settings> = {
 
   authentication: {
     scheme: 'oauth2',
-    fields: {},
+    fields: {
+      portalId: {
+        description: 'The Hub ID of your HubSpot account.',
+        label: 'Hub ID',
+        type: 'string'
+      }
+    },
     testAuthentication: (request) => {
       // HubSpot doesn't have a test authentication endpoint, so we using a lightweight CRM API to validate access token
       return request(`${HUBSPOT_BASE_URL}/crm/v3/objects/contacts?limit=1`)

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/__snapshots__/index.test.ts.snap
@@ -12,3 +12,16 @@ Object {
   "utk": "abverazffa===1314122f",
 }
 `;
+
+exports[`HubSpot.sendCustomBehavioralEvent should succeed when all fields are given 1`] = `
+Object {
+  "email": "vep@beri.dz",
+  "eventName": "pe22596207_test_event_http",
+  "objectId": "802",
+  "occurredAt": "2023-07-05T08:28:35.216Z",
+  "properties": Object {
+    "hs_city": "city",
+  },
+  "utk": "abverazffa===1314122f",
+}
+`;

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,37 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing snapshot for HubSpot's sendCustomBehavioralEvent destination action: all fields 1`] = `
-Object {
-  "email": "mur@lumbafat.ad",
-  "eventName": "9B#[dv&Iy",
-  "objectId": "9B#[dv&Iy",
-  "occurredAt": "2021-02-01T00:00:00.000Z",
-  "properties": Object {
-    "testType": "9B#[dv&Iy",
-  },
-  "utk": "9B#[dv&Iy",
-}
-`;
+exports[`Testing snapshot for HubSpot's sendCustomBehavioralEvent destination action: all fields 1`] = `[PayloadValidationError: EventName should begin with pe9B#[dv&Iy_]`;
 
-exports[`Testing snapshot for HubSpot's sendCustomBehavioralEvent destination action: required fields 1`] = `
-Object {
-  "email": "hello@world.com",
-  "eventName": "9B#[dv&Iy",
-}
-`;
-
-exports[`Testing snapshot for HubSpot's sendCustomBehavioralEvent destination action: required fields 2`] = `
-Headers {
-  Symbol(map): Object {
-    "authorization": Array [
-      "Bearer undefined",
-    ],
-    "content-type": Array [
-      "application/json",
-    ],
-    "user-agent": Array [
-      "Segment (Actions)",
-    ],
-  },
-}
-`;
+exports[`Testing snapshot for HubSpot's sendCustomBehavioralEvent destination action: required fields 1`] = `[PayloadValidationError: EventName should begin with pe9B#[dv&Iy_]`;

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/index.test.ts
@@ -169,7 +169,7 @@ describe('HubSpot.sendCustomBehavioralEvent', () => {
     })
   })
 
-  test('should fail when event name is not start with pe{hubId}_ and hubId configured in settings', async () => {
+  test('should fail when event name does not start with pe{hubId}_ and hubId is configured in settings', async () => {
     const event = createTestEvent({
       type: 'track',
       event: 'test_event',
@@ -208,7 +208,7 @@ describe('HubSpot.sendCustomBehavioralEvent', () => {
     ).rejects.toThrowError(`EventName should begin with pe${settings.portalId}_`)
   })
 
-  test('should fail when event name is not start with pe{hubId}_ and hubId is not configured in settings', async () => {
+  test('should fail when event name does not start with pe{hubId}_ and hubId is not configured in settings', async () => {
     const event = createTestEvent({
       type: 'track',
       event: 'test_event',

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/index.test.ts
@@ -4,6 +4,9 @@ import Destination from '../../index'
 import { HUBSPOT_BASE_URL } from '../../properties'
 
 let testDestination = createTestIntegration(Destination)
+const settings = {
+  portalId: '22596207'
+}
 
 beforeEach((done) => {
   // Re-Initialize the destination before each test
@@ -164,6 +167,139 @@ describe('HubSpot.sendCustomBehavioralEvent', () => {
         custom_property_3: '1;two;true;{"four":4}'
       }
     })
+  })
+
+  test('should fail when event name is not start with pe{hubId}_ and hubId configured in settings', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      event: 'test_event',
+      properties: {
+        email: 'vep@beri.dz',
+        utk: 'abverazffa===1314122f',
+        userId: '802',
+        city: 'city'
+      }
+    })
+
+    const mapping = {
+      eventName: {
+        '@path': '$.event'
+      },
+      utk: {
+        '@path': '$.properties.utk'
+      },
+      objectId: {
+        '@path': '$.properties.userId'
+      },
+      properties: {
+        hs_city: {
+          '@path': '$.properties.city'
+        }
+      }
+    }
+
+    return expect(
+      testDestination.testAction('sendCustomBehavioralEvent', {
+        event,
+        settings,
+        useDefaultMappings: true,
+        mapping: mapping
+      })
+    ).rejects.toThrowError(`EventName should begin with pe${settings.portalId}_`)
+  })
+
+  test('should fail when event name is not start with pe{hubId}_ and hubId is not configured in settings', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      event: 'test_event',
+      properties: {
+        email: 'vep@beri.dz',
+        utk: 'abverazffa===1314122f',
+        userId: '802',
+        city: 'city'
+      }
+    })
+
+    settings.portalId = ''
+
+    const mapping = {
+      eventName: {
+        '@path': '$.event'
+      },
+      utk: {
+        '@path': '$.properties.utk'
+      },
+      objectId: {
+        '@path': '$.properties.userId'
+      },
+      properties: {
+        hs_city: {
+          '@path': '$.properties.city'
+        }
+      }
+    }
+
+    return expect(
+      testDestination.testAction('sendCustomBehavioralEvent', {
+        event,
+        settings,
+        useDefaultMappings: true,
+        mapping: mapping
+      })
+    ).rejects.toThrowError(`EventName should begin with pe<hubId>_`)
+  })
+
+  test('should succeed when all fields are given', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      event: 'pe22596207_test_event_http',
+      timestamp: '2023-07-05T08:28:35.216Z',
+      properties: {
+        email: 'vep@beri.dz',
+        utk: 'abverazffa===1314122f',
+        userId: '802',
+        city: 'city'
+      }
+    })
+
+    const expectedPayload = {
+      eventName: event.event,
+      occurredAt: event.timestamp as string,
+      utk: event.properties?.utk,
+      email: event.properties?.email,
+      objectId: event.properties?.userId,
+      properties: {
+        hs_city: event.properties?.city
+      }
+    }
+
+    const mapping = {
+      eventName: {
+        '@path': '$.event'
+      },
+      utk: {
+        '@path': '$.properties.utk'
+      },
+      objectId: {
+        '@path': '$.properties.userId'
+      },
+      properties: {
+        hs_city: {
+          '@path': '$.properties.city'
+        }
+      }
+    }
+
+    nock(HUBSPOT_BASE_URL).post('/events/v3/send', expectedPayload).reply(204, {})
+
+    const responses = await testDestination.testAction('sendCustomBehavioralEvent', {
+      event,
+      useDefaultMappings: true,
+      mapping: mapping
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(204)
+    expect(responses[0].options.json).toMatchSnapshot()
   })
 
   test('should fail when email, utk and objectId is not provided', async () => {

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/snapshot.test.ts
@@ -21,19 +21,29 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       properties: { ...eventData, email: 'hello@world.com' }
     })
 
-    const responses = await testDestination.testAction(actionSlug, {
-      event: event,
-      mapping: event.properties,
-      settings: settingsData,
-      auth: undefined
-    })
+    try {
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
 
-    const request = responses[0].request
-    const json = await request.json()
+      const request = responses[0].request
+      const rawBody = await request.text()
 
-    expect(json).toMatchSnapshot()
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
 
-    expect(request.headers).toMatchSnapshot()
+      expect(request.headers).toMatchSnapshot()
+    } catch (e) {
+      expect(e).toMatchSnapshot()
+    }
   })
 
   it('all fields', async () => {
@@ -46,15 +56,28 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       properties: eventData
     })
 
-    const responses = await testDestination.testAction(actionSlug, {
-      event: event,
-      mapping: event.properties,
-      settings: settingsData,
-      auth: undefined
-    })
+    try {
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
 
-    const request = responses[0].request
-    const json = await request.json()
-    expect(json).toMatchSnapshot()
+      const request = responses[0].request
+      const rawBody = await request.json()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    } catch (e) {
+      expect(e).toMatchSnapshot()
+    }
   })
 })

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
@@ -67,7 +67,7 @@ const action: ActionDefinition<Settings, Payload> = {
       defaultObjectUI: 'keyvalue:only'
     }
   },
-  perform: async (request, { payload, settings }) => {
+  perform: (request, { payload, settings }) => {
     const event: CustomBehavioralEvent = {
       eventName: payload.eventName,
       occurredAt: payload.occurredAt,
@@ -78,10 +78,12 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     const hubId = settings?.portalId
+    const regExp = /^pe\d+_.*/
 
-    if (!hubId && !/^pe\d+_.*/.exec(payload?.eventName)) {
+    if (!hubId && !regExp.exec(payload?.eventName)) {
       throw new PayloadValidationError(`EventName should begin with pe<hubId>_`)
-    } else if (hubId && !payload?.eventName.startsWith(`pe${hubId}_`)) {
+    }
+    if (hubId && !payload?.eventName.startsWith(`pe${hubId}_`)) {
       throw new PayloadValidationError(`EventName should begin with pe${hubId}_`)
     }
 

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
@@ -67,7 +67,7 @@ const action: ActionDefinition<Settings, Payload> = {
       defaultObjectUI: 'keyvalue:only'
     }
   },
-  perform: (request, { payload }) => {
+  perform: async (request, { payload, settings }) => {
     const event: CustomBehavioralEvent = {
       eventName: payload.eventName,
       occurredAt: payload.occurredAt,
@@ -75,6 +75,14 @@ const action: ActionDefinition<Settings, Payload> = {
       email: payload.email,
       objectId: payload.objectId,
       properties: flattenObject(payload.properties)
+    }
+
+    const hubId = settings?.portalId
+
+    if (!hubId && !/^pe\d+_.*/.exec(payload?.eventName)) {
+      throw new PayloadValidationError(`EventName should begin with pe<hubId>_`)
+    } else if (hubId && !payload?.eventName.startsWith(`pe${hubId}_`)) {
+      throw new PayloadValidationError(`EventName should begin with pe${hubId}_`)
     }
 
     if (!payload.utk && !payload.email && !payload.objectId) {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

The  Custom Behavioral Event requests in Hubspot includes event name which must start with `pe{connected_Hub_ID}_` . So, to reduce the 400 error from api call, added the  condition before API call and throws payload validation error.

JIRA link:- https://segment.atlassian.net/browse/STRATCONN-2696

Screenshot:- 
<img width="1505" alt="Screenshot 2023-06-28 at 12 08 13 PM" src="https://github.com/segmentio/action-destinations/assets/117922634/6a1a6211-ea09-4e5b-94a6-cf63d326ddf1">


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] [Segmenters] Tested in the staging environment
