### PR TITLE
[The Trade Desk] Add error message

### DIFF
--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/functions.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/functions.ts
@@ -49,7 +49,12 @@ export const TTD_LEGACY_FLOW_FLAG_NAME = 'actions-the-trade-desk-crm-legacy-flow
 export const TTD_LIST_ACTION_FLOW_FLAG_NAME = 'ttd-list-action-destination'
 
 export async function processPayload(input: ProcessPayloadInput) {
-  const crmID = input?.payloads?.[0]?.external_id || ''
+  let crmID
+  if (!input.payloads[0].external_id) {
+    throw new PayloadValidationError(`No external_id found in payload.`)
+  } else {
+    crmID = input.payloads[0].external_id
+  }
 
   // Get user emails from the payloads
   const usersFormatted = extractUsers(input.payloads)

--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/index.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/index.ts
@@ -1,4 +1,5 @@
 import type { AudienceDestinationDefinition, ModifiedResponse } from '@segment/actions-core'
+import { defaultValues } from '@segment/actions-core'
 import type { Settings, AudienceSettings } from './generated-types'
 import { IntegrationError } from '@segment/actions-core'
 
@@ -152,7 +153,16 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   },
   actions: {
     syncAudience
-  }
+  },
+  presets: [
+    {
+      name: 'Sync Audience to CRM Data Segment',
+      subscribe: 'event = "Audience Entered"',
+      partnerAction: 'syncAudience',
+      mapping: defaultValues(syncAudience.fields),
+      type: 'automatic'
+    }
+  ]
 }
 
 export default destination

--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/index.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/index.ts
@@ -1,5 +1,4 @@
 import type { AudienceDestinationDefinition, ModifiedResponse } from '@segment/actions-core'
-import { defaultValues } from '@segment/actions-core'
 import type { Settings, AudienceSettings } from './generated-types'
 import { IntegrationError } from '@segment/actions-core'
 
@@ -153,16 +152,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   },
   actions: {
     syncAudience
-  },
-  presets: [
-    {
-      name: 'Sync Audience to CRM Data Segment',
-      subscribe: 'event = "Audience Entered"',
-      partnerAction: 'syncAudience',
-      mapping: defaultValues(syncAudience.fields),
-      type: 'automatic'
-    }
-  ]
+  }
 }
 
 export default destination


### PR DESCRIPTION
Adds an error message if external_id not found.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
