### PR TITLE
APP-86828 Pendo browser destination

### DIFF
--- a/packages/browser-destinations/destinations/pendo-web-actions/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/generated-types.ts
@@ -6,19 +6,7 @@ export interface Settings {
    */
   apiKey: string
   /**
-   * Segment can set the Pendo Account ID upon page load. This can be overridden via the Account ID field in the Send Identify/Group Actions
-   */
-  accountId?: string
-  /**
-   * Segment can set the Pendo Parent Account ID upon page load. This can be overridden via the Parent Account ID field in the Send Identify/Group Actions. Note: Contact Pendo to request enablement of Parent Account feature.
-   */
-  parentAccountId?: string
-  /**
    * The Pendo Region you'd like to send data to
    */
   region: string
-  /**
-   * Segment can set the Pendo Visitor ID upon page load to either the Segment userId or anonymousId. This can be overridden via the Visitor ID field in the Send Identify/Group Actions
-   */
-  setVisitorIdOnLoad: string
 }

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/generated-types.ts
@@ -6,7 +6,11 @@ export interface Settings {
    */
   apiKey: string
   /**
-   * The Pendo Region you'd like to send data to
+   * The region for your Pendo subscription.
    */
   region: string
+  /**
+   * If you are using Pendo's CNAME feature, this will update your Pendo install snippet with your content host.
+   */
+  cnameContentHost?: string
 }

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/group/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/group/__tests__/index.test.ts
@@ -46,7 +46,8 @@ describe('Pendo.group', () => {
         initialize: jest.fn(),
         isReady: jest.fn(),
         track: jest.fn(),
-        identify: jest.fn()
+        identify: jest.fn(),
+        flushNow: jest.fn()
       }
       return Promise.resolve(mockPendo)
     })

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/group/generated-types.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/group/generated-types.ts
@@ -15,4 +15,11 @@ export interface Payload {
   accountData?: {
     [k: string]: unknown
   }
+  /**
+   * Additional Parent Account data to send. Note: Contact Pendo to request enablement of Parent Account feature.
+   */
+  parentAccountData?: {
+    id: string
+    [k: string]: unknown
+  }
 }

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/group/generated-types.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/group/generated-types.ts
@@ -2,27 +2,17 @@
 
 export interface Payload {
   /**
-   * Pendo Visitor ID. Defaults to Segment userId
+   * Pendo Visitor ID. Maps to Segment userId
    */
   visitorId: string
   /**
-   * Pendo Account ID. This overrides the Pendo Account ID setting
+   * Pendo Account ID
    */
   accountId: string
   /**
    * Additional Account data to send
    */
   accountData?: {
-    [k: string]: unknown
-  }
-  /**
-   * Pendo Parent Account ID. This overrides the Pendo Parent Account ID setting. Note: Contact Pendo to request enablement of Parent Account feature.
-   */
-  parentAccountId?: string
-  /**
-   * Additional Parent Account data to send. Note: Contact Pendo to request enablement of Parent Account feature.
-   */
-  parentAccountData?: {
     [k: string]: unknown
   }
 }

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/group/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/group/index.ts
@@ -11,59 +11,49 @@ const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
   fields: {
     visitorId: {
       label: 'Visitor ID',
-      description: 'Pendo Visitor ID. Defaults to Segment userId',
+      description: 'Pendo Visitor ID. Maps to Segment userId',
       type: 'string',
       required: true,
       default: {
         '@path': '$.userId'
-      }
+      },
+      readOnly: true
     },
     accountId: {
       label: 'Account ID',
-      description: 'Pendo Account ID. This overrides the Pendo Account ID setting',
+      description: 'Pendo Account ID',
       type: 'string',
       required: true,
-      default: { '@path': '$.groupId' }
+      default: { '@path': '$.groupId' },
+      readOnly: true
     },
     accountData: {
       label: 'Account Metadata',
       description: 'Additional Account data to send',
       type: 'object',
-      required: false
-    },
-    parentAccountId: {
-      label: 'Parent Account ID',
-      description:
-        'Pendo Parent Account ID. This overrides the Pendo Parent Account ID setting. Note: Contact Pendo to request enablement of Parent Account feature.',
-      type: 'string',
-      required: false
-    },
-    parentAccountData: {
-      label: 'Parent Account Metadata',
-      description:
-        'Additional Parent Account data to send. Note: Contact Pendo to request enablement of Parent Account feature.',
-      type: 'object',
-      required: false
+      required: false,
+      default: { '@path': '$.traits' },
+      readOnly: true
     }
   },
   perform: (pendo, event) => {
     const payload: PendoOptions = {
       visitor: {
         id: event.payload.visitorId
-      }
-    }
-    if (event.payload.accountId) {
-      payload.account = {
+      },
+      account: {
         ...event.payload.accountData,
         id: event.payload.accountId
       }
     }
-    if (event.payload.parentAccountId) {
-      payload.parentAccount = {
-        ...event.payload.parentAccountData,
-        id: event.payload.parentAccountId
-      }
+
+    // If parentAccount exists in group traits, lift it out of account properties into options properties
+    // https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/pendo/lib/index.js#L136
+    if (payload.account?.parentAccount) {
+      payload.parentAccount = payload.account.parentAccount
+      delete payload.account.parentAccount
     }
+
     pendo.identify(payload)
   }
 }

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/group/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/group/index.ts
@@ -1,7 +1,7 @@
 import type { BrowserActionDefinition } from '@segment/browser-destination-runtime/types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import type { PendoSDK, identifyPayload } from '../types'
+import type { PendoSDK, PendoOptions } from '../types'
 
 const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
   title: 'Send Group Event',
@@ -47,21 +47,21 @@ const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
     }
   },
   perform: (pendo, event) => {
-    const payload: identifyPayload = {
+    const payload: PendoOptions = {
       visitor: {
         id: event.payload.visitorId
       }
     }
-    if (event.payload.accountId || event.settings.accountId) {
+    if (event.payload.accountId) {
       payload.account = {
-        id: event.payload.accountId ?? (event.settings.accountId as string),
-        ...event.payload.accountData
+        ...event.payload.accountData,
+        id: event.payload.accountId
       }
     }
-    if (event.payload.parentAccountId || event.settings.parentAccountId) {
+    if (event.payload.parentAccountId) {
       payload.parentAccount = {
-        id: (event.payload.parentAccountId as string) ?? (event.settings.parentAccountId as string),
-        ...event.payload.parentAccountData
+        ...event.payload.parentAccountData,
+        id: event.payload.parentAccountId
       }
     }
     pendo.identify(payload)

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/group/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/group/index.ts
@@ -34,6 +34,22 @@ const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
       required: false,
       default: { '@path': '$.traits' },
       readOnly: true
+    },
+    parentAccountData: {
+      label: 'Parent Account Metadata',
+      description:
+        'Additional Parent Account data to send. Note: Contact Pendo to request enablement of Parent Account feature.',
+      type: 'object',
+      properties: {
+        id: {
+          label: 'Parent Account ID',
+          type: 'string',
+          required: true
+        }
+      },
+      additionalProperties: true,
+      default: { '@path': '$.traits.parentAccount' },
+      required: false
     }
   },
   perform: (pendo, event) => {
@@ -47,11 +63,8 @@ const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
       }
     }
 
-    // If parentAccount exists in group traits, lift it out of account properties into options properties
-    // https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/pendo/lib/index.js#L136
-    if (payload.account?.parentAccount) {
-      payload.parentAccount = payload.account.parentAccount
-      delete payload.account.parentAccount
+    if (event.payload.parentAccountData) {
+      payload.parentAccount = event.payload.parentAccountData
     }
 
     pendo.identify(payload)

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/identify/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/identify/__tests__/index.test.ts
@@ -46,7 +46,8 @@ describe('Pendo.identify', () => {
         initialize: jest.fn(),
         isReady: jest.fn(),
         track: jest.fn(),
-        identify: jest.fn()
+        identify: jest.fn(),
+        flushNow: jest.fn()
       }
       return Promise.resolve(mockPendo)
     })

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/identify/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/identify/__tests__/index.test.ts
@@ -15,9 +15,6 @@ const subscriptions: Subscription[] = [
       },
       visitorData: {
         '@path': '$.traits'
-      },
-      accountId: {
-        '@path': '$.context.group_id'
       }
     }
   }
@@ -26,7 +23,6 @@ const subscriptions: Subscription[] = [
 describe('Pendo.identify', () => {
   const settings = {
     apiKey: 'abc123',
-    setVisitorIdOnLoad: 'disabled',
     region: 'io'
   }
 
@@ -60,15 +56,11 @@ describe('Pendo.identify', () => {
       userId: 'testUserId',
       traits: {
         first_name: 'Jimbo'
-      },
-      context: {
-        group_id: 'company_id_1'
       }
     })
     await identifyAction.identify?.(context)
 
     expect(mockPendo.identify).toHaveBeenCalledWith({
-      account: { id: 'company_id_1' },
       visitor: { first_name: 'Jimbo', id: 'testUserId' }
     })
   })

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/identify/generated-types.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/identify/generated-types.ts
@@ -2,33 +2,13 @@
 
 export interface Payload {
   /**
-   * Pendo Visitor ID. Defaults to Segment userId
+   * Pendo Visitor ID. Maps to Segment userId
    */
   visitorId: string
   /**
    * Additional Visitor data to send
    */
   visitorData?: {
-    [k: string]: unknown
-  }
-  /**
-   * Pendo Account ID. This overrides the Pendo Account ID setting
-   */
-  accountId?: string
-  /**
-   * Additional Account data to send
-   */
-  accountData?: {
-    [k: string]: unknown
-  }
-  /**
-   * Pendo Parent Account ID. This overrides the Pendo Parent Account ID setting. Note: Contact Pendo to request enablement of Parent Account feature.
-   */
-  parentAccountId?: string
-  /**
-   * Additional Parent Account data to send. Note: Contact Pendo to request enablement of Parent Account feature.
-   */
-  parentAccountData?: {
     [k: string]: unknown
   }
 }

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/identify/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/identify/index.ts
@@ -1,7 +1,7 @@
 import type { BrowserActionDefinition } from '@segment/browser-destination-runtime/types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import type { PendoSDK, identifyPayload } from '../types'
+import type { PendoSDK, PendoOptions } from '../types'
 
 const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
   title: 'Send Identify Event',
@@ -61,22 +61,22 @@ const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
     }
   },
   perform: (pendo, event) => {
-    const payload: identifyPayload = {
+    const payload: PendoOptions = {
       visitor: {
-        id: event.payload.visitorId,
-        ...event.payload.visitorData
+        ...event.payload.visitorData,
+        id: event.payload.visitorId
       }
     }
-    if (event.payload.accountId || event.settings.accountId) {
+    if (event.payload.accountId) {
       payload.account = {
-        id: (event.payload.accountId as string) ?? (event.settings.accountId as string),
-        ...event.payload.accountData
+        ...event.payload.accountData,
+        id: event.payload.accountId
       }
     }
-    if (event.payload.parentAccountId || event.settings.parentAccountId) {
+    if (event.payload.parentAccountId) {
       payload.parentAccount = {
-        id: (event.payload.parentAccountId as string) ?? (event.settings.parentAccountId as string),
-        ...event.payload.parentAccountData
+        ...event.payload.parentAccountData,
+        id: event.payload.parentAccountId
       }
     }
     pendo.identify(payload)

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/identify/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/identify/index.ts
@@ -11,12 +11,13 @@ const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
   fields: {
     visitorId: {
       label: 'Visitor ID',
-      description: 'Pendo Visitor ID. Defaults to Segment userId',
+      description: 'Pendo Visitor ID. Maps to Segment userId',
       type: 'string',
       required: true,
       default: {
         '@path': '$.userId'
-      }
+      },
+      readOnly: true
     },
     visitorData: {
       label: 'Visitor Metadata',
@@ -24,40 +25,8 @@ const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
       type: 'object',
       default: {
         '@path': '$.traits'
-      }
-    },
-    accountId: {
-      label: 'Account ID',
-      description: 'Pendo Account ID. This overrides the Pendo Account ID setting',
-      type: 'string',
-      required: false,
-      default: {
-        '@if': {
-          exists: { '@path': '$.context.group_id' },
-          then: { '@path': '$.context.group_id' },
-          else: { '@path': '$.groupId' }
-        }
-      }
-    },
-    accountData: {
-      label: 'Account Metadata',
-      description: 'Additional Account data to send',
-      type: 'object',
-      required: false
-    },
-    parentAccountId: {
-      label: 'Parent Account ID',
-      description:
-        'Pendo Parent Account ID. This overrides the Pendo Parent Account ID setting. Note: Contact Pendo to request enablement of Parent Account feature.',
-      type: 'string',
-      required: false
-    },
-    parentAccountData: {
-      label: 'Parent Account Metadata',
-      description:
-        'Additional Parent Account data to send. Note: Contact Pendo to request enablement of Parent Account feature.',
-      type: 'object',
-      required: false
+      },
+      readOnly: true
     }
   },
   perform: (pendo, event) => {
@@ -67,18 +36,7 @@ const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
         id: event.payload.visitorId
       }
     }
-    if (event.payload.accountId) {
-      payload.account = {
-        ...event.payload.accountData,
-        id: event.payload.accountId
-      }
-    }
-    if (event.payload.parentAccountId) {
-      payload.parentAccount = {
-        ...event.payload.parentAccountData,
-        id: event.payload.parentAccountId
-      }
-    }
+
     pendo.identify(payload)
   }
 }

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/index.ts
@@ -35,7 +35,7 @@ export const destination: BrowserDestinationDefinition<Settings, PendoSDK> = {
       description:
         'The region for your Pendo subscription.  If you access Pendo at https://us1.app.pendo.io/ then choose us-only.',
       required: true,
-      default: 'io',
+      default: 'https://cdn.pendo.io',
       choices: [
         { value: 'https://cdn.pendo.io', label: 'io' },
         { value: 'https://cdn.eu.pendo.io', label: 'eu' },

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/index.ts
@@ -32,14 +32,14 @@ export const destination: BrowserDestinationDefinition<Settings, PendoSDK> = {
     region: {
       label: 'Region',
       type: 'string',
-      description:
-        'The region for your Pendo subscription.  If you access Pendo at https://us1.app.pendo.io/ then choose us-only.',
+      description: 'The region for your Pendo subscription.',
       required: true,
       default: 'https://cdn.pendo.io',
       choices: [
-        { value: 'https://cdn.pendo.io', label: 'io' },
-        { value: 'https://cdn.eu.pendo.io', label: 'eu' },
-        { value: 'https://us1.cdn.pendo.io', label: 'us-only' }
+        { value: 'https://cdn.pendo.io', label: 'US (default)' },
+        { value: 'https://cdn.eu.pendo.io', label: 'EU' },
+        { value: 'https://us1.cdn.pendo.io', label: 'US restricted' },
+        { value: 'https://cdn.jpn.pendo.io', label: 'Japan' }
       ]
     }
   },

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/index.ts
@@ -90,13 +90,6 @@ export const destination: BrowserDestinationDefinition<Settings, PendoSDK> = {
         : {})
     }
 
-    // If parentAccount exists in group traits, lift it out of account properties into options properties
-    // https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/pendo/lib/index.js#L136
-    if (options.account?.parentAccount) {
-      options.parentAccount = options.account.parentAccount
-      delete options.account.parentAccount
-    }
-
     window.pendo.initialize(options)
 
     return window.pendo

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/index.ts
@@ -32,13 +32,14 @@ export const destination: BrowserDestinationDefinition<Settings, PendoSDK> = {
     region: {
       label: 'Region',
       type: 'string',
-      description: "The Pendo Region you'd like to send data to",
+      description:
+        'The region for your Pendo subscription.  If you access Pendo at https://us1.app.pendo.io/ then choose us-only.',
       required: true,
       default: 'io',
       choices: [
-        { value: 'io', label: 'app.pendo.io' },
-        { value: 'eu', label: 'app.eu.pendo.io' },
-        { value: 'us1', label: 'us1.app.pendo.io' }
+        { value: 'https://cdn.pendo.io', label: 'io' },
+        { value: 'https://cdn.eu.pendo.io', label: 'eu' },
+        { value: 'https://us1.cdn.pendo.io', label: 'us-only' }
       ]
     }
   },

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/index.ts
@@ -41,11 +41,22 @@ export const destination: BrowserDestinationDefinition<Settings, PendoSDK> = {
         { value: 'https://us1.cdn.pendo.io', label: 'US restricted' },
         { value: 'https://cdn.jpn.pendo.io', label: 'Japan' }
       ]
+    },
+    cnameContentHost: {
+      label: 'Optional CNAME content host',
+      description:
+        "If you are using Pendo's CNAME feature, this will update your Pendo install snippet with your content host.",
+      type: 'string',
+      required: false
     }
   },
 
   initialize: async ({ settings, analytics }, deps) => {
-    loadPendo(settings.apiKey, settings.region)
+    if (settings.cnameContentHost && !/^https?:/.exec(settings.cnameContentHost) && settings.cnameContentHost.length) {
+      settings.cnameContentHost = 'https://' + settings.cnameContentHost
+    }
+
+    loadPendo(settings.apiKey, settings.region, settings.cnameContentHost)
 
     await deps.resolveWhen(() => window.pendo != null, 100)
 

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/loadScript.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/loadScript.ts
@@ -16,10 +16,7 @@ export function loadPendo(apiKey, region) {
       })(v[w])
     y = e.createElement(n)
     y.async = !0
-    y.src =
-      `https://${region === 'us1' ? 'us1.' : ''}cdn.${region === 'eu' ? 'eu.' : ''}pendo.io/agent/static/` +
-      apiKey +
-      '/pendo.js'
+    y.src = `${region}/agent/static/${apiKey}/pendo.js`
     z = e.getElementsByTagName(n)[0]
     z.parentNode.insertBefore(y, z)
   })(window, document, 'script', 'pendo')

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/loadScript.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/loadScript.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 // @ts-nocheck
-export function loadPendo(apiKey, region) {
+export function loadPendo(apiKey, region, cnameContentHost) {
   ;(function (p, e, n, d, o) {
     var v, w, x, y, z
     o = p[d] = p[d] || {}
@@ -16,7 +16,7 @@ export function loadPendo(apiKey, region) {
       })(v[w])
     y = e.createElement(n)
     y.async = !0
-    y.src = `${region}/agent/static/${apiKey}/pendo.js`
+    y.src = `${cnameContentHost ?? region}/agent/static/${apiKey}/pendo.js`
     z = e.getElementsByTagName(n)[0]
     z.parentNode.insertBefore(y, z)
   })(window, document, 'script', 'pendo')

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/loadScript.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/loadScript.ts
@@ -16,7 +16,10 @@ export function loadPendo(apiKey, region) {
       })(v[w])
     y = e.createElement(n)
     y.async = !0
-    y.src = `https://cdn.pendo.${region}/agent/static/` + apiKey + '/pendo.js'
+    y.src =
+      `https://${region === 'us1' ? 'us1.' : ''}cdn.${region === 'eu' ? 'eu.' : ''}pendo.io/agent/static/` +
+      apiKey +
+      '/pendo.js'
     z = e.getElementsByTagName(n)[0]
     z.parentNode.insertBefore(y, z)
   })(window, document, 'script', 'pendo')

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/track/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/track/index.ts
@@ -3,7 +3,6 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import type { PendoSDK } from '../types'
 
-// Change from unknown to the partner SDK types
 const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
   title: 'Send Track Event',
   description: 'Send Segment track() events to Pendo',
@@ -17,7 +16,8 @@ const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
       required: true,
       default: {
         '@path': '$.event'
-      }
+      },
+      readOnly: true
     },
     metadata: {
       label: 'Metadata',
@@ -25,7 +25,8 @@ const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
       type: 'object',
       default: {
         '@path': '$.properties'
-      }
+      },
+      readOnly: true
     }
   },
   perform: (pendo, { payload }) => {

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/track/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/track/index.ts
@@ -31,7 +31,6 @@ const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
   },
   perform: (pendo, { payload }) => {
     pendo.track(payload.event, payload.metadata)
-    pendo.flushNow(true)
   }
 }
 

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/types.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/types.ts
@@ -1,27 +1,25 @@
+import { ID } from '@segment/analytics-next'
+
 export type Visitor = {
-  id?: string | null | undefined
+  id: ID
+  [propName: string]: unknown
 }
 
 export type Account = {
-  id?: string | null | undefined
+  id: ID
+  [propName: string]: unknown
 }
 
-export type InitializeData = {
+export type PendoOptions = {
   visitor?: Visitor
   account?: Account
-  parentAccount?: Account
-}
-
-export type identifyPayload = {
-  visitor: { [key: string]: string }
-  account?: { [key: string]: string }
-  parentAccount?: { [key: string]: string }
+  [propName: string]: unknown
 }
 
 export type PendoSDK = {
-  initialize: ({ visitor, account }: InitializeData) => void
+  initialize: ({ visitor, account }: PendoOptions) => void
   track: (eventName: string, metadata?: { [key: string]: unknown }) => void
-  identify: (data: identifyPayload) => void
+  identify: (data: PendoOptions) => void
   flushNow: (force: boolean) => void
   isReady: () => boolean
 }

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/types.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/types.ts
@@ -13,7 +13,7 @@ export type Account = {
 export type PendoOptions = {
   visitor?: Visitor
   account?: Account
-  [propName: string]: unknown
+  parentAccount?: Account
 }
 
 export type PendoSDK = {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

Pendo would like to release a 1:1 Segment data => Pendo data implementation and possibly add more customizations or mappings for the user later.  I removed the settings for `accountId`, `parentAccountId`, and `setVisitorIdOnLoad`.  We want the Pendo visitorId to always be the Segment userId or Segment anonymous id with a Pendo prefix applied to it.  Same with Segment groupId to Pendo accountId, then we forward the user traits and group traits to Pendo as well.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
