### PR TITLE
[STRATCONN-3023]-Added traits support in sendTrack action

### DIFF
--- a/packages/destination-actions/src/destinations/segment/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -392,6 +392,9 @@ Object {
       "width": -29887526831390.72,
     },
     "timezone": "CYyxkIddLM",
+    "traits": Object {
+      "testType": "CYyxkIddLM",
+    },
     "userAgent": "CYyxkIddLM",
   },
   "event": "CYyxkIddLM",
@@ -408,6 +411,7 @@ Object {
   "anonymousId": "CYyxkIddLM",
   "context": Object {
     "groupId": "CYyxkIddLM",
+    "traits": Object {},
   },
   "event": "CYyxkIddLM",
   "properties": Object {},

--- a/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -60,6 +60,9 @@ Object {
       "width": 17838569150218.24,
     },
     "timezone": "ET^Xg5cIGF]2ok",
+    "traits": Object {
+      "testType": "ET^Xg5cIGF]2ok",
+    },
     "userAgent": "ET^Xg5cIGF]2ok",
   },
   "event": "ET^Xg5cIGF]2ok",
@@ -76,6 +79,7 @@ Object {
   "anonymousId": "ET^Xg5cIGF]2ok",
   "context": Object {
     "groupId": "ET^Xg5cIGF]2ok",
+    "traits": Object {},
   },
   "event": "ET^Xg5cIGF]2ok",
   "properties": Object {},

--- a/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/index.test.ts
@@ -21,6 +21,9 @@ const defaultTrackMapping = {
   },
   properties: {
     '@path': '$.properties'
+  },
+  traits: {
+    '@path': '$.traits'
   }
 }
 
@@ -76,6 +79,7 @@ describe('Segment.sendTrack', () => {
       properties: {
         plan: 'Business'
       },
+      traits: { email: 'testuser@gmail.com', age: 47 },
       userId: 'test-user-ufi5bgkko5',
       anonymousId: 'arky4h2sh7k',
       event: 'Test Event'
@@ -98,7 +102,7 @@ describe('Segment.sendTrack', () => {
       properties: {
         ...event.properties
       },
-      context: {}
+      context: { traits: { email: 'testuser@gmail.com', age: 47 } }
     })
   })
 

--- a/packages/destination-actions/src/destinations/segment/sendTrack/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/generated-types.ts
@@ -227,4 +227,10 @@ export interface Payload {
   properties?: {
     [k: string]: unknown
   }
+  /**
+   * Free-form dictionary of traits that describe the user or group of users.
+   */
+  traits?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/segment/sendTrack/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/index.ts
@@ -19,7 +19,8 @@ import {
   user_agent,
   timezone,
   group_id,
-  properties
+  properties,
+  traits
 } from '../segment-properties'
 import { SEGMENT_ENDPOINTS } from '../properties'
 import { MissingUserOrAnonymousIdThrowableError, InvalidEndpointSelectedThrowableError } from '../errors'
@@ -46,7 +47,8 @@ const action: ActionDefinition<Settings, Payload> = {
     user_agent,
     timezone,
     group_id,
-    properties
+    properties,
+    traits
   },
   perform: (request, { payload, settings, features, statsContext }) => {
     if (!payload.anonymous_id && !payload.user_id) {
@@ -59,6 +61,9 @@ const action: ActionDefinition<Settings, Payload> = {
       timestamp: payload?.timestamp,
       event: payload?.event_name,
       context: {
+        traits: {
+          ...payload?.traits
+        },
         app: payload?.application,
         campaign: payload?.campaign_parameters,
         device: payload?.device,


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pull request is to add support for traits in sendTrack action of segment.

<img width="1512" alt="Screenshot 2023-09-21 at 1 24 51 PM" src="https://github.com/segmentio/action-destinations/assets/117165746/1052bb3c-767a-4c4c-b6dd-8e99929c9b48">

<img width="614" alt="Screenshot 2023-09-21 at 1 25 02 PM" src="https://github.com/segmentio/action-destinations/assets/117165746/1dd1be00-431a-4502-a3da-9e5c95139b7b">

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment - **Not required in Staging environment**
