### PR TITLE
[STRATCONN-3038] Add removeFromAudience action

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
@@ -12,6 +12,8 @@ import createAudience from './createAudience'
 
 import addToAudience from './addToAudience'
 
+import removeFromAudience from './removeFromAudience'
+
 const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   name: 'TikTok Audiences',
   slug: 'actions-tiktok-audiences',
@@ -172,7 +174,8 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     addUser,
     removeUser,
     createAudience,
-    addToAudience
+    addToAudience,
+    removeFromAudience
   }
 }
 

--- a/packages/destination-actions/src/destinations/tiktok-audiences/removeFromAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/removeFromAudience/__tests__/index.test.ts
@@ -1,0 +1,162 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { BASE_URL, TIKTOK_API_VERSION } from '../../constants'
+
+const testDestination = createTestIntegration(Destination)
+
+interface AuthTokens {
+  accessToken: string
+  refreshToken: string
+}
+
+const auth: AuthTokens = {
+  accessToken: 'test',
+  refreshToken: 'test'
+}
+
+const EXTERNAL_AUDIENCE_ID = '12345'
+const ADVERTISER_ID = '123' // References audienceSettings.advertiserId
+const ADVERTISING_ID = '4242' // References device.advertisingId
+const ID_TYPE = 'EMAIL_SHA256' // References audienceSettings.idType
+
+const event = createTestEvent({
+  event: 'Audience Exited',
+  type: 'track',
+  properties: {},
+  context: {
+    device: {
+      advertisingId: ADVERTISING_ID
+    },
+    traits: {
+      email: 'testing@testing.com'
+    },
+    personas: {
+      audience_settings: {
+        advertiserId: ADVERTISER_ID,
+        idType: ID_TYPE
+      },
+      external_audience_id: EXTERNAL_AUDIENCE_ID
+    }
+  }
+})
+
+const updateUsersRequestBody = {
+  id_schema: ['EMAIL_SHA256', 'IDFA_SHA256'],
+  advertiser_ids: [ADVERTISER_ID],
+  action: 'delete',
+  batch_data: [
+    [
+      {
+        id: '584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777',
+        audience_ids: [EXTERNAL_AUDIENCE_ID]
+      },
+      {
+        id: '0315b4020af3eccab7706679580ac87a710d82970733b8719e70af9b57e7b9e6',
+        audience_ids: [EXTERNAL_AUDIENCE_ID]
+      }
+    ]
+  ]
+}
+
+describe('TiktokAudiences.removeFromAudience', () => {
+  it('should succeed if audience id is valid', async () => {
+    nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`).post(/.*/, updateUsersRequestBody).reply(200)
+
+    await expect(
+      testDestination.testAction('removeFromAudience', {
+        event,
+        settings: {
+          advertiser_ids: ['123']
+        },
+        useDefaultMappings: true,
+        auth,
+        mapping: {
+          selected_advertiser_id: '123',
+          audience_id: '1234345'
+        }
+      })
+    ).resolves.not.toThrowError()
+  })
+
+  it('should fail if audienceid is invalid', async () => {
+    const anotherEvent = createTestEvent({
+      event: 'Audience Entered',
+      type: 'track',
+      properties: {
+        audience_key: 'personas_test_audience'
+      },
+      context: {
+        device: {
+          advertisingId: ADVERTISING_ID
+        },
+        traits: {
+          email: 'testing@testing.com'
+        },
+        personas: {
+          audience_settings: {
+            advertiserId: ADVERTISER_ID,
+            idType: ID_TYPE
+          },
+          external_audience_id: 'THIS_ISNT_REAL'
+        }
+      }
+    })
+
+    nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`)
+      .post(/.*/, {
+        id_schema: ['EMAIL_SHA256', 'IDFA_SHA256'],
+        advertiser_ids: [ADVERTISER_ID],
+        action: 'add',
+        batch_data: [
+          [
+            {
+              id: '584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777',
+              audience_ids: ['THIS_ISNT_REAL']
+            },
+            {
+              id: '0315b4020af3eccab7706679580ac87a710d82970733b8719e70af9b57e7b9e6',
+              audience_ids: ['THIS_ISNT_REAL']
+            }
+          ]
+        ]
+      })
+      .reply(400)
+
+    await expect(
+      testDestination.testAction('removeFromAudience', {
+        event: anotherEvent,
+        settings: {
+          advertiser_ids: ['123']
+        },
+        useDefaultMappings: true,
+        auth,
+        mapping: {
+          selected_advertiser_id: '123',
+          audience_id: 'personas_test_audience'
+        }
+      })
+    ).rejects.toThrowError()
+  })
+
+  it('should fail if all the send fields are false', async () => {
+    nock(`${BASE_URL}${TIKTOK_API_VERSION}/segment/mapping/`).post(/.*/, updateUsersRequestBody).reply(200)
+
+    await expect(
+      testDestination.testAction('removeFromAudience', {
+        event,
+        settings: {
+          advertiser_ids: ['123']
+        },
+        useDefaultMappings: true,
+        auth,
+        mapping: {
+          selected_advertiser_id: '123',
+          audience_id: '123456',
+          send_email: false,
+          send_advertising_id: false
+        }
+      })
+    ).rejects.toThrow('At least one of `Send Email`, or `Send Advertising ID` must be set to `true`.')
+  })
+})

--- a/packages/destination-actions/src/destinations/tiktok-audiences/removeFromAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/removeFromAudience/generated-types.ts
@@ -1,0 +1,32 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The user's email address to send to TikTok.
+   */
+  email?: string
+  /**
+   * The user's mobile advertising ID to send to TikTok. This could be a GAID, IDFA, or AAID
+   */
+  advertising_id?: string
+  /**
+   * Send email to TikTok. Segment will hash this value before sending
+   */
+  send_email?: boolean
+  /**
+   * Send mobile advertising ID (IDFA, AAID or GAID) to TikTok. Segment will hash this value before sending.
+   */
+  send_advertising_id?: boolean
+  /**
+   * The name of the current Segment event.
+   */
+  event_name?: string
+  /**
+   * Enable batching of requests to the TikTok Audiences.
+   */
+  enable_batching?: boolean
+  /**
+   * The Audience ID in TikTok's DB.
+   */
+  external_audience_id?: string
+}

--- a/packages/destination-actions/src/destinations/tiktok-audiences/removeFromAudience/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/removeFromAudience/index.ts
@@ -34,10 +34,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
       throw new IntegrationError('Bad Request: no audienceSettings found.', 'INVALID_REQUEST_DATA', 400)
     }
 
-    if (statsClient) {
-      statsContext?.statsClient?.incr('actions-tiktok-audiences.removeFromAudience', 1, statsTag)
-    }
-
+    statsClient?.incr('actions-tiktok-audiences.removeFromAudience', 1, statsTag)
     return processPayload(request, audienceSettings, [payload], 'delete')
   },
   performBatch: async (request, { audienceSettings, payload, statsContext }) => {
@@ -48,10 +45,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
       throw new IntegrationError('Bad Request: no audienceSettings found.', 'INVALID_REQUEST_DATA', 400)
     }
 
-    if (statsClient) {
-      statsContext?.statsClient?.incr('actions-tiktok-audiences.removeFromAudience', 1, statsTag)
-    }
-
+    statsClient?.incr('actions-tiktok-audiences.removeFromAudience', 1, statsTag)
     return processPayload(request, audienceSettings, payload, 'delete')
   }
 }

--- a/packages/destination-actions/src/destinations/tiktok-audiences/removeFromAudience/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/removeFromAudience/index.ts
@@ -1,0 +1,44 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings, AudienceSettings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { processPayload } from '../functions'
+import {
+  email,
+  send_email,
+  send_advertising_id,
+  advertising_id,
+  event_name,
+  enable_batching,
+  external_audience_id
+} from '../properties'
+import { IntegrationError } from '@segment/actions-core'
+
+const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
+  title: 'Remove from Audience',
+  description: 'Remove contacts from an Engage Audience to a TikTok Audience Segment.',
+  defaultSubscription: 'event = "Audience Exited"',
+  fields: {
+    email: { ...email },
+    advertising_id: { ...advertising_id },
+    send_email: { ...send_email },
+    send_advertising_id: { ...send_advertising_id },
+    event_name: { ...event_name },
+    enable_batching: { ...enable_batching },
+    external_audience_id: { ...external_audience_id }
+  },
+  perform: async (request, { audienceSettings, payload }) => {
+    if (!audienceSettings) {
+      throw new IntegrationError('Bad Request: no audienceSettings found.', 'INVALID_REQUEST_DATA', 400)
+    }
+    return processPayload(request, audienceSettings, [payload], 'delete')
+  },
+  performBatch: async (request, { audienceSettings, payload }) => {
+    if (!audienceSettings) {
+      throw new IntegrationError('Bad Request: no audienceSettings found.', 'INVALID_REQUEST_DATA', 400)
+    }
+
+    return processPayload(request, audienceSettings, payload, 'delete')
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/tiktok-audiences/removeFromAudience/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/removeFromAudience/index.ts
@@ -26,15 +26,30 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     enable_batching: { ...enable_batching },
     external_audience_id: { ...external_audience_id }
   },
-  perform: async (request, { audienceSettings, payload }) => {
+  perform: async (request, { audienceSettings, payload, statsContext }) => {
+    const statsClient = statsContext?.statsClient
+    const statsTag = statsContext?.tags
+
     if (!audienceSettings) {
       throw new IntegrationError('Bad Request: no audienceSettings found.', 'INVALID_REQUEST_DATA', 400)
     }
+
+    if (statsClient) {
+      statsContext?.statsClient?.incr('actions-tiktok-audiences.removeFromAudience', 1, statsTag)
+    }
+
     return processPayload(request, audienceSettings, [payload], 'delete')
   },
-  performBatch: async (request, { audienceSettings, payload }) => {
+  performBatch: async (request, { audienceSettings, payload, statsContext }) => {
+    const statsClient = statsContext?.statsClient
+    const statsTag = statsContext?.tags
+
     if (!audienceSettings) {
       throw new IntegrationError('Bad Request: no audienceSettings found.', 'INVALID_REQUEST_DATA', 400)
+    }
+
+    if (statsClient) {
+      statsContext?.statsClient?.incr('actions-tiktok-audiences.removeFromAudience', 1, statsTag)
     }
 
     return processPayload(request, audienceSettings, payload, 'delete')


### PR DESCRIPTION
This PR brings native support for removing records from a TikTok audience. It will be hidden in the UI by default until the feature is fully released. Flagon will allow us to support both legacy and new data flows.

**This PR is safe to merge as the action it adds will be hidden in the UI.**

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
