### PR TITLE
flushing track() function

### DIFF
--- a/packages/browser-destinations/destinations/pendo-web-actions/src/track/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/track/index.ts
@@ -30,6 +30,7 @@ const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
   },
   perform: (pendo, { payload }) => {
     pendo.track(payload.event, payload.metadata)
+    pendo.flush(true)
   }
 }
 

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/types.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/types.ts
@@ -22,5 +22,6 @@ export type PendoSDK = {
   initialize: ({ visitor, account }: InitializeData) => void
   track: (eventName: string, metadata?: { [key: string]: unknown }) => void
   identify: (data: identifyPayload) => void
+  flush: (force: boolean) => void
   isReady: () => boolean
 }


### PR DESCRIPTION
Change to call the pendo.flush() function after pendo.track() to ensure the event leaves the browser immediately. 

## Testing

Tested using Actions Tester. No customers using the Integration yet. 
