### PR TITLE
Iterable — Adds Data Center Support to Destination Settings

### DIFF
--- a/packages/destination-actions/src/destinations/iterable/generated-types.ts
+++ b/packages/destination-actions/src/destinations/iterable/generated-types.ts
@@ -5,4 +5,8 @@ export interface Settings {
    * To obtain the API Key, go to the Iterable app and naviate to Integrations > API Keys. Create a new API Key with the 'Server-Side' type.
    */
   apiKey: string
+  /**
+   * The region to send your data.
+   */
+  apiRegion?: string
 }

--- a/packages/destination-actions/src/destinations/iterable/generated-types.ts
+++ b/packages/destination-actions/src/destinations/iterable/generated-types.ts
@@ -6,7 +6,7 @@ export interface Settings {
    */
   apiKey: string
   /**
-   * The region to send your data.
+   * The location where your Iterable data is hosted.
    */
-  apiRegion?: string
+  dataCenterLocation?: string
 }

--- a/packages/destination-actions/src/destinations/iterable/index.test.ts
+++ b/packages/destination-actions/src/destinations/iterable/index.test.ts
@@ -12,7 +12,7 @@ describe('Iterable', () => {
 
       const settings = {
         apiKey: 'iterableApiKey',
-        apiRegion: 'north_america'
+        apiRegion: 'united_states'
       }
 
       await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()
@@ -23,7 +23,7 @@ describe('Iterable', () => {
 
       const settings = {
         apiKey: 'badApiKey',
-        apiRegion: 'north_america'
+        apiRegion: 'united_states'
       }
 
       await expect(testDestination.testAuthentication(settings)).rejects.toThrowError(

--- a/packages/destination-actions/src/destinations/iterable/index.test.ts
+++ b/packages/destination-actions/src/destinations/iterable/index.test.ts
@@ -1,0 +1,53 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from './index'
+import { getRegionalEndpoint } from './utils'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Iterable', () => {
+  describe('testAuthentication', () => {
+    it('should authenticate with Iterable API key', async () => {
+      nock('https://api.iterable.com').get('/api/webhooks').reply(200, {})
+
+      const settings = {
+        apiKey: 'iterableApiKey',
+        apiRegion: 'north_america'
+      }
+
+      await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()
+    })
+
+    it('should throw error on invalid Iterable API key', async () => {
+      nock('https://api.iterable.com').get('/api/webhooks').reply(401, { msg: 'Invalid API key' })
+
+      const settings = {
+        apiKey: 'badApiKey',
+        apiRegion: 'north_america'
+      }
+
+      await expect(testDestination.testAuthentication(settings)).rejects.toThrowError(
+        'Credentials are invalid: 401 Unauthorized'
+      )
+    })
+  })
+})
+
+describe('getRegionalEndpoint', () => {
+  test('should return the correct endpoint for a specific action and region', () => {
+    const action = 'updateUser'
+    const apiRegion = 'europe'
+    const expectedEndpoint = 'https://api.eu.iterable.com/api/users/update'
+    const endpoint = getRegionalEndpoint(action, apiRegion)
+
+    expect(endpoint).toBe(expectedEndpoint)
+  })
+
+  test('should use the default region if no region is provided', () => {
+    const action = 'updateCart'
+    const expectedEndpoint = 'https://api.iterable.com/api/commerce/updateCart'
+    const endpoint = getRegionalEndpoint(action)
+
+    expect(endpoint).toBe(expectedEndpoint)
+  })
+})

--- a/packages/destination-actions/src/destinations/iterable/index.test.ts
+++ b/packages/destination-actions/src/destinations/iterable/index.test.ts
@@ -12,7 +12,7 @@ describe('Iterable', () => {
 
       const settings = {
         apiKey: 'iterableApiKey',
-        apiRegion: 'united_states'
+        dataCenterLocation: 'united_states'
       }
 
       await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()
@@ -23,7 +23,7 @@ describe('Iterable', () => {
 
       const settings = {
         apiKey: 'badApiKey',
-        apiRegion: 'united_states'
+        dataCenterLocation: 'united_states'
       }
 
       await expect(testDestination.testAuthentication(settings)).rejects.toThrowError(
@@ -36,14 +36,14 @@ describe('Iterable', () => {
 describe('getRegionalEndpoint', () => {
   test('should return the correct endpoint for a specific action and region', () => {
     const action = 'updateUser'
-    const apiRegion = 'europe'
+    const dataCenterLocation = 'europe'
     const expectedEndpoint = 'https://api.eu.iterable.com/api/users/update'
-    const endpoint = getRegionalEndpoint(action, apiRegion)
+    const endpoint = getRegionalEndpoint(action, dataCenterLocation)
 
     expect(endpoint).toBe(expectedEndpoint)
   })
 
-  test('should use the default region if no region is provided', () => {
+  test('should use the default dataCenterLocation if no dataCenterLocation is provided', () => {
     const action = 'updateCart'
     const expectedEndpoint = 'https://api.iterable.com/api/commerce/updateCart'
     const endpoint = getRegionalEndpoint(action)

--- a/packages/destination-actions/src/destinations/iterable/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/index.ts
@@ -5,6 +5,8 @@ import updateUser from './updateUser'
 import trackEvent from './trackEvent'
 import updateCart from './updateCart'
 import trackPurchase from './trackPurchase'
+import { Region } from './shared-fields'
+import { getRegionalEndpoint } from './utils'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Iterable (Actions)',
@@ -20,10 +22,28 @@ const destination: DestinationDefinition<Settings> = {
         description:
           "To obtain the API Key, go to the Iterable app and naviate to Integrations > API Keys. Create a new API Key with the 'Server-Side' type.",
         required: true
+      },
+      apiRegion: {
+        label: 'Endpoint Region',
+        description: 'The region to send your data.',
+        type: 'string',
+        format: 'text',
+        choices: [
+          {
+            label: 'North America',
+            value: 'north_america'
+          },
+          {
+            label: 'Europe',
+            value: 'europe'
+          }
+        ],
+        default: 'north_america'
       }
     },
     testAuthentication: (request, { settings }) => {
-      return request('https://api.iterable.com/api/webhooks', {
+      const endpoint = getRegionalEndpoint('getWebhooks', settings.apiRegion as Region)
+      return request(endpoint, {
         method: 'get',
         headers: { 'Api-Key': settings.apiKey }
       })

--- a/packages/destination-actions/src/destinations/iterable/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/index.ts
@@ -5,7 +5,7 @@ import updateUser from './updateUser'
 import trackEvent from './trackEvent'
 import updateCart from './updateCart'
 import trackPurchase from './trackPurchase'
-import { Region } from './shared-fields'
+import { DataCenterLocation } from './shared-fields'
 import { getRegionalEndpoint } from './utils'
 
 const destination: DestinationDefinition<Settings> = {
@@ -23,9 +23,9 @@ const destination: DestinationDefinition<Settings> = {
           "To obtain the API Key, go to the Iterable app and naviate to Integrations > API Keys. Create a new API Key with the 'Server-Side' type.",
         required: true
       },
-      apiRegion: {
-        label: 'Endpoint Region',
-        description: 'The region to send your data.',
+      dataCenterLocation: {
+        label: 'Data Center Location',
+        description: 'The location where your Iterable data is hosted.',
         type: 'string',
         format: 'text',
         choices: [
@@ -42,7 +42,7 @@ const destination: DestinationDefinition<Settings> = {
       }
     },
     testAuthentication: (request, { settings }) => {
-      const endpoint = getRegionalEndpoint('getWebhooks', settings.apiRegion as Region)
+      const endpoint = getRegionalEndpoint('getWebhooks', settings.dataCenterLocation as DataCenterLocation)
       return request(endpoint, {
         method: 'get',
         headers: { 'Api-Key': settings.apiKey }

--- a/packages/destination-actions/src/destinations/iterable/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/index.ts
@@ -30,15 +30,15 @@ const destination: DestinationDefinition<Settings> = {
         format: 'text',
         choices: [
           {
-            label: 'North America',
-            value: 'north_america'
+            label: 'United States',
+            value: 'united_states'
           },
           {
             label: 'Europe',
             value: 'europe'
           }
         ],
-        default: 'north_america'
+        default: 'united_states'
       }
     },
     testAuthentication: (request, { settings }) => {

--- a/packages/destination-actions/src/destinations/iterable/shared-fields.ts
+++ b/packages/destination-actions/src/destinations/iterable/shared-fields.ts
@@ -192,3 +192,5 @@ export type CommerceItem = {
     [k: string]: unknown
   }
 }
+
+export type Region = 'north_america' | 'europe'

--- a/packages/destination-actions/src/destinations/iterable/shared-fields.ts
+++ b/packages/destination-actions/src/destinations/iterable/shared-fields.ts
@@ -193,4 +193,4 @@ export type CommerceItem = {
   }
 }
 
-export type Region = 'north_america' | 'europe'
+export type Region = 'united_states' | 'europe'

--- a/packages/destination-actions/src/destinations/iterable/shared-fields.ts
+++ b/packages/destination-actions/src/destinations/iterable/shared-fields.ts
@@ -193,4 +193,4 @@ export type CommerceItem = {
   }
 }
 
-export type Region = 'united_states' | 'europe'
+export type DataCenterLocation = 'united_states' | 'europe'

--- a/packages/destination-actions/src/destinations/iterable/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/trackEvent/index.ts
@@ -9,7 +9,7 @@ import {
   CAMPAGIN_ID_FIELD,
   TEMPLATE_ID_FIELD,
   EVENT_DATA_FIELDS,
-  Region
+  DataCenterLocation
 } from '../shared-fields'
 import { convertDatesInObject, getRegionalEndpoint } from '../utils'
 
@@ -76,7 +76,7 @@ const action: ActionDefinition<Settings, Payload> = {
       createdAt: dayjs(payload.createdAt).unix()
     }
 
-    const endpoint = getRegionalEndpoint('trackEvent', settings.apiRegion as Region)
+    const endpoint = getRegionalEndpoint('trackEvent', settings.dataCenterLocation as DataCenterLocation)
     return request(endpoint, {
       method: 'post',
       json: trackEventRequest

--- a/packages/destination-actions/src/destinations/iterable/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/trackEvent/index.ts
@@ -8,9 +8,10 @@ import {
   CREATED_AT_FIELD,
   CAMPAGIN_ID_FIELD,
   TEMPLATE_ID_FIELD,
-  EVENT_DATA_FIELDS
+  EVENT_DATA_FIELDS,
+  Region
 } from '../shared-fields'
-import { convertDatesInObject } from '../utils'
+import { convertDatesInObject, getRegionalEndpoint } from '../utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Custom Event',
@@ -50,7 +51,7 @@ const action: ActionDefinition<Settings, Payload> = {
       ...TEMPLATE_ID_FIELD
     }
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, settings }) => {
     if (!payload.email && !payload.userId) {
       throw new PayloadValidationError('Must include email or userId.')
     }
@@ -75,7 +76,8 @@ const action: ActionDefinition<Settings, Payload> = {
       createdAt: dayjs(payload.createdAt).unix()
     }
 
-    return request('https://api.iterable.com/api/events/track', {
+    const endpoint = getRegionalEndpoint('trackEvent', settings.apiRegion as Region)
+    return request(endpoint, {
       method: 'post',
       json: trackEventRequest
     })

--- a/packages/destination-actions/src/destinations/iterable/trackPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/trackPurchase/index.ts
@@ -14,7 +14,7 @@ import {
   USER_DATA_FIELDS,
   USER_PHONE_NUMBER_FIELD,
   CommerceItem,
-  Region
+  DataCenterLocation
 } from '../shared-fields'
 import { transformItems, convertDatesInObject, getRegionalEndpoint } from '../utils'
 
@@ -147,7 +147,7 @@ const action: ActionDefinition<Settings, Payload> = {
       dataFields: formattedDataFields
     }
 
-    const endpoint = getRegionalEndpoint('trackPurchase', settings.apiRegion as Region)
+    const endpoint = getRegionalEndpoint('trackPurchase', settings.dataCenterLocation as DataCenterLocation)
     return request(endpoint, {
       method: 'post',
       json: trackPurchaseRequest

--- a/packages/destination-actions/src/destinations/iterable/trackPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/trackPurchase/index.ts
@@ -13,9 +13,10 @@ import {
   EVENT_DATA_FIELDS,
   USER_DATA_FIELDS,
   USER_PHONE_NUMBER_FIELD,
-  CommerceItem
+  CommerceItem,
+  Region
 } from '../shared-fields'
-import { transformItems, convertDatesInObject } from '../utils'
+import { transformItems, convertDatesInObject, getRegionalEndpoint } from '../utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track Purchase',
@@ -93,7 +94,7 @@ const action: ActionDefinition<Settings, Payload> = {
       ...TEMPLATE_ID_FIELD
     }
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, settings }) => {
     const { user, dataFields } = payload
 
     if (!user.email && !user.userId) {
@@ -146,7 +147,8 @@ const action: ActionDefinition<Settings, Payload> = {
       dataFields: formattedDataFields
     }
 
-    return request('https://api.iterable.com/api/commerce/trackPurchase', {
+    const endpoint = getRegionalEndpoint('trackPurchase', settings.apiRegion as Region)
+    return request(endpoint, {
       method: 'post',
       json: trackPurchaseRequest
     })

--- a/packages/destination-actions/src/destinations/iterable/updateCart/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/updateCart/index.ts
@@ -8,9 +8,10 @@ import {
   EMAIL_FIELD,
   USER_DATA_FIELDS,
   USER_PHONE_NUMBER_FIELD,
-  CommerceItem
+  CommerceItem,
+  Region
 } from '../shared-fields'
-import { transformItems, convertDatesInObject } from '../utils'
+import { transformItems, convertDatesInObject, getRegionalEndpoint } from '../utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Cart Updates',
@@ -59,7 +60,7 @@ const action: ActionDefinition<Settings, Payload> = {
       ...ITEMS_FIELD
     }
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, settings }) => {
     const { user, items } = payload
     if (!user.email && !user.userId) {
       throw new PayloadValidationError('Must include email or userId.')
@@ -94,7 +95,8 @@ const action: ActionDefinition<Settings, Payload> = {
       items: transformItems(items)
     }
 
-    return request('https://api.iterable.com/api/commerce/updateCart', {
+    const endpoint = getRegionalEndpoint('updateCart', settings.apiRegion as Region)
+    return request(endpoint, {
       method: 'post',
       json: updateCartRequest
     })

--- a/packages/destination-actions/src/destinations/iterable/updateCart/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/updateCart/index.ts
@@ -9,7 +9,7 @@ import {
   USER_DATA_FIELDS,
   USER_PHONE_NUMBER_FIELD,
   CommerceItem,
-  Region
+  DataCenterLocation
 } from '../shared-fields'
 import { transformItems, convertDatesInObject, getRegionalEndpoint } from '../utils'
 
@@ -95,7 +95,7 @@ const action: ActionDefinition<Settings, Payload> = {
       items: transformItems(items)
     }
 
-    const endpoint = getRegionalEndpoint('updateCart', settings.apiRegion as Region)
+    const endpoint = getRegionalEndpoint('updateCart', settings.dataCenterLocation as DataCenterLocation)
     return request(endpoint, {
       method: 'post',
       json: updateCartRequest

--- a/packages/destination-actions/src/destinations/iterable/updateUser/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/updateUser/index.ts
@@ -7,7 +7,7 @@ import {
   USER_DATA_FIELDS,
   MERGE_NESTED_OBJECTS_FIELD,
   USER_PHONE_NUMBER_FIELD,
-  Region
+  DataCenterLocation
 } from '../shared-fields'
 import { convertDatesInObject, getRegionalEndpoint } from '../utils'
 
@@ -62,7 +62,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
 
-    const endpoint = getRegionalEndpoint('updateUser', settings.apiRegion as Region)
+    const endpoint = getRegionalEndpoint('updateUser', settings.dataCenterLocation as DataCenterLocation)
     return request(endpoint, {
       method: 'post',
       json: userUpdateRequest

--- a/packages/destination-actions/src/destinations/iterable/updateUser/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/updateUser/index.ts
@@ -6,9 +6,10 @@ import {
   USER_ID_FIELD,
   USER_DATA_FIELDS,
   MERGE_NESTED_OBJECTS_FIELD,
-  USER_PHONE_NUMBER_FIELD
+  USER_PHONE_NUMBER_FIELD,
+  Region
 } from '../shared-fields'
-import { convertDatesInObject } from '../utils'
+import { convertDatesInObject, getRegionalEndpoint } from '../utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Upsert User',
@@ -32,7 +33,7 @@ const action: ActionDefinition<Settings, Payload> = {
       ...MERGE_NESTED_OBJECTS_FIELD
     }
   },
-  perform: (request, { payload }) => {
+  perform: (request, { payload, settings }) => {
     const { email, userId, dataFields } = payload
 
     if (!email && !userId) {
@@ -61,7 +62,8 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
 
-    return request('https://api.iterable.com/api/users/update', {
+    const endpoint = getRegionalEndpoint('updateUser', settings.apiRegion as Region)
+    return request(endpoint, {
       method: 'post',
       json: userUpdateRequest
     })

--- a/packages/destination-actions/src/destinations/iterable/utils.ts
+++ b/packages/destination-actions/src/destinations/iterable/utils.ts
@@ -80,7 +80,7 @@ export function transformItems(items: UpdateCart['items']): CommerceItem[] {
   }))
 }
 
-const regionEndpoints = {
+const regionBaseUrls = {
   united_states: 'https://api.iterable.com',
   europe: 'https://api.eu.iterable.com'
   // Add more regions and their corresponding endpoints here
@@ -106,7 +106,7 @@ export function getRegionalEndpoint(
   action: keyof typeof apiEndpoints,
   dataCenterLocation: DataCenterLocation = 'united_states'
 ): string {
-  const regionEndpoint = regionEndpoints[dataCenterLocation] || regionEndpoints['united_states']
+  const regionBaseUrl = regionBaseUrls[dataCenterLocation] || regionBaseUrls['united_states']
   const endpoint = apiEndpoints[action]
-  return regionEndpoint + endpoint
+  return regionBaseUrl + endpoint
 }

--- a/packages/destination-actions/src/destinations/iterable/utils.ts
+++ b/packages/destination-actions/src/destinations/iterable/utils.ts
@@ -1,6 +1,6 @@
 import { omit } from '@segment/actions-core'
 import { Payload as UpdateCart } from './updateCart/generated-types'
-import { CommerceItem, Region } from './shared-fields'
+import { CommerceItem, DataCenterLocation } from './shared-fields'
 
 // Regular expression for matching ISO date strings in various formats
 // Taken from https://github.com/segmentio/isodate/blob/master/lib/index.js
@@ -96,14 +96,17 @@ export const apiEndpoints = {
 
 /**
  * Retrieves the regional API endpoint for a specific API action.
- * If the region provided is invalid or not specified, it defaults to 'united_states'.
+ * If the data center location provided is invalid or not specified, it defaults to 'united_states'.
  *
  * @param action The name of the API action.
- * @param region The region for data residency.
+ * @param dataCenterLocation The data center location for data residency.
  * @returns The regional API endpoint.
  */
-export function getRegionalEndpoint(action: keyof typeof apiEndpoints, region: Region = 'united_states'): string {
-  const regionEndpoint = regionEndpoints[region] || regionEndpoints['united_states']
+export function getRegionalEndpoint(
+  action: keyof typeof apiEndpoints,
+  dataCenterLocation: DataCenterLocation = 'united_states'
+): string {
+  const regionEndpoint = regionEndpoints[dataCenterLocation] || regionEndpoints['united_states']
   const endpoint = apiEndpoints[action]
   return regionEndpoint + endpoint
 }

--- a/packages/destination-actions/src/destinations/iterable/utils.ts
+++ b/packages/destination-actions/src/destinations/iterable/utils.ts
@@ -82,35 +82,35 @@ export function transformItems(items: UpdateCart['items']): CommerceItem[] {
 
 export const apiEndpoints = {
   updateUser: {
-    north_america: 'https://api.iterable.com/api/users/update',
+    united_states: 'https://api.iterable.com/api/users/update',
     europe: 'https://api.eu.iterable.com/api/users/update'
   },
   trackEvent: {
-    north_america: 'https://api.iterable.com/api/events/track',
+    united_states: 'https://api.iterable.com/api/events/track',
     europe: 'https://api.eu.iterable.com/api/events/track'
   },
   updateCart: {
-    north_america: 'https://api.iterable.com/api/commerce/updateCart',
+    united_states: 'https://api.iterable.com/api/commerce/updateCart',
     europe: 'https://api.eu.iterable.com/api/commerce/updateCart'
   },
   trackPurchase: {
-    north_america: 'https://api.iterable.com/api/commerce/trackPurchase',
+    united_states: 'https://api.iterable.com/api/commerce/trackPurchase',
     europe: 'https://api.eu.iterable.com/api/commerce/trackPurchase'
   },
   getWebhooks: {
-    north_america: 'https://api.iterable.com/api/webhooks',
+    united_states: 'https://api.iterable.com/api/webhooks',
     europe: 'https://api.eu.iterable.com/api/webhooks'
   }
 }
 
 /**
  * Retrieves the regional API endpoint for a specific API action.
- * If the region provided is invalid or not specified, it defaults to 'north_america'.
+ * If the region provided is invalid or not specified, it defaults to 'united_states'.
  *
  * @param action The name of the API action.
  * @param region The region for data residency.
  * @returns The regional API endpoint.
  */
-export function getRegionalEndpoint(action: keyof typeof apiEndpoints, region: Region = 'north_america'): string {
-  return apiEndpoints[action][region] ?? apiEndpoints[action]['north_america']
+export function getRegionalEndpoint(action: keyof typeof apiEndpoints, region: Region = 'united_states'): string {
+  return apiEndpoints[action][region] ?? apiEndpoints[action]['united_states']
 }

--- a/packages/destination-actions/src/destinations/iterable/utils.ts
+++ b/packages/destination-actions/src/destinations/iterable/utils.ts
@@ -1,6 +1,6 @@
 import { omit } from '@segment/actions-core'
 import { Payload as UpdateCart } from './updateCart/generated-types'
-import { CommerceItem } from './shared-fields'
+import { CommerceItem, Region } from './shared-fields'
 
 // Regular expression for matching ISO date strings in various formats
 // Taken from https://github.com/segmentio/isodate/blob/master/lib/index.js
@@ -78,4 +78,39 @@ export function transformItems(items: UpdateCart['items']): CommerceItem[] {
     dataFields: convertDatesInObject(omit(rest, reservedItemKeys) || {}),
     ...(categories && { categories: [categories] })
   }))
+}
+
+export const apiEndpoints = {
+  updateUser: {
+    north_america: 'https://api.iterable.com/api/users/update',
+    europe: 'https://api.eu.iterable.com/api/users/update'
+  },
+  trackEvent: {
+    north_america: 'https://api.iterable.com/api/events/track',
+    europe: 'https://api.eu.iterable.com/api/events/track'
+  },
+  updateCart: {
+    north_america: 'https://api.iterable.com/api/commerce/updateCart',
+    europe: 'https://api.eu.iterable.com/api/commerce/updateCart'
+  },
+  trackPurchase: {
+    north_america: 'https://api.iterable.com/api/commerce/trackPurchase',
+    europe: 'https://api.eu.iterable.com/api/commerce/trackPurchase'
+  },
+  getWebhooks: {
+    north_america: 'https://api.iterable.com/api/webhooks',
+    europe: 'https://api.eu.iterable.com/api/webhooks'
+  }
+}
+
+/**
+ * Retrieves the regional API endpoint for a specific API action.
+ * If the region provided is invalid or not specified, it defaults to 'north_america'.
+ *
+ * @param action The name of the API action.
+ * @param region The region for data residency.
+ * @returns The regional API endpoint.
+ */
+export function getRegionalEndpoint(action: keyof typeof apiEndpoints, region: Region = 'north_america'): string {
+  return apiEndpoints[action][region] ?? apiEndpoints[action]['north_america']
 }

--- a/packages/destination-actions/src/destinations/iterable/utils.ts
+++ b/packages/destination-actions/src/destinations/iterable/utils.ts
@@ -80,27 +80,18 @@ export function transformItems(items: UpdateCart['items']): CommerceItem[] {
   }))
 }
 
+const regionEndpoints = {
+  united_states: 'https://api.iterable.com',
+  europe: 'https://api.eu.iterable.com'
+  // Add more regions and their corresponding endpoints here
+}
+
 export const apiEndpoints = {
-  updateUser: {
-    united_states: 'https://api.iterable.com/api/users/update',
-    europe: 'https://api.eu.iterable.com/api/users/update'
-  },
-  trackEvent: {
-    united_states: 'https://api.iterable.com/api/events/track',
-    europe: 'https://api.eu.iterable.com/api/events/track'
-  },
-  updateCart: {
-    united_states: 'https://api.iterable.com/api/commerce/updateCart',
-    europe: 'https://api.eu.iterable.com/api/commerce/updateCart'
-  },
-  trackPurchase: {
-    united_states: 'https://api.iterable.com/api/commerce/trackPurchase',
-    europe: 'https://api.eu.iterable.com/api/commerce/trackPurchase'
-  },
-  getWebhooks: {
-    united_states: 'https://api.iterable.com/api/webhooks',
-    europe: 'https://api.eu.iterable.com/api/webhooks'
-  }
+  updateUser: '/api/users/update',
+  trackEvent: '/api/events/track',
+  updateCart: '/api/commerce/updateCart',
+  trackPurchase: '/api/commerce/trackPurchase',
+  getWebhooks: '/api/webhooks'
 }
 
 /**
@@ -112,5 +103,7 @@ export const apiEndpoints = {
  * @returns The regional API endpoint.
  */
 export function getRegionalEndpoint(action: keyof typeof apiEndpoints, region: Region = 'united_states'): string {
-  return apiEndpoints[action][region] ?? apiEndpoints[action]['united_states']
+  const regionEndpoint = regionEndpoints[region] || regionEndpoints['united_states']
+  const endpoint = apiEndpoints[action]
+  return regionEndpoint + endpoint
 }


### PR DESCRIPTION
_Enhances Destination settings with EU data center support._

1. Added a new input field called dataCenterLocation in the destination settings. It includes a dropdown with two choices: North America or Europe, with North America set as the default selection.
2. When an action is triggered, the chosen dataCenterLocation setting is utilized to determine the appropriate API for sending the request. Depending on the selection, the request is directed to the respective region's API.

## Testing

Added tests for new functionality, as well as test for authentication.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
