### PR TITLE
bugfix: make position optional in Algolia insights destination action

### DIFF
--- a/packages/destination-actions/src/destinations/algolia-insights/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -78,10 +78,6 @@ Object {
       "objectIDs": Array [
         "LLjxSD^^GnH",
       ],
-      "position": -1912532923056128,
-      "positions": Array [
-        -1912532923056128,
-      ],
       "userToken": "LLjxSD^^GnH",
     },
   ],

--- a/packages/destination-actions/src/destinations/algolia-insights/algolia-insight-api.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/algolia-insight-api.ts
@@ -19,7 +19,7 @@ export type AlgoliaProductViewedEvent = EventCommon & {
 
 export type AlgoliaProductClickedEvent = EventCommon & {
   eventType: 'click'
-  positions: number[]
+  positions?: number[]
 }
 
 export type AlgoliaConversionEvent = EventCommon & {

--- a/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -34,10 +34,6 @@ Object {
       "objectIDs": Array [
         "tTO6#",
       ],
-      "position": -8127732168785920,
-      "positions": Array [
-        -8127732168785920,
-      ],
       "timestamp": 1674843786677,
       "userToken": "tTO6#",
     },

--- a/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/__tests__/index.test.ts
@@ -57,8 +57,7 @@ describe('AlgoliaInsights.productClickedEvents', () => {
       event: 'Product Clicked',
       properties: {
         search_index: 'fashion_1',
-        product_id: '9876',
-        position: 5
+        product_id: '9876'
       }
     })
     const algoliaEvent = await testAlgoliaDestination(event)
@@ -72,11 +71,25 @@ describe('AlgoliaInsights.productClickedEvents', () => {
       properties: {
         query_id: '1234',
         search_index: 'fashion_1',
+        product_id: '9876'
+      }
+    })
+    const algoliaEvent = await testAlgoliaDestination(event)
+    expect(algoliaEvent.queryID).toBe(event.properties?.query_id)
+  })
+
+  it('should pass position if present', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      event: 'Product Clicked',
+      properties: {
+        query_id: '1234',
+        search_index: 'fashion_1',
         product_id: '9876',
         position: 5
       }
     })
     const algoliaEvent = await testAlgoliaDestination(event)
-    expect(algoliaEvent.queryID).toBe(event.properties?.query_id)
+    expect(algoliaEvent.positions?.[0]).toBe(event.properties?.position)
   })
 })

--- a/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/generated-types.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/generated-types.ts
@@ -16,7 +16,7 @@ export interface Payload {
   /**
    * Position of the click in the list of Algolia search results.
    */
-  position: number
+  position?: number
   /**
    * The ID associated with the user.
    */

--- a/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/index.ts
@@ -39,7 +39,7 @@ export const productClickedEvents: ActionDefinition<Settings, Payload> = {
       label: 'Position',
       description: 'Position of the click in the list of Algolia search results.',
       type: 'integer',
-      required: true,
+      required: false,
       default: {
         '@path': '$.properties.position'
       }
@@ -73,7 +73,7 @@ export const productClickedEvents: ActionDefinition<Settings, Payload> = {
       eventType: 'click',
       objectIDs: [data.payload.objectID],
       userToken: data.payload.userToken,
-      positions: [data.payload.position],
+      positions: data.payload.position ? [data.payload.position] : undefined,
       timestamp: data.payload.timestamp ? new Date(data.payload.timestamp).valueOf() : undefined
     }
     const insightPayload = { events: [insightEvent] }


### PR DESCRIPTION
Algolia Insights destination was added here: https://github.com/segmentio/action-destinations/pull/975 and merged here: https://github.com/segmentio/action-destinations/pull/1027.

In those additions, `position` was mistakenly made required which is not the case in the downstream API (Algolia Insights). This PR fixes that problem.

## Testing

The snapshot tests seem to test this without a query ID. I've added additional unit tests that ensure the queryID is forwarded as expected when it is present.

I've booted up my local environment and tested this manually as well. 👍 

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
