### PR TITLE
Fix crash when 'personas' missing in event context

### DIFF
--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -289,7 +289,7 @@ function setupRoutes(def: DestinationDefinition | null): void {
           const eventParams = {
             data: req.body.payload || {},
             settings: req.body.settings || {},
-            audienceSettings: req.body.payload.context.personas.audience_settings || {},
+            audienceSettings: req.body.payload.context.personas?.audience_settings || {},
             mapping: mapping || req.body.payload || {},
             auth: req.body.auth || {}
           }


### PR DESCRIPTION
This PR fixes a crash trying to access the `audience_settings` field, when `context.personas` doesn't exist, which is the case for the generated test events.

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
