### PR TITLE
Added error in case email, utk and object is not provided

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -13,11 +13,7 @@ Object {
 }
 `;
 
-exports[`Testing snapshot for actions-hubspot-cloud destination: sendCustomBehavioralEvent action - required fields 1`] = `
-Object {
-  "eventName": "NTxWtuPi(z!bOHmgT^*3",
-}
-`;
+exports[`Testing snapshot for actions-hubspot-cloud destination: sendCustomBehavioralEvent action - required fields 1`] = `[PayloadValidationError: One of the following parameters: email, user token, or objectId is required]`;
 
 exports[`Testing snapshot for actions-hubspot-cloud destination: upsertCompany action - all fields 1`] = `
 Object {

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/__snapshots__/index.test.ts.snap
@@ -5,7 +5,7 @@ Object {
   "email": undefined,
   "eventName": "pe22596207_test_event_http",
   "objectId": undefined,
-  "occurredAt": "2023-07-04T10:19:44.569Z",
+  "occurredAt": "2023-07-04T10:25:44.778Z",
   "properties": Object {
     "hs_city": "city",
   },

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/__snapshots__/index.test.ts.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HubSpot.sendCustomBehavioralEvent One of email, utk or objectId is provided 1`] = `
+Object {
+  "email": undefined,
+  "eventName": "pe22596207_test_event_http",
+  "objectId": undefined,
+  "occurredAt": "2023-07-04T10:19:44.569Z",
+  "properties": Object {
+    "hs_city": "city",
+  },
+  "utk": "abverazffa===1314122f",
+}
+`;

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/index.test.ts
@@ -165,4 +165,52 @@ describe('HubSpot.sendCustomBehavioralEvent', () => {
       }
     })
   })
+
+  test('should fail when email, utk and objectId is not provided', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      event: 'pe22596207_test_event_http',
+      properties: {
+        city: 'city'
+      }
+    })
+
+    const expectedPayload = {
+      eventName: event.event,
+      occurredAt: event.timestamp as string,
+      utk: event.properties?.utk,
+      email: event.properties?.email,
+      objectId: event.properties?.userId,
+      properties: {
+        hs_city: event.properties?.city
+      }
+    }
+
+    const mapping = {
+      eventName: {
+        '@path': '$.event'
+      },
+      utk: {
+        '@path': '$.properties.utk'
+      },
+      objectId: {
+        '@path': '$.properties.userId'
+      },
+      properties: {
+        hs_city: {
+          '@path': '$.properties.city'
+        }
+      }
+    }
+
+    nock(HUBSPOT_BASE_URL).post('/events/v3/send', expectedPayload).reply(400, {})
+
+    return expect(
+      testDestination.testAction('sendCustomBehavioralEvent', {
+        event,
+        useDefaultMappings: true,
+        mapping: mapping
+      })
+    ).rejects.toThrowError('One of the following parameters: email, user token, or objectId is required')
+  })
 })

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/index.test.ts
@@ -221,7 +221,8 @@ describe('HubSpot.sendCustomBehavioralEvent', () => {
       properties: {
         utk: 'abverazffa===1314122f',
         city: 'city'
-      }
+      },
+      timestamp: '2023-07-04T10:25:44.778Z'
     })
 
     const expectedPayload = {

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/index.test.ts
@@ -213,4 +213,55 @@ describe('HubSpot.sendCustomBehavioralEvent', () => {
       })
     ).rejects.toThrowError('One of the following parameters: email, user token, or objectId is required')
   })
+
+  it('One of email, utk or objectId is provided', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      event: 'pe22596207_test_event_http',
+      properties: {
+        utk: 'abverazffa===1314122f',
+        city: 'city'
+      }
+    })
+
+    const expectedPayload = {
+      eventName: event.event,
+      occurredAt: event.timestamp as string,
+      utk: event.properties?.utk,
+      email: event.properties?.email,
+      objectId: event.properties?.userId,
+      properties: {
+        hs_city: event.properties?.city
+      }
+    }
+
+    const mapping = {
+      eventName: {
+        '@path': '$.event'
+      },
+      utk: {
+        '@path': '$.properties.utk'
+      },
+      objectId: {
+        '@path': '$.properties.userId'
+      },
+      properties: {
+        hs_city: {
+          '@path': '$.properties.city'
+        }
+      }
+    }
+
+    nock(HUBSPOT_BASE_URL).post('/events/v3/send', expectedPayload).reply(204, {})
+
+    const responses = await testDestination.testAction('sendCustomBehavioralEvent', {
+      event,
+      useDefaultMappings: true,
+      mapping: mapping
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(204)
+    expect(responses[0].options.json).toMatchSnapshot()
+  })
 })

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
@@ -1,4 +1,4 @@
-import type { ActionDefinition } from '@segment/actions-core'
+import { ActionDefinition, PayloadValidationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import { HUBSPOT_BASE_URL } from '../properties'
 import type { Payload } from './generated-types'
@@ -76,6 +76,11 @@ const action: ActionDefinition<Settings, Payload> = {
       objectId: payload.objectId,
       properties: flattenObject(payload.properties)
     }
+
+    if (!payload.utk && !payload.email && !payload.objectId) {
+      throw new PayloadValidationError(`One of the following parameters: email, user token, or objectId is required`)
+    }
+
     return request(`${HUBSPOT_BASE_URL}/events/v3/send`, {
       method: 'post',
       json: event


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Custom Behavioural Event requires one of email, utk or objectId. HubSpot returns a 4xx status error in this case with error message email, utk, or objectId is required.  Added PayloadValidationError if none of them found in action.

JIRA ticket link:- https://segment.atlassian.net/browse/STRATCONN-2896

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)

<img width="1474" alt="Screenshot 2023-07-03 at 10 35 08 PM" src="https://github.com/segmentio/action-destinations/assets/117922634/fa53ed69-b0fb-4851-b39e-218d12ea3bd9">
