### PR TITLE
[TikTok Audiences] fix normalization of emails

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-audiences/addUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addUser/__tests__/index.test.ts
@@ -38,7 +38,7 @@ const updateUsersRequestBody = {
   batch_data: [
     [
       {
-        id: '44d206f60172cd898051a9fb2174750aee1eca00f6f63f12801b90644321e342',
+        id: '584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777',
         audience_ids: ['1234345']
       },
       {

--- a/packages/destination-actions/src/destinations/tiktok-audiences/addUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addUser/__tests__/index.test.ts
@@ -68,6 +68,40 @@ describe('TiktokAudiences.addUser', () => {
     ).resolves.not.toThrowError()
   })
 
+  it('should normalize and hash emails correctly', async () => {
+    nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`)
+      .post(/.*/, {
+        advertiser_ids: ['123'],
+        action: 'add',
+        id_schema: ['EMAIL_SHA256'],
+        batch_data: [
+          [
+            {
+              id: '584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777',
+              audience_ids: ['1234345']
+            }
+          ]
+        ]
+      })
+      .reply(200)
+    const responses = await testDestination.testAction('addUser', {
+      event,
+      settings: {
+        advertiser_ids: ['123']
+      },
+      useDefaultMappings: true,
+      auth,
+      mapping: {
+        selected_advertiser_id: '123',
+        audience_id: '1234345',
+        send_advertising_id: false
+      }
+    })
+    expect(responses[0].options.body).toMatchInlineSnapshot(
+      `"{\\"advertiser_ids\\":[\\"123\\"],\\"action\\":\\"add\\",\\"id_schema\\":[\\"EMAIL_SHA256\\"],\\"batch_data\\":[[{\\"id\\":\\"584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777\\",\\"audience_ids\\":[\\"1234345\\"]}]]}"`
+    )
+  })
+
   it('should fail if an audience id is invalid', async () => {
     nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`).post(/.*/, updateUsersRequestBody).reply(400)
 

--- a/packages/destination-actions/src/destinations/tiktok-audiences/functions.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/functions.ts
@@ -97,7 +97,10 @@ export function extractUsers(payloads: GenericPayload[]): {}[][] {
     if (payload.send_email === true) {
       let email_id = {}
       if (payload.email) {
-        payload.email = payload.email.replace(/\+.*@/, '@').replace(/\./g, '').toLowerCase()
+        payload.email = payload.email
+          .replace(/\+.*@/, '@')
+          .replace(/\.(?=.*@)/g, '')
+          .toLowerCase()
         email_id = {
           id: createHash('sha256').update(payload.email).digest('hex'),
           audience_ids: [payload.audience_id]

--- a/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/__tests__/index.test.ts
@@ -38,7 +38,7 @@ const updateUsersRequestBody = {
   batch_data: [
     [
       {
-        id: '44d206f60172cd898051a9fb2174750aee1eca00f6f63f12801b90644321e342',
+        id: '584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777',
         audience_ids: ['1234345']
       },
       {


### PR DESCRIPTION
Upon investigation we found that our email normalization is removing all of the periods in an email instead of just the ones before the @ symbol. For example we would take we would take this `local-part.123+suffix @domain.com` and normalize it to `local-part123@domaincom` but it should be `local-part123@domain.com`

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
