### PR TITLE
Update Attio Actions destination to use IDs as unique lookup field

### DIFF
--- a/packages/destination-actions/src/destinations/attio/assertRecord/index.ts
+++ b/packages/destination-actions/src/destinations/attio/assertRecord/index.ts
@@ -75,17 +75,13 @@ const action: ActionDefinition<Settings, Payload> = {
     object: objectLookup
   },
 
-  perform: async (request, data) => {
-    const {
-      payload: { attributes, object, matching_attribute }
-    } = data
-
+  perform: async (request, { payload }) => {
     const client = new AttioClient(request)
 
     return await client.assertRecord({
-      object,
-      matching_attribute,
-      values: attributes ?? {}
+      object: payload.object,
+      matching_attribute: payload.matching_attribute,
+      values: payload.attributes ?? {}
     })
   }
 }

--- a/packages/destination-actions/src/destinations/attio/groupWorkspace/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/attio/groupWorkspace/__tests__/index.test.ts
@@ -10,14 +10,14 @@ const domain = 'example.com'
 const event = createTestEvent({
   type: 'group' as const,
   traits: {
-    name: 'The Bluth Company',
+    id: '42',
     domain
   }
 })
 
 const mapping = {
   domain: { '@path': '$.traits.domain' },
-  name: { '@path': '$.traits.name' }
+  workspace_id: { '@path': '$.traits.id' }
 }
 
 describe('Attio.groupWorkspace', () => {
@@ -45,11 +45,11 @@ describe('Attio.groupWorkspace', () => {
       .reply(200, companyResponse)
 
     nock('https://api.attio.com')
-      .put('/v2/objects/workspaces/records/simple?matching_attribute=name', {
+      .put('/v2/objects/workspaces/records/simple?matching_attribute=workspace_id', {
         data: {
           values: {
             company: 'record_id',
-            name: 'The Bluth Company'
+            workspace_id: '42'
           }
         }
       })

--- a/packages/destination-actions/src/destinations/attio/groupWorkspace/generated-types.ts
+++ b/packages/destination-actions/src/destinations/attio/groupWorkspace/generated-types.ts
@@ -6,9 +6,9 @@ export interface Payload {
    */
   domain: string
   /**
-   * The name of the Workspace
+   * The ID of the Workspace
    */
-  name: string
+  workspace_id: string
   /**
    * Additional attributes to either set or update on the Attio Company Record. The values on the left should be Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs. For example: traits.name → name
    */

--- a/packages/destination-actions/src/destinations/attio/groupWorkspace/index.ts
+++ b/packages/destination-actions/src/destinations/attio/groupWorkspace/index.ts
@@ -27,9 +27,9 @@ const workspace_id: InputField = {
   required: true,
   default: {
     '@if': {
-      exists: { '@path': '$.context.groupId' },
-      then: { '@path': '$.context.groupId' },
-      else: { '@path': '$.id' }
+      exists: { '@path': '$.groupId' },
+      then: { '@path': '$.groupId' },
+      else: { '@path': '$.context.group_id' }
     }
   }
 }

--- a/packages/destination-actions/src/destinations/attio/groupWorkspace/index.ts
+++ b/packages/destination-actions/src/destinations/attio/groupWorkspace/index.ts
@@ -19,17 +19,17 @@ const domain: InputField = {
   }
 }
 
-const name: InputField = {
+const workspace_id: InputField = {
   type: 'string',
-  label: 'Name',
-  description: 'The name of the Workspace',
+  label: 'ID',
+  description: 'The ID of the Workspace',
   format: 'text',
   required: true,
   default: {
     '@if': {
-      exists: { '@path': '$.traits.name' },
-      then: { '@path': '$.traits.name' },
-      else: { '@path': '$.name' }
+      exists: { '@path': '$.context.groupId' },
+      then: { '@path': '$.context.groupId' },
+      else: { '@path': '$.id' }
     }
   }
 }
@@ -62,14 +62,14 @@ const action: ActionDefinition<Settings, Payload> = {
 
   fields: {
     domain,
-    name,
+    workspace_id,
     company_attributes,
     workspace_attributes
   },
 
   perform: async (request, data) => {
     const {
-      payload: { domain, name, workspace_attributes, company_attributes }
+      payload: { domain, workspace_id, workspace_attributes, company_attributes }
     } = data
 
     const client = new AttioClient(request)
@@ -85,9 +85,9 @@ const action: ActionDefinition<Settings, Payload> = {
 
     return await client.assertRecord({
       object: 'workspaces',
-      matching_attribute: 'name',
+      matching_attribute: 'workspace_id',
       values: {
-        name,
+        workspace_id,
         company: company.data.data.id.record_id,
         ...(workspace_attributes ?? {})
       }

--- a/packages/destination-actions/src/destinations/attio/groupWorkspace/index.ts
+++ b/packages/destination-actions/src/destinations/attio/groupWorkspace/index.ts
@@ -67,19 +67,15 @@ const action: ActionDefinition<Settings, Payload> = {
     workspace_attributes
   },
 
-  perform: async (request, data) => {
-    const {
-      payload: { domain, workspace_id, workspace_attributes, company_attributes }
-    } = data
-
+  perform: async (request, { payload }) => {
     const client = new AttioClient(request)
 
     const company = await client.assertRecord({
       object: 'companies',
       matching_attribute: 'domains',
       values: {
-        domains: domain,
-        ...(company_attributes ?? {})
+        domains: payload.domain,
+        ...(payload.company_attributes ?? {})
       }
     })
 
@@ -87,9 +83,9 @@ const action: ActionDefinition<Settings, Payload> = {
       object: 'workspaces',
       matching_attribute: 'workspace_id',
       values: {
-        workspace_id,
+        workspace_id: payload.workspace_id,
         company: company.data.data.id.record_id,
-        ...(workspace_attributes ?? {})
+        ...(payload.workspace_attributes ?? {})
       }
     })
   }

--- a/packages/destination-actions/src/destinations/attio/identifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/attio/identifyUser/__tests__/index.test.ts
@@ -8,6 +8,7 @@ const testDestination = createTestIntegration(Destination)
 const email = 'gob@bluth.example'
 const event = createTestEvent({
   type: 'identify' as const,
+  userId: '9',
   traits: {
     name: 'George Oscar Bluth',
     email
@@ -16,6 +17,7 @@ const event = createTestEvent({
 
 const mapping = {
   email_address: { '@path': '$.traits.email' },
+  user_id: { '@path': '$.userId' },
   user_attributes: {
     name: {
       '@path': '$.traits.name'
@@ -36,12 +38,13 @@ describe('Attio.identifyUser', () => {
       .reply(200, {})
 
     nock('https://api.attio.com')
-      .put('/v2/objects/users/records/simple?matching_attribute=primary_email_address', {
+      .put('/v2/objects/users/records/simple?matching_attribute=user_id', {
         data: {
           values: {
-            name: 'George Oscar Bluth',
+            user_id: '9',
             primary_email_address: email,
-            person: email
+            person: email,
+            name: 'George Oscar Bluth'
           }
         }
       })

--- a/packages/destination-actions/src/destinations/attio/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/attio/identifyUser/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   email_address: string
   /**
+   * The ID of the User
+   */
+  user_id: string
+  /**
    * Additional attributes to either set or update on the Attio User Record. The values on the left should be Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs. For example: traits.name → name
    */
   user_attributes?: {

--- a/packages/destination-actions/src/destinations/attio/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/attio/identifyUser/index.ts
@@ -25,13 +25,7 @@ const user_id: InputField = {
   description: 'The ID of the User',
   format: 'text',
   required: true,
-  default: {
-    '@if': {
-      exists: { '@path': '$.userId' },
-      then: { '@path': '$.userId' },
-      else: { '@path': '$.anonymousId' }
-    }
-  }
+  default: { '@path': '$.userId' }
 }
 
 const user_attributes: InputField = {

--- a/packages/destination-actions/src/destinations/attio/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/attio/identifyUser/index.ts
@@ -19,6 +19,21 @@ const email_address: InputField = {
   }
 }
 
+const user_id: InputField = {
+  type: 'string',
+  label: 'ID',
+  description: 'The ID of the User',
+  format: 'text',
+  required: true,
+  default: {
+    '@if': {
+      exists: { '@path': '$.userId' },
+      then: { '@path': '$.userId' },
+      else: { '@path': '$.anonymousId' }
+    }
+  }
+}
+
 const user_attributes: InputField = {
   type: 'object',
   label: 'Additional User attributes',
@@ -49,13 +64,14 @@ const action: ActionDefinition<Settings, Payload> = {
 
   fields: {
     email_address,
+    user_id,
     user_attributes,
     person_attributes
   },
 
   perform: async (request, data) => {
     const {
-      payload: { email_address, user_attributes, person_attributes }
+      payload: { email_address, user_id, user_attributes, person_attributes }
     } = data
 
     const client = new AttioClient(request)
@@ -71,10 +87,11 @@ const action: ActionDefinition<Settings, Payload> = {
 
     return await client.assertRecord({
       object: 'users',
-      matching_attribute: 'primary_email_address',
+      matching_attribute: 'user_id',
       values: {
         primary_email_address: email_address,
         person: email_address,
+        user_id,
         ...(user_attributes ?? {})
       }
     })

--- a/packages/destination-actions/src/destinations/attio/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/attio/identifyUser/index.ts
@@ -69,19 +69,15 @@ const action: ActionDefinition<Settings, Payload> = {
     person_attributes
   },
 
-  perform: async (request, data) => {
-    const {
-      payload: { email_address, user_id, user_attributes, person_attributes }
-    } = data
-
+  perform: async (request, { payload }) => {
     const client = new AttioClient(request)
 
     await client.assertRecord({
       object: 'people',
       matching_attribute: 'email_addresses',
       values: {
-        email_addresses: email_address,
-        ...(person_attributes ?? {})
+        email_addresses: payload.email_address,
+        ...(payload.person_attributes ?? {})
       }
     })
 
@@ -89,10 +85,10 @@ const action: ActionDefinition<Settings, Payload> = {
       object: 'users',
       matching_attribute: 'user_id',
       values: {
-        primary_email_address: email_address,
-        person: email_address,
-        user_id,
-        ...(user_attributes ?? {})
+        primary_email_address: payload.email_address,
+        person: payload.email_address,
+        user_id: payload.user_id,
+        ...(payload.user_attributes ?? {})
       }
     })
   }


### PR DESCRIPTION
Hi team 👋 ,

This is a relatively small change based on some feedback with our early beta testers. We've changed the data model slightly in Attio, so that with the suggested "identify User" and "group Workspace" mappings you need to specify an additional `user_id` or `workspace_id` attribute (that is likely part of your Segment event already).

While it's technically a breaking change, none of our existing testers are actually sending production data through this Action yet, so we thought it a good time to make the change, and we'll coordinate with them as it's released.

## Testing

I've updated the unit tests and run through some manual end-to-end tests locally, this should still work great like before.