### PR TITLE
[Salesforce Marketing Cloud] Enables bulk batching for RETL, Engage

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtension/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtension/generated-types.ts
@@ -29,4 +29,8 @@ export interface Payload {
    * If true, data is batched before sending to the SFMC Data Extension.
    */
   enable_batching?: boolean
+  /**
+   * Maximum number of events to include in each batch. Actual batch sizes may be lower.
+   */
+  batch_size?: number
 }

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtension/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtension/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { key, id, keys, enable_batching, values_contactFields } from '../sfmc-properties'
+import { key, id, keys, enable_batching, batch_size, values_contactFields } from '../sfmc-properties'
 import { upsertRows } from '../sfmc-operations'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -27,7 +27,8 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     values: values_contactFields,
-    enable_batching: enable_batching
+    enable_batching: enable_batching,
+    batch_size: batch_size
   },
   perform: async (request, { settings, payload }) => {
     return upsertRows(request, settings.subdomain, [payload])

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtension/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtension/generated-types.ts
@@ -25,4 +25,8 @@ export interface Payload {
    * If true, data is batched before sending to the SFMC Data Extension.
    */
   enable_batching?: boolean
+  /**
+   * Maximum number of events to include in each batch. Actual batch sizes may be lower.
+   */
+  batch_size?: number
 }

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtension/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtension/index.ts
@@ -1,7 +1,7 @@
 import { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { key, id, keys, enable_batching, values_dataExtensionFields } from '../sfmc-properties'
+import { key, id, keys, enable_batching, batch_size, values_dataExtensionFields } from '../sfmc-properties'
 import { upsertRows } from '../sfmc-operations'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -12,7 +12,8 @@ const action: ActionDefinition<Settings, Payload> = {
     id: id,
     keys: { ...keys, required: true },
     values: values_dataExtensionFields,
-    enable_batching: enable_batching
+    enable_batching: enable_batching,
+    batch_size: batch_size
   },
   perform: async (request, { settings, payload }) => {
     return upsertRows(request, settings.subdomain, [payload])

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-properties.ts
@@ -80,3 +80,12 @@ export const enable_batching: InputField = {
   type: 'boolean',
   default: false
 }
+
+export const batch_size: InputField = {
+  label: 'Batch Size',
+  description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
+  type: 'number',
+  required: false,
+  unsafe_hidden: true,
+  default: 5000
+}


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR updates Salesforce Marketing Cloud with a `batch_size` field, defaulted to `5000`. This enables bulk batching in RETL and Engage.

## Testing

Tested in successfully in stage on RETL. [Workspace link](https://app.segment.build/retl-bulk-api/reverse-etl/destinations/actions-salesforce-marketing-cloud/sources/databricks/instances/64ff81e563edeffb78ce984d/mappings/w1JcjkkGhdbfQThxJHvq7k/source-id/6eSPci3MqvnYjWr61NCkYp/model-id/9QHi3apdT4rnDmnetf3xAr/sync-details).

Bulk batching successfully enabled, batch sizes in DataDog consistently at 5k:
<img width="1579" alt="Screenshot 2023-09-11 at 4 40 49 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/50c10f08-e9fb-4653-a302-333d9e73a600">



- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
