### PR TITLE
[The Trade Desk] Hide batching fields

### DIFF
--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/properties.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/properties.ts
@@ -34,17 +34,17 @@ export const email: InputField = {
   default: {
     '@path': '$.context.traits.email'
   },
-  readOnly: true
+  unsafe_hidden: true
 }
 
 export const event_name: InputField = {
   label: 'Event Name',
   description: 'The name of the current Segment event.',
-  type: 'hidden',
+  type: 'string',
   default: {
     '@path': '$.event'
   },
-  readOnly: true
+  unsafe_hidden: true
 }
 
 export const enable_batching: InputField = {

--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/properties.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/properties.ts
@@ -30,26 +30,29 @@ export const pii_type: InputField = {
 export const email: InputField = {
   label: 'User Email',
   description: "The user's email address to send to The Trade Desk.",
-  type: 'hidden', // This field is hidden from customers because the desired value always appears at path '$.context.traits.email' in Personas events.
+  type: 'string',
   default: {
     '@path': '$.context.traits.email'
-  }
+  },
+  readOnly: true
 }
 
 export const event_name: InputField = {
   label: 'Event Name',
   description: 'The name of the current Segment event.',
-  type: 'hidden', // This field is hidden from customers because the desired value always appears at path '$.event' in Personas events.
+  type: 'hidden',
   default: {
     '@path': '$.event'
-  }
+  },
+  readOnly: true
 }
 
 export const enable_batching: InputField = {
   label: 'Enable Batching',
   description: 'Enable batching of requests to The Trade Desk CRM Segment.',
   type: 'boolean',
-  default: true
+  default: true,
+  unsafe_hidden: true
 }
 
 export const batch_size: InputField = {
@@ -57,7 +60,8 @@ export const batch_size: InputField = {
   description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
   type: 'number',
   required: false,
-  default: 100000
+  default: 100000,
+  unsafe_hidden: true
 }
 
 export const merge_mode: InputField = {
@@ -75,5 +79,6 @@ export const merge_mode: InputField = {
     }
   ],
   default: 'Replace',
-  required: false
+  required: false,
+  unsafe_hidden: true
 }

--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/properties.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/properties.ts
@@ -63,22 +63,3 @@ export const batch_size: InputField = {
   default: 100000,
   unsafe_hidden: true
 }
-
-export const merge_mode: InputField = {
-  label: 'Merge Mode',
-  description: 'The merge mode to use when syncing data to The Trade Desk CRM Segment.',
-  type: 'string',
-  choices: [
-    {
-      label: 'Add',
-      value: 'Add'
-    },
-    {
-      label: 'Replace',
-      value: 'Replace'
-    }
-  ],
-  default: 'Replace',
-  required: false,
-  unsafe_hidden: true
-}


### PR DESCRIPTION
This PR is to make some fields in TTD read_only and hidden as they should not be edited by customers.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

BEFORE
![Screenshot 2023-08-28 at 4 41 26 PM](https://github.com/segmentio/action-destinations/assets/99763167/adb94215-6872-4471-ab63-0916b559287a)


AFTER
![Screenshot 2023-08-28 at 4 51 15 PM](https://github.com/segmentio/action-destinations/assets/99763167/a5093a6b-df32-4f1a-ad42-6948600d957d)



- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
