### PR TITLE
[Publish] Registered Listark destination

### DIFF
--- a/packages/destination-actions/src/destinations/index.ts
+++ b/packages/destination-actions/src/destinations/index.ts
@@ -114,6 +114,7 @@ register('649adeaa719bd3f55fe81bef', './devrev')
 register('649a1418b31e61334c66a7e7', './webhook-audiences')
 register('64b67be0d0dd66094c162ca7', './app-fit')
 register('64b67add9c22bc2cce3bf8bc', './m3ter')
+register('64b6a221baf168a989be641a', './listrak')
 
 function register(id: MetadataId, destinationPath: string) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
This PR registers the following destinations for scheduled publish on July 18, 2023

- Listark (Actions)

Note: This is a follow-up PR of https://github.com/segmentio/action-destinations/pull/1412 to register an additional destination.

## Testing

Testing not requires as this PR registers new destination.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
