### PR TITLE
[TikTok Audiences] Remove feature flag

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-audiences/addToAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addToAudience/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
-import { BASE_URL, TIKTOK_API_VERSION } from '../../constants'
+import { BASE_URL, TIKTOK_API_VERSION, MIGRATION_FLAG_NAME } from '../../constants'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -66,7 +66,7 @@ describe('TiktokAudiences.addToAudience', () => {
     const r = await testDestination.testAction('addToAudience', {
       auth,
       event,
-      features: { 'tiktok-hide-create-audience-action': true },
+      features: { [MIGRATION_FLAG_NAME]: true },
       settings: {},
       useDefaultMappings: true,
       mapping: {
@@ -96,7 +96,7 @@ describe('TiktokAudiences.addToAudience', () => {
 
     const responses = await testDestination.testAction('addToAudience', {
       event,
-      features: { 'tiktok-hide-create-audience-action': true },
+      features: { [MIGRATION_FLAG_NAME]: true },
       settings: {
         advertiser_ids: ['123']
       },
@@ -158,7 +158,7 @@ describe('TiktokAudiences.addToAudience', () => {
 
     const r = await testDestination.testAction('addToAudience', {
       event: anotherEvent,
-      features: { 'tiktok-hide-create-audience-action': true },
+      features: { [MIGRATION_FLAG_NAME]: true },
       settings: {
         advertiser_ids: ['123']
       },
@@ -176,7 +176,7 @@ describe('TiktokAudiences.addToAudience', () => {
     await expect(
       testDestination.testAction('addToAudience', {
         event,
-        features: { 'tiktok-hide-create-audience-action': true },
+        features: { [MIGRATION_FLAG_NAME]: true },
         settings: {
           advertiser_ids: ['123']
         },
@@ -200,7 +200,7 @@ describe('TiktokAudiences.addToAudience', () => {
     await expect(
       testDestination.testAction('addToAudience', {
         event,
-        features: { 'tiktok-hide-create-audience-action': true },
+        features: { [MIGRATION_FLAG_NAME]: true },
         settings: {
           advertiser_ids: ['123']
         },

--- a/packages/destination-actions/src/destinations/tiktok-audiences/addToAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addToAudience/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
-import { BASE_URL, TIKTOK_API_VERSION, MIGRATION_FLAG_NAME } from '../../constants'
+import { BASE_URL, TIKTOK_API_VERSION } from '../../constants'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -66,7 +66,6 @@ describe('TiktokAudiences.addToAudience', () => {
     const r = await testDestination.testAction('addToAudience', {
       auth,
       event,
-      features: { [MIGRATION_FLAG_NAME]: true },
       settings: {},
       useDefaultMappings: true,
       mapping: {
@@ -96,7 +95,6 @@ describe('TiktokAudiences.addToAudience', () => {
 
     const responses = await testDestination.testAction('addToAudience', {
       event,
-      features: { [MIGRATION_FLAG_NAME]: true },
       settings: {
         advertiser_ids: ['123']
       },
@@ -158,7 +156,6 @@ describe('TiktokAudiences.addToAudience', () => {
 
     const r = await testDestination.testAction('addToAudience', {
       event: anotherEvent,
-      features: { [MIGRATION_FLAG_NAME]: true },
       settings: {
         advertiser_ids: ['123']
       },
@@ -176,7 +173,6 @@ describe('TiktokAudiences.addToAudience', () => {
     await expect(
       testDestination.testAction('addToAudience', {
         event,
-        features: { [MIGRATION_FLAG_NAME]: true },
         settings: {
           advertiser_ids: ['123']
         },
@@ -200,7 +196,6 @@ describe('TiktokAudiences.addToAudience', () => {
     await expect(
       testDestination.testAction('addToAudience', {
         event,
-        features: { [MIGRATION_FLAG_NAME]: true },
         settings: {
           advertiser_ids: ['123']
         },

--- a/packages/destination-actions/src/destinations/tiktok-audiences/addToAudience/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addToAudience/index.ts
@@ -12,7 +12,6 @@ import {
   external_audience_id
 } from '../properties'
 import { IntegrationError } from '@segment/actions-core'
-import { MIGRATION_FLAG_NAME } from '../constants'
 
 const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
   title: 'Add to Audience',
@@ -27,10 +26,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     enable_batching: { ...enable_batching },
     external_audience_id: { ...external_audience_id }
   },
-  perform: async (request, { audienceSettings, payload, statsContext, features }) => {
-    if (features && !features[MIGRATION_FLAG_NAME]) {
-      return
-    }
+  perform: async (request, { audienceSettings, payload, statsContext }) => {
     const statsClient = statsContext?.statsClient
     const statsTag = statsContext?.tags
 
@@ -44,10 +40,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
 
     return processPayload(request, audienceSettings, [payload], 'add')
   },
-  performBatch: async (request, { payload, audienceSettings, statsContext, features }) => {
-    if (features && !features[MIGRATION_FLAG_NAME]) {
-      return
-    }
+  performBatch: async (request, { payload, audienceSettings, statsContext }) => {
     const statsClient = statsContext?.statsClient
     const statsTag = statsContext?.tags
 

--- a/packages/destination-actions/src/destinations/tiktok-audiences/addUser/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addUser/index.ts
@@ -13,7 +13,6 @@ import {
   enable_batching
 } from '../properties'
 import { TikTokAudiences } from '../api'
-import { MIGRATION_FLAG_NAME } from '../constants'
 
 // NOTE
 // This action is not used by the native Segment Audiences feature.
@@ -75,17 +74,11 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
   },
-  perform: async (request, { settings, payload, statsContext, features }) => {
-    if (features && features[MIGRATION_FLAG_NAME]) {
-      return
-    }
+  perform: async (request, { settings, payload, statsContext }) => {
     statsContext?.statsClient?.incr('addUser', 1, statsContext?.tags)
     return processPayload(request, settings, [payload], 'add')
   },
-  performBatch: async (request, { settings, payload, statsContext, features }) => {
-    if (features && features[MIGRATION_FLAG_NAME]) {
-      return
-    }
+  performBatch: async (request, { settings, payload, statsContext }) => {
     statsContext?.statsClient?.incr('addUser', 1, statsContext?.tags)
     return processPayload(request, settings, payload, 'add')
   }

--- a/packages/destination-actions/src/destinations/tiktok-audiences/constants.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/constants.ts
@@ -2,4 +2,4 @@ export const TIKTOK_API_VERSION = 'v1.3'
 export const BASE_URL = 'https://business-api.tiktok.com/open_api/'
 export const CREATE_AUDIENCE_URL = `${BASE_URL}${TIKTOK_API_VERSION}/segment/audience/`
 export const GET_AUDIENCE_URL = `${BASE_URL}${TIKTOK_API_VERSION}/dmp/custom_audience/get`
-export const MIGRATION_FLAG_NAME = 'tiktok-hide-create-audience-action'
+export const MIGRATION_FLAG_NAME = 'actions-migrated-tiktok'

--- a/packages/destination-actions/src/destinations/tiktok-audiences/removeFromAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/removeFromAudience/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
-import { BASE_URL, TIKTOK_API_VERSION, MIGRATION_FLAG_NAME } from '../../constants'
+import { BASE_URL, TIKTOK_API_VERSION } from '../../constants'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -66,7 +66,6 @@ describe('TiktokAudiences.removeFromAudience', () => {
     await expect(
       testDestination.testAction('removeFromAudience', {
         event,
-        features: { [MIGRATION_FLAG_NAME]: true },
         settings: {
           advertiser_ids: ['123']
         },
@@ -127,7 +126,6 @@ describe('TiktokAudiences.removeFromAudience', () => {
     await expect(
       testDestination.testAction('removeFromAudience', {
         event: anotherEvent,
-        features: { [MIGRATION_FLAG_NAME]: true },
         settings: {
           advertiser_ids: ['123']
         },
@@ -147,7 +145,6 @@ describe('TiktokAudiences.removeFromAudience', () => {
     await expect(
       testDestination.testAction('removeFromAudience', {
         event,
-        features: { [MIGRATION_FLAG_NAME]: true },
         settings: {
           advertiser_ids: ['123']
         },

--- a/packages/destination-actions/src/destinations/tiktok-audiences/removeFromAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/removeFromAudience/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
-import { BASE_URL, TIKTOK_API_VERSION } from '../../constants'
+import { BASE_URL, TIKTOK_API_VERSION, MIGRATION_FLAG_NAME } from '../../constants'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -66,7 +66,7 @@ describe('TiktokAudiences.removeFromAudience', () => {
     await expect(
       testDestination.testAction('removeFromAudience', {
         event,
-        features: { 'tiktok-hide-create-audience-action': true },
+        features: { [MIGRATION_FLAG_NAME]: true },
         settings: {
           advertiser_ids: ['123']
         },
@@ -127,7 +127,7 @@ describe('TiktokAudiences.removeFromAudience', () => {
     await expect(
       testDestination.testAction('removeFromAudience', {
         event: anotherEvent,
-        features: { 'tiktok-hide-create-audience-action': true },
+        features: { [MIGRATION_FLAG_NAME]: true },
         settings: {
           advertiser_ids: ['123']
         },
@@ -147,7 +147,7 @@ describe('TiktokAudiences.removeFromAudience', () => {
     await expect(
       testDestination.testAction('removeFromAudience', {
         event,
-        features: { 'tiktok-hide-create-audience-action': true },
+        features: { [MIGRATION_FLAG_NAME]: true },
         settings: {
           advertiser_ids: ['123']
         },

--- a/packages/destination-actions/src/destinations/tiktok-audiences/removeFromAudience/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/removeFromAudience/index.ts
@@ -12,7 +12,6 @@ import {
   external_audience_id
 } from '../properties'
 import { IntegrationError } from '@segment/actions-core'
-import { MIGRATION_FLAG_NAME } from '../constants'
 
 const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
   title: 'Remove from Audience',
@@ -27,11 +26,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     enable_batching: { ...enable_batching },
     external_audience_id: { ...external_audience_id }
   },
-  perform: async (request, { audienceSettings, payload, statsContext, features }) => {
-    if (features && !features[MIGRATION_FLAG_NAME]) {
-      return
-    }
-
+  perform: async (request, { audienceSettings, payload, statsContext }) => {
     const statsClient = statsContext?.statsClient
     const statsTag = statsContext?.tags
 
@@ -42,11 +37,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     statsClient?.incr('removeFromAudience', 1, statsTag)
     return processPayload(request, audienceSettings, [payload], 'delete')
   },
-  performBatch: async (request, { audienceSettings, payload, statsContext, features }) => {
-    if (features && !features[MIGRATION_FLAG_NAME]) {
-      return
-    }
-
+  performBatch: async (request, { audienceSettings, payload, statsContext }) => {
     const statsClient = statsContext?.statsClient
     const statsTag = statsContext?.tags
 

--- a/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/index.ts
@@ -13,7 +13,6 @@ import {
   enable_batching
 } from '../properties'
 import { TikTokAudiences } from '../api'
-import { MIGRATION_FLAG_NAME } from '../constants'
 
 // NOTE
 // This action is not used by the native Segment Audiences feature.
@@ -74,17 +73,11 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
   },
-  perform: async (request, { settings, payload, statsContext, features }) => {
-    if (features && features[MIGRATION_FLAG_NAME]) {
-      return
-    }
+  perform: async (request, { settings, payload, statsContext }) => {
     statsContext?.statsClient?.incr('removeUser', 1, statsContext?.tags)
     return processPayload(request, settings, [payload], 'delete')
   },
-  performBatch: async (request, { settings, payload, statsContext, features }) => {
-    if (features && features[MIGRATION_FLAG_NAME]) {
-      return
-    }
+  performBatch: async (request, { settings, payload, statsContext }) => {
     statsContext?.statsClient?.incr('removeUser', 1, statsContext?.tags)
     return processPayload(request, settings, payload, 'delete')
   }


### PR DESCRIPTION
This PR removed the flag that was in actions for TikTok's migration.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
