### PR TITLE
disables sabil browser destination tests

### DIFF
--- a/packages/browser-destinations/destinations/sabil/src/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/sabil/src/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { Analytics, Context } from '@segment/analytics-next'
 import sabil, { destination } from '../index'
 import { subscriptions, TEST_CLIENT_ID } from '../test-utils'
 
-test('load Sabil', async () => {
+test.skip('load Sabil', async () => {
   const [event] = await sabil({
     client_id: TEST_CLIENT_ID,
     subscriptions

--- a/packages/browser-destinations/destinations/sabil/src/attach/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/sabil/src/attach/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { Analytics, Context } from '@segment/analytics-next'
 import sabil from '../../index'
 import { subscriptions, TEST_CLIENT_ID, TEST_USER_ID } from '../../test-utils'
 
-describe('Sabil.attach', () => {
+describe.skip('Sabil.attach', () => {
   it('should call attach on identify event', async () => {
     const [plugin] = await sabil({
       client_id: TEST_CLIENT_ID,


### PR DESCRIPTION
Disables sabil browser destinations tests since their CDN is inaccessible and test failures are blocking CI.

## Testing

None needed since we're disabling tests for a specific package.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
