### PR TITLE
Adds missing generated types from JIMO and Segment Profile desitnations

### DIFF
--- a/packages/browser-destinations/destinations/jimo/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/jimo/src/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Settings {
   /**
-   * Id of the Jimo project. You can find it here: https://i.usejimo.com/settings/install/portal
+   * Id of the Jimo project. You can find the Project Id here: https://i.usejimo.com/settings/install/portal
    */
   projectId: string
   /**
-   * Make sure Jimo is not initialized automatically after being added to your website. For more information, check out: https://help.usejimo.com/knowledge-base/for-developers/sdk-guides/manual-initialization
+   * Toggling to true will prevent Jimo from initializing automatically. For more information, check out: https://help.usejimo.com/knowledge-base/for-developers/sdk-guides/manual-initialization
    */
   manualInit?: boolean
 }

--- a/packages/browser-destinations/destinations/jimo/src/sendUserData/generated-types.ts
+++ b/packages/browser-destinations/destinations/jimo/src/sendUserData/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * The users's id provided by segment
+   * The unique user identifier
    */
   userId?: string | null
   /**

--- a/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/generated-types.ts
@@ -18,11 +18,11 @@ export interface Payload {
    */
   email?: string
   /**
-   * Global status of the email subscription. True is subscribed, false is unsubscribed and did-not-subscribe is did-not-subscribe.
+   * Global status of the email subscription. True is subscribed, false is unsubscribed, and did_not_subscribe is did_not_subscribe.
    */
   email_subscription_status?: string | null
   /**
-   * Subscription status for the groups. Object containing group names as keys and statuses as values. True is subscribed, false is unsubscribed and did-not-subscribe is did-not-subscribe.
+   * Group Subscription statuses are supported for the email channel. This object contains group names as keys and statuses as values. True is subscribed, false is unsubscribed, and did_not_subscribe is did_not_subscribe.
    */
   subscription_groups?: {
     [k: string]: unknown
@@ -32,11 +32,11 @@ export interface Payload {
    */
   phone?: string
   /**
-   * Global status of the SMS subscription. True is subscribed, false is unsubscribed and did-not-subscribe is did-not-subscribe.
+   * Global status of the SMS subscription. True is subscribed, false is unsubscribed, and did_not_subscribe is did_not_subscribe.
    */
   sms_subscription_status?: string | null
   /**
-   * Global status of the WhatsApp subscription. True is subscribed, false is unsubscribed and did-not-subscribe is did-not-subscribe.
+   * Global status of the WhatsApp subscription. True is subscribed, false is unsubscribed, and did_not_subscribe is did_not_subscribe.
    */
   whatsapp_subscription_status?: string | null
   /**
@@ -44,7 +44,7 @@ export interface Payload {
    */
   android_push_token?: string
   /**
-   * Global status of the android push subscription. True is subscribed, false is unsubscribed and did-not-subscribe is did-not-subscribe.
+   * Global status of the android push subscription. True is subscribed, false is unsubscribed, and did_not_subscribe is did_not_subscribe.
    */
   android_push_subscription_status?: string | null
   /**
@@ -52,7 +52,7 @@ export interface Payload {
    */
   ios_push_token?: string
   /**
-   * Global status of the ios push subscription. True is subscribed, false is unsubscribed and did-not-subscribe is did-not-subscribe.
+   * Global status of the ios push subscription. True is subscribed, false is unsubscribed, and did_not_subscribe is did_not_subscribe.
    */
   ios_push_subscription_status?: string | null
   /**


### PR DESCRIPTION
This PR adds missing generated types from JIMO and Segment Profile destinations.

## Testing

Testing not required as this just updates missing generated types

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
