### PR TITLE
Add support for audience-exclusive settings

### DIFF
--- a/packages/cli/src/commands/generate/types.ts
+++ b/packages/cli/src/commands/generate/types.ts
@@ -11,6 +11,7 @@ import path from 'path'
 import prettier from 'prettier'
 import { loadDestination, hasOauthAuthentication } from '../../lib/destinations'
 import { RESERVED_FIELD_NAMES } from '../../constants'
+import { AudienceDestinationDefinition } from '@segment/actions-core/destination-kit'
 
 const pretterOptions = prettier.resolveConfig.sync(process.cwd())
 
@@ -113,7 +114,16 @@ export default class GenerateTypes extends Command {
       }
     }
 
-    const types = await generateTypes(settings, 'Settings')
+    let types = await generateTypes(settings, 'Settings')
+
+    const audienceSettings = {
+      ...(destination as AudienceDestinationDefinition)?.audienceFields
+    }
+    if (Object.keys(audienceSettings).length > 0) {
+      const audienceTypes = await generateTypes(audienceSettings, 'AudienceSettings')
+      types += audienceTypes
+    }
+
     fs.writeFileSync(path.join(parentDir, './generated-types.ts'), types)
 
     // TODO how to load directory structure consistently?

--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -11,11 +11,13 @@ import {
   DestinationDefinition as CloudDestinationDefinition,
   HTTPError,
   ModifiedResponse,
-  JSONObject
+  JSONObject,
+  AudienceDestinationDefinition
 } from '@segment/actions-core'
 import asyncHandler from './async-handler'
 import getExchanges from './summarize-http'
 import { AggregateAjvError } from '../../../ajv-human-errors/src/aggregate-ajv-error'
+import { AudienceDestinationConfigurationWithCreateGet } from '@segment/actions-core/destination-kit'
 interface ResponseError extends Error {
   status?: number
 }
@@ -147,9 +149,11 @@ app.use((req, res, next) => {
 function setupRoutes(def: DestinationDefinition | null): void {
   const destination = new Destination(def as CloudDestinationDefinition)
   const supportsDelete = destination.onDelete
-  const audienceSettings = destination?.definition.audienceSettings !== undefined
-  const supportsCreateAudience = !!(audienceSettings && destination.createAudience)
-  const supportsGetAudience = !!(audienceSettings && destination.getAudience)
+  const audienceDef = destination?.definition as AudienceDestinationDefinition
+  const audienceSettings = audienceDef.audienceConfig !== undefined
+  const audienceConfigWithGetCreate = audienceDef.audienceConfig as AudienceDestinationConfigurationWithCreateGet
+  const supportsCreateAudience = !!(audienceSettings && audienceConfigWithGetCreate.createAudience)
+  const supportsGetAudience = !!(audienceSettings && audienceConfigWithGetCreate.getAudience)
 
   const router = express.Router()
 
@@ -284,6 +288,7 @@ function setupRoutes(def: DestinationDefinition | null): void {
           const eventParams = {
             data: req.body.payload || {},
             settings: req.body.settings || {},
+            audienceSettings: req.body.audienceSettings || {},
             mapping: mapping || req.body.payload || {},
             auth: req.body.auth || {}
           }
@@ -319,7 +324,8 @@ function setupRoutes(def: DestinationDefinition | null): void {
                 settings: req.body.settings || {},
                 payload: req.body.payload || {},
                 page: req.body.page || 1,
-                auth: req.body.auth || {}
+                auth: req.body.auth || {},
+                audienceSettings: req.body.audienceSettings
               }
               const action = destination.actions[actionSlug]
               const result = await action.executeDynamicField(field, data)

--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -325,7 +325,7 @@ function setupRoutes(def: DestinationDefinition | null): void {
                 payload: req.body.payload || {},
                 page: req.body.page || 1,
                 auth: req.body.auth || {},
-                audienceSettings: req.body.audienceSettings
+                audienceSettings: req.body.audienceSettings || {}
               }
               const action = destination.actions[actionSlug]
               const result = await action.executeDynamicField(field, data)

--- a/packages/core/src/create-test-integration.ts
+++ b/packages/core/src/create-test-integration.ts
@@ -46,7 +46,7 @@ interface InputData<Settings> {
   stateContext?: StateContext
 }
 
-class TestDestination<T> extends Destination<T> {
+class TestDestination<T, AudienceSettings = any> extends Destination<T, AudienceSettings> {
   responses: Destination['responses'] = []
 
   constructor(destination: DestinationDefinition<T>) {

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -18,9 +18,9 @@ type MaybePromise<T> = T | Promise<T>
 type RequestClient = ReturnType<typeof createRequestClient>
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type RequestFn<Settings, Payload, Return = any> = (
+export type RequestFn<Settings, Payload, Return = any, AudienceSettings = any> = (
   request: RequestClient,
-  data: ExecuteInput<Settings, Payload>
+  data: ExecuteInput<Settings, Payload, AudienceSettings>
 ) => MaybePromise<Return>
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -50,32 +50,34 @@ export interface BaseActionDefinition {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface ActionDefinition<Settings, Payload = any> extends BaseActionDefinition {
+export interface ActionDefinition<Settings, Payload = any, AudienceSettings = any> extends BaseActionDefinition {
   /**
    * A way to "register" dynamic fields.
    * This is likely going to change as we productionalize the data model and definition object
    */
   dynamicFields?: {
-    [K in keyof Payload]?: RequestFn<Settings, Payload, DynamicFieldResponse>
+    [K in keyof Payload]?: RequestFn<Settings, Payload, DynamicFieldResponse, AudienceSettings>
   }
 
   /** The operation to perform when this action is triggered */
-  perform: RequestFn<Settings, Payload>
+  perform: RequestFn<Settings, Payload, any, AudienceSettings>
 
   /** The operation to perform when this action is triggered for a batch of events */
-  performBatch?: RequestFn<Settings, Payload[]>
+  performBatch?: RequestFn<Settings, Payload[], any, AudienceSettings>
 }
 
-export interface ExecuteDynamicFieldInput<Settings, Payload> {
+export interface ExecuteDynamicFieldInput<Settings, Payload, AudienceSettings = any> {
   settings: Settings
+  audienceSettings: AudienceSettings
   payload: Payload
   page?: string
   auth?: AuthTokens
 }
 
-interface ExecuteBundle<T = unknown, Data = unknown> {
+interface ExecuteBundle<T = unknown, Data = unknown, AudienceSettings = any> {
   data: Data
   settings: T
+  audienceSettings: AudienceSettings
   mapping: JSONObject
   auth: AuthTokens | undefined
   /** For internal Segment/Twilio use only. */
@@ -90,8 +92,8 @@ interface ExecuteBundle<T = unknown, Data = unknown> {
  * Action is the beginning step for all partner actions. Entrypoints always start with the
  * MapAndValidateInput step.
  */
-export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitter {
-  readonly definition: ActionDefinition<Settings, Payload>
+export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings = any> extends EventEmitter {
+  readonly definition: ActionDefinition<Settings, Payload, AudienceSettings>
   readonly destinationName: string
   readonly schema?: JSONSchema4
   readonly hasBatchSupport: boolean
@@ -101,7 +103,7 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
 
   constructor(
     destinationName: string,
-    definition: ActionDefinition<Settings, Payload>,
+    definition: ActionDefinition<Settings, Payload, AudienceSettings>,
     // Payloads may be any type so we use `any` explicitly here.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     extendRequest?: RequestExtension<Settings, any>
@@ -118,7 +120,7 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
     }
   }
 
-  async execute(bundle: ExecuteBundle<Settings, InputData | undefined>): Promise<Result[]> {
+  async execute(bundle: ExecuteBundle<Settings, InputData | undefined, AudienceSettings>): Promise<Result[]> {
     // TODO cleanup results... not sure it's even used
     const results: Result[] = []
 
@@ -147,7 +149,8 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
       statsContext: bundle.statsContext,
       logger: bundle.logger,
       transactionContext: bundle.transactionContext,
-      stateContext: bundle.stateContext
+      stateContext: bundle.stateContext,
+      audienceSettings: bundle.audienceSettings
     }
 
     // Construct the request client and perform the action
@@ -157,7 +160,7 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
     return results
   }
 
-  async executeBatch(bundle: ExecuteBundle<Settings, InputData[]>): Promise<void> {
+  async executeBatch(bundle: ExecuteBundle<Settings, InputData[], AudienceSettings>): Promise<void> {
     if (!this.hasBatchSupport) {
       throw new IntegrationError('This action does not support batched requests.', 'NotImplemented', 501)
     }
@@ -189,6 +192,7 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
         rawData: bundle.data,
         rawMapping: bundle.mapping,
         settings: bundle.settings,
+        audienceSettings: bundle.audienceSettings,
         payload: payloads,
         auth: bundle.auth,
         features: bundle.features,
@@ -203,7 +207,7 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
 
   async executeDynamicField(
     field: string,
-    data: ExecuteDynamicFieldInput<Settings, Payload>
+    data: ExecuteDynamicFieldInput<Settings, Payload, AudienceSettings>
   ): Promise<DynamicFieldResponse> {
     const fn = this.definition.dynamicFields?.[field]
     if (typeof fn !== 'function') {
@@ -227,8 +231,8 @@ export class Action<Settings, Payload extends JSONLikeObject> extends EventEmitt
    * and given data bundle
    */
   private async performRequest<T extends Payload | Payload[]>(
-    requestFn: RequestFn<Settings, T>,
-    data: ExecuteInput<Settings, T>
+    requestFn: RequestFn<Settings, T, any, AudienceSettings>,
+    data: ExecuteInput<Settings, T, AudienceSettings>
   ): Promise<unknown> {
     const requestClient = this.createRequestClient(data)
     const response = await requestFn(requestClient, data)

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -68,7 +68,7 @@ export interface ActionDefinition<Settings, Payload = any, AudienceSettings = an
 
 export interface ExecuteDynamicFieldInput<Settings, Payload, AudienceSettings = any> {
   settings: Settings
-  audienceSettings: AudienceSettings
+  audienceSettings?: AudienceSettings
   payload: Payload
   page?: string
   auth?: AuthTokens
@@ -77,7 +77,7 @@ export interface ExecuteDynamicFieldInput<Settings, Payload, AudienceSettings = 
 interface ExecuteBundle<T = unknown, Data = unknown, AudienceSettings = any> {
   data: Data
   settings: T
-  audienceSettings: AudienceSettings
+  audienceSettings?: AudienceSettings
   mapping: JSONObject
   auth: AuthTokens | undefined
   /** For internal Segment/Twilio use only. */

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -507,7 +507,7 @@ export class Destination<Settings = JSONObject, AudienceSettings = JSONObject> {
 
     let audienceSettings = {} as AudienceSettings
     if (event.context?.personas) {
-      audienceSettings = event.context?.personas?.settings as AudienceSettings
+      audienceSettings = event.context?.personas?.audience_settings as AudienceSettings
     }
 
     return action.execute({
@@ -546,7 +546,7 @@ export class Destination<Settings = JSONObject, AudienceSettings = JSONObject> {
     let audienceSettings = {} as AudienceSettings
     // All events should be batched on the same audience
     if (events[0].context?.personas) {
-      audienceSettings = events[0].context?.personas?.settings as AudienceSettings
+      audienceSettings = events[0].context?.personas?.audience_settings as AudienceSettings
     }
 
     await action.executeBatch({

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -70,7 +70,7 @@ export type AudienceMode = { type: 'realtime' } | { type: 'synced'; full_audienc
 export type CreateAudienceInput<Settings = unknown, AudienceSettings = unknown> = {
   settings: Settings
 
-  audienceSettings: AudienceSettings
+  audienceSettings?: AudienceSettings
 
   audienceName: string
 }
@@ -78,7 +78,7 @@ export type CreateAudienceInput<Settings = unknown, AudienceSettings = unknown> 
 export type GetAudienceInput<Settings = unknown, AudienceSettings = unknown> = {
   settings: Settings
 
-  audienceSettings: AudienceSettings
+  audienceSettings?: AudienceSettings
 
   externalId: string
 }
@@ -416,8 +416,7 @@ export class Destination<Settings = JSONObject, AudienceSettings = JSONObject> {
     const context: ExecuteInput<Settings, any> = {
       settings: destinationSettings,
       payload: undefined,
-      auth,
-      audienceSettings: undefined
+      auth
     }
 
     // Validate settings according to the destination's `authentication.fields` schema
@@ -454,7 +453,6 @@ export class Destination<Settings = JSONObject, AudienceSettings = JSONObject> {
     // TODO: clean up context/extendRequest so we don't have to send information that is not needed (payload & cachedFields)
     const context: ExecuteInput<Settings, any> = {
       settings,
-      audienceSettings: undefined,
       payload: undefined,
       auth: getAuthData(settings as unknown as JSONObject)
     }
@@ -678,14 +676,12 @@ export class Destination<Settings = JSONObject, AudienceSettings = JSONObject> {
     const data: ExecuteInput<Settings, DeletionPayload> = {
       payload,
       settings: destinationSettings,
-      auth,
-      audienceSettings: undefined
+      auth
     }
     const context: ExecuteInput<Settings, any> = {
       settings: destinationSettings,
       payload,
-      auth,
-      audienceSettings: undefined
+      auth
     }
 
     const opts = this.extendRequest?.(context) ?? {}

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -29,8 +29,8 @@ export interface SubscriptionStats {
   output: Result[] | null
 }
 
-interface PartnerActions<Settings, Payload extends JSONLikeObject> {
-  [key: string]: Action<Settings, Payload>
+interface PartnerActions<Settings, Payload extends JSONLikeObject, AudienceSettings = any> {
+  [key: string]: Action<Settings, Payload, AudienceSettings>
 }
 
 export interface BaseDefinition {
@@ -67,32 +67,54 @@ export type AudienceResult = {
 
 export type AudienceMode = { type: 'realtime' } | { type: 'synced'; full_audience_sync: boolean }
 
-export type CreateAudienceInput<Settings = unknown> = {
+export type CreateAudienceInput<Settings = unknown, AudienceSettings = unknown> = {
   settings: Settings
+
+  audienceSettings: AudienceSettings
 
   audienceName: string
 }
 
-export type GetAudienceInput<Settings = unknown> = {
+export type GetAudienceInput<Settings = unknown, AudienceSettings = unknown> = {
   settings: Settings
+
+  audienceSettings: AudienceSettings
 
   externalId: string
 }
 
-export interface AudienceDestinationSettings {
+export interface AudienceDestinationConfiguration {
   mode: AudienceMode
 }
 
-export interface AudienceDestinationSettingsWithCreateGet<Settings = unknown> extends AudienceDestinationSettings {
-  createAudience(request: RequestClient, createAudienceInput: CreateAudienceInput<Settings>): Promise<AudienceResult>
+export interface AudienceDestinationConfigurationWithCreateGet<Settings = unknown, AudienceSettings = unknown>
+  extends AudienceDestinationConfiguration {
+  createAudience(
+    request: RequestClient,
+    createAudienceInput: CreateAudienceInput<Settings, AudienceSettings>
+  ): Promise<AudienceResult>
 
-  getAudience(request: RequestClient, getAudienceInput: GetAudienceInput<Settings>): Promise<AudienceResult>
+  getAudience(
+    request: RequestClient,
+    getAudienceInput: GetAudienceInput<Settings, AudienceSettings>
+  ): Promise<AudienceResult>
 }
 
 const instanceOfAudienceDestinationSettingsWithCreateGet = (
   object: any
-): object is AudienceDestinationSettingsWithCreateGet => {
+): object is AudienceDestinationConfigurationWithCreateGet => {
   return 'createAudience' in object && 'getAudience' in object
+}
+
+export interface AudienceDestinationDefinition<Settings = unknown, AudienceSettings = unknown>
+  extends DestinationDefinition<Settings> {
+  audienceConfig:
+    | AudienceDestinationConfiguration
+    | AudienceDestinationConfigurationWithCreateGet<Settings, AudienceSettings>
+
+  audienceFields: Record<string, GlobalSetting>
+
+  actions: Record<string, ActionDefinition<Settings, any, AudienceSettings>>
 }
 
 export interface DestinationDefinition<Settings = unknown> extends BaseDefinition {
@@ -112,8 +134,6 @@ export interface DestinationDefinition<Settings = unknown> extends BaseDefinitio
 
   /** Optional authentication configuration */
   authentication?: AuthenticationScheme<Settings>
-
-  audienceSettings?: AudienceDestinationSettings | AudienceDestinationSettingsWithCreateGet<Settings>
 
   onDelete?: Deletion<Settings>
 }
@@ -300,7 +320,7 @@ export interface Logger {
   withTags(extraTags: any): void
 }
 
-export class Destination<Settings = JSONObject> {
+export class Destination<Settings = JSONObject, AudienceSettings = JSONObject> {
   readonly definition: DestinationDefinition<Settings>
   readonly name: string
   readonly authentication?: AuthenticationScheme<Settings>
@@ -308,7 +328,7 @@ export class Destination<Settings = JSONObject> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly extendRequest?: RequestExtension<Settings, any>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readonly actions: PartnerActions<Settings, any>
+  readonly actions: PartnerActions<Settings, any, AudienceSettings>
   readonly responses: DecoratedResponse[]
   readonly settingsSchema?: JSONSchema4
   onDelete?: (event: SegmentEvent, settings: JSONObject, options?: OnEventOptions) => Promise<Result>
@@ -350,30 +370,42 @@ export class Destination<Settings = JSONObject> {
     }
   }
 
-  async createAudience(createAudienceInput: CreateAudienceInput<Settings>) {
-    if (!instanceOfAudienceDestinationSettingsWithCreateGet(this.definition.audienceSettings)) {
+  async createAudience(createAudienceInput: CreateAudienceInput<Settings, AudienceSettings>) {
+    const audienceDefinition = this.definition as AudienceDestinationDefinition
+    if (!instanceOfAudienceDestinationSettingsWithCreateGet(audienceDefinition.audienceConfig)) {
       throw new Error('Unexpected call to createAudience')
     }
     const destinationSettings = this.getDestinationSettings(createAudienceInput.settings as unknown as JSONObject)
     const auth = getAuthData(createAudienceInput.settings as unknown as JSONObject)
-    const context: ExecuteInput<Settings, any> = { settings: destinationSettings, payload: undefined, auth }
+    const context: ExecuteInput<Settings, any, AudienceSettings> = {
+      audienceSettings: createAudienceInput.audienceSettings,
+      settings: destinationSettings,
+      payload: undefined,
+      auth
+    }
     const options = this.extendRequest?.(context) ?? {}
     const requestClient = createRequestClient({ ...options, statsContext: context.statsContext })
 
-    return this.definition.audienceSettings?.createAudience(requestClient, createAudienceInput)
+    return audienceDefinition.audienceConfig?.createAudience(requestClient, createAudienceInput)
   }
 
-  async getAudience(getAudienceInput: GetAudienceInput<Settings>) {
-    if (!instanceOfAudienceDestinationSettingsWithCreateGet(this.definition.audienceSettings)) {
+  async getAudience(getAudienceInput: GetAudienceInput<Settings, AudienceSettings>) {
+    const audienceDefinition = this.definition as AudienceDestinationDefinition
+    if (!instanceOfAudienceDestinationSettingsWithCreateGet(audienceDefinition.audienceConfig)) {
       throw new Error('Unexpected call to getAudience')
     }
     const destinationSettings = this.getDestinationSettings(getAudienceInput.settings as unknown as JSONObject)
     const auth = getAuthData(getAudienceInput.settings as unknown as JSONObject)
-    const context: ExecuteInput<Settings, any> = { settings: destinationSettings, payload: undefined, auth }
+    const context: ExecuteInput<Settings, any, AudienceSettings> = {
+      audienceSettings: getAudienceInput.audienceSettings,
+      settings: destinationSettings,
+      payload: undefined,
+      auth
+    }
     const options = this.extendRequest?.(context) ?? {}
     const requestClient = createRequestClient({ ...options, statsContext: context.statsContext })
 
-    return this.definition.audienceSettings?.getAudience(requestClient, getAudienceInput)
+    return audienceDefinition.audienceConfig?.getAudience(requestClient, getAudienceInput)
   }
 
   async testAuthentication(settings: Settings): Promise<void> {
@@ -381,7 +413,12 @@ export class Destination<Settings = JSONObject> {
     const auth = getAuthData(settings as unknown as JSONObject)
     const data = { settings: destinationSettings, auth }
 
-    const context: ExecuteInput<Settings, any> = { settings: destinationSettings, payload: undefined, auth }
+    const context: ExecuteInput<Settings, any> = {
+      settings: destinationSettings,
+      payload: undefined,
+      auth,
+      audienceSettings: undefined
+    }
 
     // Validate settings according to the destination's `authentication.fields` schema
     this.validateSettings(destinationSettings)
@@ -417,6 +454,7 @@ export class Destination<Settings = JSONObject> {
     // TODO: clean up context/extendRequest so we don't have to send information that is not needed (payload & cachedFields)
     const context: ExecuteInput<Settings, any> = {
       settings,
+      audienceSettings: undefined,
       payload: undefined,
       auth: getAuthData(settings as unknown as JSONObject)
     }
@@ -433,8 +471,11 @@ export class Destination<Settings = JSONObject> {
     return this.authentication.refreshAccessToken(requestClient, { settings, auth: oauthData })
   }
 
-  private partnerAction(slug: string, definition: ActionDefinition<Settings>): Destination<Settings> {
-    const action = new Action<Settings, {}>(this.name, definition, this.extendRequest)
+  private partnerAction(
+    slug: string,
+    definition: ActionDefinition<Settings, any, AudienceSettings>
+  ): Destination<Settings, AudienceSettings> {
+    const action = new Action<Settings, {}, AudienceSettings>(this.name, definition, this.extendRequest)
 
     action.on('response', (response) => {
       if (response) {
@@ -466,10 +507,16 @@ export class Destination<Settings = JSONObject> {
       return []
     }
 
+    let audienceSettings = {} as AudienceSettings
+    if (event.context?.personas) {
+      audienceSettings = event.context?.personas?.settings as AudienceSettings
+    }
+
     return action.execute({
       mapping,
       data: event as unknown as InputData,
       settings,
+      audienceSettings,
       auth,
       features,
       statsContext,
@@ -498,10 +545,17 @@ export class Destination<Settings = JSONObject> {
       return []
     }
 
+    let audienceSettings = {} as AudienceSettings
+    // All events should be batched on the same audience
+    if (events[0].context?.personas) {
+      audienceSettings = events[0].context?.personas?.settings as AudienceSettings
+    }
+
     await action.executeBatch({
       mapping,
       data: events as unknown as InputData[],
       settings,
+      audienceSettings,
       auth,
       features,
       statsContext,
@@ -621,8 +675,18 @@ export class Destination<Settings = JSONObject> {
     const destinationSettings = this.getDestinationSettings(settings as unknown as JSONObject)
     this.validateSettings(destinationSettings)
     const auth = getAuthData(settings as unknown as JSONObject)
-    const data: ExecuteInput<Settings, DeletionPayload> = { payload, settings: destinationSettings, auth }
-    const context: ExecuteInput<Settings, any> = { settings: destinationSettings, payload, auth }
+    const data: ExecuteInput<Settings, DeletionPayload> = {
+      payload,
+      settings: destinationSettings,
+      auth,
+      audienceSettings: undefined
+    }
+    const context: ExecuteInput<Settings, any> = {
+      settings: destinationSettings,
+      payload,
+      auth,
+      audienceSettings: undefined
+    }
 
     const opts = this.extendRequest?.(context) ?? {}
     const requestClient = createRequestClient({ ...opts, statsContext: context.statsContext })

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -20,7 +20,7 @@ export interface ExecuteInput<Settings, Payload, AudienceSettings = unknown> {
   /** The global destination settings */
   readonly settings: Settings
   /** The audience-specific destination settings */
-  readonly audienceSettings: AudienceSettings
+  readonly audienceSettings?: AudienceSettings
   /** The transformed input data, based on `mapping` + `event` (or `events` if batched) */
   payload: Payload
   /** The page used in dynamic field requests */

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -14,11 +14,13 @@ export interface Result {
   error?: JSONObject | null
 }
 
-export interface ExecuteInput<Settings, Payload> {
+export interface ExecuteInput<Settings, Payload, AudienceSettings = unknown> {
   /** The subscription mapping definition */
   readonly mapping?: JSONObject
   /** The global destination settings */
   readonly settings: Settings
+  /** The audience-specific destination settings */
+  readonly audienceSettings: AudienceSettings
   /** The transformed input data, based on `mapping` + `event` (or `events` if batched) */
   payload: Payload
   /** The page used in dynamic field requests */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ export type {
   ActionDefinition,
   BaseDefinition,
   DestinationDefinition,
+  AudienceDestinationDefinition,
   ExecuteInput,
   Subscription,
   SubscriptionStats,

--- a/packages/destination-actions/src/destinations/webhook-audiences/__test__/index.test.ts
+++ b/packages/destination-actions/src/destinations/webhook-audiences/__test__/index.test.ts
@@ -56,7 +56,7 @@ describe('Webhook Audience Tests', () => {
     const event = createTestEvent({
       context: {
         personas: {
-          settings: {
+          audience_settings: {
             extras: JSON.stringify({ nice: 'ok' })
           }
         }

--- a/packages/destination-actions/src/destinations/webhook-audiences/__test__/index.test.ts
+++ b/packages/destination-actions/src/destinations/webhook-audiences/__test__/index.test.ts
@@ -21,7 +21,7 @@ describe('Webhook Audience Tests', () => {
     const expectedResponse = await testDestination.createAudience({
       audienceName: 'My Cool Audience',
       audienceSettings: {
-        extraSettings: JSON.stringify({ nice: 'ok' })
+        extras: JSON.stringify({ nice: 'ok' })
       },
       settings: { createAudienceUrl: fakeUrl }
     })
@@ -44,7 +44,7 @@ describe('Webhook Audience Tests', () => {
       externalId: 'abc123xyz',
       settings: { getAudienceUrl: fakeUrl },
       audienceSettings: {
-        extraSettings: JSON.stringify({ nice: 'ok' })
+        extras: JSON.stringify({ nice: 'ok' })
       }
     })
 
@@ -57,7 +57,7 @@ describe('Webhook Audience Tests', () => {
       context: {
         personas: {
           settings: {
-            extraSettings: JSON.stringify({ nice: 'ok' })
+            extras: JSON.stringify({ nice: 'ok' })
           }
         }
       }

--- a/packages/destination-actions/src/destinations/webhook-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/webhook-audiences/generated-types.ts
@@ -14,3 +14,11 @@ export interface Settings {
    */
   getAudienceUrl?: string
 }
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface AudienceSettings {
+  /**
+   * Extra json fields to pass on to every request. Note: "externalId" and "audienceName" are reserved.
+   */
+  extras?: string
+}

--- a/packages/destination-actions/src/destinations/webhook/__test__/webhook.test.ts
+++ b/packages/destination-actions/src/destinations/webhook/__test__/webhook.test.ts
@@ -116,7 +116,6 @@ export const baseWebhookTests = (def: DestinationDefinition<any>) => {
         ]
 
         const payload = JSON.stringify(events.map(({ properties }) => properties))
-        console.log(payload)
         const sharedSecret = 'abc123'
         nock(url)
           .post('/', payload)


### PR DESCRIPTION
As part of adding support for audience only settings, this PR makes some enhancements to how we define destination definitions that support audiences. 

New behavior/changes:
* calls to createAudience/getAudience will now be supplied with an optional `audienceSettings` params 
* calls to perform/performBatch will now be supplied with an optional `audienceSettings` params 
* audience-specific fields should be defined in the `audienceFields` property 
 
As an example, I've added changes to the webhook-audiences destination to serve as an example for future implementations. 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
