### PR TITLE
Return updated refresh token so that it can be saved

### DIFF
--- a/packages/destination-actions/src/destinations/hilo/index.ts
+++ b/packages/destination-actions/src/destinations/hilo/index.ts
@@ -9,6 +9,7 @@ import screen from './screen'
 
 interface RefreshTokenResponse {
   access_token: string
+  refresh_token: string
 }
 
 const destination: DestinationDefinition<Settings> = {
@@ -42,7 +43,7 @@ const destination: DestinationDefinition<Settings> = {
         })
       })
 
-      return { accessToken: res.data?.access_token }
+      return { accessToken: res.data?.access_token, refreshToken: res.data?.refresh_token }
     }
   },
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR updates Hilo Destination refreshAccessToken method return value to include a new [refreshToken](https://github.com/segmentio/action-destinations/blob/e868e4a7f3f495a3d01660bc8484b3a9da2a011c/packages/core/src/destination-kit/index.ts#L103), so that it can be stored on the Segment side.

Inspired by https://github.com/segmentio/action-destinations/pull/1111 which does the same for Blackbaud Raiser's Edge NXT Destination.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
