### PR TITLE
[STRATCONN-2850] [Segment] Return transformed payload from all actions

### DIFF
--- a/packages/destination-actions/src/destinations/segment/properties.ts
+++ b/packages/destination-actions/src/destinations/segment/properties.ts
@@ -7,7 +7,7 @@ interface SegmentEndpoint {
 export const SEGMENT_ENDPOINTS: { [key: string]: SegmentEndpoint } = {
   north_america: {
     label: 'North America',
-    url: 'https://api.segment.io/v1',
+    url: 'https://api.segment.com/v1',
     cdn: 'https://cdn.segment.com/v1'
   },
   europe: {

--- a/packages/destination-actions/src/destinations/segment/properties.ts
+++ b/packages/destination-actions/src/destinations/segment/properties.ts
@@ -7,7 +7,7 @@ interface SegmentEndpoint {
 export const SEGMENT_ENDPOINTS: { [key: string]: SegmentEndpoint } = {
   north_america: {
     label: 'North America',
-    url: 'https://api.segment.com/v1',
+    url: 'https://api.segment.io/v1',
     cdn: 'https://cdn.segment.com/v1'
   },
   europe: {

--- a/packages/destination-actions/src/destinations/segment/sendGroup/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment/sendGroup/__tests__/index.test.ts
@@ -105,4 +105,45 @@ describe('Segment.sendGroup', () => {
       context: {}
     })
   })
+
+  test('Should not send event if actions-segment-tapi-internal flag is enabled', async () => {
+    const event = createTestEvent({
+      traits: {
+        name: 'Example Corp',
+        industry: 'Technology'
+      },
+      userId: 'test-user-ufi5bgkko5',
+      anonymousId: 'arky4h2sh7k',
+      groupId: 'test-group-ks2i7e'
+    })
+
+    const responses = await testDestination.testAction('sendGroup', {
+      event,
+      mapping: defaultGroupMapping,
+      settings: {
+        source_write_key: 'test-source-write-key',
+        endpoint: DEFAULT_SEGMENT_ENDPOINT
+      },
+      features: {
+        'actions-segment-tapi-internal': true
+      }
+    })
+
+    const results = testDestination.results
+    expect(responses.length).toBe(0)
+    expect(results.length).toBe(3)
+    expect(results[2].data).toMatchObject({
+      batch: [
+        {
+          userId: event.userId,
+          anonymousId: event.anonymousId,
+          groupId: event.groupId,
+          traits: {
+            ...event.traits
+          },
+          context: {}
+        }
+      ]
+    })
+  })
 })

--- a/packages/destination-actions/src/destinations/segment/sendGroup/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendGroup/index.ts
@@ -46,7 +46,7 @@ const action: ActionDefinition<Settings, Payload> = {
     timezone,
     traits
   },
-  perform: (request, { payload, settings }) => {
+  perform: (request, { payload, settings, features }) => {
     if (!payload.anonymous_id && !payload.user_id) {
       throw MissingUserOrAnonymousIdThrowableError
     }
@@ -78,6 +78,11 @@ const action: ActionDefinition<Settings, Payload> = {
     // Throw an error if endpoint is not defined or invalid
     if (!settings.endpoint || !(settings.endpoint in SEGMENT_ENDPOINTS)) {
       throw InvalidEndpointSelectedThrowableError
+    }
+
+    if (features && features['actions-segment-tapi-internal']) {
+      const payload = { ...groupPayload, type: 'group' }
+      return { batch: [payload] }
     }
 
     const selectedSegmentEndpoint = SEGMENT_ENDPOINTS[settings.endpoint].url

--- a/packages/destination-actions/src/destinations/segment/sendIdentify/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment/sendIdentify/__tests__/index.test.ts
@@ -97,4 +97,44 @@ describe('Segment.sendIdentify', () => {
       context: {}
     })
   })
+
+  test('Should not send event if actions-segment-tapi-internal flag is enabled', async () => {
+    const event = createTestEvent({
+      type: 'identify',
+      traits: {
+        name: 'Test User',
+        email: 'test-user@test-company.com'
+      },
+      userId: 'test-user-ufi5bgkko5',
+      anonymousId: 'arky4h2sh7k'
+    })
+
+    const responses = await testDestination.testAction('sendIdentify', {
+      event,
+      mapping: defaultIdentifyMapping,
+      settings: {
+        source_write_key: 'test-source-write-key',
+        endpoint: DEFAULT_SEGMENT_ENDPOINT
+      },
+      features: {
+        'actions-segment-tapi-internal': true
+      }
+    })
+
+    const results = testDestination.results
+    expect(responses.length).toBe(0)
+    expect(results.length).toBe(3)
+    expect(results[2].data).toMatchObject({
+      batch: [
+        {
+          userId: event.userId,
+          anonymousId: event.anonymousId,
+          traits: {
+            ...event.traits
+          },
+          context: {}
+        }
+      ]
+    })
+  })
 })

--- a/packages/destination-actions/src/destinations/segment/sendIdentify/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendIdentify/index.ts
@@ -47,7 +47,7 @@ const action: ActionDefinition<Settings, Payload> = {
     group_id,
     traits
   },
-  perform: (request, { payload, settings }) => {
+  perform: (request, { payload, settings, features }) => {
     if (!payload.anonymous_id && !payload.user_id) {
       throw MissingUserOrAnonymousIdThrowableError
     }
@@ -80,6 +80,12 @@ const action: ActionDefinition<Settings, Payload> = {
     if (!settings.endpoint || !(settings.endpoint in SEGMENT_ENDPOINTS)) {
       throw InvalidEndpointSelectedThrowableError
     }
+
+    if (features && features['actions-segment-tapi-internal']) {
+      const payload = { ...identifyPayload, type: 'identify' }
+      return { batch: [payload] }
+    }
+
     const selectedSegmentEndpoint = SEGMENT_ENDPOINTS[settings.endpoint].url
 
     return request(`${selectedSegmentEndpoint}/identify`, {

--- a/packages/destination-actions/src/destinations/segment/sendPage/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment/sendPage/__tests__/index.test.ts
@@ -100,4 +100,45 @@ describe('Segment.sendPage', () => {
       context: {}
     })
   })
+
+  test('Should not send event if actions-segment-tapi-internal flag is enabled', async () => {
+    const event = createTestEvent({
+      name: 'Home',
+      properties: {
+        title: 'Home | Example Company',
+        url: 'http://www.example.com'
+      },
+      userId: 'test-user-ufi5bgkko5',
+      anonymousId: 'arky4h2sh7k'
+    })
+
+    const responses = await testDestination.testAction('sendPage', {
+      event,
+      mapping: defaultPageMapping,
+      settings: {
+        source_write_key: 'test-source-write-key',
+        endpoint: DEFAULT_SEGMENT_ENDPOINT
+      },
+      features: {
+        'actions-segment-tapi-internal': true
+      }
+    })
+
+    const results = testDestination.results
+    expect(responses.length).toBe(0)
+    expect(results.length).toBe(3)
+    expect(results[2].data).toMatchObject({
+      batch: [
+        {
+          userId: event.userId,
+          anonymousId: event.anonymousId,
+          properties: {
+            name: event.name,
+            ...event.properties
+          },
+          context: {}
+        }
+      ]
+    })
+  })
 })

--- a/packages/destination-actions/src/destinations/segment/sendPage/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendPage/index.ts
@@ -50,7 +50,7 @@ const action: ActionDefinition<Settings, Payload> = {
     group_id,
     properties
   },
-  perform: (request, { payload, settings }) => {
+  perform: (request, { payload, settings, features }) => {
     if (!payload.anonymous_id && !payload.user_id) {
       throw MissingUserOrAnonymousIdThrowableError
     }
@@ -90,6 +90,11 @@ const action: ActionDefinition<Settings, Payload> = {
     // Throw an error if endpoint is not defined or invalid
     if (!settings.endpoint || !(settings.endpoint in SEGMENT_ENDPOINTS)) {
       throw InvalidEndpointSelectedThrowableError
+    }
+
+    if (features && features['actions-segment-tapi-internal']) {
+      const payload = { ...pagePayload, type: 'page' }
+      return { batch: [payload] }
     }
 
     const selectedSegmentEndpoint = SEGMENT_ENDPOINTS[settings.endpoint].url

--- a/packages/destination-actions/src/destinations/segment/sendScreen/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment/sendScreen/__tests__/index.test.ts
@@ -94,4 +94,43 @@ describe('Segment.sendScreen', () => {
       context: {}
     })
   })
+
+  test('Should not send event if actions-segment-tapi-internal flag is enabled', async () => {
+    const event = createTestEvent({
+      name: 'Home',
+      properties: {
+        'Feed Type': 'private'
+      },
+      userId: 'test-user-ufi5bgkko5',
+      anonymousId: 'arky4h2sh7k'
+    })
+
+    const responses = await testDestination.testAction('sendScreen', {
+      event,
+      mapping: defaultScreenMapping,
+      settings: {
+        source_write_key: 'test-source-write-key',
+        endpoint: DEFAULT_SEGMENT_ENDPOINT
+      },
+      features: {
+        'actions-segment-tapi-internal': true
+      }
+    })
+
+    const results = testDestination.results
+    expect(responses.length).toBe(0)
+    expect(results.length).toBe(3)
+    expect(results[2].data).toMatchObject({
+      batch: [
+        {
+          userId: event.userId,
+          anonymousId: event.anonymousId,
+          properties: {
+            ...event.properties
+          },
+          context: {}
+        }
+      ]
+    })
+  })
 })

--- a/packages/destination-actions/src/destinations/segment/sendScreen/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendScreen/index.ts
@@ -48,7 +48,7 @@ const action: ActionDefinition<Settings, Payload> = {
     group_id,
     properties
   },
-  perform: (request, { payload, settings }) => {
+  perform: (request, { payload, settings, features }) => {
     if (!payload.anonymous_id && !payload.user_id) {
       throw MissingUserOrAnonymousIdThrowableError
     }
@@ -81,6 +81,11 @@ const action: ActionDefinition<Settings, Payload> = {
     // Throw an error if endpoint is not defined or invalid
     if (!settings.endpoint || !(settings.endpoint in SEGMENT_ENDPOINTS)) {
       throw InvalidEndpointSelectedThrowableError
+    }
+
+    if (features && features['actions-segment-tapi-internal']) {
+      const payload = { ...screenPayload, type: 'screen' }
+      return { batch: [payload] }
     }
 
     const selectedSegmentEndpoint = SEGMENT_ENDPOINTS[settings.endpoint].url

--- a/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/index.test.ts
@@ -101,4 +101,43 @@ describe('Segment.sendTrack', () => {
       context: {}
     })
   })
+
+  test('Should not send event if actions-segment-tapi-internal flag is enabled', async () => {
+    const event = createTestEvent({
+      properties: {
+        plan: 'Business'
+      },
+      userId: 'test-user-ufi5bgkko5',
+      anonymousId: 'arky4h2sh7k',
+      event: 'Test Event'
+    })
+
+    const responses = await testDestination.testAction('sendTrack', {
+      event,
+      mapping: defaultTrackMapping,
+      settings: {
+        source_write_key: 'test-source-write-key',
+        endpoint: DEFAULT_SEGMENT_ENDPOINT
+      },
+      features: {
+        'actions-segment-tapi-internal': true
+      }
+    })
+
+    const results = testDestination.results
+    expect(responses.length).toBe(0)
+    expect(results.length).toBe(3)
+    expect(results[2].data).toMatchObject({
+      batch: [
+        {
+          userId: event.userId,
+          anonymousId: event.anonymousId,
+          properties: {
+            ...event.properties
+          },
+          context: {}
+        }
+      ]
+    })
+  })
 })

--- a/packages/destination-actions/src/destinations/segment/sendTrack/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/index.ts
@@ -48,7 +48,7 @@ const action: ActionDefinition<Settings, Payload> = {
     group_id,
     properties
   },
-  perform: (request, { payload, settings }) => {
+  perform: (request, { payload, settings, features }) => {
     if (!payload.anonymous_id && !payload.user_id) {
       throw MissingUserOrAnonymousIdThrowableError
     }
@@ -81,6 +81,11 @@ const action: ActionDefinition<Settings, Payload> = {
     // Throw an error if endpoint is not defined or invalid
     if (!settings.endpoint || !(settings.endpoint in SEGMENT_ENDPOINTS)) {
       throw InvalidEndpointSelectedThrowableError
+    }
+
+    if (features && features['actions-segment-tapi-internal']) {
+      const payload = { ...trackPayload, type: 'track' }
+      return { batch: [payload] }
     }
 
     const selectedSegmentEndpoint = SEGMENT_ENDPOINTS[settings.endpoint].url


### PR DESCRIPTION
This is a follow-up PR to https://github.com/segmentio/action-destinations/pull/1507

[RFC](https://docs.google.com/document/d/19uKcgtbNE9TJZHUYIPWqE9i0QwunkYPpBIDqP8vMeHw/edit) - Refer Solution 3.

[JIRA EPIC](https://segment.atlassian.net/browse/STRATCONN-2850)

This PR updates Segment Profiles to return the transformed payload and not make the API call. The transformed payload will no longer be sent from action-destination and instead will be delivered from centrifuge. To aid in returning transformed payload, this PR also adds a `data` node to Result object returned by action. This will be referenced in this [Integrations PR](https://github.com/segmentio/integrations/pull/2700)
Other Related PR
- [integrations-go](https://github.com/segmentio/integrations-go/pull/380)

## Testing

Stage test results can be found here for [Segment Destination](https://docs.google.com/document/d/19uKcgtbNE9TJZHUYIPWqE9i0QwunkYPpBIDqP8vMeHw/edit#heading=h.8ogs60px2e7z)

Changes to int monoservice response as a result of this change

**Flag Off**
Request response exchange is recorded as destination works as is.

<img width="1471" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/bc477e49-a13e-4016-af1f-b8385f8f26a9">

**Flag On**
Transformed payload is returned, but no exchange is recorded as destination doesn't deliver to TAPI endpoint.

<img width="1463" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/6f7fc5c2-7f25-450a-9e80-353076ec512e">

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
