### PR TITLE
 STRATCONN-3229 | Hubspot Cloud Actions- Can not read properties of undefined (Setting actions)

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/upsertContact/__tests__/__helpers__/test-utils.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertContact/__tests__/__helpers__/test-utils.ts
@@ -7,6 +7,7 @@ export type BatchContactListItem = {
   firstname: string
   lastname: string
   lifecyclestage?: string | undefined
+  additionalemail?: string | null
 }
 
 export const createBatchTestEvents = (batchContactList: BatchContactListItem[]) =>
@@ -51,6 +52,7 @@ export const generateBatchReadResponse = (batchContactList: BatchContactListItem
         properties: {
           createdate: '2023-07-06T12:47:47.626Z',
           email: contact.email,
+          hs_additional_emails: contact?.additionalemail ?? null,
           hs_object_id: contact.id,
           lastmodifieddate: '2023-07-06T12:48:02.784Z'
         }

--- a/packages/destination-actions/src/destinations/hubspot/upsertContact/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/hubspot/upsertContact/__tests__/__snapshots__/index.test.ts.snap
@@ -1,5 +1,87 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`HubSpot.upsertContactBatch Should update contact on the basis of secondary email if it's not getting mapped with Primary email addresses 1`] = `
+Object {
+  "afterResponse": Array [
+    [Function],
+    [Function],
+    [Function],
+  ],
+  "beforeRequest": Array [
+    [Function],
+  ],
+  "body": "{\\"properties\\":[\\"email\\",\\"lifecyclestage\\",\\"hs_additional_emails\\"],\\"idProperty\\":\\"email\\",\\"inputs\\":[{\\"id\\":\\"secondaryemail@gmail.com\\"}]}",
+  "headers": Headers {
+    Symbol(map): Object {
+      "authorization": Array [
+        "Bearer undefined",
+      ],
+      "user-agent": Array [
+        "Segment (Actions)",
+      ],
+    },
+  },
+  "json": Object {
+    "idProperty": "email",
+    "inputs": Array [
+      Object {
+        "id": "secondaryemail@gmail.com",
+      },
+    ],
+    "properties": Array [
+      "email",
+      "lifecyclestage",
+      "hs_additional_emails",
+    ],
+  },
+  "method": "POST",
+  "signal": AbortSignal {},
+  "skipResponseCloning": true,
+  "statsContext": Object {},
+  "throwHttpErrors": true,
+  "timeout": 10000,
+}
+`;
+
+exports[`HubSpot.upsertContactBatch Should update contact on the basis of secondary email if it's not getting mapped with Primary email addresses 2`] = `
+Object {
+  "errors": Array [],
+  "numErrors": 0,
+  "results": Array [
+    Object {
+      "id": "113",
+      "properties": Object {
+        "createdate": "2023-07-06T12:47:47.626Z",
+        "email": "userthree@somecompany.com",
+        "hs_additional_emails": "secondaryemail@gmail.com;secondaryemail+2@gmail.com",
+        "hs_object_id": "113",
+        "lastmodifieddate": "2023-07-06T12:48:02.784Z",
+      },
+    },
+  ],
+  "status": "COMPLETE",
+}
+`;
+
+exports[`HubSpot.upsertContactBatch Should update contact on the basis of secondary email if it's not getting mapped with Primary email addresses 3`] = `
+Object {
+  "results": Array [
+    Object {
+      "id": "113",
+      "properties": Object {
+        "createdate": "2023-07-06T12:47:47.626Z",
+        "email": "secondaryemail@gmail.com",
+        "firstname": "User",
+        "lastmodifieddate": "2023-07-06T12:48:02.784Z",
+        "lastname": "Three",
+        "lifecyclestage": "subscriber",
+      },
+    },
+  ],
+  "status": "COMPLETE",
+}
+`;
+
 exports[`HubSpot.upsertContactBatch should create and update contact successfully 1`] = `
 Object {
   "afterResponse": Array [
@@ -10,7 +92,7 @@ Object {
   "beforeRequest": Array [
     [Function],
   ],
-  "body": "{\\"properties\\":[\\"email\\",\\"lifecyclestage\\"],\\"idProperty\\":\\"email\\",\\"inputs\\":[{\\"id\\":\\"userone@somecompany.com\\"},{\\"id\\":\\"usertwo@somecompany.com\\"},{\\"id\\":\\"userthree@somecompany.com\\"},{\\"id\\":\\"userfour@somecompany.com\\"}]}",
+  "body": "{\\"properties\\":[\\"email\\",\\"lifecyclestage\\",\\"hs_additional_emails\\"],\\"idProperty\\":\\"email\\",\\"inputs\\":[{\\"id\\":\\"userone@somecompany.com\\"},{\\"id\\":\\"usertwo@somecompany.com\\"},{\\"id\\":\\"userthree@somecompany.com\\"},{\\"id\\":\\"userfour@somecompany.com\\"}]}",
   "headers": Headers {
     Symbol(map): Object {
       "authorization": Array [
@@ -40,6 +122,7 @@ Object {
     "properties": Array [
       "email",
       "lifecyclestage",
+      "hs_additional_emails",
     ],
   },
   "method": "POST",
@@ -73,6 +156,7 @@ Object {
       "properties": Object {
         "createdate": "2023-07-06T12:47:47.626Z",
         "email": "userthree@somecompany.com",
+        "hs_additional_emails": null,
         "hs_object_id": "103",
         "lastmodifieddate": "2023-07-06T12:48:02.784Z",
       },
@@ -82,6 +166,7 @@ Object {
       "properties": Object {
         "createdate": "2023-07-06T12:47:47.626Z",
         "email": "userfour@somecompany.com",
+        "hs_additional_emails": null,
         "hs_object_id": "104",
         "lastmodifieddate": "2023-07-06T12:48:02.784Z",
       },
@@ -161,7 +246,7 @@ Object {
   "beforeRequest": Array [
     [Function],
   ],
-  "body": "{\\"properties\\":[\\"email\\",\\"lifecyclestage\\"],\\"idProperty\\":\\"email\\",\\"inputs\\":[{\\"id\\":\\"userone@somecompany.com\\"},{\\"id\\":\\"usertwo@somecompany.com\\"}]}",
+  "body": "{\\"properties\\":[\\"email\\",\\"lifecyclestage\\",\\"hs_additional_emails\\"],\\"idProperty\\":\\"email\\",\\"inputs\\":[{\\"id\\":\\"userone@somecompany.com\\"},{\\"id\\":\\"usertwo@somecompany.com\\"}]}",
   "headers": Headers {
     Symbol(map): Object {
       "authorization": Array [
@@ -185,6 +270,7 @@ Object {
     "properties": Array [
       "email",
       "lifecyclestage",
+      "hs_additional_emails",
     ],
   },
   "method": "POST",
@@ -257,7 +343,7 @@ Object {
   "beforeRequest": Array [
     [Function],
   ],
-  "body": "{\\"properties\\":[\\"email\\",\\"lifecyclestage\\"],\\"idProperty\\":\\"email\\",\\"inputs\\":[{\\"id\\":\\"userone@somecompany.com\\"}]}",
+  "body": "{\\"properties\\":[\\"email\\",\\"lifecyclestage\\",\\"hs_additional_emails\\"],\\"idProperty\\":\\"email\\",\\"inputs\\":[{\\"id\\":\\"userone@somecompany.com\\"}]}",
   "headers": Headers {
     Symbol(map): Object {
       "authorization": Array [
@@ -278,6 +364,7 @@ Object {
     "properties": Array [
       "email",
       "lifecyclestage",
+      "hs_additional_emails",
     ],
   },
   "method": "POST",
@@ -299,6 +386,7 @@ Object {
       "properties": Object {
         "createdate": "2023-07-06T12:47:47.626Z",
         "email": "userone@somecompany.com",
+        "hs_additional_emails": null,
         "hs_object_id": "103",
         "lastmodifieddate": "2023-07-06T12:48:02.784Z",
       },
@@ -375,7 +463,7 @@ Object {
   "beforeRequest": Array [
     [Function],
   ],
-  "body": "{\\"properties\\":[\\"email\\",\\"lifecyclestage\\"],\\"idProperty\\":\\"email\\",\\"inputs\\":[{\\"id\\":\\"userthree@somecompany.com\\"},{\\"id\\":\\"userfour@somecompany.com\\"}]}",
+  "body": "{\\"properties\\":[\\"email\\",\\"lifecyclestage\\",\\"hs_additional_emails\\"],\\"idProperty\\":\\"email\\",\\"inputs\\":[{\\"id\\":\\"userthree@somecompany.com\\"},{\\"id\\":\\"userfour@somecompany.com\\"}]}",
   "headers": Headers {
     Symbol(map): Object {
       "authorization": Array [
@@ -399,6 +487,7 @@ Object {
     "properties": Array [
       "email",
       "lifecyclestage",
+      "hs_additional_emails",
     ],
   },
   "method": "POST",
@@ -420,6 +509,7 @@ Object {
       "properties": Object {
         "createdate": "2023-07-06T12:47:47.626Z",
         "email": "userthree@somecompany.com",
+        "hs_additional_emails": null,
         "hs_object_id": "103",
         "lastmodifieddate": "2023-07-06T12:48:02.784Z",
       },
@@ -429,6 +519,7 @@ Object {
       "properties": Object {
         "createdate": "2023-07-06T12:47:47.626Z",
         "email": "userfour@somecompany.com",
+        "hs_additional_emails": null,
         "hs_object_id": "104",
         "lastmodifieddate": "2023-07-06T12:48:02.784Z",
       },


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pull request is to fix the internal error (Cannot set properties of undefined (setting 'action')) in upsertContact of Hubspot Cloud Actions.
[Sentry Issue](https://segment.sentry.io/issues/4315964286/events/02244c9900ef46f1a880b730949234f3/?project=1110287)
[Jira Ticket](https://segment.atlassian.net/jira/software/c/projects/STRATCONN/boards/310?modal=detail&selectedIssue=STRATCONN-3229&assignee=63617339fc0cc7a600b03c6b)


<img width="1512" alt="Screenshot 2023-10-04 at 6 15 15 PM" src="https://github.com/segmentio/action-destinations/assets/117165746/5a773547-0604-4c94-a515-c81268cf7f50">

<img width="622" alt="Screenshot 2023-10-04 at 6 17 10 PM" src="https://github.com/segmentio/action-destinations/assets/117165746/a02c77cd-1256-493c-9794-0d6e358b8681">


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
