### PR TITLE
tidying up package.json for 2 Integrations

### DIFF
--- a/packages/browser-destinations/destinations/google-campaign-manager/package.json
+++ b/packages/browser-destinations/destinations/google-campaign-manager/package.json
@@ -2,10 +2,9 @@
   "name": "@segment/analytics-browser-actions-google-campaign-manager",
   "version": "1.2.0",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/segmentio/action-destinations",
-    "directory": "packages/browser-destinations/destinations/google-campaign-manager"
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
   },
   "main": "./dist/cjs",
   "module": "./dist/esm",
@@ -16,7 +15,7 @@
   },
   "typings": "./dist/esm",
   "dependencies": {
-    "@segment/browser-destination-runtime": "^1.4.0"
+    "@segment/browser-destination-runtime": "^1.3.0"
   },
   "peerDependencies": {
     "@segment/analytics-next": "*"

--- a/packages/browser-destinations/destinations/pendo-web-actions/package.json
+++ b/packages/browser-destinations/destinations/pendo-web-actions/package.json
@@ -15,7 +15,6 @@
   },
   "typings": "./dist/esm",
   "dependencies": {
-    "@segment/actions-core": "^3.82.0",
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This PR is to fix the package.json files for 2 Integrations: 

**Google Campaign Manager** - the version of browser runtime was incorrect, and it was missing the publishConfig added by Neek a couple weeks ago (which other Destinations have). 

**Pendo Web** - removing unnecessary reference to actions-core

## Testing

No testing needed - both are new Integrations. 