### PR TITLE
[SENTRY-UpsertContact-HubSpot Cloud Actions] || Fix issue of Cannot set properties of undefined (setting action)

### DIFF
--- a/packages/browser-destinations/destinations/cdpresolution/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/cdpresolution/src/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Settings {
   /**
-   * Client identifier provided by CDP Resolution [Hashed Account ID]
-   */
-  clientIdentifier: string
-  /**
    * Identity resolution endpoint. [CDP Resolution documentation](https://www.cdpresolution.com/docs/)
    */
   endpoint: string
+  /**
+   * Client identifier provided by CDP Resolution [CDP Resultion Account](https://www.cdpresolution.com/accountsettings)
+   */
+  clientIdentifier: string
 }

--- a/packages/browser-destinations/destinations/cdpresolution/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/cdpresolution/src/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Settings {
   /**
+   * Client identifier provided by CDP Resolution [Hashed Account ID]
+   */
+  clientIdentifier: string
+  /**
    * Identity resolution endpoint. [CDP Resolution documentation](https://www.cdpresolution.com/docs/)
    */
   endpoint: string
-  /**
-   * Client identifier provided by CDP Resolution [CDP Resultion Account](https://www.cdpresolution.com/accountsettings)
-   */
-  clientIdentifier: string
 }

--- a/packages/destination-actions/src/destinations/hubspot/upsertContact/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/upsertContact/__tests__/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HubSpot.upsertContactBatch should create and update contact successfully 1`] = `
+exports[`HubSpot.upsertContactBatch should create and update contact successfully and skip that contact which is not available in 'contactsUpsertMap' object 1`] = `
 Object {
   "afterResponse": Array [
     [Function],
@@ -51,7 +51,7 @@ Object {
 }
 `;
 
-exports[`HubSpot.upsertContactBatch should create and update contact successfully 2`] = `
+exports[`HubSpot.upsertContactBatch should create and update contact successfully and skip that contact which is not available in 'contactsUpsertMap' object 2`] = `
 Object {
   "errors": Array [
     Object {
@@ -72,7 +72,7 @@ Object {
       "id": "103",
       "properties": Object {
         "createdate": "2023-07-06T12:47:47.626Z",
-        "email": "userthree@somecompany.com",
+        "email": "userthree@SomeCompany.com",
         "hs_object_id": "103",
         "lastmodifieddate": "2023-07-06T12:48:02.784Z",
       },
@@ -91,7 +91,7 @@ Object {
 }
 `;
 
-exports[`HubSpot.upsertContactBatch should create and update contact successfully 3`] = `
+exports[`HubSpot.upsertContactBatch should create and update contact successfully and skip that contact which is not available in 'contactsUpsertMap' object 3`] = `
 Object {
   "results": Array [
     Object {
@@ -121,20 +121,9 @@ Object {
 }
 `;
 
-exports[`HubSpot.upsertContactBatch should create and update contact successfully 4`] = `
+exports[`HubSpot.upsertContactBatch should create and update contact successfully and skip that contact which is not available in 'contactsUpsertMap' object 4`] = `
 Object {
   "results": Array [
-    Object {
-      "id": "103",
-      "properties": Object {
-        "createdate": "2023-07-06T12:47:47.626Z",
-        "email": "userthree@somecompany.com",
-        "firstname": "User",
-        "lastmodifieddate": "2023-07-06T12:48:02.784Z",
-        "lastname": "Three",
-        "lifecyclestage": "subscriber",
-      },
-    },
     Object {
       "id": "104",
       "properties": Object {

--- a/packages/destination-actions/src/destinations/hubspot/upsertContact/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/upsertContact/__tests__/__snapshots__/index.test.ts.snap
@@ -59,7 +59,7 @@ Object {
       "context": Object {
         "ids": Array [
           "userone@somecompany.com",
-          "usertwo@somecompany.com",
+          "usertwo@someothercompany.com",
         ],
       },
       "message": "Could not get some CONTACT objects, they may be deleted or not exist. Check that ids are valid.",
@@ -72,7 +72,7 @@ Object {
       "id": "103",
       "properties": Object {
         "createdate": "2023-07-06T12:47:47.626Z",
-        "email": "userthree@SomeCompany.com",
+        "email": "userthree@someothercompany.com",
         "hs_object_id": "103",
         "lastmodifieddate": "2023-07-06T12:48:02.784Z",
       },
@@ -103,17 +103,6 @@ Object {
         "lastmodifieddate": "2023-07-06T12:48:02.784Z",
         "lastname": "One",
         "lifecyclestage": "lead",
-      },
-    },
-    Object {
-      "id": "102",
-      "properties": Object {
-        "createdate": "2023-07-06T12:47:47.626Z",
-        "email": "usertwo@somecompany.com",
-        "firstname": "User",
-        "lastmodifieddate": "2023-07-06T12:48:02.784Z",
-        "lastname": "Two",
-        "lifecyclestage": "subscriber",
       },
     },
   ],

--- a/packages/destination-actions/src/destinations/hubspot/upsertContact/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/upsertContact/__tests__/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HubSpot.upsertContactBatch should create and update contact successfully and skip that contact which is not available in 'contactsUpsertMap' object 1`] = `
+exports[`HubSpot.upsertContactBatch should create and update contact successfully and skip that contact which is different from those are specified in segment events  1`] = `
 Object {
   "afterResponse": Array [
     [Function],
@@ -51,7 +51,7 @@ Object {
 }
 `;
 
-exports[`HubSpot.upsertContactBatch should create and update contact successfully and skip that contact which is not available in 'contactsUpsertMap' object 2`] = `
+exports[`HubSpot.upsertContactBatch should create and update contact successfully and skip that contact which is different from those are specified in segment events  2`] = `
 Object {
   "errors": Array [
     Object {
@@ -91,7 +91,7 @@ Object {
 }
 `;
 
-exports[`HubSpot.upsertContactBatch should create and update contact successfully and skip that contact which is not available in 'contactsUpsertMap' object 3`] = `
+exports[`HubSpot.upsertContactBatch should create and update contact successfully and skip that contact which is different from those are specified in segment events  3`] = `
 Object {
   "results": Array [
     Object {
@@ -110,7 +110,7 @@ Object {
 }
 `;
 
-exports[`HubSpot.upsertContactBatch should create and update contact successfully and skip that contact which is not available in 'contactsUpsertMap' object 4`] = `
+exports[`HubSpot.upsertContactBatch should create and update contact successfully and skip that contact which is different from those are specified in segment events  4`] = `
 Object {
   "results": Array [
     Object {

--- a/packages/destination-actions/src/destinations/hubspot/upsertContact/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertContact/__tests__/index.test.ts
@@ -492,17 +492,28 @@ describe('HubSpot.upsertContactBatch', () => {
   test("should create and update contact successfully and skip that contact which is not available in 'contactsUpsertMap' object", async () => {
     const events = createBatchTestEvents([...createContactList, ...updateContactList])
 
-    // Mock: Read Contact Using Email and considering a email as case sensitive for now for testing perspective.
-    //In ideal case,it should not be like this.Hubspot takes all emails as case insenstivity and will return the email in lowercase while sending response.
+    // Mock: Read Contact Using Email and considering a differenet email in batch read response for testing perspective.
+    //In ideal case,it should not be like this, it would be same as specified in event!
     nock(HUBSPOT_BASE_URL)
       .post(`/crm/v3/objects/contacts/batch/read`)
       .reply(
         200,
         generateBatchReadResponse([
-          ...createContactList,
+          {
+            email: 'userone@somecompany.com',
+            firstname: 'User',
+            lastname: 'One',
+            lifecyclestage: 'lead'
+          },
+          {
+            email: 'usertwo@someothercompany.com',
+            firstname: 'User',
+            lastname: 'Two',
+            lifecyclestage: 'subscriber'
+          },
           {
             id: '103',
-            email: 'userthree@SomeCompany.com',
+            email: 'userthree@someothercompany.com',
             firstname: 'User',
             lastname: 'Three',
             lifecyclestage: 'subscriber'
@@ -536,7 +547,17 @@ describe('HubSpot.upsertContactBatch', () => {
     // Mock: Create Contact
     nock(HUBSPOT_BASE_URL)
       .post(`/crm/v3/objects/contacts/batch/create`)
-      .reply(201, generateBatchCreateResponse(createContactList))
+      .reply(
+        201,
+        generateBatchCreateResponse([
+          {
+            email: 'userone@somecompany.com',
+            firstname: 'User',
+            lastname: 'One',
+            lifecyclestage: 'lead'
+          }
+        ])
+      )
 
     const mapping = {
       properties: {

--- a/packages/destination-actions/src/destinations/hubspot/upsertContact/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertContact/__tests__/index.test.ts
@@ -489,7 +489,7 @@ describe('HubSpot.upsertContactBatch', () => {
     expect(testBatchResponses[1].data).toMatchSnapshot()
   })
 
-  test("should create and update contact successfully and skip that contact which is not available in 'contactsUpsertMap' object", async () => {
+  test('should create and update contact successfully and skip that contact which is different from those are specified in segment events ', async () => {
     const events = createBatchTestEvents([...createContactList, ...updateContactList])
 
     // Mock: Read Contact Using Email and considering a differenet email in batch read response for testing perspective.

--- a/packages/destination-actions/src/destinations/hubspot/upsertContact/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertContact/index.ts
@@ -377,15 +377,17 @@ function updateActionsForBatchedContacts(
   // Case 1: Loop over results if there are any
   if (readResponse.data?.results && readResponse.data.results.length > 0) {
     for (const result of readResponse.data.results) {
-      // Set the action to update for contacts that exist in HubSpot
-      contactsUpsertMap[result.properties.email].action = 'update'
+      if (contactsUpsertMap[result.properties.email]) {
+        // Set the action to update for contacts that exist in HubSpot
+        contactsUpsertMap[result.properties.email].action = 'update'
 
-      // Set the id for contacts that exist in HubSpot
-      contactsUpsertMap[result.properties.email].payload.id = result.id
+        // Set the id for contacts that exist in HubSpot
+        contactsUpsertMap[result.properties.email].payload.id = result.id
 
-      // Re-index the payload with ID
-      contactsUpsertMap[result.id] = { ...contactsUpsertMap[result.properties.email] }
-      delete contactsUpsertMap[result.properties.email]
+        // Re-index the payload with ID
+        contactsUpsertMap[result.id] = { ...contactsUpsertMap[result.properties.email] }
+        delete contactsUpsertMap[result.properties.email]
+      }
     }
   }
 

--- a/packages/destination-actions/src/destinations/hubspot/upsertContact/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertContact/index.ts
@@ -398,7 +398,9 @@ function updateActionsForBatchedContacts(
         // Set the action to create for contacts that don't exist in HubSpot
         for (const id of error.context.ids) {
           //Set Action to create
-          contactsUpsertMap[id].action = 'create'
+          if (contactsUpsertMap[id]) {
+            contactsUpsertMap[id].action = 'create'
+          }
         }
       } else {
         // Throw any other error responses


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pull request is to fix the internal error (Cannot set properties of undefined (setting 'action')) in upsertContact of Hubspot Cloud Actions.
[Sentry Issue ](https://segment.sentry.io/issues/4315964286/events/02244c9900ef46f1a880b730949234f3/?project=1110287)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality -
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)- 
- [ ] [Segmenters] Tested in the staging environment - **Not Required**
