### PR TITLE
[STRATCONN-2981] TTD - Added Flagon support for legacy flow

### DIFF
--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/properties.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/properties.ts
@@ -59,3 +59,21 @@ export const batch_size: InputField = {
   required: false,
   default: 100000
 }
+
+export const merge_mode: InputField = {
+  label: 'Merge Mode',
+  description: 'The merge mode to use when syncing data to The Trade Desk CRM Segment.',
+  type: 'string',
+  choices: [
+    {
+      label: 'Add',
+      value: 'Add'
+    },
+    {
+      label: 'Replace',
+      value: 'Replace'
+    }
+  ],
+  default: 'Replace',
+  required: false
+}

--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/syncAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/syncAudience/generated-types.ts
@@ -18,6 +18,10 @@ export interface Payload {
    */
   email?: string
   /**
+   * The merge mode to use when syncing data to The Trade Desk CRM Segment.
+   */
+  merge_mode?: string
+  /**
    * Enable batching of requests to The Trade Desk CRM Segment.
    */
   enable_batching?: boolean

--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/syncAudience/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { name, region, pii_type, email, enable_batching, event_name, batch_size } from '../properties'
+import { name, region, pii_type, email, enable_batching, event_name, batch_size, merge_mode } from '../properties'
 import { processPayload } from '../functions'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -13,15 +13,26 @@ const action: ActionDefinition<Settings, Payload> = {
     region: { ...region },
     pii_type: { ...pii_type },
     email: { ...email },
+    merge_mode: { ...merge_mode },
     enable_batching: { ...enable_batching },
     event_name: { ...event_name },
     batch_size: { ...batch_size }
   },
-  perform: async (request, { settings, payload }) => {
-    return processPayload(request, settings, [payload])
+  perform: async (request, { settings, payload, features }) => {
+    return processPayload({
+      request,
+      settings,
+      payloads: [payload],
+      features
+    })
   },
-  performBatch: async (request, { settings, payload }) => {
-    return processPayload(request, settings, payload)
+  performBatch: async (request, { settings, payload, features }) => {
+    return processPayload({
+      request,
+      settings,
+      payloads: payload,
+      features
+    })
   }
 }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR adds a FLAGON support to The TradeDesk CRM destination.

Adding `actions-the-trade-desk-crm-legacy-flow` triggers the Legacy Flow as opposed to the AWS Flow.

## Testing

Testing completed successfully in Local and with Unit Test cases.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
