### PR TITLE
Add support for self hosted Adobe Library

### DIFF
--- a/packages/browser-destinations/destinations/adobe-target/src/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/adobe-target/src/__tests__/index.test.ts
@@ -3,7 +3,8 @@ import adobeTarget, { destination } from '../index'
 import { Subscription } from '@segment/browser-destination-runtime/types'
 
 describe('Adobe Target Web', () => {
-  test('can load ATJS', async () => {
+  // Skipping this test as we don't load at.js in the destination anymore
+  test.skip('can load ATJS', async () => {
     const subscriptions: Subscription[] = [
       {
         partnerAction: 'upsertProfile',

--- a/packages/browser-destinations/destinations/adobe-target/src/index.ts
+++ b/packages/browser-destinations/destinations/adobe-target/src/index.ts
@@ -80,8 +80,7 @@ export const destination: BrowserDestinationDefinition<Settings, Adobe> = {
       dependencyCheckLimit--
 
       // If at.js library is never loaded fail silently.
-      // Don't throw exception as loading at.js can be blocked by an Ad-blocker.
-      // Throwing can result in a noisy destination.
+      // Don't throw exception as throwing can result in a noisy destination.
       // Return true to stop the eventListener from hanging.
       if (!dependencyCheckLimit) {
         return true

--- a/packages/browser-destinations/destinations/adobe-target/src/init-script.ts
+++ b/packages/browser-destinations/destinations/adobe-target/src/init-script.ts
@@ -3,11 +3,11 @@
 
 import { getPageParams } from './utils'
 
-export function initScript(settings) {
+export function initScript(_settings) {
   window.pageParams = {}
-  window.targetGlobalSettings = {
-    cookieDomain: settings.cookie_domain,
-    enabled: true
+
+  if (!window.targetGlobalSettings) {
+    console.log('Warning! window.targetGlobalSettings should be set before loading your Segment library.')
   }
 
   // DO NOT RENAME. This function is required by Adobe Target.

--- a/packages/browser-destinations/destinations/adobe-target/src/trackEvent/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/adobe-target/src/trackEvent/__tests__/index.test.ts
@@ -56,6 +56,9 @@ describe('Adobe Target Web', () => {
         subscriptions
       })
 
+      // Mock adobe object as it will be sourced from a self-hosted library
+      window.adobe = { target: { trackEvent: () => {}, triggerView: () => {} } }
+
       jest.spyOn(destination, 'initialize')
 
       destination.actions.trackEvent.perform = jest.fn(destination.actions.trackEvent.perform)

--- a/packages/browser-destinations/destinations/adobe-target/src/trackEvent/index.ts
+++ b/packages/browser-destinations/destinations/adobe-target/src/trackEvent/index.ts
@@ -52,6 +52,10 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
     }
   },
   perform: (Adobe, event) => {
+    if (!Object.prototype.hasOwnProperty.call(window, 'adobe')) {
+      return Promise.reject()
+    }
+
     const payload = event.payload
     setMbox3rdPartyId(payload.userId)
 

--- a/packages/browser-destinations/destinations/adobe-target/src/trackEvent/index.ts
+++ b/packages/browser-destinations/destinations/adobe-target/src/trackEvent/index.ts
@@ -53,7 +53,7 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   },
   perform: (Adobe, event) => {
     if (!Object.prototype.hasOwnProperty.call(window, 'adobe')) {
-      return Promise.reject()
+      return Promise.resolve()
     }
 
     const payload = event.payload

--- a/packages/browser-destinations/destinations/adobe-target/src/triggerView/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/adobe-target/src/triggerView/__tests__/index.test.ts
@@ -47,6 +47,9 @@ describe('Adobe Target Web', () => {
         subscriptions
       })
 
+      // Mock adobe object as it will be sourced from a self-hosted library
+      window.adobe = { target: { trackEvent: () => {}, triggerView: () => {} } }
+
       jest.spyOn(destination, 'initialize')
 
       destination.actions.triggerView.perform = jest.fn(destination.actions.triggerView.perform)

--- a/packages/browser-destinations/destinations/adobe-target/src/triggerView/index.ts
+++ b/packages/browser-destinations/destinations/adobe-target/src/triggerView/index.ts
@@ -50,7 +50,7 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   },
   perform: (Adobe, event) => {
     if (!Object.prototype.hasOwnProperty.call(window, 'adobe')) {
-      return Promise.reject()
+      return Promise.resolve()
     }
 
     const sendNotification = event.payload.sendNotification

--- a/packages/browser-destinations/destinations/adobe-target/src/triggerView/index.ts
+++ b/packages/browser-destinations/destinations/adobe-target/src/triggerView/index.ts
@@ -49,6 +49,10 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
     }
   },
   perform: (Adobe, event) => {
+    if (!Object.prototype.hasOwnProperty.call(window, 'adobe')) {
+      return Promise.reject()
+    }
+
     const sendNotification = event.payload.sendNotification
     const pageParams = event.payload.pageParameters
 

--- a/packages/browser-destinations/destinations/adobe-target/src/upsertProfile/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/adobe-target/src/upsertProfile/__tests__/index.test.ts
@@ -55,6 +55,9 @@ describe('Adobe Target Web', () => {
         subscriptions
       })
 
+      // Mock adobe object as it will be sourced from a self-hosted library
+      window.adobe = { target: { trackEvent: () => {}, triggerView: () => {} } }
+
       jest.spyOn(destination, 'initialize')
 
       destination.actions.upsertProfile.perform = jest.fn(destination.actions.upsertProfile.perform)

--- a/packages/browser-destinations/destinations/adobe-target/src/upsertProfile/index.ts
+++ b/packages/browser-destinations/destinations/adobe-target/src/upsertProfile/index.ts
@@ -33,7 +33,7 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   },
   perform: (Adobe, event) => {
     if (!Object.prototype.hasOwnProperty.call(window, 'adobe')) {
-      return Promise.reject()
+      return Promise.resolve()
     }
 
     /*

--- a/packages/browser-destinations/destinations/adobe-target/src/upsertProfile/index.ts
+++ b/packages/browser-destinations/destinations/adobe-target/src/upsertProfile/index.ts
@@ -32,6 +32,10 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
     }
   },
   perform: (Adobe, event) => {
+    if (!Object.prototype.hasOwnProperty.call(window, 'adobe')) {
+      return Promise.reject()
+    }
+
     /*
        NOTE:
        identify() and track() actions leverage the same function (adobe.target.trackEvent()) to send data to Adobe.


### PR DESCRIPTION
This PR will allow users to bring their own version of AT.JS. This branch is not supposed to be merged against `main` since it will be released as a pinned version to a given source.

## Testing

Testing completed successfully via replit. Ask via DM for it if you are interested.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
