### PR TITLE
Fix PluginFactory type

### DIFF
--- a/packages/browser-destination-runtime/src/types.ts
+++ b/packages/browser-destination-runtime/src/types.ts
@@ -64,6 +64,6 @@ export interface Subscription {
 }
 
 export interface PluginFactory {
-  (settings: JSONValue): Plugin | Plugin[] | Promise<Plugin | Plugin[]>
+  (settings: JSONValue): Plugin[] | Promise<Plugin[]>
   pluginName: string
 }


### PR DESCRIPTION
The type poorly described the actual return value of `generatePlugins`. It now aligns and type errors are resolved.
