### PR TITLE
[STRATCONN-3301] Add createAudience/getAudience to DV360

### DIFF
--- a/packages/destination-actions/src/destinations/display-video-360/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/__tests__/index.test.ts
@@ -1,5 +1,148 @@
+import nock from 'nock'
+import { createTestIntegration, IntegrationError } from '@segment/actions-core'
+import Destination from '../index'
+import { GET_AUDIENCE_URL, CREATE_AUDIENCE_URL } from '../constants'
+
+const advertiserId = '424242'
+const audienceName = 'The Super Mario Brothers Fans'
+const testDestination = createTestIntegration(Destination)
+const advertiserCreateAudienceUrl = CREATE_AUDIENCE_URL.replace('advertiserID', advertiserId)
+const advertiserGetAudienceUrl = GET_AUDIENCE_URL.replace('advertiserID', advertiserId)
+const expectedExternalID = `products/DISPLAY_VIDEO_ADVERTISER/customers/${advertiserId}/userLists/8457147615`
+
+const createAudienceInput = {
+  settings: {},
+  audienceName: '',
+  audienceSettings: {
+    advertiserId: advertiserId
+  }
+}
+
+const getAudienceInput = {
+  settings: {},
+  audienceSettings: {
+    advertiserId: advertiserId
+  },
+  audienceName: audienceName,
+  externalId: expectedExternalID
+}
+
+const getAudienceResponse = [
+  {
+    results: [
+      {
+        userList: {
+          resourceName: expectedExternalID,
+          membershipStatus: 'OPEN',
+          name: audienceName,
+          description: 'Created by Segment.'
+        }
+      }
+    ],
+    fieldMask: 'userList.name,userList.description,userList.membershipStatus,userList.matchRatePercentage',
+    requestId: 'Hw7-_h0P-vCzQ'
+  }
+]
+
 describe('Display Video 360', () => {
-  it('is a placeholder for an actual test', () => {
-    expect(true).toBe(true)
+  describe('createAudience', () => {
+    it('should fail if no audience name is set', async () => {
+      await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(IntegrationError)
+    })
+
+    it('should fail if no advertiser ID is set', async () => {
+      createAudienceInput.audienceName = 'The Void'
+      createAudienceInput.audienceSettings.advertiserId = ''
+      await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(IntegrationError)
+    })
+
+    it('creates an audience', async () => {
+      nock(advertiserCreateAudienceUrl)
+        .post(/.*/)
+        .reply(200, {
+          results: [
+            {
+              resourceName: `products/DISPLAY_VIDEO_ADVERTISER/customers/${advertiserId}/userLists/8460733279`
+            }
+          ]
+        })
+
+      createAudienceInput.audienceName = audienceName
+      createAudienceInput.audienceSettings.advertiserId = advertiserId
+
+      const r = await testDestination.createAudience(createAudienceInput)
+      expect(r).toEqual({
+        externalId: `products/DISPLAY_VIDEO_ADVERTISER/customers/${advertiserId}/userLists/8460733279`
+      })
+    })
+
+    it('errors out when audience with same name already exists', async () => {
+      nock(advertiserCreateAudienceUrl)
+        .post(/.*/)
+        .reply(400, {
+          error: {
+            code: 400,
+            message: 'Request contains an invalid argument.',
+            status: 'INVALID_ARGUMENT',
+            details: [
+              {
+                '@type': 'type.googleapis.com/google.ads.audiencepartner.v2.errors.AudiencePartnerFailure',
+                errors: [
+                  {
+                    errorCode: {
+                      userListError: 'NAME_ALREADY_USED'
+                    },
+                    message: 'Name is already being used for another user list for the account.',
+                    trigger: {
+                      stringValue: audienceName
+                    },
+                    location: {
+                      fieldPathElements: [
+                        {
+                          fieldName: 'operations',
+                          index: 0
+                        },
+                        {
+                          fieldName: 'create'
+                        },
+                        {
+                          fieldName: 'name'
+                        }
+                      ]
+                    }
+                  }
+                ],
+                requestId: 'gMjeoMWem82kFnHKBnmzsA'
+              }
+            ]
+          }
+        })
+
+      createAudienceInput.audienceName = audienceName
+      createAudienceInput.audienceSettings.advertiserId = advertiserId
+
+      await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(IntegrationError)
+    })
+  })
+
+  describe('getAudience', () => {
+    it("should fail if Segment Audience ID doesn't match Google Audience ID", async () => {
+      const bogusGetAudienceInput = {
+        ...getAudienceInput,
+        externalId: 'bogus'
+      }
+
+      nock(advertiserGetAudienceUrl).post(/.*/).reply(200, getAudienceResponse)
+      await expect(testDestination.getAudience(bogusGetAudienceInput)).rejects.toThrowError(IntegrationError)
+    })
+
+    it('should succeed when Segment Audience ID matches Google audience ID', async () => {
+      nock(advertiserGetAudienceUrl).post(/.*/).reply(200, getAudienceResponse)
+
+      const r = await testDestination.getAudience(getAudienceInput)
+      expect(r).toEqual({
+        externalId: expectedExternalID
+      })
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/display-video-360/constants.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/constants.ts
@@ -1,0 +1,4 @@
+export const GOOGLE_API_VERSION = 'v2'
+export const BASE_URL = `https://audiencepartner.googleapis.com/${GOOGLE_API_VERSION}/products/DISPLAY_VIDEO_ADVERTISER/customers/advertiserID/`
+export const CREATE_AUDIENCE_URL = `${BASE_URL}userLists:mutate`
+export const GET_AUDIENCE_URL = `${BASE_URL}audiencePartner:searchStream`

--- a/packages/destination-actions/src/destinations/display-video-360/generated-types.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/generated-types.ts
@@ -1,3 +1,11 @@
 // Generated file. DO NOT MODIFY IT BY HAND.
 
 export interface Settings {}
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface AudienceSettings {
+  /**
+   * The ID of your advertiser, used throughout Display & Video 360. Use this ID when you contact Display & Video 360 support to help our teams locate your specific account.
+   */
+  advertiserId?: string
+}

--- a/packages/destination-actions/src/destinations/display-video-360/index.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/index.ts
@@ -1,14 +1,129 @@
-import type { DestinationDefinition } from '@segment/actions-core'
-import type { Settings } from './generated-types'
+import { AudienceDestinationDefinition, IntegrationError } from '@segment/actions-core'
+import type { Settings, AudienceSettings } from './generated-types'
 
 import addToAudience from './addToAudience'
-
 import removeFromAudience from './removeFromAudience'
 
-const destination: DestinationDefinition<Settings> = {
+import { CREATE_AUDIENCE_URL, GET_AUDIENCE_URL } from './constants'
+
+const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   name: 'Display and Video 360 (Actions)',
   slug: 'actions-display-video-360',
   mode: 'cloud',
+  extendRequest() {
+    // TODO: extendRequest doesn't work within createAudience and getAudience
+    return {}
+  },
+  audienceFields: {
+    advertiserId: {
+      type: 'string',
+      label: 'Advertiser ID',
+      description:
+        'The ID of your advertiser, used throughout Display & Video 360. Use this ID when you contact Display & Video 360 support to help our teams locate your specific account.'
+    }
+  },
+  audienceConfig: {
+    mode: {
+      type: 'synced',
+      full_audience_sync: true
+    },
+    async createAudience(request, createAudienceInput) {
+      const audienceName = createAudienceInput.audienceName
+      const advertiserId = createAudienceInput.audienceSettings?.advertiserId
+      const statsClient = createAudienceInput?.statsContext?.statsClient
+      const statsTags = createAudienceInput?.statsContext?.tags
+
+      if (!audienceName) {
+        throw new IntegrationError('Missing audience name value', 'MISSING_REQUIRED_FIELD', 400)
+      }
+
+      if (!advertiserId) {
+        throw new IntegrationError('Missing advertiser ID value', 'MISSING_REQUIRED_FIELD', 400)
+      }
+
+      const partnerCreateAudienceUrl = CREATE_AUDIENCE_URL.replace('advertiserID', advertiserId)
+      let response
+      try {
+        response = await request(partnerCreateAudienceUrl, {
+          method: 'POST',
+          headers: {
+            // 'Authorization': `Bearer ${authToken}`, // TODO: Replace with auth token
+            'Content-Type': 'application/json',
+            'Login-Customer-Id': `products/DISPLAY_VIDEO_ADVERTISER/customers/${advertiserId}`
+          },
+          json: {
+            operations: [
+              {
+                create: {
+                  basicUserList: {},
+                  name: audienceName,
+                  description: 'Created by Segment',
+                  membershipStatus: 'OPEN',
+                  type: 'REMARKETING',
+                  membershipLifeSpan: '540'
+                }
+              }
+            ]
+          }
+        })
+      } catch (error) {
+        const errorMessage = await JSON.parse(error.response.content).error.details[0].errors[0].message
+        statsClient?.incr('createAudience.error', 1, statsTags)
+        throw new IntegrationError(errorMessage, 'INVALID_RESPONSE', 400)
+      }
+
+      const r = await response.json()
+      statsClient?.incr('createAudience.success', 1, statsTags)
+
+      return {
+        externalId: r['results'][0]['resourceName']
+      }
+    },
+    async getAudience(request, getAudienceInput) {
+      const statsClient = getAudienceInput?.statsContext?.statsClient
+      const statsTags = getAudienceInput?.statsContext?.tags
+      const advertiserId = getAudienceInput.audienceSettings?.advertiserId
+
+      if (!advertiserId) {
+        throw new IntegrationError('Missing required advertiser ID value', 'MISSING_REQUIRED_FIELD', 400)
+      }
+
+      const advertiserGetAudienceUrl = GET_AUDIENCE_URL.replace('advertiserID', advertiserId)
+      const response = await request(advertiserGetAudienceUrl, {
+        headers: {
+          // 'Authorization': `Bearer ${authToken}`, // TODO: Replace with auth token
+          'Content-Type': 'application/json',
+          'Login-Customer-Id': `products/DISPLAY_VIDEO_ADVERTISER/customers/${advertiserId}`
+        },
+        method: 'POST',
+        json: {
+          query: `SELECT user_list.name, user_list.description, user_list.membership_status, user_list.match_rate_percentage FROM user_list WHERE user_list.resource_name = "${getAudienceInput.externalId}"`
+        }
+      })
+
+      const r = await response.json()
+
+      if (response.status !== 200) {
+        statsClient?.incr('getAudience.error', 1, statsTags)
+        throw new IntegrationError('Invalid response from get audience request', 'INVALID_RESPONSE', 400)
+      }
+
+      const externalId = r[0]?.results[0]?.userList?.resourceName
+
+      if (externalId !== getAudienceInput.externalId) {
+        throw new IntegrationError(
+          "Unable to verify ownership over audience. Segment Audience ID doesn't match Googles Audience ID.",
+          'INVALID_REQUEST_DATA',
+          400
+        )
+      }
+
+      statsClient?.incr('getAudience.success', 1, statsTags)
+      return {
+        externalId: externalId
+      }
+    }
+  },
   actions: {
     addToAudience,
     removeFromAudience


### PR DESCRIPTION
This PR adds the createAudience and getAudience methods to DV360. At this point they only work locally until we add the new OAuth provider.

## Testing

Testing completed successfully via local actions tester and HTTP client. 

```
curl -X "POST" "http://localhost:3000/createAudience" \
     -H 'Content-Type: application/json' \
     -d $'{
  "audienceName": "The Super Mario Brothers Super Audience 2",
  "audienceSettings": {
    "authToken": "AYOOOO",
    "advertiserId": "AskMeAboutIt"
  },
  "settings": {}
}'

```

```
## DV360 - getAudience
curl -X "POST" "http://localhost:3000/getAudience" \
     -H 'Content-Type: application/json' \
     -d $'{
  "audienceSettings": {
    "authToken": "AY0",
    "advertiserId": "AskMeAboutIT"
  },
  "audienceName": "The Super Mario Brothers Super Audience 2",
  "settings": {},
  "externalId": "products/DISPLAY_VIDEO_ADVERTISER/customers/ASK/userLists/ME"
}'

```

## Results

<img width="357" alt="Screenshot 2023-10-19 at 3 09 00 PM" src="https://github.com/segmentio/action-destinations/assets/316711/43891536-595e-40b9-96f8-c7aeb67c466f">