### PR TITLE
Custom validation in Google Ads for email address to allow hashed email addresses.

### DIFF
--- a/packages/destination-actions/package.json
+++ b/packages/destination-actions/package.json
@@ -43,6 +43,7 @@
     "@segment/actions-core": "^3.68.0",
     "@segment/actions-shared": "^1.50.0",
     "@types/node": "^18.11.15",
+    "ajv-formats": "^2.1.1",
     "aws4": "^1.12.0",
     "cheerio": "^1.0.0-rc.10",
     "dayjs": "^1.10.7",

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -3,6 +3,7 @@ import { ConversionCustomVariable, PartialErrorResponse, QueryResponse } from '.
 import { ModifiedResponse, RequestClient, IntegrationError, PayloadValidationError } from '@segment/actions-core'
 import { StatsContext } from '@segment/actions-core/src/destination-kit'
 import { Features } from '@segment/actions-core/src/mapping-kit'
+import { fullFormats } from 'ajv-formats/dist/formats'
 
 export const API_VERSION = 'v12'
 export const CANARY_API_VERSION = 'v13'
@@ -101,11 +102,7 @@ export const commonHashedEmailValidation = (email: string): string => {
   }
 
   // https://github.com/ajv-validator/ajv-formats/blob/master/src/formats.ts#L64-L65
-  if (
-    !/^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(
-      email
-    )
-  ) {
+  if (!(fullFormats.email as RegExp).test(email)) {
     throw new PayloadValidationError("Email provided doesn't seem to be in a valid format.")
   }
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'crypto'
 import { ConversionCustomVariable, PartialErrorResponse, QueryResponse } from './types'
-import { ModifiedResponse, RequestClient, IntegrationError } from '@segment/actions-core'
+import { ModifiedResponse, RequestClient, IntegrationError, PayloadValidationError } from '@segment/actions-core'
 import { StatsContext } from '@segment/actions-core/src/destination-kit'
 import { Features } from '@segment/actions-core/src/mapping-kit'
 
@@ -95,3 +95,14 @@ export function getApiVersion(features?: Features, statsContext?: StatsContext):
 }
 
 export const isHashedEmail = (email: string): boolean => new RegExp(/[0-9abcdef]{64}/gi).test(email)
+export const commonHashedEmailValidation = (email: string): string => {
+  if (isHashedEmail(email)) {
+    return email
+  }
+
+  if (!/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(email)) {
+    throw new PayloadValidationError("Email provided doesn't seem to be in a valid format.")
+  }
+
+  return String(hash(email))
+}

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -100,7 +100,12 @@ export const commonHashedEmailValidation = (email: string): string => {
     return email
   }
 
-  if (!/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(email)) {
+  // https://github.com/ajv-validator/ajv-formats/blob/master/src/formats.ts#L64-L65
+  if (
+    !/^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(
+      email
+    )
+  ) {
     throw new PayloadValidationError("Email provided doesn't seem to be in a valid format.")
   }
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -9,7 +9,7 @@ import {
   handleGoogleErrors,
   convertTimestamp,
   getApiVersion,
-  isHashedEmail
+  commonHashedEmailValidation
 } from '../functions'
 import { ModifiedResponse } from '@segment/actions-core'
 
@@ -56,7 +56,6 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'Email address of the individual who triggered the conversion event. Segment will hash this value before sending to Google.',
       type: 'string',
-      format: 'email',
       default: {
         '@if': {
           exists: { '@path': '$.properties.email' },
@@ -240,8 +239,10 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (payload.email_address) {
+      const validatedEmail: string = commonHashedEmailValidation(payload.email_address)
+
       request_object.userIdentifiers.push({
-        hashedEmail: isHashedEmail(payload.email_address) ? payload.email_address : hash(payload.email_address)
+        hashedEmail: validatedEmail
       })
     }
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, PayloadValidationError } from '@segment/actions-core'
-import { hash, handleGoogleErrors, convertTimestamp, getApiVersion, isHashedEmail } from '../functions'
+import { hash, handleGoogleErrors, convertTimestamp, getApiVersion, commonHashedEmailValidation } from '../functions'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { PartialErrorResponse } from '../types'
@@ -79,7 +79,6 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'Email address of the individual who triggered the conversion event. Segment will hash this value before sending to Google.',
       type: 'string',
-      format: 'email',
       default: {
         '@if': {
           exists: { '@path': '$.properties.email' },
@@ -235,8 +234,10 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (payload.email_address) {
+      const validatedEmail: string = commonHashedEmailValidation(payload.email_address)
+
       request_object.userIdentifiers.push({
-        hashedEmail: isHashedEmail(payload.email_address) ? payload.email_address : hash(payload.email_address)
+        hashedEmail: validatedEmail
       })
     }
 


### PR DESCRIPTION
Disabling default AJV default email validation to allow incoming hashed emails.

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [X] [Segmenters] Tested in the staging environment
