### PR TITLE
[The Trade Desk CRM] Avoid double hashing

### DIFF
--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/functions.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/functions.ts
@@ -109,8 +109,7 @@ function extractUsers(payloads: Payload[]): string {
     }
 
     if (payload.pii_type == 'EmailHashedUnifiedId2') {
-      const normalizedEmail = normalizeEmail(payload.email)
-      const hashedEmail = hash(normalizedEmail)
+      const hashedEmail = hash(payload.email)
       users += `${hashedEmail}\n`
     }
   })
@@ -139,8 +138,20 @@ function normalizeEmail(email: string) {
 }
 
 export const hash = (value: string): string => {
+  const isSha256HashedEmail = /^[a-f0-9]{64}$/i.test(value)
+  const isBase64Hashed = /^[A-Za-z0-9+/]*={0,2}$/i.test(value)
+
+  if (isSha256HashedEmail) {
+    return Buffer.from(value, 'hex').toString('base64')
+  }
+
+  if (isBase64Hashed) {
+    return value
+  }
+
+  const normalizedEmail = normalizeEmail(value)
   const hash = createHash('sha256')
-  hash.update(value)
+  hash.update(normalizedEmail)
   return hash.digest('base64')
 }
 

--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/syncAudience/__tests__/index.test.ts
@@ -230,4 +230,160 @@ describe('TheTradeDeskCrm.syncAudience', () => {
       })
     ).rejects.toThrow(`No external_id found in payload.`)
   })
+
+  it('should not double hash an email that is already base64 encoded', async () => {
+    const dropReferenceId = 'aabbcc5b01-c9c7-4000-9191-000000000000'
+    const dropEndpoint = `https://thetradedesk-crm-data.s3.us-east-1.amazonaws.com/data/advertiser/advertiser-id/drop/${dropReferenceId}/pii?X-Amz-Security-Token=token&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=date&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Credential=credentials&X-Amz-Signature=signature&`
+
+    nock(`https://api.thetradedesk.com/v3/crmdata/segment/advertiser_id/crm_data_id`)
+      .post(/.*/, { PiiType: 'EmailHashedUnifiedId2', MergeMode: 'Replace', RetentionEnabled: true })
+      .reply(200, { ReferenceId: dropReferenceId, Url: dropEndpoint })
+
+    nock(dropEndpoint).put(/.*/).reply(200)
+
+    const events: SegmentEvent[] = []
+    for (let index = 1; index <= 1500; index++) {
+      events.push(
+        createTestEvent({
+          event: 'Audience Entered',
+          type: 'track',
+          properties: {
+            audience_key: 'personas_test_audience'
+          },
+          context: {
+            device: {
+              advertisingId: '123'
+            },
+            personas: {
+              external_audience_id: 'external_audience_id'
+            }
+          }
+        })
+      )
+    }
+
+    events.push(
+      createTestEvent({
+        event: 'Audience Entered',
+        type: 'track',
+        properties: {
+          audience_key: 'personas_test_audience'
+        },
+        context: {
+          device: {
+            advertisingId: '123'
+          },
+          traits: {
+            email: `yhI0QL7dpdaHFq6DEyKlqKPn2vj7KX91BQeqhniYRvI=`
+          },
+          personas: {
+            external_audience_id: 'external_audience_id'
+          }
+        }
+      })
+    )
+
+    const responses = await testDestination.testBatchAction('syncAudience', {
+      events,
+      settings: {
+        advertiser_id: 'advertiser_id',
+        auth_token: 'test_token',
+        __segment_internal_engage_force_full_sync: true,
+        __segment_internal_engage_batch_sync: true
+      },
+      features: {
+        [TTD_LEGACY_FLOW_FLAG_NAME]: true
+      },
+      useDefaultMappings: true,
+      mapping: {
+        name: 'test_audience',
+        region: 'US',
+        pii_type: 'EmailHashedUnifiedId2'
+      }
+    })
+
+    expect(responses.length).toBe(2)
+    expect(responses[1].options.body).toMatchInlineSnapshot(`
+      "yhI0QL7dpdaHFq6DEyKlqKPn2vj7KX91BQeqhniYRvI=
+      "
+    `)
+  })
+
+  it('should base64 encode a sha256 hashed email', async () => {
+    const dropReferenceId = 'aabbcc5b01-c9c7-4000-9191-000000000000'
+    const dropEndpoint = `https://thetradedesk-crm-data.s3.us-east-1.amazonaws.com/data/advertiser/advertiser-id/drop/${dropReferenceId}/pii?X-Amz-Security-Token=token&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=date&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Credential=credentials&X-Amz-Signature=signature&`
+
+    nock(`https://api.thetradedesk.com/v3/crmdata/segment/advertiser_id/crm_data_id`)
+      .post(/.*/, { PiiType: 'EmailHashedUnifiedId2', MergeMode: 'Replace', RetentionEnabled: true })
+      .reply(200, { ReferenceId: dropReferenceId, Url: dropEndpoint })
+
+    nock(dropEndpoint).put(/.*/).reply(200)
+
+    const events: SegmentEvent[] = []
+    for (let index = 1; index <= 1500; index++) {
+      events.push(
+        createTestEvent({
+          event: 'Audience Entered',
+          type: 'track',
+          properties: {
+            audience_key: 'personas_test_audience'
+          },
+          context: {
+            device: {
+              advertisingId: '123'
+            },
+            personas: {
+              external_audience_id: 'external_audience_id'
+            }
+          }
+        })
+      )
+    }
+
+    events.push(
+      createTestEvent({
+        event: 'Audience Entered',
+        type: 'track',
+        properties: {
+          audience_key: 'personas_test_audience'
+        },
+        context: {
+          device: {
+            advertisingId: '123'
+          },
+          traits: {
+            email: `ca123440bedda5d68716ae831322a5a8a3e7daf8fb297f750507aa86789846f2`
+          },
+          personas: {
+            external_audience_id: 'external_audience_id'
+          }
+        }
+      })
+    )
+
+    const responses = await testDestination.testBatchAction('syncAudience', {
+      events,
+      settings: {
+        advertiser_id: 'advertiser_id',
+        auth_token: 'test_token',
+        __segment_internal_engage_force_full_sync: true,
+        __segment_internal_engage_batch_sync: true
+      },
+      features: {
+        [TTD_LEGACY_FLOW_FLAG_NAME]: true
+      },
+      useDefaultMappings: true,
+      mapping: {
+        name: 'test_audience',
+        region: 'US',
+        pii_type: 'EmailHashedUnifiedId2'
+      }
+    })
+
+    expect(responses.length).toBe(2)
+    expect(responses[1].options.body).toMatchInlineSnapshot(`
+      "yhI0QL7dpdaHFq6DEyKlqKPn2vj7KX91BQeqhniYRvI=
+      "
+    `)
+  })
 })


### PR DESCRIPTION
This PR addresses [STRATCONN-3288](https://segment.atlassian.net/browse/STRATCONN-3288) to avoid hashing an email that comes in already hashed.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

Tested using this email example provided in TTD documenation.
![Screenshot 2023-10-23 at 1 35 32 PM](https://github.com/segmentio/action-destinations/assets/99763167/175486de-136f-45e9-bdc5-5beb86493ef4)

Raw email
<img width="1440" alt="Screenshot 2023-10-23 at 1 36 29 PM" src="https://github.com/segmentio/action-destinations/assets/99763167/8b0471ae-aac2-4758-aec8-b2ec848af9a0">


SHA-256 of normalized email
<img width="1433" alt="Screenshot 2023-10-23 at 1 37 15 PM" src="https://github.com/segmentio/action-destinations/assets/99763167/dc821b11-05b1-48f7-9967-324a4ef0dc13">

base64-encoded SHA-256 of normalized email
<img width="1422" alt="Screenshot 2023-10-23 at 1 37 58 PM" src="https://github.com/segmentio/action-destinations/assets/99763167/ee08d4b3-1b68-4890-ac91-66a77f2c720c">



- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment


[STRATCONN-3288]: https://segment.atlassian.net/browse/STRATCONN-3288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ