### PR TITLE
Lowers SFMC Batch size to 50

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-properties.ts
@@ -87,5 +87,10 @@ export const batch_size: InputField = {
   type: 'number',
   required: false,
   unsafe_hidden: true,
-  default: 1000 // values < 4000 will disable bulk batching
+  /**
+   * SFMC has very low limits on maximum batch size.
+   * See: https://developer.salesforce.com/docs/marketing/marketing-cloud/guide/postDataExtensionRowsetByKey.html
+   * And: inc-sev3-6609-sfmc-timeouts-in-bulk-batching-2023-10-23
+   *  */
+  default: 50
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR lowers the maximum batch size for Salesforce Marketing Cloud to 50, based on the recommendation in [SF's docs](https://developer.salesforce.com/docs/marketing/marketing-cloud/references/mc_rest_address?meta=Summary).

## Testing

Testing not required.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
