### PR TITLE
[CCP-392] - Track call to s3 for fetching email template bodies

### DIFF
--- a/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
+++ b/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
@@ -94,6 +94,7 @@ export class SendEmailPerformer extends MessageSendPerformer<Settings, Payload> 
     this.logOnError(() => 'Content type: ' + contentType)
     return parsedContent
   }
+
   async sendToRecepient(emailProfile: ExtId<Payload>) {
     const traits = await this.getProfileTraits()
 
@@ -212,6 +213,12 @@ export class SendEmailPerformer extends MessageSendPerformer<Settings, Payload> 
   }
 
   @track()
+  async getBodyTemplateFromS3(bodyUrl: string) {
+    const { content } = await this.request(bodyUrl, { method: 'GET', skipResponseCloning: true })
+    return content
+  }
+
+  @track()
   async getBodyHtml(
     profile: Profile,
     apiLookupData: Record<string, unknown>,
@@ -228,7 +235,7 @@ export class SendEmailPerformer extends MessageSendPerformer<Settings, Payload> 
   ) {
     let parsedBodyHtml
     if (this.payload.bodyUrl && this.settings.unlayerApiKey) {
-      const { content: body } = await this.request(this.payload.bodyUrl, { method: 'GET', skipResponseCloning: true })
+      const body = await this.getBodyTemplateFromS3(this.payload.bodyUrl)
       const bodyHtml = this.payload.bodyType === 'html' ? body : await this.generateEmailHtml(body)
       parsedBodyHtml = await this.parseTemplating(bodyHtml, { profile, [apiLookupLiquidKey]: apiLookupData }, 'Body')
     } else {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

This pulls out the call to s3 so that we can easily track it in datadog for better observability.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ x] [Segmenters] Tested in the staging environment
