### PR TITLE
Integration of Rehook as a new destination in Segment

### DIFF
--- a/packages/destination-actions/src/destinations/rehook/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/rehook/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -12,9 +12,6 @@ Object {
 
 exports[`Testing snapshot for actions-rehook destination: identifyUser action - required fields 1`] = `
 Object {
-  "metadata": Object {
-    "testType": "POZi46v3T29EjRK])q8",
-  },
   "source_id": "POZi46v3T29EjRK])q8",
 }
 `;
@@ -32,9 +29,6 @@ Object {
 exports[`Testing snapshot for actions-rehook destination: trackEvent action - required fields 1`] = `
 Object {
   "event_name": "tPnhwFBXwdz)OE8P]1",
-  "metadata": Object {
-    "testType": "tPnhwFBXwdz)OE8P]1",
-  },
   "source_id": "tPnhwFBXwdz)OE8P]1",
 }
 `;

--- a/packages/destination-actions/src/destinations/rehook/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/rehook/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-rehook destination: identifyUser action - all fields 1`] = `
+Object {
+  "metadata": Object {
+    "testType": "POZi46v3T29EjRK])q8",
+  },
+  "referral_code": "POZi46v3T29EjRK])q8",
+  "source_id": "POZi46v3T29EjRK])q8",
+}
+`;
+
+exports[`Testing snapshot for actions-rehook destination: identifyUser action - required fields 1`] = `
+Object {
+  "metadata": Object {
+    "testType": "POZi46v3T29EjRK])q8",
+  },
+  "source_id": "POZi46v3T29EjRK])q8",
+}
+`;
+
+exports[`Testing snapshot for actions-rehook destination: trackEvent action - all fields 1`] = `
+Object {
+  "event_name": "tPnhwFBXwdz)OE8P]1",
+  "metadata": Object {
+    "testType": "tPnhwFBXwdz)OE8P]1",
+  },
+  "source_id": "tPnhwFBXwdz)OE8P]1",
+}
+`;
+
+exports[`Testing snapshot for actions-rehook destination: trackEvent action - required fields 1`] = `
+Object {
+  "event_name": "tPnhwFBXwdz)OE8P]1",
+  "metadata": Object {
+    "testType": "tPnhwFBXwdz)OE8P]1",
+  },
+  "source_id": "tPnhwFBXwdz)OE8P]1",
+}
+`;

--- a/packages/destination-actions/src/destinations/rehook/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/rehook/__tests__/index.test.ts
@@ -1,0 +1,23 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+
+const api_key = 'API_KEY'
+const api_secret = 'API_SECRET'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Rehook', () => {
+  describe('testAuthentication', () => {
+    it('should validate authentication inputs', async () => {
+      nock('https://api.rehook.ai').get('/events/segment/check-auth').reply(200, { status: 'ok' })
+
+      const settings = {
+        api_key: api_key,
+        api_secret: api_secret
+      }
+
+      await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/rehook/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/rehook/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-rehook'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/rehook/generated-types.ts
+++ b/packages/destination-actions/src/destinations/rehook/generated-types.ts
@@ -1,0 +1,12 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your Rehook API Key
+   */
+  api_key: string
+  /**
+   * Your Rehook API Secret
+   */
+  api_secret: string
+}

--- a/packages/destination-actions/src/destinations/rehook/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/rehook/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Rehook's identifyUser destination action: all fields 1`] = `
+Object {
+  "metadata": Object {
+    "testType": "R(qF3CS",
+  },
+  "referral_code": "R(qF3CS",
+  "source_id": "R(qF3CS",
+}
+`;
+
+exports[`Testing snapshot for Rehook's identifyUser destination action: required fields 1`] = `
+Object {
+  "metadata": Object {
+    "testType": "R(qF3CS",
+  },
+  "source_id": "R(qF3CS",
+}
+`;

--- a/packages/destination-actions/src/destinations/rehook/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/rehook/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -12,9 +12,6 @@ Object {
 
 exports[`Testing snapshot for Rehook's identifyUser destination action: required fields 1`] = `
 Object {
-  "metadata": Object {
-    "testType": "R(qF3CS",
-  },
   "source_id": "R(qF3CS",
 }
 `;

--- a/packages/destination-actions/src/destinations/rehook/identifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/rehook/identifyUser/__tests__/index.test.ts
@@ -1,0 +1,42 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+const REHOOK_API_KEY = 'SOME_API_KEY'
+const REHOOK_API_SECRET = 'SOME_API_SECRET'
+
+describe('Rehook.identifyUser', () => {
+  it('should validate action fields', async () => {
+    const event = createTestEvent({ traits: { name: 'abc' } })
+
+    nock(`https://api.rehook.ai`).post(`/customers`).reply(200, {})
+
+    const responses = await testDestination.testAction('identifyUser', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        api_key: REHOOK_API_KEY,
+        api_secret: REHOOK_API_SECRET
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.body).toBe(`{"source_id":"user1234","metadata":{"name":"abc"}}`)
+  })
+
+  it('should require api_id and api_key', async () => {
+    const event = createTestEvent()
+    nock(`https://api.rehook.ai`).post(`/customers`).reply(200, {})
+
+    await expect(
+      testDestination.testAction('identifyUser', {
+        event,
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError('Missing API KEY or API SECRET')
+  })
+})

--- a/packages/destination-actions/src/destinations/rehook/identifyUser/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/rehook/identifyUser/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'identifyUser'
+const destinationSlug = 'Rehook'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/rehook/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/rehook/identifyUser/generated-types.ts
@@ -8,7 +8,7 @@ export interface Payload {
   /**
    * Properties to set on the user profile
    */
-  metadata: {
+  metadata?: {
     [k: string]: unknown
   }
   /**

--- a/packages/destination-actions/src/destinations/rehook/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/rehook/identifyUser/generated-types.ts
@@ -1,0 +1,18 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The unique user identifier set by you
+   */
+  source_id: string
+  /**
+   * Properties to set on the user profile
+   */
+  metadata: {
+    [k: string]: unknown
+  }
+  /**
+   * The referral code of the user
+   */
+  referral_code?: string | null
+}

--- a/packages/destination-actions/src/destinations/rehook/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/rehook/identifyUser/index.ts
@@ -26,11 +26,7 @@ const action: ActionDefinition<Settings, Payload> = {
       required: true,
       description: 'Properties to set on the user profile',
       default: {
-        '@if': {
-          exists: { '@path': '$.traits' },
-          then: { '@path': '$.traits' },
-          else: { '@path': '$.context' }
-        }
+        '@path': '$.traits'
       }
     },
     referral_code: {

--- a/packages/destination-actions/src/destinations/rehook/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/rehook/identifyUser/index.ts
@@ -1,0 +1,54 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Identify User',
+  description: 'Send the identify event to create or update the customer in rehook.',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    source_id: {
+      label: 'Source ID',
+      type: 'string',
+      required: true,
+      description: 'The unique user identifier set by you',
+      default: {
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      }
+    },
+    metadata: {
+      label: 'User Metadata',
+      type: 'object',
+      required: true,
+      description: 'Properties to set on the user profile',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits' },
+          then: { '@path': '$.traits' },
+          else: { '@path': '$.context' }
+        }
+      }
+    },
+    referral_code: {
+      label: 'Referral Code',
+      type: 'string',
+      allowNull: true,
+      description: 'The referral code of the user',
+      default: {
+        '@path': '$.traits.referral_code'
+      }
+    }
+  },
+  perform: async (request, { payload }) => {
+    return request('https://api.rehook.ai/customers', {
+      method: 'post',
+      json: payload
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/rehook/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/rehook/identifyUser/index.ts
@@ -23,7 +23,7 @@ const action: ActionDefinition<Settings, Payload> = {
     metadata: {
       label: 'User Metadata',
       type: 'object',
-      required: true,
+      required: false,
       description: 'Properties to set on the user profile',
       default: {
         '@path': '$.traits'

--- a/packages/destination-actions/src/destinations/rehook/index.ts
+++ b/packages/destination-actions/src/destinations/rehook/index.ts
@@ -1,0 +1,55 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import trackEvent from './trackEvent'
+
+import identifyUser from './identifyUser'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Rehook',
+  slug: 'actions-rehook',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'basic',
+    fields: {
+      api_key: {
+        label: 'Api Key',
+        description: 'Your Rehook API Key',
+        type: 'string',
+        required: true
+      },
+      api_secret: {
+        label: 'Api Secret',
+        description: 'Your Rehook API Secret',
+        type: 'string',
+        required: true
+      }
+    },
+    testAuthentication: (request, { settings }) => {
+      return request(`https://api.rehook.ai/events/segment/check-auth`, {
+        method: 'get',
+        headers: {
+          authorization: `Basic ${Buffer.from(`${settings.api_key}:${settings.api_secret}`).toString('base64')}`
+        }
+      })
+    }
+  },
+  extendRequest({ settings }) {
+    if (!settings.api_key || !settings.api_secret) {
+      throw new Error('Missing API KEY or API SECRET')
+    }
+
+    return {
+      headers: {
+        authorization: `Basic ${Buffer.from(`${settings.api_key}:${settings.api_secret}`).toString('base64')}`
+      }
+    }
+  },
+  actions: {
+    trackEvent,
+    identifyUser
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/rehook/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/rehook/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -13,9 +13,6 @@ Object {
 exports[`Testing snapshot for Rehook's trackEvent destination action: required fields 1`] = `
 Object {
   "event_name": "c8Wjj300JvaVIqdQny0O",
-  "metadata": Object {
-    "testType": "c8Wjj300JvaVIqdQny0O",
-  },
   "source_id": "c8Wjj300JvaVIqdQny0O",
 }
 `;

--- a/packages/destination-actions/src/destinations/rehook/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/rehook/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Rehook's trackEvent destination action: all fields 1`] = `
+Object {
+  "event_name": "c8Wjj300JvaVIqdQny0O",
+  "metadata": Object {
+    "testType": "c8Wjj300JvaVIqdQny0O",
+  },
+  "source_id": "c8Wjj300JvaVIqdQny0O",
+}
+`;
+
+exports[`Testing snapshot for Rehook's trackEvent destination action: required fields 1`] = `
+Object {
+  "event_name": "c8Wjj300JvaVIqdQny0O",
+  "metadata": Object {
+    "testType": "c8Wjj300JvaVIqdQny0O",
+  },
+  "source_id": "c8Wjj300JvaVIqdQny0O",
+}
+`;

--- a/packages/destination-actions/src/destinations/rehook/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/rehook/trackEvent/__tests__/index.test.ts
@@ -1,0 +1,53 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+const REHOOK_API_KEY = 'SOME_API_KEY'
+const REHOOK_API_SECRET = 'SOME_API_SECRET'
+
+describe('Rehook.trackEvent', () => {
+  it('should validate action fields', async () => {
+    const event = createTestEvent({ event: 'Test Event' })
+
+    nock(`https://api.rehook.ai`).post(`/events/invoke`).reply(200, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        api_key: REHOOK_API_KEY,
+        api_secret: REHOOK_API_SECRET
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.json).toMatchObject({
+      event_name: 'Test Event',
+      metadata: {},
+      source_id: 'user1234'
+    })
+  })
+
+  it('should require userId and anonymousId field', async () => {
+    const event = createTestEvent({})
+    event.userId = undefined
+    event.anonymousId = undefined
+
+    nock(`https://api.rehook.ai`).post(`/events/invoke`).reply(200, {})
+
+    await expect(
+      testDestination.testAction('trackEvent', {
+        event,
+        useDefaultMappings: true,
+        settings: {
+          api_key: REHOOK_API_KEY,
+          api_secret: REHOOK_API_SECRET
+        }
+      })
+    ).rejects.toThrowError("The root value is missing the required field 'source_id'.")
+  })
+})

--- a/packages/destination-actions/src/destinations/rehook/trackEvent/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/rehook/trackEvent/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'trackEvent'
+const destinationSlug = 'Rehook'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/rehook/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/rehook/trackEvent/generated-types.ts
@@ -1,0 +1,18 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The name of the event being performed.
+   */
+  event_name: string
+  /**
+   * The unique user identifier set by you
+   */
+  source_id: string
+  /**
+   * An object of key-value pairs that represent event properties to be sent along with the event.
+   */
+  metadata: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/rehook/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/rehook/trackEvent/generated-types.ts
@@ -12,7 +12,7 @@ export interface Payload {
   /**
    * An object of key-value pairs that represent event properties to be sent along with the event.
    */
-  metadata: {
+  metadata?: {
     [k: string]: unknown
   }
 }

--- a/packages/destination-actions/src/destinations/rehook/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/rehook/trackEvent/index.ts
@@ -1,0 +1,58 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Track Event',
+  description: 'Send the Track, Page or Screen event to rehook.',
+  defaultSubscription: 'type = "track" or type = "page" or type = "screen"',
+  fields: {
+    event_name: {
+      label: 'Event Name',
+      type: 'string',
+      required: true,
+      description: 'The name of the event being performed.',
+      default: {
+        '@if': {
+          exists: { '@path': '$.event' },
+          then: { '@path': '$.event' },
+          else: { '@path': '$.type' }
+        }
+      }
+    },
+    source_id: {
+      label: 'Source ID',
+      type: 'string',
+      required: true,
+      description: 'The unique user identifier set by you',
+      default: {
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      }
+    },
+    metadata: {
+      label: 'Event Properties',
+      type: 'object',
+      required: true,
+      description: 'An object of key-value pairs that represent event properties to be sent along with the event.',
+      default: {
+        '@if': {
+          exists: { '@path': '$.properties' },
+          then: { '@path': '$.properties' },
+          else: { '@path': '$.context' }
+        }
+      }
+    }
+  },
+  perform: async (request, { payload }) => {
+    return request('https://api.rehook.ai/events/invoke', {
+      method: 'post',
+      json: payload
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/rehook/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/rehook/trackEvent/index.ts
@@ -39,11 +39,7 @@ const action: ActionDefinition<Settings, Payload> = {
       required: true,
       description: 'An object of key-value pairs that represent event properties to be sent along with the event.',
       default: {
-        '@if': {
-          exists: { '@path': '$.properties' },
-          then: { '@path': '$.properties' },
-          else: { '@path': '$.context' }
-        }
+        '@path': '$.properties'
       }
     }
   },

--- a/packages/destination-actions/src/destinations/rehook/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/rehook/trackEvent/index.ts
@@ -36,7 +36,7 @@ const action: ActionDefinition<Settings, Payload> = {
     metadata: {
       label: 'Event Properties',
       type: 'object',
-      required: true,
+      required: false,
       description: 'An object of key-value pairs that represent event properties to be sent along with the event.',
       default: {
         '@path': '$.properties'


### PR DESCRIPTION
This Pull Request (PR) outlines the creation of a brand-new destination, which integrates Rehook into the Segment platform. 

Our focus at Rehook involves the tracking of user activity and the events they generate. To accommodate this, we have introduced two distinct actions:

1. `trackEvent`: This action is designed to monitor and document user events.
2. `identifyUser`: This action is used to determine and catalogue the users that need to be added.

These two actions embody the scope of our current user tracking at Rehook.

For both the `trackEvent` and `identifyUser` actions, we have defined all input fields as per the requirements of our API. These defined fields also correspond to the data points we currently track. 

The `perform` function, associated with each action, encompasses the specific logic needed for generating payloads that are compatible with the Rehook system. Additionally, this function manages the call to our integrations API.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [v] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [v] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
