### PR TITLE
CCP-322: Add to email to to name fallback list before User in sendgrid DA

### DIFF
--- a/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
+++ b/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
@@ -122,7 +122,7 @@ export class SendEmailPerformer extends MessageSendPerformer<Settings, Payload> 
     } else if (traits.name) {
       name = traits.name
     } else {
-      name = traits.first_name || traits.last_name || traits.firstName || traits.lastName || 'User'
+      name = traits.first_name || traits.last_name || traits.firstName || traits.lastName || toEmail
     }
 
     const bcc = JSON.parse(this.payload.bcc ?? '[]')


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR is to use email as default name instead of 'User'

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
