### PR TITLE
[STRATCONN] 3183 Added email subscribe as dynamic field in braze

### DIFF
--- a/packages/browser-destinations/destinations/braze/src/updateUserProfile/index.ts
+++ b/packages/browser-destinations/destinations/braze/src/updateUserProfile/index.ts
@@ -79,7 +79,12 @@ const action: BrowserActionDefinition<Settings, BrazeDestinationClient, Payload>
     email_subscribe: {
       label: 'Email Subscribe',
       description: `The user's email subscription preference: “opted_in” (explicitly registered to receive email messages), “unsubscribed” (explicitly opted out of email messages), and “subscribed” (neither opted in nor out).`,
-      type: 'string'
+      type: 'string',
+      choices: [
+        { label: 'OTPED_IN', value: 'opted_in' },
+        { label: 'SUBSCRIBED', value: 'subscribed' },
+        { label: 'UNSUBSCRIBED', value: 'unsubscribed' }
+      ]
     },
     first_name: {
       label: 'First Name',

--- a/packages/browser-destinations/destinations/cdpresolution/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/cdpresolution/src/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Settings {
   /**
+   * Client identifier provided by CDP Resolution [Hashed Account ID]
+   */
+  clientIdentifier: string
+  /**
    * Identity resolution endpoint. [CDP Resolution documentation](https://www.cdpresolution.com/docs/)
    */
   endpoint: string
-  /**
-   * Client identifier provided by CDP Resolution [CDP Resultion Account](https://www.cdpresolution.com/accountsettings)
-   */
-  clientIdentifier: string
 }

--- a/packages/browser-destinations/destinations/cdpresolution/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/cdpresolution/src/generated-types.ts
@@ -8,5 +8,5 @@ export interface Settings {
   /**
    * Identity resolution endpoint. [CDP Resolution documentation](https://www.cdpresolution.com/docs/)
    */
-  clientIdentifier: string
+  endpoint: string
 }

--- a/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
+++ b/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
@@ -154,7 +154,12 @@ const action: ActionDefinition<Settings, Payload> = {
     email_subscribe: {
       label: 'Email Subscribe',
       description: `The user's email subscription preference: “opted_in” (explicitly registered to receive email messages), “unsubscribed” (explicitly opted out of email messages), and “subscribed” (neither opted in nor out).`,
-      type: 'string'
+      type: 'string',
+      choices: [
+        { label: 'OTPED_IN', value: 'opted_in' },
+        { label: 'SUBSCRIBED', value: 'subscribed' },
+        { label: 'UNSUBSCRIBED', value: 'unsubscribed' }
+      ]
     },
     email_open_tracking_disabled: {
       label: 'Email Open Tracking Disabled',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

Added dynamic field (Email Subscribed) for braze cloud action mode destination and braze browser mode destinations
JIRA TICKET: https://segment.atlassian.net/browse/STRATCONN-3183?atlOrigin=eyJpIjoiOTMzMzllNWJhMTJlNGU2NDk5MDkzNmQ5OGUwMDM0ZWIiLCJwIjoiaiJ9


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

![Screenshot 2023-09-25 at 4 36 31 AM](https://github.com/segmentio/action-destinations/assets/139338151/9a513990-97b1-4e74-8ade-75cb96e014a6)


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
