### PR TITLE
Fix handling of errors salesforce bulk updates

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/lead/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/index.ts
@@ -163,7 +163,7 @@ const action: ActionDefinition<Settings, Payload> = {
       return await sf.deleteRecord(payload, OBJECT_NAME)
     }
   },
-  performBatch: async (request, { settings, payload }) => {
+  performBatch: async (request, { settings, payload, statsContext }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)
 
     if (payload[0].operation === 'upsert') {
@@ -172,7 +172,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
 
-    return sf.bulkHandler(payload, OBJECT_NAME)
+    return sf.bulkHandler(payload, OBJECT_NAME, statsContext)
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/lead/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/index.ts
@@ -163,7 +163,7 @@ const action: ActionDefinition<Settings, Payload> = {
       return await sf.deleteRecord(payload, OBJECT_NAME)
     }
   },
-  performBatch: async (request, { settings, payload, statsContext }) => {
+  performBatch: async (request, { settings, payload }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, request)
 
     if (payload[0].operation === 'upsert') {
@@ -172,7 +172,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
 
-    return sf.bulkHandler(payload, OBJECT_NAME, statsContext)
+    return sf.bulkHandler(payload, OBJECT_NAME)
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
@@ -143,7 +143,7 @@ export default class Salesforce {
     return await this.baseDelete(recordId, sobject)
   }
 
-  bulkHandler = async (payloads: GenericPayload[], sobject: string, statsContext: StatsContext) => {
+  bulkHandler = async (payloads: GenericPayload[], sobject: string, statsContext?: StatsContext) => {
     if (!payloads[0].enable_batching) {
       throwBulkMismatchError()
     }
@@ -203,7 +203,7 @@ export default class Salesforce {
     }
   }
 
-  private bulkUpsert = async (payloads: GenericPayload[], sobject: string, statsContext: StatsContext) => {
+  private bulkUpsert = async (payloads: GenericPayload[], sobject: string, statsContext?: StatsContext) => {
     if (
       !payloads[0].bulkUpsertExternalId ||
       !payloads[0].bulkUpsertExternalId.externalIdName ||
@@ -219,7 +219,7 @@ export default class Salesforce {
     return this.handleBulkJob(payloads, sobject, externalIdFieldName, 'upsert', statsContext)
   }
 
-  private bulkUpdate = async (payloads: GenericPayload[], sobject: string, statsContext: StatsContext) => {
+  private bulkUpdate = async (payloads: GenericPayload[], sobject: string, statsContext?: StatsContext) => {
     if (!payloads[0].bulkUpdateRecordId) {
       throw new IntegrationError(
         'Undefined bulkUpdateRecordId when using bulkUpdate operation',
@@ -236,7 +236,7 @@ export default class Salesforce {
     sobject: string,
     idField: string,
     operation: string,
-    statsContext: StatsContext
+    statsContext?: StatsContext
   ): Promise<ModifiedResponse<unknown>> {
     // construct the CSV data to catch errors before creating a bulk job
     const csv = buildCSVData(payloads, idField)
@@ -263,7 +263,7 @@ export default class Salesforce {
     sobject: string,
     externalIdFieldName: string,
     operation: string,
-    statsContext: StatsContext
+    statsContext?: StatsContext
   ) => {
     const res = await this.request<CreateJobResponseData>(
       `${this.instanceUrl}services/data/${API_VERSION}/jobs/ingest`,

--- a/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
@@ -3,6 +3,7 @@ import type { GenericPayload } from './sf-types'
 import { mapObjectToShape } from './sf-object-to-shape'
 import { buildCSVData, validateInstanceURL } from './sf-utils'
 import { DynamicFieldResponse } from '@segment/actions-core'
+import { StatsContext } from '@segment/actions-core/destination-kit'
 
 export const API_VERSION = 'v53.0'
 
@@ -142,15 +143,15 @@ export default class Salesforce {
     return await this.baseDelete(recordId, sobject)
   }
 
-  bulkHandler = async (payloads: GenericPayload[], sobject: string) => {
+  bulkHandler = async (payloads: GenericPayload[], sobject: string, statsContext: StatsContext) => {
     if (!payloads[0].enable_batching) {
       throwBulkMismatchError()
     }
 
     if (payloads[0].operation === 'upsert') {
-      return await this.bulkUpsert(payloads, sobject)
+      return await this.bulkUpsert(payloads, sobject, statsContext)
     } else if (payloads[0].operation === 'update') {
-      return await this.bulkUpdate(payloads, sobject)
+      return await this.bulkUpdate(payloads, sobject, statsContext)
     }
 
     if (payloads[0].operation === 'delete') {
@@ -202,7 +203,7 @@ export default class Salesforce {
     }
   }
 
-  private bulkUpsert = async (payloads: GenericPayload[], sobject: string) => {
+  private bulkUpsert = async (payloads: GenericPayload[], sobject: string, statsContext: StatsContext) => {
     if (
       !payloads[0].bulkUpsertExternalId ||
       !payloads[0].bulkUpsertExternalId.externalIdName ||
@@ -215,10 +216,10 @@ export default class Salesforce {
       )
     }
     const externalIdFieldName = payloads[0].bulkUpsertExternalId.externalIdName
-    return this.handleBulkJob(payloads, sobject, externalIdFieldName, 'upsert')
+    return this.handleBulkJob(payloads, sobject, externalIdFieldName, 'upsert', statsContext)
   }
 
-  private bulkUpdate = async (payloads: GenericPayload[], sobject: string) => {
+  private bulkUpdate = async (payloads: GenericPayload[], sobject: string, statsContext: StatsContext) => {
     if (!payloads[0].bulkUpdateRecordId) {
       throw new IntegrationError(
         'Undefined bulkUpdateRecordId when using bulkUpdate operation',
@@ -227,18 +228,19 @@ export default class Salesforce {
       )
     }
 
-    return this.handleBulkJob(payloads, sobject, 'Id', 'update')
+    return this.handleBulkJob(payloads, sobject, 'Id', 'update', statsContext)
   }
 
   private async handleBulkJob(
     payloads: GenericPayload[],
     sobject: string,
     idField: string,
-    operation: string
+    operation: string,
+    statsContext: StatsContext
   ): Promise<ModifiedResponse<unknown>> {
     // construct the CSV data to catch errors before creating a bulk job
     const csv = buildCSVData(payloads, idField)
-    const jobId = await this.createBulkJob(sobject, idField, operation)
+    const jobId = await this.createBulkJob(sobject, idField, operation, statsContext)
     try {
       await this.uploadBulkCSV(jobId, csv)
     } catch (err) {
@@ -247,15 +249,22 @@ export default class Salesforce {
       //
       // run in background to ensure this service has time to respond
       // with useful information before the connection closes.
+      statsContext?.statsClient.incr('sf_bulk_job_closed_timedout', 1, statsContext.tags)
       this.closeBulkJob(jobId).catch((_) => {
         // ignore close error to avoid masking the root error
       })
       throw err
     }
+    statsContext?.statsClient.incr('sf_bulk_job_closed_successfully', 1, statsContext.tags)
     return await this.closeBulkJob(jobId)
   }
 
-  private createBulkJob = async (sobject: string, externalIdFieldName: string, operation: string) => {
+  private createBulkJob = async (
+    sobject: string,
+    externalIdFieldName: string,
+    operation: string,
+    statsContext: StatsContext
+  ) => {
     const res = await this.request<CreateJobResponseData>(
       `${this.instanceUrl}services/data/${API_VERSION}/jobs/ingest`,
       {
@@ -273,6 +282,7 @@ export default class Salesforce {
       throw new IntegrationError('Failed to create bulk job', 'Failed to create bulk job', 500)
     }
 
+    statsContext?.statsClient.incr('sf_bulk_job_created', 1, statsContext.tags)
     return res.data.id
   }
 

--- a/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
@@ -12,7 +12,8 @@ const isSettingsKey = new Set<string>([
   'bulkUpsertExternalId',
   'bulkUpdateRecordId',
   'recordMatcherOperator',
-  'customObjectName'
+  'customObjectName',
+  'batch_size'
 ])
 
 const NO_VALUE = `#N/A`

--- a/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
@@ -111,17 +111,13 @@ const buildCSVFromHeaderMap = (
 
   for (let i = 0; i < n; i++) {
     let row = ''
-    for (const [key, _] of headerMap.entries()) {
+    for (const column of headerMap.values()) {
       let noValueFound = true
-      if (headerMap.has(key)) {
-        const column = headerMap.get(key) as [[CSVData, number]]
-
-        if (column !== undefined && column.length > 0 && column[column.length - 1][1] === i) {
-          const valueTuple = column.pop()
-          if (valueTuple !== undefined && valueTuple[0] !== undefined && valueTuple[0] !== null) {
-            row += `"${escapeDoubleQuotes(valueTuple[0])}",`
-            noValueFound = false
-          }
+      if (column != null && column.length > 0 && column[column.length - 1][1] === i) {
+        const valueTuple = column.pop()
+        if (valueTuple != null && valueTuple[0] != null) {
+          row += `"${escapeDoubleQuotes(valueTuple[0])}",`
+          noValueFound = false
         }
       }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

When a Saleforce bulk upload request times out, the "bulk job" is left open, leaving job stuck in "in progress" from our customer's perspective. This change ensures we do a better job of closing the batch whenever we open it.

## Testing

Tested successfully in stage by sending several million events through Salesforce Bulk until timeouts occurred. Tracked those bulk job closures with:
* `sf_bulk_job_closed_timedout`
* `sf_bulk_job_closed_successfully`
* `sf_bulk_job_created`

Timeouts firing:
<img width="1568" alt="Screenshot 2023-08-30 at 8 17 22 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/e8800955-1544-460d-a0a1-dfdbda3e2fdd">

All jobs triggered during test (August 30) closed. The jobs seen open here are from before this fix was deployed.
<img width="1629" alt="Screenshot 2023-08-30 at 8 17 49 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/b537cf6b-2362-4a97-8b6e-02c365ac1689">

Link to datadog notebook with stats:
https://segment.datadoghq.com/notebook/6405536/nicholas-aug-30-2023-18-35?range=14400000&view=view-mode&start=1693437953021&live=false 

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
