### PR TITLE
Update Liveramp batch_size

### DIFF
--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/index.ts
@@ -77,7 +77,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'number',
       required: false,
       unsafe_hidden: true,
-      default: 100000
+      default: 50000
     }
   },
   perform: async (_, { payload }) => {


### PR DESCRIPTION
This PR changes the audienceEnteredSftp/index.ts default batch size from 100000 to 50000.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
