### PR TITLE
Register DV360 and Marketo Static Lists

### DIFF
--- a/packages/destination-actions/src/destinations/display-video-360/addToAudience/index.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/addToAudience/index.ts
@@ -4,7 +4,7 @@ import type { Payload } from './generated-types'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Add to Audience',
-  description: '',
+  description: 'Add users into an audience',
   fields: {},
   perform: () => {
     return

--- a/packages/destination-actions/src/destinations/display-video-360/removeFromAudience/index.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/removeFromAudience/index.ts
@@ -4,7 +4,7 @@ import type { Payload } from './generated-types'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Remove from Audience',
-  description: '',
+  description: 'Remove users from an audience',
   fields: {},
   perform: () => {
     return

--- a/packages/destination-actions/src/destinations/index.ts
+++ b/packages/destination-actions/src/destinations/index.ts
@@ -134,6 +134,8 @@ register('651c1db19de92d8e595ff55d', './hyperengage')
 register('65256052ac030f823df6c1a5', './trackey')
 register('652e765dbea0a2319209d193', './linkedin-conversions')
 register('652ea51a327a62b351aa12c0', './kameleoon')
+register('65302a514ce4a2f0f14cd426', './marketo-static-lists')
+register('65302a3acb309a8a3d5593f2', './display-video-360')
 
 function register(id: MetadataId, destinationPath: string) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/destination-actions/src/destinations/marketo-static-lists/addToList/index.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/addToList/index.ts
@@ -4,7 +4,7 @@ import type { Payload } from './generated-types'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Add to List',
-  description: '',
+  description: 'Add users into a list',
   fields: {},
   perform: () => {
     return

--- a/packages/destination-actions/src/destinations/marketo-static-lists/removeFromList/index.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/removeFromList/index.ts
@@ -4,7 +4,7 @@ import type { Payload } from './generated-types'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Remove from List',
-  description: '',
+  description: 'Remove users from a list',
   fields: {},
   perform: () => {
     return


### PR DESCRIPTION
Registering DV360 and Marketo Static Lists.

## Testing

Testing not required because this is just registering new destinations.
