### PR TITLE
Revert "[STRATCONN] 3183 Added email subscribe as dynamic field in braze"

### DIFF
--- a/packages/browser-destinations/destinations/braze/src/updateUserProfile/index.ts
+++ b/packages/browser-destinations/destinations/braze/src/updateUserProfile/index.ts
@@ -79,12 +79,7 @@ const action: BrowserActionDefinition<Settings, BrazeDestinationClient, Payload>
     email_subscribe: {
       label: 'Email Subscribe',
       description: `The user's email subscription preference: “opted_in” (explicitly registered to receive email messages), “unsubscribed” (explicitly opted out of email messages), and “subscribed” (neither opted in nor out).`,
-      type: 'string',
-      choices: [
-        { label: 'OTPED_IN', value: 'opted_in' },
-        { label: 'SUBSCRIBED', value: 'subscribed' },
-        { label: 'UNSUBSCRIBED', value: 'unsubscribed' }
-      ]
+      type: 'string'
     },
     first_name: {
       label: 'First Name',

--- a/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
+++ b/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
@@ -154,12 +154,7 @@ const action: ActionDefinition<Settings, Payload> = {
     email_subscribe: {
       label: 'Email Subscribe',
       description: `The user's email subscription preference: “opted_in” (explicitly registered to receive email messages), “unsubscribed” (explicitly opted out of email messages), and “subscribed” (neither opted in nor out).`,
-      type: 'string',
-      choices: [
-        { label: 'OTPED_IN', value: 'opted_in' },
-        { label: 'SUBSCRIBED', value: 'subscribed' },
-        { label: 'UNSUBSCRIBED', value: 'unsubscribed' }
-      ]
+      type: 'string'
     },
     email_open_tracking_disabled: {
       label: 'Email Open Tracking Disabled',


### PR DESCRIPTION
Reverts segmentio/action-destinations#1606

as its not working on PROD due to lowercase and uppercase of "email subscribe" value