### PR TITLE
engage/sendgrid onResponse undefined bug

### DIFF
--- a/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
+++ b/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
@@ -379,7 +379,7 @@ export class SendEmailPerformer extends MessageSendPerformer<Settings, Payload> 
   }
 
   onResponse(args: { response?: Response; error?: ResponseError; operation: OperationContext }) {
-    const headers = args.response?.headers || args.error?.response.headers
+    const headers = args.response?.headers || args.error?.response?.headers
     // if we need to investigate with sendgrid, we'll need this: https://docs.sendgrid.com/glossary/message-id
     const sgMsgId = headers?.get('X-Message-ID')
     if (sgMsgId) args.operation.logs.push('[sendgrid]X-Message-ID: ' + sgMsgId)


### PR DESCRIPTION
Small bug noticed causing broken logs in case of timeout error during sendgrid/send request:
![image](https://github.com/segmentio/action-destinations/assets/7120440/c82579a7-234e-41ed-8183-800dc26ee7a0)

## Testing

- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
