### PR TITLE
Add Rupt integration (prev. Sabil)

### DIFF
--- a/packages/browser-destinations/destinations/rupt/README.md
+++ b/packages/browser-destinations/destinations/rupt/README.md
@@ -1,0 +1,31 @@
+# @segment/analytics-browser-actions-rupt
+
+The Rupt browser action destination for use with @segment/analytics-next.
+
+## License
+
+MIT License
+
+Copyright (c) 2023 Segment
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Contributing
+
+All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

--- a/packages/browser-destinations/destinations/rupt/package.json
+++ b/packages/browser-destinations/destinations/rupt/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@segment/analytics-browser-actions-rupt",
+  "version": "1.0.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/rupt"
+  },
+  "main": "./dist/cjs",
+  "module": "./dist/esm",
+  "scripts": {
+    "build": "yarn build:esm && yarn build:cjs",
+    "build:cjs": "tsc --module commonjs --outDir ./dist/cjs",
+    "build:esm": "tsc --outDir ./dist/esm"
+  },
+  "typings": "./dist/esm",
+  "dependencies": {
+    "@segment/browser-destination-runtime": "^1.4.0"
+  },
+  "peerDependencies": {
+    "@segment/analytics-next": "*"
+  }
+}

--- a/packages/browser-destinations/destinations/rupt/package.json
+++ b/packages/browser-destinations/destinations/rupt/package.json
@@ -16,7 +16,7 @@
   },
   "typings": "./dist/esm",
   "dependencies": {
-    "@segment/browser-destination-runtime": "^1.4.0"
+    "@segment/browser-destination-runtime": "^1.12.2"
   },
   "peerDependencies": {
     "@segment/analytics-next": "*"

--- a/packages/browser-destinations/destinations/rupt/src/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/rupt/src/__tests__/index.test.ts
@@ -1,0 +1,28 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import plugins, { destination } from '../index'
+
+describe('Rupt', () => {
+  it('should load Rupt script', async () => {
+    const [event] = await plugins({
+      client_id: '123',
+
+      subscriptions: [
+        {
+          enabled: true,
+          name: 'Attach Device',
+          subscribe: 'type = "page"',
+          partnerAction: 'attach',
+          mapping: {
+            metadata: { unitTest: 'true' }
+          }
+        }
+      ]
+    })
+
+    jest.spyOn(destination, 'initialize')
+
+    await event.load(Context.system(), {} as Analytics)
+    expect(destination.initialize).toHaveBeenCalled()
+    expect(window).toHaveProperty('Rupt')
+  })
+})

--- a/packages/browser-destinations/destinations/rupt/src/attach.types.ts
+++ b/packages/browser-destinations/destinations/rupt/src/attach.types.ts
@@ -1,0 +1,26 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The account to attach the device to.
+   */
+  account: string
+  /**
+   * The email of the user to attach the device to.
+   */
+  email?: string
+  /**
+   * The phone number of the user to attach the device to.
+   */
+  phone?: string
+  /**
+   * Metadata to attach to the device.
+   */
+  metadata?: {
+    [k: string]: unknown
+  }
+  /**
+   * Whether to include the page in the metadata.
+   */
+  include_page?: boolean
+}

--- a/packages/browser-destinations/destinations/rupt/src/attach/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/rupt/src/attach/__tests__/index.test.ts
@@ -1,0 +1,77 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import rupt from '../../index'
+
+describe('Rupt', () => {
+  it('should attach a device', async () => {
+    const TEST_USER_ID = 'segment-unit-test-user-id'
+    const TEST_USER_EMAIL = 'unit-test+segment@rupt.dev'
+    const TEST_USER_PHONE = '555-555-5555'
+    const TEST_METADATA = { url: 'https://segment.com', source: 'segment' }
+
+    const [event] = await rupt({
+      client_id: 'bf9ce83b-d44b-4da2-97df-1094decbdd56',
+
+      subscriptions: [
+        {
+          enabled: true,
+          name: 'Attach Device',
+          subscribe: 'type = "page"',
+          partnerAction: 'attach',
+          mapping: {
+            account: {
+              '@path': '$.userId'
+            },
+            email: {
+              '@if': {
+                exists: { '@path': '$.traits.email' },
+                then: { '@path': '$.traits.email' },
+                else: { '@path': '$.email' }
+              }
+            },
+            phone: {
+              '@if': {
+                exists: { '@path': '$.traits.phone' },
+                then: { '@path': '$.traits.phone' },
+                else: { '@path': '$.properties.phone' }
+              }
+            },
+            metadata: {
+              '@path': '$.properties.metadata'
+            }
+          }
+        }
+      ]
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+    const attach = jest.spyOn(window.Rupt, 'attach')
+    await event.page?.(
+      new Context({
+        type: 'page',
+        event: 'Page Viewed - test',
+        userId: TEST_USER_ID,
+        traits: {
+          email: TEST_USER_EMAIL
+        },
+        properties: {
+          phone: TEST_USER_PHONE,
+          metadata: TEST_METADATA
+        }
+      })
+    )
+    expect(attach).toHaveBeenCalledWith({
+      client_id: 'bf9ce83b-d44b-4da2-97df-1094decbdd56',
+      account: TEST_USER_ID,
+      email: TEST_USER_EMAIL,
+      phone: TEST_USER_PHONE,
+      metadata: TEST_METADATA,
+      include_page: undefined,
+      redirect_urls: {
+        logout_url: undefined,
+        new_account_url: undefined,
+        success_url: undefined,
+        suspended_url: undefined
+      }
+    })
+  })
+})

--- a/packages/browser-destinations/destinations/rupt/src/attach/generated-types.ts
+++ b/packages/browser-destinations/destinations/rupt/src/attach/generated-types.ts
@@ -1,0 +1,26 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The account to attach the device to.
+   */
+  account: string
+  /**
+   * The email of the user to attach the device to.
+   */
+  email?: string
+  /**
+   * The phone number of the user to attach the device to.
+   */
+  phone?: string
+  /**
+   * Metadata to attach to the device.
+   */
+  metadata?: {
+    [k: string]: unknown
+  }
+  /**
+   * Whether to include the page (url) in the attach request
+   */
+  include_page?: boolean
+}

--- a/packages/browser-destinations/destinations/rupt/src/attach/index.ts
+++ b/packages/browser-destinations/destinations/rupt/src/attach/index.ts
@@ -1,0 +1,81 @@
+import { BrowserActionDefinition } from '@segment/browser-destination-runtime/types'
+import { Payload } from 'src/attach.types'
+import { Settings } from 'src/generated-types'
+import Rupt from 'src/types'
+
+const attach: BrowserActionDefinition<Settings, Rupt, Payload> = {
+  title: 'Attach Device',
+  description: 'Attach a device to an account.',
+  defaultSubscription: 'type = "page"',
+  platform: 'web',
+  fields: {
+    account: {
+      description: 'The account to attach the device to.',
+      label: 'Account',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    email: {
+      description: 'The email of the user to attach the device to.',
+      label: 'Email',
+      type: 'string',
+      required: false,
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.email' },
+          then: { '@path': '$.traits.email' },
+          else: { '@path': '$.email' }
+        }
+      }
+    },
+    phone: {
+      description: 'The phone number of the user to attach the device to.',
+      label: 'Phone',
+      type: 'string',
+      required: false,
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.phone' },
+          then: { '@path': '$.traits.phone' },
+          else: { '@path': '$.properties.phone' }
+        }
+      }
+    },
+    metadata: {
+      description: 'Metadata to attach to the device.',
+      label: 'Metadata',
+      type: 'object',
+      required: false,
+      defaultObjectUI: 'keyvalue'
+    },
+    include_page: {
+      description: 'Whether to include the page (url) in the attach request',
+      label: 'Include Page',
+      type: 'boolean',
+      required: false
+    }
+  },
+  perform(rupt, data) {
+    console.log('attach', data)
+
+    rupt.attach({
+      client_id: data.settings.client_id,
+      account: data.payload.account,
+      email: data.payload.email,
+      phone: data.payload.phone,
+      metadata: data.payload.metadata,
+      include_page: data.payload.include_page,
+      redirect_urls: {
+        new_account_url: data.settings.new_account_url,
+        success_url: data.settings.success_url,
+        suspended_url: data.settings.suspended_url,
+        logout_url: data.settings.logout_url
+      }
+    })
+  }
+}
+
+export default attach

--- a/packages/browser-destinations/destinations/rupt/src/attach/index.ts
+++ b/packages/browser-destinations/destinations/rupt/src/attach/index.ts
@@ -25,9 +25,9 @@ const attach: BrowserActionDefinition<Settings, Rupt, Payload> = {
       required: false,
       default: {
         '@if': {
-          exists: { '@path': '$.traits.email' },
-          then: { '@path': '$.traits.email' },
-          else: { '@path': '$.email' }
+          exists: { '@path': '$.context.traits.email' },
+          then: { '@path': '$.context.traits.email' },
+          else: { '@path': '$.properties.email' }
         }
       }
     },
@@ -38,8 +38,8 @@ const attach: BrowserActionDefinition<Settings, Rupt, Payload> = {
       required: false,
       default: {
         '@if': {
-          exists: { '@path': '$.traits.phone' },
-          then: { '@path': '$.traits.phone' },
+          exists: { '@path': '$.context.traits.phone' },
+          then: { '@path': '$.context.traits.phone' },
           else: { '@path': '$.properties.phone' }
         }
       }
@@ -59,8 +59,6 @@ const attach: BrowserActionDefinition<Settings, Rupt, Payload> = {
     }
   },
   perform(rupt, data) {
-    console.log('attach', data)
-
     rupt.attach({
       client_id: data.settings.client_id,
       account: data.payload.account,

--- a/packages/browser-destinations/destinations/rupt/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/rupt/src/generated-types.ts
@@ -1,0 +1,24 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * The API client id of your Rupt project.
+   */
+  client_id: string
+  /**
+   * A URL to redirect the user to if they want to stop account sharing and create a new account.
+   */
+  new_account_url: string
+  /**
+   * A URL to redirect the user to if they choose to logout or if they are kicked out by a verified owner.
+   */
+  logout_url?: string
+  /**
+   * A URL to redirect the user to if they are successfully verified and are within the device limit.
+   */
+  success_url?: string
+  /**
+   * A URL to redirect the user to if they are suspended.
+   */
+  suspended_url?: string
+}

--- a/packages/browser-destinations/destinations/rupt/src/index.ts
+++ b/packages/browser-destinations/destinations/rupt/src/index.ts
@@ -1,0 +1,78 @@
+import { defaultValues, DestinationDefinition } from '@segment/actions-core'
+import { browserDestination } from '@segment/browser-destination-runtime/shim'
+import type { BrowserDestinationDefinition } from '@segment/browser-destination-runtime/types'
+import attach from './attach'
+import type { Settings } from './generated-types'
+import Rupt from './types'
+
+declare global {
+  interface Window {
+    Rupt: Rupt
+  }
+}
+
+const presets: DestinationDefinition['presets'] = [
+  {
+    name: 'Attach Device',
+    subscribe: "type = 'page'",
+    partnerAction: 'attach',
+    mapping: defaultValues(attach.fields),
+    type: 'automatic'
+  }
+]
+export const destination: BrowserDestinationDefinition<Settings, Rupt> = {
+  name: 'Rupt',
+  slug: 'actions-rupt',
+  mode: 'device',
+
+  presets,
+
+  settings: {
+    client_id: {
+      description: 'The API client id of your Rupt project.',
+      label: 'Client ID',
+      type: 'string',
+      required: true
+    },
+    new_account_url: {
+      description: 'A URL to redirect the user to if they want to stop account sharing and create a new account.',
+      label: 'New Account URL',
+      type: 'string',
+      required: true
+    },
+    logout_url: {
+      description:
+        'A URL to redirect the user to if they choose to logout or if they are kicked out by a verified owner.',
+      label: 'Logout URL',
+      type: 'string',
+      required: false
+    },
+    success_url: {
+      description: 'A URL to redirect the user to if they are successfully verified and are within the device limit.',
+      label: 'Success URL',
+      type: 'string',
+      required: false
+    },
+    suspended_url: {
+      description: 'A URL to redirect the user to if they are suspended.',
+      label: 'Suspended URL',
+      type: 'string',
+      required: false
+    }
+  },
+
+  initialize: async (_, deps) => {
+    try {
+      await deps.loadScript('https://cdn.rupt.dev/js/rupt.js')
+      await deps.resolveWhen(() => Object.prototype.hasOwnProperty.call(window, 'Rupt'), 500)
+      return window.Rupt
+    } catch (error) {
+      throw new Error('Failed to load Rupt. ' + error)
+    }
+  },
+  actions: {
+    attach
+  }
+}
+
+export default browserDestination(destination)

--- a/packages/browser-destinations/destinations/rupt/src/index.ts
+++ b/packages/browser-destinations/destinations/rupt/src/index.ts
@@ -41,8 +41,7 @@ export const destination: BrowserDestinationDefinition<Settings, Rupt> = {
       required: true
     },
     logout_url: {
-      description:
-        'A URL to redirect the user to if they choose to logout or if they are kicked out by a verified owner.',
+      description: 'A URL to redirect the user to if they choose to logout or if they are removed by a verified owner.',
       label: 'Logout URL',
       type: 'string',
       required: false

--- a/packages/browser-destinations/destinations/rupt/src/types.ts
+++ b/packages/browser-destinations/destinations/rupt/src/types.ts
@@ -1,0 +1,76 @@
+interface Redirects {
+  logout_url?: string
+  new_account_url: string
+  success_url?: string
+  suspended_url?: string
+}
+
+interface DetachConfig {
+  client_id: string
+  secret?: string
+  device: string
+  account?: string
+  domain?: string
+}
+export interface LimitConfig {
+  /**
+   * @description The maximum devices that can be attached to a single account.
+   */
+  overall_device_limit?: number
+  /**
+   * @description The number of people allowed to use the same account. This is useful for family plans. If Rupt detects more than this number of people using the same account (even if not using at the same time), it will trigger the on_limit_exceeded callback.
+   */
+  people_limit?: number
+}
+
+export interface AttachResponse {
+  success: boolean
+  attached_devices: number
+  device_id: string
+  default_device_limit: number
+  block_over_usage: boolean
+  suspended?: boolean
+  access: string
+  identity: string
+}
+
+export interface AttachConfig {
+  client_id: string
+  secret?: string
+  account: string
+  email?: string
+  phone?: string
+  metadata?: object
+  debug?: boolean
+  identity?: string
+  include_page?: boolean
+  limit_config?: LimitConfig
+  redirect_urls?: Redirects
+  on_challenge?: () => boolean
+  on_limit_exceeded?: () => void
+  domain?: string
+}
+
+type attach = ({
+  client_id,
+  secret,
+  account,
+  email,
+  phone,
+  metadata,
+  debug,
+  identity,
+  include_page,
+  domain,
+  limit_config,
+  redirect_urls,
+  on_challenge,
+  on_limit_exceeded
+}: AttachConfig) => Promise<AttachResponse | null>
+
+type detach = ({ device, account, client_id, secret, domain }: DetachConfig) => Promise<any>
+
+export default interface Rupt {
+  attach: attach
+  detach: detach
+}

--- a/packages/browser-destinations/destinations/rupt/tsconfig.json
+++ b/packages/browser-destinations/destinations/rupt/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "baseUrl": "."
+  },
+  "include": ["src"],
+  "exclude": ["dist", "**/__tests__"]
+}


### PR DESCRIPTION
Added Rupt integration [https://rupt.dev](https://rupt.dev). Already had a valid integration under Sabil. But took that down because of a name and domain change.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment -- Not doable by Rupt :)
