### PR TITLE
CHANNELS-819 fixing error tags

### DIFF
--- a/packages/destination-actions/src/destinations/engage/utils/EngageActionPerformer.ts
+++ b/packages/destination-actions/src/destinations/engage/utils/EngageActionPerformer.ts
@@ -59,10 +59,17 @@ export abstract class EngageActionPerformer<TSettings = any, TPayload = any, TRe
       const respError = op?.error as ResponseError
       if (respError) {
         const errorDetails = getErrorDetails(respError)
+        const msgLowercare = errorDetails?.message?.toLowerCase()
 
-        if (errorDetails.message?.toLowerCase().includes('timeout') && !respError.status)
-          // to fix missing status of Integrations/ETIMEOUT error that makes it not retryable
-          respError.status = 408
+        // some Timeout errors are coming as FetchError-s somehow (https://segment.atlassian.net/browse/CHANNELS-819)
+        const isTimeoutError =
+          msgLowercare?.includes('timeout') ||
+          msgLowercare?.includes('timedout') ||
+          msgLowercare?.includes('exceeded the deadline') ||
+          errorDetails.code?.toLowerCase().includes('etimedout')
+
+        // CHANNELS-651 somehow Timeouts are not retried by Integrations, this is fixing it
+        if (isTimeoutError && !respError.status) respError.status = 408
 
         if (errorDetails.code) op.tags.push(`response_code:${errorDetails.code}`)
         if (errorDetails.status) op.tags.push(`response_status:${errorDetails.status}`)

--- a/packages/destination-actions/src/destinations/engage/utils/EngageStats.ts
+++ b/packages/destination-actions/src/destinations/engage/utils/EngageStats.ts
@@ -9,7 +9,7 @@ import {
 } from './operationTracking'
 import { EngageActionPerformer } from './EngageActionPerformer'
 import { OperationContext } from './track'
-import { ResponseError } from './ResponseError'
+import { getErrorDetails } from './ResponseError'
 
 export class EngageStats extends OperationStats {
   static getTryCatchFinallyHook(_ctx: OperationStatsContext): TryCatchFinallyHook<OperationStatsContext> {
@@ -57,8 +57,8 @@ export class EngageStats extends OperationStats {
     let statsFunc = this.statsClient?.[statsMethod || 'incr'].bind(this.statsClient)
     if (!statsFunc)
       switch (
-        statsMethod ||
-        'incr' // have to do this to avoid issues with JS bundler/minifier
+      statsMethod ||
+      'incr' // have to do this to avoid issues with JS bundler/minifier
       ) {
         case 'incr':
           statsFunc = this.statsClient?.incr.bind(this.statsClient)
@@ -96,12 +96,9 @@ export class EngageStats extends OperationStats {
   extractTagsFromError(error: TrackedError, ctx: OperationStatsContext): string[] {
     const res = super.extractTagsFromError(error, ctx)
 
-    const respError = error as ResponseError
-    const error_code = respError?.response?.data?.code || respError?.code
-    if (error_code) res.push(`error_code:${error_code}`)
-
-    const error_status = respError?.response?.data?.status || respError?.status
-    if (error_status) res.push(`error_status:${error_status}`)
+    const errDetails = getErrorDetails(error)
+    if (errDetails?.code) res.push(`error_code:${errDetails.code}`)
+    if (errDetails?.status) res.push(`error_status:${errDetails.status}`)
 
     if (error.underlyingError) {
       const underlyingErrorTags = this.extractTagsFromError(error.underlyingError as any, ctx)

--- a/packages/destination-actions/src/destinations/engage/utils/ResponseError.ts
+++ b/packages/destination-actions/src/destinations/engage/utils/ResponseError.ts
@@ -8,6 +8,9 @@ export interface ResponseError extends HTTPError {
       more_info: string
       status?: number
       statusCode?: number
+      errors?: {
+        message: string
+      }[]
     }
     headers?: Response['headers']
   }
@@ -17,15 +20,30 @@ export interface ResponseError extends HTTPError {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getErrorDetails(error: any) {
+  //example of errors are here: https://segment.atlassian.net/browse/CHANNELS-819
+  // each API may have its own response.data structure. E.g. Twilio has code, message, more_info, status, while Sendgrid has array of errors where each has `message`, `field`, `help`.
   const respError = error as ResponseError
-  const status =
-    respError.response?.data?.status ||
-    respError.response?.data?.statusCode ||
-    respError.response?.status ||
-    respError.status
-  const code = respError?.response?.data?.code || respError.code
-  const message = [respError.name || respError.constructor?.name, respError.message, respError?.response?.data?.message]
+  // some errors noticed to have no status and no response (e.g. ECONNRESET, ETIMEDOUT)
+  // there are tests impling it supposed to be retried: https://github.com/segmentio/integrations/blob/995f96a0526c3aba051c3948c3bfc306c704aec9/src/createIntegration/test/proto.js#L728, but ETIMEDOUT were still not retried
+  const status = respError.status || respError.response?.status
+  // || respError.response?.data?.status // twilio apis provides status and statusCode in data, but we assume it's the same as response.status
+  // || respError.response?.data?.statusCode
+
+  const code = respError.code || respError.response?.data?.code
+  // || respError.response?.statusText // e.g. 'Not Found' for 404
+
+  const message = [
+    respError.name || respError.constructor?.name,
+    respError.message,
+    respError.response?.statusText && !respError.message.includes(respError.response?.statusText)
+      ? respError.response?.statusText
+      : undefined,
+
+    // Api specific error messages (later should be abstracted in EngageActionPerformer and implemented separately for TwilioMessageSender and sendgrid/SendEmailPerformer)
+    respError?.response?.data?.message, //twilio
+    respError?.response?.data?.errors?.[0]?.message //sendgrid
+  ]
     .filter(Boolean)
-    .join(' - ')
+    .join('; ')
   return { status, code, message }
 }


### PR DESCRIPTION
Plz see the [ticket](https://segment.atlassian.net/browse/CHANNELS-819)
![image](https://github.com/segmentio/action-destinations/assets/7120440/d5ae1f16-5e0a-4edc-9614-60dbf59191ef)

The [Logging already extracts](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/engage/utils/EngageLogger.ts#L51-L55) and shows correct status and code. So this PR is making stats consistent with logger.

The error where the bug was discovered are [here](Specifically the scenario where we found this bug: https://s3logs.segment.com/?service=integrations&since=20230727T2100Z&until=20230727T2101Z&filter=TE+Messaging
): 
![image](https://github.com/segmentio/action-destinations/assets/7120440/1b82417e-86c7-4981-8b5f-1729ef8fd363)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
