### PR TITLE
Fallback to sendgrid unsubscribe tag if global unsubscribe link is ab…

### DIFF
--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/index.ts
@@ -42,20 +42,33 @@ const insertUnsubscribeLinks = (
   const preferencesLink = emailProfile?.preferencesLink
   const unsubscribeLinkRef = 'a[href*="[upa_unsubscribe_link]"]'
   const preferencesLinkRef = 'a[href*="[upa_preferences_link]"]'
+  const sendgridUnsubscribeLinkTag = '[unsubscribe]'
   const $ = cheerio.load(html)
   if (groupId) {
     const group = emailProfile?.groups.find((group: { id: string }) => group?.id === groupId)
     const groupUnsubscribeLink = group?.groupUnsubscribeLink
     $(unsubscribeLinkRef).each(function () {
-      logger?.info(`TE Messaging: Email Group Unsubscribe link replaced  - ${spaceId} ${groupId}`)
-      statsClient?.incr('actions-personas-messaging-sendgrid.replaced_group_unsubscribe_link', 1, tags)
-      $(this).attr('href', groupUnsubscribeLink)
+      if (!groupUnsubscribeLink) {
+        logger?.info(`TE Messaging: Email Group Unsubscribe link missing  - ${spaceId}`)
+        statsClient?.incr('actions-personas-messaging-sendgrid.group_unsubscribe_link_missing', 1, tags)
+        $(this).attr('href', sendgridUnsubscribeLinkTag)
+      } else {
+        $(this).attr('href', groupUnsubscribeLink)
+        logger?.info(`TE Messaging: Email Group Unsubscribe link replaced  - ${spaceId}`)
+        statsClient?.incr('actions-personas-messaging-sendgrid.replaced_group_unsubscribe_link', 1, tags)
+      }
     })
   } else {
     $(unsubscribeLinkRef).each(function () {
-      logger?.info(`TE Messaging: Email Global Unsubscribe link replaced  - ${spaceId}`)
-      statsClient?.incr('actions-personas-messaging-sendgrid.replaced_global_unsubscribe_link', 1, tags)
-      $(this).attr('href', globalUnsubscribeLink)
+      if (!globalUnsubscribeLink) {
+        logger?.info(`TE Messaging: Email Global Unsubscribe link missing  - ${spaceId}`)
+        statsClient?.incr('actions-personas-messaging-sendgrid.global_unsubscribe_link_missing', 1, tags)
+        $(this).attr('href', sendgridUnsubscribeLinkTag)
+      } else {
+        $(this).attr('href', globalUnsubscribeLink)
+        logger?.info(`TE Messaging: Email Global Unsubscribe link replaced  - ${spaceId}`)
+        statsClient?.incr('actions-personas-messaging-sendgrid.replaced_global_unsubscribe_link', 1, tags)
+      }
     })
   }
   $(preferencesLinkRef).each(function () {


### PR DESCRIPTION
Fall back to sendgrid [unsubscribe] tag if global unsubscribe link is missing: https://segment.atlassian.net/browse/CONMAN-576

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
