### PR TITLE
tiktok conversions api upgrade to v 1-3

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-conversions/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/__tests__/index.test.ts
@@ -38,7 +38,7 @@ describe('Tiktok Conversions', () => {
         userId: 'testId123'
       })
 
-      nock('https://business-api.tiktok.com/open_api/v1.2/pixel/track').post('/').reply(200, {})
+      nock('https://business-api.tiktok.com/open_api/v1.3/pixel/track').post('/').reply(200, {})
       const responses = await testDestination.testAction('reportWebEvent', {
         event,
         settings,
@@ -106,7 +106,7 @@ describe('Tiktok Conversions', () => {
         userId: 'testId123'
       })
 
-      nock('https://business-api.tiktok.com/open_api/v1.2/pixel/track').post('/').reply(200, {})
+      nock('https://business-api.tiktok.com/open_api/v1.3/pixel/track').post('/').reply(200, {})
       const responses = await testDestination.testAction('reportWebEvent', {
         event,
         settings,
@@ -172,7 +172,7 @@ describe('Tiktok Conversions', () => {
         userId: 'testId123'
       })
 
-      nock('https://business-api.tiktok.com/open_api/v1.2/pixel/track').post('/').reply(200, {})
+      nock('https://business-api.tiktok.com/open_api/v1.3/pixel/track').post('/').reply(200, {})
       const responses = await testDestination.testAction('reportWebEvent', {
         event,
         settings,
@@ -237,7 +237,7 @@ describe('Tiktok Conversions', () => {
         userId: 'testId123'
       })
 
-      nock('https://business-api.tiktok.com/open_api/v1.2/pixel/track').post('/').reply(200, {})
+      nock('https://business-api.tiktok.com/open_api/v1.3/pixel/track').post('/').reply(200, {})
       const responses = await testDestination.testAction('reportWebEvent', {
         event,
         settings,
@@ -303,7 +303,7 @@ describe('Tiktok Conversions', () => {
         userId: 'testId123'
       })
 
-      nock('https://business-api.tiktok.com/open_api/v1.2/pixel/track').post('/').reply(200, {})
+      nock('https://business-api.tiktok.com/open_api/v1.3/pixel/track').post('/').reply(200, {})
       const responses = await testDestination.testAction('reportWebEvent', {
         event,
         settings,
@@ -369,7 +369,7 @@ describe('Tiktok Conversions', () => {
         userId: 'testId123'
       })
 
-      nock('https://business-api.tiktok.com/open_api/v1.2/pixel/track').post('/').reply(200, {})
+      nock('https://business-api.tiktok.com/open_api/v1.3/pixel/track').post('/').reply(200, {})
       const responses = await testDestination.testAction('reportWebEvent', {
         event,
         settings,

--- a/packages/destination-actions/src/destinations/tiktok-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/index.ts
@@ -146,7 +146,7 @@ const destination: DestinationDefinition<Settings> = {
     testAuthentication: (request, { settings }) => {
       // Return a request that tests/validates the user's credentials.
       // Send a blank event to events API.
-      return request('https://business-api.tiktok.com/open_api/v1.2/pixel/track/', {
+      return request('https://business-api.tiktok.com/open_api/v1.3/pixel/track/', {
         method: 'post',
         json: {
           pixel_code: settings.pixelCode,

--- a/packages/destination-actions/src/destinations/tiktok-conversions/reportWebEvent/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/reportWebEvent/index.ts
@@ -217,7 +217,7 @@ const action: ActionDefinition<Settings, Payload> = {
     if (payloadUrl) urlTtclid = payloadUrl.searchParams.get('ttclid')
 
     // Request to tiktok Events Web API
-    return request('https://business-api.tiktok.com/open_api/v1.2/pixel/track/', {
+    return request('https://business-api.tiktok.com/open_api/v1.3/pixel/track/', {
       method: 'post',
       json: {
         pixel_code: settings.pixelCode,


### PR DESCRIPTION

Fixing a PR raised by TikTok for the TikTok Conversions Destination. 
- Tests were failing
- testAuthentication endpoint was not updated (and should have been). 
- Original PR here: https://github.com/segmentio/action-destinations/pull/1498
- PR is to upgrade TikTok Conversions from API v1.2 to v1.3. 


## Testing

Testing done using Actions Tester. Partner provided screenshots of tests here https://drive.google.com/file/d/1J8bX5gse9kQokw3_Cb8ZJSplTwwUCghB/view?usp=drive_link  
