### PR TITLE
Safe access to audience_settings in action tester

### DIFF
--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -289,7 +289,7 @@ function setupRoutes(def: DestinationDefinition | null): void {
           const eventParams = {
             data: req.body.payload || {},
             settings: req.body.settings || {},
-            audienceSettings: req.body.payload.context?.personas?.audience_settings || {},
+            audienceSettings: req.body.payload?.context?.personas?.audience_settings || {},
             mapping: mapping || req.body.payload || {},
             auth: req.body.auth || {}
           }

--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -289,7 +289,7 @@ function setupRoutes(def: DestinationDefinition | null): void {
           const eventParams = {
             data: req.body.payload || {},
             settings: req.body.settings || {},
-            audienceSettings: req.body.payload.context.personas.audience_settings || {},
+            audienceSettings: req.body.payload.context?.personas?.audience_settings || {},
             mapping: mapping || req.body.payload || {},
             auth: req.body.auth || {}
           }


### PR DESCRIPTION
Unsafe access was causing the server to break. This PR adds safe access to audienceSettings fixing the issue.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
