### PR TITLE
New integration: Prodeology destination

### DIFF
--- a/packages/destination-actions/src/destinations/prodeology/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/prodeology/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for prodeology destination: group action - all fields 1`] = `
+Object {
+  "anonymousId": "a71QY4",
+  "groupId": "a71QY4",
+  "messageId": "a71QY4",
+  "timestamp": Any<String>,
+  "traits": Object {
+    "testType": "a71QY4",
+  },
+  "userId": "a71QY4",
+}
+`;
+
+exports[`Testing snapshot for prodeology destination: group action - required fields 1`] = `
+Object {
+  "groupId": "a71QY4",
+  "messageId": "a71QY4",
+  "timestamp": Any<String>,
+}
+`;
+
+exports[`Testing snapshot for prodeology destination: identify action - all fields 1`] = `
+Object {
+  "anonymousId": "!r8gRCxrLk6J)@",
+  "messageId": "!r8gRCxrLk6J)@",
+  "timestamp": Any<String>,
+  "traits": Object {
+    "testType": "!r8gRCxrLk6J)@",
+  },
+  "userId": "!r8gRCxrLk6J)@",
+}
+`;
+
+exports[`Testing snapshot for prodeology destination: identify action - required fields 1`] = `
+Object {
+  "messageId": "!r8gRCxrLk6J)@",
+  "timestamp": Any<String>,
+}
+`;
+
+exports[`Testing snapshot for prodeology destination: page action - all fields 1`] = `
+Object {
+  "anonymousId": "gQ$[^Ym^qN!FR[Wh5",
+  "context": Object {
+    "testType": "gQ$[^Ym^qN!FR[Wh5",
+  },
+  "name": "gQ$[^Ym^qN!FR[Wh5",
+  "properties": Object {
+    "testType": "gQ$[^Ym^qN!FR[Wh5",
+  },
+  "timestamp": Any<String>,
+  "userId": "gQ$[^Ym^qN!FR[Wh5",
+}
+`;
+
+exports[`Testing snapshot for prodeology destination: page action - required fields 1`] = `
+Object {
+  "timestamp": Any<String>,
+}
+`;
+
+exports[`Testing snapshot for prodeology destination: track action - all fields 1`] = `
+Object {
+  "anonymousId": "FnC)K2zK8xDyxn!Hr",
+  "context": Object {
+    "testType": "FnC)K2zK8xDyxn!Hr",
+  },
+  "event": "FnC)K2zK8xDyxn!Hr",
+  "messageId": "FnC)K2zK8xDyxn!Hr",
+  "properties": Object {
+    "testType": "FnC)K2zK8xDyxn!Hr",
+  },
+  "timestamp": Any<String>,
+  "userId": "FnC)K2zK8xDyxn!Hr",
+}
+`;
+
+exports[`Testing snapshot for prodeology destination: track action - required fields 1`] = `
+Object {
+  "event": "FnC)K2zK8xDyxn!Hr",
+  "messageId": "FnC)K2zK8xDyxn!Hr",
+  "timestamp": Any<String>,
+}
+`;

--- a/packages/destination-actions/src/destinations/prodeology/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/prodeology/__tests__/index.test.ts
@@ -1,0 +1,22 @@
+import nock from 'nock';
+import { createTestIntegration } from '@segment/actions-core';
+import Definition from '../index';
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Prodeology', () => {
+  describe('testAuthentication', () => {
+    it('should validate authentication inputs', async () => {
+      nock('https://api-dev.prodeology.com/api/v1/event-collection/validate-api-key')
+        .get(/.*/)
+        .matchHeader('authorization', `Basic api-key`)
+        .reply(200, {})
+
+      const authData = {
+        apiKey: 'api-key'
+      }
+
+      await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/prodeology/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/prodeology/__tests__/snapshot.test.ts
@@ -1,0 +1,81 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'prodeology'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot({
+          timestamp: expect.any(String)
+        })
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot({
+          timestamp: expect.any(String)
+        })
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/prodeology/generated-types.ts
+++ b/packages/destination-actions/src/destinations/prodeology/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your Prodeology API Key
+   */
+  apiKey: string
+}

--- a/packages/destination-actions/src/destinations/prodeology/group/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/prodeology/group/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Prodeology's group destination action: all fields 1`] = `
+Object {
+  "anonymousId": "vn$doX7fYns)$aV",
+  "groupId": "vn$doX7fYns)$aV",
+  "messageId": "vn$doX7fYns)$aV",
+  "timestamp": Any<String>,
+  "traits": Object {
+    "testType": "vn$doX7fYns)$aV",
+  },
+  "userId": "vn$doX7fYns)$aV",
+}
+`;
+
+exports[`Testing snapshot for Prodeology's group destination action: required fields 1`] = `
+Object {
+  "groupId": "vn$doX7fYns)$aV",
+  "messageId": "vn$doX7fYns)$aV",
+  "timestamp": Any<String>,
+}
+`;

--- a/packages/destination-actions/src/destinations/prodeology/group/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/prodeology/group/__tests__/index.test.ts
@@ -1,0 +1,27 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Prodeology.group', () => {
+  it('should work', async () => {
+    nock('https://api-dev.prodeology.com/api/v1').post('/event-collection/group').reply(200, {})
+
+    const responses = await testDestination.testAction('group', {
+      mapping: {
+        anonymousId: 'my-anonymous-id',
+        groupId: 'my-group-id',
+        timestamp: '2021-01-01T00:00:00.000Z',
+        messageId: 'message-id'
+      },
+      settings: { apiKey: 'api-key' }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.body).toContain('my-anonymous-id')
+    expect(responses[0].options.body).toContain('my-group-id')
+  })
+})

--- a/packages/destination-actions/src/destinations/prodeology/group/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/prodeology/group/__tests__/snapshot.test.ts
@@ -1,0 +1,79 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'group'
+const destinationSlug = 'Prodeology'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot({
+        timestamp: expect.any(String)
+      })
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot({
+        timestamp: expect.any(String)
+      })
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/prodeology/group/generated-types.ts
+++ b/packages/destination-actions/src/destinations/prodeology/group/generated-types.ts
@@ -1,0 +1,30 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Anonymous id
+   */
+  anonymousId?: string
+  /**
+   * The ID associated with the user
+   */
+  userId?: string
+  /**
+   * The group id
+   */
+  groupId: string
+  /**
+   * Traits to associate with the group
+   */
+  traits?: {
+    [k: string]: unknown
+  }
+  /**
+   * The timestamp of the event
+   */
+  timestamp: string
+  /**
+   * The Segment messageId
+   */
+  messageId: string
+}

--- a/packages/destination-actions/src/destinations/prodeology/group/index.ts
+++ b/packages/destination-actions/src/destinations/prodeology/group/index.ts
@@ -1,0 +1,66 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Group',
+  description: 'Group user in Prodeology',
+  defaultSubscription: 'type = "group"',
+  fields: {
+    anonymousId: {
+      type: 'string',
+      description: 'Anonymous id',
+      label: 'Anonymous ID',
+      default: { '@path': '$.anonymousId' }
+    },
+    userId: {
+      type: 'string',
+      description: 'The ID associated with the user',
+      label: 'User ID',
+      default: { '@path': '$.userId' }
+    },
+    groupId: {
+      type: 'string',
+      description: 'The group id',
+      label: 'Group ID',
+      required: true,
+      default: { '@path': '$.groupId' }
+    },
+    traits: {
+      type: 'object',
+      label: 'Traits',
+      description: 'Traits to associate with the group',
+      default: { '@path': '$.traits' }
+    },
+    timestamp: {
+      type: 'string',
+      format: 'date-time',
+      required: true,
+      description: 'The timestamp of the event',
+      label: 'Timestamp',
+      default: { '@path': '$.timestamp' }
+    },
+    messageId: {
+      type: 'string',
+      required: true,
+      description: 'The Segment messageId',
+      label: 'MessageId',
+      default: { '@path': '$.messageId' }
+    }
+  },
+  perform: (request, { payload }) => {
+    return request('https://api-dev.prodeology.com/api/v1/event-collection/group', {
+      method: 'post',
+      json: {
+        anonymousId: payload.anonymousId,
+        userId: payload.userId,
+        groupId: payload.groupId,
+        traits: payload.traits,
+        messageId: payload.messageId,
+        timestamp: payload.timestamp
+      }
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/prodeology/identify/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/prodeology/identify/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Prodeology's identify destination action: all fields 1`] = `
+Object {
+  "anonymousId": "[0xsdYE9W(c$m",
+  "messageId": "[0xsdYE9W(c$m",
+  "timestamp": Any<String>,
+  "traits": Object {
+    "testType": "[0xsdYE9W(c$m",
+  },
+  "userId": "[0xsdYE9W(c$m",
+}
+`;
+
+exports[`Testing snapshot for Prodeology's identify destination action: required fields 1`] = `
+Object {
+  "messageId": "[0xsdYE9W(c$m",
+  "timestamp": Any<String>,
+}
+`;

--- a/packages/destination-actions/src/destinations/prodeology/identify/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/prodeology/identify/__tests__/index.test.ts
@@ -1,0 +1,22 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Prodeology.identify', () => {
+  it('should work', async () => {
+    nock('https://api-dev.prodeology.com/api/v1').post('/event-collection/identify').reply(200, {})
+
+    const responses = await testDestination.testAction('identify', {
+      mapping: { anonymousId: 'my-id', traits: {}, timestamp: '2021-01-01T00:00:00.000Z', messageId: 'message-id' },
+      settings: { apiKey: 'api-key' }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.body).toContain('my-id')
+    expect(responses[0].options.body).toContain('traits')
+  })
+})

--- a/packages/destination-actions/src/destinations/prodeology/identify/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/prodeology/identify/__tests__/snapshot.test.ts
@@ -1,0 +1,79 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'identify'
+const destinationSlug = 'Prodeology'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot({
+        timestamp: expect.any(String)
+      })
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot({
+        timestamp: expect.any(String)
+      })
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/prodeology/identify/generated-types.ts
+++ b/packages/destination-actions/src/destinations/prodeology/identify/generated-types.ts
@@ -1,0 +1,26 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * An anonymous identifier
+   */
+  anonymousId?: string
+  /**
+   * The ID associated with the user
+   */
+  userId?: string
+  /**
+   * Traits to associate with the user
+   */
+  traits?: {
+    [k: string]: unknown
+  }
+  /**
+   * The timestamp of the event
+   */
+  timestamp: string
+  /**
+   * The Segment messageId
+   */
+  messageId: string
+}

--- a/packages/destination-actions/src/destinations/prodeology/identify/index.ts
+++ b/packages/destination-actions/src/destinations/prodeology/identify/index.ts
@@ -1,0 +1,59 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Identify',
+  description: 'Identify user in Prodeology',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    anonymousId: {
+      type: 'string',
+      description: 'An anonymous identifier',
+      label: 'Anonymous ID',
+      default: { '@path': '$.anonymousId' }
+    },
+    userId: {
+      type: 'string',
+      description: 'The ID associated with the user',
+      label: 'User ID',
+      default: { '@path': '$.userId' }
+    },
+    traits: {
+      type: 'object',
+      label: 'Traits',
+      description: 'Traits to associate with the user',
+      required: false,
+      default: { '@path': '$.traits' }
+    },
+    timestamp: {
+      type: 'string',
+      format: 'date-time',
+      required: true,
+      description: 'The timestamp of the event',
+      label: 'Timestamp',
+      default: { '@path': '$.timestamp' }
+    },
+    messageId: {
+      type: 'string',
+      required: true,
+      description: 'The Segment messageId',
+      label: 'MessageId',
+      default: { '@path': '$.messageId' }
+    }
+  },
+  perform: (request, { payload }) => {
+    return request('https://api-dev.prodeology.com/api/v1/event-collection/identify', {
+      method: 'post',
+      json: {
+        anonymousId: payload.anonymousId,
+        userId: payload.userId,
+        traits: payload.traits,
+        messageId: payload.messageId,
+        timestamp: payload.timestamp
+      }
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/prodeology/index.ts
+++ b/packages/destination-actions/src/destinations/prodeology/index.ts
@@ -34,7 +34,7 @@ const presets: DestinationDefinition['presets'] = [
 ]
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Prodeology',
+  name: 'actions-prodeology',
   slug: 'prodeology-actions',
   mode: 'cloud',
 

--- a/packages/destination-actions/src/destinations/prodeology/index.ts
+++ b/packages/destination-actions/src/destinations/prodeology/index.ts
@@ -1,0 +1,70 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+import { defaultValues } from '@segment/actions-core'
+import track from './track'
+import page from './page'
+import identify from './identify'
+import group from './group'
+
+const presets: DestinationDefinition['presets'] = [
+  {
+    name: 'Track Calls',
+    subscribe: 'type = "track"',
+    partnerAction: 'track',
+    mapping: defaultValues(track.fields)
+  },
+  {
+    name: 'Page Calls',
+    subscribe: 'type = "page"',
+    partnerAction: 'page',
+    mapping: defaultValues(page.fields)
+  },
+  {
+    name: 'Identify Calls',
+    subscribe: 'type = "identify"',
+    partnerAction: 'identify',
+    mapping: defaultValues(identify.fields)
+  },
+  {
+    name: 'Group Calls',
+    subscribe: 'type = "group"',
+    partnerAction: 'group',
+    mapping: defaultValues(group.fields)
+  }
+]
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Prodeology',
+  slug: 'prodeology-actions',
+  mode: 'cloud',
+
+  extendRequest: ({ settings }) => {
+    return {
+      headers: { Authorization: `Basic ${settings.apiKey}`, 'Content-Type': 'application/json' }
+    }
+  },
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      apiKey: {
+        label: 'API Key',
+        description: 'Your Prodeology API Key',
+        type: 'string',
+        required: true
+      }
+    },
+    testAuthentication: (request) => {
+      return request('https://api-dev.prodeology.com/api/v1/event-collection/validate-api-key', { method: 'GET' })
+    }
+  },
+  presets,
+  actions: {
+    track,
+    identify,
+    group,
+    page
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/prodeology/index.ts
+++ b/packages/destination-actions/src/destinations/prodeology/index.ts
@@ -50,7 +50,7 @@ const destination: DestinationDefinition<Settings> = {
       apiKey: {
         label: 'API Key',
         description: 'Your Prodeology API Key',
-        type: 'string',
+        type: 'password',
         required: true
       }
     },

--- a/packages/destination-actions/src/destinations/prodeology/index.ts
+++ b/packages/destination-actions/src/destinations/prodeology/index.ts
@@ -34,8 +34,8 @@ const presets: DestinationDefinition['presets'] = [
 ]
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'actions-prodeology',
-  slug: 'prodeology-actions',
+  name: 'Prodeology',
+  slug: 'actions-prodeology',
   mode: 'cloud',
 
   extendRequest: ({ settings }) => {

--- a/packages/destination-actions/src/destinations/prodeology/page/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/prodeology/page/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Prodeology's page destination action: all fields 1`] = `
+Object {
+  "anonymousId": "UsTN]PKjU",
+  "context": Object {
+    "testType": "UsTN]PKjU",
+  },
+  "name": "UsTN]PKjU",
+  "properties": Object {
+    "testType": "UsTN]PKjU",
+  },
+  "timestamp": Any<String>,
+  "userId": "UsTN]PKjU",
+}
+`;
+
+exports[`Testing snapshot for Prodeology's page destination action: required fields 1`] = `
+Object {
+  "timestamp": Any<String>,
+}
+`;

--- a/packages/destination-actions/src/destinations/prodeology/page/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/prodeology/page/__tests__/index.test.ts
@@ -1,0 +1,29 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Prodeology.page', () => {
+  it('should work', async () => {
+    nock('https://api-dev.prodeology.com/api/v1').post('/event-collection/page').reply(200, {})
+
+    const responses = await testDestination.testAction('page', {
+      mapping: {
+        anonymousId: 'my-id',
+        properties: {},
+        name: 'page-name',
+        timestamp: '2021-01-01T00:00:00.000Z',
+        messageId: 'message-id'
+      },
+      settings: { apiKey: 'api-key' }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.body).toContain('my-id')
+    expect(responses[0].options.body).toContain('properties')
+    expect(responses[0].options.body).toContain('page-name')
+  })
+})

--- a/packages/destination-actions/src/destinations/prodeology/page/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/prodeology/page/__tests__/snapshot.test.ts
@@ -1,0 +1,79 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'page'
+const destinationSlug = 'Prodeology'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot({
+        timestamp: expect.any(String)
+      })
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot({
+        timestamp: expect.any(String)
+      })
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/prodeology/page/generated-types.ts
+++ b/packages/destination-actions/src/destinations/prodeology/page/generated-types.ts
@@ -1,0 +1,36 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * An anonymous identifier
+   */
+  anonymousId?: string
+  /**
+   * The ID associated with the user
+   */
+  userId?: string
+  /**
+   * Page properties
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+  /**
+   * The name of the page
+   */
+  name?: string
+  /**
+   * Context properties to send with the event
+   */
+  context?: {
+    [k: string]: unknown
+  }
+  /**
+   * The timestamp of the event
+   */
+  timestamp: string
+  /**
+   * The Segment messageId
+   */
+  messageId?: string
+}

--- a/packages/destination-actions/src/destinations/prodeology/page/index.ts
+++ b/packages/destination-actions/src/destinations/prodeology/page/index.ts
@@ -1,0 +1,74 @@
+import { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Page Event',
+  description: 'Send a page event to Prodeology.',
+  defaultSubscription: 'type = "page"',
+  fields: {
+    anonymousId: {
+      type: 'string',
+      description: 'An anonymous identifier',
+      label: 'Anonymous ID',
+      default: { '@path': '$.anonymousId' }
+    },
+    userId: {
+      type: 'string',
+      description: 'The ID associated with the user',
+      label: 'User ID',
+      default: { '@path': '$.userId' }
+    },
+    properties: {
+      type: 'object',
+      required: false,
+      description: 'Page properties',
+      label: 'Properties',
+      default: { '@path': '$.properties' }
+    },
+    name: {
+      type: 'string',
+      required: false,
+      description: 'The name of the page',
+      label: 'Page Name',
+      default: { '@path': '$.properties.name' }
+    },
+    context: {
+      type: 'object',
+      required: false,
+      description: 'Context properties to send with the event',
+      label: 'Context properties',
+      default: { '@path': '$.context' }
+    },
+    timestamp: {
+      type: 'string',
+      format: 'date-time',
+      required: true,
+      description: 'The timestamp of the event',
+      label: 'Timestamp',
+      default: { '@path': '$.timestamp' }
+    },
+    messageId: {
+      type: 'string',
+      required: false,
+      description: 'The Segment messageId',
+      label: 'MessageId',
+      default: { '@path': '$.messageId' }
+    }
+  },
+  perform: (request, { payload }) => {
+    return request('https://api-dev.prodeology.com/api/v1/event-collection/page', {
+      method: 'POST',
+      json: {
+        anonymousId: payload.anonymousId,
+        userId: payload.userId,
+        properties: payload.properties,
+        name: payload.name,
+        context: payload.context,
+        timestamp: payload.timestamp
+      }
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/prodeology/track/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/prodeology/track/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Prodeology's track destination action: all fields 1`] = `
+Object {
+  "anonymousId": "c^vP[G2edJi33c",
+  "context": Object {
+    "testType": "c^vP[G2edJi33c",
+  },
+  "event": "c^vP[G2edJi33c",
+  "messageId": "c^vP[G2edJi33c",
+  "properties": Object {
+    "testType": "c^vP[G2edJi33c",
+  },
+  "timestamp": Any<String>,
+  "userId": "c^vP[G2edJi33c",
+}
+`;
+
+exports[`Testing snapshot for Prodeology's track destination action: required fields 1`] = `
+Object {
+  "event": "c^vP[G2edJi33c",
+  "messageId": "c^vP[G2edJi33c",
+  "timestamp": Any<String>,
+}
+`;

--- a/packages/destination-actions/src/destinations/prodeology/track/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/prodeology/track/__tests__/index.test.ts
@@ -1,0 +1,29 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Prodeology.track', () => {
+  it('should work', async () => {
+    nock('https://api-dev.prodeology.com/api/v1').post('/event-collection/track').reply(200, {})
+
+    const responses = await testDestination.testAction('track', {
+      mapping: {
+        anonymousId: 'anonymous-id',
+        event: 'event-name',
+        userId: 'user-id',
+        timestamp: '2021-01-01T00:00:00.000Z',
+        messageId: 'message-id'
+      },
+      settings: { apiKey: 'api-key' }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.body).toContain('anonymous-id')
+    expect(responses[0].options.body).toContain('event-name')
+    expect(responses[0].options.body).toContain('user-id')
+  })
+})

--- a/packages/destination-actions/src/destinations/prodeology/track/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/prodeology/track/__tests__/snapshot.test.ts
@@ -1,0 +1,79 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'track'
+const destinationSlug = 'Prodeology'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot({
+        timestamp: expect.any(String)
+      })
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot({
+        timestamp: expect.any(String)
+      })
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/prodeology/track/generated-types.ts
+++ b/packages/destination-actions/src/destinations/prodeology/track/generated-types.ts
@@ -1,0 +1,36 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The event name
+   */
+  event: string
+  /**
+   * Properties to send with the event
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+  /**
+   * The timestamp of the event
+   */
+  timestamp: string
+  /**
+   * The anonymous ID associated with the user
+   */
+  anonymousId?: string
+  /**
+   * The ID associated with the user
+   */
+  userId?: string
+  /**
+   * Context properties to send with the event
+   */
+  context?: {
+    [k: string]: unknown
+  }
+  /**
+   * The Segment messageId
+   */
+  messageId: string
+}

--- a/packages/destination-actions/src/destinations/prodeology/track/index.ts
+++ b/packages/destination-actions/src/destinations/prodeology/track/index.ts
@@ -1,0 +1,77 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Track Event',
+  description: 'Send an event to Prodeology.',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    event: {
+      type: 'string',
+      required: true,
+      description: 'The event name',
+      label: 'Event Name',
+      default: { '@path': '$.event' }
+    },
+    properties: {
+      type: 'object',
+      required: false,
+      description: 'Properties to send with the event',
+      label: 'Event properties',
+      default: { '@path': '$.properties' }
+    },
+    timestamp: {
+      type: 'string',
+      format: 'date-time',
+      required: true,
+      description: 'The timestamp of the event',
+      label: 'Timestamp',
+      default: { '@path': '$.timestamp' }
+    },
+    anonymousId: {
+      type: 'string',
+      required: false,
+      description: 'The anonymous ID associated with the user',
+      label: 'Anonymous ID',
+      default: { '@path': '$.anonymousId' }
+    },
+    userId: {
+      type: 'string',
+      required: false,
+      description: 'The ID associated with the user',
+      label: 'User ID',
+      default: { '@path': '$.userId' }
+    },
+    context: {
+      type: 'object',
+      required: false,
+      description: 'Context properties to send with the event',
+      label: 'Context properties',
+      default: { '@path': '$.context' }
+    },
+    messageId: {
+      type: 'string',
+      required: true,
+      description: 'The Segment messageId',
+      label: 'MessageId',
+      default: { '@path': '$.messageId' }
+    }
+  },
+  perform: (request, { payload }) => {
+    return request('https://api-dev.prodeology.com/api/v1/event-collection/track', {
+      method: 'POST',
+      json: {
+        event: payload.event,
+        properties: payload.properties,
+        timestamp: payload.timestamp,
+        userId: payload.userId,
+        anonymousId: payload.anonymousId,
+        context: payload.context,
+        messageId: payload.messageId
+      }
+    })
+  }
+}
+
+export default action


### PR DESCRIPTION
This PR adds [Prodeology](https://app.prodeology.com/) as a new destination.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
