### PR TITLE
Extra context fields requested by client in Mixpanel

### DIFF
--- a/packages/destination-actions/src/destinations/mixpanel/mixpanel-properties.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/mixpanel-properties.ts
@@ -325,7 +325,11 @@ export const eventProperties: Record<string, InputField> = {
     description: 'The Event Original Name, if applicable',
     required: false,
     default: {
-      '@path': '$.name'
+      '@if': {
+        exists: { '@path': '$.event' },
+        then: { '@path': '$.event' },
+        else: { '@path': '$.name' }
+      }
     }
   },
   event_properties: {

--- a/packages/destination-actions/src/destinations/mixpanel/mixpanel-properties.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/mixpanel-properties.ts
@@ -283,6 +283,51 @@ export const eventProperties: Record<string, InputField> = {
       '@path': '$.context.userAgent'
     }
   },
+  advertising_id: {
+    label: 'Advertising ID',
+    type: 'string',
+    description: 'Advertising ID',
+    required: false,
+    default: {
+      '@path': '$.context.device.advertisingId'
+    }
+  },
+  ad_tracking_enabled: {
+    label: 'Ad Tracking Enabled',
+    type: 'string',
+    description: 'Ad Tracking Enabled (true or false)',
+    required: false,
+    default: {
+      '@path': '$.context.device.adTrackingEnabled'
+    }
+  },
+  timezone: {
+    label: 'Timezone',
+    type: 'string',
+    description: 'The event timezone',
+    required: false,
+    default: {
+      '@path': '$.context.timezone'
+    }
+  },
+  app_platform: {
+    label: 'App Platform',
+    type: 'string',
+    description: 'The App Platform, if applicable',
+    required: false,
+    default: {
+      '@path': '$.context.timezone'
+    }
+  },
+  name: {
+    label: 'Event Original Name',
+    type: 'string',
+    description: 'The Event Original Name, if applicable',
+    required: false,
+    default: {
+      '@path': '$.name'
+    }
+  },
   event_properties: {
     label: 'Event Properties',
     type: 'object',

--- a/packages/destination-actions/src/destinations/mixpanel/mixpanel-properties.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/mixpanel-properties.ts
@@ -316,7 +316,7 @@ export const eventProperties: Record<string, InputField> = {
     description: 'The App Platform, if applicable',
     required: false,
     default: {
-      '@path': '$.context.timezone'
+      '@path': '$.context.app.platform'
     }
   },
   name: {

--- a/packages/destination-actions/src/destinations/mixpanel/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackEvent/generated-types.ts
@@ -142,6 +142,26 @@ export interface Payload {
    */
   userAgent?: string
   /**
+   * Advertising ID
+   */
+  advertising_id?: string
+  /**
+   * Ad Tracking Enabled (true or false)
+   */
+  ad_tracking_enabled?: string
+  /**
+   * The event timezone
+   */
+  timezone?: string
+  /**
+   * The App Platform, if applicable
+   */
+  app_platform?: string
+  /**
+   * The Event Original Name, if applicable
+   */
+  name?: string
+  /**
    * An object of key-value pairs that represent additional data to be sent along with the event.
    */
   event_properties?: {

--- a/packages/destination-actions/src/destinations/mixpanel/trackPurchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackPurchase/generated-types.ts
@@ -142,6 +142,26 @@ export interface Payload {
    */
   userAgent?: string
   /**
+   * Advertising ID
+   */
+  advertising_id?: string
+  /**
+   * Ad Tracking Enabled (true or false)
+   */
+  ad_tracking_enabled?: string
+  /**
+   * The event timezone
+   */
+  timezone?: string
+  /**
+   * The App Platform, if applicable
+   */
+  app_platform?: string
+  /**
+   * The Event Original Name, if applicable
+   */
+  name?: string
+  /**
    * An object of key-value pairs that represent additional data to be sent along with the event.
    */
   event_properties?: {


### PR DESCRIPTION
Client requested optional mappings for context fields to be sent to Mixpanel (all supported events).

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [X] [Segmenters] Tested in the staging environment
