### PR TITLE
STRATCONN-2921 braze: add support for merge_behavior

### DIFF
--- a/packages/destination-actions/src/destinations/braze/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/braze/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -11,10 +11,25 @@ Object {
       },
     },
   ],
+  "merge_behavior": "merge",
 }
 `;
 
 exports[`Testing snapshot for Braze's identifyUser destination action: required fields 1`] = `
+Object {
+  "aliases_to_identify": Array [
+    Object {
+      "external_id": "L6iTV8uKjdSaPxy2fjx9",
+      "user_alias": Object {
+        "alias_label": "L6iTV8uKjdSaPxy2fjx9",
+        "alias_name": "L6iTV8uKjdSaPxy2fjx9",
+      },
+    },
+  ],
+}
+`;
+
+exports[`all fields - backwards compatibility testing 1`] = `
 Object {
   "aliases_to_identify": Array [
     Object {

--- a/packages/destination-actions/src/destinations/braze/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/braze/identifyUser/generated-types.ts
@@ -12,4 +12,8 @@ export interface Payload {
     alias_name: string
     alias_label: string
   }
+  /**
+   * Sets the endpoint to merge some fields found exclusively on the anonymous user to the identified user. See [the docs](https://www.braze.com/docs/api/endpoints/user_data/post_user_identify/#request-parameters).
+   */
+  merge_behavior?: string
 }

--- a/packages/destination-actions/src/destinations/braze/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/braze/identifyUser/index.ts
@@ -37,7 +37,10 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'Sets the endpoint to merge some fields found exclusively on the anonymous user to the identified user. See [the docs](https://www.braze.com/docs/api/endpoints/user_data/post_user_identify/#request-parameters).',
       type: 'string',
-      choices: ['none', 'merge']
+      choices: [
+        { value: 'none', label: 'None' },
+        { value: 'merge', label: 'Merge' }
+      ]
     }
   },
   perform: (request, { settings, payload }) => {

--- a/packages/destination-actions/src/destinations/braze/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/braze/identifyUser/index.ts
@@ -31,6 +31,13 @@ const action: ActionDefinition<Settings, Payload> = {
           required: true
         }
       }
+    },
+    merge_behavior: {
+      label: 'Merge Behavior',
+      description:
+        'Sets the endpoint to merge some fields found exclusively on the anonymous user to the identified user. See [the docs](https://www.braze.com/docs/api/endpoints/user_data/post_user_identify/#request-parameters).',
+      type: 'string',
+      choices: ['none', 'merge']
     }
   },
   perform: (request, { settings, payload }) => {
@@ -42,7 +49,8 @@ const action: ActionDefinition<Settings, Payload> = {
             external_id: payload.external_id,
             user_alias: payload.user_alias
           }
-        ]
+        ],
+        ...(payload.merge_behavior !== undefined && { merge_behavior: payload.merge_behavior })
       }
     })
   }


### PR DESCRIPTION
https://segment.atlassian.net/browse/STRATCONN-2921

The Braze Cloud Mode Actions destination needs to include the merge_behavior field in its Identify mapping, otherwise users will merge but not all of their data will be merged together. Details on this merge_behavior field can be found [here](https://www.braze.com/docs/api/endpoints/user_data/post_user_identify/#request-body)

## Testing

![image](https://github.com/segmentio/action-destinations/assets/103517471/a1405462-aeba-47b1-9e57-e81d809f7f57)


_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
