### PR TITLE
[Stratconn-2898 ] - Implement Association Support in UpsertCustomObjectRecord Action

### DIFF
--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -46,6 +46,7 @@ export interface DynamicFieldError {
   code: string
   message: string
 }
+
 export interface DynamicFieldItem {
   label: string
   value: string

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -49,7 +49,7 @@ export interface DynamicFieldError {
 
 export interface DynamicFieldItem {
   label: string
-  value: string
+  value: string | object
 }
 
 /** The shape of authentication and top-level settings */

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -46,13 +46,13 @@ export interface DynamicFieldError {
   code: string
   message: string
 }
-
+// Supports string and object both
 export interface DynamicFieldItem {
   label: string
   value: string | object
 }
 
-/** The shape of authentication and top-level settings */
+/** The shape of authentication and top-level settings  */
 export interface GlobalSetting {
   /** A short, human-friendly label for the field */
   label: string

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -46,13 +46,12 @@ export interface DynamicFieldError {
   code: string
   message: string
 }
-// Supports string and object both
 export interface DynamicFieldItem {
   label: string
-  value: string | object
+  value: string
 }
 
-/** The shape of authentication and top-level settings  */
+/** The shape of authentication and top-level settings */
 export interface GlobalSetting {
   /** A short, human-friendly label for the field */
   label: string

--- a/packages/destination-actions/src/destinations/hubspot/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -85,14 +85,13 @@ Object {
     },
   ],
   "properties": Array [],
-  "sorts": Array [
-    "name",
-  ],
+  "sorts": Array [],
 }
 `;
 
 exports[`Testing snapshot for actions-hubspot-cloud destination: upsertCustomObjectRecord action - required fields 1`] = `
 Object {
+  "associations": Array [],
   "properties": Object {
     "testType": "jf(2@y*W9WT2r)SLk(*",
   },

--- a/packages/destination-actions/src/destinations/hubspot/api/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/api/index.ts
@@ -121,7 +121,7 @@ export class Hubspot {
 
   async getObjectResponseToAssociate(
     searchFieldsToAssociateCustomObjects: { [key: string]: unknown } | undefined,
-    associationType: { [k: string]: unknown } | undefined
+    associationType: AssociationType | null
   ) {
     try {
       if (

--- a/packages/destination-actions/src/destinations/hubspot/api/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/api/index.ts
@@ -70,7 +70,7 @@ export class Hubspot {
    * @param {{[key: string]: unknown}} properties A list of key-value pairs of properties of the object
    * @returns {Promise<ModifiedResponse<UpsertCompanyResponse>>} A promise that resolves the updated object
    */
-  async create(properties: { [key: string]: unknown }, associations?: CreateAssociation[]) {
+  async create(properties: { [key: string]: unknown }, associations: CreateAssociation[] = []) {
     return this.request<UpsertRecordResponse>(`${HUBSPOT_BASE_URL}/crm/v3/objects/${this.objectType}`, {
       method: 'POST',
       json: {
@@ -119,13 +119,9 @@ export class Hubspot {
     })
   }
 
-  async getObjectIdAssociate(
+  async getObjectResponseToAssociate(
     searchFieldsToAssociateCustomObjects: { [key: string]: unknown } | undefined,
-    associationType:
-      | {
-          [k: string]: unknown
-        }
-      | undefined
+    associationType: { [k: string]: unknown } | undefined
   ) {
     try {
       if (

--- a/packages/destination-actions/src/destinations/hubspot/api/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/api/index.ts
@@ -1,14 +1,27 @@
+import { HTTPError } from '@segment/actions-core'
+import { ModifiedResponse } from '@segment/actions-core'
 import { RequestClient } from '@segment/actions-core'
+import { CustomSearchToAssociateThrowableError } from '../errors'
+
 import { HUBSPOT_BASE_URL } from '../properties'
-import { SearchFilterOperator, SearchPayload, SearchResponse, UpsertRecordResponse } from '../utils'
+import {
+  AssociationType,
+  CreateAssociation,
+  SearchFilterOperator,
+  SearchPayload,
+  SearchResponse,
+  UpsertRecordResponse
+} from '../utils'
 
 export class Hubspot {
   request: RequestClient
   objectType: string
+  toObjectType?: string
 
-  constructor(request: RequestClient, objectType: string) {
+  constructor(request: RequestClient, objectType: string, toObjectType?: string) {
     this.request = request
     this.objectType = objectType
+    this.toObjectType = toObjectType
   }
 
   /**
@@ -18,30 +31,38 @@ export class Hubspot {
    * @param { string[]} responseSortBy - To sort an response
    * @returns {Promise<ModifiedResponse<SearchResponse>>} A promise that resolves to a list of object records matching the search criteria
    */
-  async search(searchFields: { [key: string]: unknown }, responseProperties: string[], responseSortBy: string[]) {
-    const searchPayload: SearchPayload = {
-      filterGroups: [],
-      properties: [...responseProperties],
-      sorts: [...responseSortBy]
-    }
-    for (const [key, value] of Object.entries(searchFields)) {
-      searchPayload.filterGroups.push({
-        filters: [
-          {
-            propertyName: key,
-            operator: SearchFilterOperator.EQ,
-            value
-          }
-        ]
+  async search(
+    searchFields: { [key: string]: unknown },
+    objectType: string,
+    responseProperties: string[],
+    responseSortBy: string[]
+  ) {
+    if (typeof searchFields === 'object' && Object.keys(searchFields).length > 0) {
+      const searchPayload: SearchPayload = {
+        filterGroups: [],
+        properties: [...responseProperties],
+        sorts: [...responseSortBy]
+      }
+      for (const [key, value] of Object.entries(searchFields)) {
+        searchPayload.filterGroups.push({
+          filters: [
+            {
+              propertyName: key,
+              operator: SearchFilterOperator.EQ,
+              value
+            }
+          ]
+        })
+      }
+
+      return this.request<SearchResponse>(`${HUBSPOT_BASE_URL}/crm/v3/objects/${objectType}/search`, {
+        method: 'POST',
+        json: {
+          ...searchPayload
+        }
       })
     }
-
-    return this.request<SearchResponse>(`${HUBSPOT_BASE_URL}/crm/v3/objects/${this.objectType}/search`, {
-      method: 'POST',
-      json: {
-        ...searchPayload
-      }
-    })
+    return null
   }
 
   /**
@@ -49,11 +70,12 @@ export class Hubspot {
    * @param {{[key: string]: unknown}} properties A list of key-value pairs of properties of the object
    * @returns {Promise<ModifiedResponse<UpsertCompanyResponse>>} A promise that resolves the updated object
    */
-  async create(properties: { [key: string]: unknown }) {
+  async create(properties: { [key: string]: unknown }, associations?: CreateAssociation[]) {
     return this.request<UpsertRecordResponse>(`${HUBSPOT_BASE_URL}/crm/v3/objects/${this.objectType}`, {
       method: 'POST',
       json: {
-        properties: properties
+        properties: properties,
+        associations: associations
       }
     })
   }
@@ -79,5 +101,59 @@ export class Hubspot {
         properties: properties
       }
     })
+  }
+
+  /**
+   * Updates a CRM object in HubSPot identified by record ID or a unique property ID
+   * @param {string} fromObjectType A unique identifier value of the property
+   * @param {String} toObjectType Unique property of object record to match with uniqueIdentifier, if this parameter is not defined then uniqueIdentifier is matched with HubSpot generated record ID
+   * @param {batchInput[]} input Unique property of object record to match with uniqueIdentifier, if this parameter is not defined then uniqueIdentifier is matched with HubSpot generated record ID
+   * @returns {Promise<ModifiedResponse<UpsertRecordResponse>>} A promise that resolves the updated object
+   */
+  async associate(objectId: string, toObjectId: string, associations: AssociationType[]) {
+    const associateURL = `${HUBSPOT_BASE_URL}/crm/v4/objects/${this.objectType}/${objectId}/associations/${this.toObjectType}/${toObjectId}`
+
+    return this.request<UpsertRecordResponse>(associateURL, {
+      method: 'PUT',
+      json: associations
+    })
+  }
+
+  async getObjectIdAssociate(
+    searchFieldsToAssociateCustomObjects: { [key: string]: unknown } | undefined,
+    associationType:
+      | {
+          [k: string]: unknown
+        }
+      | undefined
+  ) {
+    try {
+      if (
+        this.toObjectType &&
+        associationType &&
+        Object.keys(associationType).length > 0 &&
+        searchFieldsToAssociateCustomObjects &&
+        Object.keys(searchFieldsToAssociateCustomObjects).length > 0
+      ) {
+        let searchCustomResponseToAssociate: ModifiedResponse<SearchResponse> | null = null
+        searchCustomResponseToAssociate = await this.search(
+          { ...searchFieldsToAssociateCustomObjects },
+          this.toObjectType,
+          [],
+          []
+        )
+        if (searchCustomResponseToAssociate?.data && searchCustomResponseToAssociate?.data?.total) {
+          return searchCustomResponseToAssociate
+        }
+      }
+      return null
+    } catch (e) {
+      // HubSpot throws a generic 400 error if an undefined property is used in search
+      // Throw a more informative error instead
+      if ((e as HTTPError)?.response?.status === 400) {
+        throw CustomSearchToAssociateThrowableError
+      }
+      throw e
+    }
   }
 }

--- a/packages/destination-actions/src/destinations/hubspot/errors.ts
+++ b/packages/destination-actions/src/destinations/hubspot/errors.ts
@@ -50,6 +50,18 @@ export const MultipleCustomRecordsInSearchResultThrowableError = new Integration
   400
 )
 
+export const CustomSearchToAssociateThrowableError = new IntegrationError(
+  "HubSpot returned 400 error while performing a custom object record search to associate. Please check if 'Search Fields to Associate custom Object' contains valid properties defined in HubSpot.",
+  'Custom Search To Associate Failed',
+  400
+)
+
+export const MultipleCustomRecordsInSearchResultToAssociateThrowableError = new IntegrationError(
+  `Upsert Custom Object operation was completed but the association failed as the search association object returned more than one items. Ensure that you use an unique identifier to lookup an association object.`,
+  'Associate Search Criteria Not Unique',
+  400
+)
+
 export function isSegmentUniqueIdentifierPropertyError(
   error: HubSpotError,
   segmentUniqueIdentifierProperty: string

--- a/packages/destination-actions/src/destinations/hubspot/upsertCompany/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCompany/__tests__/__snapshots__/index.test.ts.snap
@@ -46,6 +46,7 @@ Object {
 
 exports[`HubSpot.upsertCompany should create SEGMENT_UNIQUE_IDENTIFIER and create a company if SEGMENT_UNIQUE_IDENTIFIER property is not found 3`] = `
 Object {
+  "associations": Array [],
   "properties": Object {
     "address": undefined,
     "city": undefined,
@@ -80,6 +81,7 @@ Object {
 
 exports[`HubSpot.upsertCompany should create SEGMENT_UNIQUE_IDENTIFIER and create a company if SEGMENT_UNIQUE_IDENTIFIER property is not found 5`] = `
 Object {
+  "associations": Array [],
   "properties": Object {
     "address": undefined,
     "city": undefined,
@@ -244,6 +246,7 @@ Object {
 
 exports[`HubSpot.upsertCompany should create a company with and associate a contact 3`] = `
 Object {
+  "associations": Array [],
   "properties": Object {
     "address": undefined,
     "city": undefined,

--- a/packages/destination-actions/src/destinations/hubspot/upsertCompany/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCompany/index.ts
@@ -285,6 +285,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
           searchCompanyResponse = await hubspotApiClient.search(
             { ...payload.companysearchfields },
+            'companies',
             responseProperties,
             responseSortBy
           )

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/__tests__/__snapshots__/index.test.ts.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`HubSpot.upsertCustomObjectRecord Should only Upsert Custom Object and would skip association if no record found on the basis of search fields provided to associate 1`] = `
+Object {
+  "properties": Object {
+    "coupon_code": "TEST1234",
+    "discount_percent": "TEST1234",
+  },
+}
+`;
+
+exports[`HubSpot.upsertCustomObjectRecord Should only Upsert Custom Object record and would skip association if anyone of 'toObjectType , associationType and searchFieldsToAssociateCustomObjects' is not provided 1`] = `
+Object {
+  "properties": Object {
+    "coupon_code": "TEST1234",
+    "discount_percent": "TEST1234",
+  },
+}
+`;
+
+exports[`HubSpot.upsertCustomObjectRecord should create a custom object record and associate with another record on the basis of provided search field to associate 1`] = `
+Object {
+  "associations": Array [
+    Object {
+      "to": Object {
+        "id": "1234567890",
+      },
+      "types": Array [
+        Object {
+          "associationCategory": "HUBSPOT_DEFINED",
+          "associationTypeId": 279,
+        },
+      ],
+    },
+  ],
+  "properties": Object {
+    "coupon_code": "TEST1234",
+    "discount_percent": "TEST1234",
+  },
+}
+`;
+
 exports[`HubSpot.upsertCustomObjectRecord should update a custom Object with custom Search Field, if record matches 1`] = `
 Object {
   "filterGroups": Array [
@@ -14,9 +54,7 @@ Object {
     },
   ],
   "properties": Array [],
-  "sorts": Array [
-    "name",
-  ],
+  "sorts": Array [],
 }
 `;
 
@@ -27,4 +65,22 @@ Object {
     "discount_percent": "TEST1234",
   },
 }
+`;
+
+exports[`HubSpot.upsertCustomObjectRecord should update a custom object record and associate with another record when both search field matches a unique record 1`] = `
+Object {
+  "properties": Object {
+    "coupon_code": "TEST1234",
+    "discount_percent": "TEST1234",
+  },
+}
+`;
+
+exports[`HubSpot.upsertCustomObjectRecord should update a custom object record and associate with another record when both search field matches a unique record 2`] = `
+Array [
+  Object {
+    "associationCategory": "HUBSPOT_DEFINED",
+    "associationTypeId": 279,
+  },
+]
 `;

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/__tests__/__snapshots__/index.test.ts.snap
@@ -9,7 +9,7 @@ Object {
 }
 `;
 
-exports[`HubSpot.upsertCustomObjectRecord Should only Upsert Custom Object record and would skip association if anyone of 'toObjectType , associationType and searchFieldsToAssociateCustomObjects' is not provided 1`] = `
+exports[`HubSpot.upsertCustomObjectRecord Should only Upsert Custom Object record and would skip association if anyone of 'toObjectType , associationLabel and searchFieldsToAssociateCustomObjects' is not provided 1`] = `
 Object {
   "properties": Object {
     "coupon_code": "TEST1234",

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -14,9 +14,7 @@ Object {
     },
   ],
   "properties": Array [],
-  "sorts": Array [
-    "name",
-  ],
+  "sorts": Array [],
 }
 `;
 
@@ -24,6 +22,7 @@ exports[`Testing snapshot for HubSpot's upsertCustomObjectRecord destination act
 
 exports[`Testing snapshot for HubSpot's upsertCustomObjectRecord destination action: required fields 1`] = `
 Object {
+  "associations": Array [],
   "properties": Object {
     "testType": "3mKhorxHT$[h[CqZ2ptH",
   },

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/__tests__/index.test.ts
@@ -504,10 +504,7 @@ describe('HubSpot.upsertCustomObjectRecord', () => {
         searchFieldsToAssociateCustomObjects: {
           shopping_code: 'test_1234'
         },
-        associationType: {
-          associationCategory: 'HUBSPOT_DEFINED',
-          associationTypeId: 279
-        },
+        associationType: '{"associationCategory":"HUBSPOT_DEFINED","associationTypeId":279}',
         properties: {
           coupon_code: {
             '@path': '$.properties.couponCode'
@@ -617,10 +614,7 @@ describe('HubSpot.upsertCustomObjectRecord', () => {
         searchFieldsToAssociateCustomObjects: {
           shopping_code: 'test_1234'
         },
-        associationType: {
-          associationCategory: 'HUBSPOT_DEFINED',
-          associationTypeId: 279
-        },
+        associationType: '{"associationCategory":"HUBSPOT_DEFINED","associationTypeId":279}',
         properties: {
           coupon_code: {
             '@path': '$.properties.couponCode'
@@ -780,10 +774,7 @@ describe('HubSpot.upsertCustomObjectRecord', () => {
         searchFieldsToAssociateCustomObjects: {
           shopping_code: 'test_1234'
         },
-        associationType: {
-          associationCategory: 'HUBSPOT_DEFINED',
-          associationTypeId: 279
-        },
+        associationType: '{"associationCategory":"HUBSPOT_DEFINED","associationTypeId":279}',
         properties: {
           coupon_code: {
             '@path': '$.properties.couponCode'
@@ -893,10 +884,7 @@ describe('HubSpot.upsertCustomObjectRecord', () => {
           searchFieldsToAssociateCustomObjects: {
             shopping_code: 'test_1234'
           },
-          associationType: {
-            associationCategory: 'HUBSPOT_DEFINED',
-            associationTypeId: 279
-          },
+          associationType: '{"associationCategory":"HUBSPOT_DEFINED","associationTypeId":279}',
           properties: {
             coupon_code: {
               '@path': '$.properties.couponCode'

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/__tests__/index.test.ts
@@ -504,7 +504,7 @@ describe('HubSpot.upsertCustomObjectRecord', () => {
         searchFieldsToAssociateCustomObjects: {
           shopping_code: 'test_1234'
         },
-        associationType: '{"associationCategory":"HUBSPOT_DEFINED","associationTypeId":279}',
+        associationLabel: 'HUBSPOT_DEFINED:279',
         properties: {
           coupon_code: {
             '@path': '$.properties.couponCode'
@@ -614,7 +614,7 @@ describe('HubSpot.upsertCustomObjectRecord', () => {
         searchFieldsToAssociateCustomObjects: {
           shopping_code: 'test_1234'
         },
-        associationType: '{"associationCategory":"HUBSPOT_DEFINED","associationTypeId":279}',
+        associationLabel: 'HUBSPOT_DEFINED:279',
         properties: {
           coupon_code: {
             '@path': '$.properties.couponCode'
@@ -634,7 +634,7 @@ describe('HubSpot.upsertCustomObjectRecord', () => {
     expect(responses[3].options.json).toMatchSnapshot()
   })
 
-  it("Should only Upsert Custom Object record and would skip association if anyone of 'toObjectType , associationType and searchFieldsToAssociateCustomObjects' is not provided", async () => {
+  it("Should only Upsert Custom Object record and would skip association if anyone of 'toObjectType , associationLabel and searchFieldsToAssociateCustomObjects' is not provided", async () => {
     // Mock: Search Custom Object Record with custom Search Fields
     nock(HUBSPOT_BASE_URL)
       .post(`/crm/v3/objects/${objectType}/search`)
@@ -774,7 +774,7 @@ describe('HubSpot.upsertCustomObjectRecord', () => {
         searchFieldsToAssociateCustomObjects: {
           shopping_code: 'test_1234'
         },
-        associationType: '{"associationCategory":"HUBSPOT_DEFINED","associationTypeId":279}',
+        associationLabel: 'HUBSPOT_DEFINED:279',
         properties: {
           coupon_code: {
             '@path': '$.properties.couponCode'
@@ -884,7 +884,7 @@ describe('HubSpot.upsertCustomObjectRecord', () => {
           searchFieldsToAssociateCustomObjects: {
             shopping_code: 'test_1234'
           },
-          associationType: '{"associationCategory":"HUBSPOT_DEFINED","associationTypeId":279}',
+          associationLabel: 'HUBSPOT_DEFINED:279',
           properties: {
             coupon_code: {
               '@path': '$.properties.couponCode'

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/__tests__/index.test.ts
@@ -346,7 +346,7 @@ describe('HubSpot.upsertCustomObjectRecord', () => {
       settings: {}
     })) as DynamicFieldResponse
 
-    expect(responses.choices.length).toBe(6)
+    expect(responses.choices.length).toBe(4)
     expect(responses.choices).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -364,14 +364,6 @@ describe('HubSpot.upsertCustomObjectRecord', () => {
         expect.objectContaining({
           label: 'Tickets',
           value: 'tickets'
-        }),
-        expect.objectContaining({
-          label: 'Contacts',
-          value: 'contacts'
-        }),
-        expect.objectContaining({
-          label: 'Companies',
-          value: 'companies'
         })
       ])
     )

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/__tests__/index.test.ts
@@ -257,7 +257,7 @@ describe('HubSpot.upsertCustomObjectRecord', () => {
     ).rejects.toThrowError(MultipleCustomRecordsInSearchResultThrowableError)
   })
 
-  it('should dynamically fetch custom object name', async () => {
+  it('should dynamically fetch custom objectType', async () => {
     nock(HUBSPOT_BASE_URL)
       .get(`/crm/v3/schemas?archived=false`)
       .reply(200, {
@@ -340,9 +340,10 @@ describe('HubSpot.upsertCustomObjectRecord', () => {
           }
         ]
       })
-    const payload = {}
+
+    //Dynamically Fetch objectType
     const responses = (await testDestination.executeDynamicField('upsertCustomObjectRecord', 'objectType', {
-      payload: payload,
+      payload: {},
       settings: {}
     })) as DynamicFieldResponse
 
@@ -364,6 +365,173 @@ describe('HubSpot.upsertCustomObjectRecord', () => {
         expect.objectContaining({
           label: 'Tickets',
           value: 'tickets'
+        })
+      ])
+    )
+  })
+
+  it('should dynamically fetch toObjectType', async () => {
+    nock(HUBSPOT_BASE_URL)
+      .get(`/crm/v3/schemas?archived=false`)
+      .reply(200, {
+        results: [
+          {
+            labels: {
+              singular: 'Car',
+              plural: 'Cars'
+            },
+            fullyQualifiedName: 'p22596207_car',
+            createdAt: '2022-09-02T06:37:55.855Z',
+            updatedAt: '2022-09-02T07:04:56.159Z',
+            objectTypeId: '2-8594192',
+            properties: [
+              {
+                updatedAt: '2022-09-02T06:37:55.966Z',
+                createdAt: '2022-09-02T06:37:55.966Z',
+                name: 'color',
+                label: 'Color',
+                type: 'string',
+                fieldType: 'text',
+                description: '',
+                groupName: 'car_information',
+                options: [],
+                createdUserId: '1058338',
+                updatedUserId: '1058338',
+                displayOrder: -1,
+                calculated: false,
+                externalOptions: false,
+                archived: false,
+                hasUniqueValue: false,
+                hidden: false,
+                modificationMetadata: {
+                  archivable: true,
+                  readOnlyDefinition: false,
+                  readOnlyValue: false
+                },
+                formField: false
+              }
+            ],
+            name: 'car'
+          },
+          {
+            labels: {
+              singular: 'ServiceRequest',
+              plural: 'ServiceRequests'
+            },
+            fullyQualifiedName: 'p22596207_service_request',
+            createdAt: '2022-09-05T08:16:13.083Z',
+            updatedAt: '2022-09-05T08:16:13.083Z',
+            objectTypeId: '2-8648833',
+            properties: [
+              {
+                updatedAt: '2022-09-05T08:16:13.214Z',
+                createdAt: '2022-09-05T08:16:13.214Z',
+                name: 'customer_id',
+                label: 'Unique ID for a customer',
+                type: 'string',
+                fieldType: 'text',
+                description: '',
+                groupName: 'service_request_information',
+                options: [],
+                createdUserId: '1058338',
+                updatedUserId: '1058338',
+                displayOrder: -1,
+                calculated: false,
+                externalOptions: false,
+                archived: false,
+                hasUniqueValue: false,
+                hidden: false,
+                modificationMetadata: {
+                  archivable: true,
+                  readOnlyDefinition: false,
+                  readOnlyValue: false
+                },
+                formField: true
+              }
+            ],
+            name: 'service_request'
+          }
+        ]
+      })
+
+    //Dynamically Fetch toObjectType
+    const toObjectTypeResponses = (await testDestination.executeDynamicField(
+      'upsertCustomObjectRecord',
+      'toObjectType',
+      {
+        payload: {},
+        settings: {}
+      }
+    )) as DynamicFieldResponse
+
+    expect(toObjectTypeResponses.choices.length).toBe(6)
+    expect(toObjectTypeResponses.choices).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'Cars',
+          value: 'p22596207_car'
+        }),
+        expect.objectContaining({
+          label: 'ServiceRequests',
+          value: 'p22596207_service_request'
+        }),
+        expect.objectContaining({
+          label: 'Deals',
+          value: 'deals'
+        }),
+        expect.objectContaining({
+          label: 'Tickets',
+          value: 'tickets'
+        }),
+        expect.objectContaining({
+          label: 'Contacts',
+          value: 'contacts'
+        }),
+        expect.objectContaining({
+          label: 'Companies',
+          value: 'companies'
+        })
+      ])
+    )
+  })
+  it('should dynamically fetch association labels between objectType and toObjectType', async () => {
+    nock(HUBSPOT_BASE_URL)
+      .get(`/crm/v4/associations/${objectType}/${toObjectType}/labels`)
+      .reply(200, {
+        results: [
+          {
+            category: 'HUBSPOT_DEFINED',
+            typeId: 279,
+            label: null
+          },
+          {
+            category: 'HUBSPOT_DEFINED',
+            typeId: 1,
+            label: 'Primary'
+          }
+        ]
+      })
+
+    //Dynamically Fetch association Labels between objectType and toObjectType
+    const payload = {
+      objectType: objectType,
+      toObjectType: toObjectType
+    }
+    const responses = (await testDestination.executeDynamicField('upsertCustomObjectRecord', 'associationLabel', {
+      payload: payload,
+      settings: {}
+    })) as DynamicFieldResponse
+
+    expect(responses.choices.length).toBe(2)
+    expect(responses.choices).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'Unlabeled Association (Type 279)',
+          value: 'HUBSPOT_DEFINED:279'
+        }),
+        expect.objectContaining({
+          label: 'Primary',
+          value: 'HUBSPOT_DEFINED:1'
         })
       ])
     )

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/generated-types.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/generated-types.ts
@@ -34,5 +34,5 @@ export interface Payload {
   /**
    * Type of Association between two objectType
    */
-  associationType?: string
+  associationLabel?: string
 }

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/generated-types.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/generated-types.ts
@@ -21,4 +21,20 @@ export interface Payload {
   properties: {
     [k: string]: unknown
   }
+  /**
+   * The unique field(s) used to search for an existing custom record in HubSpot to get toObjectId so that segment will associate the record with this record. If a Record is not found on the basis of data provided here in key:value format will skip the association.
+   */
+  searchFieldsToAssociateCustomObjects?: {
+    [k: string]: unknown
+  }
+  /**
+   * The CRM object schema to use for creating a record. This can be a standard object (i.e. tickets, deals) or ***fullyQualifiedName*** of a custom object. Schema for the Custom Objects must be predefined in HubSpot. More information on Custom Objects and *fullyQualifiedName* in [HubSpot documentation](https://developers.hubspot.com/docs/api/crm/crm-custom-objects#retrieve-existing-custom-objects).
+   */
+  toObjectType?: string
+  /**
+   * The CRM object schema to use for creating a record. This can be a standard object (i.e. tickets, deals) or ***fullyQualifiedName*** of a custom object. Schema for the Custom Objects must be predefined in HubSpot. More information on Custom Objects and *fullyQualifiedName* in [HubSpot documentation](https://developers.hubspot.com/docs/api/crm/crm-custom-objects#retrieve-existing-custom-objects).
+   */
+  associationType?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/generated-types.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/generated-types.ts
@@ -34,7 +34,5 @@ export interface Payload {
   /**
    * Type of Association between two objectType
    */
-  associationType?: {
-    [k: string]: unknown
-  }
+  associationType?: string
 }

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/generated-types.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/generated-types.ts
@@ -32,7 +32,7 @@ export interface Payload {
    */
   toObjectType?: string
   /**
-   * The CRM object schema to use for creating a record. This can be a standard object (i.e. tickets, deals) or ***fullyQualifiedName*** of a custom object. Schema for the Custom Objects must be predefined in HubSpot. More information on Custom Objects and *fullyQualifiedName* in [HubSpot documentation](https://developers.hubspot.com/docs/api/crm/crm-custom-objects#retrieve-existing-custom-objects).
+   * Type of Association between two objectType
    */
   associationType?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
@@ -159,7 +159,7 @@ const action: ActionDefinition<Settings, Payload> = {
       const createNewCustomRecord = payload?.createNewCustomRecord ?? true
       // If Create New custom object record flag is set to false, skip creation
       if (!createNewCustomRecord) {
-        return `[Testing in Logic]- ${payload.associationLabel}---- ${parsedAssociationType}--There was no record found to update. If you want to create a new custom object record in such cases, enable the Create Custom Object Record if Not Found flag`
+        return 'There was no record found to update. If you want to create a new custom object record in such cases, enable the Create Custom Object Record if Not Found flag'
       }
       const properties = { ...flattenObject(payload.properties) }
       upsertCustomRecordResponse = await hubspotApiClient.create(properties, association ? [association] : [])
@@ -237,7 +237,7 @@ async function getAssociationLabel(request: RequestClient, payload: Payload) {
       }
     )
     const choices = response?.data?.results?.map((res) => ({
-      label: !res.label ? `Unlabeled-Association-Type (Type ${res.typeId})` : res.label,
+      label: !res.label ? `Unlabeled Association (Type ${res.typeId})` : res.label,
       value: `${res.category}:${res.typeId}`
     }))
     return {

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
@@ -235,7 +235,7 @@ async function getAssociationLabel(request: RequestClient, payload: Payload) {
       }
     )
     const choices = response?.data?.results?.map((res) => ({
-      label: !res.label ? `Unlabeled Association (Type ${res.typeId})` : res.label,
+      label: !res.label ? `Unlabeled Associations (Type ${res.typeId})` : res.label,
       value: JSON.stringify({ associationCategory: res.category, associationTypeId: res.typeId })
     }))
     return {

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
@@ -223,8 +223,6 @@ async function getAssociationLabel(request: RequestClient, payload: Payload) {
   try {
     // API Doc - https://developers.hubspot.com/docs/api/crm/crm-custom-objects#endpoint?spec=GET-/crm/v3/schemas
     //
-    payload.objectType = 'companies'
-    payload.toObjectType = 'tickets'
     const response = await request<GetAssociationLabelResponse>(
       `${HUBSPOT_BASE_URL}/crm/v4/associations/${payload.objectType}/${payload.toObjectType}/labels`,
       {

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
@@ -235,7 +235,7 @@ async function getAssociationLabel(request: RequestClient, payload: Payload) {
       }
     )
     const choices = response?.data?.results?.map((res) => ({
-      label: !res.label ? `Unlabeled Associations (Type ${res.typeId})` : res.label,
+      label: !res.label ? `Unlabeled Association Type (Type ${res.typeId})` : res.label,
       value: JSON.stringify({ associationCategory: res.category, associationTypeId: res.typeId })
     }))
     return {

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
@@ -3,8 +3,20 @@ import { RequestClient } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { HUBSPOT_BASE_URL } from '../properties'
-import { CustomSearchThrowableError, HubSpotError, MultipleCustomRecordsInSearchResultThrowableError } from '../errors'
-import { flattenObject, SearchResponse, UpsertRecordResponse } from '../utils'
+import {
+  CustomSearchThrowableError,
+  HubSpotError,
+  MultipleCustomRecordsInSearchResultThrowableError,
+  MultipleCustomRecordsInSearchResultToAssociateThrowableError
+} from '../errors'
+import {
+  // AssociationType,
+  CreateAssociation,
+  flattenObject,
+  GetAssociationLabelResponse,
+  SearchResponse,
+  UpsertRecordResponse
+} from '../utils'
 import { ModifiedResponse } from '@segment/actions-core'
 import { HTTPError } from '@segment/actions-core'
 import { Hubspot } from '../api'
@@ -54,39 +66,80 @@ const action: ActionDefinition<Settings, Payload> = {
       required: true,
       defaultObjectUI: 'keyvalue:only',
       allowNull: false
+    },
+    searchFieldsToAssociateCustomObjects: {
+      label: 'Search Fields to Associate custom Object',
+      description:
+        'The unique field(s) used to search for an existing custom record in HubSpot to get toObjectId so that segment will associate the record with this record. If a Record is not found on the basis of data provided here in key:value format will skip the association.',
+      type: 'object',
+      defaultObjectUI: 'keyvalue:only'
+    },
+    toObjectType: {
+      label: 'ObjectType to associate',
+      description:
+        'The CRM object schema to use for creating a record. This can be a standard object (i.e. tickets, deals) or ***fullyQualifiedName*** of a custom object. Schema for the Custom Objects must be predefined in HubSpot. More information on Custom Objects and *fullyQualifiedName* in [HubSpot documentation](https://developers.hubspot.com/docs/api/crm/crm-custom-objects#retrieve-existing-custom-objects).',
+      type: 'string',
+      dynamic: true
+    },
+    associationType: {
+      label: 'Association Label',
+      description:
+        'The CRM object schema to use for creating a record. This can be a standard object (i.e. tickets, deals) or ***fullyQualifiedName*** of a custom object. Schema for the Custom Objects must be predefined in HubSpot. More information on Custom Objects and *fullyQualifiedName* in [HubSpot documentation](https://developers.hubspot.com/docs/api/crm/crm-custom-objects#retrieve-existing-custom-objects).',
+      type: 'object',
+      dynamic: true
     }
   },
   dynamicFields: {
-    objectType: async (request, _) => {
-      return getCustomObjects(request)
+    objectType: async (request, { payload }) => {
+      return getCustomObjects(request, payload.toObjectType)
+    },
+    toObjectType: async (request, { payload }) => {
+      console.log(payload)
+      return getCustomObjects(request, payload.objectType)
+    },
+    associationType: async (request, { payload }) => {
+      return getAssociationLabel(request, payload)
     }
   },
   perform: async (request, { payload }) => {
     // Attempt to search Custom Object record with Custom Search Fields
     // If Custom Search Fields doesn't have any defined property, skip the search and assume record was not found
     let searchCustomResponse: ModifiedResponse<SearchResponse> | null = null
-    const hubspotApiClient: Hubspot = new Hubspot(request, payload.objectType)
-    if (
-      typeof payload.customObjectSearchFields === 'object' &&
-      Object.keys(payload.customObjectSearchFields).length > 0
-    ) {
-      try {
-        // Generate custom search payload
-        const responseSortBy: string[] = ['name']
-        searchCustomResponse = await hubspotApiClient.search(
-          { ...payload.customObjectSearchFields },
-          [],
-          responseSortBy
-        )
-      } catch (e) {
-        // HubSpot throws a generic 400 error if an undefined property is used in search
-        // Throw a more informative error instead
-        if ((e as HTTPError)?.response?.status === 400) {
-          throw CustomSearchThrowableError
-        }
-        throw e
+    // If Search Fields to Associate custom Object doesn't have any defined property , skip the associate
+    let searchCustomResponseToAssociate: ModifiedResponse<SearchResponse> | null = null
+    // console.log(payload)
+    const hubspotApiClient: Hubspot = new Hubspot(request, payload.objectType, payload.toObjectType)
+    let association: CreateAssociation | null = null
+    // if (
+    //   typeof payload.customObjectSearchFields === 'object' &&
+    //   Object.keys(payload.customObjectSearchFields).length > 0
+    // ) {
+    try {
+      searchCustomResponse = await hubspotApiClient.search(
+        { ...payload.customObjectSearchFields },
+        payload.objectType,
+        [],
+        []
+      )
+    } catch (e) {
+      // HubSpot throws a generic 400 error if an undefined property is used in search
+      // Throw a more informative error instead
+      console.log(e)
+      if ((e as HTTPError)?.response?.status === 400) {
+        throw CustomSearchThrowableError
       }
+      throw e
     }
+    searchCustomResponseToAssociate = await hubspotApiClient.getObjectIdAssociate(
+      payload.searchFieldsToAssociateCustomObjects,
+      payload.associationType
+    )
+    const toCustomObjectId =
+      searchCustomResponseToAssociate?.data?.total === 1 ? searchCustomResponseToAssociate?.data.results[0].id : null
+    association = createAssociationObject(toCustomObjectId, payload?.associationType)
+
+    // }
+
     // Store Custom Object Record Id in parent scope
     // This would be used to store custom object record Id after search or create.
     let upsertCustomRecordResponse: ModifiedResponse<UpsertRecordResponse>
@@ -102,7 +155,7 @@ const action: ActionDefinition<Settings, Payload> = {
         return 'There was no record found to update. If you want to create a new custom object record in such cases, enable the Create Custom Object Record if Not Found flag'
       }
       const properties = { ...flattenObject(payload.properties) }
-      upsertCustomRecordResponse = await hubspotApiClient.create(properties)
+      upsertCustomRecordResponse = await hubspotApiClient.create(properties, association ? [association] : [])
     } else {
       // Throw error if more than one custom object record were found with search criteria
       if (searchCustomResponse?.data?.total > 1) {
@@ -113,16 +166,30 @@ const action: ActionDefinition<Settings, Payload> = {
         searchCustomResponse.data.results[0].id,
         payload.properties
       )
+
+      if (toCustomObjectId) {
+        await hubspotApiClient.associate(searchCustomResponse.data.results[0].id, toCustomObjectId, [
+          {
+            associationCategory: payload.associationType?.associationCategory,
+            associationTypeId: payload.associationType?.associationTypeId
+          }
+        ])
+      }
+    }
+    if (searchCustomResponseToAssociate?.data && searchCustomResponseToAssociate?.data?.total > 1) {
+      throw MultipleCustomRecordsInSearchResultToAssociateThrowableError
     }
     return upsertCustomRecordResponse.data
   }
 }
 
-async function getCustomObjects(request: RequestClient) {
+async function getCustomObjects(request: RequestClient, objectType: string | undefined) {
   // List of HubSpot defined Objects that segment has OAuth Scope to access
   const defaultChoices = [
     { value: 'deals', label: 'Deals' },
-    { value: 'tickets', label: 'Tickets' }
+    { value: 'tickets', label: 'Tickets' },
+    { value: 'contacts', label: 'Contacts' },
+    { value: 'companies', label: 'Companies' }
   ]
 
   try {
@@ -132,10 +199,12 @@ async function getCustomObjects(request: RequestClient) {
       method: 'GET',
       skipResponseCloning: true
     })
-    const choices = response.data.results.map((schema) => ({
-      label: schema.labels.plural,
-      value: schema.fullyQualifiedName
-    }))
+    const choices = response.data.results
+      .filter((res) => res.fullyQualifiedName != objectType)
+      .map((schema) => ({
+        label: schema.labels.plural,
+        value: schema.fullyQualifiedName
+      }))
     return {
       choices: [...choices, ...defaultChoices]
     }
@@ -148,6 +217,60 @@ async function getCustomObjects(request: RequestClient) {
       }
     }
   }
+}
+
+async function getAssociationLabel(request: RequestClient, payload: Payload) {
+  try {
+    // API Doc - https://developers.hubspot.com/docs/api/crm/crm-custom-objects#endpoint?spec=GET-/crm/v3/schemas
+    //
+    payload.objectType = 'companies'
+    payload.toObjectType = 'tickets'
+    const response = await request<GetAssociationLabelResponse>(
+      `${HUBSPOT_BASE_URL}/crm/v4/associations/${payload.objectType}/${payload.toObjectType}/labels`,
+      {
+        method: 'GET',
+        skipResponseCloning: true
+      }
+    )
+    const choices = response?.data?.results?.map((res) => ({
+      label: !res.label ? `Unlabeled Association (Type ${res.typeId})` : res.label,
+      value: { associationCategory: res.category, associationTypeId: res.typeId }
+    }))
+    return {
+      choices
+    }
+  } catch (err) {
+    return {
+      choices: [],
+      error: {
+        message: (err as HubSpotError)?.response?.data?.message ?? 'Unknown error',
+        code: (err as HubSpotError)?.response?.data?.category ?? 'Unknown code'
+      }
+    }
+  }
+}
+function createAssociationObject(
+  toCustomObjectId: string | null,
+  associationType:
+    | {
+        [k: string]: unknown
+      }
+    | undefined
+) {
+  if (toCustomObjectId) {
+    return {
+      to: {
+        id: toCustomObjectId
+      },
+      types: [
+        {
+          associationCategory: associationType?.associationCategory,
+          associationTypeId: associationType?.associationTypeId
+        }
+      ]
+    }
+  }
+  return null
 }
 
 export default action

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
@@ -187,7 +187,7 @@ const action: ActionDefinition<Settings, Payload> = {
     if (searchCustomResponseToAssociate?.data && searchCustomResponseToAssociate?.data?.total > 1) {
       throw MultipleCustomRecordsInSearchResultToAssociateThrowableError
     }
-    return upsertCustomRecordResponse.data
+    return upsertCustomRecordResponse
   }
 }
 

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
@@ -132,9 +132,9 @@ const action: ActionDefinition<Settings, Payload> = {
       }
       throw e
     }
-    const parsedAssociationType: AssociationType = payload?.associationType
-      ? JSON.parse(payload?.associationType)
-      : null
+
+    const parsedAssociationType: AssociationType | null = parseAssociationType(payload.associationType)
+
     // Get Custom object response on the basis of provided search fields to associate
     searchCustomResponseToAssociate = await hubspotApiClient.getObjectResponseToAssociate(
       payload.searchFieldsToAssociateCustomObjects,
@@ -267,6 +267,14 @@ function createAssociationObject(toCustomObjectId: string | null, associationTyp
     }
   }
   return null
+}
+
+function parseAssociationType(associationType: string | undefined) {
+  try {
+    return associationType ? JSON.parse(associationType) : null
+  } catch (err) {
+    return null
+  }
 }
 
 export default action

--- a/packages/destination-actions/src/destinations/hubspot/utils.ts
+++ b/packages/destination-actions/src/destinations/hubspot/utils.ts
@@ -81,9 +81,15 @@ export interface SearchResponse {
 
 export interface UpsertRecordResponse extends ResponseInfo {}
 
+export enum AssociationCategory {
+  HUBSPOT_DEFINED = 'HUBSPOT_DEFINED',
+  USER_DEFINED = 'USER_DEFINED',
+  INTEGRATOR_DEFINED = 'INTEGRATOR_DEFINED'
+}
+
 export interface AssociationType {
-  associationCategory: string | unknown
-  associationTypeId: number | unknown
+  associationCategory: AssociationCategory
+  associationTypeId: number
 }
 export interface CreateAssociation {
   to: {
@@ -93,7 +99,7 @@ export interface CreateAssociation {
 }
 
 export interface AssociationLabel {
-  category: string
+  category: AssociationCategory
   typeId: number
   label: string
 }

--- a/packages/destination-actions/src/destinations/hubspot/utils.ts
+++ b/packages/destination-actions/src/destinations/hubspot/utils.ts
@@ -85,15 +85,6 @@ export interface AssociationType {
   associationCategory: string | unknown
   associationTypeId: number | unknown
 }
-// export interface BatchAssociationsInput {
-//   from: {
-//     id: string
-//   }
-//   to: {
-//     id: string
-//   }
-//   types: AssociationType[]
-// }
 export interface CreateAssociation {
   to: {
     id: string

--- a/packages/destination-actions/src/destinations/hubspot/utils.ts
+++ b/packages/destination-actions/src/destinations/hubspot/utils.ts
@@ -80,3 +80,32 @@ export interface SearchResponse {
 }
 
 export interface UpsertRecordResponse extends ResponseInfo {}
+
+export interface AssociationType {
+  associationCategory: string | unknown
+  associationTypeId: number | unknown
+}
+// export interface BatchAssociationsInput {
+//   from: {
+//     id: string
+//   }
+//   to: {
+//     id: string
+//   }
+//   types: AssociationType[]
+// }
+export interface CreateAssociation {
+  to: {
+    id: string
+  }
+  types: AssociationType[]
+}
+
+export interface AssociationLabel {
+  category: string
+  typeId: number
+  label: string
+}
+export interface GetAssociationLabelResponse {
+  results: AssociationLabel[]
+}


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR is to add association support in upsertCustomObjectRecord action, so that Customer can associate two different custom object records via same action.
Jira Ticket :- https://segment.atlassian.net/jira/software/c/projects/STRATCONN/boards/310?modal=detail&selectedIssue=STRATCONN-2898&assignee=63617339fc0cc7a600b03c6b

Tested in [Staging Environment](https://docs.google.com/document/d/1tKilYtBY_whxbccIWDRzzhub7pW5jnY92Z8Yt0Wxv9A/edit)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
