### PR TITLE
Adds `unsafe_hidden` and `readOnly` as InputField possibilities

### DIFF
--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -172,7 +172,8 @@ export interface InputField {
 
   /**
    * Determines whether this field should be read only in the UI. Best used for fields where the default path of the
-   * value is always known.
+   * value is always known. This should always be used in combination with some `default` value. Otherwise users will be
+   * locked out from editing an empty field.
    */
   readOnly?: boolean
 }

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -163,6 +163,18 @@ export interface InputField {
     | 'object' // Users will see the object editor by default and can change to the key value editor.
     | 'keyvalue:only' // Users will only use the key value editor.
     | 'object:only' // Users will only use the object editor.
+
+  /**
+   * Determines whether this field should be hidden in the UI. Only use this in very limited cases where the field represents
+   * some kind of hardcoded internal "setting". For example the `enable_batching` field which is hardcoded to true for some destinations.
+   */
+  unsafe_hidden?: boolean
+
+  /**
+   * Determines whether this field should be read only in the UI. Best used for fields where the default path of the
+   * value is always known.
+   */
+  readOnly?: boolean
 }
 
 export type FieldValue = string | number | boolean | object | Directive


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR adds two new `InputField` options:
* `unsafe_hidden`: Setting this to true hides the specified field from users in the UI. This should only be used in limited cases.
* `readOnly`: Setting this to true will lock the default field so that users cannot edit it. This should be used in combination with some `default` value.

## Deploy
This PR is part of a broader effort. Related PRs are:
* `action-cli` push update: https://github.com/segmentio/action-cli/pull/142
* `control-plane` https://github.com/segmentio/control-plane/pull/3813
* `app` PRs to consume the `hidden` and `readOnly` fields.

Merging this PR 

## Testing
Tested by pushing the new fields to stage DB:
Setting `read_only: true`:
| Push Command      | Result |
| ----------- | ----------- |
| <img width="696" alt="Screenshot 2023-08-18 at 4 51 53 PM" src="https://github.com/segmentio/control-plane/assets/27820201/b608b5e3-d16c-43fb-8b43-81b4973f4d72">    | <img width="826" alt="Screenshot 2023-08-21 at 4 12 08 PM" src="https://github.com/segmentio/control-plane/assets/27820201/53bac9bc-831e-404b-8711-edf3c24350f7">       |

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
