### PR TITLE
[CCP-322] Remove 'to name' from engage sendgrid destination action

### DIFF
--- a/packages/destination-actions/src/destinations/engage/sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/engage/sendgrid/__tests__/send-email.test.ts
@@ -68,8 +68,7 @@ describe.each([
       {
         to: [
           {
-            email: userData.email,
-            name: `${userData.firstName} ${userData.lastName}`
+            email: userData.email
           }
         ],
         bcc: [
@@ -286,8 +285,7 @@ describe.each([
           {
             to: [
               {
-                email: userData.email,
-                name: `${userData.firstName} ${userData.lastName}`
+                email: userData.email
               }
             ],
             bcc: [
@@ -408,8 +406,7 @@ describe.each([
           {
             to: [
               {
-                email: userData.email,
-                name: `${userData.firstName} ${userData.lastName}`
+                email: userData.email
               }
             ],
             bcc: [
@@ -491,8 +488,7 @@ describe.each([
           {
             to: [
               {
-                email: userData.email,
-                name: `${userData.firstName} ${userData.lastName}`
+                email: userData.email
               }
             ],
             bcc: [
@@ -589,8 +585,7 @@ describe.each([
           {
             to: [
               {
-                email: userData.email,
-                name: `${userData.firstName} ${userData.lastName}`
+                email: userData.email
               }
             ],
             bcc: [
@@ -702,8 +697,7 @@ describe.each([
           {
             to: [
               {
-                email: userData.email,
-                name: `${userData.firstName} ${userData.lastName}`
+                email: userData.email
               }
             ],
             bcc: [
@@ -786,8 +780,7 @@ describe.each([
           {
             to: [
               {
-                email: userData.email,
-                name: `${userData.firstName} ${userData.lastName}`
+                email: userData.email
               }
             ],
             bcc: [
@@ -870,8 +863,7 @@ describe.each([
           {
             to: [
               {
-                email: userData.email,
-                name: `${userData.firstName} ${userData.lastName}`
+                email: userData.email
               }
             ],
             bcc: [
@@ -954,8 +946,7 @@ describe.each([
           {
             to: [
               {
-                email: userData.email,
-                name: `${userData.firstName} ${userData.lastName}`
+                email: userData.email
               }
             ],
             bcc: [
@@ -1543,8 +1534,7 @@ describe.each([
           {
             to: [
               {
-                email: userData.email,
-                name: `${userData.firstName} ${userData.lastName}`
+                email: userData.email
               }
             ],
             bcc: [

--- a/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
+++ b/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
@@ -114,17 +114,6 @@ export class SendEmailPerformer extends MessageSendPerformer<Settings, Payload> 
       )
     }
 
-    let name
-    if (traits.first_name && traits.last_name) {
-      name = `${traits.first_name} ${traits.last_name}`
-    } else if (traits.firstName && traits.lastName) {
-      name = `${traits.firstName} ${traits.lastName}`
-    } else if (traits.name) {
-      name = traits.name
-    } else {
-      name = traits.first_name || traits.last_name || traits.firstName || traits.lastName || toEmail
-    }
-
     const bcc = JSON.parse(this.payload.bcc ?? '[]')
     const [parsedSubject, apiLookupData] = await Promise.all([
       this.parseTemplating(this.payload.subject, { profile }, 'Subject'),
@@ -138,8 +127,7 @@ export class SendEmailPerformer extends MessageSendPerformer<Settings, Payload> 
         {
           to: [
             {
-              email: toEmail,
-              name: name
+              email: toEmail
             }
           ],
           bcc: bcc.length > 0 ? bcc : undefined,


### PR DESCRIPTION
https://segment.atlassian.net/browse/CCP-322

The to.name field is not required per SendGrid API documentation
https://docs.sendgrid.com/api-reference/mail-send/mail-send
![image](https://github.com/segmentio/action-destinations/assets/6191537/fb96e494-d7d6-4fd8-8505-7d3e8e3b03e1)

## Testing

I confirmed emails sent without the to.name field are still delivered successfully
![image](https://github.com/segmentio/action-destinations/assets/6191537/3b6d521a-4a7e-4f38-8f1d-87ae358b6fee)

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
