### PR TITLE
[STRATCONN-3250] [GA4 Web] Run setconfiguration before all actions

### DIFF
--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/setConfigurationFields/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/setConfigurationFields/index.ts
@@ -12,6 +12,7 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
   description: 'Set custom values for the GA4 configuration fields.',
   platform: 'web',
   defaultSubscription: 'type = "identify" or type = "page"',
+  lifecycleHook: 'before',
   fields: {
     user_id: user_id,
     user_properties: user_properties,


### PR DESCRIPTION
This PR sets lifecycle hook on SetConfiguration action to `before`. This ensures that `SetConfiguration` action is triggered before all actions. 

[JIRA Ticket](https://segment.atlassian.net/browse/STRATCONN-3250)

This a safe change. We already use it in [Braze](https://github.com/segmentio/action-destinations/blob/bb112a5107107066a3fbc439b75e7909a06fd901/packages/browser-destinations/destinations/braze/src/debounce/index.ts#L47)

[Analytics Next doc reference](https://github.com/segmentio/analytics-next/blob/a6e745096aeaa3d9c7c9888a3d8beab90a8f3b62/packages/browser/README.md#-plugins)

## Testing

Testing completed successfully in staging

**Destination Setup**

<img width="1287" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/85af2c35-f0d6-4a9f-a3cb-631d8befb0d8">

**gtag datalayer**

You can see that in gtag datalayer, the config hook is triggered before other actions
<img width="1387" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/7b4afddb-ec5a-49c9-85a7-9590a79e6010">

**Event received at GA4 Web**

<img width="415" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/e9da0430-ac3c-47f0-b589-2ecb70fd3986">

I was not able to find anything in the framework that allows you to write unit test for lifecycle hooks.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
