### PR TITLE
Channels 696: add tap action buttons & default badges

### DIFF
--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/__tests__/send-mobile-push.test.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/__tests__/send-mobile-push.test.ts
@@ -41,7 +41,8 @@ const testAction = createTestAction({
       priority: null,
       badgeAmount: null,
       badgeStrategy: null,
-      ttl: null
+      ttl: null,
+      tapActionButtons: null
     }
   })
 })
@@ -68,6 +69,8 @@ const getDefaultExpectedNotifyApiReq = (extId: NonNullable<Payload['externalIds'
           }),
     CustomData: JSON.stringify({
       space_id: spaceId,
+      badgeAmount: 1,
+      badgeStrategy: 'inc',
       __segment_internal_external_id_key__: extId.type,
       __segment_internal_external_id_value__: extId.id
     })
@@ -370,6 +373,8 @@ describe('sendMobilePush action', () => {
         }),
         CustomData: JSON.stringify({
           space_id: spaceId,
+          badgeAmount: 1,
+          badgeStrategy: 'inc',
           media: ['http://myimg.com/&color=mantis_green'],
           __segment_internal_external_id_key__: 'ios.push_token',
           __segment_internal_external_id_value__: 'ios-token-1'
@@ -415,6 +420,8 @@ describe('sendMobilePush action', () => {
         }),
         CustomData: JSON.stringify({
           space_id: spaceId,
+          badgeAmount: 1,
+          badgeStrategy: 'inc',
           media: ['http://myimg.com/&color=mantis_green'],
           __segment_internal_external_id_key__: 'ios.push_token',
           __segment_internal_external_id_value__: 'ios-token-1'

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/__tests__/send-mobile-push.test.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/__tests__/send-mobile-push.test.ts
@@ -52,11 +52,15 @@ const getDefaultExpectedNotifyApiReq = (extId: NonNullable<Payload['externalIds'
     Body: defaultTemplate.types['twilio/text'].body,
     Title: customizationTitle,
     FcmPayload: JSON.stringify({
-      mutable_content: true
+      mutable_content: true,
+      notification: {
+        badge: 1
+      }
     }),
     ApnPayload: JSON.stringify({
       aps: {
-        'mutable-content': 1
+        'mutable-content': 1,
+        badge: 1
       }
     }),
     Recipients:
@@ -361,11 +365,15 @@ describe('sendMobilePush action', () => {
         Body: 'Welcome to Wadiya General Aladeen!',
         Title: 'Aladeen',
         FcmPayload: JSON.stringify({
-          mutable_content: true
+          mutable_content: true,
+          notification: {
+            badge: 1
+          }
         }),
         ApnPayload: JSON.stringify({
           aps: {
-            'mutable-content': 1
+            'mutable-content': 1,
+            badge: 1
           }
         }),
         Recipients: JSON.stringify({
@@ -408,11 +416,15 @@ describe('sendMobilePush action', () => {
         Body: 'I have Aladeeen news',
         Title: 'General',
         FcmPayload: JSON.stringify({
-          mutable_content: true
+          mutable_content: true,
+          notification: {
+            badge: 1
+          }
         }),
         ApnPayload: JSON.stringify({
           aps: {
-            'mutable-content': 1
+            'mutable-content': 1,
+            badge: 1
           }
         }),
         Recipients: JSON.stringify({
@@ -441,6 +453,139 @@ describe('sendMobilePush action', () => {
       })
       expect(responses[0].url).toEqual(notifyReqUrl)
       expect(responses[0].data).toMatchObject(externalIds[0])
+    })
+  })
+
+  describe('fields', () => {
+    const title = 'buy'
+    const body = 'now'
+    const tapAction = 'OPEN_DEEP_LINK'
+    const sound = 'app://mysound.aif'
+    const ttl = 1234
+    const priority = 'low'
+    const customizations = {
+      badgeAmount: 3,
+      badgeStrategy: 'dec',
+      media: ['http://myimg.com/product.png'],
+      deepLink: 'app://propducts-view',
+      tapActionButtons: [
+        {
+          id: '1',
+          text: 'open',
+          onTap: 'deep_link',
+          link: 'app://buy-now'
+        },
+        {
+          id: '2',
+          text: 'close',
+          onTap: 'dismiss'
+        }
+      ]
+    }
+
+    const externalIds = [
+      { type: 'ios.push_token', id: 'ios-token-1', channelType: 'IOS_PUSH', subscriptionStatus: 'subscribed' }
+    ]
+
+    it('displays all fields without content sid', async () => {
+      const notificationReq = new URLSearchParams({
+        Body: body,
+        Action: tapAction,
+        Title: title,
+        Sound: sound,
+        Priority: priority,
+        TimeToLive: ttl.toString(),
+        FcmPayload: JSON.stringify({
+          mutable_content: true,
+          notification: {
+            badge: customizations.badgeAmount
+          }
+        }),
+        ApnPayload: JSON.stringify({
+          aps: {
+            'mutable-content': 1,
+            badge: customizations.badgeAmount
+          }
+        }),
+        Recipients: JSON.stringify({
+          apn: [{ addr: 'ios-token-1' }]
+        }),
+        CustomData: JSON.stringify({
+          space_id: spaceId,
+          ...customizations,
+          __segment_internal_external_id_key__: 'ios.push_token',
+          __segment_internal_external_id_value__: 'ios-token-1'
+        })
+      })
+
+      const notifyReqUrl = `https://push.ashburn.us1.twilio.com/v1/Services/${pushServiceSid}/Notifications`
+      nock(notifyReqUrl).post('', notificationReq.toString()).reply(201, externalIds[0])
+
+      const responses = await testAction({
+        mappingOverrides: {
+          contentSid: undefined,
+          customizations: { title, body, tapAction, sound, ttl, priority, ...customizations },
+          externalIds
+        }
+      })
+      expect(responses[0].url).toEqual(notifyReqUrl)
+      expect(responses[0].data).toMatchObject(externalIds[0])
+    })
+
+    it('displays all fields with content sid replacements', async () => {
+      const template = {
+        types: {
+          ['twilio/media']: {
+            body: 'text body',
+            media: ['http://myimg.com/me.png']
+          }
+        }
+      }
+
+      const notificationReq = new URLSearchParams({
+        Body: template.types['twilio/media'].body,
+        Action: tapAction,
+        Title: title,
+        Sound: sound,
+        Priority: priority,
+        TimeToLive: ttl.toString(),
+        FcmPayload: JSON.stringify({
+          mutable_content: true,
+          notification: {
+            badge: customizations.badgeAmount
+          }
+        }),
+        ApnPayload: JSON.stringify({
+          aps: {
+            'mutable-content': 1,
+            badge: customizations.badgeAmount
+          }
+        }),
+        Recipients: JSON.stringify({
+          apn: [{ addr: 'ios-token-1' }]
+        }),
+        CustomData: JSON.stringify({
+          space_id: spaceId,
+          ...customizations,
+          media: template.types['twilio/media'].media,
+          __segment_internal_external_id_key__: 'ios.push_token',
+          __segment_internal_external_id_value__: 'ios-token-1'
+        })
+      })
+
+      const notifyReqUrl = `https://push.ashburn.us1.twilio.com/v1/Services/${pushServiceSid}/Notifications`
+      nock(`https://content.twilio.com`).get(`/v1/Content/${contentSid}`).reply(200, template)
+      nock(notifyReqUrl).post('', notificationReq.toString()).reply(201, externalIds[0])
+
+      const responses = await testAction({
+        mappingOverrides: {
+          contentSid,
+          customizations: { title, body, tapAction, sound, ttl, priority, ...customizations },
+          externalIds
+        }
+      })
+      expect(responses[1].url).toEqual(notifyReqUrl)
+      expect(responses[1].data).toMatchObject(externalIds[0])
     })
   })
 })

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush/generated-types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush/generated-types.ts
@@ -26,7 +26,7 @@ export interface Payload {
      */
     media?: string[]
     /**
-     * Sets the noitfication click action/category
+     * Sets the notification click action/category
      */
     tapAction?: string
     /**
@@ -53,6 +53,27 @@ export interface Payload {
      * Sets the time to live for the notification
      */
     ttl?: number
+    /**
+     * Sets the buttons to show when interacting with a notification
+     */
+    tapActionButtons?: {
+      /**
+       * Button id
+       */
+      id: string
+      /**
+       * Button text
+       */
+      text: string
+      /**
+       * The action to perform when this button is tapped
+       */
+      onTap: string
+      /**
+       * Deep link or URL to navigate to when this button is tapped
+       */
+      link?: string
+    }[]
   }
   /**
    * Additional custom arguments that will be opaquely sent back on webhook events

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush/index.ts
@@ -47,7 +47,7 @@ const action: ActionDefinition<Settings, Payload> = {
         },
         tapAction: {
           label: 'Notification open action',
-          description: 'Sets the noitfication click action/category',
+          description: 'Sets the notification click action/category',
           type: 'string',
           required: false
         },
@@ -77,6 +77,7 @@ const action: ActionDefinition<Settings, Payload> = {
           label: 'Badge amount',
           description: 'The badge count which is used in combination with badge strategy to determine the final badge',
           type: 'number',
+          default: 1,
           required: false
         },
         badgeStrategy: {
@@ -84,6 +85,7 @@ const action: ActionDefinition<Settings, Payload> = {
           description: 'Sets the badge count strategy in the notification',
           type: 'string',
           required: false,
+          default: 'inc',
           choices: [
             {
               value: 'inc',
@@ -104,6 +106,57 @@ const action: ActionDefinition<Settings, Payload> = {
           description: 'Sets the time to live for the notification',
           type: 'number',
           required: false
+        },
+        tapActionButtons: {
+          label: 'Tap action buttons',
+          description: 'Sets the buttons to show when interacting with a notification',
+          required: false,
+          type: 'object',
+          multiple: true,
+          properties: {
+            id: {
+              label: 'Id',
+              description: 'Button id',
+              type: 'string',
+              required: true
+            },
+            text: {
+              label: 'Text',
+              description: 'Button text',
+              type: 'string',
+              required: true
+            },
+            onTap: {
+              label: 'Tap action',
+              description: 'The action to perform when this button is tapped',
+              type: 'string',
+              required: true,
+              choices: [
+                {
+                  label: 'Open App',
+                  value: 'open_app'
+                },
+                {
+                  label: 'Open URL',
+                  value: 'open_url'
+                },
+                {
+                  label: 'Deep Link',
+                  value: 'deep_link'
+                },
+                {
+                  label: 'Dismiss',
+                  value: 'dismiss'
+                }
+              ]
+            },
+            link: {
+              label: 'Link',
+              description: 'Deep link or URL to navigate to when this button is tapped',
+              type: 'string',
+              required: false
+            }
+          }
         }
       }
     },

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush/push-sender.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush/push-sender.ts
@@ -195,12 +195,15 @@ export class PushSender<Payload extends PushPayload> extends MessageSender<Paylo
       profile
     )
 
+    const badgeAmount = this.payload.customizations?.badgeAmount ?? 1
+    const badgeStrategy = this.payload.customizations?.badgeStrategy ?? 'inc'
+
     try {
       const customData: Record<string, unknown> = this.removeEmpties({
         ...this.payload.customArgs,
         space_id: this.settings.spaceId,
-        badgeAmount: this.payload.customizations?.badgeAmount ?? 1,
-        badgeStrategy: this.payload.customizations?.badgeStrategy ?? 'inc',
+        badgeAmount,
+        badgeStrategy,
         media: parsedTemplateContent.media?.length ? parsedTemplateContent.media : undefined,
         deepLink: this.payload.customizations?.deepLink,
         tapActionButtons: this.payload.customizations?.tapActionButtons
@@ -216,13 +219,13 @@ export class PushSender<Payload extends PushPayload> extends MessageSender<Paylo
         FcmPayload: this.removeEmpties({
           mutable_content: true,
           notification: {
-            badge: this.payload.customizations?.badgeAmount
+            badge: badgeAmount
           }
         }),
         ApnPayload: {
           aps: {
             'mutable-content': 1,
-            badge: this.payload.customizations?.badgeAmount
+            badge: badgeAmount
           }
         }
       })

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush/push-sender.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush/push-sender.ts
@@ -199,10 +199,11 @@ export class PushSender<Payload extends PushPayload> extends MessageSender<Paylo
       const customData: Record<string, unknown> = this.removeEmpties({
         ...this.payload.customArgs,
         space_id: this.settings.spaceId,
-        badgeAmount: this.payload.customizations?.badgeAmount,
-        badgeStrategy: this.payload.customizations?.badgeStrategy,
+        badgeAmount: this.payload.customizations?.badgeAmount ?? 1,
+        badgeStrategy: this.payload.customizations?.badgeStrategy ?? 'inc',
         media: parsedTemplateContent.media?.length ? parsedTemplateContent.media : undefined,
-        deepLink: this.payload.customizations?.deepLink
+        deepLink: this.payload.customizations?.deepLink,
+        tapActionButtons: this.payload.customizations?.tapActionButtons
       })
 
       const body = this.removeEmpties({


### PR DESCRIPTION
[CHANNELS-696](https://segment.atlassian.net/browse/CHANNELS-696)

https://docs.google.com/document/d/146zEWepEmEU_aWylrm8mwQaJyNN0THwBqgIhApGfa00/edit#heading=h.ey172oupso6g

This PR adds the tapActionButtons field to the push notification customData object, and sets defaults for badge amount & badge strategy.

_**NOTE**: this action is not customer facing at the moment._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment


[CHANNELS-696]: https://segment.atlassian.net/browse/CHANNELS-696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ