### PR TITLE
TikTok and Trade Desk changes

### DIFF
--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/functions.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/functions.ts
@@ -176,7 +176,11 @@ export async function getAllDataSegments(request: RequestClient, advertiserId: s
   const allDataSegments: Segments[] = []
   // initial call to get first page
   let response: ModifiedResponse<GET_CRMS_API_RESPONSE> = await request(`${BASE_URL}/crmdata/segment/${advertiserId}`, {
-    method: 'GET'
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'TTD-Auth': authToken
+    }
   })
 
   if (response.status != 200 || !response.data.Segments) {

--- a/packages/destination-actions/src/destinations/tiktok-audiences/addUser/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/addUser/index.ts
@@ -75,11 +75,11 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, { settings, payload, statsContext }) => {
-    statsContext?.statsClient?.incr('addUser', 1, statsContext?.tags)
+    statsContext?.statsClient?.incr('addUserLegacy', 1, statsContext?.tags)
     return processPayload(request, settings, [payload], 'add')
   },
   performBatch: async (request, { settings, payload, statsContext }) => {
-    statsContext?.statsClient?.incr('addUser', 1, statsContext?.tags)
+    statsContext?.statsClient?.incr('addUserLegacy', 1, statsContext?.tags)
     return processPayload(request, settings, payload, 'add')
   }
 }

--- a/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/removeUser/index.ts
@@ -74,11 +74,11 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, { settings, payload, statsContext }) => {
-    statsContext?.statsClient?.incr('removeUser', 1, statsContext?.tags)
+    statsContext?.statsClient?.incr('removeUserLegacy', 1, statsContext?.tags)
     return processPayload(request, settings, [payload], 'delete')
   },
   performBatch: async (request, { settings, payload, statsContext }) => {
-    statsContext?.statsClient?.incr('removeUser', 1, statsContext?.tags)
+    statsContext?.statsClient?.incr('removeUserLegacy', 1, statsContext?.tags)
     return processPayload(request, settings, payload, 'delete')
   }
 }


### PR DESCRIPTION
For TikTok the name of the statsclient was updated for TikTok Legacy Actions. We noticed that the original dashboard was not updating so we could not properly monitor the Legacy flow. When we switched the name and tested in staging we started to see the graph update.

<img width="877" alt="Screenshot 2023-10-18 at 10 03 25 AM" src="https://github.com/segmentio/action-destinations/assets/99763167/bf4a86b4-c23b-4fec-87e3-d64669645b37">

For Trade Desk this PR adds headers to the getAudience request. Extend request works locally with the create/getAudience but when deployed to stage/prod it gives this error `The supplied auth token is not valid or has expired. Please obtain a new token via the Authentication API.`

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
