### PR TITLE
[Trade Desk] Fix Auth Error for createAudience

### DIFF
--- a/packages/browser-destinations/destinations/cdpresolution/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/cdpresolution/src/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Settings {
   /**
-   * Client identifier provided by CDP Resolution [Hashed Account ID]
-   */
-  clientIdentifier: string
-  /**
    * Identity resolution endpoint. [CDP Resolution documentation](https://www.cdpresolution.com/docs/)
    */
   endpoint: string
+  /**
+   * Client identifier provided by CDP Resolution [CDP Resultion Account](https://www.cdpresolution.com/accountsettings)
+   */
+  clientIdentifier: string
 }

--- a/packages/browser-destinations/destinations/cdpresolution/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/cdpresolution/src/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Settings {
   /**
+   * Client identifier provided by CDP Resolution [Hashed Account ID]
+   */
+  clientIdentifier: string
+  /**
    * Identity resolution endpoint. [CDP Resolution documentation](https://www.cdpresolution.com/docs/)
    */
   endpoint: string
-  /**
-   * Client identifier provided by CDP Resolution [CDP Resultion Account](https://www.cdpresolution.com/accountsettings)
-   */
-  clientIdentifier: string
 }

--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/index.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/index.ts
@@ -74,13 +74,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     region: {
       type: 'string',
       label: 'Region',
-      description: 'Region of your audience.',
-      default: 'US',
-      choices: [
-        { label: 'US', value: 'US' },
-        { label: 'EU', value: 'EU' },
-        { label: 'APAC', value: 'APAC' }
-      ]
+      description: 'Region of your audience.'
     }
   },
   audienceConfig: {
@@ -92,6 +86,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       const audienceName = createAudienceInput.audienceName
       const advertiserId = createAudienceInput.settings.advertiser_id
       const region = createAudienceInput.audienceSettings?.region
+      const authToken = createAudienceInput.settings.auth_token
 
       if (audienceName?.length == 0) {
         throw new IntegrationError('Missing audience name value', 'MISSING_REQUIRED_FIELD', 400)
@@ -99,6 +94,10 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
 
       const response: ModifiedResponse<CreateApiResponse> = await request(`${BASE_URL}/crmdata/segment`, {
         method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'TTD-Auth': authToken
+        },
         json: {
           AdvertiserId: advertiserId,
           SegmentName: audienceName,
@@ -117,11 +116,16 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     async getAudience(request, getAudienceInput) {
       const crmDataId = getAudienceInput.externalId
       const advertiserId = getAudienceInput.settings.advertiser_id
+      const authToken = getAudienceInput.settings.auth_token
 
       const response: ModifiedResponse<GetApiResponse> = await request(
         `${BASE_URL}/crmdata/segment/${advertiserId}/${crmDataId}`,
         {
-          method: 'GET'
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            'TTD-Auth': authToken
+          }
         }
       )
 


### PR DESCRIPTION
The auth field was originally only defined in the `extendRequest` function but when createAudience is called from ADS the `extendRequest` does not actually input the values to these requests resulting in audiences not being created and NULL being saved as the external_id. This PR fixes this issue.

Also removing the dropdown for region because the UI does not support the drop-downs correctly causing it to look like the field is filled but it is really not saved in the DB.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

Before
![Screenshot 2023-09-25 at 6 05 06 PM](https://github.com/segmentio/action-destinations/assets/99763167/27b4c276-6449-4d15-9e7a-034fb7e37f76)

After
![Screenshot 2023-09-25 at 6 05 27 PM](https://github.com/segmentio/action-destinations/assets/99763167/71b672d9-9d27-4f18-8849-08ead3e945bd)



- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
