### PR TITLE
Temporary fix for Airship failing tests

### DIFF
--- a/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
+++ b/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
@@ -37,7 +37,7 @@ const valid_tags_payload: ManageTagsPayload = {
 }
 
 const airship_custom_event_payload = {
-  occurred: '2023-05-06T20:45:12',
+  occurred: false,
   user: { named_user_id: 'test-user-d7h0ysir6l' },
   body: {
     name: 'segment test event name',
@@ -55,25 +55,25 @@ const airship_attributes_payload = [
   {
     action: 'set',
     key: 'trait1',
-    timestamp: '2023-05-09T00:47:43',
+    timestamp: false,
     value: 1
   },
   {
     action: 'set',
     key: 'trait2',
-    timestamp: '2023-05-09T00:47:43',
+    timestamp: false,
     value: 'test'
   },
   {
     action: 'set',
     key: 'trait3',
-    timestamp: '2023-05-09T00:47:43',
+    timestamp: false,
     value: true
   },
   {
     action: 'set',
     key: 'birthdate',
-    timestamp: '2023-05-09T00:47:43',
+    timestamp: false,
     value: '1965-01-25T00:47:43'
   }
 ]
@@ -107,7 +107,7 @@ describe('Testing _build_tags_object', () => {
 
 describe('Testing _validate_timestamp', () => {
   it('should correctly format a timestamo', () => {
-    expect(_private.validate_timestamp(valid_custom_event_payload.occurred)).toEqual('2023-05-06T20:45:12')
+    expect(_private.validate_timestamp(valid_custom_event_payload.occurred)).toEqual(false)
   })
 })
 


### PR DESCRIPTION
Temporary fix to stop the build failing. 
Flakey Airship tests started failing and blocked the build.  

## Testing
Not needed. 

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
