### PR TITLE
Rename push link

### DIFF
--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/__tests__/send-mobile-push.test.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/__tests__/send-mobile-push.test.ts
@@ -36,7 +36,7 @@ const testAction = createTestAction({
     customizations: {
       title: customizationTitle,
       tapAction: null,
-      deepLink: null,
+      link: null,
       sound: null,
       priority: null,
       badgeAmount: null,
@@ -467,7 +467,7 @@ describe('sendMobilePush action', () => {
       badgeAmount: 3,
       badgeStrategy: 'dec',
       media: ['http://myimg.com/product.png'],
-      deepLink: 'app://propducts-view',
+      link: 'app://propducts-view',
       tapActionButtons: [
         {
           id: '1',

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush/generated-types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush/generated-types.ts
@@ -66,7 +66,7 @@ export interface Payload {
        */
       text: string
       /**
-       * The action to perform when this button is tapped
+       * The action to perform when this button is tapped. open_app, open_url, deep_link, dismiss, or a custom string
        */
       onTap: string
       /**

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush/generated-types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush/generated-types.ts
@@ -26,13 +26,13 @@ export interface Payload {
      */
     media?: string[]
     /**
-     * Sets the notification click action/category
+     * Sets the notification click action/category: open_app, open_url, deep_link, dismiss, or a custom string
      */
     tapAction?: string
     /**
-     * Sets the deep link
+     * Deep link or URL to navigate to when the notification is tapped
      */
-    deepLink?: string
+    link?: string
     /**
      * Sets the sound played when the notification arrives
      */
@@ -66,7 +66,7 @@ export interface Payload {
        */
       text: string
       /**
-       * The action to perform when this button is tapped. open_app, open_url, deep_link, dismiss, or a custom string
+       * The action to perform when this button is tapped: open_app, open_url, deep_link, dismiss, or a custom string
        */
       onTap: string
       /**

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush/index.ts
@@ -47,13 +47,14 @@ const action: ActionDefinition<Settings, Payload> = {
         },
         tapAction: {
           label: 'Notification open action',
-          description: 'Sets the notification click action/category',
+          description:
+            'Sets the notification click action/category: open_app, open_url, deep_link, dismiss, or a custom string',
           type: 'string',
           required: false
         },
         link: {
-          label: 'Notification title',
-          description: 'Deep link or URL to navigate to when this button is tapped',
+          label: 'Notification Link',
+          description: 'Deep link or URL to navigate to when the notification is tapped',
           type: 'string',
           required: false
         },
@@ -129,7 +130,7 @@ const action: ActionDefinition<Settings, Payload> = {
             onTap: {
               label: 'Tap action',
               description:
-                'The action to perform when this button is tapped. open_app, open_url, deep_link, dismiss, or a custom string ',
+                'The action to perform when this button is tapped: open_app, open_url, deep_link, dismiss, or a custom string',
               type: 'string',
               required: true
             },

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush/index.ts
@@ -51,9 +51,9 @@ const action: ActionDefinition<Settings, Payload> = {
           type: 'string',
           required: false
         },
-        deepLink: {
+        link: {
           label: 'Notification title',
-          description: 'Sets the deep link',
+          description: 'Deep link or URL to navigate to when this button is tapped',
           type: 'string',
           required: false
         },
@@ -128,27 +128,10 @@ const action: ActionDefinition<Settings, Payload> = {
             },
             onTap: {
               label: 'Tap action',
-              description: 'The action to perform when this button is tapped',
+              description:
+                'The action to perform when this button is tapped. open_app, open_url, deep_link, dismiss, or a custom string ',
               type: 'string',
-              required: true,
-              choices: [
-                {
-                  label: 'Open App',
-                  value: 'open_app'
-                },
-                {
-                  label: 'Open URL',
-                  value: 'open_url'
-                },
-                {
-                  label: 'Deep Link',
-                  value: 'deep_link'
-                },
-                {
-                  label: 'Dismiss',
-                  value: 'dismiss'
-                }
-              ]
+              required: true
             },
             link: {
               label: 'Link',

--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush/push-sender.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush/push-sender.ts
@@ -205,7 +205,7 @@ export class PushSender<Payload extends PushPayload> extends MessageSender<Paylo
         badgeAmount,
         badgeStrategy,
         media: parsedTemplateContent.media?.length ? parsedTemplateContent.media : undefined,
-        deepLink: this.payload.customizations?.deepLink,
+        link: this.payload.customizations?.link,
         tapActionButtons: this.payload.customizations?.tapActionButtons
       })
 


### PR DESCRIPTION
This PR renames deepLink to link in the mobile push fields. This allows us flexibility in storing a regular url or a deeplink in that field.

<img width="941" alt="Screenshot 2023-07-07 at 12 30 09 PM" src="https://github.com/segmentio/action-destinations/assets/119889384/82e27370-9149-4bb1-8bfd-14f2664f32a6">


**NOTE:** This action is not customer facing yet.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
