### PR TITLE
Stratconn 2695 eliminate 403 missing scopes errors

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
@@ -13,6 +13,13 @@ interface CustomBehavioralEvent {
   objectId?: string
 }
 
+interface AccessTokenInfo {
+  token: string
+  user: string
+  scopes: string[]
+  hub_id: number
+}
+
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Custom Behavioral Event',
   description: 'Send a custom behavioral event to HubSpot.',
@@ -74,7 +81,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
     let response
     try {
-      response = await request(`https://api.hubapi.com/oauth/v1/access-tokens/${auth?.accessToken}`, {
+      response = await request<AccessTokenInfo>(`https://api.hubapi.com/oauth/v1/access-tokens/${auth?.accessToken}`, {
         method: 'get'
       })
     } catch (err) {

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
@@ -75,10 +75,6 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, { payload, settings, auth }) => {
-    //Will remove after testing
-    console.log('Hubspot oauth credentials:', auth)
-    console.log('Hubspot settings:', settings)
-
     let response
     try {
       response = await request<AccessTokenInfo>(`https://api.hubapi.com/oauth/v1/access-tokens/${auth?.accessToken}`, {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Over the last 30 days, 1.3% of the app's API calls (2M) resulted in 403 errors. All of these are due to some 59 portals missing the analytics.behavioral_events.send scope necessary to access the [Custom Behavioral Events API](https://developers.hubspot.com/docs/api/analytics/events) (POST /events/v3/send). So, in this PR applied check on access-token for a scope for Custom behavioural event action when user perform the action.

JIRA ticket link:- https://segment.atlassian.net/browse/STRATCONN-2695

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)

