### PR TITLE
convert and cast predefined phone attributes as numbers

### DIFF
--- a/packages/destination-actions/src/destinations/airship/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/airship/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -137,19 +137,19 @@ Object {
       "action": "set",
       "key": "mobile_phone",
       "timestamp": false,
-      "value": -8736782938013696,
+      "value": 75,
     },
     Object {
       "action": "set",
       "key": "home_phone",
       "timestamp": false,
-      "value": -8736782938013696,
+      "value": 75,
     },
     Object {
       "action": "set",
       "key": "work_phone",
       "timestamp": false,
-      "value": -8736782938013696,
+      "value": 75,
     },
     Object {
       "action": "set",

--- a/packages/destination-actions/src/destinations/airship/setAttributes/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/airship/setAttributes/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -73,19 +73,19 @@ Object {
       "action": "set",
       "key": "mobile_phone",
       "timestamp": false,
-      "value": -7931935682723840,
+      "value": 4,
     },
     Object {
       "action": "set",
       "key": "home_phone",
       "timestamp": false,
-      "value": -7931935682723840,
+      "value": 4,
     },
     Object {
       "action": "set",
       "key": "work_phone",
       "timestamp": false,
-      "value": -7931935682723840,
+      "value": 4,
     },
     Object {
       "action": "set",

--- a/packages/destination-actions/src/destinations/airship/setAttributes/generated-types.ts
+++ b/packages/destination-actions/src/destinations/airship/setAttributes/generated-types.ts
@@ -60,15 +60,15 @@ export interface Payload {
     /**
      * The user's mobile phone number.
      */
-    mobile_phone?: number
+    mobile_phone?: string
     /**
      * The user's home phone number.
      */
-    home_phone?: number
+    home_phone?: string
     /**
      * The user's work phone number.
      */
-    work_phone?: number
+    work_phone?: string
     /**
      * The user's loyalty tier.
      */

--- a/packages/destination-actions/src/destinations/airship/setAttributes/index.ts
+++ b/packages/destination-actions/src/destinations/airship/setAttributes/index.ts
@@ -92,17 +92,17 @@ const action: ActionDefinition<Settings, Payload> = {
         },
         mobile_phone: {
           label: 'Mobile Phone Number',
-          type: 'integer',
+          type: 'string',
           description: "The user's mobile phone number."
         },
         home_phone: {
           label: 'Home Phone Number',
-          type: 'integer',
+          type: 'string',
           description: "The user's home phone number."
         },
         work_phone: {
           label: 'Work Phone Number',
-          type: 'integer',
+          type: 'string',
           description: "The user's work phone number."
         },
         loyalty_tier: {

--- a/packages/destination-actions/src/destinations/airship/utilities.ts
+++ b/packages/destination-actions/src/destinations/airship/utilities.ts
@@ -229,6 +229,10 @@ function _build_attribute(attribute_key: string, attribute_value: any, occurred:
     adjustedDate = _parse_date(attribute_value)
   }
 
+  if (['home_phone', 'work_phone', 'mobile_phone'].includes(attribute_key) && typeof(attribute_value) == "string") {
+    attribute_value = parseInt(attribute_value.replace(/[^0-9]/g, ""))
+  }
+
   const attribute: {
     action: string
     key: string
@@ -251,6 +255,7 @@ function _build_attribute(attribute_key: string, attribute_value: any, occurred:
   }
   return attribute
 }
+
 
 function _build_tags_object(payload: TagsPayload): object {
   /*


### PR DESCRIPTION
Since phone numbers in Segment can include non-number elements, and predefined Airship phone Attributes are "number" by default, sanitize/cast these for the Set Attributes action

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
