### PR TITLE
Stratconn 2975 full story web action

### DIFF
--- a/packages/browser-destinations/destinations/fullstory/src/__tests__/fullstory.test.ts
+++ b/packages/browser-destinations/destinations/fullstory/src/__tests__/fullstory.test.ts
@@ -202,4 +202,37 @@ describe('#identify', () => {
       'segment-browser-actions'
     )
   })
+
+  it('should set displayName correctly', async () => {
+    const [_, identifyUser] = await fullstory({
+      orgId: 'thefullstory.com',
+      subscriptions: example
+    })
+
+    await identifyUser.load(Context.system(), {} as Analytics)
+    const fs = jest.spyOn(window.FS, 'identify')
+
+    await identifyUser.identify?.(
+      new Context({
+        type: 'identify',
+        userId: 'userId',
+        traits: {
+          name: 'Hasbulla',
+          email: 'thegoat@world',
+          height: '50cm'
+        }
+      })
+    )
+
+    expect(fs).toHaveBeenCalledWith(
+      'userId',
+      {
+        displayName: 'Hasbulla',
+        email: 'thegoat@world',
+        height: '50cm',
+        name: 'Hasbulla'
+      },
+      'segment-browser-actions'
+    )
+  })
 })

--- a/packages/browser-destinations/destinations/fullstory/src/identifyUser/index.ts
+++ b/packages/browser-destinations/destinations/fullstory/src/identifyUser/index.ts
@@ -75,14 +75,16 @@ const action: BrowserActionDefinition<Settings, FS, Payload> = {
       newTraits.segmentAnonymousId_str = event.payload.anonymousId
     }
 
+    const userVars = {
+      ...newTraits,
+      ...(event.payload.email !== undefined && { email: event.payload.email }),
+      ...(event.payload.displayName !== undefined && { displayName: event.payload.displayName })
+    }
+
     if (event.payload.userId) {
-      FS.identify(event.payload.userId, newTraits, segmentEventSource)
+      FS.identify(event.payload.userId, userVars, segmentEventSource)
     } else {
-      FS.setUserVars({
-        ...newTraits,
-        ...(event.payload.email !== undefined && { email: event.payload.email }),
-        ...(event.payload.displayName !== undefined && { displayName: event.payload.displayName })
-      }, segmentEventSource)
+      FS.setUserVars(userVars, segmentEventSource)
     }
   }
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/user-data.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/user-data.test.ts
@@ -116,7 +116,7 @@ describe('FacebookConversionsApi', () => {
 
         expect(hashed_data.em).toEqual(undefined)
         expect(hashed_data.ph).toEqual('cf9b0227ee02d8f8f9dbb6060fa2941bb667efc71f6ee2e6ee17b40121a5f4a6')
-        expect(hashed_data.ge).toEqual('62c66a7a5dd70c3146618063c344e531e6d4b59e379808443ce962b3abd63c5a'),
+        expect(hashed_data.ge).toEqual('62c66a7a5dd70c3146618063c344e531e6d4b59e379808443ce962b3abd63c5a')
         expect(hashed_data.db).toEqual(undefined)
       })
     })


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

The `Fullstory (Actions)` destination contains the displayName fields which is not getting updated in FullStory when set up, and it uses a random [user ‘number’] in FS .  This issue has been resolve in this PR.

JIRA ticket link:- https://segment.atlassian.net/browse/STRATCONN-2975

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] [Segmenters] Tested in the staging environment

Screenshots:-

<img width="622" alt="Screenshot 2023-08-23 at 4 53 25 PM" src="https://github.com/segmentio/action-destinations/assets/117922634/e11cf27c-4cf2-406d-bd74-3b1b52f84d3c">


<img width="345" alt="Screenshot 2023-08-23 at 4 53 48 PM" src="https://github.com/segmentio/action-destinations/assets/117922634/0e66c70b-0b3d-40e3-9978-703fe1830d5b">
