### PR TITLE
LaunchDarkly: add enable_batching field to Audiences destination action.

### DIFF
--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/generated-types.ts
@@ -36,6 +36,10 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
+   * When enabled, the action will batch events before sending them to LaunchDarkly. In most cases, batching should be enabled.
+   */
+  enable_batching?: boolean
+  /**
    * Indicates if the user will be added or removed from the Audience
    */
   audience_action?: string

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/index.ts
@@ -92,6 +92,14 @@ const action: ActionDefinition<Settings, Payload> = {
         }
       }
     },
+    enable_batching: {
+      type: 'boolean',
+      label: 'Batch events',
+      description:
+        'When enabled, the action will batch events before sending them to LaunchDarkly. In most cases, batching should be enabled.',
+      required: false,
+      default: true
+    },
     audience_action: {
       label: 'Audience Action',
       description: 'Indicates if the user will be added or removed from the Audience',


### PR DESCRIPTION
This PR adds the `enable_batching` field to LaunchDarkly Audiences' `syncAudiences` action. This was done to override the default value of false because batching should be enabled in most cases. I decided to make this change after chatting with @joe-ayoub-segment.

## Testing

I can see the new field when testing locally.

![image](https://github.com/segmentio/action-destinations/assets/47337653/83b7fd2c-6eec-4b18-8817-762fdb9598b1)

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
