### PR TITLE
[Strat-2879] | Set up DataDog Dashboard to track requests to Linkedin-audiences Actions

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
@@ -1,4 +1,4 @@
-import type { ActionDefinition } from '@segment/actions-core'
+import type { ActionDefinition, StatsContext } from '@segment/actions-core'
 import { RequestClient, RetryableError, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -77,20 +77,25 @@ const action: ActionDefinition<Settings, Payload> = {
       default: 'AUTO'
     }
   },
-  perform: async (request, { settings, payload }) => {
-    return processPayload(request, settings, [payload])
+  perform: async (request, { settings, payload, statsContext }) => {
+    return processPayload(request, settings, [payload], statsContext)
   },
-  performBatch: async (request, { settings, payload }) => {
-    return processPayload(request, settings, payload)
+  performBatch: async (request, { settings, payload, statsContext }) => {
+    return processPayload(request, settings, payload, statsContext)
   }
 }
 
-async function processPayload(request: RequestClient, settings: Settings, payloads: Payload[]) {
+async function processPayload(
+  request: RequestClient,
+  settings: Settings,
+  payloads: Payload[],
+  statsContext: StatsContext | undefined
+) {
   validate(settings, payloads)
 
   const linkedinApiClient: LinkedInAudiences = new LinkedInAudiences(request)
 
-  const dmpSegmentId = await getDmpSegmentId(linkedinApiClient, settings, payloads[0])
+  const dmpSegmentId = await getDmpSegmentId(linkedinApiClient, settings, payloads[0], statsContext)
   const elements = extractUsers(settings, payloads)
 
   // We should never hit this condition because at least an email or a
@@ -102,7 +107,10 @@ async function processPayload(request: RequestClient, settings: Settings, payloa
   if (elements.length < 1) {
     return
   }
-
+  statsContext?.statsClient?.incr('oauth_app_api_call', 1, [
+    ...statsContext?.tags,
+    `endpoint:add-or-remove-users-from-dmpSegment`
+  ])
   const res = await linkedinApiClient.batchUpdate(dmpSegmentId, elements)
 
   // At this point, if LinkedIn's API returns a 404 error, it's because the audience
@@ -135,18 +143,29 @@ function validate(settings: Settings, payloads: Payload[]): void {
   }
 }
 
-async function getDmpSegmentId(linkedinApiClient: LinkedInAudiences, settings: Settings, payload: Payload) {
+async function getDmpSegmentId(
+  linkedinApiClient: LinkedInAudiences,
+  settings: Settings,
+  payload: Payload,
+  statsContext: StatsContext | undefined
+) {
+  statsContext?.statsClient?.incr('oauth_app_api_call', 1, [...statsContext?.tags, `endpoint:get-dmpSegment`])
   const res = await linkedinApiClient.getDmpSegment(settings, payload)
   const body = await res.json()
 
   if (body.elements?.length > 0) {
     return body.elements[0].id
   }
-
-  return createDmpSegment(linkedinApiClient, settings, payload)
+  return createDmpSegment(linkedinApiClient, settings, payload, statsContext)
 }
 
-async function createDmpSegment(linkedinApiClient: LinkedInAudiences, settings: Settings, payload: Payload) {
+async function createDmpSegment(
+  linkedinApiClient: LinkedInAudiences,
+  settings: Settings,
+  payload: Payload,
+  statsContext: StatsContext | undefined
+) {
+  statsContext?.statsClient?.incr('oauth_app_api_call', 1, [...statsContext?.tags, `endpoint:create-dmpSegment`])
   const res = await linkedinApiClient.createDmpSegment(settings, payload)
   const headers = res.headers.toJSON()
   return headers['x-linkedin-id']

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
@@ -165,7 +165,6 @@ async function createDmpSegment(
   payload: Payload,
   statsContext: StatsContext | undefined
 ) {
-  console.log('Oauth_supported-destination')
   statsContext?.statsClient?.incr('oauth_app_api_call', 1, [...statsContext?.tags, `endpoint:create-dmpSegment`])
   const res = await linkedinApiClient.createDmpSegment(settings, payload)
   const headers = res.headers.toJSON()

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
@@ -165,6 +165,7 @@ async function createDmpSegment(
   payload: Payload,
   statsContext: StatsContext | undefined
 ) {
+  console.log('Oauth_supported-destination')
   statsContext?.statsClient?.incr('oauth_app_api_call', 1, [...statsContext?.tags, `endpoint:create-dmpSegment`])
   const res = await linkedinApiClient.createDmpSegment(settings, payload)
   const headers = res.headers.toJSON()


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pull request is to set up DataDog dashboard to track requests to Oauth Supported Destinations
Jira Ticket:- https://segment.atlassian.net/jira/software/c/projects/STRATCONN/boards/310?modal=detail&selectedIssue=STRATCONN-2879&assignee=63617339fc0cc7a600b03c6b

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality - **Not required**
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)- **Not required**
- [x] [Segmenters] Tested in the staging environment - **Not required**
