### PR TITLE
[DevRev]: update API base URL in destination

### DIFF
--- a/packages/destination-actions/src/destinations/devrev/createWork/index.ts
+++ b/packages/destination-actions/src/destinations/devrev/createWork/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { RequestOptions } from '@segment/actions-core'
 import { DynamicFieldResponse } from '@segment/actions-core'
-import { DevUserListResponse, PartListResponse, devrevApiPaths, devrevApiRoot } from '../utils'
+import { DevUserListResponse, PartListResponse, devrevApiPaths, getBaseUrl } from '../utils'
 import { APIError } from '@segment/actions-core'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -79,9 +79,9 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   dynamicFields: {
-    partId: async (request): Promise<DynamicFieldResponse> => {
+    partId: async (request, { settings }): Promise<DynamicFieldResponse> => {
       try {
-        const result: PartListResponse = await request(`${devrevApiRoot}${devrevApiPaths.partsList}`, {
+        const result: PartListResponse = await request(`${getBaseUrl(settings)}${devrevApiPaths.partsList}`, {
           method: 'get',
           skipResponseCloning: true
         })
@@ -103,9 +103,9 @@ const action: ActionDefinition<Settings, Payload> = {
         }
       }
     },
-    assignTo: async (request): Promise<DynamicFieldResponse> => {
+    assignTo: async (request, { settings }): Promise<DynamicFieldResponse> => {
       try {
-        const results: DevUserListResponse = await request(`${devrevApiRoot}${devrevApiPaths.devUsersList}`, {
+        const results: DevUserListResponse = await request(`${getBaseUrl(settings)}${devrevApiPaths.devUsersList}`, {
           method: 'get',
           skipResponseCloning: true
         })
@@ -129,9 +129,9 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
 
-  perform: (request, { payload }) => {
+  perform: (request, { settings, payload }) => {
     const { partId, title, description, assignTo, type, priority } = payload
-    const url = `${devrevApiRoot}${devrevApiPaths.worksCreate}`
+    const url = `${getBaseUrl(settings)}${devrevApiPaths.worksCreate}`
     const options: RequestOptions = {
       method: 'POST',
       json: {

--- a/packages/destination-actions/src/destinations/devrev/index.ts
+++ b/packages/destination-actions/src/destinations/devrev/index.ts
@@ -4,7 +4,7 @@ import type { Settings } from './generated-types'
 import createWork from './createWork'
 
 import createRevUser from './createRevUser'
-import { devrevApiPaths, devrevApiRoot } from './utils'
+import { devrevApiPaths, getBaseUrl } from './utils'
 
 import streamEvent from './streamEvent'
 
@@ -36,11 +36,11 @@ const destination: DestinationDefinition<Settings> = {
         default: 'gmail.com,hotmail.com,outlook.com,yahoo.com,aol.com,icloud.com,me.com,msn.com'
       }
     },
-    testAuthentication: (request) => {
+    testAuthentication: (request, { settings }) => {
       // Return a request that tests/validates the user's credentials.
       // If you do not have a way to validate the authentication fields safely,
       // you can remove the `testAuthentication` function, though discouraged.
-      const url = `${devrevApiRoot}${devrevApiPaths.authTest}`
+      const url = `${getBaseUrl(settings)}${devrevApiPaths.authTest}`
       return request(url)
     }
   },

--- a/packages/destination-actions/src/destinations/devrev/streamEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/devrev/streamEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -13,6 +13,7 @@ Object {
         },
         "email": "opemal@ner.kr",
         "eventName": "sZcTM%n(kDC3tsz4iK5h",
+        "event_source": "segment",
         "messageId": "sZcTM%n(kDC3tsz4iK5h",
         "properties": Object {
           "testType": "sZcTM%n(kDC3tsz4iK5h",
@@ -33,6 +34,7 @@ Object {
       "name": "sZcTM%n(kDC3tsz4iK5h",
       "payload": Object {
         "eventName": "sZcTM%n(kDC3tsz4iK5h",
+        "event_source": "segment",
         "timestamp": "2021-02-01T00:00:00.000Z",
       },
     },

--- a/packages/destination-actions/src/destinations/devrev/streamEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/devrev/streamEvent/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
-import { TrackEventsPublishBody, devrevApiPaths, devrevApiRoot } from '../../utils'
+import { TrackEventsPublishBody, devrevApiPaths, getBaseUrl } from '../../utils'
 import { settings, testAnonymousId, testContext, testEventPayload, testMessageId, testUserId } from '../../mocks'
 
 const testDestination = createTestIntegration(Destination)
@@ -9,7 +9,7 @@ const testDestination = createTestIntegration(Destination)
 describe('Devrev.streamEvent', () => {
   it('makes the correct API call to publish track events with default mapping', async () => {
     // Mock the publish API
-    nock(`${devrevApiRoot}`)
+    nock(`${getBaseUrl(settings)}`)
       .post(`${devrevApiPaths.trackEventsPublish}`)
       .reply(201, (_, body) => body)
 
@@ -47,7 +47,8 @@ describe('Devrev.streamEvent', () => {
             messageId: testMessageId,
             anonymousId: testAnonymousId,
             context: testContext,
-            properties: testEventPayload.properties
+            properties: testEventPayload.properties,
+            event_source: 'segment'
           }
         }
       ]

--- a/packages/destination-actions/src/destinations/devrev/streamEvent/index.ts
+++ b/packages/destination-actions/src/destinations/devrev/streamEvent/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { TrackEventsPublishBody, devrevApiPaths, devrevApiRoot } from '../utils'
+import { TrackEventsPublishBody, devrevApiPaths, getBaseUrl } from '../utils'
 import { RequestOptions } from '@segment/actions-core'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -74,7 +74,7 @@ const action: ActionDefinition<Settings, Payload> = {
       default: { '@path': '$.anonymousId' }
     }
   },
-  perform: (request, { payload }) => {
+  perform: (request, { settings, payload }) => {
     const { eventName, timestamp } = payload
 
     // Track API payload
@@ -85,12 +85,13 @@ const action: ActionDefinition<Settings, Payload> = {
           event_time: timestamp.toString(),
           payload: {
             // add mapped data to payload
-            ...payload
+            ...payload,
+            event_source: 'segment'
           }
         }
       ]
     }
-    const url = `${devrevApiRoot}${devrevApiPaths.trackEventsPublish}`
+    const url = `${getBaseUrl(settings)}${devrevApiPaths.trackEventsPublish}`
     const options: RequestOptions = {
       method: 'POST',
       json: reqBody

--- a/packages/destination-actions/src/destinations/devrev/utils/constants.ts
+++ b/packages/destination-actions/src/destinations/devrev/utils/constants.ts
@@ -15,5 +15,3 @@ export const devrevApiPaths = {
   timelineEntriesCreate: '/timeline-entries.create',
   trackEventsPublish: '/internal/track-events.publish'
 }
-
-export const devrevApiRoot = 'https://api.devrev.ai'

--- a/packages/destination-actions/src/destinations/devrev/utils/helpers.ts
+++ b/packages/destination-actions/src/destinations/devrev/utils/helpers.ts
@@ -1,22 +1,27 @@
 import type { Settings } from '../generated-types'
+import type { JwtPayload } from './types'
 
-export const parseJwt = (token: string) => {
+export const parseJwt = (token: string): JwtPayload => {
   return JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString())
 }
 
+export const getBaseUrl = (settings: Settings) => {
+  try {
+    const url = parseJwt(settings.apiKey)
+      .iss.replace(/auth-token/g, 'api')
+      .slice(0, -1)
+    return url
+  } catch (e) {
+    return 'https://api.devrev.ai'
+  }
+}
+
 export const getDevOrgId = (settings: Settings) => {
-  const { apiKey } = settings
-  const parsed = parseJwt(apiKey)
-  const orgId = parsed['http://devrev.ai/devo_don']
-  return orgId
+  return parseJwt(settings.apiKey)['http://devrev.ai/devo_don']
 }
 
 export const getDevUserId = (settings: Settings) => {
-  const { apiKey } = settings
-  const parsed = parseJwt(apiKey)
-  const orgId = parsed['http://devrev.ai/devo_don']
-  const userId = `${orgId}:devu/${parsed['']}`
-  return userId
+  return parseJwt(settings.apiKey).sub
 }
 
 export const isBlacklisted = (settings: Settings, domain: string) => {

--- a/packages/destination-actions/src/destinations/devrev/utils/types.ts
+++ b/packages/destination-actions/src/destinations/devrev/utils/types.ts
@@ -128,3 +128,22 @@ export interface TraceEvent {
 export interface TrackEventsPublishBody {
   events_list: TraceEvent[]
 }
+
+export interface JwtPayload {
+  aud: string[]
+  azp: string
+  exp: number
+  'http://devrev.ai/auth0_user_id': string
+  'http://devrev.ai/devo_don': string
+  'http://devrev.ai/devoid': string
+  'http://devrev.ai/devuid': string
+  'http://devrev.ai/displayname': string
+  'http://devrev.ai/email': string
+  'http://devrev.ai/fullname': string
+  'http://devrev.ai/tokentype': string
+  iat: number
+  iss: string
+  jti: string
+  org_id: string
+  sub: string
+}


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._
Update DevRev destination get the API base URL by parsing the input API token. We are doing this because this will enable us in testing Segment events in multiple environments (Dev, QA, Prod)
Adds "event_source" to payload before calling DevRev API. We are doing this because there is a requirement for our target processor  of event data, which gets events from many sources, to know its source.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
