### PR TITLE
UserMotion Browser Destionation

### DIFF
--- a/packages/browser-destinations/destinations/usermotion/README.md
+++ b/packages/browser-destinations/destinations/usermotion/README.md
@@ -1,0 +1,31 @@
+# @segment/analytics-browser-actions-usermotion
+
+The Usermotion browser action destination for use with @segment/analytics-next.
+
+## License
+
+MIT License
+
+Copyright (c) 2023 Segment
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Contributing
+
+All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

--- a/packages/browser-destinations/destinations/usermotion/package.json
+++ b/packages/browser-destinations/destinations/usermotion/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@segment/analytics-browser-actions-usermotion",
+  "version": "1.0.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/usermotion"
+  },
+  "main": "./dist/cjs",
+  "module": "./dist/esm",
+  "scripts": {
+    "build": "yarn build:esm && yarn build:cjs",
+    "build:cjs": "tsc --module commonjs --outDir ./dist/cjs",
+    "build:esm": "tsc --outDir ./dist/esm"
+  },
+  "typings": "./dist/esm",
+  "dependencies": {
+    "@segment/browser-destination-runtime": "^1.4.0"
+  },
+  "peerDependencies": {
+    "@segment/analytics-next": ">=1.55.0"
+  }
+}

--- a/packages/browser-destinations/destinations/usermotion/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your UserMotion Api Key
+   */
+  apiKey: string
+}

--- a/packages/browser-destinations/destinations/usermotion/src/group/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/group/__tests__/index.test.ts
@@ -1,0 +1,72 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import UserMotionDestination from '../../index'
+
+import { mockedSdk, groupSubscription, TEST_API_KEY } from '../../testIUtils'
+
+beforeEach(async () => {
+  window.usermotion = mockedSdk()
+})
+
+describe('UserMotion.group', () => {
+  test('should call group if groupId is provided', async () => {
+    const [event] = await UserMotionDestination({
+      subscriptions: [groupSubscription],
+      apiKey: TEST_API_KEY
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+    const umock = jest.spyOn(window.usermotion, 'group')
+
+    await event.group?.(
+      new Context({
+        type: 'group',
+        groupId: '1453',
+        traits: {
+          email: 'n.amirali@gmail.com'
+        }
+      })
+    )
+
+    expect(umock).toHaveBeenCalledWith('1453', { email: 'n.amirali@gmail.com' })
+  })
+
+  test('should not call group if groupId is not provided', async () => {
+    const [event] = await UserMotionDestination({
+      subscriptions: [groupSubscription],
+      apiKey: TEST_API_KEY
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+    const umock = jest.spyOn(window.usermotion, 'group')
+
+    await event.group?.(
+      new Context({
+        type: 'group'
+      })
+    )
+
+    expect(umock).not.toHaveBeenCalled()
+  })
+
+  test('should not send traits if its not an object', async () => {
+    const [event] = await UserMotionDestination({
+      subscriptions: [groupSubscription],
+      apiKey: TEST_API_KEY
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+    const umock = jest.spyOn(window.usermotion, 'group')
+
+    await event.group?.(
+      new Context({
+        type: 'group',
+        groupId: '1453',
+        traits: () => {
+          1
+        }
+      })
+    )
+
+    expect(umock).toHaveBeenCalledWith('1453', undefined)
+  })
+})

--- a/packages/browser-destinations/destinations/usermotion/src/group/generated-types.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/group/generated-types.ts
@@ -1,0 +1,14 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID of the company.
+   */
+  groupId: string
+  /**
+   * Company traits
+   */
+  traits?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/destinations/usermotion/src/group/index.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/group/index.ts
@@ -29,8 +29,8 @@ const action: BrowserActionDefinition<Settings, UserMotion, Payload> = {
       }
     }
   },
-  perform: (_, events) => {
-    window.usermotion.group(events.payload.groupId, events.payload.traits ?? {})
+  perform: (UserMotion, events) => {
+    UserMotion.group(events.payload.groupId, events.payload.traits ?? {})
   }
 }
 

--- a/packages/browser-destinations/destinations/usermotion/src/group/index.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/group/index.ts
@@ -1,0 +1,37 @@
+import type { BrowserActionDefinition } from '@segment/browser-destination-runtime/types'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import type { UserMotion } from '../types'
+
+// Change from unknown to the partner SDK types
+const action: BrowserActionDefinition<Settings, UserMotion, Payload> = {
+  title: 'Identify Company',
+  description: 'Create or update a company in UserMotion',
+  platform: 'web',
+  defaultSubscription: 'type = "group"',
+  fields: {
+    groupId: {
+      type: 'string',
+      required: true,
+      description: 'The ID of the company.',
+      label: 'Company ID',
+      default: {
+        '@path': '$.groupId'
+      }
+    },
+    traits: {
+      type: 'object',
+      required: false,
+      description: 'Company traits',
+      label: 'Traits',
+      default: {
+        '@path': '$.traits'
+      }
+    }
+  },
+  perform: (_, events) => {
+    window.usermotion.group(events.payload.groupId, events.payload.traits ?? {})
+  }
+}
+
+export default action

--- a/packages/browser-destinations/destinations/usermotion/src/group/index.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/group/index.ts
@@ -29,8 +29,12 @@ const action: BrowserActionDefinition<Settings, UserMotion, Payload> = {
       }
     }
   },
-  perform: (UserMotion, events) => {
-    UserMotion.group(events.payload.groupId, events.payload.traits ?? {})
+  perform: (UserMotion, event) => {
+    const { groupId, traits } = event.payload
+    if (!groupId) return
+
+    const props = typeof traits === 'object' ? { ...traits } : undefined
+    UserMotion.group(groupId, props)
   }
 }
 

--- a/packages/browser-destinations/destinations/usermotion/src/identify/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/identify/__tests__/index.test.ts
@@ -1,0 +1,73 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import UserMotionDestination from '../../index'
+
+import { mockedSdk, identifySubscription, TEST_API_KEY } from '../../testIUtils'
+
+beforeEach(async () => {
+  window.usermotion = mockedSdk()
+})
+
+describe('UserMotion.identify', () => {
+  test('should map userId and traits and pass them into UserMotion.identify', async () => {
+    const [event] = await UserMotionDestination({
+      subscriptions: [identifySubscription],
+      apiKey: TEST_API_KEY
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+    const umock = jest.spyOn(window.usermotion, 'identify')
+
+    await event.identify?.(
+      new Context({
+        type: 'identify',
+        userId: '1453',
+        traits: {
+          email: 'n.amirali@gmail.com'
+        }
+      })
+    )
+
+    expect(umock).toHaveBeenCalledWith('1453', { email: 'n.amirali@gmail.com' })
+  })
+
+  test('should not call identify if userId is not provided', async () => {
+    const [event] = await UserMotionDestination({
+      subscriptions: [identifySubscription],
+      apiKey: TEST_API_KEY
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+    const umock = jest.spyOn(window.usermotion, 'identify')
+
+    await event.identify?.(
+      new Context({
+        type: 'identify',
+        userId: null
+      })
+    )
+
+    expect(umock).not.toHaveBeenCalled()
+  })
+
+  test('should not send traits if its not an object', async () => {
+    const [event] = await UserMotionDestination({
+      subscriptions: [identifySubscription],
+      apiKey: TEST_API_KEY
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+    const umock = jest.spyOn(window.usermotion, 'identify')
+
+    await event.identify?.(
+      new Context({
+        type: 'identify',
+        userId: '1453',
+        traits: () => {
+          1
+        }
+      })
+    )
+
+    expect(umock).toHaveBeenCalledWith('1453', undefined)
+  })
+})

--- a/packages/browser-destinations/destinations/usermotion/src/identify/generated-types.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/identify/generated-types.ts
@@ -1,0 +1,14 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID of the logged-in user.
+   */
+  userId: string
+  /**
+   * User traits.
+   */
+  traits?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/destinations/usermotion/src/identify/index.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/identify/index.ts
@@ -33,10 +33,10 @@ const action: BrowserActionDefinition<Settings, UserMotion, Payload> = {
       }
     }
   },
-  perform: (_, event) => {
+  perform: (UserMotion, event) => {
     const { userId, traits } = event.payload
 
-    window.usermotion.identify(userId, { ...traits })
+    UserMotion.identify(userId, { ...traits })
   }
 }
 

--- a/packages/browser-destinations/destinations/usermotion/src/identify/index.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/identify/index.ts
@@ -14,20 +14,13 @@ const action: BrowserActionDefinition<Settings, UserMotion, Payload> = {
       required: true,
       description: 'The ID of the logged-in user.',
       label: 'User ID',
-      default: {
-        '@if': {
-          exists: { '@path': '$.userId' },
-          then: { '@path': '$.userId' },
-          else: { '@path': '$.anonymousId' }
-        }
-      }
+      default: { '@path': '$.userId' }
     },
     traits: {
       type: 'object',
       required: false,
       description: 'User traits.',
       label: 'Traits',
-      defaultObjectUI: 'object',
       default: {
         '@path': '$.traits'
       }
@@ -36,7 +29,10 @@ const action: BrowserActionDefinition<Settings, UserMotion, Payload> = {
   perform: (UserMotion, event) => {
     const { userId, traits } = event.payload
 
-    UserMotion.identify(userId, { ...traits })
+    if (!userId) return
+
+    const properties = typeof traits === 'object' ? { ...traits } : undefined
+    UserMotion.identify(userId, properties)
   }
 }
 

--- a/packages/browser-destinations/destinations/usermotion/src/identify/index.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/identify/index.ts
@@ -1,0 +1,43 @@
+import type { BrowserActionDefinition } from '@segment/browser-destination-runtime/types'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import type { UserMotion } from '../types'
+
+const action: BrowserActionDefinition<Settings, UserMotion, Payload> = {
+  title: 'Identify User',
+  description: 'Identify user to UserMotion',
+  platform: 'web',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    userId: {
+      type: 'string',
+      required: true,
+      description: 'The ID of the logged-in user.',
+      label: 'User ID',
+      default: {
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      }
+    },
+    traits: {
+      type: 'object',
+      required: false,
+      description: 'User traits.',
+      label: 'Traits',
+      defaultObjectUI: 'object',
+      default: {
+        '@path': '$.traits'
+      }
+    }
+  },
+  perform: (_, event) => {
+    const { userId, traits } = event.payload
+
+    window.usermotion.identify(userId, { ...traits })
+  }
+}
+
+export default action

--- a/packages/browser-destinations/destinations/usermotion/src/identify/index.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/identify/index.ts
@@ -12,9 +12,30 @@ const action: BrowserActionDefinition<Settings, UserMotion, Payload> = {
     userId: {
       type: 'string',
       required: true,
-      description: 'The ID of the logged-in user.',
+      description: 'A identifier for a known user.',
       label: 'User ID',
       default: { '@path': '$.userId' }
+    },
+    anonymousId: {
+      type: 'string',
+      required: false,
+      description: 'An identifier for an anonymous user',
+      label: 'Anonymous ID',
+      default: { '@path': '$.anonymousId' }
+    },
+    email: {
+      type: 'string',
+      required: true,
+      description: 'The email address for the user',
+      label: 'Email address',
+      default: { '@path': '$.traits.email' }
+    },
+    first_name: {
+      type: 'string',
+      required: false,
+      description: 'The First Name of the user',
+      label: 'User First Name',
+      default: { '@path': '$.traits.first_name' }
     },
     traits: {
       type: 'object',
@@ -27,7 +48,7 @@ const action: BrowserActionDefinition<Settings, UserMotion, Payload> = {
     }
   },
   perform: (UserMotion, event) => {
-    const { userId, traits } = event.payload
+    const { userId, email, traits } = event.payload
 
     if (!userId) return
 

--- a/packages/browser-destinations/destinations/usermotion/src/index.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/index.ts
@@ -1,0 +1,53 @@
+import type { Settings } from './generated-types'
+import type { BrowserDestinationDefinition } from '@segment/browser-destination-runtime/types'
+import type { UserMotion } from './types'
+
+import { browserDestination } from '@segment/browser-destination-runtime/shim'
+
+import identify from './identify'
+import { defaultValues } from '@segment/actions-core'
+
+import group from './group'
+
+declare global {
+  interface Window {
+    usermotion: UserMotion
+  }
+}
+
+// Switch from unknown to the partner SDK client types
+export const destination: BrowserDestinationDefinition<Settings, UserMotion> = {
+  name: 'UserMotion (Actions)',
+  slug: 'actions-usermotion-web',
+  mode: 'device',
+  presets: [
+    {
+      name: 'Identify User',
+      subscribe: 'type = "identify"',
+      partnerAction: 'identify',
+      mapping: defaultValues(identify.fields),
+      type: 'automatic'
+    }
+  ],
+  settings: {
+    apiKey: {
+      label: 'Api Key',
+      description: 'Your UserMotion Api Key',
+      required: true,
+      type: 'string'
+    }
+  },
+  initialize: async ({ settings }, deps) => {
+    await deps.loadScript(`//api.usermotion.com/js/${settings.apiKey}.js}`)
+    await deps.resolveWhen(() => Object.prototype.hasOwnProperty.call(window, 'usermotion'), 100)
+
+    return window.usermotion
+  },
+
+  actions: {
+    identify,
+    group
+  }
+}
+
+export default browserDestination(destination)

--- a/packages/browser-destinations/destinations/usermotion/src/index.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/index.ts
@@ -11,6 +11,8 @@ import group from './group'
 
 import track from './track'
 
+import pageview from './pageview'
+
 declare global {
   interface Window {
     usermotion: UserMotion
@@ -43,6 +45,13 @@ export const destination: BrowserDestinationDefinition<Settings, UserMotion> = {
       partnerAction: 'track',
       mapping: defaultValues(track.fields),
       type: 'automatic'
+    },
+    {
+      name: 'Page View',
+      subscribe: 'type = "page"',
+      partnerAction: 'pageview',
+      mapping: defaultValues(pageview.fields),
+      type: 'automatic'
     }
   ],
   settings: {
@@ -63,7 +72,8 @@ export const destination: BrowserDestinationDefinition<Settings, UserMotion> = {
   actions: {
     identify,
     group,
-    track
+    track,
+    pageview
   }
 }
 

--- a/packages/browser-destinations/destinations/usermotion/src/index.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/index.ts
@@ -63,7 +63,11 @@ export const destination: BrowserDestinationDefinition<Settings, UserMotion> = {
     }
   },
   initialize: async ({ settings }, deps) => {
-    await deps.loadScript(`//api.usermotion.com/js/${settings.apiKey}.js}`)
+    if (window.usermotion) {
+      return window.usermotion
+    }
+
+    await deps.loadScript(`https://api.usermotion.com/js/${settings.apiKey}.js`)
     await deps.resolveWhen(() => Object.prototype.hasOwnProperty.call(window, 'usermotion'), 100)
 
     return window.usermotion

--- a/packages/browser-destinations/destinations/usermotion/src/index.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/index.ts
@@ -27,6 +27,13 @@ export const destination: BrowserDestinationDefinition<Settings, UserMotion> = {
       partnerAction: 'identify',
       mapping: defaultValues(identify.fields),
       type: 'automatic'
+    },
+    {
+      name: 'Identify Group',
+      subscribe: 'type = "group"',
+      partnerAction: 'group',
+      mapping: defaultValues(group.fields),
+      type: 'automatic'
     }
   ],
   settings: {

--- a/packages/browser-destinations/destinations/usermotion/src/index.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/index.ts
@@ -9,6 +9,8 @@ import { defaultValues } from '@segment/actions-core'
 
 import group from './group'
 
+import track from './track'
+
 declare global {
   interface Window {
     usermotion: UserMotion
@@ -34,6 +36,13 @@ export const destination: BrowserDestinationDefinition<Settings, UserMotion> = {
       partnerAction: 'group',
       mapping: defaultValues(group.fields),
       type: 'automatic'
+    },
+    {
+      name: 'Track Event',
+      subscribe: 'type = "track"',
+      partnerAction: 'track',
+      mapping: defaultValues(track.fields),
+      type: 'automatic'
     }
   ],
   settings: {
@@ -53,7 +62,8 @@ export const destination: BrowserDestinationDefinition<Settings, UserMotion> = {
 
   actions: {
     identify,
-    group
+    group,
+    track
   }
 }
 

--- a/packages/browser-destinations/destinations/usermotion/src/pageview/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/pageview/__tests__/index.test.ts
@@ -1,0 +1,50 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import UserMotionDestination from '../../index'
+
+import { mockedSdk, TEST_API_KEY, pageviewSubscription } from '../../testIUtils'
+
+beforeEach(async () => {
+  window.usermotion = mockedSdk()
+})
+
+describe('UserMotion.pageview', () => {
+  test('should call pageview', async () => {
+    const [event] = await UserMotionDestination({
+      subscriptions: [pageviewSubscription],
+      apiKey: TEST_API_KEY
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+    const umock = jest.spyOn(window.usermotion, 'pageview')
+
+    await event.page?.(
+      new Context({
+        type: 'page'
+      })
+    )
+
+    expect(umock).toHaveBeenCalled()
+    // expect(umock).toHaveBeenCalledWith('1453', { email: 'n.amirali@gmail.com' })
+  })
+
+  test('should call pageview with properties', async () => {
+    const [event] = await UserMotionDestination({
+      subscriptions: [pageviewSubscription],
+      apiKey: TEST_API_KEY
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+    const umock = jest.spyOn(window.usermotion, 'pageview')
+
+    await event.page?.(
+      new Context({
+        type: 'page',
+        properties: {
+          url: 'https://www.segment.com'
+        }
+      })
+    )
+
+    expect(umock).toHaveBeenCalledWith({ url: 'https://www.segment.com' })
+  })
+})

--- a/packages/browser-destinations/destinations/usermotion/src/pageview/generated-types.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/pageview/generated-types.ts
@@ -1,0 +1,10 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Page properties
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/destinations/usermotion/src/pageview/index.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/pageview/index.ts
@@ -17,9 +17,9 @@ const action: BrowserActionDefinition<Settings, UserMotion, Payload> = {
       default: { '@path': '$.properties' }
     }
   },
-  perform: (_, event) => {
+  perform: (UserMotion, event) => {
     const { properties } = event.payload
-    window.usermotion.pageview(properties)
+    UserMotion.pageview(properties)
   }
 }
 export default action

--- a/packages/browser-destinations/destinations/usermotion/src/pageview/index.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/pageview/index.ts
@@ -1,0 +1,25 @@
+import type { BrowserActionDefinition } from '@segment/browser-destination-runtime/types'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import type { UserMotion } from '../types'
+
+const action: BrowserActionDefinition<Settings, UserMotion, Payload> = {
+  title: 'Track Page View',
+  description: 'Track the page view for the current page in UserMotion.',
+  defaultSubscription: 'type = "page"',
+  platform: 'web',
+  fields: {
+    properties: {
+      type: 'object',
+      required: false,
+      description: 'Page properties',
+      label: 'Properties',
+      default: { '@path': '$.properties' }
+    }
+  },
+  perform: (_, event) => {
+    const { properties } = event.payload
+    window.usermotion.pageview(properties)
+  }
+}
+export default action

--- a/packages/browser-destinations/destinations/usermotion/src/testIUtils.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/testIUtils.ts
@@ -53,6 +53,18 @@ export const groupSubscription: Subscription = {
   }
 }
 
+export const pageviewSubscription: Subscription = {
+  partnerAction: 'pageview',
+  name: 'Page View',
+  enabled: true,
+  subscribe: 'type = "page"',
+  mapping: {
+    properties: {
+      '@path': '$.properties'
+    }
+  }
+}
+
 export const mockJsHttpRequest = (): void => {
   nock('https://api.usermotion.com').get(`/js/${TEST_API_KEY}.js`).reply(200, {})
 }

--- a/packages/browser-destinations/destinations/usermotion/src/testIUtils.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/testIUtils.ts
@@ -1,0 +1,28 @@
+import { UserMotion } from './types'
+import { Subscription } from '@segment/browser-destination-runtime/types'
+import nock from 'nock'
+
+export const TEST_API_KEY = '0000000000000001'
+
+export const mockedSdk = (): UserMotion => {
+  return {
+    track: jest.fn(),
+    identify: jest.fn(),
+    pageview: jest.fn(),
+    group: jest.fn()
+  }
+}
+export const identifySubscription: Subscription = {
+  partnerAction: 'identify',
+  name: 'Identify User',
+  enabled: true,
+  subscribe: 'type = "identify"',
+  mapping: {
+    userId: { '@path': '$.userId' },
+    traits: { '@path': '$.traits' }
+  }
+}
+
+export const mockJsHttpRequest = (): void => {
+  nock('https://api.usermotion.com').get(`/js/${TEST_API_KEY}.js`).reply(200, {})
+}

--- a/packages/browser-destinations/destinations/usermotion/src/testIUtils.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/testIUtils.ts
@@ -23,6 +23,21 @@ export const identifySubscription: Subscription = {
   }
 }
 
+export const trackSubscription: Subscription = {
+  partnerAction: 'track',
+  name: 'Track Event',
+  enabled: true,
+  subscribe: 'type = "track"',
+  mapping: {
+    event: {
+      '@path': '$.name'
+    },
+    properties: {
+      '@path': '$.properties'
+    }
+  }
+}
+
 export const mockJsHttpRequest = (): void => {
   nock('https://api.usermotion.com').get(`/js/${TEST_API_KEY}.js`).reply(200, {})
 }

--- a/packages/browser-destinations/destinations/usermotion/src/testIUtils.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/testIUtils.ts
@@ -38,6 +38,21 @@ export const trackSubscription: Subscription = {
   }
 }
 
+export const groupSubscription: Subscription = {
+  partnerAction: 'group',
+  name: 'Group User',
+  enabled: true,
+  subscribe: 'type = "group"',
+  mapping: {
+    groupId: {
+      '@path': '$.groupId'
+    },
+    traits: {
+      '@path': '$.traits'
+    }
+  }
+}
+
 export const mockJsHttpRequest = (): void => {
   nock('https://api.usermotion.com').get(`/js/${TEST_API_KEY}.js`).reply(200, {})
 }

--- a/packages/browser-destinations/destinations/usermotion/src/track/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/track/__tests__/index.test.ts
@@ -1,0 +1,54 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import UserMotionDestination from '../../index'
+
+import { mockedSdk, TEST_API_KEY, trackSubscription } from '../../testIUtils'
+
+beforeEach(async () => {
+  window.usermotion = mockedSdk()
+})
+
+describe('UserMotion.track', () => {
+  test('should call track if event name is provided', async () => {
+    const [event] = await UserMotionDestination({
+      subscriptions: [trackSubscription],
+      apiKey: TEST_API_KEY
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+    const umock = jest.spyOn(window.usermotion, 'track')
+
+    await event.track?.(
+      new Context({
+        type: 'track',
+        name: 'TestEvent',
+        properties: {
+          email: 'n.amirali@gmail.com'
+        }
+      })
+    )
+
+    expect(umock).toHaveBeenCalledWith('TestEvent', { email: 'n.amirali@gmail.com' })
+  })
+
+  test('should not call track if event name is not provided', async () => {
+    const [event] = await UserMotionDestination({
+      subscriptions: [trackSubscription],
+      apiKey: TEST_API_KEY
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+    const umock = jest.spyOn(window.usermotion, 'track')
+
+    await event.track?.(
+      new Context({
+        type: 'track',
+        name: '',
+        properties: {
+          email: 'n.amirali@gmail.com'
+        }
+      })
+    )
+
+    expect(umock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/browser-destinations/destinations/usermotion/src/track/generated-types.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/track/generated-types.ts
@@ -1,0 +1,14 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Event name.
+   */
+  event: string
+  /**
+   * Properties to send with the event.
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/destinations/usermotion/src/track/index.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/track/index.ts
@@ -26,9 +26,9 @@ const action: BrowserActionDefinition<Settings, UserMotion, Payload> = {
       defaultObjectUI: 'object'
     }
   },
-  perform: (_, event) => {
+  perform: (UserMotion, event) => {
     const { event: eventName, properties } = event.payload
-    window.usermotion.track(eventName, { ...properties })
+    UserMotion.track(eventName, { ...properties })
   }
 }
 export default action

--- a/packages/browser-destinations/destinations/usermotion/src/track/index.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/track/index.ts
@@ -1,0 +1,34 @@
+import type { BrowserActionDefinition } from '@segment/browser-destination-runtime/types'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import type { UserMotion } from '../types'
+
+const action: BrowserActionDefinition<Settings, UserMotion, Payload> = {
+  title: 'Track Event',
+  description: 'Send user events to UserMotion',
+  defaultSubscription: 'type = "track"',
+  platform: 'web',
+  fields: {
+    event: {
+      type: 'string',
+      required: true,
+      description: 'Event name.',
+      label: 'Event Name',
+      default: { '@path': '$.event' }
+    },
+    properties: {
+      type: 'object',
+      required: false,
+      description: 'Properties to send with the event.',
+      label: 'Event Properties',
+      default: { '@path': '$.properties' },
+
+      defaultObjectUI: 'object'
+    }
+  },
+  perform: (_, event) => {
+    const { event: eventName, properties } = event.payload
+    window.usermotion.track(eventName, { ...properties })
+  }
+}
+export default action

--- a/packages/browser-destinations/destinations/usermotion/src/track/index.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/track/index.ts
@@ -21,14 +21,16 @@ const action: BrowserActionDefinition<Settings, UserMotion, Payload> = {
       required: false,
       description: 'Properties to send with the event.',
       label: 'Event Properties',
-      default: { '@path': '$.properties' },
-
-      defaultObjectUI: 'object'
+      default: { '@path': '$.properties' }
     }
   },
   perform: (UserMotion, event) => {
     const { event: eventName, properties } = event.payload
-    UserMotion.track(eventName, { ...properties })
+    if (!eventName) return
+
+    const props = typeof properties === 'object' ? { ...properties } : undefined
+
+    UserMotion.track(eventName, props)
   }
 }
 export default action

--- a/packages/browser-destinations/destinations/usermotion/src/track/index.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/track/index.ts
@@ -4,17 +4,50 @@ import type { Payload } from './generated-types'
 import type { UserMotion } from '../types'
 
 const action: BrowserActionDefinition<Settings, UserMotion, Payload> = {
-  title: 'Track Event',
-  description: 'Send user events to UserMotion',
-  defaultSubscription: 'type = "track"',
+  title: 'Track Analytics Event',
+  description: 'Send user and page events to UserMotion',
+  defaultSubscription: 'type = "track" or type = page',
   platform: 'web',
   fields: {
-    event: {
+    userId: {
       type: 'string',
       required: true,
-      description: 'Event name.',
+      description: 'A identifier for a known user.',
+      label: 'User ID',
+      default: { '@path': '$.userId' }
+    },
+    anonymousId: {
+      type: 'string',
+      required: false,
+      description: 'An identifier for an anonymous user',
+      label: 'Anonymous ID',
+      default: { '@path': '$.anonymousId' }
+    },
+    email: {
+      type: 'string',
+      required: true,
+      description: 'The email address for the user',
+      label: 'Email address',
+      default: {
+        '@if': {
+          exists: { '@path': '$.context.traits.email' },
+          then: { '@path': '$.context.traits.email' },
+          else: { '@path': '$.properties.email' }
+        }
+      }
+    },
+    event_name: {
+      type: 'string',
+      required: true,
+      description: 'The name of the track() event or page() event',
       label: 'Event Name',
-      default: { '@path': '$.event' }
+      default: {
+        '@if': {
+          exists: { '@path': '$.event' },
+          then: { '@path': '$.event' },
+          else: { '@path': '$.name' }
+        }
+      }
     },
     properties: {
       type: 'object',

--- a/packages/browser-destinations/destinations/usermotion/src/types.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/types.ts
@@ -1,6 +1,6 @@
 export type UserMotion = {
-  identify: (userId: String, traits: { [key: string]: unknown }) => void
-  track: (eventName: String, eventProperties: { [key: string]: unknown }) => void
+  identify: (userId: String, traits?: { [key: string]: unknown }) => void
+  track: (eventName: String, eventProperties?: { [key: string]: unknown }) => void
   group: (groupId: String, groupTraits: Object) => void
-  pageview: (properties: Object) => void
+  pageview: (properties?: Object) => void
 }

--- a/packages/browser-destinations/destinations/usermotion/src/types.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/types.ts
@@ -1,0 +1,6 @@
+export type UserMotion = {
+  identify: (userId: String, traits: { [key: string]: unknown }) => void
+  track: (eventName: String, eventProperties: { [key: string]: unknown }) => void
+  group: (groupId: String, groupTraits: Object) => void
+  pageview: (properties: Object) => void
+}

--- a/packages/browser-destinations/destinations/usermotion/src/types.ts
+++ b/packages/browser-destinations/destinations/usermotion/src/types.ts
@@ -1,6 +1,6 @@
 export type UserMotion = {
   identify: (userId: String, traits?: { [key: string]: unknown }) => void
   track: (eventName: String, eventProperties?: { [key: string]: unknown }) => void
-  group: (groupId: String, groupTraits: Object) => void
+  group: (groupId: String, groupTraits: { [key: string]: unknown }) => void
   pageview: (properties?: Object) => void
 }

--- a/packages/browser-destinations/destinations/usermotion/tsconfig.json
+++ b/packages/browser-destinations/destinations/usermotion/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "baseUrl": "."
+  },
+  "include": ["src"],
+  "exclude": ["dist", "**/__tests__"]
+}


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

**What is UserMotion?**
UserMotion is a sales intelligence platform that uses predictive lead scoring to identify leads most likely to buy, expand, or churn. Our customers are GTM teams, sales, CX, revops, founder-led b2b saas companies. 

**How it works?**
It connects with the modern data stack, including CRMs (such as HubSpot), payment processors (such as Stripe and Paddle), customer support tools (such as Intercom), JS SDK, and Rest API, and collects all event data from such data points, organizes, and analyzes data to come with actionable insights. 

Our users may already have Segment implemented on their platform, so that would help them to quickly connect UserMotion.


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
