### PR TITLE
STRATCONN-3147: Introduce DefinitelyTyped for GCM and GA4

### DIFF
--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/addPaymentInfo.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/addPaymentInfo.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleAnalytics4Web, { destination } from '../index'
-import { GA } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -47,7 +46,7 @@ describe('GoogleAnalytics4Web.addPaymentInfo', () => {
     measurementID: 'test123'
   }
 
-  let mockGA4: GA
+  let mockGA4: typeof gtag
   let addPaymentInfoEvent: any
   beforeEach(async () => {
     jest.restoreAllMocks()
@@ -59,10 +58,8 @@ describe('GoogleAnalytics4Web.addPaymentInfo', () => {
     addPaymentInfoEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGA4 = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGA4.gtag)
+      mockGA4 = jest.fn()
+      return Promise.resolve(mockGA4)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -87,7 +84,7 @@ describe('GoogleAnalytics4Web.addPaymentInfo', () => {
     })
     await addPaymentInfoEvent.track?.(context)
 
-    expect(mockGA4.gtag).toHaveBeenCalledWith(
+    expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('add_payment_info'),
       expect.objectContaining({

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/addToCart.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/addToCart.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleAnalytics4Web, { destination } from '../index'
-import { GA } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -44,7 +43,7 @@ describe('GoogleAnalytics4Web.addToCart', () => {
     measurementID: 'test123'
   }
 
-  let mockGA4: GA
+  let mockGA4: typeof gtag
   let addToCartEvent: any
   beforeEach(async () => {
     jest.restoreAllMocks()
@@ -56,10 +55,8 @@ describe('GoogleAnalytics4Web.addToCart', () => {
     addToCartEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGA4 = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGA4.gtag)
+      mockGA4 = jest.fn()
+      return Promise.resolve(mockGA4)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -82,7 +79,7 @@ describe('GoogleAnalytics4Web.addToCart', () => {
     })
     await addToCartEvent.track?.(context)
 
-    expect(mockGA4.gtag).toHaveBeenCalledWith(
+    expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('add_to_cart'),
       expect.objectContaining({

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/addToWishlist.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/addToWishlist.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleAnalytics4Web, { destination } from '../index'
-import { GA } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -44,7 +43,7 @@ describe('GoogleAnalytics4Web.addToWishlist', () => {
     measurementID: 'test123'
   }
 
-  let mockGA4: GA
+  let mockGA4: typeof gtag
   let addToWishlistEvent: any
   beforeEach(async () => {
     jest.restoreAllMocks()
@@ -56,10 +55,8 @@ describe('GoogleAnalytics4Web.addToWishlist', () => {
     addToWishlistEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGA4 = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGA4.gtag)
+      mockGA4 = jest.fn()
+      return Promise.resolve(mockGA4)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -82,7 +79,7 @@ describe('GoogleAnalytics4Web.addToWishlist', () => {
     })
     await addToWishlistEvent.track?.(context)
 
-    expect(mockGA4.gtag).toHaveBeenCalledWith(
+    expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('add_to_wishlist'),
       expect.objectContaining({

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/beginCheckout.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/beginCheckout.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleAnalytics4Web, { destination } from '../index'
-import { GA } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -47,7 +46,7 @@ describe('GoogleAnalytics4Web.beginCheckout', () => {
     measurementID: 'test123'
   }
 
-  let mockGA4: GA
+  let mockGA4: typeof gtag
   let beginCheckoutEvent: any
   beforeEach(async () => {
     jest.restoreAllMocks()
@@ -59,10 +58,8 @@ describe('GoogleAnalytics4Web.beginCheckout', () => {
     beginCheckoutEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGA4 = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGA4.gtag)
+      mockGA4 = jest.fn()
+      return Promise.resolve(mockGA4)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -87,7 +84,7 @@ describe('GoogleAnalytics4Web.beginCheckout', () => {
     })
     await beginCheckoutEvent.track?.(context)
 
-    expect(mockGA4.gtag).toHaveBeenCalledWith(
+    expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('begin_checkout'),
       expect.objectContaining({

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/customEvent.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/customEvent.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleAnalytics4Web, { destination } from '../index'
-import { GA } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -37,10 +36,8 @@ describe('GoogleAnalytics4Web.customEvent', () => {
     customEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGA4 = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGA4.gtag)
+      mockGA4 = jest.fn()
+      return Promise.resolve(mockGA4)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -61,7 +58,7 @@ describe('GoogleAnalytics4Web.customEvent', () => {
     })
     await customEvent.track?.(context)
 
-    expect(mockGA4.gtag).toHaveBeenCalledWith(
+    expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('Custom_Event'),
       expect.objectContaining([{ paramOne: 'test123', paramThree: 123, paramTwo: 'test123' }])

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/generateLead.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/generateLead.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleAnalytics4Web, { destination } from '../index'
-import { GA } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -25,7 +24,7 @@ describe('GoogleAnalytics4Web.generateLead', () => {
     measurementID: 'test123'
   }
 
-  let mockGA4: GA
+  let mockGA4: typeof gtag
   let generateLeadEvent: any
   beforeEach(async () => {
     jest.restoreAllMocks()
@@ -37,10 +36,8 @@ describe('GoogleAnalytics4Web.generateLead', () => {
     generateLeadEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGA4 = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGA4.gtag)
+      mockGA4 = jest.fn()
+      return Promise.resolve(mockGA4)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -56,7 +53,7 @@ describe('GoogleAnalytics4Web.generateLead', () => {
     })
     await generateLeadEvent.track?.(context)
 
-    expect(mockGA4.gtag).toHaveBeenCalledWith(
+    expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('generate_lead'),
       expect.objectContaining({

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/login.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/login.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleAnalytics4Web, { destination } from '../index'
-import { GA } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -34,10 +33,8 @@ describe('GoogleAnalytics4Web.login', () => {
     loginEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGA4 = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGA4.gtag)
+      mockGA4 = jest.fn()
+      return Promise.resolve(mockGA4)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -52,7 +49,7 @@ describe('GoogleAnalytics4Web.login', () => {
     })
     await loginEvent.track?.(context)
 
-    expect(mockGA4.gtag).toHaveBeenCalledWith(
+    expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('login'),
       expect.objectContaining({

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/purchase.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/purchase.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleAnalytics4Web, { destination } from '../index'
-import { GA } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -50,7 +49,7 @@ describe('GoogleAnalytics4Web.purchase', () => {
     measurementID: 'test123'
   }
 
-  let mockGA4: GA
+  let mockGA4: typeof gtag
   let purchaseEvent: any
   beforeEach(async () => {
     jest.restoreAllMocks()
@@ -62,10 +61,8 @@ describe('GoogleAnalytics4Web.purchase', () => {
     purchaseEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGA4 = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGA4.gtag)
+      mockGA4 = jest.fn()
+      return Promise.resolve(mockGA4)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -89,7 +86,7 @@ describe('GoogleAnalytics4Web.purchase', () => {
     })
     await purchaseEvent.track?.(context)
 
-    expect(mockGA4.gtag).toHaveBeenCalledWith(
+    expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('purchase'),
       expect.objectContaining({

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/refund.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/refund.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleAnalytics4Web, { destination } from '../index'
-import { GA } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -50,7 +49,7 @@ describe('GoogleAnalytics4Web.refund', () => {
     measurementID: 'test123'
   }
 
-  let mockGA4: GA
+  let mockGA4: typeof gtag
   let refundEvent: any
   beforeEach(async () => {
     jest.restoreAllMocks()
@@ -62,10 +61,8 @@ describe('GoogleAnalytics4Web.refund', () => {
     refundEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGA4 = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGA4.gtag)
+      mockGA4 = jest.fn()
+      return Promise.resolve(mockGA4)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -89,7 +86,7 @@ describe('GoogleAnalytics4Web.refund', () => {
     })
     await refundEvent.track?.(context)
 
-    expect(mockGA4.gtag).toHaveBeenCalledWith(
+    expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('refund'),
       expect.objectContaining({

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/removeFromCart.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/removeFromCart.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleAnalytics4Web, { destination } from '../index'
-import { GA } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -47,7 +46,7 @@ describe('GoogleAnalytics4Web.removeFromCart', () => {
     measurementID: 'test123'
   }
 
-  let mockGA4: GA
+  let mockGA4: typeof gtag
   let removeFromCartEvent: any
   beforeEach(async () => {
     jest.restoreAllMocks()
@@ -59,10 +58,8 @@ describe('GoogleAnalytics4Web.removeFromCart', () => {
     removeFromCartEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGA4 = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGA4.gtag)
+      mockGA4 = jest.fn()
+      return Promise.resolve(mockGA4)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -86,7 +83,7 @@ describe('GoogleAnalytics4Web.removeFromCart', () => {
 
     await removeFromCartEvent.track?.(context)
 
-    expect(mockGA4.gtag).toHaveBeenCalledWith(
+    expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('remove_from_cart'),
       expect.objectContaining({

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/search.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/search.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleAnalytics4Web, { destination } from '../index'
-import { GA } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -22,7 +21,7 @@ describe('GoogleAnalytics4Web.search', () => {
     measurementID: 'test123'
   }
 
-  let mockGA4: GA
+  let mockGA4: typeof gtag
   let searchEvent: any
   beforeEach(async () => {
     jest.restoreAllMocks()
@@ -34,10 +33,8 @@ describe('GoogleAnalytics4Web.search', () => {
     searchEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGA4 = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGA4.gtag)
+      mockGA4 = jest.fn()
+      return Promise.resolve(mockGA4)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -53,7 +50,7 @@ describe('GoogleAnalytics4Web.search', () => {
 
     await searchEvent.track?.(context)
 
-    expect(mockGA4.gtag).toHaveBeenCalledWith(
+    expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('search'),
       expect.objectContaining({

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/selectItem.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/selectItem.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleAnalytics4Web, { destination } from '../index'
-import { GA } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -44,7 +43,7 @@ describe('GoogleAnalytics4Web.selectItem', () => {
     measurementID: 'test123'
   }
 
-  let mockGA4: GA
+  let mockGA4: typeof gtag
   let selectItemEvent: any
   beforeEach(async () => {
     jest.restoreAllMocks()
@@ -56,10 +55,8 @@ describe('GoogleAnalytics4Web.selectItem', () => {
     selectItemEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGA4 = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGA4.gtag)
+      mockGA4 = jest.fn()
+      return Promise.resolve(mockGA4)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -83,7 +80,7 @@ describe('GoogleAnalytics4Web.selectItem', () => {
 
     await selectItemEvent.track?.(context)
 
-    expect(mockGA4.gtag).toHaveBeenCalledWith(
+    expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('select_item'),
       expect.objectContaining({

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/selectPromotion.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/selectPromotion.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleAnalytics4Web, { destination } from '../index'
-import { GA } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -53,7 +52,7 @@ describe('GoogleAnalytics4Web.selectPromotion', () => {
     measurementID: 'test123'
   }
 
-  let mockGA4: GA
+  let mockGA4: typeof gtag
   let selectPromotionEvent: any
   beforeEach(async () => {
     jest.restoreAllMocks()
@@ -65,10 +64,8 @@ describe('GoogleAnalytics4Web.selectPromotion', () => {
     selectPromotionEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGA4 = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGA4.gtag)
+      mockGA4 = jest.fn()
+      return Promise.resolve(mockGA4)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -95,7 +92,7 @@ describe('GoogleAnalytics4Web.selectPromotion', () => {
 
     await selectPromotionEvent.track?.(context)
 
-    expect(mockGA4.gtag).toHaveBeenCalledWith(
+    expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('select_promotion'),
       expect.objectContaining({

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/signUp.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/signUp.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleAnalytics4Web, { destination } from '../index'
-import { GA } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -22,7 +21,7 @@ describe('GoogleAnalytics4Web.signUp', () => {
     measurementID: 'test123'
   }
 
-  let mockGA4: GA
+  let mockGA4: typeof gtag
   let signUpEvent: any
   beforeEach(async () => {
     jest.restoreAllMocks()
@@ -34,10 +33,8 @@ describe('GoogleAnalytics4Web.signUp', () => {
     signUpEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGA4 = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGA4.gtag)
+      mockGA4 = jest.fn()
+      return Promise.resolve(mockGA4)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -53,7 +50,7 @@ describe('GoogleAnalytics4Web.signUp', () => {
 
     await signUpEvent.track?.(context)
 
-    expect(mockGA4.gtag).toHaveBeenCalledWith(
+    expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('sign_up'),
       expect.objectContaining({ method: 'Google' })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/viewCart.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/viewCart.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleAnalytics4Web, { destination } from '../index'
-import { GA } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -44,7 +43,7 @@ describe('GoogleAnalytics4Web.viewCart', () => {
     measurementID: 'test123'
   }
 
-  let mockGA4: GA
+  let mockGA4: typeof gtag
   let viewCartEvent: any
   beforeEach(async () => {
     jest.restoreAllMocks()
@@ -56,10 +55,8 @@ describe('GoogleAnalytics4Web.viewCart', () => {
     viewCartEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGA4 = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGA4.gtag)
+      mockGA4 = jest.fn()
+      return Promise.resolve(mockGA4)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -83,7 +80,7 @@ describe('GoogleAnalytics4Web.viewCart', () => {
 
     await viewCartEvent.track?.(context)
 
-    expect(mockGA4.gtag).toHaveBeenCalledWith(
+    expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('view_cart'),
       expect.objectContaining({

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/viewItem.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/viewItem.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleAnalytics4Web, { destination } from '../index'
-import { GA } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -44,7 +43,7 @@ describe('GoogleAnalytics4Web.viewItem', () => {
     measurementID: 'test123'
   }
 
-  let mockGA4: GA
+  let mockGA4: typeof gtag
   let viewItemEvent: any
   beforeEach(async () => {
     jest.restoreAllMocks()
@@ -56,10 +55,8 @@ describe('GoogleAnalytics4Web.viewItem', () => {
     viewItemEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGA4 = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGA4.gtag)
+      mockGA4 = jest.fn()
+      return Promise.resolve(mockGA4)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -83,7 +80,7 @@ describe('GoogleAnalytics4Web.viewItem', () => {
 
     await viewItemEvent.track?.(context)
 
-    expect(mockGA4.gtag).toHaveBeenCalledWith(
+    expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('view_item'),
       expect.objectContaining({

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/viewItemList.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/viewItemList.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleAnalytics4Web, { destination } from '../index'
-import { GA } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -44,7 +43,7 @@ describe('GoogleAnalytics4Web.viewItemList', () => {
     measurementID: 'test123'
   }
 
-  let mockGA4: GA
+  let mockGA4: typeof gtag
   let viewItemListEvent: any
   beforeEach(async () => {
     jest.restoreAllMocks()
@@ -56,10 +55,8 @@ describe('GoogleAnalytics4Web.viewItemList', () => {
     viewItemListEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGA4 = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGA4.gtag)
+      mockGA4 = jest.fn()
+      return Promise.resolve(mockGA4)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -83,7 +80,7 @@ describe('GoogleAnalytics4Web.viewItemList', () => {
 
     await viewItemListEvent.track?.(context)
 
-    expect(mockGA4.gtag).toHaveBeenCalledWith(
+    expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('view_item_list'),
       expect.objectContaining({

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/viewPromotion.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/viewPromotion.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleAnalytics4Web, { destination } from '../index'
-import { GA } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -53,7 +52,7 @@ describe('GoogleAnalytics4Web.viewPromotion', () => {
     measurementID: 'test123'
   }
 
-  let mockGA4: GA
+  let mockGA4: typeof gtag
   let viewPromotionEvent: any
   beforeEach(async () => {
     jest.restoreAllMocks()
@@ -65,10 +64,8 @@ describe('GoogleAnalytics4Web.viewPromotion', () => {
     viewPromotionEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGA4 = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGA4.gtag)
+      mockGA4 = jest.fn()
+      return Promise.resolve(mockGA4)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -95,7 +92,7 @@ describe('GoogleAnalytics4Web.viewPromotion', () => {
 
     await viewPromotionEvent.track?.(context)
 
-    expect(mockGA4.gtag).toHaveBeenCalledWith(
+    expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('view_promotion'),
       expect.objectContaining({

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/index.ts
@@ -30,6 +30,8 @@ declare global {
   }
 }
 
+type ConsentParamsArg = 'granted' | 'denied' | undefined
+
 const presets: DestinationDefinition['presets'] = [
   {
     name: `Set Configuration Fields`,
@@ -153,8 +155,8 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
     window.gtag('js', new Date())
     if (settings.enableConsentMode) {
       window.gtag('consent', 'default', {
-        ad_storage: settings.defaultAdsStorageConsentState,
-        analytics_storage: settings.defaultAnalyticsStorageConsentState,
+        ad_storage: settings.defaultAdsStorageConsentState as ConsentParamsArg,
+        analytics_storage: settings.defaultAnalyticsStorageConsentState as ConsentParamsArg,
         wait_for_update: settings.waitTimeToUpdateConsentStage
       })
     }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/setConfigurationFields/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/setConfigurationFields/index.ts
@@ -4,6 +4,8 @@ import type { Payload } from './generated-types'
 import { user_id, user_properties } from '../ga4-properties'
 import { updateUser } from '../ga4-functions'
 
+type ConsentParamsArg = 'granted' | 'denied' | undefined
+
 // Change from unknown to the partner SDK types
 const action: BrowserActionDefinition<Settings, Function, Payload> = {
   title: 'Set Configuration Fields',
@@ -96,8 +98,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     updateUser(payload.user_id, payload.user_properties, gtag)
     if (settings.enableConsentMode) {
       window.gtag('consent', 'update', {
-        ad_storage: payload.ads_storage_consent_state,
-        analytics_storage: payload.analytics_storage_consent_state
+        ad_storage: payload.ads_storage_consent_state as ConsentParamsArg,
+        analytics_storage: payload.analytics_storage_consent_state as ConsentParamsArg
       })
     }
     type ConfigType = { [key: string]: unknown }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/types.ts
@@ -1,3 +1,0 @@
-export type GA = {
-  gtag: Function
-}

--- a/packages/browser-destinations/destinations/google-campaign-manager/src/__tests__/counterActivity.test.ts
+++ b/packages/browser-destinations/destinations/google-campaign-manager/src/__tests__/counterActivity.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleCampaignManager, { destination } from '../index'
-import { GTAG } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -44,7 +43,7 @@ describe('GoogleCampaignManager.counterActivity', () => {
     conversionLinker: false
   }
 
-  let mockGTAG: GTAG
+  let mockGTAG: typeof gtag
   let counterActivityEvent: any
   beforeEach(async () => {
     jest.restoreAllMocks()
@@ -56,10 +55,9 @@ describe('GoogleCampaignManager.counterActivity', () => {
     counterActivityEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGTAG = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGTAG.gtag)
+      mockGTAG = jest.fn()
+
+      return Promise.resolve(mockGTAG)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -82,7 +80,7 @@ describe('GoogleCampaignManager.counterActivity', () => {
     })
     await counterActivityEvent.track?.(context)
 
-    expect(mockGTAG.gtag).toHaveBeenCalledWith(
+    expect(mockGTAG).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('conversion'),
       expect.objectContaining({
@@ -115,7 +113,7 @@ describe('GoogleCampaignManager.counterActivity', () => {
     })
     await counterActivityEvent.track?.(context)
 
-    expect(mockGTAG.gtag).toHaveBeenCalledWith(
+    expect(mockGTAG).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('conversion'),
       expect.objectContaining({

--- a/packages/browser-destinations/destinations/google-campaign-manager/src/__tests__/salesActivity.test.ts
+++ b/packages/browser-destinations/destinations/google-campaign-manager/src/__tests__/salesActivity.test.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import googleCampaignManager, { destination } from '../index'
-import { GTAG } from '../types'
 
 const subscriptions: Subscription[] = [
   {
@@ -48,7 +47,7 @@ describe('GoogleCampaignManager.salesActivity', () => {
     conversionLinker: false
   }
 
-  let mockGTAG: GTAG
+  let mockGTAG: typeof gtag
   let salesActivityEvent: any
   beforeEach(async () => {
     jest.restoreAllMocks()
@@ -60,10 +59,9 @@ describe('GoogleCampaignManager.salesActivity', () => {
     salesActivityEvent = trackEventPlugin
 
     jest.spyOn(destination, 'initialize').mockImplementation(() => {
-      mockGTAG = {
-        gtag: jest.fn()
-      }
-      return Promise.resolve(mockGTAG.gtag)
+      mockGTAG = jest.fn()
+
+      return Promise.resolve(mockGTAG)
     })
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
@@ -89,7 +87,7 @@ describe('GoogleCampaignManager.salesActivity', () => {
     })
     await salesActivityEvent.track?.(context)
 
-    expect(mockGTAG.gtag).toHaveBeenCalledWith(
+    expect(mockGTAG).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('purchase'),
       expect.objectContaining({

--- a/packages/browser-destinations/destinations/google-campaign-manager/src/counterActivity/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-campaign-manager/src/counterActivity/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   activityTagString: string
   /**
-   * In Campaign Manager, go to Floodlight -> Configuration, under Tags, if **Dynamic** is selected, select **True**
+   * In Campaign Manager, go to Floodlight -> Configuration, under Tags, if **Dynamic** is selected, select **True**.
    */
   enableDynamicTags?: boolean
   /**

--- a/packages/browser-destinations/destinations/google-campaign-manager/src/index.ts
+++ b/packages/browser-destinations/destinations/google-campaign-manager/src/index.ts
@@ -6,7 +6,7 @@ import salesActivity from './salesActivity'
 
 declare global {
   interface Window {
-    gtag: Function
+    gtag: typeof gtag
     dataLayer: any
   }
 }

--- a/packages/browser-destinations/destinations/google-campaign-manager/src/salesActivity/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-campaign-manager/src/salesActivity/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   activityTagString: string
   /**
-   * In Campaign Manager, go to Floodlight -> Configuration, under Tags, if **Dynamic** is selected, select **True**
+   * In Campaign Manager, go to Floodlight -> Configuration, under Tags, if **Dynamic** is selected, select **True**.
    */
   enableDynamicTags?: boolean
   /**

--- a/packages/browser-destinations/destinations/google-campaign-manager/src/types.ts
+++ b/packages/browser-destinations/destinations/google-campaign-manager/src/types.ts
@@ -1,3 +1,0 @@
-export type GTAG = {
-  gtag: Function
-}

--- a/packages/browser-destinations/destinations/rupt/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/rupt/src/generated-types.ts
@@ -10,7 +10,7 @@ export interface Settings {
    */
   new_account_url: string
   /**
-   * A URL to redirect the user to if they choose to logout or if they are kicked out by a verified owner.
+   * A URL to redirect the user to if they choose to logout or if they are removed by a verified owner.
    */
   logout_url?: string
   /**

--- a/packages/browser-destinations/package.json
+++ b/packages/browser-destinations/package.json
@@ -32,6 +32,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.13.8",
     "@babel/preset-env": "^7.13.10",
     "@babel/preset-typescript": "^7.13.0",
+    "@types/gtag.js": "^0.0.13",
     "@types/jest": "^27.0.0",
     "babel-jest": "^27.3.1",
     "compression-webpack-plugin": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3710,6 +3710,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/gtag.js@^0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.13.tgz#54d746635e09fa61242e05b574b1ac068e6a90dd"
+  integrity sha512-yOXFkfnt1DQr1v9B4ERulJOGnbdVqnPHV8NG4nkQhnu4qbrJecQ06DlaKmSjI3nzIwBj5U9/X61LY4sTc2KbaQ==
+
 "@types/http-cache-semantics@*":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz#0ea7b61496902b95890dc4c3a116b60cb8dae812"
@@ -4860,10 +4865,25 @@ ansi-html-community@^0.0.8:
   resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
   integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
 
-ansi-regex@5.0.1, ansi-regex@^2.0.0, ansi-regex@^2.1.1, ansi-regex@^3.0.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1, ansi-regex@^6.0.1:
+ansi-regex@^2.0.0, ansi-regex@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  integrity sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==
+
+ansi-regex@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
+  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
+
+ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-regex@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
+  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -7435,13 +7455,6 @@ dot-prop@6.0.1:
   dependencies:
     is-obj "^2.0.0"
 
-dot-prop@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.1.tgz#45884194a71fc2cda71cbb4bceb3a4dd2f433ba4"
-  integrity sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==
-  dependencies:
-    is-obj "^1.0.0"
-
 dot-prop@^5.1.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
@@ -8927,13 +8940,6 @@ glob-parent@5.1.2, glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^6.0.1:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
-  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
-  dependencies:
-    is-glob "^4.0.3"
-
 glob-promise@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/glob-promise/-/glob-promise-3.4.0.tgz#b6b8f084504216f702dc2ce8c9bc9ac8866fdb20"
@@ -10026,7 +10032,7 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-obj@^1.0.0, is-obj@^1.0.1:
+is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4865,25 +4865,10 @@ ansi-html-community@^0.0.8:
   resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
   integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
 
-ansi-regex@^2.0.0, ansi-regex@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==
-
-ansi-regex@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
-  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
-
-ansi-regex@^5.0.0, ansi-regex@^5.0.1:
+ansi-regex@5.0.1, ansi-regex@^2.0.0, ansi-regex@^2.1.1, ansi-regex@^3.0.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1, ansi-regex@^6.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
-
-ansi-regex@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
-  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -7455,6 +7440,13 @@ dot-prop@6.0.1:
   dependencies:
     is-obj "^2.0.0"
 
+dot-prop@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.1.tgz#45884194a71fc2cda71cbb4bceb3a4dd2f433ba4"
+  integrity sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==
+  dependencies:
+    is-obj "^1.0.0"
+
 dot-prop@^5.1.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
@@ -8940,6 +8932,13 @@ glob-parent@5.1.2, glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
+glob-parent@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+  dependencies:
+    is-glob "^4.0.3"
+
 glob-promise@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/glob-promise/-/glob-promise-3.4.0.tgz#b6b8f084504216f702dc2ce8c9bc9ac8866fdb20"
@@ -10032,7 +10031,7 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-obj@^1.0.1:
+is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==


### PR DESCRIPTION
This removes our custom declaration of the GTag SDK and uses the DefinitelyTyped option as a best practice

## Testing

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment

![image](https://github.com/segmentio/action-destinations/assets/103517471/67df7cad-731f-49f9-80db-5c16c86837d3)

Validated that upon adding an item to cart, the GTAG call to both destinations is preserved:
![image](https://github.com/segmentio/action-destinations/assets/103517471/10c8a3e2-ed42-40c0-b5c3-335a1d6fdfdb)
![image](https://github.com/segmentio/action-destinations/assets/103517471/8a53c2e1-c624-4179-aa2e-818422bea188)
