### PR TITLE
[STRATCONN-3090] TikTok Audiences - Implement statsClient for create/get audience 

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-audiences/addUser/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addUser/index.ts
@@ -60,10 +60,12 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
   },
-  perform: async (request, { settings, payload }) => {
+  perform: async (request, { settings, payload, statsContext }) => {
+    statsContext?.statsClient?.incr('actions-tiktok-audiences.addUser', 1, statsContext?.tags)
     return processPayload(request, settings, [payload], 'add')
   },
-  performBatch: async (request, { settings, payload }) => {
+  performBatch: async (request, { settings, payload, statsContext }) => {
+    statsContext?.statsClient?.incr('actions-tiktok-audiences.addUser', 1, statsContext?.tags)
     return processPayload(request, settings, payload, 'add')
   }
 }

--- a/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
@@ -86,6 +86,8 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       const audienceName = createAudienceInput.audienceName
       const idType = createAudienceInput.audienceSettings?.idType
       const advertiserId = createAudienceInput.audienceSettings?.advertiserId
+      const statsClient = createAudienceInput?.statsContext?.statsClient
+      const statsTags = createAudienceInput?.statsContext?.tags
 
       if (!audienceName) {
         throw new IntegrationError('Missing audience name value', 'MISSING_REQUIRED_FIELD', 400)
@@ -107,21 +109,21 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
 
       const r = await response.json()
       if (r['message'] !== 'OK') {
-        // TODO: Add statsClient calls
-        // statsContext?.statsClient.incr('actions-tiktok-audiences.createAudience.native', 1, statsContext?.tags)
+        statsClient?.incr('actions-tiktok-audiences.createAudience.error', 1, statsTags)
         throw new IntegrationError('Invalid response from create audience request', 'INVALID_RESPONSE', 400)
       }
 
+      statsClient?.incr('actions-tiktok-audiences.createAudience.success', 1, statsTags)
       return {
         externalId: r.data['audience_id']
       }
     },
     async getAudience(request, getAudienceInput) {
-      // TODO: Add statsClient calls
-      // statsContext?.statsClient.incr('actions-tiktok-audiences.getAudience.native', 1, statsContext?.tags)
       const url = new URL(GET_AUDIENCE_URL)
       const audienceIds = [getAudienceInput.externalId]
       const advertiserId = getAudienceInput.audienceSettings?.advertiserId
+      const statsClient = getAudienceInput?.statsContext?.statsClient
+      const statsTags = getAudienceInput?.statsContext?.tags
 
       if (!advertiserId) {
         throw new IntegrationError(
@@ -144,6 +146,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
 
       const r = await response.json()
       if (r['message'] !== 'OK') {
+        statsClient?.incr('actions-tiktok-audiences.getAudience.error', 1, statsTags)
         throw new IntegrationError('Invalid response from get audience request', 'INVALID_RESPONSE', 400)
       }
 
@@ -157,6 +160,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         )
       }
 
+      statsClient?.incr('actions-tiktok-audiences.getAudience.success', 1, statsTags)
       return {
         externalId: externalId
       }

--- a/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/index.ts
@@ -59,10 +59,12 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
   },
-  perform: async (request, { settings, payload }) => {
+  perform: async (request, { settings, payload, statsContext }) => {
+    statsContext?.statsClient?.incr('actions-tiktok-audiences.removeUser', 1, statsContext?.tags)
     return processPayload(request, settings, [payload], 'delete')
   },
-  performBatch: async (request, { settings, payload }) => {
+  performBatch: async (request, { settings, payload, statsContext }) => {
+    statsContext?.statsClient?.incr('actions-tiktok-audiences.removeUser', 1, statsContext?.tags)
     return processPayload(request, settings, payload, 'delete')
   }
 }


### PR DESCRIPTION
This PR starts to use the statsClient in createAudience and getAudience for the TikTok Audiences destination. It also adds the client to the legacy actions in it.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
