### PR TITLE
[SEV] update LinkedIn-Version to 202307

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -13,7 +13,7 @@ Headers {
       "Bearer undefined",
     ],
     "linkedin-version": Array [
-      "202207",
+      "202307",
     ],
     "user-agent": Array [
       "Segment (Actions)",

--- a/packages/destination-actions/src/destinations/linkedin-audiences/constants.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/constants.ts
@@ -1,3 +1,3 @@
-export const LINKEDIN_API_VERSION = '202207'
+export const LINKEDIN_API_VERSION = '202307'
 export const BASE_URL = 'https://api.linkedin.com/rest'
 export const LINKEDIN_SOURCE_PLATFORM = 'SEGMENT'

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -13,7 +13,7 @@ Headers {
       "Bearer undefined",
     ],
     "linkedin-version": Array [
-      "202207",
+      "202307",
     ],
     "user-agent": Array [
       "Segment (Actions)",


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_LinkedIn deprecated the API versions we're using: https://learn.microsoft.com/en-us/linkedin/marketing/integrations/matched-audiences/create-and-manage-segments?view=li-lms-2023-06&tabs=http.This PR updates the version._

## Testing

Old Version 
<img width="1000" alt="image" src="https://github.com/segmentio/action-destinations/assets/89420099/64934ae2-f571-4de2-b26d-a513b697c74d">


New Version 
<img width="1320" alt="image" src="https://github.com/segmentio/action-destinations/assets/89420099/e68d2c46-ae3a-4315-b815-21c481568928">


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
