### PR TITLE
Stratconn 3154 - LiveRamp audiences should emit a proper error message if the SFTP folders are not found

### DIFF
--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/index.ts
@@ -28,7 +28,7 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'Path within the LiveRamp SFTP server to upload the files to. This path must exist and all subfolders must be pre-created.',
       type: 'string',
-      default: { '@template': '/uploads/{{properties.audience_key}}/' },
+      default: { '@template': '/uploads/' },
       format: 'uri-reference'
     },
     audience_key: {

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/sftp.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/sftp.ts
@@ -1,10 +1,9 @@
-import { InvalidAuthenticationError } from '@segment/actions-core'
+import { InvalidAuthenticationError, PayloadValidationError } from '@segment/actions-core'
 import Client from 'ssh2-sftp-client'
 import path from 'path'
 import { Payload } from './generated-types'
 
 import { LIVERAMP_SFTP_SERVER, LIVERAMP_SFTP_PORT } from '../properties'
-import { PayloadValidationError } from '@segment/actions-core/*'
 
 enum SFTPErrorCode {
   NO_SUCH_FILE = 2


### PR DESCRIPTION
This PR returns a friendlier error message to the user if a path cannot be found. It also removes the `audience_name` from the default path so users are not required to create folders in LR's SFTP as part of initial setup.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment

![image](https://github.com/segmentio/action-destinations/assets/103517471/ea160f86-a2e2-4c19-8d11-56a849fb55ed)

