### PR TITLE
Channels-911 Remove Eventstreams flagon

### DIFF
--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
@@ -1,7 +1,6 @@
 import nock from 'nock'
 import { createTestAction, expectErrorLogged, expectInfoLogged, loggerMock as logger } from './__helpers__/test-utils'
 import { FLAGON_NAME_LOG_ERROR, FLAGON_NAME_LOG_INFO, SendabilityStatus } from '../../utils'
-import { FLAGON_EVENT_STREAMS_ONBOARDING } from '../utils'
 
 const defaultTags = JSON.stringify({})
 
@@ -660,8 +659,6 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
   })
 
   it('add tags to body', async () => {
-    const features = { [FLAGON_EVENT_STREAMS_ONBOARDING]: true }
-
     const expectedTwilioRequest = new URLSearchParams({
       Body: 'Hello world, jane!',
       From: 'MG1111222233334444',
@@ -674,7 +671,6 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       .reply(201, {})
 
     const responses = await testAction({
-      features,
       mappingOverrides: {
         customArgs: {
           audience_id: '1',

--- a/packages/destination-actions/src/destinations/engage/twilio/utils/PhoneMessageSender.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/utils/PhoneMessageSender.ts
@@ -3,8 +3,6 @@
 import { TwilioMessageSender, TwilioPayloadBase } from './TwilioMessageSender'
 import { OperationDecorator, TrackedError, OperationContext, ExtId } from '../../utils'
 
-export const FLAGON_EVENT_STREAMS_ONBOARDING = 'event-streams-onboarding'
-
 /**
  * Base class for sending sms/mms
  */


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR removes eventStreams flagon as it is no longer used

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
