### PR TITLE
autocomplete choices for action-tester

### DIFF
--- a/packages/cli-internal/src/commands/push.ts
+++ b/packages/cli-internal/src/commands/push.ts
@@ -55,7 +55,7 @@ export default class Push extends Command {
     await deprecationWarning(this.warn)
 
     const { metadataIds } = await prompt<{ metadataIds: string[] }>({
-      type: 'multiselect',
+      type: 'autocompleteMultiselect',
       name: 'metadataIds',
       message: 'Pick the definitions you would like to push to Segment:',
       choices: sortBy(Object.entries(manifest), '[1].definition.name').map(([metadataId, entry]) => ({


### PR DESCRIPTION
## Description

Allow users to autocomplete for action tester

## Testing

<img width="563" alt="Screen Shot 2023-07-20 at 6 14 28 PM" src="https://github.com/segmentio/action-destinations/assets/1487616/a77658ec-fece-40af-95c6-642dfaab5707">

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
