### PR TITLE
[canny-functions] Add userId to group request

### DIFF
--- a/packages/destination-actions/src/destinations/canny-functions/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/canny-functions/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -7,6 +7,7 @@ Object {
     "testType": "s1D5kBYs]jP",
   },
   "type": "s1D5kBYs]jP",
+  "userId": "s1D5kBYs]jP",
 }
 `;
 

--- a/packages/destination-actions/src/destinations/canny-functions/group/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/canny-functions/group/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -7,6 +7,7 @@ Object {
     "testType": "iFCL@q",
   },
   "type": "iFCL@q",
+  "userId": "iFCL@q",
 }
 `;
 

--- a/packages/destination-actions/src/destinations/canny-functions/group/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/canny-functions/group/__tests__/index.test.ts
@@ -14,7 +14,8 @@ describe('CannyFunctions.group', () => {
       timestamp: new Date().toISOString(),
       traits: {
         name: 'Group Name'
-      }
+      },
+      userId: 'user-id'
     }
     const event = createTestEvent(eventData)
     nock(BASE_API_URL).post('/group').reply(200, {})
@@ -36,7 +37,8 @@ describe('CannyFunctions.group', () => {
     expect(parsedBody).toEqual({
       groupId: event.groupId,
       traits: eventData.traits,
-      type: event.type
+      type: event.type,
+      userId: event.userId
     })
   })
 })

--- a/packages/destination-actions/src/destinations/canny-functions/group/generated-types.ts
+++ b/packages/destination-actions/src/destinations/canny-functions/group/generated-types.ts
@@ -15,4 +15,8 @@ export interface Payload {
    * The type of the event
    */
   type: string
+  /**
+   * The unique identifier of the user.
+   */
+  userId?: string
 }

--- a/packages/destination-actions/src/destinations/canny-functions/group/index.ts
+++ b/packages/destination-actions/src/destinations/canny-functions/group/index.ts
@@ -33,12 +33,20 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.type'
       }
+    },
+    userId: {
+      label: 'User ID',
+      type: 'string',
+      description: 'The unique identifier of the user.',
+      default: {
+        '@path': '$.userId'
+      }
     }
   },
   perform: (request, { payload }) => {
-    const { groupId, type, traits } = payload
+    const { groupId, type, traits, userId } = payload
 
-    const body = JSON.stringify({ groupId, traits, type })
+    const body = JSON.stringify({ groupId, traits, type, userId })
     return request(`${BASE_API_URL}/group`, {
       method: 'post',
       body


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

We'd like to add `userId` in `group` request to associate to create a relation between users and groups created in Canny. 

## Testing

- Unit tests
- Manually tested sending group events with/without `userId` property. Server responds as expected.

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
