### PR TITLE
Add createAudience/getAudience support in testing-cli

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -167,7 +167,7 @@ curl --location --request POST 'http://localhost:3000/authentication' \
 
 ### Example request to test createAudience() and getAudience()
 
-You can test the createAudience and getAudience methods as well. Use the commands bellow as an example and populate the
+You can test the createAudience and getAudience methods as well. Use the commands below as an example and populate the
 settings according to the needs of your destination.
 
 **createAudience**

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -165,6 +165,37 @@ curl --location --request POST 'http://localhost:3000/authentication' \
 }'
 ```
 
+### Example request to test createAudience() and getAudience()
+
+You can test the createAudience and getAudience methods as well. Use the commands bellow as an example and populate the
+settings according to the needs of your destination.
+
+**createAudience**
+
+```sh
+curl --location 'http://localhost:3000/createAudience' \
+--header 'Content-Type: application/json' \
+--data '{
+    "settings": {
+        "createAudienceUrl": "http://localhost:4242"
+    },
+    "audienceName": "The Super Mario Brothers Super Audience"
+}'
+```
+
+**getAudience**
+
+```sh
+curl --location 'http://localhost:3000/getAudience' \
+--header 'Content-Type: application/json' \
+--data '{
+    "settings": {
+        "getAudienceUrl": "http://localhost:4242/getAudience"
+    },
+    "externalId": 21
+}'
+```
+
 ## Unit Testing
 
 When building a destination action, you should write unit and end-to-end tests to ensure your action is working as intended. Tests are automatically run on every commit in Github Actions. Pull requests that do not include relevant tests will not be approved.

--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -147,6 +147,9 @@ app.use((req, res, next) => {
 function setupRoutes(def: DestinationDefinition | null): void {
   const destination = new Destination(def as CloudDestinationDefinition)
   const supportsDelete = destination.onDelete
+  const audienceSettings = destination?.definition.audienceSettings !== undefined
+  const supportsCreateAudience = !!(audienceSettings && destination.createAudience)
+  const supportsGetAudience = !!(audienceSettings && destination.getAudience)
 
   const router = express.Router()
 
@@ -203,6 +206,44 @@ function setupRoutes(def: DestinationDefinition | null): void {
       }
     })
   )
+
+  if (supportsCreateAudience) {
+    router.post(
+      '/createAudience',
+      asyncHandler(async (req: express.Request, res: express.Response) => {
+        try {
+          const data = await destination.createAudience(req.body)
+          res.status(200).json(data)
+        } catch (e) {
+          const error = e as HTTPError
+          const message = (await error?.response?.json()) ?? error.message
+          res.status(400).json({
+            ok: false,
+            error: message
+          })
+        }
+      })
+    )
+  }
+
+  if (supportsGetAudience) {
+    router.post(
+      '/getAudience',
+      asyncHandler(async (req: express.Request, res: express.Response) => {
+        try {
+          const data = await destination.getAudience(req.body)
+          res.status(200).json(data)
+        } catch (e) {
+          const error = e as HTTPError
+          const message = (await error?.response?.json()) ?? error.message
+          res.status(400).json({
+            ok: false,
+            error: message
+          })
+        }
+      })
+    )
+  }
 
   router.post(
     '/refreshAccessToken',


### PR DESCRIPTION
This PR adds support for createAudience/getAudience from the testing-cli. It only exposes these methods if the destination supports it. I included a couple of examples in how to use it.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
