### PR TITLE
CHANNELS-850: Twilio/Sendgrid stats showing N/A error_code for error in datadog

### DIFF
--- a/packages/destination-actions/src/destinations/engage/utils/EngageActionPerformer.ts
+++ b/packages/destination-actions/src/destinations/engage/utils/EngageActionPerformer.ts
@@ -6,7 +6,7 @@ import { EngageLogger } from './EngageLogger'
 import { EngageStats } from './EngageStats'
 import { OperationContext, track } from './track'
 import { isDestinationActionService } from './isDestinationActionService'
-import { ErrorDetails, ResponseError, getErrorDetails } from './ResponseError'
+import { ResponseError, getErrorDetails } from './ResponseError'
 import { RequestOptions } from '@segment/actions-core/request-client'
 import { IntegrationError } from '@segment/actions-core'
 import { IntegrationErrorWrapper } from './IntegrationErrorWrapper'
@@ -58,7 +58,7 @@ export abstract class EngageActionPerformer<TSettings = any, TPayload = any, TRe
       // log response from error or success
       const respError = op?.error as ResponseError
       if (respError) {
-        const errorDetails: ErrorDetails = getErrorDetails(respError)
+        const errorDetails = getErrorDetails(respError)
         const msgLowercare = errorDetails?.message?.toLowerCase()
 
         // some Timeout errors are coming as FetchError-s somehow (https://segment.atlassian.net/browse/CHANNELS-819)

--- a/packages/destination-actions/src/destinations/engage/utils/EngageActionPerformer.ts
+++ b/packages/destination-actions/src/destinations/engage/utils/EngageActionPerformer.ts
@@ -6,7 +6,7 @@ import { EngageLogger } from './EngageLogger'
 import { EngageStats } from './EngageStats'
 import { OperationContext, track } from './track'
 import { isDestinationActionService } from './isDestinationActionService'
-import { ResponseError, getErrorDetails } from './ResponseError'
+import { ErrorDetails, ResponseError, getErrorDetails } from './ResponseError'
 import { RequestOptions } from '@segment/actions-core/request-client'
 import { IntegrationError } from '@segment/actions-core'
 import { IntegrationErrorWrapper } from './IntegrationErrorWrapper'
@@ -58,7 +58,7 @@ export abstract class EngageActionPerformer<TSettings = any, TPayload = any, TRe
       // log response from error or success
       const respError = op?.error as ResponseError
       if (respError) {
-        const errorDetails = getErrorDetails(respError)
+        const errorDetails: ErrorDetails = getErrorDetails(respError)
         const msgLowercare = errorDetails?.message?.toLowerCase()
 
         // some Timeout errors are coming as FetchError-s somehow (https://segment.atlassian.net/browse/CHANNELS-819)

--- a/packages/destination-actions/src/destinations/engage/utils/EngageActionPerformer.ts
+++ b/packages/destination-actions/src/destinations/engage/utils/EngageActionPerformer.ts
@@ -69,7 +69,21 @@ export abstract class EngageActionPerformer<TSettings = any, TPayload = any, TRe
           errorDetails.code?.toLowerCase().includes('etimedout')
 
         // CHANNELS-651 somehow Timeouts are not retried by Integrations, this is fixing it
-        if (isTimeoutError && !respError.status) respError.status = 408
+        if (isTimeoutError) {
+          if (!respError.status) {
+            respError.status = 408
+          }
+          if (!errorDetails.status) {
+            errorDetails.status = 408;
+          }
+
+          if (!respError.code) {
+            respError.code = 'etimedout'
+          }
+          if (!errorDetails.code) {
+            errorDetails.code = 'etimedout'
+          }
+        }
 
         if (errorDetails.code) op.tags.push(`response_code:${errorDetails.code}`)
         if (errorDetails.status) op.tags.push(`response_status:${errorDetails.status}`)

--- a/packages/destination-actions/src/destinations/engage/utils/EngageActionPerformer.ts
+++ b/packages/destination-actions/src/destinations/engage/utils/EngageActionPerformer.ts
@@ -70,19 +70,13 @@ export abstract class EngageActionPerformer<TSettings = any, TPayload = any, TRe
 
         // CHANNELS-651 somehow Timeouts are not retried by Integrations, this is fixing it
         if (isTimeoutError) {
-          if (!respError.status) {
-            respError.status = 408
-          }
-          if (!errorDetails.status) {
-            errorDetails.status = 408;
-          }
+          const status = errorDetails.status ?? respError.status ?? 408
+          respError.status = status
+          errorDetails.status = status
 
-          if (!respError.code) {
-            respError.code = 'etimedout'
-          }
-          if (!errorDetails.code) {
-            errorDetails.code = 'etimedout'
-          }
+          const errorCode = errorDetails.code ?? respError.code ?? 'etimedout'
+          respError.code = errorCode
+          errorDetails.code = errorCode
         }
 
         if (errorDetails.code) op.tags.push(`response_code:${errorDetails.code}`)

--- a/packages/destination-actions/src/destinations/engage/utils/EngageLogger.ts
+++ b/packages/destination-actions/src/destinations/engage/utils/EngageLogger.ts
@@ -3,7 +3,7 @@
 import { Logger } from '@segment/actions-core/destination-kit'
 import { OperationLogger, OperationLoggerContext, TryCatchFinallyHook } from './operationTracking'
 import { EngageActionPerformer } from './EngageActionPerformer'
-import { ErrorDetails, getErrorDetails } from './ResponseError'
+import { getErrorDetails } from './ResponseError'
 
 export const FLAGON_NAME_LOG_INFO = 'engage-messaging-log-info'
 export const FLAGON_NAME_LOG_ERROR = 'engage-messaging-log-error'
@@ -48,7 +48,7 @@ export class EngageLogger extends OperationLogger {
   }
 
   getErrorMessage(error: unknown) {
-    const errorDetails: ErrorDetails = getErrorDetails(error)
+    const errorDetails = getErrorDetails(error)
     let res = `${errorDetails.message}`
     if (errorDetails.code) res += `. Code: ${errorDetails.code}`
     if (errorDetails.status) res += `. Status: ${errorDetails.status}`

--- a/packages/destination-actions/src/destinations/engage/utils/EngageLogger.ts
+++ b/packages/destination-actions/src/destinations/engage/utils/EngageLogger.ts
@@ -3,7 +3,7 @@
 import { Logger } from '@segment/actions-core/destination-kit'
 import { OperationLogger, OperationLoggerContext, TryCatchFinallyHook } from './operationTracking'
 import { EngageActionPerformer } from './EngageActionPerformer'
-import { getErrorDetails } from './ResponseError'
+import { ErrorDetails, getErrorDetails } from './ResponseError'
 
 export const FLAGON_NAME_LOG_INFO = 'engage-messaging-log-info'
 export const FLAGON_NAME_LOG_ERROR = 'engage-messaging-log-error'
@@ -48,7 +48,7 @@ export class EngageLogger extends OperationLogger {
   }
 
   getErrorMessage(error: unknown) {
-    const errorDetails = getErrorDetails(error)
+    const errorDetails: ErrorDetails = getErrorDetails(error)
     let res = `${errorDetails.message}`
     if (errorDetails.code) res += `. Code: ${errorDetails.code}`
     if (errorDetails.status) res += `. Status: ${errorDetails.status}`

--- a/packages/destination-actions/src/destinations/engage/utils/EngageStats.ts
+++ b/packages/destination-actions/src/destinations/engage/utils/EngageStats.ts
@@ -9,7 +9,7 @@ import {
 } from './operationTracking'
 import { EngageActionPerformer } from './EngageActionPerformer'
 import { OperationContext } from './track'
-import { ErrorDetails, getErrorDetails } from './ResponseError'
+import { getErrorDetails } from './ResponseError'
 
 export class EngageStats extends OperationStats {
   static getTryCatchFinallyHook(_ctx: OperationStatsContext): TryCatchFinallyHook<OperationStatsContext> {
@@ -96,7 +96,7 @@ export class EngageStats extends OperationStats {
   extractTagsFromError(error: TrackedError, ctx: OperationStatsContext): string[] {
     const res = super.extractTagsFromError(error, ctx)
 
-    const errDetails: ErrorDetails = getErrorDetails(error)
+    const errDetails = getErrorDetails(error)
     if (errDetails?.code) res.push(`error_code:${errDetails.code}`)
     if (errDetails?.status) res.push(`error_status:${errDetails.status}`)
 

--- a/packages/destination-actions/src/destinations/engage/utils/EngageStats.ts
+++ b/packages/destination-actions/src/destinations/engage/utils/EngageStats.ts
@@ -9,7 +9,7 @@ import {
 } from './operationTracking'
 import { EngageActionPerformer } from './EngageActionPerformer'
 import { OperationContext } from './track'
-import { getErrorDetails } from './ResponseError'
+import { ErrorDetails, getErrorDetails } from './ResponseError'
 
 export class EngageStats extends OperationStats {
   static getTryCatchFinallyHook(_ctx: OperationStatsContext): TryCatchFinallyHook<OperationStatsContext> {
@@ -57,8 +57,8 @@ export class EngageStats extends OperationStats {
     let statsFunc = this.statsClient?.[statsMethod || 'incr'].bind(this.statsClient)
     if (!statsFunc)
       switch (
-      statsMethod ||
-      'incr' // have to do this to avoid issues with JS bundler/minifier
+        statsMethod ||
+        'incr' // have to do this to avoid issues with JS bundler/minifier
       ) {
         case 'incr':
           statsFunc = this.statsClient?.incr.bind(this.statsClient)
@@ -96,7 +96,7 @@ export class EngageStats extends OperationStats {
   extractTagsFromError(error: TrackedError, ctx: OperationStatsContext): string[] {
     const res = super.extractTagsFromError(error, ctx)
 
-    const errDetails = getErrorDetails(error)
+    const errDetails: ErrorDetails = getErrorDetails(error)
     if (errDetails?.code) res.push(`error_code:${errDetails.code}`)
     if (errDetails?.status) res.push(`error_status:${errDetails.status}`)
 

--- a/packages/destination-actions/src/destinations/engage/utils/ResponseError.ts
+++ b/packages/destination-actions/src/destinations/engage/utils/ResponseError.ts
@@ -29,12 +29,15 @@ export function getErrorDetails(error: any): ErrorDetails {
   //example of errors are here: https://segment.atlassian.net/browse/CHANNELS-819
   // each API may have its own response.data structure. E.g. Twilio has code, message, more_info, status, while Sendgrid has array of errors where each has `message`, `field`, `help`.
   const respError = error as ResponseError
-  const status =
-    respError.status ||
-    respError.response?.status ||
-    respError.response?.data?.status ||
-    respError.response?.data?.statusCode
-  const code = respError.code || respError?.response?.data?.code
+  // some errors noticed to have no status and no response (e.g. ECONNRESET, ETIMEDOUT)
+  // there are tests impling it supposed to be retried: https://github.com/segmentio/integrations/blob/995f96a0526c3aba051c3948c3bfc306c704aec9/src/createIntegration/test/proto.js#L728, but ETIMEDOUT were still not retried
+  const status = respError.status || respError.response?.status
+  // || respError.response?.data?.status // twilio apis provides status and statusCode in data, but we assume it's the same as response.status
+  // || respError.response?.data?.statusCode
+
+  const code = respError.code || respError.response?.data?.code
+  // || respError.response?.statusText // e.g. 'Not Found' for 404
+  
   const message = [
     respError.name || respError.constructor?.name,
     respError.message,

--- a/packages/destination-actions/src/destinations/engage/utils/ResponseError.ts
+++ b/packages/destination-actions/src/destinations/engage/utils/ResponseError.ts
@@ -48,5 +48,5 @@ export function getErrorDetails(error: any): ErrorDetails {
   ]
     .filter(Boolean)
     .join('; ')
-  return { status, code: code.toString(), message }
+  return { status, code: code?.toString(), message }
 }

--- a/packages/destination-actions/src/destinations/engage/utils/ResponseError.ts
+++ b/packages/destination-actions/src/destinations/engage/utils/ResponseError.ts
@@ -3,7 +3,7 @@ import { HTTPError } from '@segment/actions-core/request-client'
 export interface ResponseError extends HTTPError {
   response: HTTPError['response'] & {
     data: {
-      code: string
+      code: string | number
       message: string
       more_info: string
       status?: number
@@ -18,20 +18,23 @@ export interface ResponseError extends HTTPError {
   status?: number
 }
 
+export interface ErrorDetails {
+  message: string
+  code: string
+  status?: number
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function getErrorDetails(error: any) {
+export function getErrorDetails(error: any): ErrorDetails {
   //example of errors are here: https://segment.atlassian.net/browse/CHANNELS-819
   // each API may have its own response.data structure. E.g. Twilio has code, message, more_info, status, while Sendgrid has array of errors where each has `message`, `field`, `help`.
   const respError = error as ResponseError
-  // some errors noticed to have no status and no response (e.g. ECONNRESET, ETIMEDOUT)
-  // there are tests impling it supposed to be retried: https://github.com/segmentio/integrations/blob/995f96a0526c3aba051c3948c3bfc306c704aec9/src/createIntegration/test/proto.js#L728, but ETIMEDOUT were still not retried
-  const status = respError.status || respError.response?.status
-  // || respError.response?.data?.status // twilio apis provides status and statusCode in data, but we assume it's the same as response.status
-  // || respError.response?.data?.statusCode
-
-  const code = respError.code || respError.response?.data?.code
-  // || respError.response?.statusText // e.g. 'Not Found' for 404
-
+  const status =
+    respError.status ||
+    respError.response?.status ||
+    respError.response?.data?.status ||
+    respError.response?.data?.statusCode
+  const code = respError.code || respError?.response?.data?.code
   const message = [
     respError.name || respError.constructor?.name,
     respError.message,
@@ -45,5 +48,5 @@ export function getErrorDetails(error: any) {
   ]
     .filter(Boolean)
     .join('; ')
-  return { status, code, message }
+  return { status, code: code.toString(), message }
 }


### PR DESCRIPTION
The main issue was we were assigning `408` status error to the response when the error was a timeout and status was `undefined`, but we also need to assign `408` to the `response_status` and the same the with the response code (it is possible to get a timeout from the message and the code to be `undefined`, in that case we will set it to `etimedout`)

Another issue I found is when calling `.toLowercase()` function on a number (since sometimes the code is a number) in EngageActionPerformer --> request --> onFinally

I extended the code to be string or number now and always calling `toString()` first

[Ticket](https://segment.atlassian.net/browse/CHANNELS-850)

## Testing

Tested it locally. I simulated a timeout error and found out we were only assigning the response status, not the response_status that we see in the metrics in Datadog
