### PR TITLE
Update delete method to a POST

### DIFF
--- a/packages/destination-actions/src/destinations/loops/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/loops/__tests__/index.test.ts
@@ -25,7 +25,7 @@ describe('Loops', () => {
   })
   describe('deletes', () => {
     it('should support gdpr deletes', async () => {
-      nock('https://app.loops.so/api/v1').delete('/contacts/delete').reply(200, {})
+      nock('https://app.loops.so/api/v1').post('/contacts/delete').reply(200, {})
       if (testDestination.onDelete) {
         const response = await testDestination.onDelete(
           { type: 'track', userId: 'sloth@segment.com' },

--- a/packages/destination-actions/src/destinations/loops/index.ts
+++ b/packages/destination-actions/src/destinations/loops/index.ts
@@ -36,7 +36,7 @@ const destination: DestinationDefinition<Settings> = {
   },
   onDelete: async (request, { payload }) => {
     return request('https://app.loops.so/api/v1/contacts/delete', {
-      method: 'DELETE',
+      method: 'POST',
       json: {
         userId: [payload.userId]
       }


### PR DESCRIPTION
We recently changed our contact deletion endpoint to a POST request.

## Testing
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
