### PR TITLE
Launchdarkly Audiences - keying off of audience_id 

### DIFF
--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Testing snapshot for actions-launchdarkly-audiences destination: syncAu
 Object {
   "batch": Array [
     Object {
-      "cohortId": "test_audience",
+      "cohortId": "uKRBKG",
       "cohortName": "Test audience",
       "userId": "uKRBKG",
       "value": true,

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Testing snapshot for LaunchDarklyAudiences's syncAudience destination a
 Object {
   "batch": Array [
     Object {
-      "cohortId": "test_audience",
+      "cohortId": "ld_segment_audience_id",
       "cohortName": "Test audience",
       "userId": "&bUSudpNPsUWT",
       "value": true,
@@ -38,7 +38,7 @@ exports[`Testing snapshot for LaunchDarklyAudiences's syncAudience destination a
 Object {
   "batch": Array [
     Object {
-      "cohortId": "test_audience",
+      "cohortId": "ld_segment_audience_id",
       "cohortName": "Test audience",
       "userId": "&bUSudpNPsUWT",
       "value": false,

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/index.test.ts
@@ -10,7 +10,8 @@ const goodTrackEvent = createTestEvent({
   context: {
     personas: {
       computation_class: 'audience',
-      computation_key: 'ld_segment_test'
+      computation_key: 'ld_segment_test',
+      computation_id: 'ld_segment_audience_id'
     },
     traits: {
       email: 'test@email.com'
@@ -27,7 +28,8 @@ const goodIdentifyEvent = createTestEvent({
   context: {
     personas: {
       computation_class: 'audience',
-      computation_key: 'ld_segment_test'
+      computation_key: 'ld_segment_test',
+      computation_id: 'ld_segment_audience_id'
     }
   },
   traits: {
@@ -40,7 +42,8 @@ const goodIdentifyEvent = createTestEvent({
 const badEvent = createTestEvent({
   context: {
     personas: {
-      computation_key: 'ld_segment_test'
+      computation_key: 'ld_segment_test',
+      computation_id: 'ld_segment_audience_id'
     },
     traits: {
       email: 'test@email.com'

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/snapshot.test.ts
@@ -13,11 +13,13 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const action = destination.actions[actionSlug]
     const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
     eventData['segment_audience_key'] = 'test_audience'
+    eventData['segment_audience_id'] = 'ld_segment_audience_id'
     eventData['segment_computation_action'] = 'audience'
     eventData['traits_or_props'] = { [eventData['segment_audience_key']]: true }
 
     setStaticDataForSnapshot(eventData, 'context_kind', 'customContextKind')
     setStaticDataForSnapshot(eventData, 'context_key', 'user_id_only')
+    setStaticDataForSnapshot(eventData, 'context_id', 'ld_segment_audience_id')
 
     setStaticDataForSnapshot(settingsData, 'clientId', 'environment-id')
     setStaticDataForSnapshot(settingsData, 'apiKey', 'api-key')
@@ -50,6 +52,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const action = destination.actions[actionSlug]
     const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
     eventData['segment_audience_key'] = 'test_audience'
+    eventData['segment_audience_id'] = 'ld_segment_audience_id'
     eventData['segment_computation_action'] = 'audience'
     eventData['traits_or_props'] = { [eventData['segment_audience_key']]: false }
 

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/custom-audience-operations.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/custom-audience-operations.ts
@@ -34,9 +34,14 @@ const snakeCaseToSentenceCase = (key: string) => {
  * @param audienceId audience ID
  * @param include include or exclude the context from LaunchDarkly's segment
  */
-const createContextForBatch = (contextKey: string, audienceId: string, audienceAction: AudienceAction) => ({
+const createContextForBatch = (
+  contextKey: string,
+  audienceKey: string,
+  audienceId: string,
+  audienceAction: AudienceAction
+) => ({
   userId: contextKey,
-  cohortName: snakeCaseToSentenceCase(audienceId),
+  cohortName: snakeCaseToSentenceCase(audienceKey),
   cohortId: audienceId,
   value: audienceAction === CONSTANTS.ADD ? true : false
 })
@@ -78,7 +83,7 @@ const parseCustomAudienceBatches = (payload: Payload[], settings: Settings): Aud
   const audienceMap = new Map<AudienceName, AudienceBatch>()
 
   for (const p of payload) {
-    const audienceId = p.segment_audience_key
+    const audienceId = p.segment_audience_id
     const contextKey = getContextKey(p)
 
     let audienceBatch: AudienceBatch = {
@@ -97,7 +102,9 @@ const parseCustomAudienceBatches = (payload: Payload[], settings: Settings): Aud
       audienceMap.set(audienceId, audienceBatch)
     }
 
-    audienceBatch.batch.push(createContextForBatch(contextKey, audienceId, p.audience_action as AudienceAction))
+    audienceBatch.batch.push(
+      createContextForBatch(contextKey, p.segment_audience_key, audienceId, p.audience_action as AudienceAction)
+    )
   }
 
   return Array.from(audienceMap.values())

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/generated-types.ts
@@ -2,6 +2,10 @@
 
 export interface Payload {
   /**
+   * Segment Audience ID to which user identifier should be added or removed
+   */
+  segment_audience_id: string
+  /**
    * Segment Audience key to which user identifier should be added or removed
    */
   segment_audience_key: string

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/index.ts
@@ -10,6 +10,16 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Sync Engage Audiences to LaunchDarkly segments',
   defaultSubscription: 'type = "identify" or type = "track"',
   fields: {
+    segment_audience_id: {
+      label: 'Audience ID',
+      description: 'Segment Audience ID to which user identifier should be added or removed',
+      type: 'string',
+      unsafe_hidden: true,
+      required: true,
+      default: {
+        '@path': '$.context.personas.computation_id'
+      }
+    },
     segment_audience_key: {
       label: 'Audience Key',
       description: 'Segment Audience key to which user identifier should be added or removed',

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/index.ts
@@ -99,6 +99,7 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'A computed object for track and identify events. This field should not need to be edited.',
       type: 'object',
       required: true,
+      unsafe_hidden: true,
       default: {
         '@if': {
           exists: { '@path': '$.properties' },


### PR DESCRIPTION
Adjusting LD Audience Destination to key off of Audience ID instead of Audience Key. Note: Destination still in Private Beta, so OK to make this breaking change. 

## Testing

Updated unit tests. 
