### PR TITLE
STRATCONN-3184 - fix for iterable date issue

### DIFF
--- a/packages/browser-destinations/destinations/cdpresolution/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/cdpresolution/src/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Settings {
   /**
-   * Client identifier provided by CDP Resolution [Hashed Account ID]
-   */
-  clientIdentifier: string
-  /**
    * Identity resolution endpoint. [CDP Resolution documentation](https://www.cdpresolution.com/docs/)
    */
   endpoint: string
+  /**
+   * Client identifier provided by CDP Resolution [CDP Resultion Account](https://www.cdpresolution.com/accountsettings)
+   */
+  clientIdentifier: string
 }

--- a/packages/browser-destinations/destinations/cdpresolution/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/cdpresolution/src/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Settings {
   /**
+   * Client identifier provided by CDP Resolution [Hashed Account ID]
+   */
+  clientIdentifier: string
+  /**
    * Identity resolution endpoint. [CDP Resolution documentation](https://www.cdpresolution.com/docs/)
    */
   endpoint: string
-  /**
-   * Client identifier provided by CDP Resolution [CDP Resultion Account](https://www.cdpresolution.com/accountsettings)
-   */
-  clientIdentifier: string
 }

--- a/packages/destination-actions/src/destinations/iterable/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/iterable/trackEvent/__tests__/index.test.ts
@@ -63,6 +63,39 @@ describe('Iterable.trackEvent', () => {
     })
   })
 
+  it('does not convert a non date string into a standard Iterable date format', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      userId: 'user1234',
+      properties: {
+        badDate1: '1234',
+        badDate2: '1234-12',
+        badDate3: '1234-12-00',
+        badDate4: '1234-12-99',
+        myGoodDate: '2023-05-17T22:49:53.310Z'
+      }
+    })
+
+    nock('https://api.iterable.com/api').post('/events/track').reply(200, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].options.json).toMatchObject({
+      userId: 'user1234',
+      dataFields: {
+        badDate1: '1234',
+        badDate2: '1234-12',
+        badDate3: '1234-12-00',
+        badDate4: '1234-12-99',
+        myGoodDate: '2023-05-17 22:49:53 +00:00'
+      }
+    })
+  })
+
   it('should success with mapping of preset and Entity Added event(presets) ', async () => {
     const event = createTestEvent({
       type: 'track',

--- a/packages/destination-actions/src/destinations/iterable/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/trackEvent/index.ts
@@ -77,6 +77,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     const endpoint = getRegionalEndpoint('trackEvent', settings.dataCenterLocation as DataCenterLocation)
+    console.log(JSON.stringify(trackEventRequest))
     return request(endpoint, {
       method: 'post',
       json: trackEventRequest

--- a/packages/destination-actions/src/destinations/iterable/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/trackEvent/index.ts
@@ -77,7 +77,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     const endpoint = getRegionalEndpoint('trackEvent', settings.dataCenterLocation as DataCenterLocation)
-    console.log(JSON.stringify(trackEventRequest))
+
     return request(endpoint, {
       method: 'post',
       json: trackEventRequest

--- a/packages/destination-actions/src/destinations/iterable/utils.ts
+++ b/packages/destination-actions/src/destinations/iterable/utils.ts
@@ -4,9 +4,10 @@ import { CommerceItem, DataCenterLocation } from './shared-fields'
 
 // Regular expression for matching ISO date strings in various formats
 // Taken from https://github.com/segmentio/isodate/blob/master/lib/index.js
+//const isoDateRegExp =
+//  /^(\d{4})(?:-?(\d{2})(?:-?(\d{2}))?)?(?:([ T])(\d{2}):?(\d{2})(?::?(\d{2})(?:[,\.](\d{1,}))?)?(?:(Z)|([+\-])(\d{2})(?::?(\d{2}))?)?)?$/
 const isoDateRegExp =
-  /^(\d{4})(?:-?(\d{2})(?:-?(\d{2}))?)?(?:([ T])(\d{2}):?(\d{2})(?::?(\d{2})(?:[,\.](\d{1,}))?)?(?:(Z)|([+\-])(\d{2})(?::?(\d{2}))?)?)?$/ // eslint-disable-line no-useless-escape
-
+  /^(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])(?:([ T])(\d{2}):?(\d{2})(?::?(\d{2})(?:[,\.](\d{1,}))?)?(?:(Z)|([+\-])(\d{2})(?::?(\d{2}))?)?)?$/ // eslint-disable-line no-useless-escape
 /**
  * Converts a given ISO date string to the format accepted by Iterable's API.
  * @param {string} isoDateStr - An ISO date string, such as "2022-05-13T10:30:52.853Z".


### PR DESCRIPTION
As per https://segment.atlassian.net/browse/STRATCONN-3184

Before a payload is sent to Iterable, the object is parsed for strings that might be dates. If there's a match then the date string is converted into a date string format that Iterable expects. 

However this parsing is converting non date strings into Iterable date strings. 

For example the following string "1234" gets converted into "1234-01-01 00:00:00 +00:00"

Proposed fix for this is to edit the regex responsible for evaluating strings as dates so that it only works if the string starts with a YYYY-MM-DD format.  

## Testing

Tested with local testing tool. 
Also wrote a unit test. 
