### PR TITLE
Fullstory V2 API Actions

### DIFF
--- a/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
@@ -156,7 +156,7 @@ describe('FullStory', () => {
   describe('onDelete', () => {
     const falsyUserIds = ['', undefined, null]
     it('makes expected request given a valid user id', async () => {
-      nock(baseUrl).delete(`/users/v1/individual/${urlEncodedUserId}`).reply(200)
+      nock(baseUrl).delete(`/v2beta/users?uid=${urlEncodedUserId}`).reply(200)
       await expect(testDestination.onDelete!({ type: 'delete', userId }, settings)).resolves.not.toThrowError()
     })
 

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
@@ -2,7 +2,8 @@ import {
   listOperationsRequestParams,
   customEventRequestParams,
   setUserPropertiesRequestParams,
-  deleteUserRequestParams
+  deleteUserRequestParams,
+  createUserRequestParams
 } from '../request-params'
 import {
   anonymousId,
@@ -12,6 +13,7 @@ import {
   urlEncodedUserId,
   baseUrl,
   settings,
+  integrationSource,
   integrationSourceQueryParam
 } from './fullstory.test'
 
@@ -22,6 +24,7 @@ describe('requestParams', () => {
       expect(options.method).toBe('get')
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
+      expect(options.headers!['Integration-Source']).toBe(integrationSource)
       expect(url).toBe(`${baseUrl}/operations/v1?limit=1`)
     })
   })
@@ -44,6 +47,7 @@ describe('requestParams', () => {
       expect(options.method).toBe('post')
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
+      expect(options.headers!['Integration-Source']).toBe(integrationSource)
       expect(url).toBe(`${baseUrl}/users/v1/individual/${urlEncodedUserId}/customevent?${integrationSourceQueryParam}`)
       expect(options.json).toEqual({
         event: {
@@ -66,6 +70,7 @@ describe('requestParams', () => {
       expect(options.method).toBe('post')
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
+      expect(options.headers!['Integration-Source']).toBe(integrationSource)
       expect(url).toBe(`${baseUrl}/users/v1/individual/${urlEncodedUserId}/customevent?${integrationSourceQueryParam}`)
       expect(options.json).toEqual({
         event: {
@@ -86,6 +91,7 @@ describe('requestParams', () => {
       expect(options.method).toBe('post')
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
+      expect(options.headers!['Integration-Source']).toBe(integrationSource)
       expect(url).toBe(`${baseUrl}/users/v1/individual/${urlEncodedUserId}/customevent?${integrationSourceQueryParam}`)
       expect(options.json).toEqual({
         event: {
@@ -109,6 +115,7 @@ describe('requestParams', () => {
       expect(options.method).toBe('post')
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
+      expect(options.headers!['Integration-Source']).toBe(integrationSource)
       expect(url).toBe(`${baseUrl}/users/v1/individual/${urlEncodedUserId}/customvars?${integrationSourceQueryParam}`)
       expect(options.json).toEqual(requestBody)
     })
@@ -120,7 +127,28 @@ describe('requestParams', () => {
       expect(options.method).toBe('delete')
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
+      expect(options.headers!['Integration-Source']).toBe(integrationSource)
       expect(url).toBe(`${baseUrl}/users/v1/individual/${urlEncodedUserId}`)
+    })
+  })
+
+  describe('createUserV2', () => {
+    it('returns expected request params', () => {
+      const requestBody = {
+        userId,
+        anonymousId,
+        traits: {
+          displayName,
+          email
+        }
+      }
+      const { url, options } = createUserRequestParams(settings, requestBody)
+      expect(options.method).toBe('post')
+      expect(options.headers!['Content-Type']).toBe('application/json')
+      expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
+      expect(options.headers!['Integration-Source']).toBe(integrationSource)
+      expect(url).toBe(`${baseUrl}/v2beta/users?${integrationSourceQueryParam}`)
+      expect(options.json).toEqual(requestBody)
     })
   })
 })

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
@@ -3,7 +3,8 @@ import {
   customEventRequestParams,
   setUserPropertiesRequestParams,
   deleteUserRequestParams,
-  createUserRequestParams
+  createUserRequestParams,
+  createEventRequestParams
 } from '../request-params'
 import {
   anonymousId,
@@ -149,6 +150,85 @@ describe('requestParams', () => {
       expect(options.headers!['Integration-Source']).toBe(integrationSource)
       expect(url).toBe(`${baseUrl}/v2beta/users?${integrationSourceQueryParam}`)
       expect(options.json).toEqual(requestBody)
+    })
+  })
+
+  describe('customEventV2', () => {
+    it('returns expected request params', () => {
+      const sessionId = 'ec5218650ee0:a58ec087'
+      const requestValues = {
+        userId,
+        eventName: 'test-event',
+        properties: {
+          'first-property': 'first-value',
+          second_property: 'second_value',
+          thirdProperty: 'thirdValue'
+        },
+        timestamp: new Date(Date.UTC(2022, 1, 2, 3, 4, 5)).toISOString(),
+        useRecentSession: true,
+        sessionUrl: `session/url/${encodeURIComponent(sessionId)}`
+      }
+      const { url, options } = createEventRequestParams(settings, requestValues)
+      expect(options.method).toBe('post')
+      expect(options.headers!['Content-Type']).toBe('application/json')
+      expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
+      expect(options.headers!['Integration-Source']).toBe(integrationSource)
+      expect(url).toBe(`${baseUrl}/v2beta/events?${integrationSourceQueryParam}`)
+      expect(options.json).toEqual({
+        name: requestValues.eventName,
+        properties: requestValues.properties,
+        user: {
+          uid: userId
+        },
+        timestamp: requestValues.timestamp,
+        session: {
+          id: sessionId,
+          use_most_recent: requestValues.useRecentSession
+        }
+      })
+    })
+
+    it('handles undefined request values', () => {
+      const requestValues = {
+        userId,
+        eventName: 'test-event',
+        properties: {}
+      }
+      const { url, options } = createEventRequestParams(settings, requestValues)
+      expect(options.method).toBe('post')
+      expect(options.headers!['Content-Type']).toBe('application/json')
+      expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
+      expect(options.headers!['Integration-Source']).toBe(integrationSource)
+      expect(url).toBe(`${baseUrl}/v2beta/events?${integrationSourceQueryParam}`)
+      expect(options.json).toEqual({
+        name: requestValues.eventName,
+        properties: requestValues.properties,
+        user: {
+          uid: userId
+        }
+      })
+    })
+
+    it('omits use_most_recent request param if false', () => {
+      const requestValues = {
+        userId,
+        eventName: 'test-event',
+        properties: {},
+        useRecentSession: false
+      }
+      const { url, options } = createEventRequestParams(settings, requestValues)
+      expect(options.method).toBe('post')
+      expect(options.headers!['Content-Type']).toBe('application/json')
+      expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
+      expect(options.headers!['Integration-Source']).toBe(integrationSource)
+      expect(url).toBe(`${baseUrl}/v2beta/events?${integrationSourceQueryParam}`)
+      expect(options.json).toEqual({
+        name: requestValues.eventName,
+        properties: requestValues.properties,
+        user: {
+          uid: userId
+        }
+      })
     })
   })
 })

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
@@ -129,7 +129,7 @@ describe('requestParams', () => {
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
       expect(options.headers!['Integration-Source']).toBe(integrationSource)
-      expect(url).toBe(`${baseUrl}/users/v1/individual/${urlEncodedUserId}`)
+      expect(url).toBe(`${baseUrl}/v2beta/users?uid=${urlEncodedUserId}`)
     })
   })
 

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
@@ -22,7 +22,7 @@ describe('normalizePropertyNames', () => {
     const obj = {
       someProp: undefined
     }
-    const normalizedObj = normalizePropertyNames(obj)
+    const normalizedObj = normalizePropertyNames(obj, { typeSuffix: true })
     expect(normalizedObj).toEqual(obj)
   })
 
@@ -35,8 +35,18 @@ describe('normalizePropertyNames', () => {
     Object.entries(suffixToExampleValuesMap).forEach(([suffix, value]) => {
       obj[`${suffix}_prop_${suffix}`] = value
     })
-    const normalizedObj = normalizePropertyNames(obj)
+    const normalizedObj = normalizePropertyNames(obj, { typeSuffix: true })
     expect(normalizedObj).toEqual(obj)
+  })
+
+  it('does not add type suffix if parameter is undefined/false', () => {
+    const originalPayload = {
+      str_prop: suffixToExampleValuesMap.str
+    }
+    const normalizedObj = normalizePropertyNames(originalPayload)
+    expect(normalizedObj).toEqual(originalPayload)
+    const normalizedObj2 = normalizePropertyNames(originalPayload, { typeSuffix: false })
+    expect(normalizedObj2).toEqual(originalPayload)
   })
 
   it('adds type suffixes when type can be inferred and known type suffix is absent', () => {
@@ -75,7 +85,7 @@ describe('normalizePropertyNames', () => {
       objs_prop_objs: originalPayload.objs_prop
     }
 
-    const transformedPayload = normalizePropertyNames(originalPayload)
+    const transformedPayload = normalizePropertyNames(originalPayload, { typeSuffix: true })
     expect(transformedPayload).toEqual(expectedPayload)
   })
 
@@ -96,7 +106,7 @@ describe('normalizePropertyNames', () => {
       dottedDate_date: obj['dotted.date'],
       spacedReal_real: obj['spaced real']
     }
-    const actual = normalizePropertyNames(obj, { camelCase: true })
+    const actual = normalizePropertyNames(obj, { camelCase: true, typeSuffix: true })
     expect(actual).toEqual(expected)
   })
 
@@ -129,7 +139,7 @@ describe('normalizePropertyNames', () => {
         }
       }
     }
-    const transformedPayload = normalizePropertyNames(originalPayload, { camelCase: true })
+    const transformedPayload = normalizePropertyNames(originalPayload, { camelCase: true, typeSuffix: true })
     expect(transformedPayload).toEqual(expectedPayload)
   })
 
@@ -153,7 +163,7 @@ describe('normalizePropertyNames', () => {
         [expectedNameAddingTypeSuffix]: obj[originalNameExcludingTypeSuffix]
       }
 
-      const actual = normalizePropertyNames(obj)
+      const actual = normalizePropertyNames(obj, { typeSuffix: true })
       expect(actual).toEqual(expected)
     })
   })
@@ -170,7 +180,7 @@ describe('normalizePropertyNames', () => {
       [expectedNamePreservingTypeSuffix]: obj[originalNameIncludingTypeSuffix]
     }
 
-    const actual = normalizePropertyNames(obj, { camelCase: true })
+    const actual = normalizePropertyNames(obj, { camelCase: true, typeSuffix: true })
     expect(actual).toEqual(expected)
   })
 })

--- a/packages/destination-actions/src/destinations/fullstory/generated-types.ts
+++ b/packages/destination-actions/src/destinations/fullstory/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Settings {
   /**
-   * [FullStory API key](https://help.fullstory.com/hc/en-us/articles/360052021773-Managing-API-Keys)
+   * [FullStory Admin API key](https://help.fullstory.com/hc/en-us/articles/360052021773-Managing-API-Keys)
    */
   apiKey: string
 }

--- a/packages/destination-actions/src/destinations/fullstory/identifyUserV2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/fullstory/identifyUserV2/generated-types.ts
@@ -1,0 +1,26 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The user's id
+   */
+  uid: string
+  /**
+   * The user's anonymous id
+   */
+  anonymousId?: string
+  /**
+   * The user's display name
+   */
+  displayName?: string
+  /**
+   * The user's email
+   */
+  email?: string
+  /**
+   * The Segment traits to be forwarded to FullStory
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/fullstory/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/index.ts
@@ -4,6 +4,7 @@ import type { Settings } from './generated-types'
 import identifyUser from './identifyUser'
 import trackEvent from './trackEvent'
 import identifyUserV2 from './identifyUserV2'
+import trackEventV2 from './trackEventV2'
 import { listOperationsRequestParams, deleteUserRequestParams } from './request-params'
 
 const destination: DestinationDefinition<Settings> = {
@@ -54,6 +55,7 @@ const destination: DestinationDefinition<Settings> = {
   actions: {
     trackEvent,
     identifyUser,
+    trackEventV2,
     identifyUserV2
   }
 }

--- a/packages/destination-actions/src/destinations/fullstory/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/index.ts
@@ -3,6 +3,7 @@ import { defaultValues, PayloadValidationError } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import identifyUser from './identifyUser'
 import trackEvent from './trackEvent'
+import identifyUserV2 from './identifyUserV2'
 import { listOperationsRequestParams, deleteUserRequestParams } from './request-params'
 
 const destination: DestinationDefinition<Settings> = {
@@ -52,7 +53,8 @@ const destination: DestinationDefinition<Settings> = {
 
   actions: {
     trackEvent,
-    identifyUser
+    identifyUser,
+    identifyUserV2
   }
 }
 

--- a/packages/destination-actions/src/destinations/fullstory/request-params.ts
+++ b/packages/destination-actions/src/destinations/fullstory/request-params.ts
@@ -26,7 +26,8 @@ const defaultRequestParams = (settings: Settings, relativeUrl: string): RequestP
       method: 'get',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Basic ${settings.apiKey}`
+        Authorization: `Basic ${settings.apiKey}`,
+        'Integration-Source': segmentIntegrationSource
       }
     }
   }
@@ -41,7 +42,7 @@ export const listOperationsRequestParams = (settings: Settings): RequestParams =
   defaultRequestParams(settings, `operations/v1?limit=1`)
 
 /**
- * Returns {@link RequestParams} for the custom events HTTP API endpoint.
+ * Returns {@link RequestParams} for the V1 custom events HTTP API endpoint.
  *
  * @param settings Settings configured for the cloud mode destination.
  * @param requestValues Values to send with the request.
@@ -96,7 +97,7 @@ export const customEventRequestParams = (
 }
 
 /**
- * Returns {@link RequestParams} for the set user properties HTTP API endpoint.
+ * Returns {@link RequestParams} for the V1 set user properties HTTP API endpoint.
  *
  * @param settings Settings configured for the cloud mode destination.
  * @param userId The id of the user to update.
@@ -136,6 +137,26 @@ export const deleteUserRequestParams = (settings: Settings, userId: string): Req
     options: {
       ...defaultParams.options,
       method: 'delete'
+    }
+  }
+}
+
+/**
+ * Returns {@link RequestParams} for the V2 Create User HTTP API endpoint.
+ *
+ * @param settings Settings configured for the cloud mode destination.
+ * @param requestBody The request body containing user properties to set.
+ */
+
+export const createUserRequestParams = (settings: Settings, requestBody: Object): RequestParams => {
+  const defaultParams = defaultRequestParams(settings, `v2beta/users?${integrationSourceQueryParam}`)
+
+  return {
+    ...defaultParams,
+    options: {
+      ...defaultParams.options,
+      method: 'post',
+      json: requestBody
     }
   }
 }

--- a/packages/destination-actions/src/destinations/fullstory/request-params.ts
+++ b/packages/destination-actions/src/destinations/fullstory/request-params.ts
@@ -124,13 +124,13 @@ export const setUserPropertiesRequestParams = (
 }
 
 /**
- * Returns {@link RequestParams} for the delete user HTTP API endpoint.
+ * Returns {@link RequestParams} for the V2 delete user HTTP API endpoint.
  *
  * @param settings Settings configured for the cloud mode destination.
  * @param userId The id of the user to delete.
  */
 export const deleteUserRequestParams = (settings: Settings, userId: string): RequestParams => {
-  const defaultParams = defaultRequestParams(settings, `users/v1/individual/${encodeURIComponent(userId)}`)
+  const defaultParams = defaultRequestParams(settings, `v2beta/users?uid=${encodeURIComponent(userId)}`)
 
   return {
     ...defaultParams,

--- a/packages/destination-actions/src/destinations/fullstory/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/trackEvent/index.ts
@@ -70,7 +70,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const { url, options } = customEventRequestParams(settings, {
       userId,
       eventName: name,
-      eventData: normalizePropertyNames(properties),
+      eventData: normalizePropertyNames(properties, { typeSuffix: true }),
       timestamp: utcTimestamp && utcTimestamp.isValid() ? utcTimestamp.toISOString() : undefined,
       useRecentSession,
       sessionUrl

--- a/packages/destination-actions/src/destinations/fullstory/trackEventV2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/fullstory/trackEventV2/generated-types.ts
@@ -1,0 +1,30 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The user's id
+   */
+  userId: string
+  /**
+   * The name of the event.
+   */
+  name: string
+  /**
+   * A JSON object containing additional information about the event that will be indexed by FullStory.
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+  /**
+   * The date and time when the event occurred. If not provided, the current FullStory server time will be used.
+   */
+  timestamp?: string | number
+  /**
+   * Set to true if the custom event should be attached to the user's most recent session. The most recent session must have had activity within the past 30 minutes.
+   */
+  useRecentSession?: boolean
+  /**
+   * If known, the FullStory session playback URL to which the event should be attached, as returned by the FS.getCurrentSessionURL() client API.
+   */
+  sessionUrl?: string
+}

--- a/packages/destination-actions/src/destinations/fullstory/trackEventV2/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/trackEventV2/index.ts
@@ -1,0 +1,82 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import dayjs from '../../../lib/dayjs'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { createEventRequestParams } from '../request-params'
+import { normalizePropertyNames } from '../vars'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Track Event V2',
+  description: 'Track events V2.',
+  platform: 'cloud',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    userId: {
+      type: 'string',
+      required: true,
+      description: "The user's id",
+      label: 'User ID',
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    name: {
+      description: 'The name of the event.',
+      label: 'Name',
+      required: true,
+      type: 'string',
+      default: {
+        '@path': '$.event'
+      }
+    },
+    properties: {
+      description: 'A JSON object containing additional information about the event that will be indexed by FullStory.',
+      label: 'Properties',
+      required: false,
+      type: 'object',
+      default: {
+        '@path': '$.properties'
+      }
+    },
+    timestamp: {
+      description:
+        'The date and time when the event occurred. If not provided, the current FullStory server time will be used.',
+      label: 'Timestamp',
+      required: false,
+      type: 'datetime',
+      default: {
+        '@path': '$.timestamp'
+      }
+    },
+    useRecentSession: {
+      description:
+        "Set to true if the custom event should be attached to the user's most recent session. The most recent session must have had activity within the past 30 minutes.",
+      label: 'Use Recent Session',
+      required: false,
+      type: 'boolean'
+    },
+    sessionUrl: {
+      description:
+        'If known, the FullStory session playback URL to which the event should be attached, as returned by the FS.getCurrentSessionURL() client API.',
+      label: 'Session URL',
+      required: false,
+      type: 'string'
+    }
+  },
+  perform: (request, { payload, settings }) => {
+    const { userId, name, properties, timestamp, useRecentSession, sessionUrl } = payload
+    const utcTimestamp = timestamp ? dayjs.utc(timestamp) : undefined
+
+    const { url, options } = createEventRequestParams(settings, {
+      userId,
+      eventName: name,
+      properties: normalizePropertyNames(properties),
+      timestamp: utcTimestamp && utcTimestamp.isValid() ? utcTimestamp.toISOString() : undefined,
+      useRecentSession,
+      sessionUrl
+    })
+    return request(url, options)
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/fullstory/vars.ts
+++ b/packages/destination-actions/src/destinations/fullstory/vars.ts
@@ -183,7 +183,10 @@ const recursivelyTransformPropertyNames = (
  * @param options Extended normalization options, including whether to camel case property names.
  * @returns A new object with property names normalized.
  */
-export const normalizePropertyNames = (obj?: any, options?: { camelCase?: boolean }): Record<string, unknown> => {
+export const normalizePropertyNames = (
+  obj?: any,
+  options?: { camelCase?: boolean; typeSuffix?: boolean }
+): Record<string, unknown> => {
   if (!obj) {
     return {}
   }
@@ -196,7 +199,7 @@ export const normalizePropertyNames = (obj?: any, options?: { camelCase?: boolea
 
   const normalizePropertyName = (name: string, value: unknown) => {
     const transformedName = transformPropertyName(name, transformations)
-    return typeSuffixPropertyName(transformedName, value)
+    return options?.typeSuffix ? typeSuffixPropertyName(transformedName, value) : transformedName
   }
 
   return recursivelyTransformPropertyNames(obj, normalizePropertyName, 1)


### PR DESCRIPTION
## Changes

### Adding two new Actions to allow users to migrate from our V1 to V2 API
 - Track Events V2
 - Identify User V2
 
 New actions are being created over changing existing actions to allow users to make the change when they want instead of being automatically switched.
 
### Updated `onDelete` to use our new V2 API

This isn't really a callable action so little harm in automatically switching this call to V2.

## Testing

Created unit tests for new functions/actions being added.
Ran everything through the local server and verified it came through correctly.

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
