### PR TITLE
STRATCONN 3059 - LiveRamp: add special hash handling for email and phone number

### DIFF
--- a/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -7363,5 +7363,7 @@ Array [
   "testemail@domain.com",
   "test@test.com",
   "valid@domain.com",
+  "first+last@names.com",
+  "first.last@names.com",
 ]
 `;

--- a/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -7346,3 +7346,22 @@ Array [
   "\\"5'8\\"\\"\\"",
 ]
 `;
+
+exports[`Testing snapshot for LiverampAudiences's generic functions: normalizes identifiers correctly 1`] = `
+Array [
+  "5551234567",
+  "5551234567",
+  "5551234567",
+  "5551234567",
+  "5551234567",
+  "5551234567",
+]
+`;
+
+exports[`Testing snapshot for LiverampAudiences's generic functions: normalizes identifiers correctly 2`] = `
+Array [
+  "testemail@domain.com",
+  "test@test.com",
+  "valid@domain.com",
+]
+`;

--- a/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/snapshot.test.ts
@@ -257,7 +257,13 @@ describe(`Testing snapshot for ${destinationSlug}'s generic functions:`, () => {
     const normalizedNumbers = phoneNumbers.map((value) => normalize('phone_number', value))
     expect(normalizedNumbers).toMatchSnapshot()
 
-    const emails = ['TestEmail@domain.com', 'test@test.com ', 'valid@domain.com']
+    const emails = [
+      'TestEmail@domain.com',
+      'test@test.com ',
+      'valid@domain.com',
+      'first+last@names.com',
+      'first.last@names.com'
+    ]
     const normalizedEmails = emails.map((value) => normalize('email', value))
     expect(normalizedEmails).toMatchSnapshot()
   })

--- a/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/snapshot.test.ts
@@ -5,7 +5,7 @@ import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import { generateTestData } from '../../../lib/test-data'
 import destination from '../index'
 import nock from 'nock'
-import { enquoteIdentifier } from '../operations'
+import { enquoteIdentifier, normalize } from '../operations'
 
 const testDestination = createTestIntegration(destination)
 const destinationSlug = 'LiverampAudiences'
@@ -233,5 +233,32 @@ describe(`Testing snapshot for ${destinationSlug}'s generic functions:`, () => {
     const enquotedIdentifiers = identifiers.map(enquoteIdentifier)
 
     expect(enquotedIdentifiers).toMatchSnapshot()
+  })
+
+  it('normalizes identifiers correctly', async () => {
+    /*
+      allowed formats listed below:
+
+      +1XXXXXXXXXX
+      +1 (XXX) XXX-XXXX
+      (XXX) XXX-XXXX
+      XXX-XXX-XXXX
+      XXX XXX XXXX
+      XXXXXXXXXX
+    */
+    const phoneNumbers = [
+      '+15551234567',
+      '+1 (555) 123-4567',
+      '(555) 123-4567',
+      '555-123-4567',
+      '555 123 4567',
+      '5551234567'
+    ]
+    const normalizedNumbers = phoneNumbers.map((value) => normalize('phone_number', value))
+    expect(normalizedNumbers).toMatchSnapshot()
+
+    const emails = ['TestEmail@domain.com', 'test@test.com ', 'valid@domain.com']
+    const normalizedEmails = emails.map((value) => normalize('email', value))
+    expect(normalizedEmails).toMatchSnapshot()
   })
 })

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/generated-types.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/generated-types.ts
@@ -28,7 +28,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * Additional data pertaining to the user to be hashed before written to the file
+   * Additional data pertaining to the user to be hashed before written to the file. Use field name **phone_number** or **email** to apply LiveRamp specific hashing rules.
    */
   unhashed_identifier_data?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/generated-types.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/generated-types.ts
@@ -28,7 +28,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * Additional data pertaining to the user to be hashed before written to the file. Use field name **phone_number** or **email** to apply LiveRamp specific hashing rules.
+   * Additional data pertaining to the user to be hashed before written to the file. Use field name **phone_number** or **email** to apply LiveRamp's specific hashing rules.
    */
   unhashed_identifier_data?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
@@ -45,7 +45,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     unhashed_identifier_data: {
       label: 'Hashable Identifier Data',
-      description: `Additional data pertaining to the user to be hashed before written to the file`,
+      description: `Additional data pertaining to the user to be hashed before written to the file. Use field name **phone_number** or **email** to apply LiveRamp specific hashing rules.`,
       type: 'object',
       required: false,
       defaultObjectUI: 'keyvalue:only'

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
@@ -45,7 +45,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     unhashed_identifier_data: {
       label: 'Hashable Identifier Data',
-      description: `Additional data pertaining to the user to be hashed before written to the file. Use field name **phone_number** or **email** to apply LiveRamp specific hashing rules.`,
+      description: `Additional data pertaining to the user to be hashed before written to the file. Use field name **phone_number** or **email** to apply LiveRamp's specific hashing rules.`,
       type: 'object',
       required: false,
       defaultObjectUI: 'keyvalue:only'

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/generated-types.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/generated-types.ts
@@ -24,7 +24,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * Additional data pertaining to the user to be hashed before written to the file
+   * Additional data pertaining to the user to be hashed before written to the file. Use field name **phone_number** or **email** to apply LiveRamp's specific hashing rules.
    */
   unhashed_identifier_data?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/index.ts
@@ -43,7 +43,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     unhashed_identifier_data: {
       label: 'Hashable Identifier Data',
-      description: `Additional data pertaining to the user to be hashed before written to the file`,
+      description: `Additional data pertaining to the user to be hashed before written to the file. Use field name **phone_number** or **email** to apply LiveRamp's specific hashing rules.`,
       type: 'object',
       required: false,
       defaultObjectUI: 'keyvalue:only'


### PR DESCRIPTION
https://segment.atlassian.net/browse/STRATCONN-3059

The following changes ensure we correctly follow LiveRamp's normalization of email and phone number prior to hashing.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
