### PR TITLE
Ccp 419

### DIFF
--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -289,7 +289,7 @@ function setupRoutes(def: DestinationDefinition | null): void {
           const eventParams = {
             data: req.body.payload || {},
             settings: req.body.settings || {},
-            audienceSettings: req.body.payload.context.personas.audience_settings || {},
+            audienceSettings: req.body.payload?.context?.personas?.audience_settings || {},
             mapping: mapping || req.body.payload || {},
             auth: req.body.auth || {}
           }

--- a/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
+++ b/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
@@ -118,7 +118,18 @@ export class SendEmailPerformer extends MessageSendPerformer<Settings, Payload> 
     }
 
     const bcc = JSON.parse(this.payload.bcc ?? '[]')
-    const [parsedSubject, apiLookupData] = await Promise.all([
+    const [
+      parsedFromEmail,
+      parsedFromName,
+      parsedFromReplyToEmail,
+      parsedFromReplyToName,
+      parsedSubject,
+      apiLookupData
+    ] = await Promise.all([
+      this.parseTemplating(this.payload.fromEmail, { profile }, 'FromEmail'),
+      this.parseTemplating(this.payload.fromName, { profile }, 'FromName'),
+      this.parseTemplating(this.payload.replyToEmail, { profile }, 'ReplyToEmail'),
+      this.parseTemplating(this.payload.replyToName, { profile }, 'ReplyToName'),
       this.parseTemplating(this.payload.subject, { profile }, 'Subject'),
       this.performApiLookups(this.payload.apiLookups, profile)
     ])
@@ -145,12 +156,12 @@ export class SendEmailPerformer extends MessageSendPerformer<Settings, Payload> 
         }
       ],
       from: {
-        email: this.payload.fromEmail,
-        name: this.payload.fromName
+        email: parsedFromEmail,
+        name: parsedFromName
       },
       reply_to: {
-        email: this.payload.replyToEmail,
-        name: this.payload.replyToName
+        email: parsedFromReplyToEmail,
+        name: parsedFromReplyToName
       },
       subject: parsedSubject,
       content: [


### PR DESCRIPTION
## Jira Ticket

https://segment.atlassian.net/jira/software/c/projects/CCP/boards/562?modal=detail&selectedIssue=CCP-419

## Summary: 

Engage customers want to be able to send emails from email templates with custom sender fields.
{{ profile.traits.from_name }} for example.

The appropriate payload fields have been parsed so they can be worked with merge tags.

## Testing


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [X ] [Segmenters] Tested in the staging environment
