### PR TITLE
[DevRev]: Update streamEvent with new fields for RevUser identification

### DIFF
--- a/packages/destination-actions/src/destinations/devrev/mocks/index.ts
+++ b/packages/destination-actions/src/destinations/devrev/mocks/index.ts
@@ -17,6 +17,9 @@ export const email = 'test-user@test.com'
 export const domain = email.split('@')[1]
 
 export const testUserId = 'test-user-id'
+export const testUserRef = 'test-user-ref'
+export const testAccountRef = 'test-account-ref'
+export const testWorkspaceRef = 'test-workspace-ref'
 export const testUserFullName = 'test-user-full-name'
 export const testDescription = 'test-description'
 export const testEventName = 'test-event-name'

--- a/packages/destination-actions/src/destinations/devrev/streamEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/devrev/streamEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -7,19 +7,22 @@ Object {
       "event_time": "2021-02-01T00:00:00.000Z",
       "name": "sZcTM%n(kDC3tsz4iK5h",
       "payload": Object {
+        "accountRef": "sZcTM%n(kDC3tsz4iK5h",
         "anonymousId": "sZcTM%n(kDC3tsz4iK5h",
         "context": Object {
           "testType": "sZcTM%n(kDC3tsz4iK5h",
         },
+        "devrev_source_identifier": "segment",
         "email": "opemal@ner.kr",
         "eventName": "sZcTM%n(kDC3tsz4iK5h",
-        "event_source": "segment",
         "messageId": "sZcTM%n(kDC3tsz4iK5h",
         "properties": Object {
           "testType": "sZcTM%n(kDC3tsz4iK5h",
         },
         "timestamp": "2021-02-01T00:00:00.000Z",
         "userId": "sZcTM%n(kDC3tsz4iK5h",
+        "userRef": "sZcTM%n(kDC3tsz4iK5h",
+        "workspaceRef": "sZcTM%n(kDC3tsz4iK5h",
       },
     },
   ],
@@ -33,8 +36,8 @@ Object {
       "event_time": "2021-02-01T00:00:00.000Z",
       "name": "sZcTM%n(kDC3tsz4iK5h",
       "payload": Object {
+        "devrev_source_identifier": "segment",
         "eventName": "sZcTM%n(kDC3tsz4iK5h",
-        "event_source": "segment",
         "timestamp": "2021-02-01T00:00:00.000Z",
       },
     },

--- a/packages/destination-actions/src/destinations/devrev/streamEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/devrev/streamEvent/__tests__/index.test.ts
@@ -2,7 +2,17 @@ import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 import { TrackEventsPublishBody, devrevApiPaths, getBaseUrl } from '../../utils'
-import { settings, testAnonymousId, testContext, testEventPayload, testMessageId, testUserId } from '../../mocks'
+import {
+  settings,
+  testAccountRef,
+  testAnonymousId,
+  testContext,
+  testEventPayload,
+  testMessageId,
+  testUserId,
+  testUserRef,
+  testWorkspaceRef
+} from '../../mocks'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -18,6 +28,14 @@ describe('Devrev.streamEvent', () => {
       ...testEventPayload,
       messageId: testMessageId,
       anonymousId: testAnonymousId,
+      integrations: {
+        // @ts-expect-error integrations should accept complex objects;
+        DevRev: {
+          userRef: testUserRef,
+          accountRef: testAccountRef,
+          workspaceRef: testWorkspaceRef
+        }
+      },
       context: testContext,
       userId: testUserId,
       properties: {
@@ -44,11 +62,14 @@ describe('Devrev.streamEvent', () => {
             timestamp: testEventPayload.timestamp,
             email: testEventPayload.properties?.email,
             userId: testUserId,
+            userRef: testUserRef,
+            accountRef: testAccountRef,
+            workspaceRef: testWorkspaceRef,
             messageId: testMessageId,
             anonymousId: testAnonymousId,
             context: testContext,
             properties: testEventPayload.properties,
-            event_source: 'segment'
+            devrev_source_identifier: 'segment'
           }
         }
       ]

--- a/packages/destination-actions/src/destinations/devrev/streamEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/devrev/streamEvent/generated-types.ts
@@ -10,9 +10,21 @@ export interface Payload {
    */
   timestamp: string | number
   /**
-   * User ID, ideally mappable to external ref of a Rev User.
+   * User ID as received from Segment.
    */
   userId?: string
+  /**
+   * User Ref, ideally mappable to external ref of a Rev User.
+   */
+  userRef?: string
+  /**
+   * Account Ref, ideally mappable to external ref of a Rev Account.
+   */
+  accountRef?: string
+  /**
+   * Workspace Ref, ideally mappable to external ref of a Rev Workspace.
+   */
+  workspaceRef?: string
   /**
    * The email of the contact associated with this event.
    */

--- a/packages/destination-actions/src/destinations/devrev/streamEvent/index.ts
+++ b/packages/destination-actions/src/destinations/devrev/streamEvent/index.ts
@@ -26,10 +26,49 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     userId: {
       label: 'User ID',
-      description: 'User ID, ideally mappable to external ref of a Rev User.',
+      description: 'User ID as received from Segment.',
       type: 'string',
       required: false,
       default: { '@path': '$.userId' }
+    },
+    userRef: {
+      label: 'User Ref',
+      description: 'User Ref, ideally mappable to external ref of a Rev User.',
+      type: 'string',
+      required: false,
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.userRef' },
+          then: { '@path': '$.traits.userRef' },
+          else: { '@path': '$.integrations.DevRev.userRef' }
+        }
+      }
+    },
+    accountRef: {
+      label: 'Account Ref',
+      description: 'Account Ref, ideally mappable to external ref of a Rev Account.',
+      type: 'string',
+      required: false,
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.accountRef' },
+          then: { '@path': '$.traits.accountRef' },
+          else: { '@path': '$.integrations.DevRev.accountRef' }
+        }
+      }
+    },
+    workspaceRef: {
+      label: 'Workspace Ref',
+      description: 'Workspace Ref, ideally mappable to external ref of a Rev Workspace.',
+      type: 'string',
+      required: false,
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.workspaceRef' },
+          then: { '@path': '$.traits.workspaceRef' },
+          else: { '@path': '$.integrations.DevRev.workspaceRef' }
+        }
+      }
     },
     email: {
       label: 'Email Address',
@@ -86,7 +125,7 @@ const action: ActionDefinition<Settings, Payload> = {
           payload: {
             // add mapped data to payload
             ...payload,
-            event_source: 'segment'
+            devrev_source_identifier: 'segment'
           }
         }
       ]


### PR DESCRIPTION
- Make the `streamEvent` action uses the fields `userRef`, `accountRef`, and `workspaceRef` from the integrations object. The enrichment is done by [identifyRevUser](https://github.com/segmentio/action-destinations/pull/1582)
- Change the event source field in payload from event_source to devrev_source_identifier, to make it a field that is more specific to DevRev

This PR depends on changes from #1582

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
