### PR TITLE
[The Trade Desk CRM] Change getAudience method

### DIFF
--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/__tests__/index.test.ts
@@ -1,0 +1,72 @@
+import nock from 'nock'
+import { createTestIntegration, IntegrationError } from '@segment/actions-core'
+import Destination from '../index'
+
+const testDestination = createTestIntegration(Destination)
+
+const createAudienceInput = {
+  settings: {
+    auth_token: 'AUTH_TOKEN',
+    advertiser_id: 'ADVERTISER_ID',
+    __segment_internal_engage_force_full_sync: true,
+    __segment_internal_engage_batch_sync: true
+  },
+  audienceName: '',
+  audienceSettings: {
+    region: 'US'
+  }
+}
+
+const getAudienceInput = {
+  settings: {
+    auth_token: 'AUTH_TOKEN',
+    advertiser_id: 'ADVERTISER_ID',
+    __segment_internal_engage_force_full_sync: true,
+    __segment_internal_engage_batch_sync: true
+  },
+  externalId: 'crm_data_id',
+  audienceSettings: {
+    region: 'US'
+  }
+}
+
+describe('The Trade Desk CRM', () => {
+  describe('createAudience', () => {
+    it('should fail if no audience name is set', async () => {
+      await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(IntegrationError)
+    })
+
+    it('should create a new Trade Desk CRM Data Segment', async () => {
+      nock(`https://api.thetradedesk.com/v3/crmdata/segment`).post(/.*/).reply(200, {
+        CrmDataId: 'test_audience'
+      })
+
+      createAudienceInput.audienceName = 'The Super Mario Brothers Fans'
+      createAudienceInput.audienceSettings.region = 'US'
+
+      const r = await testDestination.createAudience(createAudienceInput)
+      expect(r).toEqual({ externalId: 'test_audience' })
+    })
+  })
+
+  describe('getAudience', () => {
+    it('should fail if Trade Desk replies with an error', async () => {
+      await expect(testDestination.getAudience(getAudienceInput)).rejects.toThrowError()
+    })
+
+    it('should succeed when Segment External ID matches Data Segment in TikTok', async () => {
+      nock(`https://api.thetradedesk.com/v3/crmdata/segment/advertiser_id`)
+        .get(/.*/)
+        .reply(200, {
+          Segments: [{ SegmentName: 'not_test_audience', CrmDataId: 'crm_data_id' }],
+          PagingToken: 'paging_token'
+        })
+      nock(`https://api.thetradedesk.com/v3/crmdata/segment/advertiser_id?pagingToken=paging_token`)
+        .get(/.*/)
+        .reply(200, { Segments: [], PagingToken: null })
+
+      const r = await testDestination.getAudience(getAudienceInput)
+      expect(r).toEqual({ externalId: 'crm_data_id' })
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestIntegration, IntegrationError } from '@segment/actions-core'
 import Destination from '../index'
+import { API_VERSION } from '../index'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -37,7 +38,7 @@ describe('The Trade Desk CRM', () => {
     })
 
     it('should create a new Trade Desk CRM Data Segment', async () => {
-      nock(`https://api.thetradedesk.com/v3/crmdata/segment`).post(/.*/).reply(200, {
+      nock(`https://api.thetradedesk.com/${API_VERSION}/crmdata/segment`).post(/.*/).reply(200, {
         CrmDataId: 'test_audience'
       })
 
@@ -51,17 +52,20 @@ describe('The Trade Desk CRM', () => {
 
   describe('getAudience', () => {
     it('should fail if Trade Desk replies with an error', async () => {
+      nock(`https://api.thetradedesk.com/${API_VERSION}/crmdata/segment/advertiser_id?pagingToken=paging_token`)
+        .get(/.*/)
+        .reply(400, { Segments: [], PagingToken: null })
       await expect(testDestination.getAudience(getAudienceInput)).rejects.toThrowError()
     })
 
     it('should succeed when Segment External ID matches Data Segment in TikTok', async () => {
-      nock(`https://api.thetradedesk.com/v3/crmdata/segment/advertiser_id`)
+      nock(`https://api.thetradedesk.com/${API_VERSION}/crmdata/segment/advertiser_id`)
         .get(/.*/)
         .reply(200, {
           Segments: [{ SegmentName: 'not_test_audience', CrmDataId: 'crm_data_id' }],
           PagingToken: 'paging_token'
         })
-      nock(`https://api.thetradedesk.com/v3/crmdata/segment/advertiser_id?pagingToken=paging_token`)
+      nock(`https://api.thetradedesk.com/${API_VERSION}/crmdata/segment/advertiser_id?pagingToken=paging_token`)
         .get(/.*/)
         .reply(200, { Segments: [], PagingToken: null })
 

--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/functions.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/functions.ts
@@ -2,6 +2,7 @@ import { RequestClient, ModifiedResponse, PayloadValidationError } from '@segmen
 import { Settings } from './generated-types'
 import { Payload } from './syncAudience/generated-types'
 import { createHash } from 'crypto'
+import { IntegrationError } from '@segment/actions-core'
 
 import { sendEventToAWS } from './awsClient'
 
@@ -177,6 +178,10 @@ export async function getAllDataSegments(request: RequestClient, advertiserId: s
   let response: ModifiedResponse<GET_CRMS_API_RESPONSE> = await request(`${BASE_URL}/crmdata/segment/${advertiserId}`, {
     method: 'GET'
   })
+
+  if (response.status != 200 || !response.data.Segments) {
+    throw new IntegrationError('Invalid response from get audience request', 'INVALID_RESPONSE', 400)
+  }
   let segments = response.data.Segments
   // pagingToken leads you to the next page
   let pagingToken = response.data.PagingToken

--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/functions.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/functions.ts
@@ -170,3 +170,29 @@ async function uploadCRMDataToDropEndpoint(request: RequestClient, endpoint: str
     body: users
   })
 }
+
+export async function getAllDataSegments(request: RequestClient, advertiserId: string, authToken: string) {
+  const allDataSegments: Segments[] = []
+  // initial call to get first page
+  let response: ModifiedResponse<GET_CRMS_API_RESPONSE> = await request(`${BASE_URL}/crmdata/segment/${advertiserId}`, {
+    method: 'GET'
+  })
+  let segments = response.data.Segments
+  // pagingToken leads you to the next page
+  let pagingToken = response.data.PagingToken
+  // keep iterating through pages until the last empty page
+  while (segments.length > 0) {
+    allDataSegments.push(...segments)
+    response = await request(`${BASE_URL}/crmdata/segment/${advertiserId}?pagingToken=${pagingToken}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'TTD-Auth': authToken
+      }
+    })
+
+    segments = response.data.Segments
+    pagingToken = response.data.PagingToken
+  }
+  return allDataSegments
+}

--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/index.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/index.ts
@@ -4,7 +4,7 @@ import { IntegrationError } from '@segment/actions-core'
 import { getAllDataSegments } from './functions'
 
 import syncAudience from './syncAudience'
-const API_VERSION = 'v3'
+export const API_VERSION = 'v3'
 const BASE_URL = `https://api.thetradedesk.com/${API_VERSION}`
 
 export interface CreateApiResponse {
@@ -129,7 +129,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         }
       })
 
-      if (!segmentExists) {
+      if (segmentExists.length != 1) {
         throw new IntegrationError(
           `No CRM Data Segment with Id ${crmDataId} found for advertiser ${advertiserId}`,
           'INVALID_REQUEST_DATA',

--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/index.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/index.ts
@@ -1,6 +1,7 @@
 import type { AudienceDestinationDefinition, ModifiedResponse } from '@segment/actions-core'
 import type { Settings, AudienceSettings } from './generated-types'
 import { IntegrationError } from '@segment/actions-core'
+import { getAllDataSegments } from './functions'
 
 import syncAudience from './syncAudience'
 const API_VERSION = 'v3'
@@ -120,33 +121,24 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       const advertiserId = getAudienceInput.settings.advertiser_id
       const authToken = getAudienceInput.settings.auth_token
 
-      const response: ModifiedResponse<GetApiResponse> = await request(
-        `${BASE_URL}/crmdata/segment/${advertiserId}/${crmDataId}`,
-        {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-            'TTD-Auth': authToken
-          }
+      const allDataSegments = await getAllDataSegments(request, advertiserId, authToken)
+
+      const segmentExists = allDataSegments.filter(function (segment: Segments) {
+        if (segment.CrmDataId == crmDataId) {
+          return segment
         }
-      )
+      })
 
-      if (response.status !== 200) {
-        throw new IntegrationError('Invalid response from get audience request', 'INVALID_RESPONSE', 400)
-      }
-
-      const externalId = response.data.CrmDataId
-
-      if (externalId !== getAudienceInput.externalId) {
+      if (!segmentExists) {
         throw new IntegrationError(
-          "Unable to verify ownership over audience. Segment Audience ID doesn't match The Trade Desk's Audience ID.",
+          `No CRM Data Segment with Id ${crmDataId} found for advertiser ${advertiserId}`,
           'INVALID_REQUEST_DATA',
           400
         )
       }
 
       return {
-        externalId: externalId
+        externalId: crmDataId
       }
     }
   },


### PR DESCRIPTION
This ticket addresses [STRATCONN-3290](https://segment.atlassian.net/browse/STRATCONN-3290) to change the getAudience method because the [original endpoint](https://partner.thetradedesk.com/v3/portal/api/ref/get-crmdata-segment-advertiserid-crmdataid) we were using would fail if there was no users in the CRM Data Segment. This way we just get all the Data Segments a user has and verify the external_id we have in the DB matches one of these data segments.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
```
curl --location 'http://localhost:3000/getAudience' \
--header 'Content-Type: application/json' \
--data '{
        "settings": {
                "auth_token": "<REDACTED>",
                "advertiser_id": "cxpowqgj"
        },
        "externalId": "yc6vn3l"
}'
{"externalId":"yc6vn3l"}%   
```
- [ ] [Segmenters] Tested in the staging environment


[STRATCONN-3290]: https://segment.atlassian.net/browse/STRATCONN-3290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ