### PR TITLE
STRATCONN-3148 Fix usermaven test

### DIFF
--- a/packages/destination-actions/src/destinations/usermaven/vars.ts
+++ b/packages/destination-actions/src/destinations/usermaven/vars.ts
@@ -1,11 +1,5 @@
+import random from 'lodash/random'
+
 export const generateId = () => {
-  const length = 10
-  let result = ''
-
-  for (let i = 0; i < length; i++) {
-    const randomNumber = Math.floor(Math.random() * 10) // Generates a random digit between 0 and 9
-    result += randomNumber.toString() // Convert the digit to a string and append it to the result
-  }
-
-  return result
+  return random(1000000000, 9999999999)
 }

--- a/packages/destination-actions/src/destinations/usermaven/vars.ts
+++ b/packages/destination-actions/src/destinations/usermaven/vars.ts
@@ -1,7 +1,11 @@
 export const generateId = () => {
-  let randomString = Math.random().toString(36).substring(2, 12)
-  while (randomString.length < 10) {
-    randomString += '0'
+  const length = 10
+  let result = ''
+
+  for (let i = 0; i < length; i++) {
+    const randomNumber = Math.floor(Math.random() * 10) // Generates a random digit between 0 and 9
+    result += randomNumber.toString() // Convert the digit to a string and append it to the result
   }
-  return randomString.substring(0, 10)
+
+  return result
 }

--- a/packages/destination-actions/src/destinations/usermaven/vars.ts
+++ b/packages/destination-actions/src/destinations/usermaven/vars.ts
@@ -1,1 +1,7 @@
-export const generateId = () => Math.random().toString(36).substring(2, 12)
+export const generateId = () => {
+  let randomString = Math.random().toString(36).substring(2, 12)
+  while (randomString.length < 10) {
+    randomString += '0'
+  }
+  return randomString.substring(0, 10)
+}

--- a/packages/destination-actions/src/destinations/usermaven/vars.ts
+++ b/packages/destination-actions/src/destinations/usermaven/vars.ts
@@ -1,5 +1,5 @@
 import random from 'lodash/random'
 
 export const generateId = () => {
-  return random(1000000000, 9999999999)
+  return random(1000000000, 9999999999).toString()
 }


### PR DESCRIPTION
Fixes flakey test. 

[STRATCONN-3148](https://segment.atlassian.net/browse/STRATCONN-3148)

generateId needs to always return 10 character string. However sometimes it returns a 9 char string which causes a test to fail. 

This PR changes the function to ensure that it always returns a 10 character string.  

## Testing

Tests pass when run locally. 
![image](https://github.com/segmentio/action-destinations/assets/45374896/45a80ae2-ade9-49ea-addc-ad3196579e08)



[STRATCONN-3148]: https://segment.atlassian.net/browse/STRATCONN-3148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ