### PR TITLE
[PINT 1852]

### DIFF
--- a/packages/destination-actions/src/destinations/airship/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/airship/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -53,6 +53,19 @@ Object {
 }
 `;
 
+exports[`Testing snapshot for actions-airship destination: registerAndAssociate action - all fields 1`] = `""`;
+
+exports[`Testing snapshot for actions-airship destination: registerAndAssociate action - required fields 1`] = `
+Object {
+  "channel": Object {
+    "address": "$D%LNw)2",
+    "locale_language": "$D%LNw)2",
+    "timezone": "$D%LNw)2",
+    "type": "email",
+  },
+}
+`;
+
 exports[`Testing snapshot for actions-airship destination: setAttributes action - all fields 1`] = `
 Object {
   "attributes": Array [

--- a/packages/destination-actions/src/destinations/airship/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/airship/__tests__/snapshot.test.ts
@@ -13,7 +13,12 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
       const action = destination.actions[actionSlug]
       const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
       settingsData.endpoint = 'https://go.airship.com'
-      nock(/.*/).persist().get(/.*/).reply(200)
+      // nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/)
+        .persist()
+        .post('/api/channels/email')
+        .reply(200, { ok: true, channel_id: '6be90795-a7d7-4657-b959-6a5afc199b06' })
+      nock(/.*/).persist().post('/api/named_users/associate').reply(200, { ok: true })
       nock(/.*/).persist().post(/.*/).reply(200)
       nock(/.*/).persist().put(/.*/).reply(200)
 
@@ -48,7 +53,21 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
       const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
       settingsData.endpoint = 'https://go.airship.com'
 
-      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/)
+        .persist()
+        .get(/.*/)
+        .reply(200, {
+          // content: {
+          ok: true,
+          channel: {
+            channel_id: '6be90795-a7d7-4657-b959-6a5afc199b06'
+          }
+          // }
+        })
+      nock(/.*/)
+        .persist()
+        .post('/api/channels/email')
+        .reply(200, { ok: true, channel_id: '6be90795-a7d7-4657-b959-6a5afc199b06' })
       nock(/.*/).persist().post(/.*/).reply(200)
       nock(/.*/).persist().put(/.*/).reply(200)
 

--- a/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
+++ b/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
@@ -120,3 +120,9 @@ describe('Testing parse_date', () => {
     expect(_private.parse_date('2023-05-09T00:47:43.378Z')).toBeInstanceOf(Date)
   })
 })
+
+describe('Testing parse_date', () => {
+  it('should parse a date into a date object', () => {
+    expect(_private.parse_date('2023-05-09T00:47:43.378Z')).toBeInstanceOf(Date)
+  })
+})

--- a/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
+++ b/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
@@ -5,9 +5,12 @@ import { Payload as ManageTagsPayload } from '../manageTags/generated-types'
 
 const occurred = new Date()
 
+const occurred = new Date()
+
 const valid_custom_event_payload: CustomEventsPayload = {
   named_user_id: 'test-user-d7h0ysir6l',
   name: 'Segment Test Event Name',
+  occurred: occurred.toISOString(),
   occurred: occurred.toISOString(),
   properties: {
     property1: 1,
@@ -19,6 +22,7 @@ const valid_custom_event_payload: CustomEventsPayload = {
 
 const valid_attributes_payload: AttributesPayload = {
   named_user_id: 'test-user-rzoj4u7gqw',
+  occurred: occurred.toISOString(),
   occurred: occurred.toISOString(),
   attributes: {
     trait1: 1,
@@ -42,6 +46,7 @@ const valid_tags_payload: ManageTagsPayload = {
 
 const airship_custom_event_payload = {
   occurred: occurred.toISOString().split('.')[0],
+  occurred: occurred.toISOString().split('.')[0],
   user: { named_user_id: 'test-user-d7h0ysir6l' },
   body: {
     name: 'segment test event name',
@@ -60,11 +65,13 @@ const airship_attributes_payload = [
     action: 'set',
     key: 'trait1',
     timestamp: occurred.toISOString().split('.')[0],
+    timestamp: occurred.toISOString().split('.')[0],
     value: 1
   },
   {
     action: 'set',
     key: 'trait2',
+    timestamp: occurred.toISOString().split('.')[0],
     timestamp: occurred.toISOString().split('.')[0],
     value: 'test'
   },
@@ -72,11 +79,13 @@ const airship_attributes_payload = [
     action: 'set',
     key: 'trait3',
     timestamp: occurred.toISOString().split('.')[0],
+    timestamp: occurred.toISOString().split('.')[0],
     value: true
   },
   {
     action: 'set',
     key: 'birthdate',
+    timestamp: occurred.toISOString().split('.')[0],
     timestamp: occurred.toISOString().split('.')[0],
     value: '1965-01-25T00:47:43'
   }
@@ -123,8 +132,8 @@ describe('Testing parse_date', () => {
   })
 })
 
-describe('Testing parse_date', () => {
+describe('Testing _parse_date', () => {
   it('should parse a date into a date object', () => {
-    expect(_private.parse_date('2023-05-09T00:47:43.378Z')).toBeInstanceOf(Date)
+    expect(_private._parse_date('2023-05-09T00:47:43.378Z')).toBeInstanceOf(Date)
   })
 })

--- a/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
+++ b/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
@@ -5,12 +5,9 @@ import { Payload as ManageTagsPayload } from '../manageTags/generated-types'
 
 const occurred = new Date()
 
-const occurred = new Date()
-
 const valid_custom_event_payload: CustomEventsPayload = {
   named_user_id: 'test-user-d7h0ysir6l',
   name: 'Segment Test Event Name',
-  occurred: occurred.toISOString(),
   occurred: occurred.toISOString(),
   properties: {
     property1: 1,
@@ -23,12 +20,9 @@ const valid_custom_event_payload: CustomEventsPayload = {
 const valid_attributes_payload: AttributesPayload = {
   named_user_id: 'test-user-rzoj4u7gqw',
   occurred: occurred.toISOString(),
-  occurred: occurred.toISOString(),
   attributes: {
     trait1: 1,
     trait2: 'test',
-    trait3: true,
-    birthdate: '1965-01-25T00:47:43.378Z'
     trait3: true,
     birthdate: '1965-01-25T00:47:43.378Z'
   }
@@ -45,7 +39,6 @@ const valid_tags_payload: ManageTagsPayload = {
 }
 
 const airship_custom_event_payload = {
-  occurred: occurred.toISOString().split('.')[0],
   occurred: occurred.toISOString().split('.')[0],
   user: { named_user_id: 'test-user-d7h0ysir6l' },
   body: {
@@ -65,13 +58,11 @@ const airship_attributes_payload = [
     action: 'set',
     key: 'trait1',
     timestamp: occurred.toISOString().split('.')[0],
-    timestamp: occurred.toISOString().split('.')[0],
     value: 1
   },
   {
     action: 'set',
     key: 'trait2',
-    timestamp: occurred.toISOString().split('.')[0],
     timestamp: occurred.toISOString().split('.')[0],
     value: 'test'
   },
@@ -79,13 +70,11 @@ const airship_attributes_payload = [
     action: 'set',
     key: 'trait3',
     timestamp: occurred.toISOString().split('.')[0],
-    timestamp: occurred.toISOString().split('.')[0],
     value: true
   },
   {
     action: 'set',
     key: 'birthdate',
-    timestamp: occurred.toISOString().split('.')[0],
     timestamp: occurred.toISOString().split('.')[0],
     value: '1965-01-25T00:47:43'
   }
@@ -118,17 +107,11 @@ describe('Testing _build_tags_object', () => {
   })
 })
 
-describe('Testing validate_timestamp', () => {
+describe('Testing _validate_timestamp', () => {
   it('should correctly format a timestamo', () => {
-    expect(_private.validate_timestamp(valid_custom_event_payload.occurred)).toEqual(
+    expect(_private._validate_timestamp(valid_custom_event_payload.occurred)).toEqual(
       occurred.toISOString().split('.')[0]
     )
-  })
-})
-
-describe('Testing parse_date', () => {
-  it('should parse a date into a date object', () => {
-    expect(_private.parse_date('2023-05-09T00:47:43.378Z')).toBeInstanceOf(Date)
   })
 })
 

--- a/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
+++ b/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
@@ -25,6 +25,8 @@ const valid_attributes_payload: AttributesPayload = {
     trait2: 'test',
     trait3: true,
     birthdate: '1965-01-25T00:47:43.378Z'
+    trait3: true,
+    birthdate: '1965-01-25T00:47:43.378Z'
   }
 }
 

--- a/packages/destination-actions/src/destinations/airship/index.ts
+++ b/packages/destination-actions/src/destinations/airship/index.ts
@@ -64,18 +64,21 @@ const destination: DestinationDefinition<Settings> = {
   presets: [
     {
       name: 'Custom Events',
+      type: 'automatic',
       subscribe: 'type = "track"',
       partnerAction: 'customEvents',
       mapping: defaultValues(customEvents.fields)
     },
     {
       name: 'Set Attributes',
+      type: 'automatic',
       subscribe: 'type = "identify"',
       partnerAction: 'setAttributes',
       mapping: defaultValues(setAttributes.fields)
     },
     {
       name: 'Register and Associate',
+      type: 'automatic',
       subscribe: 'type = "identify"',
       partnerAction: 'register_and_associate',
       mapping: defaultValues(setAttributes.fields)

--- a/packages/destination-actions/src/destinations/airship/index.ts
+++ b/packages/destination-actions/src/destinations/airship/index.ts
@@ -9,6 +9,8 @@ import manageTags from './manageTags'
 
 import { map_endpoint } from './utilities'
 
+import registerAndAssociate from './registerAndAssociate'
+
 const destination: DestinationDefinition<Settings> = {
   name: 'Airship (Actions)',
   slug: 'actions-airship',
@@ -22,14 +24,14 @@ const destination: DestinationDefinition<Settings> = {
         label: 'Access Token',
         description: 'Create in the Airship Go dashboard in Settings->Partner Integrations->Segment',
         type: 'password',
-        // default: process.env.DEFAULT_ACCESS_TOKEN,
+        default: process.env.DEFAULT_ACCESS_TOKEN,
         required: true
       },
       app_key: {
         label: 'App Key',
         description: 'The App Key identifies the Airship Project to which API requests are made.',
         type: 'string',
-        // default: process.env.DEFAULT_APP_KEY,
+        default: process.env.DEFAULT_APP_KEY,
         required: true
       },
       endpoint: {
@@ -64,15 +66,19 @@ const destination: DestinationDefinition<Settings> = {
       name: 'Custom Events',
       subscribe: 'type = "track"',
       partnerAction: 'customEvents',
-      mapping: defaultValues(customEvents.fields),
-      type: 'automatic'
+      mapping: defaultValues(customEvents.fields)
     },
     {
       name: 'Set Attributes',
       subscribe: 'type = "identify"',
       partnerAction: 'setAttributes',
-      mapping: defaultValues(setAttributes.fields),
-      type: 'automatic'
+      mapping: defaultValues(setAttributes.fields)
+    },
+    {
+      name: 'Register and Associate',
+      subscribe: 'type = "identify"',
+      partnerAction: 'register_and_associate',
+      mapping: defaultValues(setAttributes.fields)
     }
   ],
   onDelete: async (request, { settings, payload }) => {
@@ -97,7 +103,8 @@ const destination: DestinationDefinition<Settings> = {
   actions: {
     customEvents,
     setAttributes,
-    manageTags
+    manageTags,
+    registerAndAssociate
   }
 }
 export default destination

--- a/packages/destination-actions/src/destinations/airship/registerAndAssociate/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/airship/registerAndAssociate/__tests__/__snapshots__/index.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Airship's registerAndAssociate destination action: required fields 1`] = `
+Object {
+  "channel": Object {
+    "address": "f%VfPi0]O9eIkSaU",
+    "locale_language": "f%VfPi0]O9eIkSaU",
+    "timezone": "f%VfPi0]O9eIkSaU",
+    "type": "email",
+  },
+}
+`;

--- a/packages/destination-actions/src/destinations/airship/registerAndAssociate/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/airship/registerAndAssociate/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Airship's registerAndAssociate destination action: all fields 1`] = `""`;
+
+exports[`Testing snapshot for Airship's registerAndAssociate destination action: required fields 1`] = `
+Object {
+  "channel": Object {
+    "address": "f%VfPi0]O9eIkSaU",
+    "locale_language": "f%VfPi0]O9eIkSaU",
+    "timezone": "f%VfPi0]O9eIkSaU",
+    "type": "email",
+  },
+}
+`;

--- a/packages/destination-actions/src/destinations/airship/registerAndAssociate/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/airship/registerAndAssociate/__tests__/index.test.ts
@@ -1,47 +1,49 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
-import Destination from '../../index'
 import destination from '../../index'
 import { generateTestData } from '../../../../lib/test-data'
-import * as fs from 'fs'
+
+const testDestination = createTestIntegration(destination)
 
 const actionSlug = 'registerAndAssociate'
 const destinationSlug = 'Airship'
 const seedName = `${destinationSlug}#${actionSlug}`
 
-const testDestination = createTestIntegration(Destination)
-
-describe(`Testing ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
   it('required fields', async () => {
     const action = destination.actions[actionSlug]
-    let [test_data, settingsData] = generateTestData(seedName, destination, action, true)
-    test_data = fs.readFileSync('src/destinations/airship/registerAndAssociate/__tests__/test_data.json', 'utf-8')
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
     settingsData.endpoint = 'https://go.airship.com'
+
     nock(/.*/).persist().get(/.*/).reply(200)
-    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/)
+      .persist()
+      .post('/api/channels/email')
+      .reply(200, { ok: true, channel_id: '6be90795-a7d7-4657-b959-6a5afc199b06' })
+    nock(/.*/).persist().post('/api/named_users/associate').reply(200, { ok: true })
     nock(/.*/).persist().put(/.*/).reply(200)
+
     const event = createTestEvent({
-      properties: JSON.parse(test_data)
+      properties: eventData
     })
+
     const responses = await testDestination.testAction(actionSlug, {
       event: event,
       mapping: event.properties,
       settings: settingsData,
       auth: undefined
     })
+
     const request = responses[0].request
     const rawBody = await request.text()
-    console.log(rawBody)
-    console.log(createTestIntegration)
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
 
-    // try {
-    //   const json = JSON.parse(rawBody)
-    //   expect(json).toMatchSnapshot()
-    //   return
-    // } catch (err) {
-    //   expect(rawBody).toMatchSnapshot()
-    // }
-
-    // expect(request.headers).toMatchSnapshot()
+    expect(request.headers).toMatchSnapshot()
   })
 })

--- a/packages/destination-actions/src/destinations/airship/registerAndAssociate/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/airship/registerAndAssociate/__tests__/index.test.ts
@@ -1,0 +1,47 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import destination from '../../index'
+import { generateTestData } from '../../../../lib/test-data'
+import * as fs from 'fs'
+
+const actionSlug = 'registerAndAssociate'
+const destinationSlug = 'Airship'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+const testDestination = createTestIntegration(Destination)
+
+describe(`Testing ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    let [test_data, settingsData] = generateTestData(seedName, destination, action, true)
+    test_data = fs.readFileSync('src/destinations/airship/registerAndAssociate/__tests__/test_data.json', 'utf-8')
+    settingsData.endpoint = 'https://go.airship.com'
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+    const event = createTestEvent({
+      properties: JSON.parse(test_data)
+    })
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+    const request = responses[0].request
+    const rawBody = await request.text()
+    console.log(rawBody)
+    console.log(createTestIntegration)
+
+    // try {
+    //   const json = JSON.parse(rawBody)
+    //   expect(json).toMatchSnapshot()
+    //   return
+    // } catch (err) {
+    //   expect(rawBody).toMatchSnapshot()
+    // }
+
+    // expect(request.headers).toMatchSnapshot()
+  })
+})

--- a/packages/destination-actions/src/destinations/airship/registerAndAssociate/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/airship/registerAndAssociate/__tests__/snapshot.test.ts
@@ -4,7 +4,7 @@ import destination from '../../index'
 import nock from 'nock'
 
 const testDestination = createTestIntegration(destination)
-const actionSlug = 'register'
+const actionSlug = 'registerAndAssociate'
 const destinationSlug = 'Airship'
 const seedName = `${destinationSlug}#${actionSlug}`
 
@@ -14,7 +14,11 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
 
     nock(/.*/).persist().get(/.*/).reply(200)
-    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/)
+      .persist()
+      .post('/api/channels/email')
+      .reply(200, { ok: true, channel_id: '6be90795-a7d7-4657-b959-6a5afc199b06' })
+    nock(/.*/).persist().post('/api/named_users/associate').reply(200, { ok: true })
     nock(/.*/).persist().put(/.*/).reply(200)
 
     const event = createTestEvent({
@@ -46,7 +50,21 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const action = destination.actions[actionSlug]
     const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
 
-    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/)
+      .persist()
+      .get(/.*/)
+      .reply(200, {
+        // content: {
+        ok: true,
+        channel: {
+          channel_id: '6be90795-a7d7-4657-b959-6a5afc199b06'
+        }
+        // }
+      })
+    nock(/.*/)
+      .persist()
+      .post('/api/channels/email')
+      .reply(200, { ok: true, channel_id: '6be90795-a7d7-4657-b959-6a5afc199b06' })
     nock(/.*/).persist().post(/.*/).reply(200)
     nock(/.*/).persist().put(/.*/).reply(200)
 

--- a/packages/destination-actions/src/destinations/airship/registerAndAssociate/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/airship/registerAndAssociate/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'register'
+const destinationSlug = 'Airship'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/airship/registerAndAssociate/__tests__/test_data.json
+++ b/packages/destination-actions/src/destinations/airship/registerAndAssociate/__tests__/test_data.json
@@ -1,0 +1,85 @@
+{
+  "messageId": "test-message-uqh4ymzl02a",
+  "timestamp": "2023-08-07T16:34:24.112Z",
+  "type": "track",
+  "email": "test@example.org",
+  "properties": {
+    "property1": 1,
+    "property2": "test",
+    "property3": true
+  },
+  "userId": "test-user-a7ut2cf4kt",
+  "event": "Segment Test Event Name",
+  "anonymousId": "cdhipr3wzq8",
+  "context": {
+    "active": true,
+    "app": {
+      "name": "InitechGlobal",
+      "version": "545",
+      "build": "3.0.1.545",
+      "namespace": "com.production.segment"
+    },
+    "campaign": {
+      "name": "TPS Innovation Newsletter",
+      "source": "Newsletter",
+      "medium": "email",
+      "term": "tps reports",
+      "content": "image link"
+    },
+    "device": {
+      "id": "B5372DB0-C21E-11E4-8DFC-AA07A5B093DB",
+      "advertisingId": "7A3CBEA0-BDF5-11E4-8DFC-AA07A5B093DB",
+      "adTrackingEnabled": true,
+      "manufacturer": "Apple",
+      "model": "iPhone7,2",
+      "name": "maguro",
+      "type": "ios",
+      "token": "ff15bc0c20c4aa6cd50854ff165fd265c838e5405bfeb9571066395b8c9da449"
+    },
+    "ip": "8.8.8.8",
+    "library": {
+      "name": "analytics.js",
+      "version": "2.11.1"
+    },
+    "locale": "en-US",
+    "location": {
+      "city": "San Francisco",
+      "country": "United States",
+      "latitude": 40.2964197,
+      "longitude": -76.9411617,
+      "speed": 0
+    },
+    "network": {
+      "bluetooth": false,
+      "carrier": "T-Mobile US",
+      "cellular": true,
+      "wifi": false
+    },
+    "os": {
+      "name": "iPhone OS",
+      "version": "8.1.3"
+    },
+    "page": {
+      "path": "/academy/",
+      "referrer": "",
+      "search": "",
+      "title": "Analytics Academy",
+      "url": "https://segment.com/academy/"
+    },
+    "referrer": {
+      "id": "ABCD582CDEFFFF01919",
+      "type": "dataxu"
+    },
+    "screen": {
+      "width": 320,
+      "height": 568,
+      "density": 2
+    },
+    "groupId": "12345",
+    "timezone": "Europe/Amsterdam",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1"
+  },
+  "receivedAt": "2023-08-07T16:34:24.112Z",
+  "sentAt": "2023-08-07T16:34:24.112Z",
+  "version": 2
+}

--- a/packages/destination-actions/src/destinations/airship/registerAndAssociate/generated-types.ts
+++ b/packages/destination-actions/src/destinations/airship/registerAndAssociate/generated-types.ts
@@ -1,0 +1,70 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The identifier assigned in Airship as the Named User
+   */
+  named_user_id?: string
+  /**
+   * Locale includes country and language
+   */
+  locale: string
+  /**
+   * Timezone
+   */
+  timezone: string
+  /**
+   * Classic or Double
+   */
+  opt_in_choices?: string
+  /**
+   * Information about the email registration.
+   */
+  channel_object: {
+    /**
+     * Email address to register (required)
+     */
+    address: string
+    /**
+     * Email address to replace old one
+     */
+    new_address?: string
+    /**
+     * The date-time when a user gave explicit permission to receive commercial emails
+     */
+    commercial_opted_in?: string
+    /**
+     * The date-time when a user explicitly denied permission to receive commercial emails.
+     */
+    commercial_opted_out?: string
+    /**
+     * The date-time when a user opted in to click tracking.
+     */
+    click_tracking_opted_in?: string
+    /**
+     * The date-time when a user opted out of click tracking.
+     */
+    click_tracking_opted_out?: string
+    /**
+     * The date-time when a user opted in to open tracking.
+     */
+    open_tracking_opted_in?: string
+    /**
+     * The date-time when a user opted out of open tracking.
+     */
+    open_tracking_opted_out?: string
+    /**
+     * The date-time when a user gave explicit permission to receive transactional emails. Users do not need to opt-in to receive transactional emails unless they have previously opted out.
+     */
+    transactional_opted_in?: string
+    /**
+     * The date-time when a user explicitly denied permission to receive transactional emails.
+     */
+    transactional_opted_out?: string
+    /**
+     * If an email channel is suppressed, the reason for its suppression. Email channels with any suppression state set will not have any delivery to them fulfilled. If a more specific reason is not known, use imported. Possible values: spam_complaint, bounce, imported
+     */
+    suppression_state?: string
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/airship/registerAndAssociate/index.ts
+++ b/packages/destination-actions/src/destinations/airship/registerAndAssociate/index.ts
@@ -147,7 +147,6 @@ const action: ActionDefinition<Settings, Payload> = {
     if (payload.channel_object.new_address) {
       const old_email_channel_response = await getChannelId(request, settings, payload.channel_object.address)
       const old_email_response_content: any = JSON.parse(old_email_channel_response.content)
-      console.log(old_email_response_content.channel.channel_id)
       if (old_email_response_content.channel.channel_id) {
         return await register(request, settings, payload, old_email_response_content.channel.channel_id)
       }

--- a/packages/destination-actions/src/destinations/airship/registerAndAssociate/index.ts
+++ b/packages/destination-actions/src/destinations/airship/registerAndAssociate/index.ts
@@ -1,0 +1,175 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { register, associate_named_user, getChannelId } from '../utilities'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Register And Associate',
+  description: 'Register an Email address and associate it with a Named User ID.',
+  defaultSubscription: 'type = "track" and event="Address Registered"',
+  fields: {
+    named_user_id: {
+      label: 'Airship Named User ID',
+      description: 'The identifier assigned in Airship as the Named User',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    locale: {
+      label: 'Locale',
+      description: 'Locale includes country and language',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.context.locale'
+      }
+    },
+    timezone: {
+      label: 'Timezone',
+      description: 'Timezone',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.context.timezone'
+      }
+    },
+    opt_in_choices: {
+      label: 'Registration Type',
+      description: 'Classic or Double',
+      type: 'string',
+      default: 'classic',
+      choices: [
+        {
+          label: 'Classic',
+          value: 'classic'
+        },
+        {
+          label: 'Double',
+          value: 'double'
+        }
+      ]
+    },
+    channel_object: {
+      label: 'Channel',
+      description: 'Information about the email registration.',
+      type: 'object',
+      additionalProperties: true,
+      defaultObjectUI: 'keyvalue',
+      required: true,
+      properties: {
+        address: {
+          label: 'Email Address',
+          description: 'Email address to register (required)',
+          type: 'string',
+          required: true
+        },
+        new_address: {
+          label: 'New Email Address',
+          description: 'Email address to replace old one',
+          type: 'string',
+          required: false
+        },
+        commercial_opted_in: {
+          label: 'Commercial Opted In Date-Time',
+          description: 'The date-time when a user gave explicit permission to receive commercial emails',
+          type: 'string',
+          required: false
+        },
+        commercial_opted_out: {
+          label: 'Commercial Opted Out Date-Time',
+          description: 'The date-time when a user explicitly denied permission to receive commercial emails.',
+          type: 'string',
+          required: false
+        },
+        click_tracking_opted_in: {
+          label: 'Click Tracking Opted in Date-Time',
+          description: 'The date-time when a user opted in to click tracking.',
+          type: 'string',
+          required: false
+        },
+        click_tracking_opted_out: {
+          label: 'Click Tracking Opted out Date-Time',
+          description: 'The date-time when a user opted out of click tracking.',
+          type: 'string',
+          required: false
+        },
+        open_tracking_opted_in: {
+          label: 'Open Tracking Opted in Date-Time',
+          description: 'The date-time when a user opted in to open tracking.',
+          type: 'string',
+          required: false
+        },
+        open_tracking_opted_out: {
+          label: 'Open Tracking Opted out Date-Time',
+          description: 'The date-time when a user opted out of open tracking.',
+          type: 'string',
+          required: false
+        },
+        transactional_opted_in: {
+          label: 'Transactional Email Opt In Date-Time',
+          description:
+            'The date-time when a user gave explicit permission to receive transactional emails. Users do not need to opt-in to receive transactional emails unless they have previously opted out.',
+          type: 'string',
+          required: false
+        },
+        transactional_opted_out: {
+          label: 'Transactional Email Opt Out Date-Time',
+          description: 'The date-time when a user explicitly denied permission to receive transactional emails.',
+          type: 'string',
+          required: false
+        },
+        suppression_state: {
+          label: 'Suppression State',
+          description:
+            'If an email channel is suppressed, the reason for its suppression. Email channels with any suppression state set will not have any delivery to them fulfilled. If a more specific reason is not known, use imported. Possible values: spam_complaint, bounce, imported',
+          type: 'string',
+          required: false
+        }
+      },
+      default: {
+        address: { '@path': '$.email' },
+        new_address: { '@path': '$.properties.new_email' },
+        commercial_opted_in: { '@path': '$.properties.commercial_opted_in' },
+        commercial_opted_out: { '@path': '$.properties.commercial_opted_out' },
+        click_tracking_opted_in: { '@path': '$.properties.click_tracking_opted_in' },
+        click_tracking_opted_out: { '@path': '$.properties.click_tracking_opted_out' },
+        open_tracking_opted_in: { '@path': '$.properties.open_tracking_opted_in' },
+        open_tracking_opted_out: { '@path': '$.properties.open_tracking_opted_out' },
+        transactional_opted_in: { '@path': '$.properties.transactional_opted_in' },
+        transactional_opted_out: { '@path': '$.properties.transactional_opted_out' },
+        suppression_state: { '@path': '$.context.suppression_state' }
+      }
+    }
+  },
+  perform: async (request, { settings, payload }) => {
+    if (payload.channel_object.new_address) {
+      const old_email_channel_response = await getChannelId(request, settings, payload.channel_object.address)
+      const old_email_response_content: any = JSON.parse(old_email_channel_response.content)
+      console.log(old_email_response_content.channel.channel_id)
+      if (old_email_response_content.channel.channel_id) {
+        return await register(request, settings, payload, old_email_response_content.channel.channel_id)
+      }
+    }
+    const register_response = await register(request, settings, payload, null)
+    const response_content = register_response.content
+    const data = JSON.parse(response_content)
+
+    if (!data.ok || !data.channel_id) {
+      throw new Error(`Registration Failed, didn't create channel_id for ${payload.channel_object.address}`)
+    }
+    const channel_id = data.channel_id
+    if (payload.named_user_id && payload.named_user_id.length > 0) {
+      const associate_response = await associate_named_user(request, settings, channel_id, payload.named_user_id)
+      if (!associate_response.ok) {
+        throw new Error(`Associate Failed for named user ${payload.named_user_id}`)
+      }
+      return associate_response
+    } else {
+      return data
+    }
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/airship/register_and_associate.types.ts
+++ b/packages/destination-actions/src/destinations/airship/register_and_associate.types.ts
@@ -1,0 +1,66 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The identifier assigned in Airship as the Named User
+   */
+  named_user_id?: string
+  /**
+   * Locale includes country and language
+   */
+  locale: string
+  /**
+   * Timezone
+   */
+  timezone: string
+  /**
+   * Classic or Double
+   */
+  opt_in_choices?: string
+  /**
+   * Information about the email registration.
+   */
+  channel_object: {
+    /**
+     * Email address to register (required)
+     */
+    address: string
+    /**
+     * The date-time when a user gave explicit permission to receive commercial emails
+     */
+    commercial_opted_in?: string
+    /**
+     * The date-time when a user explicitly denied permission to receive commercial emails.
+     */
+    commercial_opted_out?: string
+    /**
+     * The date-time when a user opted in to click tracking.
+     */
+    click_tracking_opted_in?: string
+    /**
+     * The date-time when a user opted out of click tracking.
+     */
+    click_tracking_opted_out?: string
+    /**
+     * The date-time when a user opted in to open tracking.
+     */
+    open_tracking_opted_in?: string
+    /**
+     * The date-time when a user opted out of open tracking.
+     */
+    open_tracking_opted_out?: string
+    /**
+     * The date-time when a user gave explicit permission to receive transactional emails. Users do not need to opt-in to receive transactional emails unless they have previously opted out.
+     */
+    transactional_opted_in?: string
+    /**
+     * The date-time when a user explicitly denied permission to receive transactional emails.
+     */
+    transactional_opted_out?: string
+    /**
+     * If an email channel is suppressed, the reason for its suppression. Email channels with any suppression state set will not have any delivery to them fulfilled. If a more specific reason is not known, use imported. Possible values: spam_complaint, bounce, imported
+     */
+    suppression_state?: string
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/airship/utilities.ts
+++ b/packages/destination-actions/src/destinations/airship/utilities.ts
@@ -3,6 +3,110 @@ import type { Settings } from './generated-types'
 import { Payload as CustomEventsPayload } from './customEvents/generated-types'
 import { Payload as AttributesPayload } from './setAttributes/generated-types'
 import { Payload as TagsPayload } from './manageTags/generated-types'
+import { Payload as RegisterPayload } from './registerAndAssociate/generated-types'
+
+// exported Action function
+export function register(
+  request: RequestClient,
+  settings: Settings,
+  payload: RegisterPayload,
+  old_channel: string | null
+) {
+  let address_to_use = payload.channel_object.address
+  const endpoint = map_endpoint(settings.endpoint)
+  let register_uri = `${endpoint}/api/channels/email`
+  if (old_channel && payload.channel_object.new_address) {
+    register_uri = `${endpoint}/api/channels/email/replace/${old_channel}`
+    address_to_use = payload.channel_object.new_address
+  }
+  const country_language = _extract_country_language(payload.locale)
+  let register_payload: {
+    channel: {
+      commercial_opted_in?: string
+      commercial_opted_out?: string
+      click_tracking_opted_in?: string
+      click_tracking_opted_out?: string
+      open_tracking_opted_in?: string
+      open_tracking_opted_out?: string
+      transactional_opted_in?: string
+      transactional_opted_out?: string
+      suppression_state?: string
+      type: string
+      address: string
+      timezone: string
+      locale_language: string
+      locale_country: string
+    }
+  } = {
+    channel: {
+      type: 'email',
+      address: address_to_use,
+      timezone: payload.timezone,
+      locale_language: country_language[0],
+      locale_country: country_language[1]
+    }
+  }
+  // handle and format all optional date params
+  if (payload.channel_object.commercial_opted_in) {
+    register_payload.channel.commercial_opted_in = _parse_and_format_date(payload.channel_object.commercial_opted_in)
+  }
+  if (payload.channel_object.commercial_opted_out) {
+    register_payload.channel.commercial_opted_out = _parse_and_format_date(payload.channel_object.commercial_opted_out)
+  }
+  if (payload.channel_object.click_tracking_opted_in) {
+    register_payload.channel.commercial_opted_in = _parse_and_format_date(
+      payload.channel_object.click_tracking_opted_in
+    )
+  }
+  if (payload.channel_object.click_tracking_opted_out) {
+    register_payload.channel.click_tracking_opted_in = _parse_and_format_date(
+      payload.channel_object.click_tracking_opted_out
+    )
+  }
+  if (payload.channel_object.open_tracking_opted_in) {
+    register_payload.channel.open_tracking_opted_in = _parse_and_format_date(
+      payload.channel_object.open_tracking_opted_in
+    )
+  }
+  if (payload.channel_object.open_tracking_opted_out) {
+    register_payload.channel.open_tracking_opted_out = _parse_and_format_date(
+      payload.channel_object.open_tracking_opted_out
+    )
+  }
+  if (payload.channel_object.transactional_opted_in) {
+    register_payload.channel.transactional_opted_in = _parse_and_format_date(
+      payload.channel_object.transactional_opted_in
+    )
+  }
+  if (payload.channel_object.transactional_opted_out) {
+    register_payload.channel.transactional_opted_out = _parse_and_format_date(
+      payload.channel_object.transactional_opted_out
+    )
+  }
+  if (payload.channel_object.suppression_state) {
+    register_payload.channel.suppression_state = payload.channel_object.suppression_state
+  }
+
+  return do_request(request, register_uri, register_payload)
+}
+
+// exported Action function
+export function associate_named_user(
+  request: RequestClient,
+  settings: Settings,
+  channel_id: string,
+  named_user_id: string
+) {
+  const endpoint = map_endpoint(settings.endpoint)
+  const uri = `${endpoint}/api/named_users/associate`
+
+  const associate_payload = {
+    channel_id: channel_id,
+    named_user_id: named_user_id
+  }
+
+  return do_request(request, uri, associate_payload)
+}
 
 // exported Action function
 export function setCustomEvent(request: RequestClient, settings: Settings, payload: CustomEventsPayload) {
@@ -35,6 +139,13 @@ export function setAttribute(request: RequestClient, settings: Settings, payload
     }
   }
   return do_request(request, uri, airship_payload)
+}
+
+// exported Action function
+export function getChannelId(request: RequestClient, settings: Settings, emailAddress: string) {
+  const endpoint = map_endpoint(settings.endpoint)
+  const uri = `${endpoint}/api/channels/email/${emailAddress}`
+  return request(uri, { method: 'GET' })
 }
 
 // exported Action function
@@ -74,7 +185,7 @@ function _build_custom_event_object(payload: CustomEventsPayload): object {
     }
   }
   const airship_payload = {
-    occurred: validate_timestamp(payload.occurred),
+    occurred: _validate_timestamp(payload.occurred),
     user: {
       named_user_id: payload.named_user_id
     },
@@ -107,7 +218,7 @@ function _build_attribute(attribute_key: string, attribute_value: any, occurred:
   */
   let adjustedDate = null
   if (typeof attribute_value == 'string') {
-    adjustedDate = parse_date(attribute_value)
+    adjustedDate = _parse_date(attribute_value)
   }
 
   const attribute: {
@@ -118,7 +229,7 @@ function _build_attribute(attribute_key: string, attribute_value: any, occurred:
   } = {
     action: 'set',
     key: attribute_key,
-    timestamp: validate_timestamp(occurred)
+    timestamp: _validate_timestamp(occurred)
   }
 
   if (attribute_value == null || (typeof attribute_value == 'string' && attribute_value.length === 0)) {
@@ -165,7 +276,7 @@ function _build_tags_object(payload: TagsPayload): object {
   return airship_payload
 }
 
-function validate_timestamp(timestamp: string | number | Date) {
+function _validate_timestamp(timestamp: string | number | Date) {
   const payload_time_stamp: Date = new Date(timestamp)
   const three_months_ago: Date = new Date()
   three_months_ago.setDate(three_months_ago.getDate() - 90)
@@ -176,7 +287,24 @@ function validate_timestamp(timestamp: string | number | Date) {
   }
 }
 
-function parse_date(attribute_value: any): Date | null {
+function _parse_and_format_date(date_string: string) {
+  /*
+  take a string, and if it can be used to create a valid Date instance,
+   format it into a date string that Airship can use. Otherwise, return
+   the original string
+   */
+  const date_obj = _parse_date(date_string)
+  if (date_obj) {
+    return date_obj.toISOString().split('.')[0]
+  } else {
+    return date_string
+  }
+}
+
+function _parse_date(attribute_value: any): Date | null {
+  /*
+  This function is for converting dates or returning null if they're not valid.
+  */
   // Attempt to parse the attribute_value as a Date
   const date = new Date(attribute_value)
 
@@ -188,11 +316,16 @@ function parse_date(attribute_value: any): Date | null {
   return null // Return null for invalid dates
 }
 
+function _extract_country_language(locale: string): string[] {
+  const country_language = locale.split('-')
+  return country_language
+}
+
 export const _private = {
   _build_custom_event_object,
   _build_attributes_object,
   _build_attribute,
   _build_tags_object,
-  parse_date,
-  validate_timestamp
+  _parse_date,
+  _validate_timestamp
 }

--- a/packages/destination-actions/src/destinations/fullstory/generated-types.ts
+++ b/packages/destination-actions/src/destinations/fullstory/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Settings {
   /**
-   * [FullStory Admin API key](https://help.fullstory.com/hc/en-us/articles/360052021773-Managing-API-Keys)
+   * [FullStory API key](https://help.fullstory.com/hc/en-us/articles/360052021773-Managing-API-Keys)
    */
   apiKey: string
 }


### PR DESCRIPTION
Adding an Action that allows for registering an email address with Airship and associating it with a Named User ID. Also allows for replacing an email address with a new one.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
