### PR TITLE
double batch_size for liveramp sftp mapping

### DIFF
--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/index.ts
@@ -74,7 +74,7 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
       type: 'number',
       required: false,
-      default: 50000
+      default: 100000
     }
   },
   perform: async (_, { payload }) => {


### PR DESCRIPTION
As per our testing in PROD, we are doubling the batch size for SFTP to accomodate our current test data.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
