### PR TITLE
Install necessary dep yet exclude  other optional deps

### DIFF
--- a/.github/workflows/ext.yml
+++ b/.github/workflows/ext.yml
@@ -24,7 +24,7 @@ jobs:
           cache: yarn
 
       - name: Install
-        run: yarn add -W @nx/nx-linux-x64-gnu && yarn install --frozen-lockfile --ignore-optional
+        run: yarn install --frozen-lockfile --ignore-optional --ignore-scripts
 
       - name: Bootstrap
         run: yarn bootstrap --no-ci

--- a/.github/workflows/ext.yml
+++ b/.github/workflows/ext.yml
@@ -24,7 +24,7 @@ jobs:
           cache: yarn
 
       - name: Install
-        run: yarn install --frozen-lockfile
+        run: yarn add -W @nx/nx-linux-x64-gnu && yarn install --frozen-lockfile --ignore-optional
 
       - name: Bootstrap
         run: yarn bootstrap --no-ci


### PR DESCRIPTION
One of the optional deps is referenced by a post-install script, but we must also ignore other optional deps to preserve the integrity of the test