### PR TITLE
Fix ./bin/run generate:action for browser

### DIFF
--- a/packages/cli/src/commands/generate/action.ts
+++ b/packages/cli/src/commands/generate/action.ts
@@ -50,9 +50,10 @@ export default class GenerateAction extends Command {
 
   async run() {
     const { args, flags } = this.parseArgs()
+    const isBrowserDestination = (args.type as string).includes('browser')
     let integrationsGlob = './packages/destination-actions/src/destinations/*'
-    if ((args.type as string).includes('browser')) {
-      integrationsGlob = './packages/browser-destinations/src/destinations/*'
+    if (isBrowserDestination) {
+      integrationsGlob = './packages/browser-destinations/destinations/*'
     }
     const integrationDirs = await this.integrationDirs(integrationsGlob)
 
@@ -70,9 +71,10 @@ export default class GenerateAction extends Command {
         message: 'Which integration (directory)?',
         choices: integrationDirs.map((integrationPath) => {
           const [name] = integrationPath.split(path.sep).reverse()
+          const value = isBrowserDestination ? path.join(integrationPath, 'src') : integrationPath;
           return {
             title: name,
-            value: integrationPath
+            value: value
           }
         })
       }


### PR DESCRIPTION
The `bin/run generate:action NAME browser` CLI command was broken due to a difference in the `browser-destinations` and `destination-actions` file structure.

```
packages/
|-- browser-destionations/
|   `-- destinations/
|       `-- braze/
|           `-- src/
|               |-- trackEvent/
|               |-- index.ts
|               `-- package.json
`-- destination-actions/
    `-- src/
        `-- destinations/
            `-- braze/
                |-- trackEvent/
                `-- index.ts
```
          
For this reason, the CLI was exiting (silently) when trying to build and update the browser-destinations path.

## Testing

After this proposed change, I tested scaffolding browser and server actions successfully.

<img width="503" alt="image" src="https://github.com/segmentio/action-destinations/assets/7410770/58f59c4c-d179-4067-b7e9-8a2a11023267">

