### PR TITLE
CUSTINT-20007: segment.com Emarsys destination - remove mandatory fields

### DIFF
--- a/packages/destination-actions/src/destinations/emarsys/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/emarsys/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -60,9 +60,6 @@ exports[`Testing snapshot for actions-emarsys destination: upsertContact action 
 Object {
   "contacts": Array [
     Object {
-      "1": "ADOas@%XS83LqVu9",
-      "2": "ADOas@%XS83LqVu9",
-      "3": "ADOas@%XS83LqVu9",
       "ADOas@%XS83LqVu9": "ADOas@%XS83LqVu9",
     },
   ],

--- a/packages/destination-actions/src/destinations/emarsys/upsertContact/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/emarsys/upsertContact/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,9 +4,6 @@ exports[`Testing snapshot for Emarsys's upsertContact destination action: all fi
 Object {
   "contacts": Array [
     Object {
-      "1": "UAl@hlNFqwIzyXq",
-      "2": "UAl@hlNFqwIzyXq",
-      "3": "UAl@hlNFqwIzyXq",
       "UAl@hlNFqwIzyXq": "UAl@hlNFqwIzyXq",
     },
   ],

--- a/packages/destination-actions/src/destinations/emarsys/upsertContact/generated-types.ts
+++ b/packages/destination-actions/src/destinations/emarsys/upsertContact/generated-types.ts
@@ -13,9 +13,6 @@ export interface Payload {
    * Use the emarsys field id (number) as key and set a value (string) (static, function or event variable)
    */
   write_field: {
-    '1'?: string
-    '2'?: string
-    '3'?: string
     [k: string]: unknown
   }
 }

--- a/packages/destination-actions/src/destinations/emarsys/upsertContact/index.ts
+++ b/packages/destination-actions/src/destinations/emarsys/upsertContact/index.ts
@@ -52,6 +52,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const contact: ContactData = {}
 
     contact[data.payload.key_field] = data.payload.key_value
+    console.log(data.payload.write_field)
     Object.assign(contact, data.payload.write_field)
     const payload: ContactsApiPayload = {
       key_id: data.payload.key_field,

--- a/packages/destination-actions/src/destinations/emarsys/upsertContact/index.ts
+++ b/packages/destination-actions/src/destinations/emarsys/upsertContact/index.ts
@@ -52,7 +52,6 @@ const action: ActionDefinition<Settings, Payload> = {
     const contact: ContactData = {}
 
     contact[data.payload.key_field] = data.payload.key_value
-    console.log(data.payload.write_field)
     Object.assign(contact, data.payload.write_field)
     const payload: ContactsApiPayload = {
       key_id: data.payload.key_field,

--- a/packages/destination-actions/src/destinations/emarsys/upsertContact/index.ts
+++ b/packages/destination-actions/src/destinations/emarsys/upsertContact/index.ts
@@ -35,20 +35,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'object',
       required: true,
       additionalProperties: true,
-      properties: {
-        1: {
-          label: 'Given name',
-          type: 'string'
-        },
-        2: {
-          label: 'Last name',
-          type: 'string'
-        },
-        3: {
-          label: 'Email',
-          type: 'string'
-        }
-      },
+      properties: {},
       default: {
         1: { '@path': '$.traits.firstName' },
         2: { '@path': '$.traits.lastName' },


### PR DESCRIPTION

This change should remove mandatory fields 1, 2 and 3 from the upsertContact settings screen. In the tester, these fields are removable (with an X-Button next to each field)

## Testing

- [/] Unit test passed
- [/] Tested end to end with the tester

