### PR TITLE
[STRATCONN-3087] Pass statsContext to audience methods

### DIFF
--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -74,6 +74,8 @@ export type CreateAudienceInput<Settings = unknown, AudienceSettings = unknown> 
   audienceSettings?: AudienceSettings
 
   audienceName: string
+
+  statsContext?: StatsContext
 }
 
 export type GetAudienceInput<Settings = unknown, AudienceSettings = unknown> = {
@@ -82,6 +84,8 @@ export type GetAudienceInput<Settings = unknown, AudienceSettings = unknown> = {
   audienceSettings?: AudienceSettings
 
   externalId: string
+
+  statsContext?: StatsContext
 }
 
 export interface AudienceDestinationConfiguration {


### PR DESCRIPTION
Pass statsContext object to create/get audience methods so the `statsClient` is available from within. This will be very useful for the future migrations we will run.

## Testing

Testing completed successfully via localhost. I only verified the availability of the object and not its use. I'll do that with the upcoming Tiktok createAudience method.

![Screenshot 2023-08-17 at 3 42 01 PM](https://github.com/segmentio/action-destinations/assets/316711/0f7fe759-a92a-46b6-b80b-0492ab872a94)


_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
