### PR TITLE
adding audience id field to Dynamic Yield Destination

### DIFF
--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/__tests__/index.test.ts
@@ -9,7 +9,8 @@ const goodTrackEvent = createTestEvent({
   context: {
     personas: {
       computation_class: 'audience',
-      computation_key: 'dy_segment_test'
+      computation_key: 'dy_segment_test',
+      computation_id: 'dy_segment_audience_id'
     },
     traits: {
       email: 'test@email.com'
@@ -26,7 +27,8 @@ const goodIdentifyEvent = createTestEvent({
   context: {
     personas: {
       computation_class: 'audience',
-      computation_key: 'dy_segment_test'
+      computation_key: 'dy_segment_test',
+      computation_id: 'dy_segment_audience_id'
     }
   },
   traits: {

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   segment_audience_key: string
   /**
+   * Segment Audience ID
+   */
+  segment_audience_id: string
+  /**
    * Segment computation class used to determine if input event is from an Engage Audience'. Value must be = 'audience'.
    */
   segment_computation_action: string

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
@@ -20,6 +20,16 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.context.personas.computation_key'
       }
     },
+    segment_audience_id: {
+      label: 'Audience ID',
+      description: 'Segment Audience ID',
+      type: 'string',
+      unsafe_hidden: true,
+      required: true,
+      default: {
+        '@path': '$.context.personas.computation_id'
+      }
+    },
     segment_computation_action: {
       label: 'Segment Computation Action',
       description:
@@ -69,6 +79,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const payload = data.payload
     const settings = data.settings
     const audienceName = payload.segment_audience_key
+    const audienceID = payload.segment_audience_id
     const audienceValue = d?.rawData?.properties?.[audienceName] ?? d?.rawData?.traits?.[audienceName]
 
     const URL = getUpsertURL(settings)
@@ -77,6 +88,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         audienceValue,
         audienceName,
+        audienceID,
         identifier: payload.segment_user_id ?? payload.segment_anonymous_id,
         email: payload.user_email ? hashAndEncode(payload.user_email) : undefined,
         sectionId: settings.sectionId,


### PR DESCRIPTION
Adding an audience_id field to Dynamic Yield Destination. 

Not used by customers yet. 

## Testing

Tested with Actions Tester. 
