### PR TITLE
LiveRamp: add support for hashing

### DIFF
--- a/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -14,18 +14,18 @@ Array [
 `;
 
 exports[`Testing snapshot for LiverampAudiences's audienceEntered destination action: required fields 1`] = `
-"audience_key,testType
-\\"PywYAY\\",\\"PywYAY\\""
+"audience_key,testType,testType
+\\"PywYAY\\",\\"PywYAY\\",\\"7c7ff3a8560d336d69d788505dafaee28b45e77aecd04dd34648e3435865bb38\\""
 `;
 
 exports[`Testing snapshot for LiverampAudiences's audienceEntered destination action: required fields 2`] = `
 Headers {
   Symbol(map): Object {
     "authorization": Array [
-      "AWS4-HMAC-SHA256 Credential=PywYAY/19700101/PywYAY/s3/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-content-sha256;x-amz-date, Signature=0e2838c897a25891722f065e3c21b3592e67626b4a50f2f1ad0f78ad1a7ad524",
+      "AWS4-HMAC-SHA256 Credential=PywYAY/19700101/PywYAY/s3/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-content-sha256;x-amz-date, Signature=e2fe7f56f215ba3c674806db5629bdfffdd3ab2d2b03450c20a219aa713ed8d4",
     ],
     "content-length": Array [
-      "39",
+      "115",
     ],
     "content-type": Array [
       "application/x-www-form-urlencoded; charset=utf-8",
@@ -37,7 +37,7 @@ Headers {
       "Segment (Actions)",
     ],
     "x-amz-content-sha256": Array [
-      "c52b8202716894946461f92ea7d3ae902483d4c0339c06e616618d84bce9d642",
+      "7a49d5af27bc7082b91a53af6cdf36cb91586b219e408b0873a7f4740c7545b8",
     ],
     "x-amz-date": Array [
       "19700101T000012Z",

--- a/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing snapshot for LiverampAudiences's audienceEntered destination action: all fields 1`] = `
-"audience_key,testType
-\\"PywYAY\\",\\"PywYAY\\""
+"audience_key,testType,testType
+\\"PywYAY\\",\\"PywYAY\\",\\"7c7ff3a8560d336d69d788505dafaee28b45e77aecd04dd34648e3435865bb38\\""
 `;
 
 exports[`Testing snapshot for LiverampAudiences's audienceEntered destination action: enquotated indentifier data 1`] = `

--- a/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/snapshot.test.ts
@@ -15,7 +15,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     jest.spyOn(global, 'Date').mockImplementation(() => mockDate as unknown as string)
   })
 
-  it('required fields', async () => {
+  it.only('required fields', async () => {
     const action = destination.actions[actionSlug]
     const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
     eventData.delimiter = ','

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEntered/generated-types.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEntered/generated-types.ts
@@ -6,9 +6,15 @@ export interface Payload {
    */
   audience_key: string
   /**
-   * Additional data pertaining to the user.
+   * Additional data pertaining to the user to be written to the file.
    */
   identifier_data?: {
+    [k: string]: unknown
+  }
+  /**
+   * Additional data pertaining to the user to be hashed before written to the file
+   */
+  unhashed_identifier_data?: {
     [k: string]: unknown
   }
   /**

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEntered/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEntered/index.ts
@@ -19,11 +19,17 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     identifier_data: {
       label: 'Identifier Data',
-      description: `Additional data pertaining to the user.`,
+      description: `Additional data pertaining to the user to be written to the file.`,
       type: 'object',
       required: false,
-      defaultObjectUI: 'keyvalue:only',
-      default: { '@path': '$.context.traits' }
+      defaultObjectUI: 'keyvalue:only'
+    },
+    unhashed_identifier_data: {
+      label: 'Hashable Identifier Data',
+      description: `Additional data pertaining to the user to be hashed before written to the file`,
+      type: 'object',
+      required: false,
+      defaultObjectUI: 'keyvalue:only'
     },
     delimiter: {
       label: 'Delimeter',


### PR DESCRIPTION
https://segment.atlassian.net/browse/STRATCONN-2888

The following PR adds support for specifying which columns of the resulting CSV file should be hashed before sending it in. This is accomplished by having two separate objects, one for unhashed identifier data and one for hashed identifier data.

![image](https://github.com/segmentio/action-destinations/assets/103517471/c6968db9-3243-4a79-b958-dced882251ce)

![image](https://github.com/segmentio/action-destinations/assets/103517471/8ab22bec-cea3-45f9-96f0-7481dcc86494)


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
