### PR TITLE
[PINT-1988] Specify device type when associating named user

### DIFF
--- a/packages/destination-actions/src/destinations/airship/utilities.ts
+++ b/packages/destination-actions/src/destinations/airship/utilities.ts
@@ -110,6 +110,7 @@ export function associate_named_user(
 
   const associate_payload = {
     channel_id: channel_id,
+    device_type: 'email',
     named_user_id: named_user_id
   }
 


### PR DESCRIPTION
This should solve the occasional race condition between registering an email address and associating it with a named user.

## Testing
Registering and associating as per the documentation should work as advertised.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
