### PR TITLE
[STRATCONN-3037] Add new action "addToAudience" to TikTok Audiences

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-audiences/addToAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addToAudience/__tests__/index.test.ts
@@ -1,0 +1,211 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { BASE_URL, TIKTOK_API_VERSION } from '../../constants'
+
+const testDestination = createTestIntegration(Destination)
+
+interface AuthTokens {
+  accessToken: string
+  refreshToken: string
+}
+
+const auth: AuthTokens = {
+  accessToken: 'test',
+  refreshToken: 'test'
+}
+
+const EXTERNAL_AUDIENCE_ID = '12345'
+const ADVERTISER_ID = '123' // References audienceSettings.advertiserId
+const ADVERTISING_ID = '4242' // References device.advertisingId
+const ID_TYPE = 'EMAIL_SHA256' // References audienceSettings.idType
+
+const event = createTestEvent({
+  event: 'Audience Entered',
+  type: 'track',
+  properties: {},
+  context: {
+    device: {
+      advertisingId: ADVERTISING_ID
+    },
+    traits: {
+      email: 'testing@testing.com'
+    },
+    personas: {
+      audience_settings: {
+        advertiserId: ADVERTISER_ID,
+        idType: ID_TYPE
+      },
+      external_audience_id: EXTERNAL_AUDIENCE_ID
+    }
+  }
+})
+
+const updateUsersRequestBody = {
+  id_schema: ['EMAIL_SHA256', 'IDFA_SHA256'],
+  advertiser_ids: [ADVERTISER_ID],
+  action: 'add',
+  batch_data: [
+    [
+      {
+        id: '584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777',
+        audience_ids: [EXTERNAL_AUDIENCE_ID]
+      },
+      {
+        id: '0315b4020af3eccab7706679580ac87a710d82970733b8719e70af9b57e7b9e6',
+        audience_ids: [EXTERNAL_AUDIENCE_ID]
+      }
+    ]
+  ]
+}
+
+describe('TiktokAudiences.addToAudience', () => {
+  it('should succeed if audience id is valid', async () => {
+    nock(`${BASE_URL}${TIKTOK_API_VERSION}`).post('/segment/mapping/', updateUsersRequestBody).reply(200)
+
+    const r = await testDestination.testAction('addToAudience', {
+      auth,
+      event,
+      settings: {},
+      useDefaultMappings: true,
+      mapping: {
+        send_advertising_id: true
+      }
+    })
+
+    expect(r[0].status).toEqual(200)
+  })
+
+  it('should normalize and hash emails correctly', async () => {
+    nock(`${BASE_URL}${TIKTOK_API_VERSION}`)
+      .post('/segment/mapping/', {
+        advertiser_ids: ['123'],
+        action: 'add',
+        id_schema: ['EMAIL_SHA256'],
+        batch_data: [
+          [
+            {
+              id: '584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777',
+              audience_ids: [EXTERNAL_AUDIENCE_ID]
+            }
+          ]
+        ]
+      })
+      .reply(200)
+
+    const responses = await testDestination.testAction('addToAudience', {
+      event,
+      settings: {
+        advertiser_ids: ['123']
+      },
+      useDefaultMappings: true,
+      auth,
+      mapping: {
+        send_advertising_id: false
+      }
+    })
+
+    expect(responses[0].options.body).toMatchInlineSnapshot(
+      `"{\\"advertiser_ids\\":[\\"123\\"],\\"action\\":\\"add\\",\\"id_schema\\":[\\"EMAIL_SHA256\\"],\\"batch_data\\":[[{\\"id\\":\\"584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777\\",\\"audience_ids\\":[\\"12345\\"]}]]}"`
+    )
+  })
+
+  it('should fail if an audience id is invalid', async () => {
+    const anotherEvent = createTestEvent({
+      event: 'Audience Entered',
+      type: 'track',
+      properties: {
+        audience_key: 'personas_test_audience'
+      },
+      context: {
+        device: {
+          advertisingId: ADVERTISING_ID
+        },
+        traits: {
+          email: 'testing@testing.com'
+        },
+        personas: {
+          audience_settings: {
+            advertiserId: ADVERTISER_ID,
+            idType: ID_TYPE
+          },
+          external_audience_id: 'THIS_ISNT_REAL'
+        }
+      }
+    })
+
+    nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`)
+      .post(/.*/, {
+        id_schema: ['EMAIL_SHA256', 'IDFA_SHA256'],
+        advertiser_ids: [ADVERTISER_ID],
+        action: 'add',
+        batch_data: [
+          [
+            {
+              id: '584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777',
+              audience_ids: ['THIS_ISNT_REAL']
+            },
+            {
+              id: '0315b4020af3eccab7706679580ac87a710d82970733b8719e70af9b57e7b9e6',
+              audience_ids: ['THIS_ISNT_REAL']
+            }
+          ]
+        ]
+      })
+      .reply(400)
+
+    const r = await testDestination.testAction('addToAudience', {
+      event: anotherEvent,
+      settings: {
+        advertiser_ids: ['123']
+      },
+      useDefaultMappings: true,
+      auth,
+      mapping: {}
+    })
+
+    expect(r[0].status).toEqual(400)
+  })
+
+  it('should fail if all the send fields are false', async () => {
+    nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`).post(/.*/, updateUsersRequestBody).reply(200)
+
+    await expect(
+      testDestination.testAction('addToAudience', {
+        event,
+        settings: {
+          advertiser_ids: ['123']
+        },
+        useDefaultMappings: true,
+        auth,
+        mapping: {
+          selected_advertiser_id: '123',
+          audience_id: '123456',
+          send_email: false,
+          send_advertising_id: false
+        }
+      })
+    ).rejects.toThrow('At least one of `Send Email`, or `Send Advertising ID` must be set to `true`.')
+  })
+  it('should fail if email and/or advertising_id is not in the payload', async () => {
+    nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`).post(/.*/, updateUsersRequestBody).reply(400)
+
+    delete event?.context?.device
+    delete event?.context?.traits
+
+    await expect(
+      testDestination.testAction('addToAudience', {
+        event,
+        settings: {
+          advertiser_ids: ['123']
+        },
+        useDefaultMappings: true,
+        auth,
+        mapping: {
+          send_email: true,
+          send_advertising_id: true
+        }
+      })
+    ).rejects.toThrowError('At least one of Email Id or Advertising ID must be provided.')
+  })
+})

--- a/packages/destination-actions/src/destinations/tiktok-audiences/addToAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addToAudience/generated-types.ts
@@ -1,0 +1,32 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The user's email address to send to TikTok.
+   */
+  email?: string
+  /**
+   * The user's mobile advertising ID to send to TikTok. This could be a GAID, IDFA, or AAID
+   */
+  advertising_id?: string
+  /**
+   * Send email to TikTok. Segment will hash this value before sending
+   */
+  send_email?: boolean
+  /**
+   * Send mobile advertising ID (IDFA, AAID or GAID) to TikTok. Segment will hash this value before sending.
+   */
+  send_advertising_id?: boolean
+  /**
+   * The name of the current Segment event.
+   */
+  event_name?: string
+  /**
+   * Enable batching of requests to the TikTok Audiences.
+   */
+  enable_batching?: boolean
+  /**
+   * The Audience ID in TikTok's DB.
+   */
+  external_audience_id?: string
+}

--- a/packages/destination-actions/src/destinations/tiktok-audiences/addToAudience/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addToAudience/index.ts
@@ -26,17 +26,32 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     enable_batching: { ...enable_batching },
     external_audience_id: { ...external_audience_id }
   },
-  perform: async (request, { audienceSettings, payload }) => {
+  perform: async (request, { audienceSettings, payload, statsContext }) => {
+    const statsClient = statsContext?.statsClient
+    const statsTag = statsContext?.tags
+
     if (!audienceSettings) {
       throw new IntegrationError('Bad Request: no audienceSettings found.', 'INVALID_REQUEST_DATA', 400)
     }
 
+    if (statsClient) {
+      statsClient?.incr('actions-tiktok-audiences.addToAudience', 1, statsTag)
+    }
+
     return processPayload(request, audienceSettings, [payload], 'add')
   },
-  performBatch: async (request, { payload, audienceSettings }) => {
+  performBatch: async (request, { payload, audienceSettings, statsContext }) => {
+    const statsClient = statsContext?.statsClient
+    const statsTag = statsContext?.tags
+
     if (!audienceSettings) {
       throw new IntegrationError('Bad Request: no audienceSettings found.', 'INVALID_REQUEST_DATA', 400)
     }
+
+    if (statsClient) {
+      statsClient?.incr('actions-tiktok-audiences.addToAudience', 1, statsTag)
+    }
+
     return processPayload(request, audienceSettings, payload, 'add')
   }
 }

--- a/packages/destination-actions/src/destinations/tiktok-audiences/addToAudience/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addToAudience/index.ts
@@ -1,0 +1,44 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings, AudienceSettings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { processPayload } from '../functions'
+import {
+  email,
+  advertising_id,
+  send_email,
+  send_advertising_id,
+  event_name,
+  enable_batching,
+  external_audience_id
+} from '../properties'
+import { IntegrationError } from '@segment/actions-core'
+
+const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
+  title: 'Add to Audience',
+  description: 'Add records from an Engage Audience to a TikTok Audience Segment.',
+  defaultSubscription: 'event = "Audience Entered"',
+  fields: {
+    email: { ...email },
+    advertising_id: { ...advertising_id },
+    send_email: { ...send_email },
+    send_advertising_id: { ...send_advertising_id },
+    event_name: { ...event_name },
+    enable_batching: { ...enable_batching },
+    external_audience_id: { ...external_audience_id }
+  },
+  perform: async (request, { audienceSettings, payload }) => {
+    if (!audienceSettings) {
+      throw new IntegrationError('Bad Request: no audienceSettings found.', 'INVALID_REQUEST_DATA', 400)
+    }
+
+    return processPayload(request, audienceSettings, [payload], 'add')
+  },
+  performBatch: async (request, { payload, audienceSettings }) => {
+    if (!audienceSettings) {
+      throw new IntegrationError('Bad Request: no audienceSettings found.', 'INVALID_REQUEST_DATA', 400)
+    }
+    return processPayload(request, audienceSettings, payload, 'add')
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/tiktok-audiences/addUser/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addUser/index.ts
@@ -14,6 +14,10 @@ import {
 } from '../properties'
 import { TikTokAudiences } from '../api'
 
+// NOTE
+// This action is not used by the native Segment Audiences feature.
+// TODO: Remove on cleanup.
+
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Add Users',
   description: 'Add contacts from an Engage Audience to a TikTok Audience Segment.',
@@ -33,7 +37,17 @@ const action: ActionDefinition<Settings, Payload> = {
       try {
         const tiktok = new TikTokAudiences(request)
 
-        return tiktok.fetchAdvertisers(settings.advertiser_ids)
+        if (settings.advertiser_ids) {
+          return tiktok.fetchAdvertisers(settings.advertiser_ids)
+        }
+
+        return {
+          choices: [],
+          error: {
+            message: JSON.stringify('BAD REQUEST - expected settings.advertiser_ids and got nothing!'),
+            code: '400'
+          }
+        }
       } catch (err) {
         return {
           choices: [],

--- a/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/index.ts
@@ -23,7 +23,17 @@ const action: ActionDefinition<Settings, Payload> = {
       try {
         const tiktok = new TikTokAudiences(request)
 
-        return tiktok.fetchAdvertisers(settings.advertiser_ids)
+        if (settings.advertiser_ids) {
+          return tiktok.fetchAdvertisers(settings.advertiser_ids)
+        }
+
+        return {
+          choices: [],
+          error: {
+            message: JSON.stringify('BAD REQUEST - expected settings.advertiser_ids and got nothing!'),
+            code: '400'
+          }
+        }
       } catch (err) {
         return {
           choices: [],

--- a/packages/destination-actions/src/destinations/tiktok-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/generated-types.ts
@@ -4,7 +4,7 @@ export interface Settings {
   /**
    * The Advertiser IDs where audiences should be synced. Hidden in production and should not be altered by users.
    */
-  advertiser_ids: string[]
+  advertiser_ids?: string[]
 }
 // Generated file. DO NOT MODIFY IT BY HAND.
 

--- a/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
@@ -10,6 +10,8 @@ import { CREATE_AUDIENCE_URL, GET_AUDIENCE_URL } from './constants'
 
 import createAudience from './createAudience'
 
+import addToAudience from './addToAudience'
+
 const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   name: 'TikTok Audiences',
   slug: 'actions-tiktok-audiences',
@@ -24,7 +26,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         description:
           'The Advertiser IDs where audiences should be synced. Hidden in production and should not be altered by users.',
         type: 'string',
-        required: true,
+        required: false, // Make it optional so the native methods aren't expecting this.
         multiple: true
       }
     },
@@ -169,7 +171,8 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   actions: {
     addUser,
     removeUser,
-    createAudience
+    createAudience,
+    addToAudience
   }
 }
 

--- a/packages/destination-actions/src/destinations/tiktok-audiences/properties.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/properties.ts
@@ -87,3 +87,12 @@ export const enable_batching: InputField = {
   type: 'boolean',
   default: true
 }
+
+export const external_audience_id: InputField = {
+  label: 'External Audience ID',
+  description: "The Audience ID in TikTok's DB.",
+  type: 'hidden',
+  default: {
+    '@path': '$.context.personas.external_audience_id'
+  }
+}

--- a/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/index.ts
@@ -14,6 +14,10 @@ import {
 } from '../properties'
 import { TikTokAudiences } from '../api'
 
+// NOTE
+// This action is not used by the native Segment Audiences feature.
+// TODO: Remove on cleanup.
+
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Remove Users',
   description: 'Remove contacts from an Engage Audience to a TikTok Audience Segment.',
@@ -32,7 +36,17 @@ const action: ActionDefinition<Settings, Payload> = {
     selected_advertiser_id: async (request, { settings }) => {
       try {
         const tiktok = new TikTokAudiences(request)
-        return tiktok.fetchAdvertisers(settings.advertiser_ids)
+        if (settings.advertiser_ids) {
+          return tiktok.fetchAdvertisers(settings.advertiser_ids)
+        }
+
+        return {
+          choices: [],
+          error: {
+            message: JSON.stringify('BAD REQUEST - expected settings.advertiser_ids and got nothing!'),
+            code: '400'
+          }
+        }
       } catch (err) {
         return {
           choices: [],


### PR DESCRIPTION
This action will be used by the native audience flow. It will be hidden in the UI by default until the feature is fully released. Flagon will allow us to support both legacy and new data flows.

**This PR is safe to merge as the action it adds will be hidden in the UI**.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
