### PR TITLE
Revert changes made to result object

### DIFF
--- a/packages/core/src/__tests__/destination-kit.test.ts
+++ b/packages/core/src/__tests__/destination-kit.test.ts
@@ -179,7 +179,7 @@ describe('destination kit', () => {
       expect(res).toEqual([
         { output: 'Mappings resolved' },
         { output: 'Payload validated' },
-        { output: 'Action Executed', data: ['this is a test', {}] }
+        { output: ['this is a test', {}] }
       ])
     })
 
@@ -210,7 +210,7 @@ describe('destination kit', () => {
       expect(res).toEqual([
         { output: 'Mappings resolved' },
         { output: 'Payload validated' },
-        { output: 'Action Executed', data: ['this is a test', {}] }
+        { output: ['this is a test', {}] }
       ])
     })
 
@@ -241,7 +241,7 @@ describe('destination kit', () => {
       expect(res).toEqual([
         { output: 'Mappings resolved' },
         { output: 'Payload validated' },
-        { output: 'Action Executed', data: ['this is a test', {}] }
+        { output: ['this is a test', {}] }
       ])
     })
   })
@@ -272,7 +272,7 @@ describe('destination kit', () => {
       expect(res).toEqual([
         { output: 'Mappings resolved' },
         { output: 'Payload validated' },
-        { output: 'Action Executed', data: ['this is a test', {}] }
+        { output: ['this is a test', {}] }
       ])
     })
   })
@@ -404,8 +404,7 @@ describe('destination kit', () => {
       expect(res).toEqual([
         { output: 'Mappings resolved' },
         {
-          output: 'Action Executed',
-          data: {
+          output: {
             features: eventOptions.features,
             statsContext: {}
           }
@@ -446,8 +445,7 @@ describe('destination kit', () => {
       expect(res).toEqual([
         { output: 'Mappings resolved' },
         {
-          output: 'Action Executed',
-          data: {
+          output: {
             features: {},
             statsContext: eventOptions.statsContext
           }
@@ -485,8 +483,7 @@ describe('destination kit', () => {
       expect(res).toEqual([
         { output: 'Mappings resolved' },
         {
-          output: 'Action Executed',
-          data: {
+          output: {
             features: {},
             statsContext: {},
             logger: eventOptions.logger
@@ -528,8 +525,7 @@ describe('destination kit', () => {
       expect(res).toEqual([
         { output: 'Mappings resolved' },
         {
-          output: 'Action Executed',
-          data: {
+          output: {
             features: {},
             statsContext: {},
             logger: eventOptions.logger,
@@ -581,8 +577,7 @@ describe('destination kit', () => {
       expect(res).toEqual([
         { output: 'Mappings resolved' },
         {
-          output: 'Action Executed',
-          data: {
+          output: {
             features: {},
             statsContext: {},
             logger: eventOptions.logger,

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -155,7 +155,7 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
 
     // Construct the request client and perform the action
     const output = await this.performRequest(this.definition.perform, dataBundle)
-    results.push({ data: output as JSONObject, output: 'Action Executed' })
+    results.push({ output: output as JSONObject })
 
     return results
   }

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -12,8 +12,6 @@ export type MaybePromise<T> = T | Promise<T>
 export interface Result {
   output?: JSONObject | string | null | undefined
   error?: JSONObject | null
-  // Data to be returned from action
-  data?: JSONObject | null
 }
 
 export interface ExecuteInput<Settings, Payload, AudienceSettings = unknown> {

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/index.test.ts
@@ -124,6 +124,6 @@ describe('SegmentProfiles.sendGroup', () => {
 
     expect(responses.length).toBe(0)
     expect(results.length).toBe(3)
-    expect(results[2].data).toMatchSnapshot()
+    expect(results[2].output).toMatchSnapshot()
   })
 })

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/index.test.ts
@@ -118,6 +118,6 @@ describe('Segment.sendIdentify', () => {
 
     expect(responses.length).toBe(0)
     expect(results.length).toBe(3)
-    expect(results[2].data).toMatchSnapshot()
+    expect(results[2].output).toMatchSnapshot()
   })
 })

--- a/packages/destination-actions/src/destinations/segment/sendGroup/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment/sendGroup/__tests__/index.test.ts
@@ -132,7 +132,7 @@ describe('Segment.sendGroup', () => {
     const results = testDestination.results
     expect(responses.length).toBe(0)
     expect(results.length).toBe(3)
-    expect(results[2].data).toMatchObject({
+    expect(results[2].output).toMatchObject({
       batch: [
         {
           userId: event.userId,

--- a/packages/destination-actions/src/destinations/segment/sendIdentify/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment/sendIdentify/__tests__/index.test.ts
@@ -124,7 +124,7 @@ describe('Segment.sendIdentify', () => {
     const results = testDestination.results
     expect(responses.length).toBe(0)
     expect(results.length).toBe(3)
-    expect(results[2].data).toMatchObject({
+    expect(results[2].output).toMatchObject({
       batch: [
         {
           userId: event.userId,

--- a/packages/destination-actions/src/destinations/segment/sendPage/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment/sendPage/__tests__/index.test.ts
@@ -127,7 +127,7 @@ describe('Segment.sendPage', () => {
     const results = testDestination.results
     expect(responses.length).toBe(0)
     expect(results.length).toBe(3)
-    expect(results[2].data).toMatchObject({
+    expect(results[2].output).toMatchObject({
       batch: [
         {
           userId: event.userId,

--- a/packages/destination-actions/src/destinations/segment/sendScreen/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment/sendScreen/__tests__/index.test.ts
@@ -120,7 +120,7 @@ describe('Segment.sendScreen', () => {
     const results = testDestination.results
     expect(responses.length).toBe(0)
     expect(results.length).toBe(3)
-    expect(results[2].data).toMatchObject({
+    expect(results[2].output).toMatchObject({
       batch: [
         {
           userId: event.userId,

--- a/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/index.test.ts
@@ -127,7 +127,7 @@ describe('Segment.sendTrack', () => {
     const results = testDestination.results
     expect(responses.length).toBe(0)
     expect(results.length).toBe(3)
-    expect(results[2].data).toMatchObject({
+    expect(results[2].output).toMatchObject({
       batch: [
         {
           userId: event.userId,


### PR DESCRIPTION
Reverts the results object change made as part of https://github.com/segmentio/action-destinations/pull/1507

Reason for revert - In hindsight, I felt that it is possible to achieve what I intended to without this change. This PR will impact `integration` test cases. This`integrations` PR will fix the tests that break as a result of this change.

This is a safe change as it reverts Result object to the state as it was before.

## Testing

Tested E2E in local

<img width="1039" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/90d5fb4f-58bd-48cc-b63f-813d53dfc3bc">

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
