### PR TITLE
Plugin.ready now returns correct promise

### DIFF
--- a/packages/browser-destination-runtime/src/__tests__/plugin.test.ts
+++ b/packages/browser-destination-runtime/src/__tests__/plugin.test.ts
@@ -2,6 +2,10 @@ import { BrowserDestinationDefinition } from '../types'
 import { generatePlugins } from '../plugin'
 
 describe('generatePlugins', () => {
+  let useInitializeLock = false
+  let releaseInitializeLock: () => void
+  const initializeLock = () =>
+    useInitializeLock ? new Promise<void>((res) => (releaseInitializeLock = res)) : Promise.resolve()
   const initializeSpy = jest.fn()
   const destinationDefinition: BrowserDestinationDefinition<{}, unknown> = {
     name: 'Test destination',
@@ -9,6 +13,7 @@ describe('generatePlugins', () => {
     mode: 'device',
     settings: {},
     initialize: async () => {
+      await initializeLock()
       initializeSpy()
     },
     actions: {
@@ -31,32 +36,63 @@ describe('generatePlugins', () => {
     }
   }
 
+  const defaultSubscriptions = [
+    {
+      enabled: true,
+      mapping: {},
+      name: 'a',
+      partnerAction: 'trackEventA',
+      subscribe: 'type = "track"'
+    },
+    {
+      enabled: true,
+      mapping: {},
+      name: 'b',
+      partnerAction: 'trackEventB',
+      subscribe: 'type = "track"'
+    }
+  ]
+
   beforeEach(() => {
     jest.resetAllMocks()
+    useInitializeLock = false
   })
 
   test('only loads once', async () => {
-    const plugins = generatePlugins(destinationDefinition, {}, [
-      {
-        enabled: true,
-        mapping: {},
-        name: 'a',
-        partnerAction: 'trackEventA',
-        subscribe: 'type = "track"'
-      },
-      {
-        enabled: true,
-        mapping: {},
-        name: 'b',
-        partnerAction: 'trackEventB',
-        subscribe: 'type = "track"'
-      }
-    ])
+    const plugins = generatePlugins(destinationDefinition, {}, defaultSubscriptions)
 
     expect(plugins.length).toBe(2)
 
     await Promise.all(plugins.map((p) => p.load({} as any, {} as any)))
 
     expect(initializeSpy).toHaveBeenCalledTimes(1)
+  })
+
+  test('promise returned by ready can be awaited even before calling load, it resolves when done', async () => {
+    const plugins = generatePlugins(destinationDefinition, {}, defaultSubscriptions)
+
+    useInitializeLock = true
+    let readyResolved = false
+
+    // tap into promise returned by ready - even before load executes
+    plugins[0].ready?.().then(() => (readyResolved = true))
+
+    expect(readyResolved).toBe(false)
+
+    // trigger the load
+    const loadP = plugins[0].load({} as any, {} as any).catch(() => {})
+
+    // wait some time
+    await new Promise((res) => setTimeout(res, 1000))
+
+    // still nothing
+    expect(readyResolved).toBe(false)
+
+    // release the blocker
+    releaseInitializeLock()
+    await loadP
+
+    // all clear now
+    expect(readyResolved).toBe(true)
   })
 })


### PR DESCRIPTION
Previously Plugin.ready would simply return Promise.resolve() just so the "waterfall" like flow of analytics and other compoenents won't come hold up, potentially indefintely.

However, the recent architecture changes to ajs where destinations are loaded in lazy mode require ready to report their real readiness status since indefinite hold up is no longer a concern.

This change to Plugin.ready has been unanimously discussed across Pooya Jaferian, Oscar Bazaldua, Seth Silesky
