### PR TITLE
Migrates `type: hidden` to `type: 'string', hidden: true`

### DIFF
--- a/packages/core/src/__tests__/schema-validation.test.ts
+++ b/packages/core/src/__tests__/schema-validation.test.ts
@@ -111,11 +111,12 @@ describe('validateSchema', () => {
     expect(payload).toMatchInlineSnapshot(`Object {}`)
   })
 
-  it('should not throw when type = hidden', () => {
+  it('should not throw when hidden = true', () => {
     const hiddenSchema = fieldsToJsonSchema({
       h: {
         label: 'h',
-        type: 'hidden'
+        type: 'string',
+        unsafe_hidden: true
       }
     })
 

--- a/packages/core/src/destination-kit/fields-to-jsonschema.ts
+++ b/packages/core/src/destination-kit/fields-to-jsonschema.ts
@@ -6,7 +6,6 @@ function toJsonSchemaType(type: FieldTypeName): JSONSchema4TypeName | JSONSchema
     case 'string':
     case 'text':
     case 'password':
-    case 'hidden':
       return 'string'
     case 'datetime':
       return ['string', 'number']

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -83,16 +83,7 @@ export interface GlobalSetting {
 }
 
 /** The supported field type names */
-export type FieldTypeName =
-  | 'string'
-  | 'text'
-  | 'number'
-  | 'integer'
-  | 'datetime'
-  | 'boolean'
-  | 'password'
-  | 'object'
-  | 'hidden'
+export type FieldTypeName = 'string' | 'text' | 'number' | 'integer' | 'datetime' | 'boolean' | 'password' | 'object'
 
 /** The shape of an input field definition */
 export interface InputField {

--- a/packages/destination-actions/src/destinations/ambee/subscribeUserToCampaign/index.ts
+++ b/packages/destination-actions/src/destinations/ambee/subscribeUserToCampaign/index.ts
@@ -10,13 +10,15 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Segment Library',
       description:
         'The Segment library used when the event was triggered. This Integration will only work with analytics.js or Mobile Segment libraries',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       default: { '@path': '$.context.library.name' }
     },
     platform: {
       label: 'User Device Platform',
       description: 'The platform of the device which generated the event e.g. "Android" or "iOS"',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       default: { '@path': '$.context.device.type' }
     },
     campaignId: {

--- a/packages/destination-actions/src/destinations/braze-cohorts/syncAudiences/index.ts
+++ b/packages/destination-actions/src/destinations/braze-cohorts/syncAudiences/index.ts
@@ -47,7 +47,8 @@ const action: ActionDefinition<Settings, Payload> = {
     cohort_id: {
       label: 'Cohort ID',
       description: 'The Cohort Identifier',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       default: {
         '@path': '$.context.personas.computation_id'
@@ -56,7 +57,8 @@ const action: ActionDefinition<Settings, Payload> = {
     cohort_name: {
       label: 'Cohort Name',
       description: 'The name of Cohort',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       default: {
         '@path': '$.context.personas.computation_key'
@@ -92,7 +94,8 @@ const action: ActionDefinition<Settings, Payload> = {
     time: {
       label: 'Time',
       description: 'When the event occurred.',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       default: {
         '@path': '$.timestamp'

--- a/packages/destination-actions/src/destinations/cordial/identities-fields.ts
+++ b/packages/destination-actions/src/destinations/cordial/identities-fields.ts
@@ -1,17 +1,19 @@
-import {InputField} from "@segment/actions-core";
+import { InputField } from '@segment/actions-core'
 
-export const userIdentityFields : Record<string, InputField> = {
+export const userIdentityFields: Record<string, InputField> = {
   segmentId: {
     label: 'Segment User ID',
     description: 'Segment User ID value',
-    type: 'hidden',
+    type: 'string',
+    unsafe_hidden: true,
     required: false,
     default: { '@path': '$.userId' }
   },
   anonymousId: {
     label: 'Segment Anonymous ID',
     description: 'Segment Anonymous ID value',
-    type: 'hidden',
+    type: 'string',
+    unsafe_hidden: true,
     required: false,
     default: { '@path': '$.anonymousId' }
   },
@@ -22,7 +24,7 @@ export const userIdentityFields : Record<string, InputField> = {
     type: 'object',
     required: false,
     defaultObjectUI: 'keyvalue:only'
-  },
+  }
 }
 
-export default userIdentityFields;
+export default userIdentityFields

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
@@ -13,7 +13,8 @@ const action: ActionDefinition<Settings, Payload> = {
     segment_audience_key: {
       label: 'Audience Key',
       description: 'Segment Audience key / name',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       default: {
         '@path': '$.context.personas.computation_key'
@@ -23,7 +24,8 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Segment Computation Action',
       description:
         "Segment computation class used to determine if input event is from an Engage Audience'. Value must be = 'audience'.",
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       default: {
         '@path': '$.context.personas.computation_class'
@@ -33,21 +35,24 @@ const action: ActionDefinition<Settings, Payload> = {
     segment_user_id: {
       label: 'Segment User ID',
       description: 'The Segment userId value.',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: false,
       default: { '@path': '$.userId' }
     },
     segment_anonymous_id: {
       label: 'Segment Anonymous ID',
       description: 'The Segment anonymousId value.',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: false,
       default: { '@path': '$.anonymousId' }
     },
     user_email: {
       label: 'Email address',
       description: "The user's email address",
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: false,
       default: {
         '@if': {

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
@@ -21,7 +21,8 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Operation Type',
       description:
         "Describes the nature of the operation being performed. Only supported values are 'new' and 'updated'.",
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       default: { '@path': '$.event' }
     },

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/index.ts
@@ -13,7 +13,8 @@ const action: ActionDefinition<Settings, Payload> = {
     segment_audience_key: {
       label: 'Audience Key',
       description: 'Segment Audience key to which user identifier should be added or removed',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       default: {
         '@path': '$.context.personas.computation_key'
@@ -23,7 +24,8 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Segment Computation Action',
       description:
         "Segment computation class used to determine if input event is from an Engage Audience'. Value must be = 'audience'.",
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       default: {
         '@path': '$.context.personas.computation_class'
@@ -41,21 +43,24 @@ const action: ActionDefinition<Settings, Payload> = {
     segment_user_id: {
       label: 'Segment User ID',
       description: 'The Segment userId value.',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: false,
       default: { '@path': '$.userId' }
     },
     segment_anonymous_id: {
       label: 'Segment Anonymous ID',
       description: 'The Segment anonymousId value.',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: false,
       default: { '@path': '$.anonymousId' }
     },
     user_email: {
       label: 'Email address',
       description: "The user's email address",
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: false,
       default: {
         '@if': {
@@ -103,7 +108,8 @@ const action: ActionDefinition<Settings, Payload> = {
     audience_action: {
       label: 'Audience Action',
       description: 'Indicates if the user will be added or removed from the Audience',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       choices: [
         { label: CONSTANTS.ADD as AudienceAction, value: CONSTANTS.ADD as AudienceAction },
         { label: CONSTANTS.REMOVE as AudienceAction, value: CONSTANTS.REMOVE as AudienceAction }

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
@@ -28,7 +28,8 @@ const action: ActionDefinition<Settings, Payload> = {
     email: {
       label: 'User Email',
       description: "The user's email address to send to LinkedIn.",
-      type: 'hidden', // This field is hidden from customers because the desired value always appears at path '$.context.traits.email' in Personas events.
+      type: 'string',
+      unsafe_hidden: true, // This field is hidden from customers because the desired value always appears at path '$.context.traits.email' in Personas events.
       default: {
         '@path': '$.context.traits.email'
       }
@@ -36,7 +37,8 @@ const action: ActionDefinition<Settings, Payload> = {
     google_advertising_id: {
       label: 'User Google Advertising ID',
       description: "The user's Google Advertising ID to send to LinkedIn.",
-      type: 'hidden', // This field is hidden from customers because the desired value always appears at path '$.context.device.advertisingId' in Personas events.
+      type: 'string',
+      unsafe_hidden: true, // This field is hidden from customers because the desired value always appears at path '$.context.device.advertisingId' in Personas events.
       default: {
         '@path': '$.context.device.advertisingId'
       }
@@ -45,7 +47,8 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'LinkedIn Source Segment ID',
       description:
         "A Segment-specific key associated with the LinkedIn DMP Segment. This is the lookup key Segment uses to fetch the DMP Segment from LinkedIn's API.",
-      type: 'hidden', // This field is hidden from customers because the desired value always appears at '$.properties.audience_key' in Personas events.
+      type: 'string',
+      unsafe_hidden: true, // This field is hidden from customers because the desired value always appears at '$.properties.audience_key' in Personas events.
       default: {
         '@path': '$.properties.audience_key'
       }
@@ -60,7 +63,8 @@ const action: ActionDefinition<Settings, Payload> = {
     event_name: {
       label: 'Event Name',
       description: 'The name of the current Segment event.',
-      type: 'hidden', // This field is hidden from customers because the desired value always appears at path '$.event' in Personas events.
+      type: 'string',
+      unsafe_hidden: true, // This field is hidden from customers because the desired value always appears at path '$.event' in Personas events.
       default: {
         '@path': '$.event'
       }

--- a/packages/destination-actions/src/destinations/livelike-cloud/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/livelike-cloud/trackEvent/index.ts
@@ -67,7 +67,8 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Segment Anonymous ID',
       description: 'Segment Anonymous ID.',
       required: false,
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       default: {
         '@path': '$.anonymousId'
       }

--- a/packages/destination-actions/src/destinations/optimizely-advanced-audience-targeting/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/optimizely-advanced-audience-targeting/syncAudience/index.ts
@@ -33,7 +33,8 @@ const action: ActionDefinition<Settings, Payload> = {
     custom_audience_name: {
       label: 'Custom Audience Name',
       description: 'Name of custom audience to add or remove the user from',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       default: {
         '@path': '$.context.personas.computation_key'
@@ -42,7 +43,8 @@ const action: ActionDefinition<Settings, Payload> = {
     segment_computation_action: {
       label: 'Segment Computation Action',
       description: 'Segment computation class used to determine payload is for an Audience',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       default: {
         '@path': '$.context.personas.computation_class'
@@ -52,7 +54,8 @@ const action: ActionDefinition<Settings, Payload> = {
     segment_computation_id: {
       label: 'Segment Computation ID',
       description: 'Segment computation ID',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       default: {
         '@path': '$.context.personas.computation_id'
@@ -73,7 +76,8 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     timestamp: {
       label: 'Timestamp',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       description: 'Timestamp indicates when the user was added or removed from the Audience',
       default: {

--- a/packages/destination-actions/src/destinations/optimizely-feature-experimentation-actions/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/optimizely-feature-experimentation-actions/trackEvent/index.ts
@@ -93,7 +93,8 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     uuid: {
       label: 'Unique ID',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       description: 'Unique ID for the event',
       required: true,
       default: {

--- a/packages/destination-actions/src/destinations/outfunnel/forwardGroupEvent/index.ts
+++ b/packages/destination-actions/src/destinations/outfunnel/forwardGroupEvent/index.ts
@@ -1,7 +1,7 @@
-import { ActionDefinition } from '@segment/actions-core';
-import type { Settings } from '../generated-types';
-import type { Payload } from './generated-types';
-import { getEndpoint } from '../utils';
+import { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { getEndpoint } from '../utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Forward group event',
@@ -9,14 +9,16 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "group"',
   fields: {
     action: {
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       description: 'Indicates which action was triggered',
       label: 'Action name',
       default: 'group'
     },
     user_id: {
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       description: 'The identifier of the user',
       label: 'User ID',
       default: {
@@ -24,7 +26,8 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     anonymous_id: {
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       description: 'Anonymous ID of the user',
       label: 'Anonymous ID',
       default: {
@@ -32,7 +35,8 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     group_id: {
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       description: 'ID of the group',
       label: 'Group ID',
       default: {
@@ -48,7 +52,8 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     timestamp: {
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       description: 'The time the event occured in UTC',
       label: 'Event timestamp',
@@ -75,12 +80,12 @@ const action: ActionDefinition<Settings, Payload> = {
   },
 
   perform: async (request, { settings, payload }) => {
-    const endpoint = getEndpoint(settings.userId);
+    const endpoint = getEndpoint(settings.userId)
 
     return request(endpoint, {
       method: 'POST',
       json: payload
-    });
+    })
   }
 }
 

--- a/packages/destination-actions/src/destinations/outfunnel/forwardIdentifyEvent/index.ts
+++ b/packages/destination-actions/src/destinations/outfunnel/forwardIdentifyEvent/index.ts
@@ -1,7 +1,7 @@
-import { ActionDefinition } from '@segment/actions-core';
-import type { Settings } from '../generated-types';
-import type { Payload } from './generated-types';
-import { getEndpoint } from '../utils';
+import { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { getEndpoint } from '../utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Forward identify event',
@@ -9,14 +9,16 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "identify"',
   fields: {
     action: {
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       description: 'Indicates which action was triggered',
       label: 'Action name',
       default: 'identify'
     },
     user_id: {
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       description: 'The identifier of the user',
       label: 'User ID',
       default: {
@@ -24,7 +26,8 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     anonymous_id: {
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       description: 'Anonymous ID of the user',
       label: 'Anonymous ID',
       default: {
@@ -41,7 +44,8 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     timestamp: {
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       description: 'The time the event occured in UTC',
       label: 'Event timestamp',
@@ -68,12 +72,12 @@ const action: ActionDefinition<Settings, Payload> = {
   },
 
   perform: async (request, { settings, payload }) => {
-    const endpoint = getEndpoint(settings.userId);
+    const endpoint = getEndpoint(settings.userId)
 
     return request(endpoint, {
       method: 'POST',
       json: payload
-    });
+    })
   }
 }
 

--- a/packages/destination-actions/src/destinations/outfunnel/forwardTrackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/outfunnel/forwardTrackEvent/index.ts
@@ -1,7 +1,7 @@
-import { ActionDefinition } from '@segment/actions-core';
-import type { Settings } from '../generated-types';
-import type { Payload } from './generated-types';
-import { getEndpoint } from '../utils';
+import { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { getEndpoint } from '../utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Forward track event',
@@ -9,7 +9,8 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track"',
   fields: {
     action: {
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       description: 'Indicates which action was triggered',
       label: 'Action name',
@@ -25,7 +26,8 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     user_id: {
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       description: 'The identifier of the user who performed the event',
       label: 'User ID',
       default: {
@@ -33,7 +35,8 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     anonymous_id: {
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       description: 'Anonymous ID of the user',
       label: 'Anonymous ID',
       default: {
@@ -61,7 +64,8 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     timestamp: {
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       description: 'The time the event occured in UTC',
       label: 'Event timestamp',
@@ -87,7 +91,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, { settings, payload }) => {
-    const endpoint = getEndpoint(settings.userId);
+    const endpoint = getEndpoint(settings.userId)
 
     return request(endpoint, {
       method: 'POST',
@@ -96,4 +100,4 @@ const action: ActionDefinition<Settings, Payload> = {
   }
 }
 
-export default action;
+export default action

--- a/packages/destination-actions/src/destinations/tiktok-audiences/properties.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/properties.ts
@@ -42,7 +42,8 @@ export const custom_audience_name: InputField = {
 export const email: InputField = {
   label: 'User Email',
   description: "The user's email address to send to TikTok.",
-  type: 'hidden', // This field is hidden from customers because the desired value always appears at path '$.context.traits.email' in Personas events.
+  type: 'string',
+  unsafe_hidden: true, // This field is hidden from customers because the desired value always appears at path '$.context.traits.email' in Personas events.
   default: {
     '@path': '$.context.traits.email'
   }
@@ -58,7 +59,8 @@ export const send_email: InputField = {
 export const advertising_id: InputField = {
   label: 'User Advertising ID',
   description: "The user's mobile advertising ID to send to TikTok. This could be a GAID, IDFA, or AAID",
-  type: 'hidden', // This field is hidden from customers because the desired value always appears at path '$.context.device.advertisingId' in Personas events.
+  type: 'string',
+  unsafe_hidden: true, // This field is hidden from customers because the desired value always appears at path '$.context.device.advertisingId' in Personas events.
   default: {
     '@path': '$.context.device.advertisingId'
   }
@@ -75,7 +77,8 @@ export const send_advertising_id: InputField = {
 export const event_name: InputField = {
   label: 'Event Name',
   description: 'The name of the current Segment event.',
-  type: 'hidden', // This field is hidden from customers because the desired value always appears at path '$.event' in Personas events.
+  type: 'string',
+  unsafe_hidden: true, // This field is hidden from customers because the desired value always appears at path '$.event' in Personas events.
   default: {
     '@path': '$.event'
   }
@@ -91,7 +94,8 @@ export const enable_batching: InputField = {
 export const external_audience_id: InputField = {
   label: 'External Audience ID',
   description: "The Audience ID in TikTok's DB.",
-  type: 'hidden',
+  type: 'string',
+  unsafe_hidden: true,
   default: {
     '@path': '$.context.personas.external_audience_id'
   }

--- a/packages/destination-actions/src/destinations/twilio-studio/triggerStudioFlow/index.ts
+++ b/packages/destination-actions/src/destinations/twilio-studio/triggerStudioFlow/index.ts
@@ -37,18 +37,21 @@ const action: ActionDefinition<Settings, Payload> = {
     userId: {
       label: 'User ID',
       description: 'A Distinct User ID',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       default: { '@path': '$.userId' }
     },
     anonymousId: {
       label: 'Anonymous ID',
       description: 'A Distinct External ID',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       default: { '@path': '$.anonymousId' }
     },
     eventType: {
       label: 'Event type',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       description: 'The type of the event being performed.',
       required: true,
       default: {

--- a/packages/destination-actions/src/destinations/yahoo-audiences/updateSegment/index.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/updateSegment/index.ts
@@ -12,7 +12,8 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     segment_audience_id: {
       label: 'Segment Audience Id', // Maps to Yahoo Taxonomy Segment Id
       description: 'Segment Audience Id (aud_...). Maps to "Id" of a Segment node in Yahoo taxonomy',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       default: {
         '@path': '$.context.personas.computation_id'
@@ -21,7 +22,8 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     segment_audience_key: {
       label: 'Segment Audience Key',
       description: 'Segment Audience Key. Maps to the "Name" of the Segment node in Yahoo taxonomy',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       default: {
         '@path': '$.context.personas.computation_key'
@@ -46,7 +48,8 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
       label: 'Segment Computation Action',
       description:
         "Segment computation class used to determine if input event is from an Engage Audience'. Value must be = 'audience'.",
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: true,
       default: {
         '@path': '$.context.personas.computation_class'
@@ -70,7 +73,8 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     email: {
       label: 'User Email',
       description: 'Email address of a user',
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       required: false,
       default: {
         '@if': {
@@ -83,7 +87,8 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     advertising_id: {
       label: 'User Mobile Advertising ID',
       description: "User's mobile advertising Id",
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       default: {
         '@path': '$.context.device.advertisingId'
       },
@@ -92,7 +97,8 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     device_type: {
       label: 'User Mobile Device Type', // This field is required to determine the type of the advertising Id: IDFA or GAID
       description: "User's mobile device type",
-      type: 'hidden',
+      type: 'string',
+      unsafe_hidden: true,
       default: {
         '@path': '$.context.device.type'
       },


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR removes `type: 'hidden'` as a possibility for `InputField` and updates any usages of it to the new `hidden: true` property. This PR will not require a `push` for any of the updated destinations because [this PR ](https://github.com/segmentio/control-plane/pull/3984)will take care of that. 

`hidden: true` was introduced in this series of PRs: https://github.com/segmentio/control-plane/pull/3813


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

Testing will be handled in the [control-plane PR](https://github.com/segmentio/control-plane/pull/3984).

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
