### PR TITLE
Remove flagon check for event streams

### DIFF
--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/__helpers__/test-utils.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/__helpers__/test-utils.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@segment/actions-core/destination-kit'
-import { omit } from '@segment/actions-core/omit'
+import { omit } from '@segment/actions-core'
 import { createMessagingTestEvent } from '../../../../../lib/engage-test-data/create-messaging-test-event'
 import { FLAGON_NAME_LOG_ERROR, FLAGON_NAME_LOG_INFO } from '../../../utils'
 import { createTestIntegration } from '@segment/actions-core'

--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
@@ -3,6 +3,8 @@ import { createTestAction, expectErrorLogged, expectInfoLogged, loggerMock as lo
 import { FLAGON_NAME_LOG_ERROR, FLAGON_NAME_LOG_INFO, SendabilityStatus } from '../../utils'
 import { FLAGON_EVENT_STREAMS_ONBOARDING } from '../utils'
 
+const defaultTags = JSON.stringify({})
+
 describe.each(['stage', 'production'])('%s environment', (environment) => {
   const contentSid = 'g'
   const spaceId = 'd'
@@ -158,7 +160,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         Body: 'Hello world, jane!',
         From: 'MG1111222233334444',
         To: '+1234567891',
-        ShortenUrls: 'true'
+        ShortenUrls: 'true',
+        Tags: defaultTags
       })
 
       const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
@@ -205,7 +208,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         From: 'MG1111222233334444',
         To: '+1234567891',
         ShortenUrls: 'true',
-        MediaUrl: 'http://myimg.com'
+        MediaUrl: 'http://myimg.com',
+        Tags: defaultTags
       })
 
       const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
@@ -242,6 +246,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
 
       twilioContentResponse.types['twilio/media'].media.forEach((media) => {
         expectedTwilioRequest.append('MediaUrl', media)
+        expectedTwilioRequest.append('Tags', defaultTags)
       })
 
       const twilioContentRequest = nock('https://content.twilio.com')
@@ -271,7 +276,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         Body: 'Hello world, jane!',
         From: 'MG1111222233334444',
         To: '+1234567891',
-        ShortenUrls: 'true'
+        ShortenUrls: 'true',
+        Tags: defaultTags
       })
 
       const twilioHostname = 'api.nottwilio.com'
@@ -293,6 +299,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         From: 'MG1111222233334444',
         To: '+1234567891',
         ShortenUrls: 'true',
+        Tags: defaultTags,
         StatusCallback:
           'http://localhost/?foo=bar&space_id=d&__segment_internal_external_id_key__=phone&__segment_internal_external_id_value__=%2B1234567891#rp=all&rc=5'
       })
@@ -346,7 +353,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         Body: 'Hello world, jane!',
         From: 'MG1111222233334444',
         To: '+1234567891',
-        ShortenUrls: 'true'
+        ShortenUrls: 'true',
+        Tags: defaultTags
       })
 
       const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
@@ -375,7 +383,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         Body: 'Hello world, jane!',
         From: 'MG1111222233334444',
         To: '+1234567891',
-        ShortenUrls: 'true'
+        ShortenUrls: 'true',
+        Tags: defaultTags
       })
 
       const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
@@ -400,7 +409,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           Body: 'Hello world, jane!',
           From: 'MG1111222233334444',
           To: '+1234567891',
-          ShortenUrls: 'true'
+          ShortenUrls: 'true',
+          Tags: defaultTags
         })
 
         const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
@@ -427,7 +437,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           Body: 'Hello world, jane!',
           From: 'MG1111222233334444',
           To: '+1234567891',
-          ShortenUrls: 'true'
+          ShortenUrls: 'true',
+          Tags: defaultTags
         })
 
         const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
@@ -454,7 +465,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           Body: 'Hello world, jane!',
           From: 'MG1111222233334444',
           To: '+1234567891',
-          ShortenUrls: 'true'
+          ShortenUrls: 'true',
+          Tags: defaultTags
         })
 
         const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
@@ -478,7 +490,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           Body: 'Hello world, jane!',
           From: 'MG1111222233334444',
           To: '+1234567891',
-          ShortenUrls: 'true'
+          ShortenUrls: 'true',
+          Tags: defaultTags
         })
 
         const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
@@ -504,7 +517,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         Body: 'Hello world, jane!',
         From: 'MG1111222233334444',
         To: '+1234567891',
-        ShortenUrls: 'true'
+        ShortenUrls: 'true',
+        Tags: defaultTags
       })
 
       const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
@@ -529,7 +543,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       Body: 'Hello world, jane!',
       From: 'MG1111222233334444',
       To: '+1234567891',
-      ShortenUrls: 'true'
+      ShortenUrls: 'true',
+      Tags: defaultTags
     })
 
     nock('https://api.twilio.com/2010-04-01/Accounts/a')
@@ -623,7 +638,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           Body: 'Hello world, jane!',
           From: 'MG1111222233334444',
           To: '+1234567891',
-          ShortenUrls: 'true'
+          ShortenUrls: 'true',
+          Tags: defaultTags
         })
 
         const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
@@ -643,104 +659,41 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
     })
   })
 
-  describe('events stream onboarding feature flag', () => {
-    it('add webhookURL when feature undefined', async () => {
-      const expectedTwilioRequest = new URLSearchParams({
-        Body: 'Hello world, jane!',
-        From: 'MG1111222233334444',
-        To: '+1234567891',
-        ShortenUrls: 'true',
-        StatusCallback:
-          'http://localhost/?foo=bar&space_id=d&__segment_internal_external_id_key__=phone&__segment_internal_external_id_value__=%2B1234567891#rp=all&rc=5'
-      })
-      const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
-        .post('/Messages.json', expectedTwilioRequest.toString())
-        .reply(201, {})
+  it('add tags to body', async () => {
+    const features = { [FLAGON_EVENT_STREAMS_ONBOARDING]: true }
 
-      const responses = await testAction({
-        mappingOverrides: { customArgs: { foo: 'bar' } },
-        settingsOverrides: {
-          webhookUrl: 'http://localhost',
-          connectionOverrides: 'rp=all&rc=5'
+    const expectedTwilioRequest = new URLSearchParams({
+      Body: 'Hello world, jane!',
+      From: 'MG1111222233334444',
+      To: '+1234567891',
+      ShortenUrls: 'true',
+      Tags: '{"audience_id":"1","correlation_id":"1","journey_name":"j-1","step_name":"2","campaign_name":"c-3","campaign_key":"4","user_id":"u-5","message_id":"m-6"}'
+    })
+    const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
+      .post('/Messages.json', expectedTwilioRequest.toString())
+      .reply(201, {})
+
+    const responses = await testAction({
+      features,
+      mappingOverrides: {
+        customArgs: {
+          audience_id: '1',
+          correlation_id: '1',
+          journey_name: 'j-1',
+          step_name: '2',
+          campaign_name: 'c-3',
+          campaign_key: '4',
+          user_id: 'u-5',
+          message_id: 'm-6'
         }
-      })
-
-      expect(responses.length).toBeGreaterThan(0)
-      expect(responses.map((response) => response.url)).toStrictEqual([
-        'https://api.twilio.com/2010-04-01/Accounts/a/Messages.json'
-      ])
-      expect(twilioRequest.isDone()).toEqual(true)
-      expect(responses.length).toBeGreaterThan(0)
+      }
     })
 
-    it('add webhookURL when feature flag off', async () => {
-      const features = { [FLAGON_EVENT_STREAMS_ONBOARDING]: false }
-
-      const expectedTwilioRequest = new URLSearchParams({
-        Body: 'Hello world, jane!',
-        From: 'MG1111222233334444',
-        To: '+1234567891',
-        ShortenUrls: 'true',
-        StatusCallback:
-          'http://localhost/?foo=bar&space_id=d&__segment_internal_external_id_key__=phone&__segment_internal_external_id_value__=%2B1234567891#rp=all&rc=5'
-      })
-      const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
-        .post('/Messages.json', expectedTwilioRequest.toString())
-        .reply(201, {})
-
-      const responses = await testAction({
-        features,
-        mappingOverrides: { customArgs: { foo: 'bar' } },
-        settingsOverrides: {
-          webhookUrl: 'http://localhost',
-          connectionOverrides: 'rp=all&rc=5'
-        }
-      })
-
-      expect(responses.length).toBeGreaterThan(0)
-      expect(responses.map((response) => response.url)).toStrictEqual([
-        'https://api.twilio.com/2010-04-01/Accounts/a/Messages.json'
-      ])
-      expect(twilioRequest.isDone()).toEqual(true)
-      expect(responses.length).toBeGreaterThan(0)
-    })
-
-    it('add tags when feature flag on', async () => {
-      const features = { [FLAGON_EVENT_STREAMS_ONBOARDING]: true }
-
-      const expectedTwilioRequest = new URLSearchParams({
-        Body: 'Hello world, jane!',
-        From: 'MG1111222233334444',
-        To: '+1234567891',
-        ShortenUrls: 'true',
-        Tags: '{"audience_id":"1","correlation_id":"1","journey_name":"j-1","step_name":"2","campaign_name":"c-3","campaign_key":"4","user_id":"u-5","message_id":"m-6"}'
-      })
-      const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
-        .post('/Messages.json', expectedTwilioRequest.toString())
-        .reply(201, {})
-
-      const responses = await testAction({
-        features,
-        mappingOverrides: {
-          customArgs: {
-            audience_id: '1',
-            correlation_id: '1',
-            journey_name: 'j-1',
-            step_name: '2',
-            campaign_name: 'c-3',
-            campaign_key: '4',
-            user_id: 'u-5',
-            message_id: 'm-6'
-          }
-        }
-      })
-
-      expect(responses.length).toBeGreaterThan(0)
-      expect(responses.map((response) => response.url)).toStrictEqual([
-        'https://api.twilio.com/2010-04-01/Accounts/a/Messages.json'
-      ])
-      expect(twilioRequest.isDone()).toEqual(true)
-      expect(responses.length).toBeGreaterThan(0)
-    })
+    expect(responses.length).toBeGreaterThan(0)
+    expect(responses.map((response) => response.url)).toStrictEqual([
+      'https://api.twilio.com/2010-04-01/Accounts/a/Messages.json'
+    ])
+    expect(twilioRequest.isDone()).toEqual(true)
+    expect(responses.length).toBeGreaterThan(0)
   })
 })

--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-whatsapp.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-whatsapp.test.ts
@@ -3,6 +3,7 @@ import { createTestAction, expectErrorLogged, expectInfoLogged } from './__helpe
 
 const defaultTemplateSid = 'my_template'
 const defaultTo = 'whatsapp:+1234567891'
+const defaultTags = JSON.stringify({})
 
 describe.each(['stage', 'production'])('%s environment', (environment) => {
   const spaceId = 'd'
@@ -48,7 +49,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       const expectedTwilioRequest = new URLSearchParams({
         ContentSid: defaultTemplateSid,
         From: 'MG1111222233334444',
-        To: defaultTo
+        To: defaultTo,
+        Tags: defaultTags
       })
 
       const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
@@ -66,7 +68,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       const expectedTwilioRequest = new URLSearchParams({
         ContentSid: defaultTemplateSid,
         From: 'MG1111222233334444',
-        To: defaultTo
+        To: defaultTo,
+        Tags: defaultTags
       })
 
       const twilioHostname = 'api.nottwilio.com'
@@ -87,6 +90,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         ContentSid: defaultTemplateSid,
         From: 'MG1111222233334444',
         To: defaultTo,
+        Tags: defaultTags,
         StatusCallback:
           'http://localhost/?foo=bar&space_id=d&__segment_internal_external_id_key__=phone&__segment_internal_external_id_value__=%2B1234567891#rp=all&rc=5'
       })
@@ -123,7 +127,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       const expectedTwilioRequest = new URLSearchParams({
         ContentSid: defaultTemplateSid,
         From: 'MG1111222233334444',
-        To: defaultTo
+        To: defaultTo,
+        Tags: defaultTags
       })
 
       const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
@@ -147,7 +152,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         const expectedTwilioRequest = new URLSearchParams({
           ContentSid: defaultTemplateSid,
           From: 'MG1111222233334444',
-          To: defaultTo
+          To: defaultTo,
+          Tags: defaultTags
         })
 
         const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
@@ -198,7 +204,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       const expectedTwilioRequest = new URLSearchParams({
         ContentSid: defaultTemplateSid,
         From: from,
-        To: 'whatsapp:+19195551234'
+        To: 'whatsapp:+19195551234',
+        Tags: defaultTags
       })
 
       const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
@@ -264,7 +271,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         ContentSid: defaultTemplateSid,
         From: 'MG1111222233334444',
         To: defaultTo,
-        ContentVariables: JSON.stringify({ '1': 'Soap', '2': '360 Scope St' })
+        ContentVariables: JSON.stringify({ '1': 'Soap', '2': '360 Scope St' }),
+        Tags: defaultTags
       })
 
       const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
@@ -293,7 +301,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         ContentSid: defaultTemplateSid,
         From: 'MG1111222233334444',
         To: defaultTo,
-        ContentVariables: JSON.stringify({ '2': '360 Scope St' })
+        ContentVariables: JSON.stringify({ '2': '360 Scope St' }),
+        Tags: defaultTags
       })
 
       const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
@@ -322,7 +331,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         ContentSid: defaultTemplateSid,
         From: 'MG1111222233334444',
         To: defaultTo,
-        ContentVariables: JSON.stringify({ '1': 'Soap', '2': '360 Scope St' })
+        ContentVariables: JSON.stringify({ '1': 'Soap', '2': '360 Scope St' }),
+        Tags: defaultTags
       })
 
       const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')

--- a/packages/destination-actions/src/destinations/engage/twilio/utils/PhoneMessageSender.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/utils/PhoneMessageSender.ts
@@ -58,8 +58,6 @@ export abstract class PhoneMessageSender<Payload extends PhoneMessagePayload> ex
       body.append('StatusCallback', webhookUrlWithParams)
     }
 
-    this.logError('EventStreamsSevTest', body)
-
     this.statsSet('message_body_size', body?.toString().length)
 
     const response = await this.request(

--- a/packages/destination-actions/src/destinations/engage/twilio/utils/PhoneMessageSender.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/utils/PhoneMessageSender.ts
@@ -42,23 +42,23 @@ export abstract class PhoneMessageSender<Payload extends PhoneMessagePayload> ex
       this.DEFAULT_CONNECTION_OVERRIDES
     )
 
-    if (this.executeInput.features?.[FLAGON_EVENT_STREAMS_ONBOARDING]) {
-      this.currentOperation?.tags.push('event_streams_onboarding:true')
-      const tags = {
-        audience_id: this.payload.customArgs && this.payload.customArgs['audience_id'],
-        correlation_id: this.payload.customArgs && this.payload.customArgs['correlation_id'],
-        journey_name: this.payload.customArgs && this.payload.customArgs['journey_name'],
-        step_name: this.payload.customArgs && this.payload.customArgs['step_name'],
-        campaign_name: this.payload.customArgs && this.payload.customArgs['campaign_name'],
-        campaign_key: this.payload.customArgs && this.payload.customArgs['campaign_key'],
-        user_id: this.payload.customArgs && this.payload.customArgs['user_id'],
-        message_id: this.payload.customArgs && this.payload.customArgs['message_id']
-      }
-      body.append('Tags', JSON.stringify(tags))
-    } else if (webhookUrlWithParams) {
-      this.currentOperation?.tags.push('event_streams_onboarding:false')
+    const tags = {
+      audience_id: this.payload.customArgs && this.payload.customArgs['audience_id'],
+      correlation_id: this.payload.customArgs && this.payload.customArgs['correlation_id'],
+      journey_name: this.payload.customArgs && this.payload.customArgs['journey_name'],
+      step_name: this.payload.customArgs && this.payload.customArgs['step_name'],
+      campaign_name: this.payload.customArgs && this.payload.customArgs['campaign_name'],
+      campaign_key: this.payload.customArgs && this.payload.customArgs['campaign_key'],
+      user_id: this.payload.customArgs && this.payload.customArgs['user_id'],
+      message_id: this.payload.customArgs && this.payload.customArgs['message_id']
+    }
+    body.append('Tags', JSON.stringify(tags))
+
+    if (webhookUrlWithParams) {
       body.append('StatusCallback', webhookUrlWithParams)
     }
+
+    this.logError('EventStreamsSevTest', body)
 
     this.statsSet('message_body_size', body?.toString().length)
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR removes the flagon check for event streams, before passing the message tags

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
