### PR TITLE
TTD - Removed Merge Mode field

### DIFF
--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/functions.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/functions.ts
@@ -83,7 +83,7 @@ export async function processPayload(input: ProcessPayloadInput) {
       UsersFormatted: usersFormatted,
       DropOptions: {
         PiiType: input.payloads[0].pii_type,
-        MergeMode: input.payloads[0].merge_mode || 'Replace'
+        MergeMode: 'Replace'
       }
     })
   }
@@ -216,7 +216,7 @@ async function getCRMDataDropEndpoint(request: RequestClient, settings: Settings
       },
       json: {
         PiiType: payload.pii_type,
-        MergeMode: payload.merge_mode || 'Replace'
+        MergeMode: 'Replace'
       }
     }
   )

--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/syncAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/syncAudience/generated-types.ts
@@ -18,10 +18,6 @@ export interface Payload {
    */
   email?: string
   /**
-   * The merge mode to use when syncing data to The Trade Desk CRM Segment.
-   */
-  merge_mode?: string
-  /**
    * Enable batching of requests to The Trade Desk CRM Segment.
    */
   enable_batching?: boolean

--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/syncAudience/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { name, region, pii_type, email, enable_batching, event_name, batch_size, merge_mode } from '../properties'
+import { name, region, pii_type, email, enable_batching, event_name, batch_size } from '../properties'
 import { processPayload } from '../functions'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -13,7 +13,6 @@ const action: ActionDefinition<Settings, Payload> = {
     region: { ...region },
     pii_type: { ...pii_type },
     email: { ...email },
-    merge_mode: { ...merge_mode },
     enable_batching: { ...enable_batching },
     event_name: { ...event_name },
     batch_size: { ...batch_size }


### PR DESCRIPTION
This PR removes a non-required mapping field from The TradeDesk.
This destination is still in private beta and field is of type optional.

## Testing

Testing completed with unit tests.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
