### PR TITLE
STRATCONN-2967 - Hide internal mappings for LiveRamp

### DIFF
--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/generated-types.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/generated-types.ts
@@ -18,7 +18,7 @@ export interface Payload {
    */
   s3_aws_region?: string
   /**
-   * Identifies the user within the entered audience.
+   * Unique ID that identifies members of an audience. A typical audience key might be client customer IDs, email addresses, or phone numbers.
    */
   audience_key: string
   /**

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
@@ -31,7 +31,8 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     audience_key: {
       label: 'Audience Key',
-      description: 'Identifies the user within the entered audience.',
+      description:
+        'Unique ID that identifies members of an audience. A typical audience key might be client customer IDs, email addresses, or phone numbers.',
       type: 'string',
       required: true,
       default: { '@path': '$.userId' }

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
@@ -68,6 +68,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'boolean',
       label: 'Batch data',
       description: 'Receive events in a batch payload. This is required for LiveRamp audiences ingestion.',
+      unsafe_hidden: true,
       required: true,
       default: true
     },
@@ -75,6 +76,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch Size',
       description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
       type: 'number',
+      unsafe_hidden: true,
       required: false,
       default: 170000
     }

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/generated-types.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/generated-types.ts
@@ -14,7 +14,7 @@ export interface Payload {
    */
   sftp_folder_path?: string
   /**
-   * Identifies the user within the entered audience.
+   * Unique ID that identifies members of an audience. A typical audience key might be client customer IDs, email addresses, or phone numbers.
    */
   audience_key: string
   /**

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/index.ts
@@ -29,7 +29,8 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     audience_key: {
       label: 'Audience Key',
-      description: 'Identifies the user within the entered audience.',
+      description:
+        'Unique ID that identifies members of an audience. A typical audience key might be client customer IDs, email addresses, or phone numbers.',
       type: 'string',
       required: true,
       default: { '@path': '$.userId' }
@@ -67,6 +68,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch data',
       description: 'Receive events in a batch payload. This is required for LiveRamp audiences ingestion.',
       required: true,
+      unsafe_hidden: true,
       default: true
     },
     batch_size: {
@@ -74,6 +76,7 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
       type: 'number',
       required: false,
+      unsafe_hidden: true,
       default: 100000
     }
   },


### PR DESCRIPTION
This PR hides the batch_size and enable_batching internal settings in the LiveRamp audience destination.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment

![image](https://github.com/segmentio/action-destinations/assets/103517471/3f2c676f-7436-4658-96af-d47780f382c5)
