### PR TITLE
Prevent Sentry from getting unhandled HTTP errors

### DIFF
--- a/packages/destination-actions/src/destinations/webhook-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/webhook-audiences/index.ts
@@ -60,8 +60,13 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         }
       })
 
-      const jsonOutput = await response.json()
-      if (!jsonOutput[externalIdKey]) {
+      try {
+        const jsonOutput = await response.json()
+
+        if (!jsonOutput[externalIdKey]) {
+          throw new IntegrationError(`Missing ${externalIdKey} in response`, 'INVALID_RESPONSE', 400)
+        }
+      } catch {
         throw new IntegrationError('Invalid response from get audience request', 'INVALID_RESPONSE', 400)
       }
 

--- a/packages/destination-actions/src/destinations/webhook-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/webhook-audiences/index.ts
@@ -60,8 +60,10 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         }
       })
 
+      let jsonOutput
+
       try {
-        const jsonOutput = await response.json()
+        jsonOutput = await response.json()
 
         if (!jsonOutput[externalIdKey]) {
           throw new IntegrationError(`Missing ${externalIdKey} in response`, 'INVALID_RESPONSE', 400)


### PR DESCRIPTION
`const response = await request(getAudienceUrl, ... )` is failing and it's not being handled properly. By wrapping it up in a try/catch block we ensure that it's handled as an `IntegrationError` and not reported to Sentry.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
