### PR TITLE
Updated Set Configuration Fields docs, as requested by support

### DIFF
--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/setConfigurationFields/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/setConfigurationFields/index.ts
@@ -7,7 +7,7 @@ import { updateUser } from '../ga4-functions'
 // Change from unknown to the partner SDK types
 const action: BrowserActionDefinition<Settings, Function, Payload> = {
   title: 'Set Configuration Fields',
-  description: 'Set custom values for the GA4 configuration fields.',
+  description: 'Set custom values for the GA4 configuration fields and trigger a page_view event.',
   platform: 'web',
   defaultSubscription: 'type = "identify" or type = "page"',
   fields: {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Added context about what happens in the Set Configuration Fields Action, as requested by a CSE in [KCS-522](https://segment.atlassian.net/browse/KCS-522) and [segment-docs issue #5258](https://github.com/segmentio/segment-docs/issues/5258).

(Docs uses the content autogenerated from PAPI to document a destination's Actions, which is why I made the change here.)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment


[KCS-522]: https://segment.atlassian.net/browse/KCS-522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ