### PR TITLE
convert date strings to Airship-friendly format

### DIFF
--- a/packages/destination-actions/src/destinations/airship/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/airship/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -114,7 +114,7 @@ Object {
       "action": "set",
       "key": "birthdate",
       "timestamp": false,
-      "value": "2021-02-01T00:00:00.000Z",
+      "value": "2021-02-01T00:00:00",
     },
     Object {
       "action": "set",
@@ -162,7 +162,7 @@ Object {
       "action": "set",
       "key": "account_creation",
       "timestamp": false,
-      "value": "2021-02-01T00:00:00.000Z",
+      "value": "2021-02-01T00:00:00",
     },
     Object {
       "action": "set",

--- a/packages/destination-actions/src/destinations/airship/__tests__/airship.test.ts
+++ b/packages/destination-actions/src/destinations/airship/__tests__/airship.test.ts
@@ -1,0 +1,150 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Airship from '../index'
+import { DecoratedResponse } from '@segment/actions-core'
+
+const testDestination = createTestIntegration(Airship)
+
+describe('Airship', () => {
+  describe('setAttribute', () => {
+    it('should work for US', async () => {
+      const now = new Date().toISOString()
+      const event = createTestEvent({
+        userId: 'test-user-rzoj4u7gqw',
+        timestamp: now,
+        traits: {
+          trait1: 1,
+          trait2: 'test',
+          trait3: true,
+          birthdate: '2003-02-22T02:42:33.378Z'
+        }
+      })
+
+      nock('https://go.urbanairship.com').post('/api/channels/attributes').reply(200, {})
+
+      const responses = await testDestination.testAction('setAttributes', {
+        event,
+        useDefaultMappings: true,
+        settings: {
+          access_token: 'foo',
+          app_key: 'bar',
+          endpoint: 'US'
+        }
+      })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+    })
+  })
+  describe('setAttribute', () => {
+    it('should work for EU', async () => {
+      const now = new Date().toISOString()
+      const event = createTestEvent({
+        userId: 'test-user-rzoj4u7gqw',
+        timestamp: now,
+        traits: {
+          trait1: 1,
+          trait2: 'test',
+          trait3: true,
+          birthdate: '2003-02-22T02:42:33.378Z'
+        }
+      })
+
+      nock('https://go.airship.eu').post('/api/channels/attributes').reply(200, {})
+
+      const responses = await testDestination.testAction('setAttributes', {
+        event,
+        useDefaultMappings: true,
+        settings: {
+          access_token: 'foo',
+          app_key: 'bar',
+          endpoint: 'EU'
+        }
+      })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+    })
+  })
+
+  describe('customEvents', () => {
+    it('should work', async () => {
+      const now = new Date().toISOString()
+      const event = createTestEvent({
+        userId: 'test-user-rzoj4u7gqw',
+        type: 'track',
+        timestamp: now,
+        properties: {
+          foo: 'bar',
+          stuff: {
+            lots: 'of',
+            stuff: true
+          }
+        }
+      })
+
+      nock('https://go.urbanairship.com').post('/api/custom-events').reply(200, {})
+
+      const responses = await testDestination.testAction('customEvents', {
+        event,
+        useDefaultMappings: true,
+        settings: {
+          access_token: 'foo',
+          app_key: 'bar',
+          endpoint: 'US'
+        }
+      })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+    })
+  })
+
+  describe('manageTags', () => {
+    it('should work', async () => {
+      const event = createTestEvent({
+        userId: 'test-user-rzoj4u7gqw',
+        traits: {
+          trait1: 1,
+          trait2: 'test',
+          trait3: true,
+          birthdate: '2003-02-22T02:42:33.378Z'
+        }
+      })
+
+      nock('https://go.urbanairship.com').post('/api/named_users/tags').reply(200, {})
+
+      const responses = await testDestination.testAction('manageTags', {
+        event,
+        useDefaultMappings: true,
+        settings: {
+          access_token: 'foo',
+          app_key: 'bar',
+          endpoint: 'US'
+        }
+      })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].data).toMatchObject({})
+    })
+  })
+
+  describe('delete', () => {
+    it('should support deletes', async () => {
+      const event = createTestEvent({
+        userId: 'test-user-rzoj4u7gqw'
+      })
+      nock('https://go.urbanairship.com').post('/api/named_users/uninstall').reply(200, {})
+      if (testDestination.onDelete) {
+        const response = await testDestination.onDelete(event, {
+          access_token: 'foo',
+          app_key: 'bar',
+          endpoint: 'US'
+        })
+        const resp = response as DecoratedResponse
+        expect(resp.status).toBe(200)
+        expect(resp.data).toMatchObject({})
+      }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
+++ b/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
@@ -103,3 +103,9 @@ describe('Testing _validate_timestamp', () => {
     expect(_private.validate_timestamp(valid_custom_event_payload.occurred)).toEqual('2023-05-06T20:45:12')
   })
 })
+
+describe('Testing parse_date', () => {
+  it('should parse a date into a date object', () => {
+    expect(_private.parse_date('2023-05-09T00:47:43.378Z')).toBeInstanceOf(Date)
+  })
+})

--- a/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
+++ b/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
@@ -21,7 +21,8 @@ const valid_attributes_payload: AttributesPayload = {
   attributes: {
     trait1: 1,
     trait2: 'test',
-    trait3: true
+    trait3: true,
+    birthdate: '1965-01-25T00:47:43.378Z'
   }
 }
 
@@ -68,6 +69,12 @@ const airship_attributes_payload = [
     key: 'trait3',
     timestamp: '2023-05-09T00:47:43',
     value: true
+  },
+  {
+    action: 'set',
+    key: 'birthdate',
+    timestamp: '2023-05-09T00:47:43',
+    value: '1965-01-25T00:47:43'
   }
 ]
 

--- a/packages/destination-actions/src/destinations/airship/index.ts
+++ b/packages/destination-actions/src/destinations/airship/index.ts
@@ -74,7 +74,8 @@ const destination: DestinationDefinition<Settings> = {
     }
   ],
   onDelete: async (request, { settings, payload }) => {
-    return request(`${settings.endpoint}/api/named_users/uninstall`, {
+    const endpoint = map_endpoint(settings.endpoint)
+    return request(`${endpoint}/api/named_users/uninstall`, {
       method: 'post',
       json: {
         named_user_id: [payload.userId]

--- a/packages/destination-actions/src/destinations/airship/setAttributes/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/airship/setAttributes/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -61,7 +61,7 @@ Object {
       "action": "set",
       "key": "birthdate",
       "timestamp": false,
-      "value": "2021-02-01T00:00:00.000Z",
+      "value": "2021-02-01T00:00:00",
     },
     Object {
       "action": "set",
@@ -109,7 +109,7 @@ Object {
       "action": "set",
       "key": "account_creation",
       "timestamp": false,
-      "value": "2021-02-01T00:00:00.000Z",
+      "value": "2021-02-01T00:00:00",
     },
     Object {
       "action": "set",

--- a/packages/destination-actions/src/destinations/airship/utilities.ts
+++ b/packages/destination-actions/src/destinations/airship/utilities.ts
@@ -105,13 +105,27 @@ function _build_attribute(attribute_key: string, attribute_value: any, occurred:
   /*
   This function builds a single attribute from a key/value.
   */
-  const attribute: { action: string; key: string; value?: string | number | boolean; timestamp: string | boolean } = {
+  let adjustedDate = null
+  if (typeof attribute_value == 'string') {
+    adjustedDate = parse_date(attribute_value)
+  }
+
+  const attribute: {
+    action: string
+    key: string
+    value?: string | number | boolean
+    timestamp: string | boolean
+  } = {
     action: 'set',
     key: attribute_key,
     timestamp: validate_timestamp(occurred)
   }
+
   if (attribute_value == null || (typeof attribute_value == 'string' && attribute_value.length === 0)) {
     attribute.action = 'remove'
+  } else if (adjustedDate !== null) {
+    attribute.action = 'set'
+    attribute.value = adjustedDate.toISOString().split('.')[0]
   } else {
     attribute.action = 'set'
     attribute.value = attribute_value
@@ -162,10 +176,23 @@ function validate_timestamp(timestamp: string | number | Date) {
   }
 }
 
+function parse_date(attribute_value: any): Date | null {
+  // Attempt to parse the attribute_value as a Date
+  const date = new Date(attribute_value)
+
+  // Check if the parsing was successful and the result is a valid date
+  if (!isNaN(date.getTime())) {
+    return date // Return the parsed Date
+  }
+
+  return null // Return null for invalid dates
+}
+
 export const _private = {
   _build_custom_event_object,
   _build_attributes_object,
   _build_attribute,
   _build_tags_object,
+  parse_date,
   validate_timestamp
 }


### PR DESCRIPTION
Airship Attributes API expect dates to be in a specific format. This PR evaluates strings used in SetAttributes and if they are valid ISO1806 dates, converts them to the correct format for this purpose.

## Testing
- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
