### PR TITLE
Added m3ter destination action

### DIFF
--- a/packages/destination-actions/src/destinations/m3ter/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/m3ter/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for m3ter destination: submitMeasurements action - all fields 1`] = `
+Object {
+  "measurements": Array [
+    Object {
+      "account": "7]OvxqYNmsgZb1Gg3$5f",
+      "cost": Object {
+        "testType": "7]OvxqYNmsgZb1Gg3$5f",
+      },
+      "enable_batching": false,
+      "ets": "2021-02-01T00:00:00.000Z",
+      "income": Object {
+        "testType": "7]OvxqYNmsgZb1Gg3$5f",
+      },
+      "measure": Object {
+        "testType": "7]OvxqYNmsgZb1Gg3$5f",
+      },
+      "metadata": Object {
+        "testType": "7]OvxqYNmsgZb1Gg3$5f",
+      },
+      "meter": "7]OvxqYNmsgZb1Gg3$5f",
+      "other": Object {
+        "testType": "7]OvxqYNmsgZb1Gg3$5f",
+      },
+      "ts": "2021-02-01T00:00:00.000Z",
+      "uid": "7]OvxqYNmsgZb1Gg3$5f",
+      "what": Object {
+        "testType": "7]OvxqYNmsgZb1Gg3$5f",
+      },
+      "where": Object {
+        "testType": "7]OvxqYNmsgZb1Gg3$5f",
+      },
+      "who": Object {
+        "testType": "7]OvxqYNmsgZb1Gg3$5f",
+      },
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for m3ter destination: submitMeasurements action - required fields 1`] = `
+Object {
+  "measurements": Array [
+    Object {
+      "account": "7]OvxqYNmsgZb1Gg3$5f",
+      "enable_batching": false,
+      "meter": "7]OvxqYNmsgZb1Gg3$5f",
+      "ts": "2021-02-01T00:00:00.000Z",
+      "uid": "7]OvxqYNmsgZb1Gg3$5f",
+    },
+  ],
+}
+`;

--- a/packages/destination-actions/src/destinations/m3ter/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/m3ter/__tests__/index.test.ts
@@ -1,0 +1,60 @@
+import { createTestIntegration, ExecuteInput } from '@segment/actions-core'
+import Definition from '../index'
+import { Settings } from '../generated-types'
+import { M3TER_AUTH_API, USER_AGENT_HEADER } from '../constants'
+import nock from 'nock'
+import { AccessTokenResponse } from '../auth'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('m3ter', () => {
+  const settings: Settings = {
+    access_key_id: 'validAccessKeyId',
+    api_secret: 'validApiSecret',
+    org_id: 'someOrgId'
+  }
+  describe('testAuthentication', () => {
+    it('should correctly authenticate given correct settings ', async function() {
+      const response: AccessTokenResponse = {
+        'token_type': 'bearer',
+        'access_token': 'someTokenValue',
+        expires_in: 122222222
+      }
+      nock(M3TER_AUTH_API)
+        .post(`/oauth/token`, '{"grant_type":"client_credentials"}')
+        .matchHeader('authorization', `Basic ${Buffer.from(`${settings.access_key_id}:${settings.api_secret}`).toString('base64')}`)
+        .matchHeader('Content-Type', 'application/json')
+        .reply(200, response)
+
+      await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()
+    })
+    it('should throw exception if auth has failed', async function() {
+      const response = {
+        'error': 'invalid_request',
+        'error_description': 'Invalid Credentials'
+      }
+      nock(M3TER_AUTH_API)
+        .post(`/oauth/token`, '{"grant_type":"client_credentials"}')
+        .matchHeader('authorization', `Basic ${Buffer.from(`${settings.access_key_id}:${settings.api_secret}`).toString('base64')}`)
+        .matchHeader('Content-Type', 'application/json')
+        .reply(401, response)
+
+      await expect(testDestination.testAuthentication(settings)).rejects.toThrowError()
+    })
+  })
+  describe('extendRequest', () => {
+    it('should populate headers with Bearer authentication and User-Agent', async () => {
+      const accessToken = 'validAccessToken'
+      const authData: Partial<ExecuteInput<Settings, any>> = {
+        auth: {
+          accessToken,
+          refreshToken: ''
+        }
+      }
+      const extendedRequest = testDestination.extendRequest?.(authData as ExecuteInput<Settings, any>)
+
+      expect(extendedRequest?.headers?.['Authorization']).toContain(`Bearer ${accessToken}`)
+      expect(extendedRequest?.headers?.['User-Agent']).toContain(USER_AGENT_HEADER)
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/m3ter/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/m3ter/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'm3ter'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/m3ter/auth.ts
+++ b/packages/destination-actions/src/destinations/m3ter/auth.ts
@@ -1,0 +1,20 @@
+import { M3TER_AUTH_API } from './constants'
+import { RequestClient } from '@segment/actions-core'
+
+export interface AccessTokenResponse {
+  token_type: string
+  access_token: string
+  expires_in: number
+}
+
+export default async function getAccessToken(request: RequestClient, accessKeyId: string, apiSecret: string): Promise<string> {
+  const res = await request<AccessTokenResponse>(`${M3TER_AUTH_API}/oauth/token`, {
+    method: 'POST',
+    body: '{"grant_type":"client_credentials"}',
+    headers: {
+      authorization: `Basic ${Buffer.from(`${accessKeyId}:${apiSecret}`).toString('base64')}`,
+      'Content-Type': 'application/json'
+    }
+  })
+  return res.data.access_token
+}

--- a/packages/destination-actions/src/destinations/m3ter/constants.ts
+++ b/packages/destination-actions/src/destinations/m3ter/constants.ts
@@ -1,0 +1,4 @@
+export const M3TER_AUTH_API = 'https://api.m3ter.com'
+export const M3TER_INGEST_API = 'https://ingest.m3ter.com'
+export const MAX_MEASUREMENTS_PER_BATCH = 1000
+export const USER_AGENT_HEADER = 'segment-destination/1.0'

--- a/packages/destination-actions/src/destinations/m3ter/generated-types.ts
+++ b/packages/destination-actions/src/destinations/m3ter/generated-types.ts
@@ -1,0 +1,16 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your service user Access Key Id. You can generate the service user and its Access Key Id in your m3ter console under "Settings" -> "Access" -> "Service Users" -> "Create Service User". Step by step guide can be found in [m3ter Docs](https://www.m3ter.com/docs/guides/authenticating-with-the-platform/service-authentication#generating-an-api-key-and-secret-for-a-service-user)
+   */
+  access_key_id: string
+  /**
+   * Your service user Api Secret. You can generate the service user and its Api Secret in your m3ter console under "Settings" -> "Access" -> "Service Users" -> "Create Service User". Step by step guide can be found in [m3ter Docs](https://www.m3ter.com/docs/guides/authenticating-with-the-platform/service-authentication#generating-an-api-key-and-secret-for-a-service-user)
+   */
+  api_secret: string
+  /**
+   * ID of your organization where your data will be submitted to
+   */
+  org_id: string
+}

--- a/packages/destination-actions/src/destinations/m3ter/index.ts
+++ b/packages/destination-actions/src/destinations/m3ter/index.ts
@@ -1,0 +1,67 @@
+import type { Settings } from './generated-types'
+
+import submitMeasurements from './submitMeasurements'
+import getAccessToken from './auth'
+import { USER_AGENT_HEADER } from './constants'
+import { defaultValues, DestinationDefinition } from '@segment/actions-core'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'm3ter',
+  slug: 'actions-m3ter',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'oauth2',
+    fields: {
+      access_key_id: {
+        label: 'm3ter Access Key Id',
+        description: 'Your service user Access Key Id. You can generate the service user and its Access Key Id in your m3ter console under "Settings" -> "Access" -> "Service Users" -> "Create Service User".' +
+          ' Step by step guide can be found in [m3ter Docs](https://www.m3ter.com/docs/guides/authenticating-with-the-platform/service-authentication#generating-an-api-key-and-secret-for-a-service-user)',
+        type: 'string',
+        required: true
+      },
+      api_secret: {
+        label: 'm3ter Api Secret',
+        description: 'Your service user Api Secret. You can generate the service user and its Api Secret in your m3ter console under "Settings" -> "Access" -> "Service Users" -> "Create Service User".' +
+          ' Step by step guide can be found in [m3ter Docs](https://www.m3ter.com/docs/guides/authenticating-with-the-platform/service-authentication#generating-an-api-key-and-secret-for-a-service-user)',
+        type: 'password',
+        required: true
+      },
+      org_id: {
+        label: 'm3ter Organization Id',
+        description: 'ID of your organization where your data will be submitted to',
+        type: 'string',
+        required: true
+      }
+    },
+    testAuthentication: async (request, { settings }) => {
+      const accessToken = await getAccessToken(request, settings.access_key_id, settings.api_secret)
+      return { accessToken: accessToken }
+    },
+    refreshAccessToken: async (request, { settings }) => {
+      const accessToken = await getAccessToken(request, settings.access_key_id, settings.api_secret)
+      return { accessToken: accessToken }
+    }
+  },
+  extendRequest({ auth }) {
+    return {
+      headers: {
+        'Authorization': `Bearer ${auth?.accessToken}`,
+        'User-Agent': USER_AGENT_HEADER
+      }
+    }
+  },
+  actions: {
+    submitMeasurements
+  },
+  presets: [
+    {
+      name: 'Submit usage data to m3ter',
+      subscribe: submitMeasurements.defaultSubscription as string,
+      partnerAction: 'submitMeasurements',
+      mapping: defaultValues(submitMeasurements.fields)
+    }
+  ]
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/m3ter/submitMeasurements/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/m3ter/submitMeasurements/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for m3ter's submitMeasurements destination action: all fields 1`] = `
+Object {
+  "measurements": Array [
+    Object {
+      "account": "7]OvxqYNmsgZb1Gg3$5f",
+      "cost": Object {
+        "testType": "7]OvxqYNmsgZb1Gg3$5f",
+      },
+      "enable_batching": false,
+      "ets": "2021-02-01T00:00:00.000Z",
+      "income": Object {
+        "testType": "7]OvxqYNmsgZb1Gg3$5f",
+      },
+      "measure": Object {
+        "testType": "7]OvxqYNmsgZb1Gg3$5f",
+      },
+      "metadata": Object {
+        "testType": "7]OvxqYNmsgZb1Gg3$5f",
+      },
+      "meter": "7]OvxqYNmsgZb1Gg3$5f",
+      "other": Object {
+        "testType": "7]OvxqYNmsgZb1Gg3$5f",
+      },
+      "ts": "2021-02-01T00:00:00.000Z",
+      "uid": "7]OvxqYNmsgZb1Gg3$5f",
+      "what": Object {
+        "testType": "7]OvxqYNmsgZb1Gg3$5f",
+      },
+      "where": Object {
+        "testType": "7]OvxqYNmsgZb1Gg3$5f",
+      },
+      "who": Object {
+        "testType": "7]OvxqYNmsgZb1Gg3$5f",
+      },
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for m3ter's submitMeasurements destination action: required fields 1`] = `
+Object {
+  "measurements": Array [
+    Object {
+      "account": "7]OvxqYNmsgZb1Gg3$5f",
+      "enable_batching": false,
+      "meter": "7]OvxqYNmsgZb1Gg3$5f",
+      "ts": "2021-02-01T00:00:00.000Z",
+      "uid": "7]OvxqYNmsgZb1Gg3$5f",
+    },
+  ],
+}
+`;

--- a/packages/destination-actions/src/destinations/m3ter/submitMeasurements/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/m3ter/submitMeasurements/__tests__/index.test.ts
@@ -1,0 +1,134 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { M3TER_INGEST_API, MAX_MEASUREMENTS_PER_BATCH } from '../../constants'
+
+const testDestination = createTestIntegration(Destination)
+
+const orgId = '9d105e27-78d5-21f1-d212-5451a1e500cd'
+const access_token = 'validAccessToken'
+const SETTINGS = {
+  access_key_id: 'validKey',
+  api_secret: 'validSecret',
+  org_id: orgId
+}
+describe('m3ter.submitMeasurements', () => {
+  it('should submitMeasurement', async () => {
+    nock(M3TER_INGEST_API)
+      .post(`/organizations/${orgId}/measurements`)
+      .matchHeader('Authorization', `Bearer ${access_token}`)
+      .reply(200, { 'result': 'accepted' })
+
+    const event = createTestEvent({
+      type: 'track',
+      event: 'UsageRecorded',
+      properties: {
+        uid: '0059915c-dea7-4682-b06d-52f315b12f5e',
+        meter: 'meterCode',
+        account: 'accountCode',
+        ts: '2012-04-23T18:25:43.511Z'
+      }
+    })
+
+    const response = await testDestination.testAction('submitMeasurements', {
+      event,
+      settings: SETTINGS,
+      auth: { accessToken: access_token, refreshToken: 'someRefreshToken' },
+      mapping: {
+        uid: {
+          '@path': '$.properties.uid'
+        },
+        meter: {
+          '@path': '$.properties.meter'
+        },
+        account: {
+          '@path': '$.properties.account'
+        },
+        ts: {
+          '@path': '$.properties.ts'
+        },
+        enable_batching: false
+      }
+    })
+    expect(response[0].status).toBe(200)
+    expect(await response[0].request.json()).toMatchObject({
+      'measurements': [{
+        uid: event?.properties?.uid,
+        meter: event?.properties?.meter,
+        account: event?.properties?.account,
+        ts: event?.properties?.ts
+      }]
+    })
+  })
+  it('should submitMeasurement in a batch', async () => {
+    nock(M3TER_INGEST_API)
+      .post(`/organizations/${orgId}/measurements`)
+      .times(2)
+      .matchHeader('Authorization', `Bearer ${access_token}`)
+      .reply(200, { 'result': 'accepted' })
+
+
+    const event = createTestEvent({
+      type: 'track',
+      event: 'UsageRecorded',
+      properties: {
+        uid: '0059915c-dea7-4682-b06d-52f315b12f5e',
+        meter: 'meterCode',
+        account: 'accountCode',
+        ts: '2012-04-23T18:25:43.511Z'
+      }
+    })
+    const eventsExceedingMaxBatch = 10
+    const response = await testDestination.testBatchAction('submitMeasurements', {
+      events: Array(MAX_MEASUREMENTS_PER_BATCH + eventsExceedingMaxBatch).fill(event),
+      settings: SETTINGS,
+      auth: { accessToken: access_token, refreshToken: 'someRefreshToken' },
+      mapping: {
+        uid: {
+          '@path': '$.properties.uid'
+        },
+        meter: {
+          '@path': '$.properties.meter'
+        },
+        account: {
+          '@path': '$.properties.account'
+        },
+        ts: {
+          '@path': '$.properties.ts'
+        },
+        enable_batching: true
+      }
+    })
+    expect(response[0].status).toBe(200)
+    expect(await response[0].request.json()).toMatchObject({
+      'measurements': Array(MAX_MEASUREMENTS_PER_BATCH).fill({
+        uid: event?.properties?.uid,
+        meter: event?.properties?.meter,
+        account: event?.properties?.account,
+        ts: event?.properties?.ts
+      })
+    })
+
+    expect(response[1].status).toBe(200)
+    expect(await response[1].request.json()).toMatchObject({
+      'measurements': Array(eventsExceedingMaxBatch).fill({
+        uid: event?.properties?.uid,
+        meter: event?.properties?.meter,
+        account: event?.properties?.account,
+        ts: event?.properties?.ts
+      })
+    })
+  })
+
+  it('should throw error when missing required field', async () => {
+    const event = createTestEvent()
+    await expect(
+      testDestination.testAction('submitMeasurements', {
+        event,
+        settings: SETTINGS,
+        auth: { accessToken: access_token, refreshToken: 'someRefreshToken' },
+        useDefaultMappings: true
+      })
+    ).rejects.toThrow()
+  })
+})

--- a/packages/destination-actions/src/destinations/m3ter/submitMeasurements/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/m3ter/submitMeasurements/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'submitMeasurements'
+const destinationSlug = 'm3ter'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/m3ter/submitMeasurements/generated-types.ts
+++ b/packages/destination-actions/src/destinations/m3ter/submitMeasurements/generated-types.ts
@@ -1,0 +1,72 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Unique ID for this measurement
+   */
+  uid: string
+  /**
+   * Short code identifying the Meter the measurement is for
+   */
+  meter: string
+  /**
+   * Code of the Account the measurement is for
+   */
+  account: string
+  /**
+   * Timestamp for the measurement
+   */
+  ts: string | number
+  /**
+   * End timestamp for the measurement. Can be used in the case a usage event needs to have an explicit start and end rather than being instantaneous
+   */
+  ets?: string | number
+  /**
+   * Non-numeric who values for data measurements, such as: who logged-in to the service; who was contacted by the service
+   */
+  who?: {
+    [k: string]: unknown
+  }
+  /**
+   * Non-numeric where values for data measurements such as: where someone logged into your service from
+   */
+  where?: {
+    [k: string]: unknown
+  }
+  /**
+   * Non-numeric what values for data measurements such as: what level of user logged into the service
+   */
+  what?: {
+    [k: string]: unknown
+  }
+  /**
+   * Non-numeric other values for measurements such as textual data which is not applicable to Who, What, or Where events
+   */
+  other?: {
+    [k: string]: unknown
+  }
+  /**
+   * Non-numeric metadata values for measurements using high-cardinality fields that you don't intend to segment when you aggregate the data
+   */
+  metadata?: {
+    [k: string]: unknown
+  }
+  /**
+   * Numeric measure values for general quantitative measurements.
+   */
+  measure?: {
+    [k: string]: unknown
+  }
+  /**
+   * Numeric cost values for measurements associated with costs
+   */
+  cost?: {
+    [k: string]: unknown
+  }
+  /**
+   * Numeric income values for measurements associated with income
+   */
+  income?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/m3ter/submitMeasurements/index.ts
+++ b/packages/destination-actions/src/destinations/m3ter/submitMeasurements/index.ts
@@ -1,0 +1,121 @@
+import type { ActionDefinition, ModifiedResponse, RequestClient } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { M3TER_INGEST_API, MAX_MEASUREMENTS_PER_BATCH } from '../constants'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Submit Measurements',
+  description: 'Submits your measurements data to m3ter',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    uid: {
+      label: 'm3ter UUID',
+      type: 'string',
+      description: 'Unique ID for this measurement',
+      required: true
+    },
+    meter: {
+      label: 'Meter',
+      type: 'string',
+      description: 'Short code identifying the Meter the measurement is for',
+      required: true
+    },
+    account: {
+      label: 'Account',
+      type: 'string',
+      description: 'Code of the Account the measurement is for',
+      required: true
+    },
+    ts: {
+      label: 'Timestamp',
+      type: 'datetime',
+      description: 'Timestamp for the measurement',
+      required: true
+    },
+    ets: {
+      label: 'End timestamp',
+      type: 'datetime',
+      description: 'End timestamp for the measurement. Can be used in the case a usage event needs to have an explicit start and end rather than being instantaneous',
+      required: false
+    },
+    who: {
+      label: 'Who',
+      type: 'object',
+      description: 'Non-numeric who values for data measurements, such as: who logged-in to the service; who was contacted by the service',
+      required: false
+    },
+    where: {
+      label: 'Where',
+      type: 'object',
+      description: 'Non-numeric where values for data measurements such as: where someone logged into your service from',
+      required: false
+    },
+    what: {
+      label: 'What',
+      type: 'object',
+      description: 'Non-numeric what values for data measurements such as: what level of user logged into the service',
+      required: false
+    },
+    other: {
+      label: 'Other',
+      type: 'object',
+      description: 'Non-numeric other values for measurements such as textual data which is not applicable to Who, What, or Where events',
+      required: false
+    },
+    metadata: {
+      label: 'Metadata',
+      type: 'object',
+      description: 'Non-numeric metadata values for measurements using high-cardinality fields that you don\'t intend to segment when you aggregate the data',
+      required: false
+    },
+    measure: {
+      label: 'Measure',
+      type: 'object',
+      description: 'Numeric measure values for general quantitative measurements.',
+      required: false
+    },
+    cost: {
+      label: 'Cost',
+      type: 'object',
+      description: 'Numeric cost values for measurements associated with costs',
+      required: false
+    },
+    income: {
+      label: 'Income',
+      type: 'object',
+      description: 'Numeric income values for measurements associated with income',
+      required: false
+    },
+    enable_batching: {
+      type: 'boolean',
+      label: 'Send data to m3ter in batches',
+      description: 'When enabled the action will send multiple events in a single API request, improving efficiency. This is m3ter’s recommended mode.',
+      required: true,
+      default: true
+    }
+  },
+  perform: async (request, { settings, payload }) => {
+    return submitMeasurements(request, settings.org_id, [payload])
+  },
+  performBatch: async (request, { settings, payload }) => {
+    return submitMeasurements(request, settings.org_id, payload)
+  }
+}
+
+async function submitMeasurements(request: RequestClient, orgId: string, payload: Payload[]): Promise<ModifiedResponse[]> {
+  const batches = [...limitBatch(payload)]
+  const requests = batches.map(batch =>
+    request(`${M3TER_INGEST_API}/organizations/${orgId}/measurements`, {
+      method: 'post',
+      json: { 'measurements': batch }
+    }))
+  return Promise.all(requests)
+}
+
+function* limitBatch<T>(arr: T[]): Generator<T[], void> {
+  for (let index = 0; index < arr.length; index += MAX_MEASUREMENTS_PER_BATCH) {
+    yield arr.slice(index, index + MAX_MEASUREMENTS_PER_BATCH)
+  }
+}
+
+export default action


### PR DESCRIPTION
This adds [m3ter](https://www.m3ter.com/) cloud destination, so that we can support customers that want to submit their usage data to m3ter based on segment events.

The destination uses oath to [authenticate with m3ter](https://www.m3ter.com/docs/guides/authenticating-with-the-platform/service-authentication)

Destination includes the `Submit Measurements` action which translates to [SubmitMeasurements](https://www.m3ter.com/docs/api#tag/Measurements/operation/SubmitMeasurements)  m3ter API operation. It will transform the segment event to m3ter measurement and submit it via REST API. The action supports batching and if possible it should be the prefered way of using the action. By default the action subscribes to [track](https://segment.com/docs/connections/spec/track/) events however its up to the customer to configure different event types if their usage data comes from different events.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
