### PR TITLE
Update Attio integration instructions, drop required `name` property

### DIFF
--- a/packages/destination-actions/src/destinations/attio/assertRecord/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/attio/assertRecord/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -3,9 +3,7 @@
 exports[`Testing snapshot for Attio's assertRecord destination action: all fields 1`] = `
 Object {
   "data": Object {
-    "values": Object {
-      "name": "]PjNEM",
-    },
+    "values": Object {},
   },
 }
 `;

--- a/packages/destination-actions/src/destinations/attio/assertRecord/generated-types.ts
+++ b/packages/destination-actions/src/destinations/attio/assertRecord/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   matching_attribute: string
   /**
-   * Attributes to either set or update on the Attio Record. The values on the left should be Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs. The Matching Attribute must be included for assertion to work.
+   * Attributes to either set or update on the Attio Record. The values on the left should be Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs, for example: traits.name → name. The Matching Attribute must be included for assertion to work.
    */
   attributes?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/attio/assertRecord/generated-types.ts
+++ b/packages/destination-actions/src/destinations/attio/assertRecord/generated-types.ts
@@ -10,10 +10,9 @@ export interface Payload {
    */
   matching_attribute: string
   /**
-   * Attributes to either set or update on the Attio Record. The keys on the left should be Attio Attribute IDs or Slugs, and the values on the right are Segment attributes or custom text. The Matching Attribute must be included for assertion to work.
+   * Attributes to either set or update on the Attio Record. The values on the left should be Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs. The Matching Attribute must be included for assertion to work.
    */
   attributes?: {
-    name?: string
     [k: string]: unknown
   }
 }

--- a/packages/destination-actions/src/destinations/attio/assertRecord/index.ts
+++ b/packages/destination-actions/src/destinations/attio/assertRecord/index.ts
@@ -28,19 +28,14 @@ const attributes: InputField = {
   type: 'object',
   label: 'Attributes',
   description:
-    'Attributes to either set or update on the Attio Record. The keys on the left should be ' +
-    'Attio Attribute IDs or Slugs, and the values on the right are Segment attributes or custom text. ' +
+    'Attributes to either set or update on the Attio Record. The values on the left should be ' +
+    'Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs. ' +
     'The Matching Attribute must be included for assertion to work.',
   defaultObjectUI: 'keyvalue:only',
   additionalProperties: true,
-  properties: {
-    name: {
-      label: 'Name',
-      type: 'string'
-    }
-  },
+  properties: {},
   default: {
-    name: { '@path': '$.traits.name' }
+    an_example_attribute: { '@path': '$.traits.name' }
   }
 }
 

--- a/packages/destination-actions/src/destinations/attio/assertRecord/index.ts
+++ b/packages/destination-actions/src/destinations/attio/assertRecord/index.ts
@@ -29,14 +29,13 @@ const attributes: InputField = {
   label: 'Attributes',
   description:
     'Attributes to either set or update on the Attio Record. The values on the left should be ' +
-    'Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs. ' +
+    'Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs, ' +
+    'for example: traits.name → name. ' +
     'The Matching Attribute must be included for assertion to work.',
   defaultObjectUI: 'keyvalue:only',
   additionalProperties: true,
   properties: {},
-  default: {
-    an_example_attribute: { '@path': '$.traits.name' }
-  }
+  default: {}
 }
 
 export const objectLookup = async (request: RequestClient): Promise<DynamicFieldResponse> => {

--- a/packages/destination-actions/src/destinations/attio/groupWorkspace/generated-types.ts
+++ b/packages/destination-actions/src/destinations/attio/groupWorkspace/generated-types.ts
@@ -10,13 +10,13 @@ export interface Payload {
    */
   name: string
   /**
-   * Additional attributes to either set or update on the Attio Company Record. The keys on the left should be Attio Attribute IDs or Slugs, and the values on the right are Segment attributes or custom text.
+   * Additional attributes to either set or update on the Attio Company Record. The values on the left should be Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs. For example: traits.name → name
    */
   company_attributes?: {
     [k: string]: unknown
   }
   /**
-   * Additional attributes to either set or update on the Attio Workspace Record. The keys on the left should be Attio Attribute IDs or Slugs, and the values on the right are Segment attributes or custom text.
+   * Additional attributes to either set or update on the Attio Workspace Record. The values on the left should be Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs. For example: traits.name → name
    */
   workspace_attributes?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/attio/groupWorkspace/index.ts
+++ b/packages/destination-actions/src/destinations/attio/groupWorkspace/index.ts
@@ -38,8 +38,9 @@ const company_attributes: InputField = {
   type: 'object',
   label: 'Additional Company attributes',
   description:
-    'Additional attributes to either set or update on the Attio Company Record. The keys on the left should be ' +
-    'Attio Attribute IDs or Slugs, and the values on the right are Segment attributes or custom text.',
+    'Additional attributes to either set or update on the Attio Company Record. The values on the left should be ' +
+    'Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs. ' +
+    'For example: traits.name → name',
   defaultObjectUI: 'keyvalue:only',
   default: {}
 }
@@ -48,12 +49,11 @@ const workspace_attributes: InputField = {
   type: 'object',
   label: 'Additional Workspace attributes',
   description:
-    'Additional attributes to either set or update on the Attio Workspace Record. The keys on the left should be ' +
-    'Attio Attribute IDs or Slugs, and the values on the right are Segment attributes or custom text.',
+    'Additional attributes to either set or update on the Attio Workspace Record. The values on the left should be ' +
+    'Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs. ' +
+    'For example: traits.name → name',
   defaultObjectUI: 'keyvalue:only',
-  default: {
-    '@path': '$.properties'
-  }
+  default: {}
 }
 
 const action: ActionDefinition<Settings, Payload> = {

--- a/packages/destination-actions/src/destinations/attio/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/attio/identifyUser/generated-types.ts
@@ -6,10 +6,9 @@ export interface Payload {
    */
   email_address: string
   /**
-   * Additional attributes to either set or update on the Attio User Record. The keys on the left should be Attio Attribute IDs or Slugs, and the values on the right are Segment attributes or custom text.
+   * Additional attributes to either set or update on the Attio User Record. The values on the left should be Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs.
    */
   user_attributes?: {
-    name?: string
     [k: string]: unknown
   }
   /**

--- a/packages/destination-actions/src/destinations/attio/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/attio/identifyUser/generated-types.ts
@@ -6,13 +6,13 @@ export interface Payload {
    */
   email_address: string
   /**
-   * Additional attributes to either set or update on the Attio User Record. The values on the left should be Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs.
+   * Additional attributes to either set or update on the Attio User Record. The values on the left should be Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs. For example: traits.name → name
    */
   user_attributes?: {
     [k: string]: unknown
   }
   /**
-   * Additional attributes to either set or update on the Attio Person Record. The keys on the left should be Attio Attribute IDs or Slugs, and the values on the right are Segment attributes or custom text.
+   * Additional attributes to either set or update on the Attio Person Record. The values on the left should be Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs. For example: traits.name → name
    */
   person_attributes?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/attio/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/attio/identifyUser/index.ts
@@ -24,21 +24,21 @@ const user_attributes: InputField = {
   label: 'Additional User attributes',
   description:
     'Additional attributes to either set or update on the Attio User Record. The values on the left should be ' +
-    'Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs.',
+    'Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs. ' +
+    'For example: traits.name → name',
   defaultObjectUI: 'keyvalue:only',
   additionalProperties: true,
   properties: {},
-  default: {
-    an_example_attribute: { '@path': '$.traits.name' }
-  }
+  default: {}
 }
 
 const person_attributes: InputField = {
   type: 'object',
   label: 'Additional Person attributes',
   description:
-    'Additional attributes to either set or update on the Attio Person Record. The keys on the left should be ' +
-    'Attio Attribute IDs or Slugs, and the values on the right are Segment attributes or custom text.',
+    'Additional attributes to either set or update on the Attio Person Record. The values on the left should be ' +
+    'Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs. ' +
+    'For example: traits.name → name',
   defaultObjectUI: 'keyvalue:only',
   default: {}
 }

--- a/packages/destination-actions/src/destinations/attio/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/attio/identifyUser/index.ts
@@ -23,18 +23,13 @@ const user_attributes: InputField = {
   type: 'object',
   label: 'Additional User attributes',
   description:
-    'Additional attributes to either set or update on the Attio User Record. The keys on the left should be ' +
-    'Attio Attribute IDs or Slugs, and the values on the right are Segment attributes or custom text.',
+    'Additional attributes to either set or update on the Attio User Record. The values on the left should be ' +
+    'Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs.',
   defaultObjectUI: 'keyvalue:only',
   additionalProperties: true,
-  properties: {
-    name: {
-      label: 'Name',
-      type: 'string'
-    }
-  },
+  properties: {},
   default: {
-    name: { '@path': '$.traits.name' }
+    an_example_attribute: { '@path': '$.traits.name' }
   }
 }
 


### PR DESCRIPTION
We've done a bit of beta testing and found a few minor issues we'd like to fix:

* The actions tester presents the properties object in the opposite way to production, so I've swapped the descriptive text around to make that clearer:

<img width="300" alt="Screenshot 2023-09-08 at 16 58 42" src="https://github.com/segmentio/action-destinations/assets/661795/fec391c2-a4fc-4b04-9597-78b6594d2152">
<img width="300" alt="Screenshot 2023-09-08 at 16 58 49" src="https://github.com/segmentio/action-destinations/assets/661795/e3502b85-8408-4e47-bae8-2285c4060bdc">

* When we originally wrote this destination, we intended for `name` to be a required property, but this has changed in our platform; so I'm removing it here from the payload and setting the default value with a different name to show it's just an example with no specific meaning.