### PR TITLE
Changed object Id to number

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Testing snapshot for actions-hubspot-cloud destination: sendCustomBehav
 Object {
   "email": "geoli@sekuki.mg",
   "eventName": "NTxWtuPi(z!bOHmgT^*3",
-  "objectId": "NTxWtuPi(z!bOHmgT^*3",
+  "objectId": 80274305979514.88,
   "occurredAt": "2021-02-01T00:00:00.000Z",
   "properties": Object {
     "testType": "NTxWtuPi(z!bOHmgT^*3",

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Testing snapshot for HubSpot's sendCustomBehavioralEvent destination ac
 Object {
   "email": "mur@lumbafat.ad",
   "eventName": "9B#[dv&Iy",
-  "objectId": "9B#[dv&Iy",
+  "objectId": -34888567373168.64,
   "occurredAt": "2021-02-01T00:00:00.000Z",
   "properties": Object {
     "testType": "9B#[dv&Iy",

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/index.test.ts
@@ -21,7 +21,7 @@ describe('HubSpot.sendCustomBehavioralEvent', () => {
       properties: {
         email: 'vep@beri.dz',
         utk: 'abverazffa===1314122f',
-        userId: '802',
+        userId: 802,
         city: 'city'
       }
     })

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/generated-types.ts
@@ -20,7 +20,7 @@ export interface Payload {
   /**
    * The ID of the object associated with this event. This can be the HubSpot contact ID, company ID, or ID of any other object. This is required if no email or user token is provided.
    */
-  objectId?: string
+  objectId?: number
   /**
    * Default or custom properties that describe the event. On the left-hand side, input the internal name of the property as seen in your HubSpot account. On the right-hand side, map the Segment field that contains the value. See more information in [HubSpot’s documentation](https://knowledge.hubspot.com/analytics-tools/create-custom-behavioral-events#add-and-manage-event-properties).
    */

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
@@ -10,7 +10,7 @@ interface CustomBehavioralEvent {
   properties?: { [key: string]: unknown }
   utk?: string
   email?: string
-  objectId?: string
+  objectId?: number
 }
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -57,7 +57,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Object ID',
       description:
         'The ID of the object associated with this event. This can be the HubSpot contact ID, company ID, or ID of any other object. This is required if no email or user token is provided.',
-      type: 'string'
+      type: 'number'
     },
     properties: {
       label: 'Event Properties',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Change the field type to number for ObjectId from Custom Behavioral Event requests. 
As per the API (/events/v3/send), the object Id in payload must be numeric. So, when customer gives string it throws 400 error. To prevent this error, change the type to number in mapping.

JIRA ticket link:-  https://segment.atlassian.net/browse/STRATCONN-2875

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] [Segmenters] Tested in the staging environment

<img width="1505" alt="Screenshot 2023-06-30 at 6 49 57 PM" src="https://github.com/segmentio/action-destinations/assets/117922634/f2e7e9f2-1913-43b6-a4e0-930a84492c19">
