### PR TITLE
[Algolia] Support sending price data with conversion event

### DIFF
--- a/packages/destination-actions/src/destinations/algolia-insights/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,9 +4,19 @@ exports[`Testing snapshot for actions-algolia-insights destination: conversionEv
 Object {
   "events": Array [
     Object {
+      "currency": "HTG",
       "eventName": "U[ABpE$k",
+      "eventSubtype": "purchase",
       "eventType": "view",
       "index": "U[ABpE$k",
+      "objectData": Array [
+        Object {
+          "discount": -52282070788997.12,
+          "price": -52282070788997.12,
+          "quantity": -52282070788997.12,
+          "queryID": "U[ABpE$k",
+        },
+      ],
       "objectIDs": Array [
         "U[ABpE$k",
       ],
@@ -14,6 +24,7 @@ Object {
       "testType": "U[ABpE$k",
       "timestamp": null,
       "userToken": "U[ABpE$k",
+      "value": -52282070788997.12,
     },
   ],
 }

--- a/packages/destination-actions/src/destinations/algolia-insights/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -35,6 +35,7 @@ Object {
   "events": Array [
     Object {
       "eventName": "Conversion Event",
+      "eventSubtype": "purchase",
       "eventType": "conversion",
       "index": "U[ABpE$k",
       "objectIDs": Array [

--- a/packages/destination-actions/src/destinations/algolia-insights/algolia-insight-api.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/algolia-insight-api.ts
@@ -6,6 +6,8 @@ export const algoliaApiPermissionsUrl = (settings: Settings) =>
 
 export type AlgoliaEventType = 'view' | 'click' | 'conversion'
 
+export type AlgoliaEventSubtype = 'addToCart' | 'purchase'
+
 type EventCommon = {
   eventName: string
   index: string
@@ -29,7 +31,16 @@ export type AlgoliaFilterClickedEvent = EventCommon & {
 }
 
 export type AlgoliaConversionEvent = EventCommon & {
+  eventSubtype?: AlgoliaEventSubtype
   objectIDs: string[]
+  objectData?: {
+    queryID?: string
+    price?: number | string
+    discount?: number | string
+    quantity?: number
+  }[]
+  value?: number
+  currency?: string
 }
 
 export type AlgoliaApiPermissions = {

--- a/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,9 +4,19 @@ exports[`Testing snapshot for AlgoliaInsights's conversionEvents destination act
 Object {
   "events": Array [
     Object {
+      "currency": "CUC",
       "eventName": ")j)vR5%1AP*epuo8A%R",
+      "eventSubtype": "addToCart",
       "eventType": "click",
       "index": ")j)vR5%1AP*epuo8A%R",
+      "objectData": Array [
+        Object {
+          "discount": 76163635352698.88,
+          "price": 76163635352698.88,
+          "quantity": 76163635352698.88,
+          "queryID": ")j)vR5%1AP*epuo8A%R",
+        },
+      ],
       "objectIDs": Array [
         ")j)vR5%1AP*epuo8A%R",
       ],
@@ -14,6 +24,7 @@ Object {
       "testType": ")j)vR5%1AP*epuo8A%R",
       "timestamp": null,
       "userToken": ")j)vR5%1AP*epuo8A%R",
+      "value": 76163635352698.88,
     },
   ],
 }
@@ -24,6 +35,7 @@ Object {
   "events": Array [
     Object {
       "eventName": "Conversion Event",
+      "eventSubtype": "purchase",
       "eventType": "conversion",
       "index": ")j)vR5%1AP*epuo8A%R",
       "objectIDs": Array [

--- a/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/__tests__/index.test.ts
@@ -53,6 +53,7 @@ describe('AlgoliaInsights.conversionEvents', () => {
 
     expect(algoliaEvent.eventName).toBe('Conversion Event')
     expect(algoliaEvent.eventType).toBe('conversion')
+    expect(algoliaEvent.eventSubtype).toBe('purchase')
     expect(algoliaEvent.index).toBe(event.properties?.search_index)
     expect(algoliaEvent.userToken).toBe(event.userId)
     expect(algoliaEvent.objectIDs).toContain('9876')
@@ -102,5 +103,178 @@ describe('AlgoliaInsights.conversionEvents', () => {
     })
     const algoliaEvent = await testAlgoliaDestination(event)
     expect(algoliaEvent.queryID).toBe(event.properties?.query_id)
+  })
+
+  it('should pass value if present', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      event: 'Order Completed',
+      properties: {
+        query_id: '1234',
+        search_index: 'fashion_1',
+        products: [
+          {
+            product_id: '9876',
+            product_name: 'skirt 1'
+          },
+          {
+            product_id: '5432',
+            product_name: 'skirt 2'
+          }
+        ],
+        value: 200
+      }
+    })
+    const algoliaEvent = await testAlgoliaDestination(event)
+    expect(algoliaEvent.value).toBe(200)
+  })
+
+  it('should pass currency if present', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      event: 'Order Completed',
+      properties: {
+        query_id: '1234',
+        search_index: 'fashion_1',
+        products: [
+          {
+            product_id: '9876',
+            product_name: 'skirt 1'
+          },
+          {
+            product_id: '5432',
+            product_name: 'skirt 2'
+          }
+        ],
+        currency: 'AUD'
+      }
+    })
+    const algoliaEvent = await testAlgoliaDestination(event)
+    expect(algoliaEvent.currency).toBe('AUD')
+  })
+
+  describe('should pass product price data if present', () => {
+    it('all products contain all price properties', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Order Completed',
+        properties: {
+          query_id: '1234',
+          search_index: 'fashion_1',
+          products: [
+            {
+              product_id: '9876',
+              product_name: 'skirt 1',
+              price: 105.99,
+              discount: 22.99,
+              quantity: 5
+            },
+            {
+              product_id: '5432',
+              product_name: 'skirt 2',
+              price: 0.6,
+              discount: 0.1,
+              quantity: 2
+            }
+          ]
+        }
+      })
+      const algoliaEvent = await testAlgoliaDestination(event)
+      expect(algoliaEvent.objectIDs).toEqual(['9876', '5432'])
+      expect(algoliaEvent.objectData).toEqual([
+        { price: 105.99, discount: 22.99, quantity: 5 },
+        { price: 0.6, discount: 0.1, quantity: 2 }
+      ])
+    })
+
+    it('some products contain some price properties', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Order Completed',
+        properties: {
+          query_id: '1234',
+          search_index: 'fashion_1',
+          products: [
+            {
+              product_id: '9876',
+              product_name: 'skirt 1',
+              price: 105.99,
+              quantity: 5
+            },
+            {
+              product_id: '9212',
+              product_name: 'dress 1',
+              price: 299.99,
+              discount: 12.99
+            }
+          ]
+        }
+      })
+      const algoliaEvent = await testAlgoliaDestination(event)
+      expect(algoliaEvent.objectIDs).toEqual(['9876', '9212'])
+      expect(algoliaEvent.objectData).toEqual([
+        { price: 105.99, quantity: 5 },
+        { price: 299.99, discount: 12.99 }
+      ])
+    })
+
+    it('some products contain no price properties', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Order Completed',
+        properties: {
+          query_id: '1234',
+          search_index: 'fashion_1',
+          products: [
+            {
+              product_id: '9876',
+              product_name: 'skirt 1',
+              price: 105.99,
+              discount: 22.99,
+              quantity: 5
+            },
+            {
+              product_id: '5432',
+              product_name: 'skirt 2'
+            },
+            {
+              product_id: '9212',
+              product_name: 'dress 1',
+              price: 299.99,
+              discount: 12.99
+            }
+          ]
+        }
+      })
+      const algoliaEvent = await testAlgoliaDestination(event)
+      expect(algoliaEvent.objectIDs).toEqual(['9876', '5432', '9212'])
+      expect(algoliaEvent.objectData).toEqual([
+        { price: 105.99, discount: 22.99, quantity: 5 },
+        {},
+        { price: 299.99, discount: 12.99 }
+      ])
+    })
+
+    it('no products contain price properties', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Order Completed',
+        properties: {
+          query_id: '1234',
+          search_index: 'fashion_1',
+          products: [
+            {
+              product_id: '9876'
+            },
+            {
+              product_id: '5432'
+            }
+          ]
+        }
+      })
+      const algoliaEvent = await testAlgoliaDestination(event)
+      expect(algoliaEvent.objectIDs).toEqual(['9876', '5432'])
+      expect(algoliaEvent.objectData).toBeUndefined()
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/generated-types.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   eventSubtype?: string
   /**
-   * Populates the ObjectIds field in the Algolia Insights API. An array of objects representing the purchased items. Each object must contains a product_id field.
+   * Populates the ObjectIDs field in the Algolia Insights API. An array of objects representing the purchased items. Each object must contain a product_id field.
    */
   products: {
     product_id: string
@@ -36,7 +36,7 @@ export interface Payload {
    */
   value?: number
   /**
-   * Currency of the objects associated with the event, in 3-letter ISO 4217 format. Required when `value` or `price` are set.
+   * Currency of the objects associated with the event in 3-letter ISO 4217 format. Required when `value` or `price` is set.
    */
   currency?: string
   /**
@@ -46,7 +46,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * The name of the event to be send to Algolia. Defaults to 'Conversion Event'
+   * The name of the event to send to Algolia. Defaults to 'Conversion Event'
    */
   eventName?: string
   /**

--- a/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/generated-types.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/generated-types.ts
@@ -2,10 +2,18 @@
 
 export interface Payload {
   /**
+   * Sub-type of the event, "purchase" or "addToCart".
+   */
+  eventSubtype?: string
+  /**
    * Populates the ObjectIds field in the Algolia Insights API. An array of objects representing the purchased items. Each object must contains a product_id field.
    */
   products: {
     product_id: string
+    price?: number
+    quantity?: number
+    discount?: number
+    queryID?: string
   }[]
   /**
    * Name of the targeted search index.
@@ -23,6 +31,14 @@ export interface Payload {
    * The timestamp of the event.
    */
   timestamp?: string
+  /**
+   * The value of the cart that is being converted.
+   */
+  value?: number
+  /**
+   * Currency of the objects associated with the event, in 3-letter ISO 4217 format. Required when `value` or `price` are set.
+   */
+  currency?: string
   /**
    * Additional fields for this event. This field may be useful for Algolia Insights fields which are not mapped in Segment.
    */

--- a/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/index.ts
@@ -1,21 +1,45 @@
 import type { ActionDefinition, Preset } from '@segment/actions-core'
 import { defaultValues } from '@segment/actions-core'
-import { AlgoliaBehaviourURL, AlgoliaConversionEvent, AlgoliaEventType } from '../algolia-insight-api'
+import {
+  AlgoliaBehaviourURL,
+  AlgoliaConversionEvent,
+  AlgoliaEventSubtype,
+  AlgoliaEventType
+} from '../algolia-insight-api'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+
+const notUndef = (thing: unknown) => typeof thing !== 'undefined'
 
 export const conversionEvents: ActionDefinition<Settings, Payload> = {
   title: 'Conversion Events',
   description:
     'In ecommerce, conversions are purchase events often but not always involving multiple products. Outside of a conversion can be any positive signal associated with an index record. Query ID is optional and indicates that the view events is the result of a search query.',
   fields: {
+    eventSubtype: {
+      label: 'Event Subtype',
+      description: 'Sub-type of the event, "purchase" or "addToCart".',
+      type: 'string',
+      required: false,
+      choices: [
+        { value: 'purchase', label: 'Purchase' },
+        { value: 'addToCart', label: 'Add To Cart' }
+      ],
+      default: 'purchase'
+    },
     products: {
       label: 'Product Details',
       description:
         'Populates the ObjectIds field in the Algolia Insights API. An array of objects representing the purchased items. Each object must contains a product_id field.',
       type: 'object',
       multiple: true,
-      properties: { product_id: { label: 'product_id', type: 'string', required: true } },
+      properties: {
+        product_id: { label: 'product_id', type: 'string', required: true },
+        price: { label: 'price', type: 'number', required: false },
+        quantity: { label: 'quantity', type: 'number', required: false },
+        discount: { label: 'discount', type: 'number', required: false },
+        queryID: { label: 'queryID', type: 'string', required: false }
+      },
       required: true,
       default: {
         '@path': '$.properties.products'
@@ -47,7 +71,7 @@ export const conversionEvents: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: true,
       description: 'The ID associated with the user.',
-      label: 'userToken',
+      label: 'User Token',
       default: {
         '@if': {
           exists: { '@path': '$.userId' },
@@ -60,11 +84,26 @@ export const conversionEvents: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: false,
       description: 'The timestamp of the event.',
-      label: 'timestamp',
+      label: 'Timestamp',
       default: { '@path': '$.timestamp' }
     },
+    value: {
+      type: 'number',
+      required: false,
+      description: 'The value of the cart that is being converted.',
+      label: 'Value',
+      default: { '@path': '$.properties.value' }
+    },
+    currency: {
+      type: 'string',
+      required: false,
+      description:
+        'Currency of the objects associated with the event, in 3-letter ISO 4217 format. Required when `value` or `price` are set.',
+      label: 'Currency',
+      default: { '@path': '$.properties.currency' }
+    },
     extraProperties: {
-      label: 'extraProperties',
+      label: 'Extra Properties',
       required: false,
       description:
         'Additional fields for this event. This field may be useful for Algolia Insights fields which are not mapped in Segment.',
@@ -95,13 +134,27 @@ export const conversionEvents: ActionDefinition<Settings, Payload> = {
   },
   defaultSubscription: 'type = "track" and event = "Order Completed"',
   perform: (request, data) => {
+    const objectData = data.payload.products.some(({ queryID, price, discount, quantity }) => {
+      return notUndef(queryID) || notUndef(price) || notUndef(discount) || notUndef(quantity)
+    })
+      ? data.payload.products.map(({ queryID, price, discount, quantity }) => ({
+          queryID,
+          price,
+          discount,
+          quantity
+        }))
+      : undefined
     const insightEvent: AlgoliaConversionEvent = {
       ...data.payload.extraProperties,
       eventName: data.payload.eventName ?? 'Conversion Event',
       eventType: (data.payload.eventType as AlgoliaEventType) ?? ('conversion' as AlgoliaEventType),
+      eventSubtype: data.payload.eventSubtype as AlgoliaEventSubtype,
       index: data.payload.index,
       queryID: data.payload.queryID,
       objectIDs: data.payload.products.map((product) => product.product_id),
+      objectData,
+      value: data.payload.value,
+      currency: data.payload.currency,
       userToken: data.payload.userToken,
       timestamp: data.payload.timestamp ? new Date(data.payload.timestamp).valueOf() : undefined
     }

--- a/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/index.ts
@@ -30,7 +30,7 @@ export const conversionEvents: ActionDefinition<Settings, Payload> = {
     products: {
       label: 'Product Details',
       description:
-        'Populates the ObjectIds field in the Algolia Insights API. An array of objects representing the purchased items. Each object must contains a product_id field.',
+        'Populates the ObjectIDs field in the Algolia Insights API. An array of objects representing the purchased items. Each object must contain a product_id field.',
       type: 'object',
       multiple: true,
       properties: {
@@ -98,7 +98,7 @@ export const conversionEvents: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: false,
       description:
-        'Currency of the objects associated with the event, in 3-letter ISO 4217 format. Required when `value` or `price` are set.',
+        'Currency of the objects associated with the event in 3-letter ISO 4217 format. Required when `value` or `price` is set.',
       label: 'Currency',
       default: { '@path': '$.properties.currency' }
     },
@@ -114,7 +114,7 @@ export const conversionEvents: ActionDefinition<Settings, Payload> = {
     },
     eventName: {
       label: 'Event Name',
-      description: "The name of the event to be send to Algolia. Defaults to 'Conversion Event'",
+      description: "The name of the event to send to Algolia. Defaults to 'Conversion Event'",
       type: 'string',
       required: false,
       default: 'Conversion Event'
@@ -126,9 +126,9 @@ export const conversionEvents: ActionDefinition<Settings, Payload> = {
       required: false,
       default: 'conversion',
       choices: [
-        { label: 'view', value: 'view' },
-        { label: 'conversion', value: 'conversion' },
-        { label: 'click', value: 'click' }
+        { label: 'View', value: 'view' },
+        { label: 'Conversion', value: 'conversion' },
+        { label: 'Click', value: 'click' }
       ]
     }
   },
@@ -148,7 +148,7 @@ export const conversionEvents: ActionDefinition<Settings, Payload> = {
       ...data.payload.extraProperties,
       eventName: data.payload.eventName ?? 'Conversion Event',
       eventType: (data.payload.eventType as AlgoliaEventType) ?? ('conversion' as AlgoliaEventType),
-      eventSubtype: data.payload.eventSubtype as AlgoliaEventSubtype,
+      eventSubtype: (data.payload.eventSubtype as AlgoliaEventSubtype) ?? 'purchase',
       index: data.payload.index,
       queryID: data.payload.queryID,
       objectIDs: data.payload.products.map((product) => product.product_id),

--- a/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/index.ts
@@ -45,7 +45,7 @@ export const productAddedEvents: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: true,
       description: 'The ID associated with the user.',
-      label: 'userToken',
+      label: 'User Token',
       default: {
         '@if': {
           exists: { '@path': '$.userId' },
@@ -58,11 +58,11 @@ export const productAddedEvents: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: false,
       description: 'The timestamp of the event.',
-      label: 'timestamp',
+      label: 'Timestamp',
       default: { '@path': '$.timestamp' }
     },
     extraProperties: {
-      label: 'extraProperties',
+      label: 'Extra Properties',
       required: false,
       description:
         'Additional fields for this event. This field may be useful for Algolia Insights fields which are not mapped in Segment.',

--- a/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/index.ts
@@ -52,7 +52,7 @@ export const productClickedEvents: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: true,
       description: 'The ID associated with the user.',
-      label: 'userToken',
+      label: 'User Token',
       default: {
         '@if': {
           exists: { '@path': '$.userId' },
@@ -65,11 +65,11 @@ export const productClickedEvents: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: false,
       description: 'The timestamp of the event.',
-      label: 'timestamp',
+      label: 'Timestamp',
       default: { '@path': '$.timestamp' }
     },
     extraProperties: {
-      label: 'extraProperties',
+      label: 'Extra Properties',
       required: false,
       description:
         'Additional fields for this event. This field may be useful for Algolia Insights fields which are not mapped in Segment.',

--- a/packages/destination-actions/src/destinations/algolia-insights/productListFilteredEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productListFilteredEvents/index.ts
@@ -51,7 +51,7 @@ export const productListFilteredEvents: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: true,
       description: 'The ID associated with the user.',
-      label: 'userToken',
+      label: 'User Token',
       default: {
         '@if': {
           exists: { '@path': '$.userId' },
@@ -64,11 +64,11 @@ export const productListFilteredEvents: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: false,
       description: 'The timestamp of the event.',
-      label: 'timestamp',
+      label: 'Timestamp',
       default: { '@path': '$.timestamp' }
     },
     extraProperties: {
-      label: 'extraProperties',
+      label: 'Extra Properties',
       required: false,
       description:
         'Additional fields for this event. This field may be useful for Algolia Insights fields which are not mapped in Segment.',

--- a/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/index.ts
@@ -44,7 +44,7 @@ export const productViewedEvents: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: true,
       description: 'The ID associated with the user.',
-      label: 'userToken',
+      label: 'User Token',
       default: {
         '@if': {
           exists: { '@path': '$.userId' },
@@ -57,11 +57,11 @@ export const productViewedEvents: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: false,
       description: 'The timestamp of the event.',
-      label: 'timestamp',
+      label: 'Timestamp',
       default: { '@path': '$.timestamp' }
     },
     extraProperties: {
-      label: 'extraProperties',
+      label: 'Extra Properties',
       required: false,
       description:
         'Additional fields for this event. This field may be useful for Algolia Insights fields which are not mapped in Segment.',


### PR DESCRIPTION
Updated conversion/"Order Completed" event to enable price data to be passed, in line with the [Algolia Insights API](https://www.algolia.com/doc/api-reference/api-methods/purchased-object-ids-after-search/).

* Added the `eventSubtype`, `value`, and `currency` fields.
* Added `queryID`, `price`, `discount`, and `quantity` properties to the Segment `products` field, which maps to Algolia's `objectData` field.
* Added logic to prevent `objectData` from returning an array of empty objects, i.e., if object IDs are specified but price properties are not.

## Testing

* Added unit tests for conversion events
* Regenerated snapshots

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
