### PR TITLE
add more ram to lint for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
         run: NODE_ENV=production yarn build
 
       - name: Lint
+        env:
+          NODE_OPTIONS: '--max-old-space-size=4096'
         run: yarn lint
 
       - name: Validate


### PR DESCRIPTION
This fixes the current CI build error:
`FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
