### PR TITLE
[Google Ads Conversion] - Updated default API version from deprecated v12 to v13

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -5,7 +5,7 @@ import { StatsContext } from '@segment/actions-core/destination-kit'
 import { Features } from '@segment/actions-core/mapping-kit'
 import { fullFormats } from 'ajv-formats/dist/formats'
 
-export const API_VERSION = 'v12'
+export const API_VERSION = 'v13'
 export const CANARY_API_VERSION = 'v13'
 export const FLAGON_NAME = 'google-enhanced-canary-version'
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pull request is to quick fix for google ads as mapping tester is using deprecated version v12 , updated to v13.
Jira Ticket :- https://segment.atlassian.net/jira/software/c/projects/STRATCONN/boards/310?assignee=63617339fc0cc7a600b03c6b&selectedIssue=STRATCONN-3289

[Hadron Run](https://segment.datadoghq.com/dashboard/wie-q52-n97/hadron?refresh_mode=sliding&tpl_var_env=production&tpl_var_experiment=2xkzahvoy1gcwxfbizp62mjobkt&tpl_var_integration%5B0%5D=actions-google-enhanced-conversions&from_ts=1698227108104&to_ts=1698230708104&live=true)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment

<img width="1473" alt="Screenshot 2023-10-25 at 3 41 05 PM" src="https://github.com/segmentio/action-destinations/assets/117165746/88059694-8138-4c56-87ef-1ce142594f7e">

<img width="1395" alt="Screenshot 2023-10-25 at 5 05 46 PM" src="https://github.com/segmentio/action-destinations/assets/117165746/2542c242-fa3e-4f0f-9737-0b837b0579e6">


