### PR TITLE
[salesforce][Stratconn-2816] Fixes issue with Bulk API CSV generation

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
@@ -10,7 +10,9 @@ const isSettingsKey = new Set<string>([
   'enable_batching',
   'customFields',
   'bulkUpsertExternalId',
-  'bulkUpdateRecordId'
+  'bulkUpdateRecordId',
+  'recordMatcherOperator',
+  'customObjectName'
 ])
 
 const NO_VALUE = `#N/A`


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR fixes an issue where the CSV we are generating for Salesforce Bulk API incorrectly contained the names of our "settings" fields, when they should have been excluded from the CSV. This caused an error downstream in Salesforce.

Ticket: https://segment.atlassian.net/browse/STRATCONN-2816

## Testing
Able to reproduce issue, `RecordMatcherOperator` and `CustomObjectName` are both configuration settings for the destination and shouldn't be sent to Salesforce:
<img width="787" alt="Screenshot 2023-08-07 at 1 59 35 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/505ae562-f9ef-42c9-b77a-f820263923c5">
The CSV causes the reported issue:
<img width="308" alt="Screenshot 2023-08-06 at 8 26 05 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/aad84d56-b931-4bc5-8ffd-ae1622ac12bd">

Successfully tested the fix for the issue:
The CSV no longer includes our "settings" fields.
<img width="469" alt="Screenshot 2023-08-07 at 1 58 55 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/edc9cc28-97b6-4b31-8379-c118f2ccf6d3">
The Bulk job completes correctly:
<img width="1288" alt="Screenshot 2023-08-07 at 2 18 21 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/d6382115-74b4-4f67-8d56-31881ac013bc">


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
