### PR TITLE
[Attio] Change the name of the destination

### DIFF
--- a/packages/destination-actions/src/destinations/attio/index.ts
+++ b/packages/destination-actions/src/destinations/attio/index.ts
@@ -5,7 +5,7 @@ import groupWorkspace from './groupWorkspace'
 import assertRecord from './assertRecord'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Attio',
+  name: 'Attio (Actions)',
   description: 'The Attio destination allows you to assert Records in your Attio workspace based on Segment events',
   slug: 'actions-attio',
   mode: 'cloud',


### PR DESCRIPTION
When trying to register the new Attio destination we get a failing message because there is already a destination with the same name. Adding Actions to the name so we can register it.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
