### PR TITLE
[Stratconn 2954]: Add key in linkedin audience to support RETL

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-audiences/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/api/index.ts
@@ -32,7 +32,7 @@ export class LinkedInAudiences {
       searchParams: {
         q: 'account',
         account: `urn:li:sponsoredAccount:${settings.ad_account_id}`,
-        sourceSegmentId: payload.source_segment_id || '',
+        sourceSegmentId: payload.personas_audience_key || '',
         sourcePlatform: LINKEDIN_SOURCE_PLATFORM
       }
     })
@@ -44,7 +44,7 @@ export class LinkedInAudiences {
       json: {
         name: payload.dmp_segment_name,
         sourcePlatform: LINKEDIN_SOURCE_PLATFORM,
-        sourceSegmentId: payload.source_segment_id,
+        sourceSegmentId: payload.personas_audience_key,
         account: `urn:li:sponsoredAccount:${settings.ad_account_id}`,
         accessPolicy: 'PRIVATE',
         type: 'USER',

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/__tests__/index.test.ts
@@ -83,7 +83,8 @@ describe('LinkedinAudiences.updateAudience', () => {
         useDefaultMappings: true,
         auth,
         mapping: {
-          personas_audience_key: 'mismatched_audience'
+          personas_audience_key: 'mismatched_audience',
+          dmp_user_action: null
         }
       })
     ).rejects.toThrow('The value of `source_segment_id` and `personas_audience_key` must match.')

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/__tests__/index.test.ts
@@ -158,4 +158,105 @@ describe('LinkedinAudiences.updateAudience', () => {
       })
     ).resolves.not.toThrowError()
   })
+
+  it('should not throw an error if `dmp_user_action` is not "AUTO", even if `source_segment_id` does not match `personas_audience_key`', async () => {
+    nock(`${BASE_URL}/dmpSegments`)
+      .get(/.*/)
+      .query(() => true)
+      .reply(200, { elements: [{ id: 'dmp_segment_id' }] })
+    nock(`${BASE_URL}/dmpSegments/dmp_segment_id/users`).post(/.*/, updateUsersRequestBody).reply(200)
+
+    await expect(
+      testDestination.testAction('updateAudience', {
+        event,
+        settings: {
+          ad_account_id: '123',
+          send_email: true,
+          send_google_advertising_id: true
+        },
+        useDefaultMappings: true,
+        auth,
+        mapping: {
+          source_segment_id: 'mismatched_segment',
+          personas_audience_key: 'personas_test_audience',
+          dmp_user_action: 'ADD'
+        }
+      })
+    ).resolves.not.toThrowError()
+  })
+
+  it('should fail if `personas_audience_key` field does not match the `source_segment_id` field, and `dmp_user_action` is set to auto', async () => {
+    await expect(
+      testDestination.testAction('updateAudience', {
+        event,
+        settings: {
+          ad_account_id: '123',
+          send_email: true,
+          send_google_advertising_id: true
+        },
+        useDefaultMappings: true,
+        auth,
+        mapping: {
+          personas_audience_key: 'mismatched_audience',
+          dmp_user_action: 'AUTO'
+        }
+      })
+    ).rejects.toThrow('The value of `source_segment_id` and `personas_audience_key` must match.')
+  })
+
+  it('should set action to "ADD" if `dmp_user_action` is "ADD"', async () => {
+    nock(`${BASE_URL}/dmpSegments`)
+      .get(/.*/)
+      .query(() => true)
+      .reply(200, { elements: [{ id: 'dmp_segment_id' }] })
+
+    nock(`${BASE_URL}/dmpSegments/dmp_segment_id/users`)
+      .post(/.*/, (body) => body.elements[0].action === 'ADD')
+      .reply(200)
+
+    const response = await testDestination.testAction('updateAudience', {
+      event,
+      settings: {
+        ad_account_id: '123',
+        send_email: true,
+        send_google_advertising_id: true
+      },
+      useDefaultMappings: true,
+      auth,
+      mapping: {
+        personas_audience_key: 'personas_test_audience',
+        dmp_user_action: 'ADD'
+      }
+    })
+
+    expect(response).toBeTruthy()
+  })
+
+  it('should set action to "REMOVE" if `dmp_user_action` is "REMOVE"', async () => {
+    nock(`${BASE_URL}/dmpSegments`)
+      .get(/.*/)
+      .query(() => true)
+      .reply(200, { elements: [{ id: 'dmp_segment_id' }] })
+
+    nock(`${BASE_URL}/dmpSegments/dmp_segment_id/users`)
+      .post(/.*/, (body) => body.elements[0].action === 'REMOVE')
+      .reply(200)
+
+    const response = await testDestination.testAction('updateAudience', {
+      event,
+      settings: {
+        ad_account_id: '123',
+        send_email: true,
+        send_google_advertising_id: true
+      },
+      useDefaultMappings: true,
+      auth,
+      mapping: {
+        personas_audience_key: 'personas_test_audience',
+        dmp_user_action: 'REMOVE'
+      }
+    })
+
+    expect(response).toBeTruthy()
+  })
 })

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/generated-types.ts
@@ -29,4 +29,8 @@ export interface Payload {
    * The name of the current Segment event.
    */
   event_name?: string
+  /**
+   * A Segment specific key used to define action type.
+   */
+  dmp_user_action?: string
 }

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
@@ -117,7 +117,8 @@ async function processPayload(request: RequestClient, settings: Settings, payloa
 }
 
 function validate(settings: Settings, payloads: Payload[]): void {
-  if (payloads[0]?.dmp_user_action === 'AUTO' && payloads[0].source_segment_id !== payloads[0].personas_audience_key) {
+  const isAutoOrUndefined = ['AUTO', undefined].includes(payloads[0]?.dmp_user_action)
+  if (isAutoOrUndefined && payloads[0].source_segment_id !== payloads[0].personas_audience_key) {
     throw new IntegrationError(
       'The value of `source_segment_id` and `personas_audience_key` must match.',
       'INVALID_SETTINGS',

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
@@ -64,6 +64,17 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.event'
       }
+    },
+    dmp_user_action: {
+      label: 'DMP User Action',
+      description: 'A Segment specific key used to define action type.',
+      type: 'string',
+      choices: [
+        { label: `Auto Detect`, value: 'AUTO' },
+        { label: `Add`, value: 'ADD' },
+        { label: 'Remove', value: 'REMOVE' }
+      ],
+      default: 'AUTO'
     }
   },
   perform: async (request, { settings, payload }) => {
@@ -106,7 +117,7 @@ async function processPayload(request: RequestClient, settings: Settings, payloa
 }
 
 function validate(settings: Settings, payloads: Payload[]): void {
-  if (payloads[0].source_segment_id !== payloads[0].personas_audience_key) {
+  if (payloads[0]?.dmp_user_action === 'AUTO' && payloads[0].source_segment_id !== payloads[0].personas_audience_key) {
     throw new IntegrationError(
       'The value of `source_segment_id` and `personas_audience_key` must match.',
       'INVALID_SETTINGS',
@@ -158,10 +169,18 @@ function extractUsers(settings: Settings, payloads: Payload[]) {
 }
 
 function getAction(payload: Payload) {
-  if (payload.event_name === 'Audience Entered') {
+  const { dmp_user_action = 'AUTO' } = payload
+
+  if (dmp_user_action === 'ADD') {
     return 'ADD'
-  } else if (payload.event_name === 'Audience Exited') {
+  } else if (dmp_user_action === 'REMOVE') {
     return 'REMOVE'
+  } else if (dmp_user_action === 'AUTO' || !dmp_user_action) {
+    if (payload.event_name === 'Audience Entered') {
+      return 'ADD'
+    } else if (payload.event_name === 'Audience Exited') {
+      return 'REMOVE'
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._
This PR adds a new mapping to linkedin audiences, `dmp_user_action` to support RETL.

JIRA -> [STRATCONN-2954](https://segment.atlassian.net/browse/STRATCONN-2954)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

New mapping
<img width="1159" alt="Screenshot 2023-08-08 at 10 52 57 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/9724a0e1-4e85-40d3-a2dd-d951f8d71cc5">

If `dmp_user_action` is not set to auto, bypass source_segment_id and personas_audience_key check
<img width="1792" alt="Screenshot 2023-08-08 at 10 52 21 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/f4a65a35-f547-4626-960c-ae04064771b3">


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment


[STRATCONN-2954]: https://segment.atlassian.net/browse/STRATCONN-2954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ