### PR TITLE
Iterable Destination - Support allowNull for Phone Number Field

### DIFF
--- a/packages/destination-actions/src/destinations/iterable/shared-fields.ts
+++ b/packages/destination-actions/src/destinations/iterable/shared-fields.ts
@@ -38,6 +38,7 @@ export const USER_PHONE_NUMBER_FIELD: InputField = {
   label: 'User Phone Number',
   description: 'User phone number. Must be a valid phone number including country code. e.g. +14158675309',
   type: 'string',
+  allowNull: true,
   required: false,
   default: { '@path': '$.traits.phone' }
 }

--- a/packages/destination-actions/src/destinations/iterable/trackPurchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/iterable/trackPurchase/generated-types.ts
@@ -30,7 +30,7 @@ export interface Payload {
     /**
      * User phone number. Must be a valid phone number including country code. e.g. +14158675309
      */
-    phoneNumber?: string
+    phoneNumber?: string | null
   }
   /**
    * Additional event properties.

--- a/packages/destination-actions/src/destinations/iterable/updateCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/iterable/updateCart/generated-types.ts
@@ -26,7 +26,7 @@ export interface Payload {
     /**
      * User phone number. Must be a valid phone number including country code. e.g. +14158675309
      */
-    phoneNumber?: string
+    phoneNumber?: string | null
   }
   /**
    * Individual items in the cart. Each item must contain `id`, `name`, `price`, and `quantity`. Extra values are added to dataFields.

--- a/packages/destination-actions/src/destinations/iterable/updateUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/iterable/updateUser/__tests__/index.test.ts
@@ -84,4 +84,36 @@ describe('Iterable.updateUser', () => {
     expect(responses.length).toBe(1)
     expect(responses[0].status).toBe(200)
   })
+
+  it('should allow passing null values for phoneNumber', async () => {
+    const event = createTestEvent({
+      type: 'identify',
+      userId: 'user1234',
+      traits: {
+        phone: null,
+        trait1: null
+      }
+    })
+
+    nock('https://api.iterable.com/api').post('/users/update').reply(200, {})
+
+    const responses = await testDestination.testAction('updateUser', {
+      event,
+      mapping: {
+        dataFields: {
+          '@path': '$.traits'
+        }
+      },
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].options.json).toMatchObject({
+      userId: 'user1234',
+      dataFields: {
+        phoneNumber: null,
+        trait1: null
+      }
+    })
+  })
 })

--- a/packages/destination-actions/src/destinations/iterable/updateUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/iterable/updateUser/generated-types.ts
@@ -18,7 +18,7 @@ export interface Payload {
   /**
    * User phone number. Must be a valid phone number including country code. e.g. +14158675309
    */
-  phoneNumber?: string
+  phoneNumber?: string | null
   /**
    * If you'd like to merge (rather than overwrite) a user profile's top-level objects with the values provided for them in the request body, set mergeNestedObjects to true.
    */


### PR DESCRIPTION
This PR updates the phoneNumber field to support null values, enabling customers to remove the phone number from an Iterable user profile.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
