### PR TITLE
Add return values for API calls in Attio actions

### DIFF
--- a/packages/destination-actions/src/destinations/attio/assertRecord/index.ts
+++ b/packages/destination-actions/src/destinations/attio/assertRecord/index.ts
@@ -88,7 +88,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const client = new AttioClient(request)
 
-    await client.assertRecord({
+    return await client.assertRecord({
       object,
       matching_attribute,
       values: attributes ?? {}

--- a/packages/destination-actions/src/destinations/attio/groupWorkspace/index.ts
+++ b/packages/destination-actions/src/destinations/attio/groupWorkspace/index.ts
@@ -83,7 +83,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     })
 
-    await client.assertRecord({
+    return await client.assertRecord({
       object: 'workspaces',
       matching_attribute: 'name',
       values: {

--- a/packages/destination-actions/src/destinations/attio/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/attio/identifyUser/index.ts
@@ -74,7 +74,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     })
 
-    await client.assertRecord({
+    return await client.assertRecord({
       object: 'users',
       matching_attribute: 'primary_email_address',
       values: {


### PR DESCRIPTION
This is a follow-up to https://github.com/segmentio/action-destinations/pull/1399#issuecomment-1645403215

Note that the `groupWorkspace` and `identifyUser` commands make _two_ API calls. The first one should basically always succeed, the second is more likely to fail depending on object configuration on the Attio side, so I took the decision to return that second result.

@sayan-das-in is it possible to return multiple values like `[person, user]` or `[company, workspace]`? If so, I can swap.