### PR TITLE
Mass update peerDependencies for browser-destinations to specify supported analytics-next version

### DIFF
--- a/packages/browser-destinations/destinations/adobe-target/package.json
+++ b/packages/browser-destinations/destinations/adobe-target/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/amplitude-plugins/package.json
+++ b/packages/browser-destinations/destinations/amplitude-plugins/package.json
@@ -18,6 +18,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/braze-cloud-plugins/package.json
+++ b/packages/browser-destinations/destinations/braze-cloud-plugins/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/braze/package.json
+++ b/packages/browser-destinations/destinations/braze/package.json
@@ -39,6 +39,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/commandbar/package.json
+++ b/packages/browser-destinations/destinations/commandbar/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/friendbuy/package.json
+++ b/packages/browser-destinations/destinations/friendbuy/package.json
@@ -20,6 +20,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/fullstory/package.json
+++ b/packages/browser-destinations/destinations/fullstory/package.json
@@ -20,6 +20,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/package.json
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/google-campaign-manager/package.json
+++ b/packages/browser-destinations/destinations/google-campaign-manager/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.4.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/heap/package.json
+++ b/packages/browser-destinations/destinations/heap/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/hubspot-web/package.json
+++ b/packages/browser-destinations/destinations/hubspot-web/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/intercom/package.json
+++ b/packages/browser-destinations/destinations/intercom/package.json
@@ -20,6 +20,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/iterate/package.json
+++ b/packages/browser-destinations/destinations/iterate/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/koala/package.json
+++ b/packages/browser-destinations/destinations/koala/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/logrocket/package.json
+++ b/packages/browser-destinations/destinations/logrocket/package.json
@@ -20,6 +20,6 @@
     "logrocket": "^3.0.1"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/pendo-web-actions/package.json
+++ b/packages/browser-destinations/destinations/pendo-web-actions/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/playerzero-web/package.json
+++ b/packages/browser-destinations/destinations/playerzero-web/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/ripe/package.json
+++ b/packages/browser-destinations/destinations/ripe/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/rupt/package.json
+++ b/packages/browser-destinations/destinations/rupt/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/screeb/package.json
+++ b/packages/browser-destinations/destinations/screeb/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/segment-utilities-web/package.json
+++ b/packages/browser-destinations/destinations/segment-utilities-web/package.json
@@ -18,6 +18,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/sprig-web/package.json
+++ b/packages/browser-destinations/destinations/sprig-web/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/stackadapt/package.json
+++ b/packages/browser-destinations/destinations/stackadapt/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/tiktok-pixel/package.json
+++ b/packages/browser-destinations/destinations/tiktok-pixel/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/upollo/package.json
+++ b/packages/browser-destinations/destinations/upollo/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/userpilot/package.json
+++ b/packages/browser-destinations/destinations/userpilot/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/vwo/package.json
+++ b/packages/browser-destinations/destinations/vwo/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/browser-destinations/destinations/wisepops/package.json
+++ b/packages/browser-destinations/destinations/wisepops/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.13.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }

--- a/packages/cli/templates/destinations/browser/package.json
+++ b/packages/cli/templates/destinations/browser/package.json
@@ -19,6 +19,6 @@
     "@segment/browser-destination-runtime": "^1.4.0"
   },
   "peerDependencies": {
-    "@segment/analytics-next": "*"
+    "@segment/analytics-next": ">=1.55.0"
   }
 }


### PR DESCRIPTION
Now that we have released [support for npm action destinations](https://github.com/segmentio/analytics-next/releases/tag/%40segment%2Fanalytics-next%401.55.0), I am updating the peer dependencies to ensure that nobody tries to use locally-installed action destinations on an older version of ajs.