### PR TITLE
Address issue with AppFit Destination testAuth

### DIFF
--- a/packages/destination-actions/src/destinations/app-fit/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/app-fit/__tests__/index.test.ts
@@ -7,7 +7,7 @@ const testDestination = createTestIntegration(Definition)
 describe('App Fit', () => {
   describe('testAuthentication', () => {
     it('should validate authentication inputs', async () => {
-      nock(AppFitConfig.apiUrl).get('/api-key/current').reply(200, {})
+      nock(AppFitConfig.apiUrl).get('/api-keys/current').reply(200, {})
 
       // This should match your authentication.fields
       const authData = { apiKey: '1234abc' }

--- a/packages/destination-actions/src/destinations/app-fit/index.ts
+++ b/packages/destination-actions/src/destinations/app-fit/index.ts
@@ -20,8 +20,8 @@ const destination: DestinationDefinition<Settings> = {
       }
     },
     testAuthentication: (request, { settings }) => {
-      return request(`${AppFitConfig.apiUrl}/api-key/current`, {
-        headers: { Authorization: `Bearer ${settings.apiKey}` }
+      return request(`${AppFitConfig.apiUrl}/api-keys/current`, {
+        headers: { Authorization: `Basic ${settings.apiKey}` }
       })
     }
   },

--- a/packages/destination-actions/src/destinations/app-fit/track/index.ts
+++ b/packages/destination-actions/src/destinations/app-fit/track/index.ts
@@ -86,7 +86,7 @@ const action: ActionDefinition<Settings, Payload> = {
   perform: (request, { payload, settings }) => {
     return request(`${AppFitConfig.apiUrl}/metric-events`, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${settings.apiKey}` },
+      headers: { Authorization: `Basic ${settings.apiKey}` },
 
       json: {
         eventSource: 'segment',


### PR DESCRIPTION
I had copied an example of auth from elsewhere and forgot to change the auth type in the authorization header. Didn't come across this during testing because the track endpoint just records the header and forwards on to another job that processes the event. That job doesn't care about Basic vs Bearer, but the api endpoint used in the testAuthentication method does care.

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
