### PR TITLE
CHANNELS-899 Monitoring event streams feature flag

### DIFF
--- a/packages/destination-actions/src/destinations/engage/twilio/utils/PhoneMessageSender.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/utils/PhoneMessageSender.ts
@@ -43,6 +43,7 @@ export abstract class PhoneMessageSender<Payload extends PhoneMessagePayload> ex
     )
 
     if (this.executeInput.features?.[FLAGON_EVENT_STREAMS_ONBOARDING]) {
+      this.currentOperation?.tags.push('event-streams-onboarding:true')
       const tags = {
         audience_id: this.payload.customArgs && this.payload.customArgs['audience_id'],
         correlation_id: this.payload.customArgs && this.payload.customArgs['correlation_id'],
@@ -55,6 +56,7 @@ export abstract class PhoneMessageSender<Payload extends PhoneMessagePayload> ex
       }
       body.append('Tags', JSON.stringify(tags))
     } else if (webhookUrlWithParams) {
+      this.currentOperation?.tags.push('event-streams-onboarding:false')
       body.append('StatusCallback', webhookUrlWithParams)
     }
 

--- a/packages/destination-actions/src/destinations/engage/twilio/utils/PhoneMessageSender.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/utils/PhoneMessageSender.ts
@@ -43,7 +43,7 @@ export abstract class PhoneMessageSender<Payload extends PhoneMessagePayload> ex
     )
 
     if (this.executeInput.features?.[FLAGON_EVENT_STREAMS_ONBOARDING]) {
-      this.currentOperation?.tags.push('event-streams-onboarding:true')
+      this.currentOperation?.tags.push('event_streams_onboarding:true')
       const tags = {
         audience_id: this.payload.customArgs && this.payload.customArgs['audience_id'],
         correlation_id: this.payload.customArgs && this.payload.customArgs['correlation_id'],
@@ -56,7 +56,7 @@ export abstract class PhoneMessageSender<Payload extends PhoneMessagePayload> ex
       }
       body.append('Tags', JSON.stringify(tags))
     } else if (webhookUrlWithParams) {
-      this.currentOperation?.tags.push('event-streams-onboarding:false')
+      this.currentOperation?.tags.push('event_streams_onboarding:false')
       body.append('StatusCallback', webhookUrlWithParams)
     }
 

--- a/packages/destination-actions/src/destinations/engage/utils/EngageStats.ts
+++ b/packages/destination-actions/src/destinations/engage/utils/EngageStats.ts
@@ -29,6 +29,10 @@ export class EngageStats extends OperationStats {
       `settings_region:${this.actionPerformer.settings.region}`,
       `channel:${this.actionPerformer.getChannelType()}`
     )
+    const correlation_id =
+      this.actionPerformer.payload.customArgs?.correlation_id ||
+      this.actionPerformer.payload.customArgs?.__segment_internal_correlation_id__
+    if (correlation_id) ctx.sharedContext.tags.push(`correlation_id:${correlation_id}`)
 
     //for operations like request which can be used in multiple places, we need to have operation_path tag that will show where this operation is invoked from
     const parentOperation = (ctx as OperationContext).parent
@@ -57,8 +61,8 @@ export class EngageStats extends OperationStats {
     let statsFunc = this.statsClient?.[statsMethod || 'incr'].bind(this.statsClient)
     if (!statsFunc)
       switch (
-      statsMethod ||
-      'incr' // have to do this to avoid issues with JS bundler/minifier
+        statsMethod ||
+        'incr' // have to do this to avoid issues with JS bundler/minifier
       ) {
         case 'incr':
           statsFunc = this.statsClient?.incr.bind(this.statsClient)

--- a/packages/destination-actions/src/destinations/engage/utils/MessageSendPerformer.ts
+++ b/packages/destination-actions/src/destinations/engage/utils/MessageSendPerformer.ts
@@ -95,6 +95,10 @@ export abstract class MessageSendPerformer<
     // sending messages and collecting results, including exceptions
     const res = this.forAllRecepients((recepient) => this.sendToRecepient(recepient))
 
+    if (this.executeInput.features) {
+      this.logInfo('Feature flags:' + JSON.stringify(this.executeInput.features))
+    }
+
     // only if it succeeded, we can send stats
     this.statsEventDeliveryTs()
     return res


### PR DESCRIPTION
Jira ticket: [CHANNELS-899](https://segment.atlassian.net/browse/CHANNELS-899)

Adding tag to `twilio.perform` metric
Adding log message `Feature Flags:{json(features)}` before performing the event

Also added `correlation_id` tag to all TE metrics so we can filter events by specific broadcast or journey step

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment

Tag in DD:

![image](https://github.com/segmentio/action-destinations/assets/7120440/ff0a9750-e950-4da0-a26a-e6c2ff99a43a)

Log message in Loki:
```
level=INFO message="TE Messaging: SMS Feature flags:{\"USE_SLUGS_TO_IDENTIFY_EVENTS\":true,\"actions-google-analytics-4-add-timestamp\":true,\"actions-hubspot-event-name\":true,\"actions-segment-profiles-tapi-internal\":true,\"actions-segment-tapi-internal\":true,\"actions-versions-3.200.2-staging.4\":true,\"actions-versions-3.200.2-staging.5\":true,\"actions-versions-3.200.2-staging.6\":true,\"actions-versions-3.205.3-STRATCONN-3110.0\":true,\"actions-versions-3.205.4-hubspot-batch.1\":true,\"actions-versions-3.205.4-hubspot-batch.3\":true,\"actions-versions-3.205.4-hubspot-batch.4\":true,\"actions-versions-3.207.1-staging.0\":true,\"actions-versions-3.213.0-staging.2\":true,\"actions-versions-3.213.0-staging.3\":true,\"actions-versions-3.213.0-staging.4\":true,\"actions-versions-3.213.0-staging.5\":true,\"actions-versions-3.216.1-CHANNELS-899-ff.1\":true,\"actionsEscapeOff\":true,\"adwords-remarketing-lists-v12\":true,\"allow_ga_device_user_deletion\":true,\"amazon-kinesis\":true,\"amazon-kinesis-batch\":true,\"amazon-kinesis-eu-west-1\":true,\"amplitude-library\":true,\"batch-partition-affinity-enabled\":true,\"centrifuge_qa\":true,\"enable-qa-service\":true,\"engage-messaging-log-error\":true,\"engage-messaging-log-info\":true,\"event-streams-onboarding\":true,\"ext-oauth-settings\":true,\"facebook_app_events_canary_version\":true,\"facebook_app_events_error_handling\":true,\"facebook_app_events_fix_content_mapping\":true,\"facebook_capi_actions_canary_version\":true,\"facebook_offline_conversions_canary_version\":true,\"facebook_pixel_server_side_canary_version\":true,\"functions_multistatus_batch\":true,\"google_ads_destinations_migration_by_source\":true,\"individual_batch_request_for_traces\":true,\"integrations_eks_migration\":true,\"intercom_new_endpoint\":true,\"mailchimp_use_centrifuge_locking\":true,\"marketo_use_centrifuge_locking\":true,\"remove_intercom_locking\":true,\"repeater-tapi-internal\":true,\"soft-shard-affinity-enabled\":true,\"tune_retries\":true} {\"shouldSend\":true,\"settings_region\":\"us-west-2\",\"sourceId\":\"a7kgdjukebv6jwFDupRtvs\",\"spaceId\":\"spa_qVeK3DM5KWAvY7WDqPCfsj\",\"messageId\":\"personas_2VuhMmdncRuhkP2ZzLzAgjUvH9n\",\"channelType\":\"sms\",\"delivery_attempt\":\"1\",\"replay\":\"false\",\"contentSid\":\"HX1be96f6475f723cd8eac86eea07ebeeb\",\"twilioApiKeySID\":\"SK372a8535855cd6bac334bf19e186050e\"}" time=2023-09-26T01:30:34.587647366Z
```


[CHANNELS-899]: https://segment.atlassian.net/browse/CHANNELS-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ