### PR TITLE
add launchdarkly-audiences

### DIFF
--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestIntegration } from '@segment/actions-core'
 import Definition from '../index'
+import { CONSTANTS } from '../constants'
 
 const testDestination = createTestIntegration(Definition)
 
@@ -11,11 +12,8 @@ describe('Launchdarkly Audiences', () => {
         clientId: 'valid-id',
         apiKey: 'valid-key'
       }
-      nock(`https://clientsdk.launchdarkly.com`).head(`/sdk/goals/${authData.clientId}`).reply(200, {})
-      nock(`https://app.launchdarkly.com/api/v2`)
-        .get('/versions')
-        .matchHeader('authorization', authData.apiKey)
-        .reply(200, {})
+      nock(CONSTANTS.LD_CLIENT_SDK_BASE_URL).head(`/sdk/goals/${authData.clientId}`).reply(200, {})
+      nock(CONSTANTS.LD_API_BASE_URL).get('/versions').matchHeader('authorization', authData.apiKey).reply(200, {})
 
       await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
     })
@@ -25,11 +23,8 @@ describe('Launchdarkly Audiences', () => {
         clientId: 'invalid-id',
         apiKey: 'valid-key'
       }
-      nock(`https://clientsdk.launchdarkly.com`).head(`/sdk/goals/${authData.clientId}`).reply(404, {})
-      nock(`https://app.launchdarkly.com/api/v2`)
-        .get('/versions')
-        .matchHeader('authorization', authData.apiKey)
-        .reply(200, {})
+      nock(CONSTANTS.LD_CLIENT_SDK_BASE_URL).head(`/sdk/goals/${authData.clientId}`).reply(404, {})
+      nock(CONSTANTS.LD_API_BASE_URL).get('/versions').matchHeader('authorization', authData.apiKey).reply(200, {})
 
       await expect(testDestination.testAuthentication(authData)).rejects.toThrowError()
     })
@@ -39,11 +34,8 @@ describe('Launchdarkly Audiences', () => {
         clientId: 'valid-id',
         apiKey: 'invalid-key'
       }
-      nock(`https://clientsdk.launchdarkly.com`).head(`/sdk/goals/${authData.clientId}`).reply(200, {})
-      nock(`https://app.launchdarkly.com/api/v2`)
-        .get('/versions')
-        .matchHeader('authorization', authData.apiKey)
-        .reply(403, {})
+      nock(CONSTANTS.LD_CLIENT_SDK_BASE_URL).head(`/sdk/goals/${authData.clientId}`).reply(200, {})
+      nock(CONSTANTS.LD_API_BASE_URL).get('/versions').matchHeader('authorization', authData.apiKey).reply(403, {})
 
       await expect(testDestination.testAuthentication(authData)).rejects.toThrowError()
     })

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/__tests__/index.test.ts
@@ -1,0 +1,18 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Launchdarkly Audiences', () => {
+  describe('testAuthentication', () => {
+    it('should validate authentication inputs', async () => {
+      nock('https://your.destination.endpoint').get('*').reply(200, {})
+
+      // This should match your authentication.fields
+      const authData = {}
+
+      await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-launchdarkly-audiences'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/constants.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/constants.ts
@@ -1,0 +1,11 @@
+export const CONSTANTS = {
+  // rokt
+  INCLUDE: 'include',
+  EXCLUDE: 'exclude',
+  // ROKT_API_BASE_URL: 'https://data.rokt.com/api/1.0',
+  // ROKT_API_CUSTOM_AUDIENCE_ENDPOINT: '/import/suppression',
+  // ROKT_API_AUTH_ENDPOINT: '/auth-check',
+
+  // segment
+  SUPPORTED_SEGMENT_COMPUTATION_ACTION: 'audience'
+}

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/constants.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/constants.ts
@@ -1,8 +1,9 @@
 export const CONSTANTS = {
+  // TODO: update to prod URLs when testing is complete
   LD_CLIENT_SDK_BASE_URL: 'https://clientsdk-stg.launchdarkly.com',
-  LD_API_BASE_URL: 'https://ld-stg.launchdarkly.com',
-  LD_API_CUSTOM_AUDIENCE_ENDPOINT: '/api/v2/segment-targets/segment-audiences',
+  LD_API_BASE_URL: 'https://ld-stg.launchdarkly.com/api/v2',
 
-  // segment
+  LD_API_CUSTOM_AUDIENCE_ENDPOINT: '/segment-targets/segment-audiences',
+
   SUPPORTED_SEGMENT_COMPUTATION_ACTION: 'audience'
 }

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/constants.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/constants.ts
@@ -1,9 +1,7 @@
 export const CONSTANTS = {
-  INCLUDE: 'include',
-  EXCLUDE: 'exclude',
+  LD_CLIENT_SDK_BASE_URL: 'https://clientsdk-stg.launchdarkly.com',
   LD_API_BASE_URL: 'https://ld-stg.launchdarkly.com',
-  LD_API_CUSTOM_AUDIENCE_ENDPOINT: '/api/v2/segment-targets/segment',
-  LD_API_AUTH_ENDPOINT: '/teams',
+  LD_API_CUSTOM_AUDIENCE_ENDPOINT: '/api/v2/segment-targets/segment/segment-audience',
 
   // segment
   SUPPORTED_SEGMENT_COMPUTATION_ACTION: 'audience'

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/constants.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/constants.ts
@@ -1,10 +1,9 @@
 export const CONSTANTS = {
-  // rokt
   INCLUDE: 'include',
   EXCLUDE: 'exclude',
-  // ROKT_API_BASE_URL: 'https://data.rokt.com/api/1.0',
-  // ROKT_API_CUSTOM_AUDIENCE_ENDPOINT: '/import/suppression',
-  // ROKT_API_AUTH_ENDPOINT: '/auth-check',
+  LD_API_BASE_URL: 'https://ld-stg.launchdarkly.com',
+  LD_API_CUSTOM_AUDIENCE_ENDPOINT: '/api/v2/segment-targets/segment',
+  LD_API_AUTH_ENDPOINT: '/teams',
 
   // segment
   SUPPORTED_SEGMENT_COMPUTATION_ACTION: 'audience'

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/constants.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/constants.ts
@@ -1,7 +1,7 @@
 export const CONSTANTS = {
   LD_CLIENT_SDK_BASE_URL: 'https://clientsdk-stg.launchdarkly.com',
   LD_API_BASE_URL: 'https://ld-stg.launchdarkly.com',
-  LD_API_CUSTOM_AUDIENCE_ENDPOINT: '/api/v2/segment-targets/segment/segment-audience',
+  LD_API_CUSTOM_AUDIENCE_ENDPOINT: '/api/v2/segment-targets/segment-audiences',
 
   // segment
   SUPPORTED_SEGMENT_COMPUTATION_ACTION: 'audience'

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * APIKey used for LaunchDarkly API authorization before sending custom audiences data
+   */
+  apiKey: string
+}

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Settings {
   /**
-   * API Key used for [LaunchDarkly API authorization](https://app.launchdarkly.com/settings/authorization) before sending custom audiences data.
+   * API Key used for [LaunchDarkly API authorization](https://app.launchdarkly.com/settings/authorization).
    */
   apiKey: string
   /**
-   * Find and copy the [client-side ID](https://ld-stg.launchdarkly.com/settings/projects) in the LaunchDarkly account settings page.
+   * Find and copy the [client-side ID](https://app.launchdarkly.com/settings/projects) in the LaunchDarkly account settings page.
    */
-  client_id: string
+  clientId: string
 }

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Settings {
   /**
-   * APIKey used for LaunchDarkly API authorization before sending custom audiences data
+   * API Key used for [LaunchDarkly API authorization](https://app.launchdarkly.com/settings/authorization) before sending custom audiences data.
    */
   apiKey: string
   /**
-   * ID of the environment
+   * Find and copy the [client-side ID](https://ld-stg.launchdarkly.com/settings/projects) in the LaunchDarkly account settings page.
    */
-  environmentId: string
+  client_id: string
 }

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/generated-types.ts
@@ -5,4 +5,8 @@ export interface Settings {
    * APIKey used for LaunchDarkly API authorization before sending custom audiences data
    */
   apiKey: string
+  /**
+   * ID of the environment
+   */
+  environmentId: string
 }

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/index.ts
@@ -2,9 +2,8 @@ import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
 import syncAudience from './syncAudience'
-import {defaultValues} from "@segment/actions-core";
-import {CONSTANTS} from "./constants";
-import * as constants from "constants";
+import { defaultValues } from '@segment/actions-core'
+import { CONSTANTS } from './constants'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Launchdarkly Audiences',
@@ -16,13 +15,15 @@ const destination: DestinationDefinition<Settings> = {
     fields: {
       apiKey: {
         label: 'API Key provided by the LaunchDarkly integration',
-        description: 'APIKey used for LaunchDarkly API authorization before sending custom audiences data',
+        description:
+          'API Key used for [LaunchDarkly API authorization](https://app.launchdarkly.com/settings/authorization) before sending custom audiences data.',
         type: 'password',
         required: true
       },
-      environmentId: {
-        label: 'Client side ID',
-        description: 'ID of the environment',
+      client_id: {
+        label: 'LaunchDarkly client-side ID',
+        description:
+          'Find and copy the [client-side ID](https://ld-stg.launchdarkly.com/settings/projects) in the LaunchDarkly account settings page.',
         type: 'string',
         required: true
       }
@@ -30,7 +31,7 @@ const destination: DestinationDefinition<Settings> = {
     testAuthentication: (request, { settings }) => {
       // The sdk/goals/{clientID} endpoint returns a 200 if the client ID is valid and a 404 otherwise.
       return Promise.all([
-        // request(`https://clientsdk.launchdarkly.com/sdk/goals/${settings.environmentId}`, { method: 'head' }),
+        request(`${CONSTANTS.LD_CLIENT_SDK_BASE_URL}/sdk/goals/${settings.client_id}`, { method: 'head' }),
         request(`${CONSTANTS.LD_API_BASE_URL}/api/v2/versions`, {
           method: 'GET',
           headers: {
@@ -43,19 +44,16 @@ const destination: DestinationDefinition<Settings> = {
 
   extendRequest({ settings }) {
     return {
-      headers: { Authorization: `${settings.apiKey}` }
+      headers: {
+        'User-Agent': 'SegmentSyncAudiences/1.0.0',
+        'Content-Type': 'application/json',
+        Authorization: `${settings.apiKey}`
+      }
     }
   },
   actions: {
     syncAudience
   },
-
-  onDelete: async (request, { settings, payload }) => {
-    // Return a request that performs a GDPR delete for the provided Segment userId or anonymousId
-    // provided in the payload. If your destination does not support GDPR deletion you should not
-    // implement this function and should remove it completely.
-  },
-
   presets: [
     {
       name: 'Sync Engage Audience to LaunchDarkly',

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/index.ts
@@ -1,0 +1,48 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import syncAudience from './syncAudience'
+import {defaultValues} from "@segment/actions-core";
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Launchdarkly Audiences',
+  slug: 'actions-launchdarkly-audiences',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      apiKey: {
+        label: 'API Key provided by the LaunchDarkly integration',
+        description: 'APIKey used for LaunchDarkly API authorization before sending custom audiences data',
+        type: 'password',
+        required: true
+      }
+    },
+    testAuthentication: (request) => {
+      // Return a request that tests/validates the user's credentials.
+      // If you do not have a way to validate the authentication fields safely,
+      // you can remove the `testAuthentication` function, though discouraged.
+    }
+  },
+
+  onDelete: async (request, { settings, payload }) => {
+    // Return a request that performs a GDPR delete for the provided Segment userId or anonymousId
+    // provided in the payload. If your destination does not support GDPR deletion you should not
+    // implement this function and should remove it completely.
+  },
+
+  actions: {
+    syncAudience
+  },
+  presets: [
+    {
+      name: 'Sync Engage Audience to LaunchDarkly',
+      subscribe: 'type = "track" or type = "identify"',
+      partnerAction: 'syncAudience',
+      mapping: defaultValues(syncAudience.fields)
+    }
+  ]
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/index.ts
@@ -9,6 +9,7 @@ const destination: DestinationDefinition<Settings> = {
   name: 'Launchdarkly Audiences',
   slug: 'actions-launchdarkly-audiences',
   mode: 'cloud',
+  description: 'Sync Segments audiences to LaunchDarkly Big Segments.',
 
   authentication: {
     scheme: 'custom',
@@ -43,6 +44,7 @@ const destination: DestinationDefinition<Settings> = {
   },
 
   extendRequest({ settings }) {
+    console.log('extendRequest', settings)
     return {
       headers: {
         'User-Agent': 'SegmentSyncAudiences/1.0.0',

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/index.ts
@@ -17,14 +17,14 @@ const destination: DestinationDefinition<Settings> = {
       apiKey: {
         label: 'API Key provided by the LaunchDarkly integration',
         description:
-          'API Key used for [LaunchDarkly API authorization](https://app.launchdarkly.com/settings/authorization) before sending custom audiences data.',
+          'API Key used for [LaunchDarkly API authorization](https://app.launchdarkly.com/settings/authorization).',
         type: 'password',
         required: true
       },
-      client_id: {
+      clientId: {
         label: 'LaunchDarkly client-side ID',
         description:
-          'Find and copy the [client-side ID](https://ld-stg.launchdarkly.com/settings/projects) in the LaunchDarkly account settings page.',
+          'Find and copy the [client-side ID](https://app.launchdarkly.com/settings/projects) in the LaunchDarkly account settings page.',
         type: 'string',
         required: true
       }
@@ -32,8 +32,8 @@ const destination: DestinationDefinition<Settings> = {
     testAuthentication: (request, { settings }) => {
       // The sdk/goals/{clientID} endpoint returns a 200 if the client ID is valid and a 404 otherwise.
       return Promise.all([
-        request(`${CONSTANTS.LD_CLIENT_SDK_BASE_URL}/sdk/goals/${settings.client_id}`, { method: 'head' }),
-        request(`${CONSTANTS.LD_API_BASE_URL}/api/v2/versions`, {
+        request(`${CONSTANTS.LD_CLIENT_SDK_BASE_URL}/sdk/goals/${settings.clientId}`, { method: 'head' }),
+        request(`${CONSTANTS.LD_API_BASE_URL}/versions`, {
           method: 'GET',
           headers: {
             Authorization: `${settings.apiKey}`
@@ -44,7 +44,6 @@ const destination: DestinationDefinition<Settings> = {
   },
 
   extendRequest({ settings }) {
-    console.log('extendRequest', settings)
     return {
       headers: {
         'User-Agent': 'SegmentSyncAudiences/1.0.0',

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/index.ts
@@ -3,6 +3,8 @@ import type { Settings } from './generated-types'
 
 import syncAudience from './syncAudience'
 import {defaultValues} from "@segment/actions-core";
+import {CONSTANTS} from "./constants";
+import * as constants from "constants";
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Launchdarkly Audiences',
@@ -17,13 +19,35 @@ const destination: DestinationDefinition<Settings> = {
         description: 'APIKey used for LaunchDarkly API authorization before sending custom audiences data',
         type: 'password',
         required: true
+      },
+      environmentId: {
+        label: 'Client side ID',
+        description: 'ID of the environment',
+        type: 'string',
+        required: true
       }
     },
-    testAuthentication: (request) => {
-      // Return a request that tests/validates the user's credentials.
-      // If you do not have a way to validate the authentication fields safely,
-      // you can remove the `testAuthentication` function, though discouraged.
+    testAuthentication: (request, { settings }) => {
+      // The sdk/goals/{clientID} endpoint returns a 200 if the client ID is valid and a 404 otherwise.
+      return Promise.all([
+        // request(`https://clientsdk.launchdarkly.com/sdk/goals/${settings.environmentId}`, { method: 'head' }),
+        request(`${CONSTANTS.LD_API_BASE_URL}/api/v2/versions`, {
+          method: 'GET',
+          headers: {
+            Authorization: `${settings.apiKey}`
+          }
+        })
+      ])
     }
+  },
+
+  extendRequest({ settings }) {
+    return {
+      headers: { Authorization: `${settings.apiKey}` }
+    }
+  },
+  actions: {
+    syncAudience
   },
 
   onDelete: async (request, { settings, payload }) => {
@@ -32,13 +56,10 @@ const destination: DestinationDefinition<Settings> = {
     // implement this function and should remove it completely.
   },
 
-  actions: {
-    syncAudience
-  },
   presets: [
     {
       name: 'Sync Engage Audience to LaunchDarkly',
-      subscribe: 'type = "track" or type = "identify"',
+      subscribe: 'type = "identify" or type = "track"',
       partnerAction: 'syncAudience',
       mapping: defaultValues(syncAudience.fields)
     }

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/index.test.ts
@@ -1,0 +1,9 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('LaunchdarklyAudiences.syncAudience', () => {
+  // TODO: Test your action
+})

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/index.test.ts
@@ -1,9 +1,81 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
+import { CONSTANTS } from '../../constants'
 
 const testDestination = createTestIntegration(Destination)
 
+const goodEvent = createTestEvent({
+  context: {
+    personas: {
+      computation_class: 'audience',
+      computation_key: 'ld_segment_test'
+    },
+    traits: {
+      email: 'test@email.com'
+    }
+  },
+  traits: {
+    email: 'test@email.com',
+    ld_segment_test: true
+  }
+})
+
+const badEvent = createTestEvent({
+  context: {
+    personas: {
+      computation_key: 'ld_segment_test'
+    },
+    traits: {
+      email: 'test@email.com'
+    }
+  },
+  traits: {
+    email: 'test@email.com',
+    ld_segment_test: true
+  }
+})
+
 describe('LaunchdarklyAudiences.syncAudience', () => {
-  // TODO: Test your action
+  it('should not throw an error if the audience creation succeed', async () => {
+    nock(CONSTANTS.LD_API_BASE_URL).post(CONSTANTS.LD_API_CUSTOM_AUDIENCE_ENDPOINT).reply(204)
+
+    await expect(
+      testDestination.testAction('syncAudience', {
+        event: goodEvent,
+        useDefaultMappings: true
+      })
+    ).resolves.not.toThrowError()
+  })
+
+  it('should throw an error if the audience creation failed, bad body', async () => {
+    nock(CONSTANTS.LD_API_BASE_URL).post(CONSTANTS.LD_API_CUSTOM_AUDIENCE_ENDPOINT).reply(400)
+
+    await expect(
+      testDestination.testAction('syncAudience', {
+        event: goodEvent,
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError('Bad Request')
+  })
+
+  it('should throw an error if audience creation event missing mandatory field', async () => {
+    await expect(
+      testDestination.testAction('syncAudience', {
+        event: badEvent,
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError("The root value is missing the required field 'segment_computation_action'")
+  })
+
+  it('should throw an error with an invalid API key', async () => {
+    nock(CONSTANTS.LD_API_BASE_URL).post(CONSTANTS.LD_API_CUSTOM_AUDIENCE_ENDPOINT).reply(403)
+
+    await expect(
+      testDestination.testAction('syncAudience', {
+        event: goodEvent,
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError('Forbidden')
+  })
 })

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'syncAudience'
+const destinationSlug = 'LaunchdarklyAudiences'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/custom-audience-operations.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/custom-audience-operations.ts
@@ -1,0 +1,100 @@
+import type { RequestClient } from '@segment/actions-core'
+import type { Payload } from './generated-types'
+
+import { CONSTANTS } from '../constants'
+/**
+ * CustomAudienceOperation is a custom type to encapsulate the request body params
+ * for inserting/updating custom audience list in rokt data platform
+ * @action [include, exclude]
+ * @list custom audience name ( or list ) in rokt data platform
+ * @emails list of user emails to be included/excluded from custom audience list
+ */
+type CustomAudienceOperation = {
+  action: string
+  list: string
+  emails: string[]
+}
+
+/**
+ * getCustomAudienceOperations parses event payloads from segment to convert to request object for rokt api
+ * @payload payload of events
+ */
+
+const getCustomAudienceOperations = (payload: Payload[]): CustomAudienceOperation[] => {
+  // map to handle different audiences in the batch
+  // this will contain audience_name=>[action=>emails]
+  const audience_map = new Map<string, Map<string, string[]>>([])
+  for (const p of payload) {
+    if (p.segment_computation_action != CONSTANTS.SUPPORTED_SEGMENT_COMPUTATION_ACTION) {
+      // ignore event
+      continue
+    }
+
+    let action_map = new Map<string, string[]>([
+      [CONSTANTS.INCLUDE, []],
+      [CONSTANTS.EXCLUDE, []]
+    ])
+
+    // check if we have already saved this audience in map
+    const existing_action_map_for_audience = audience_map.get(p.custom_audience_name)
+    if (existing_action_map_for_audience !== undefined) {
+      // use existing map for audience, to include/exclude new email
+      action_map = existing_action_map_for_audience
+    } else {
+      // if audience is not in map, add it to the map
+      audience_map.set(p.custom_audience_name, action_map)
+    }
+
+    if (p.traits_or_props[p.custom_audience_name] === true) {
+      // audience entered 'true', include email to list
+      action_map.get(CONSTANTS.INCLUDE)?.push(p.email)
+    } else if (p.traits_or_props[p.custom_audience_name] === false) {
+      // audience entered 'false', exclude email from list
+      action_map.get(CONSTANTS.EXCLUDE)?.push(p.email)
+    }
+  }
+
+  // build operation request to be sent to rokt api
+  const custom_audience_ops: CustomAudienceOperation[] = []
+  audience_map.forEach((action_map_values: Map<string, string[]>, list: string) => {
+    // key will be audience list
+    // value will map of action=>email_list
+    action_map_values.forEach((emails: string[], action: string) => {
+      const custom_audience_op: CustomAudienceOperation = {
+        list: list,
+        action: action,
+        emails: emails
+      }
+      custom_audience_ops.push(custom_audience_op)
+    })
+  })
+  return custom_audience_ops
+}
+
+/**
+ * Takes an array of events of type Payload, decides whether event is meant for include/exclude action of rokt api
+ * and then pushes the event to proper list to build request body.
+ * @param request request object used to perform HTTP calls
+ * @param events array of events containing Rokt custom audience details
+ */
+async function processPayload(request: RequestClient, events: Payload[]) {
+  const custom_audience_ops: CustomAudienceOperation[] = getCustomAudienceOperations(events)
+  const promises = []
+
+  for (const op of custom_audience_ops) {
+    if (op.emails.length > 0) {
+      // if emails are present for action, send to rokt. Push to list of promises
+      // There will be max 2 promies for 2 http reuests ( include & exclude actions )
+      promises.push(
+        request(CONSTANTS.ROKT_API_BASE_URL + CONSTANTS.ROKT_API_CUSTOM_AUDIENCE_ENDPOINT, {
+          method: 'POST',
+          json: op
+        })
+      )
+    }
+  }
+
+  return await Promise.all(promises)
+}
+
+export { processPayload }

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/custom-audience-operations.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/custom-audience-operations.ts
@@ -50,7 +50,7 @@ const parseCustomAudienceBatches = (payload: Payload[], settings: Settings): Aud
     const contextKey = p.context_key
     const audienceId = p.custom_audience_name
     const traitsOrProps = p.traits_or_props
-    const environmentId = settings.client_id
+    const environmentId = settings.clientId
 
     let audienceBatch: AudienceBatch = {
       environmentId,

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/custom-audience-operations.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/custom-audience-operations.ts
@@ -11,7 +11,8 @@ import { CONSTANTS } from '../constants'
  */
 type CustomAudienceOperation = {
   action: string
-  list: string
+  cohortName: string
+  cohortId: string
   emails: string[]
 }
 
@@ -61,7 +62,8 @@ const getCustomAudienceOperations = (payload: Payload[]): CustomAudienceOperatio
     // value will map of action=>email_list
     action_map_values.forEach((emails: string[], action: string) => {
       const custom_audience_op: CustomAudienceOperation = {
-        list: list,
+        cohortName: list,
+        cohortId: list,
         action: action,
         emails: emails
       }
@@ -83,12 +85,13 @@ async function processPayload(request: RequestClient, events: Payload[]) {
 
   for (const op of custom_audience_ops) {
     if (op.emails.length > 0) {
-      // if emails are present for action, send to rokt. Push to list of promises
-      // There will be max 2 promies for 2 http reuests ( include & exclude actions )
+      // if emails are present for action, send to ld. Push to list of promises
+      // There will be max 2 promises for 2 http requests ( include & exclude actions )
+      console.log(CONSTANTS.LD_API_BASE_URL + CONSTANTS.LD_API_CUSTOM_AUDIENCE_ENDPOINT)
       promises.push(
-        request(CONSTANTS.ROKT_API_BASE_URL + CONSTANTS.ROKT_API_CUSTOM_AUDIENCE_ENDPOINT, {
+        request(CONSTANTS.LD_API_BASE_URL + CONSTANTS.LD_API_CUSTOM_AUDIENCE_ENDPOINT, {
           method: 'POST',
-          json: op
+          json: op,
         })
       )
     }

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * Name of custom audience list to which emails should added/removed
+   * Name of custom audience list to which user identifier should added/removed
    */
   custom_audience_name: string
   /**
@@ -10,17 +10,17 @@ export interface Payload {
    */
   segment_computation_action: string
   /**
+   * LaunchDarkly context kind
+   */
+  context_kind: string
+  /**
+   * LaunchDarkly context key
+   */
+  context_key: string
+  /**
    * Object which will be computed differently for track and identify events
    */
   traits_or_props: {
     [k: string]: unknown
   }
-  /**
-   * Set as true to ensure Segment infrastructure uses batching when possible.
-   */
-  enable_batching?: boolean
-  /**
-   * User's email address for including/excluding from custom audience
-   */
-  email: string
 }

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/generated-types.ts
@@ -1,0 +1,26 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Name of custom audience list to which emails should added/removed
+   */
+  custom_audience_name: string
+  /**
+   * Segment computation class used to determine if action is an 'Engage-Audience'
+   */
+  segment_computation_action: string
+  /**
+   * Object which will be computed differently for track and identify events
+   */
+  traits_or_props: {
+    [k: string]: unknown
+  }
+  /**
+   * Set as true to ensure Segment infrastructure uses batching when possible.
+   */
+  enable_batching?: boolean
+  /**
+   * User's email address for including/excluding from custom audience
+   */
+  email: string
+}

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/index.ts
@@ -6,7 +6,7 @@ import {processPayload} from "../../launchdarkly-audiences/syncAudience/custom-a
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Sync Audience',
   description: '',
-  defaultSubscription: 'type = "track" or type = "identify"',
+  defaultSubscription: 'type = "identify" or type = "track"',
   fields: {
     custom_audience_name: {
       label: 'Custom Audience Name',

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/index.ts
@@ -1,0 +1,73 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import {processPayload} from "../../launchdarkly-audiences/syncAudience/custom-audience-operations";
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Sync Audience',
+  description: '',
+  defaultSubscription: 'type = "track" or type = "identify"',
+  fields: {
+    custom_audience_name: {
+      label: 'Custom Audience Name',
+      description: 'Name of custom audience list to which emails should added/removed',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.context.personas.computation_key'
+      }
+    },
+    segment_computation_action: {
+      label: 'Segment Computation Action',
+      description: "Segment computation class used to determine if action is an 'Engage-Audience'",
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.context.personas.computation_class'
+      }
+    },
+    traits_or_props: {
+      label: 'traits or properties object',
+      description: 'Object which will be computed differently for track and identify events',
+      type: 'object',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.properties' },
+          then: { '@path': '$.properties' },
+          else: { '@path': '$.traits' }
+        }
+      }
+    },
+    enable_batching: {
+      type: 'boolean',
+      label: 'enable batching to rokt api',
+      description: 'Set as true to ensure Segment infrastructure uses batching when possible.',
+      default: true
+    },
+    email: {
+      label: 'Email',
+      description: "User's email address for including/excluding from custom audience",
+      type: 'string',
+      format: 'email',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.context.traits.email' },
+          then: { '@path': '$.context.traits.email' },
+          else: { '@path': '$.traits.email' }
+        }
+      }
+    }
+  },
+
+  perform: (request, { payload }) => {
+    return processPayload(request, [payload])
+  },
+
+  performBatch: (request, { payload }) => {
+    return processPayload(request, payload)
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/index.ts
@@ -63,7 +63,6 @@ const action: ActionDefinition<Settings, Payload> = {
   },
 
   perform: (request, { payload, settings }) => {
-    console.log('********', settings, payload)
     return processPayload(request, settings, [payload])
   },
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

This PR adds a new LaunchDarkly Audiences action destination, in addition to our existing Launchdarkly one. 

The only action this will support is `syncAudience`, which allows a segment audience to be synced to a LaunchDarkly [Big Segment](https://docs.launchdarkly.com/home/contexts/big-segments). 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
