### PR TITLE
[Algolia] feat: added addToCart and filterClicked events and made existing events more flexible

### DIFF
--- a/packages/browser-destinations/destinations/cdpresolution/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/cdpresolution/src/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Settings {
   /**
+   * Client identifier provided by CDP Resolution [Hashed Account ID]
+   */
+  clientIdentifier: string
+  /**
    * Identity resolution endpoint. [CDP Resolution documentation](https://www.cdpresolution.com/docs/)
    */
   endpoint: string
-  /**
-   * Client identifier provided by CDP Resolution [CDP Resultion Account](https://www.cdpresolution.com/accountsettings)
-   */
-  clientIdentifier: string
 }

--- a/packages/destination-actions/src/destinations/algolia-insights/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -10,12 +10,8 @@ Object {
       "objectIDs": Array [
         "U[ABpE$k",
       ],
-      "products": Array [
-        Object {
-          "product_id": "U[ABpE$k",
-        },
-      ],
       "queryID": "U[ABpE$k",
+      "testType": "U[ABpE$k",
       "timestamp": null,
       "userToken": "U[ABpE$k",
     },
@@ -33,12 +29,42 @@ Object {
       "objectIDs": Array [
         "U[ABpE$k",
       ],
-      "products": Array [
-        Object {
-          "product_id": "U[ABpE$k",
-        },
-      ],
       "userToken": "U[ABpE$k",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for actions-algolia-insights destination: productAddedEvents action - all fields 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "eventName": "Add to cart",
+      "eventType": "conversion",
+      "index": "g)$f*TeM",
+      "objectIDs": Array [
+        "g)$f*TeM",
+      ],
+      "queryID": "g)$f*TeM",
+      "testType": "g)$f*TeM",
+      "timestamp": null,
+      "userToken": "g)$f*TeM",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for actions-algolia-insights destination: productAddedEvents action - required fields 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "eventName": "Add to cart",
+      "eventType": "conversion",
+      "index": "g)$f*TeM",
+      "objectIDs": Array [
+        "g)$f*TeM",
+      ],
+      "userToken": "g)$f*TeM",
     },
   ],
 }
@@ -51,15 +77,14 @@ Object {
       "eventName": "Product Clicked",
       "eventType": "click",
       "index": "LLjxSD^^GnH",
-      "objectID": "LLjxSD^^GnH",
       "objectIDs": Array [
         "LLjxSD^^GnH",
       ],
-      "position": -1912532923056128,
       "positions": Array [
         -1912532923056128,
       ],
       "queryID": "LLjxSD^^GnH",
+      "testType": "LLjxSD^^GnH",
       "timestamp": null,
       "userToken": "LLjxSD^^GnH",
     },
@@ -74,11 +99,45 @@ Object {
       "eventName": "Product Clicked",
       "eventType": "click",
       "index": "LLjxSD^^GnH",
-      "objectID": "LLjxSD^^GnH",
       "objectIDs": Array [
         "LLjxSD^^GnH",
       ],
       "userToken": "LLjxSD^^GnH",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for actions-algolia-insights destination: productListFilteredEvents action - all fields 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "eventName": "Filter Clicked",
+      "eventType": "click",
+      "filters": Array [
+        "6O0djra:6O0djra",
+      ],
+      "index": "6O0djra",
+      "queryID": "6O0djra",
+      "testType": "6O0djra",
+      "timestamp": null,
+      "userToken": "6O0djra",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for actions-algolia-insights destination: productListFilteredEvents action - required fields 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "eventName": "Filter Clicked",
+      "eventType": "click",
+      "filters": Array [
+        "6O0djra:6O0djra",
+      ],
+      "index": "6O0djra",
+      "userToken": "6O0djra",
     },
   ],
 }
@@ -91,11 +150,11 @@ Object {
       "eventName": "Product Viewed",
       "eventType": "view",
       "index": "BLFCPcmz",
-      "objectID": "BLFCPcmz",
       "objectIDs": Array [
         "BLFCPcmz",
       ],
       "queryID": "BLFCPcmz",
+      "testType": "BLFCPcmz",
       "timestamp": null,
       "userToken": "BLFCPcmz",
     },
@@ -110,7 +169,6 @@ Object {
       "eventName": "Product Viewed",
       "eventType": "view",
       "index": "BLFCPcmz",
-      "objectID": "BLFCPcmz",
       "objectIDs": Array [
         "BLFCPcmz",
       ],

--- a/packages/destination-actions/src/destinations/algolia-insights/algolia-insight-api.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/algolia-insight-api.ts
@@ -8,22 +8,31 @@ type EventCommon = {
   eventName: string
   index: string
   userToken: string
-  objectIDs: string[]
   timestamp?: number
   queryID?: string
 }
 
 export type AlgoliaProductViewedEvent = EventCommon & {
   eventType: 'view'
+  objectIDs: string[]
 }
 
 export type AlgoliaProductClickedEvent = EventCommon & {
   eventType: 'click'
   positions?: number[]
+  objectIDs: string[]
+}
+
+export type AlgoliaFilterClickedEvent = EventCommon & {
+  eventType: 'click'
+  filters: string[]
 }
 
 export type AlgoliaConversionEvent = EventCommon & {
   eventType: 'conversion'
+  objectIDs: string[]
 }
 
-export type AlgoliaApiPermissions = { acl: string[] }
+export type AlgoliaApiPermissions = {
+  acl: string[]
+}

--- a/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -10,12 +10,8 @@ Object {
       "objectIDs": Array [
         ")j)vR5%1AP*epuo8A%R",
       ],
-      "products": Array [
-        Object {
-          "product_id": ")j)vR5%1AP*epuo8A%R",
-        },
-      ],
       "queryID": ")j)vR5%1AP*epuo8A%R",
+      "testType": ")j)vR5%1AP*epuo8A%R",
       "timestamp": null,
       "userToken": ")j)vR5%1AP*epuo8A%R",
     },

--- a/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/generated-types.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * An array of objects representing the purchased items. Each object must contains a product_id field.
+   * Populates the ObjectIds field in the Algolia Insights API. An array of objects representing the purchased items. Each object must contains a product_id field.
    */
   products: {
     product_id: string
@@ -23,4 +23,10 @@ export interface Payload {
    * The timestamp of the event.
    */
   timestamp?: string
+  /**
+   * Additional fields for this event. This field may be useful for Algolia Insights fields which are not mapped in Segment.
+   */
+  extraProperties?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/index.ts
@@ -6,12 +6,13 @@ import type { Payload } from './generated-types'
 
 export const conversionEvents: ActionDefinition<Settings, Payload> = {
   title: 'Conversion Events',
-  description: 'Successful product purcahses which can be tied back to an Algolia Search, Recommend or Predict result',
+  description:
+    'In ecommerce, conversions are purchase events often but not always involving multiple products. Outside of a conversion can be any positive signal associated with an index record. Query ID is optional and indicates that the view events is the result of a search query.',
   fields: {
     products: {
       label: 'Product Details',
       description:
-        'An array of objects representing the purchased items. Each object must contains a product_id field.',
+        'Populates the ObjectIds field in the Algolia Insights API. An array of objects representing the purchased items. Each object must contains a product_id field.',
       type: 'object',
       multiple: true,
       properties: { product_id: { label: 'product_id', type: 'string', required: true } },
@@ -57,14 +58,26 @@ export const conversionEvents: ActionDefinition<Settings, Payload> = {
       description: 'The timestamp of the event.',
       label: 'timestamp',
       default: { '@path': '$.timestamp' }
+    },
+    extraProperties: {
+      label: 'extraProperties',
+      required: false,
+      description:
+        'Additional fields for this event. This field may be useful for Algolia Insights fields which are not mapped in Segment.',
+      type: 'object',
+      default: {
+        '@path': '$.properties'
+      }
     }
   },
   defaultSubscription: 'type = "track" and event = "Order Completed"',
   perform: (request, data) => {
     const insightEvent: AlgoliaConversionEvent = {
-      ...data.payload,
+      ...data.payload.extraProperties,
       eventName: 'Conversion Event',
       eventType: 'conversion',
+      index: data.payload.index,
+      queryID: data.payload.queryID,
       objectIDs: data.payload.products.map((product) => product.product_id),
       userToken: data.payload.userToken,
       timestamp: data.payload.timestamp ? new Date(data.payload.timestamp).valueOf() : undefined

--- a/packages/destination-actions/src/destinations/algolia-insights/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/index.ts
@@ -8,6 +8,10 @@ import { conversionEvents, conversionPresets } from './conversionEvents'
 import { productViewedEvents, productViewedPresets } from './productViewedEvents'
 import { AlgoliaApiPermissions, algoliaApiPermissionsUrl } from './algolia-insight-api'
 
+import { productAddedEvents, productAddedPresets } from './productAddedEvents'
+
+import { productListFilteredEvents, productListFilteredPresets } from './productListFilteredEvents'
+
 export const ALGOLIA_INSIGHTS_USER_AGENT = 'algolia-segment-action-destination: 0.1'
 
 const destination: DestinationDefinition<Settings> = {
@@ -52,11 +56,19 @@ const destination: DestinationDefinition<Settings> = {
     }
   },
   // TODO: figure out how to pass multiple presets
-  presets: [productClickPresets, conversionPresets, productViewedPresets],
+  presets: [
+    productClickPresets,
+    conversionPresets,
+    productViewedPresets,
+    productAddedPresets,
+    productListFilteredPresets
+  ],
   actions: {
     productClickedEvents,
     conversionEvents,
-    productViewedEvents
+    productViewedEvents,
+    productAddedEvents,
+    productListFilteredEvents
   }
 }
 

--- a/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for AlgoliaInsights's productAddedEvents destination action: all fields 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "eventName": "Add to cart",
+      "eventType": "conversion",
+      "index": "D9W&9sjJ$g9LNBPqU",
+      "objectIDs": Array [
+        "D9W&9sjJ$g9LNBPqU",
+      ],
+      "queryID": "D9W&9sjJ$g9LNBPqU",
+      "testType": "D9W&9sjJ$g9LNBPqU",
+      "timestamp": null,
+      "userToken": "D9W&9sjJ$g9LNBPqU",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for AlgoliaInsights's productAddedEvents destination action: required fields 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "eventName": "Add to cart",
+      "eventType": "conversion",
+      "index": "D9W&9sjJ$g9LNBPqU",
+      "objectIDs": Array [
+        "D9W&9sjJ$g9LNBPqU",
+      ],
+      "userToken": "D9W&9sjJ$g9LNBPqU",
+    },
+  ],
+}
+`;

--- a/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/__tests__/index.test.ts
@@ -1,0 +1,78 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination, { ALGOLIA_INSIGHTS_USER_AGENT } from '../../index'
+import { AlgoliaConversionEvent, BaseAlgoliaInsightsURL } from '../../algolia-insight-api'
+import { SegmentEvent } from '@segment/actions-core'
+
+const testDestination = createTestIntegration(Destination)
+
+const algoliaDestinationActionSettings = {
+  appId: 'algolia-application-id',
+  apiKey: 'algolia-api-key'
+}
+const testAlgoliaDestination = async (event: SegmentEvent): Promise<AlgoliaConversionEvent> => {
+  nock(BaseAlgoliaInsightsURL).post('/1/events').reply(200, {})
+  const segmentEvent = {
+    event: { ...event },
+    settings: algoliaDestinationActionSettings,
+    useDefaultMappings: true
+  }
+  const actionResponse = await testDestination.testAction('productAddedEvents', segmentEvent)
+  const actionRequest = actionResponse[0].request
+
+  expect(actionResponse.length).toBe(1)
+  expect(actionRequest.headers.get('X-Algolia-Application-Id')).toBe(algoliaDestinationActionSettings.appId)
+  expect(actionRequest.headers.get('X-Algolia-API-Key')).toBe(algoliaDestinationActionSettings.apiKey)
+  expect(actionRequest.headers.get('X-Algolia-Agent')).toBe(ALGOLIA_INSIGHTS_USER_AGENT)
+
+  const rawBody = await actionRequest.text()
+  return JSON.parse(rawBody)['events'][0]
+}
+
+describe('AlgoliaInsights.productAddedEvents', () => {
+  it('should submit productAddedEvents on track "Product Added" event', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      event: 'Product Added',
+      properties: {
+        query_id: '1234',
+        search_index: 'fashion_1',
+        product_id: '9876'
+      }
+    })
+    const algoliaEvent = await testAlgoliaDestination(event)
+
+    expect(algoliaEvent.eventName).toBe('Add to cart')
+    expect(algoliaEvent.eventType).toBe('conversion')
+    expect(algoliaEvent.index).toBe(event.properties?.search_index)
+    expect(algoliaEvent.userToken).toBe(event.userId)
+    expect(algoliaEvent.objectIDs).toContain('9876')
+  })
+
+  it('should pass timestamp if present', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      event: 'Product Added',
+      properties: {
+        search_index: 'fashion_1',
+        product_id: '9876'
+      }
+    })
+    const algoliaEvent = await testAlgoliaDestination(event)
+    expect(algoliaEvent.timestamp).toBe(new Date(event.timestamp as string).valueOf())
+  })
+
+  it('should pass queryID if present', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      event: 'Product Added',
+      properties: {
+        query_id: '1234',
+        search_index: 'fashion_1',
+        product_id: '9876'
+      }
+    })
+    const algoliaEvent = await testAlgoliaDestination(event)
+    expect(algoliaEvent.queryID).toBe(event.properties?.query_id)
+  })
+})

--- a/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'productAddedEvents'
+const destinationSlug = 'AlgoliaInsights'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      timestamp: new Date('2023-01-27T18:23:06.677Z').toISOString(),
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      timestamp: new Date('2023-01-27T18:23:06.677Z').toISOString(),
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/generated-types.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/generated-types.ts
@@ -2,15 +2,15 @@
 
 export interface Payload {
   /**
-   * Product ID of the clicked item.
+   * Populates the ObjectIds field in the Algolia Insights API with a single ObjectId (productId) of the product added.
    */
-  objectID: string
+  product: string
   /**
    * Name of the targeted search index.
    */
   index: string
   /**
-   * Query ID of the list on which the item was viewed.
+   * Query ID of the list on which the item was purchased.
    */
   queryID?: string
   /**

--- a/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/index.ts
@@ -1,16 +1,18 @@
 import type { ActionDefinition, Preset } from '@segment/actions-core'
 import { defaultValues } from '@segment/actions-core'
-import { AlgoliaBehaviourURL, AlgoliaProductClickedEvent } from '../algolia-insight-api'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+import { AlgoliaBehaviourURL, AlgoliaConversionEvent } from '../algolia-insight-api'
 
-export const productClickedEvents: ActionDefinition<Settings, Payload> = {
-  title: 'Product Clicked Events',
-  description: 'When a product is clicked within an Algolia Search, Recommend or Predict result',
+export const productAddedEvents: ActionDefinition<Settings, Payload> = {
+  title: 'Product Added Events',
+  description:
+    'Product added events for ecommerce use cases for a customer adding an item to their cart. Query ID is optional and indicates that the event was the result of a search query.',
   fields: {
-    objectID: {
+    product: {
       label: 'Product ID',
-      description: 'Populates the ObjectIds field in the Algolia Insights API. Product ID of the clicked item.',
+      description:
+        'Populates the ObjectIds field in the Algolia Insights API with a single ObjectId (productId) of the product added.',
       type: 'string',
       required: true,
       default: {
@@ -28,20 +30,11 @@ export const productClickedEvents: ActionDefinition<Settings, Payload> = {
     },
     queryID: {
       label: 'Query ID',
-      description: 'Query ID of the list on which the item was clicked.',
+      description: 'Query ID of the list on which the item was purchased.',
       type: 'string',
       required: false,
       default: {
         '@path': '$.properties.query_id'
-      }
-    },
-    position: {
-      label: 'Position',
-      description: 'Position of the click in the list of Algolia search results.',
-      type: 'integer',
-      required: false,
-      default: {
-        '@path': '$.properties.position'
       }
     },
     userToken: {
@@ -75,17 +68,16 @@ export const productClickedEvents: ActionDefinition<Settings, Payload> = {
       }
     }
   },
-  defaultSubscription: 'type = "track" and event = "Product Clicked"',
+  defaultSubscription: 'type = "track" and event = "Product Added"',
   perform: (request, data) => {
-    const insightEvent: AlgoliaProductClickedEvent = {
+    const insightEvent: AlgoliaConversionEvent = {
       ...data.payload.extraProperties,
-      eventName: 'Product Clicked',
-      eventType: 'click',
+      eventName: 'Add to cart',
+      eventType: 'conversion',
       index: data.payload.index,
       queryID: data.payload.queryID,
-      objectIDs: [data.payload.objectID],
+      objectIDs: [data.payload.product],
       userToken: data.payload.userToken,
-      positions: data.payload.position ? [data.payload.position] : undefined,
       timestamp: data.payload.timestamp ? new Date(data.payload.timestamp).valueOf() : undefined
     }
     const insightPayload = { events: [insightEvent] }
@@ -97,11 +89,10 @@ export const productClickedEvents: ActionDefinition<Settings, Payload> = {
   }
 }
 
-/** used in the quick setup */
-export const productClickPresets: Preset = {
-  name: 'Send product clicked events to Algolia',
-  subscribe: productClickedEvents.defaultSubscription as string,
-  partnerAction: 'productClickedEvents',
-  mapping: defaultValues(productClickedEvents.fields),
+export const productAddedPresets: Preset = {
+  name: 'Send product added events to Algolia',
+  subscribe: productAddedEvents.defaultSubscription as string,
+  partnerAction: 'productAddedEvents',
+  mapping: defaultValues(productAddedEvents.fields),
   type: 'automatic'
 }

--- a/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -7,15 +7,14 @@ Object {
       "eventName": "Product Clicked",
       "eventType": "click",
       "index": "tTO6#",
-      "objectID": "tTO6#",
       "objectIDs": Array [
         "tTO6#",
       ],
-      "position": -8127732168785920,
       "positions": Array [
         -8127732168785920,
       ],
       "queryID": "tTO6#",
+      "testType": "tTO6#",
       "timestamp": null,
       "userToken": "tTO6#",
     },

--- a/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/generated-types.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * Product ID of the clicked item.
+   * Populates the ObjectIds field in the Algolia Insights API. Product ID of the clicked item.
    */
   objectID: string
   /**
@@ -25,4 +25,10 @@ export interface Payload {
    * The timestamp of the event.
    */
   timestamp?: string
+  /**
+   * Additional fields for this event. This field may be useful for Algolia Insights fields which are not mapped in Segment.
+   */
+  extraProperties?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/algolia-insights/productListFilteredEvents/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/productListFilteredEvents/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for AlgoliaInsights's productListFilteredEvents destination action: all fields 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "eventName": "Filter Clicked",
+      "eventType": "click",
+      "filters": Array [
+        "E625IsTOULbrg8:E625IsTOULbrg8",
+      ],
+      "index": "E625IsTOULbrg8",
+      "queryID": "E625IsTOULbrg8",
+      "testType": "E625IsTOULbrg8",
+      "timestamp": null,
+      "userToken": "E625IsTOULbrg8",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for AlgoliaInsights's productListFilteredEvents destination action: required fields 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "eventName": "Filter Clicked",
+      "eventType": "click",
+      "filters": Array [
+        "E625IsTOULbrg8:E625IsTOULbrg8",
+      ],
+      "index": "E625IsTOULbrg8",
+      "userToken": "E625IsTOULbrg8",
+    },
+  ],
+}
+`;

--- a/packages/destination-actions/src/destinations/algolia-insights/productListFilteredEvents/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productListFilteredEvents/__tests__/index.test.ts
@@ -1,0 +1,79 @@
+import nock from 'nock'
+import { SegmentEvent, createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination, { ALGOLIA_INSIGHTS_USER_AGENT } from '../../index'
+import { AlgoliaFilterClickedEvent, BaseAlgoliaInsightsURL } from '../../algolia-insight-api'
+
+const testDestination = createTestIntegration(Destination)
+
+const algoliaDestinationActionSettings = {
+  appId: 'algolia-application-id',
+  apiKey: 'algolia-api-key'
+}
+
+const testAlgoliaDestination = async (event: SegmentEvent): Promise<AlgoliaFilterClickedEvent> => {
+  nock(BaseAlgoliaInsightsURL).post('/1/events').reply(200, {})
+  const segmentEvent = {
+    event: { ...event },
+    settings: algoliaDestinationActionSettings,
+    useDefaultMappings: true
+  }
+  const actionResponse = await testDestination.testAction('productListFilteredEvents', segmentEvent)
+  const actionRequest = actionResponse[0].request
+
+  expect(actionResponse.length).toBe(1)
+  expect(actionRequest.headers.get('X-Algolia-Application-Id')).toBe(algoliaDestinationActionSettings.appId)
+  expect(actionRequest.headers.get('X-Algolia-API-Key')).toBe(algoliaDestinationActionSettings.apiKey)
+  expect(actionRequest.headers.get('X-Algolia-Agent')).toBe(ALGOLIA_INSIGHTS_USER_AGENT)
+
+  const rawBody = await actionRequest.text()
+  return JSON.parse(rawBody)['events'][0]
+}
+
+describe('AlgoliaInsights.productListFilteredEvents', () => {
+  it('should submit click on track "Filter Clicked" event', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      event: 'Filter Clicked',
+      properties: {
+        search_index: 'fashion_1',
+        filters: [{ attribute: 'discount', value: '10%25' }],
+        position: 5
+      }
+    })
+    const algoliaEvent = await testAlgoliaDestination(event)
+
+    expect(algoliaEvent.eventName).toBe('Filter Clicked')
+    expect(algoliaEvent.eventType).toBe('click')
+    expect(algoliaEvent.index).toBe(event.properties?.search_index)
+    expect(algoliaEvent.userToken).toBe(event.userId)
+    expect(algoliaEvent.queryID).toBe(event.properties?.query_id)
+    expect(algoliaEvent.filters).toContain('discount:10%25')
+  })
+
+  it('should pass timestamp if present', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      event: 'Filter Clicked',
+      properties: {
+        search_index: 'fashion_1',
+        filters: [{ attribute: 'discount', value: '10%25' }]
+      }
+    })
+    const algoliaEvent = await testAlgoliaDestination(event)
+    expect(algoliaEvent.timestamp).toBe(new Date(event.timestamp as string).valueOf())
+  })
+
+  it('should pass position if present', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      event: 'Filter Clicked',
+      properties: {
+        query_id: '1234',
+        search_index: 'fashion_1',
+        filters: [{ attribute: 'discount', value: '10%25' }]
+      }
+    })
+    const algoliaEvent = await testAlgoliaDestination(event)
+    expect(algoliaEvent.queryID).toBe(event.properties?.query_id)
+  })
+})

--- a/packages/destination-actions/src/destinations/algolia-insights/productListFilteredEvents/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productListFilteredEvents/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'productListFilteredEvents'
+const destinationSlug = 'AlgoliaInsights'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/algolia-insights/productListFilteredEvents/generated-types.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productListFilteredEvents/generated-types.ts
@@ -2,15 +2,24 @@
 
 export interface Payload {
   /**
-   * Product ID of the clicked item.
+   * Populates the filters field in the Algolia Insights API, a list of up to 10 facet filters. Field should be an array of strings with format ${attribute}:${value}.
    */
-  objectID: string
+  filters: {
+    /**
+     * The name of the Filter
+     */
+    attribute: string
+    /**
+     * The value of the Filter
+     */
+    value: string
+  }[]
   /**
    * Name of the targeted search index.
    */
   index: string
   /**
-   * Query ID of the list on which the item was viewed.
+   * Query ID of the list on which the item was clicked.
    */
   queryID?: string
   /**

--- a/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -7,11 +7,11 @@ Object {
       "eventName": "Product Viewed",
       "eventType": "view",
       "index": "og&DCP)aINw@qxe)",
-      "objectID": "og&DCP)aINw@qxe)",
       "objectIDs": Array [
         "og&DCP)aINw@qxe)",
       ],
       "queryID": "og&DCP)aINw@qxe)",
+      "testType": "og&DCP)aINw@qxe)",
       "timestamp": null,
       "userToken": "og&DCP)aINw@qxe)",
     },

--- a/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/index.ts
@@ -6,7 +6,8 @@ import type { Payload } from './generated-types'
 
 export const productViewedEvents: ActionDefinition<Settings, Payload> = {
   title: 'Product Viewed Events',
-  description: 'Product views which can be tied back to an Algolia Search, Recommend or Predict result',
+  description:
+    'Product view events act as a positive signal for associated record objects — the associated Product ID.  Query ID is optional and indicates that the view events is the result of a search query.',
   fields: {
     objectID: {
       label: 'Product ID',
@@ -54,14 +55,26 @@ export const productViewedEvents: ActionDefinition<Settings, Payload> = {
       description: 'The timestamp of the event.',
       label: 'timestamp',
       default: { '@path': '$.timestamp' }
+    },
+    extraProperties: {
+      label: 'extraProperties',
+      required: false,
+      description:
+        'Additional fields for this event. This field may be useful for Algolia Insights fields which are not mapped in Segment.',
+      type: 'object',
+      default: {
+        '@path': '$.properties'
+      }
     }
   },
   defaultSubscription: 'type = "track" and event = "Product Viewed"',
   perform: (request, data) => {
     const insightEvent: AlgoliaProductViewedEvent = {
-      ...data.payload,
+      ...data.payload.extraProperties,
       eventName: 'Product Viewed',
       eventType: 'view',
+      index: data.payload.index,
+      queryID: data.payload.queryID,
       objectIDs: [data.payload.objectID],
       timestamp: data.payload.timestamp ? new Date(data.payload.timestamp).valueOf() : undefined,
       userToken: data.payload.userToken


### PR DESCRIPTION
I've added two new event types to the Algolia Insights destination:
- [filterClicked event](https://www.algolia.com/doc/rest-api/insights/#method-param-filters)
- [addToCart event](https://www.algolia.com/doc/rest-api/insights/#method-param-eventname)

In addition to these two new events, I've extended the other events in the Algolia Insights destination to forward properties which are present on the event but not explicitly mapped. This is to allow us (Algolia) to expand the Insights API without requiring us to update this destination in lock-step with each udpate. Before this change, each change that we make to our API would need to be manually added to this destination. This additional flexibility enables customers to use any fields we add to the API in the future even if we haven't updated the Action Destination to explicitly map those fields. 

I've taken care to ensure this change is backward compatible so that it doesn't break any existing installs of the Algolia Insights destination.

## Testing
I've added tests for the two new events.
I've manually tested those events.
I've manually tested the new flexibility layer ensure it doesn't break existing installations. 

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
