### PR TITLE
add configurable default request timeout

### DIFF
--- a/packages/core/src/create-request-client.ts
+++ b/packages/core/src/create-request-client.ts
@@ -1,7 +1,7 @@
 import addBasicAuthHeader from './middleware/before-request/add-basic-auth-header'
 import prepareHeaders from './middleware/after-response/prepare-headers'
 import prepareResponse from './middleware/after-response/prepare-response'
-import createInstance, { AllRequestOptions, RequestOptions } from './request-client'
+import createInstance, { AllRequestOptions, RequestOptions, DEFAULT_REQUEST_TIMEOUT } from './request-client'
 import type { ModifiedResponse } from './types'
 
 export interface ResponseError extends Error {
@@ -9,7 +9,7 @@ export interface ResponseError extends Error {
 }
 
 const baseClient = createInstance({
-  timeout: 10000,
+  timeout: DEFAULT_REQUEST_TIMEOUT,
   headers: {
     'user-agent': 'Segment (Actions)'
   },

--- a/packages/core/src/request-client.ts
+++ b/packages/core/src/request-client.ts
@@ -5,6 +5,20 @@ import { isObject } from './real-type-of'
 import type https from 'https'
 import { StatsContext } from './destination-kit'
 
+const defaultRequestTimeout = 10_000
+// making this configurable will allow some environments to support a longer/shorter timeout
+if (
+  globalThis.process != null &&
+  typeof globalThis.process.env === 'object' &&
+  globalThis.process.env.DEFAULT_REQUEST_TIMEOUT
+) {
+  const parsedDefaultTimeout = parseInt(globalThis.process.env.DEFAULT_REQUEST_TIMEOUT, 10)
+  if (!Number.isNaN(parsedDefaultTimeout) && parsedDefaultTimeout > 0) {
+    defaultRequestTimeout
+  }
+}
+export const DEFAULT_REQUEST_TIMEOUT = defaultRequestTimeout
+
 /**
  * The supported request options you can use with the request client
  */
@@ -242,7 +256,7 @@ class RequestClient {
       ...options,
       method: getRequestMethod(options.method ?? 'get'),
       throwHttpErrors: options.throwHttpErrors !== false,
-      timeout: options.timeout ?? 10000
+      timeout: options.timeout ?? DEFAULT_REQUEST_TIMEOUT
     } as NormalizedOptions
 
     // Timeout support. Use our own abort controller so consumers can pass in their own `signal`


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

In order to support bulk batches, we need to be able to extend the default timeout for the requests. This is more of a proposal for the change and I am open to changes/suggestions.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

Tested as part of: https://github.com/segmentio/integrations/pull/2674

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
