### PR TITLE
STRATCONN-3141 - Ensure action liveramp audience SFTP uploads respect timeout

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -98,6 +98,22 @@ export class APIError extends IntegrationError {
 }
 
 /**
+ * Error to indicate the destination has gone over its allotted execution time
+ * and has is self-terminatng.
+ * This is typically used when the destination makes calls using a stack other than the
+ * HTTP/S RequestClient.
+ * Error will be retried.
+ */
+export class SelfTimeoutError extends IntegrationError {
+  /**
+   * @param message - a human-friendly message to display to users
+   */
+  constructor(message: string) {
+    super(message, ErrorCodes.SELF_TIMEOUT, 408)
+  }
+}
+
+/**
  * Standard error codes. Use one from this enum whenever possible.
  */
 export enum ErrorCodes {
@@ -112,5 +128,7 @@ export enum ErrorCodes {
   // Refresh token has expired
   REFRESH_TOKEN_EXPIRED = 'REFRESH_TOKEN_EXPIRED',
   // OAuth refresh failed
-  OAUTH_REFRESH_FAILED = 'OAUTH_REFRESH_FAILED'
+  OAUTH_REFRESH_FAILED = 'OAUTH_REFRESH_FAILED',
+  // Destination has spent more than the alloted time and needs to self-terminate
+  SELF_TIMEOUT = 'SELF_TIMEOUT'
 }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -99,7 +99,7 @@ export class APIError extends IntegrationError {
 
 /**
  * Error to indicate the destination has gone over its allotted execution time
- * and has is self-terminatng.
+ * and is self-terminating.
  * This is typically used when the destination makes calls using a stack other than the
  * HTTP/S RequestClient.
  * Error will be retried.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,7 @@ export {
   InvalidAuthenticationError,
   RetryableError,
   PayloadValidationError,
+  SelfTimeoutError,
   APIError,
   ErrorCodes
 } from './errors'
@@ -21,7 +22,7 @@ export { time, duration } from './time'
 export { realTypeOf, isObject, isArray, isString } from './real-type-of'
 
 export type { RequestOptions } from './request-client'
-export { HTTPError } from './request-client'
+export { HTTPError, DEFAULT_REQUEST_TIMEOUT } from './request-client'
 export { ModifiedResponse } from './types'
 export { default as fetch, Request, Response, Headers } from './fetch'
 

--- a/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/audienceEnteredSftp.test.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/audienceEnteredSftp.test.ts
@@ -1,0 +1,61 @@
+import { uploadSFTP, doSFTP } from '../audienceEnteredSftp/sftp'
+import { Payload } from '../audienceEnteredSftp/generated-types'
+import { SelfTimeoutError, DEFAULT_REQUEST_TIMEOUT } from '@segment/actions-core'
+
+import Client from 'ssh2-sftp-client'
+
+jest.mock('ssh2-sftp-client')
+
+describe('sftp library', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+    jest.clearAllTimers()
+  })
+
+  it('should upload the file successfully', async () => {
+    Client.prototype.connect = jest.fn()
+    Client.prototype.put = jest.fn()
+    Client.prototype.end = jest.fn()
+
+    const mockPayload: Payload = {
+      sftp_folder_path: 'sftp_folder_path',
+      audience_key: 'audience_key',
+      delimiter: 'delimiter',
+      filename: 'filename',
+      enable_batching: false
+    }
+
+    await uploadSFTP(new Client(), mockPayload, 'filename', jest.fn() as any)
+    expect(Client.prototype.put).toHaveBeenCalled()
+  })
+
+  // should this test ever randomly fail, please disable it without mercy
+  it('should throw SelfTimeoutError when upload takes too long', async () => {
+    jest.useFakeTimers()
+
+    Client.prototype.connect = jest.fn().mockReturnValue(Promise.resolve({ success: true }))
+    Client.prototype.end = jest.fn().mockReturnValue(Promise.resolve({ success: true }))
+
+    const mockPayload: Payload = {
+      sftp_folder_path: 'sftp_folder_path',
+      audience_key: 'audience_key',
+      delimiter: 'delimiter',
+      filename: 'filename',
+      enable_batching: false
+    }
+
+    const trigger = jest.fn()
+    const sftpAction = jest.fn(() => {
+      trigger()
+      return new Promise((resolve) => {
+        setTimeout(resolve, DEFAULT_REQUEST_TIMEOUT * 2) // Deliberately delay to trigger timeout
+      })
+    })
+    const uploadPromise = doSFTP(new Client(), mockPayload, sftpAction)
+    await trigger() // this happens after the timeout has been set but before it is concluded, but after the sftpAction ran
+
+    jest.runAllTimers() //force timeout
+
+    await expect(uploadPromise).rejects.toThrow(SelfTimeoutError)
+  })
+})

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/sftp.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/sftp.ts
@@ -50,7 +50,9 @@ async function doSFTP(sftp: Client, payload: Payload, action: { (sftp: Client): 
 
   let timeoutError
   const timeout = setTimeout(() => {
-    void sftp.end() // hang promise on purpose, we are on fault hot path
+    void sftp.end().catch((err) => {
+      console.error(err)
+    }) // hang promise on purpose, we are on fault hot path, but also catch the error to avoid an unhandledRejection
     timeoutError = new SelfTimeoutError(
       `did not complete SFTP operation under allotted time: ${DEFAULT_REQUEST_TIMEOUT}`
     )

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/sftp.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/sftp.ts
@@ -87,4 +87,4 @@ async function testAuthenticationSFTP(sftp: Client, payload: Payload) {
   })
 }
 
-export { validateSFTP, uploadSFTP, testAuthenticationSFTP, Client }
+export { validateSFTP, uploadSFTP, doSFTP, testAuthenticationSFTP, Client }


### PR DESCRIPTION
The [LiveRamp audience SFTP destination](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/sftp.ts#L30-L41) does not respect the [DEFAULT_REQUEST_TIMEOUT](https://github.com/segmentio/action-destinations/blob/d98caec37c9a9ccbbf4e8f25ca951cc68bdbc948/packages/core/src/request-client.ts#L20.) This will leave dangling executions in the case of a timeout so when the next job is processed by Integrations there will be more impact on processing time.

This PR fixes that by relying on self-managing the timeout.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment