### PR TITLE
Fix actions tester so it reads audience_settings

### DIFF
--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -289,7 +289,7 @@ function setupRoutes(def: DestinationDefinition | null): void {
           const eventParams = {
             data: req.body.payload || {},
             settings: req.body.settings || {},
-            audienceSettings: req.body.audienceSettings || {},
+            audienceSettings: req.body.payload.context.personas.audience_settings || {},
             mapping: mapping || req.body.payload || {},
             auth: req.body.auth || {}
           }


### PR DESCRIPTION
This PR updates the place the audience_settings are read from inside the actions-tester.

Settings are expected inside `context.personas` and not at the top level of the request body.

```
...
"personas": {
      "audience_settings": {
        "extras": "42"
      },
      "computation_class": "audience",
      "computation_id": "aud_2TlglcYMPHbx1bX93sUS",
      "computation_key": "no_batch_2",
      "external_audience_id": "whatever_123",
      "namespace": "spa_3YPvihi9m2Npw18iY",
      "space_id": "spa_3YPvihi9m2Ncpw18iY"
    },
...
```
## Testing

Tested completed successfully in localhost.

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
