### PR TITLE
[Twilio] Add support for self hosted AT.JS in Adobe Target - Web

### DIFF
--- a/packages/browser-destinations/destinations/adobe-target/src/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/adobe-target/src/__tests__/index.test.ts
@@ -31,7 +31,7 @@ describe('Adobe Target Web', () => {
     expect(scripts).toMatchInlineSnapshot(`
       NodeList [
         <script
-          src="https://admin10.testandtarget.omniture.com/admin/rest/v1/libraries/atjs/download?client=segmentexchangepartn&version=2.8.0"
+          src="https://www.twilio.com/content/dam/twilio-com/core-assets/at.js"
           status="loaded"
           type="text/javascript"
         />,

--- a/packages/browser-destinations/destinations/adobe-target/src/index.ts
+++ b/packages/browser-destinations/destinations/adobe-target/src/index.ts
@@ -68,10 +68,7 @@ export const destination: BrowserDestinationDefinition<Settings, Adobe> = {
   initialize: async ({ settings }, deps) => {
     initScript(settings)
 
-    const targetUrl = 'testandtarget.omniture.com/admin/rest/v1/libraries/atjs/download'
-    const atjsUrl = `https://admin${settings.admin_number}.${targetUrl}?client=${settings.client_code}&version=${settings.version}`
-
-    await deps.loadScript(atjsUrl)
+    await deps.loadScript('https://www.twilio.com/content/dam/twilio-com/core-assets/at.js')
     await deps.resolveWhen(() => Object.prototype.hasOwnProperty.call(window, 'adobe'), 100)
     return window.adobe
   },


### PR DESCRIPTION
The [first version](https://github.com/segmentio/action-destinations/pull/1440) of this helped us discover that due to a race condition the personalization component of AT breaks when at.js loads before Segment's a.js. Said first version, also helped us create an asset pipeline that now we can leverage to feed Twilio's own version of at.js into our destination.

This PR helps us do just that, point the dependency loader towards the static URL that the Twilio team has confirmed will never change and load at.js from there. That will mitigate any race condition and restore the usability of the personalization component.

This branch won't be merged to master. Instead it will be pinned to Twilio's Sources.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
