### PR TITLE
[STRATCONN-3036] Add native create/get Audience support to TikTok Audiences

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-audiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/__tests__/index.test.ts
@@ -1,0 +1,141 @@
+import nock from 'nock'
+import { createTestIntegration, IntegrationError } from '@segment/actions-core'
+import { BASE_URL, GET_AUDIENCE_URL, TIKTOK_API_VERSION } from '../constants'
+import Destination from '../index'
+
+const testDestination = createTestIntegration(Destination)
+
+const idType = 'EMAIL_SHA256'
+const audienceId = '888888888'
+const advertiserId = '42884288'
+
+const createAudienceInput = {
+  settings: {
+    advertiser_ids: [advertiserId] // TODO: Remove on cleanup
+  },
+  audienceName: '',
+  audienceSettings: {
+    advertiserId: advertiserId,
+    idType: idType
+  }
+}
+
+const getAudienceInput = {
+  settings: {
+    advertiser_ids: [advertiserId] // TODO: Remove on cleanup
+  },
+  externalId: audienceId,
+  audienceSettings: {
+    advertiserId: advertiserId,
+    idType: idType
+  }
+}
+
+const mockGetAudienceResponse = (replyObject: any) => {
+  nock(GET_AUDIENCE_URL)
+    .get('')
+    .query({
+      advertiser_id: advertiserId,
+      custom_audience_ids: JSON.stringify([audienceId])
+    })
+    .reply(200, replyObject)
+}
+
+const getAudienceResponse = {
+  code: 0,
+  message: 'OK',
+  request_id: '20230804CEF3B42',
+  data: {
+    list: [
+      {
+        audience_history: [
+          {
+            opt_time: '2023-08-03 16:27:49',
+            action: 'create',
+            msg: null,
+            editor: 'open_api',
+            action_detail: '0'
+          }
+        ],
+        audience_details: {
+          is_auto_refresh: false,
+          is_expiring: false,
+          shared: false,
+          expired_time: '2024-08-02 16:27:49',
+          calculate_type: 'MULTIPLE_TYPES',
+          error_msg: null,
+          name: 'The Super Mario Brothers Super Audience',
+          is_valid: false,
+          is_creator: true,
+          msg: null,
+          audience_sub_type: 'NORMAL',
+          type: 'Partner',
+          cover_num: 0,
+          audience_id: audienceId,
+          create_time: '2023-08-03 16:27:49',
+          rule: '{"inclusions": null, "exclusions": null}'
+        }
+      }
+    ]
+  }
+}
+
+describe('Tik Tok Audiences', () => {
+  describe('createAudience', () => {
+    it('should fail if no audience name is set', async () => {
+      await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(IntegrationError)
+    })
+
+    it('should fail if no advertiser ID is set', async () => {
+      createAudienceInput.audienceName = 'The Void'
+      createAudienceInput.audienceSettings.advertiserId = ''
+      await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(IntegrationError)
+    })
+
+    it('should create a new TikTok Audience', async () => {
+      nock(BASE_URL)
+        .post(`/${TIKTOK_API_VERSION}/segment/audience/`, {
+          custom_audience_name: 'The Super Mario Brothers Fans',
+          advertiser_id: '42884288',
+          id_type: 'EMAIL_SHA256',
+          action: 'create'
+        })
+        .reply(200, {
+          code: 0,
+          message: 'OK',
+          request_id: '202308032127455B021E952',
+          data: {
+            audience_id: audienceId
+          }
+        })
+
+      createAudienceInput.audienceName = 'The Super Mario Brothers Fans'
+      createAudienceInput.audienceSettings.advertiserId = advertiserId
+
+      const r = await testDestination.createAudience(createAudienceInput)
+      expect(r).toEqual({ externalId: audienceId })
+    })
+  })
+
+  describe('getAudience', () => {
+    it('should fail if TikTok replies with an error', async () => {
+      await expect(testDestination.getAudience(getAudienceInput)).rejects.toThrowError()
+    })
+
+    it("should fail if Segment Audience ID doesn't match TikTok Audience ID", async () => {
+      getAudienceResponse.data.list[0].audience_details.audience_id = '424242' // Different audience_id
+      mockGetAudienceResponse(getAudienceResponse)
+      await expect(testDestination.getAudience(getAudienceInput)).rejects.toThrow(
+        "Unable to verify ownership over audience. Segment Audience ID doesn't match TikToks Audience ID."
+      )
+    })
+
+    it('should succeed when Segment Audience ID matches TikTok audience ID', async () => {
+      getAudienceResponse.data.list[0].audience_details.audience_id = getAudienceInput.externalId
+      mockGetAudienceResponse(getAudienceResponse)
+
+      const r = await testDestination.getAudience(getAudienceInput)
+      expect(r).toEqual({ externalId: audienceId })
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/tiktok-audiences/constants.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/constants.ts
@@ -1,2 +1,4 @@
 export const TIKTOK_API_VERSION = 'v1.3'
 export const BASE_URL = 'https://business-api.tiktok.com/open_api/'
+export const CREATE_AUDIENCE_URL = `${BASE_URL}${TIKTOK_API_VERSION}/segment/audience/`
+export const GET_AUDIENCE_URL = `${BASE_URL}${TIKTOK_API_VERSION}/dmp/custom_audience/get`

--- a/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/index.ts
@@ -5,6 +5,10 @@ import { createAudience } from '../functions'
 import { selected_advertiser_id, custom_audience_name, id_type } from '../properties'
 import { TikTokAudiences } from '../api'
 
+// === NOTE ===
+// This createAudience is independent of the native createAudience that is implemented in ../index.ts.
+// Consider it deprecated and do not emulate its behavior.
+
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Create Audience',
   description: 'Creates a new audience in TikTok Audience Segment.',
@@ -31,7 +35,8 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
   },
-  perform: async (request, { payload }) => {
+  perform: async (request, { payload, statsContext }) => {
+    statsContext?.statsClient?.incr('actions-tiktok-audiences.createAudience.legacy', 1, statsContext?.tags)
     return createAudience(request, payload)
   }
 }

--- a/packages/destination-actions/src/destinations/tiktok-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/generated-types.ts
@@ -6,3 +6,15 @@ export interface Settings {
    */
   advertiser_ids: string[]
 }
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface AudienceSettings {
+  /**
+   * The advertiser ID to use when syncing audiences.
+   */
+  advertiserId: string
+  /**
+   * Encryption type to be used for populating the audience. This field is set only when Segment creates a new audience.
+   */
+  idType: string
+}

--- a/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
@@ -1,15 +1,16 @@
-import type { DestinationDefinition } from '@segment/actions-core'
-import { InvalidAuthenticationError } from '@segment/actions-core'
-import type { Settings } from './generated-types'
+import type { AudienceDestinationDefinition } from '@segment/actions-core'
+import { IntegrationError, InvalidAuthenticationError } from '@segment/actions-core'
+import type { Settings, AudienceSettings } from './generated-types'
 import addUser from './addUser'
 import removeUser from './removeUser'
 import { TikTokAudiences } from './api'
 import { ModifiedResponse } from '@segment/actions-core'
 import { APIResponse } from './types'
+import { CREATE_AUDIENCE_URL, GET_AUDIENCE_URL } from './constants'
 
 import createAudience from './createAudience'
 
-const destination: DestinationDefinition<Settings> = {
+const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   name: 'TikTok Audiences',
   slug: 'actions-tiktok-audiences',
   mode: 'cloud',
@@ -18,6 +19,7 @@ const destination: DestinationDefinition<Settings> = {
     scheme: 'oauth2',
     fields: {
       advertiser_ids: {
+        // TODO: Remove on cleanup
         label: 'TikTok Advertiser IDs',
         description:
           'The Advertiser IDs where audiences should be synced. Hidden in production and should not be altered by users.',
@@ -54,7 +56,112 @@ const destination: DestinationDefinition<Settings> = {
       }
     }
   },
+  audienceFields: {
+    advertiserId: {
+      type: 'string',
+      label: 'Advertiser ID',
+      description: 'The advertiser ID to use when syncing audiences.',
+      required: true
+    },
+    idType: {
+      type: 'string',
+      label: 'ID Type',
+      description:
+        'Encryption type to be used for populating the audience. This field is set only when Segment creates a new audience.',
+      choices: [
+        { label: 'Email', value: 'EMAIL_SHA256' },
+        { label: 'Google Advertising ID', value: 'GAID_SHA256' },
+        { label: 'Android Advertising ID', value: 'AAID_SHA256' },
+        { label: 'iOS Advertising ID', value: 'IDFA_SHA256' }
+      ],
+      required: true
+    }
+  },
+  audienceConfig: {
+    mode: {
+      type: 'synced',
+      full_audience_sync: false
+    },
+    async createAudience(request, createAudienceInput) {
+      const audienceName = createAudienceInput.audienceName
+      const idType = createAudienceInput.audienceSettings?.idType
+      const advertiserId = createAudienceInput.audienceSettings?.advertiserId
 
+      if (!audienceName) {
+        throw new IntegrationError('Missing audience name value', 'MISSING_REQUIRED_FIELD', 400)
+      }
+
+      if (!advertiserId) {
+        throw new IntegrationError('Missing advertiser ID value', 'MISSING_REQUIRED_FIELD', 400)
+      }
+
+      const response = await request(CREATE_AUDIENCE_URL, {
+        method: 'POST',
+        json: {
+          custom_audience_name: audienceName,
+          advertiser_id: advertiserId,
+          id_type: idType,
+          action: 'create'
+        }
+      })
+
+      const r = await response.json()
+      if (r['message'] !== 'OK') {
+        // TODO: Add statsClient calls
+        // statsContext?.statsClient.incr('actions-tiktok-audiences.createAudience.native', 1, statsContext?.tags)
+        throw new IntegrationError('Invalid response from create audience request', 'INVALID_RESPONSE', 400)
+      }
+
+      return {
+        externalId: r.data['audience_id']
+      }
+    },
+    async getAudience(request, getAudienceInput) {
+      // TODO: Add statsClient calls
+      // statsContext?.statsClient.incr('actions-tiktok-audiences.getAudience.native', 1, statsContext?.tags)
+      const url = new URL(GET_AUDIENCE_URL)
+      const audienceIds = [getAudienceInput.externalId]
+      const advertiserId = getAudienceInput.audienceSettings?.advertiserId
+
+      if (!advertiserId) {
+        throw new IntegrationError(
+          'Unable to verify ownership over audience. Missing advertiserId.',
+          'INVALID_REQUEST_DATA',
+          400
+        )
+      }
+
+      const params = new URLSearchParams()
+      params.append('advertiser_id', advertiserId)
+      params.append('custom_audience_ids', JSON.stringify(audienceIds))
+
+      const response = await request(`${url.toString()}?${params.toString()}`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        }
+      })
+
+      const r = await response.json()
+      if (r['message'] !== 'OK') {
+        throw new IntegrationError('Invalid response from get audience request', 'INVALID_RESPONSE', 400)
+      }
+
+      const externalId = r.data['list'][0]['audience_details']['audience_id']
+
+      if (externalId !== getAudienceInput.externalId) {
+        throw new IntegrationError(
+          "Unable to verify ownership over audience. Segment Audience ID doesn't match TikToks Audience ID.",
+          'INVALID_REQUEST_DATA',
+          400
+        )
+      }
+
+      return {
+        externalId: externalId
+      }
+    }
+  },
   actions: {
     addUser,
     removeUser,


### PR DESCRIPTION
This PR converts our existing TikTok audience destination into a native audience destination while keeping its existing behavior.

**It's safe to merge this code**. The existing behavior won't change due to a flagon gate.

Partially depends on https://github.com/segmentio/action-destinations/pull/1509/

## Testing

Tested completed successfully in localhost.
<img width="1023" alt="Screenshot 2023-08-17 at 4 52 02 PM" src="https://github.com/segmentio/action-destinations/assets/316711/889d9669-ef1c-43a5-8fe3-d3e309fc8cf8">
<img width="1095" alt="Screenshot 2023-08-17 at 4 54 27 PM" src="https://github.com/segmentio/action-destinations/assets/316711/94448483-ec8f-4055-b36e-4c57bf6ae7e0">

And also completed successfully in stage where we saw both flows work in accordance to their feature flag.


![Screenshot 2023-08-18 at 1 14 50 PM](https://github.com/segmentio/action-destinations/assets/316711/5762981b-2ab5-4b58-a2d9-b5a4a73b33c5)
![Screenshot 2023-08-18 at 1 17 14 PM](https://github.com/segmentio/action-destinations/assets/316711/4c51e92f-76d2-4b81-a0b5-715cc751a82c)


_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
