### PR TITLE
[Mixpanel] Increment numerical properties via $add API property

### DIFF
--- a/packages/destination-actions/src/destinations/mixpanel/identifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/identifyUser/__tests__/index.test.ts
@@ -11,7 +11,8 @@ const timestamp = '2021-08-17T15:21:15.449Z'
 describe('Mixpanel.identifyUser', () => {
   it('should validate action fields', async () => {
     const event = createTestEvent({
-      timestamp, traits: {
+      timestamp,
+      traits: {
         abc: '123',
         created: '2022-10-12T00:00:00.000Z',
         email: 'joe@mixpanel.com',
@@ -19,7 +20,7 @@ describe('Mixpanel.identifyUser', () => {
         lastName: 'Doe',
         username: 'Joe Doe',
         phone: '12345678',
-        name: 'Joe',
+        name: 'Joe'
       }
     })
 
@@ -75,20 +76,23 @@ describe('Mixpanel.identifyUser', () => {
 
   it('name should automatically be derived from the firstName and lastName traits if they are defined.', async () => {
     const event = createTestEvent({
-      timestamp, traits: {
+      timestamp,
+      traits: {
         firstName: 'Joe',
         lastName: 'Doe'
       }
     })
 
     const event2 = createTestEvent({
-      timestamp, traits: {
+      timestamp,
+      traits: {
         firstName: 'Joe'
       }
     })
 
     const event3 = createTestEvent({
-      timestamp, traits: {
+      timestamp,
+      traits: {
         lastName: 'Doe'
       }
     })
@@ -270,7 +274,7 @@ describe('Mixpanel.identifyUser', () => {
       settings: {
         projectToken: MIXPANEL_PROJECT_TOKEN,
         apiSecret: MIXPANEL_API_SECRET,
-        sourceName: 'example segment source name',
+        sourceName: 'example segment source name'
       }
     })
     expect(responses.length).toBe(2)
@@ -331,6 +335,56 @@ describe('Mixpanel.identifyUser', () => {
           $ip: '8.8.8.8',
           $set: {
             abc: '123'
+          }
+        })
+      })
+    )
+  })
+
+  it('should $add values to increment numerical properties', async () => {
+    const event = createTestEvent({
+      userId: 'user1234',
+      traits: {
+        abc: '123',
+        $add: [
+          { property: 'positive', value: 2 },
+          { property: 'negative', value: -2 }
+          // TODO: how to test this without an AggregateAjvError
+          // {property: "invalid", value: ""}
+        ]
+      }
+    })
+
+    nock('https://api.mixpanel.com').post('/track').reply(200, {})
+    nock('https://api.mixpanel.com').post('/engage').reply(200, {})
+
+    const [response] = await testDestination.testAction('identifyUser', {
+      event,
+      useDefaultMappings: false,
+      mapping: {
+        user_id: { '@path': '$.userId' },
+        traits: { '@path': '$.traits' },
+        $add: { '@path': '$.traits.$add' }
+      },
+      settings: {
+        projectToken: MIXPANEL_PROJECT_TOKEN,
+        apiSecret: MIXPANEL_API_SECRET
+      }
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.data).toMatchObject({})
+    expect(response.options.body).toMatchObject(
+      new URLSearchParams({
+        data: JSON.stringify({
+          $token: MIXPANEL_PROJECT_TOKEN,
+          $distinct_id: event.userId,
+          $set: {
+            abc: '123'
+          },
+          $add: {
+            positive: 2,
+            negative: -2
           }
         })
       })

--- a/packages/destination-actions/src/destinations/mixpanel/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/identifyUser/generated-types.ts
@@ -19,4 +19,17 @@ export interface Payload {
   traits?: {
     [k: string]: unknown
   }
+  /**
+   * Increment the value of a user profile property. Learn more about [Incrementing Numerical Properties](https://developer.mixpanel.com/reference/profile-numerical-add).
+   */
+  $add?: {
+    /**
+     * Property to increment
+     */
+    property: string
+    /**
+     * Positive or negative amount to increment
+     */
+    value: number
+  }[]
 }

--- a/packages/destination-actions/src/destinations/mixpanel/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/identifyUser/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
 import { getApiServerUrl, getConcatenatedName } from '../utils'
-import { MixpanelEngageProperties, MixpanelEngageSet } from '../mixpanel-types'
+import { MixpanelEngageProperties, MixpanelEngageSet, MixpanelIncrementPropertyObject } from '../mixpanel-types'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Identify User',
@@ -43,6 +43,27 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'Properties to set on the user profile',
       default: {
         '@path': '$.traits'
+      }
+    },
+    $add: {
+      label: 'Increment Numerical Properties',
+      type: 'object',
+      multiple: true,
+      description:
+        'Increment the value of a user profile property. Learn more about [Incrementing Numerical Properties](https://developer.mixpanel.com/reference/profile-numerical-add).',
+      properties: {
+        property: {
+          label: 'Property Name',
+          type: 'string',
+          description: 'Property to increment',
+          required: true
+        },
+        value: {
+          label: 'Increment Value',
+          type: 'number',
+          description: 'Positive or negative amount to increment',
+          required: true
+        }
       }
     }
   },
@@ -89,7 +110,8 @@ const action: ActionDefinition<Settings, Payload> = {
           'lastName',
           'name',
           'username',
-          'phone'
+          'phone',
+          '$add'
         ]),
         // to fit the Mixpanel expectations, transform the special traits to Mixpanel reserved property
         $created: payload.traits.created ?? payload.traits.createdAt ?? payload.traits.created_at,
@@ -106,6 +128,16 @@ const action: ActionDefinition<Settings, Payload> = {
         $distinct_id: payload.user_id ?? payload.anonymous_id,
         $ip: payload.ip,
         $set: traits
+      }
+
+      if (Array.isArray(payload.$add)) {
+        data.$add = {} as MixpanelIncrementPropertyObject
+        for (const item of payload.$add) {
+          const { property, value } = item
+          if (!isNaN(value)) {
+            data.$add[property] = value
+          }
+        }
       }
 
       const engageResponse = request(`${apiServerUrl}/engage`, {

--- a/packages/destination-actions/src/destinations/mixpanel/mixpanel-types.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/mixpanel-types.ts
@@ -65,9 +65,12 @@ export type MixpanelEngageSet = {
   $phone?: unknown
 } & { [key: string]: unknown }
 
+export type MixpanelIncrementPropertyObject = { [key: string]: number }
+
 export type MixpanelEngageProperties = {
   $token: string
   $distinct_id?: string | null
   $ip?: string
   $set?: MixpanelEngageSet
+  $add?: MixpanelIncrementPropertyObject
 }


### PR DESCRIPTION
Adds Mixpanel support to [increment profile properties](https://developer.mixpanel.com/reference/profile-numerical-add) via the $add API field.

## Testing
<img width="789" alt="image" src="https://github.com/segmentio/action-destinations/assets/7410770/9117d4dd-c939-47c0-9e4b-4df9a2730328">

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
