### PR TITLE
Fix ./bin/run serve for browser destinations

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -46,7 +46,7 @@ export default class Serve extends Command {
   async run() {
     const { argv, flags } = this.parse(Serve)
     let destinationName = flags.destination
-
+    const isBrowser = !!flags.browser
     if (!destinationName) {
       const integrationsGlob = `${flags.directory}/*`
       const integrationDirs = await globby(integrationsGlob, {
@@ -62,9 +62,10 @@ export default class Serve extends Command {
         message: 'Which destination?',
         choices: integrationDirs.map((integrationPath) => {
           const [name] = integrationPath.split(path.sep).reverse()
+          const destinationPath = isBrowser ? path.join(name, 'src') : name
           return {
             title: name,
-            value: { name }
+            value: { name: destinationPath }
           }
         })
       })


### PR DESCRIPTION
similar to https://github.com/segmentio/action-destinations/pull/1397

The `./bin/run serve` CLI command was broken due to a difference in the browser-destinations and destination-actions file structure.

```
packages/
|-- browser-destionations/
|   `-- destinations/
|       `-- braze/
|           `-- src/
|               |-- trackEvent/
|               |-- index.ts
|               `-- package.json
`-- destination-actions/
    `-- src/
        `-- destinations/
            `-- braze/
                |-- trackEvent/
                `-- index.ts
```

For this reason, the CLI  serve command  exits (silently) when trying to load browser destinations.

## Testing
After this proposed change, I tested scaffolding browser and server actions successfully.

Before:
<img width="830" alt="image" src="https://github.com/segmentio/action-destinations/assets/7410770/321177f3-fe12-48f8-a520-c49c11bb0f1e">

After:
<img width="798" alt="image" src="https://github.com/segmentio/action-destinations/assets/7410770/1abe109b-dc95-44e4-8ab2-3e20f8793b21">

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
