### PR TITLE
add yarn build:browser-bundles back to core build command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ node_modules
 dist
 .DS_Store
 *.log
-*.tsbuildinfo
+*.tsbuildinfo*
 .eslintcache
 package-lock.json
 .env

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "cli-internal": "yarn workspace @segment/actions-cli-internal",
     "core": "yarn workspace @segment/actions-core",
     "bootstrap": "lerna bootstrap",
-    "build": "nx run-many -t build",
+    "build": "nx run-many -t build && yarn build:browser-bundles",
     "build:browser-bundles": "nx build @segment/destinations-manifest && nx build-web @segment/browser-destinations",
     "types": "./bin/run generate:types",
     "validate": "./bin/run validate",


### PR DESCRIPTION
- I am adding this back in so people just need to run `yarn build` -- worse DX, but slightly concerned about messing with people's muscle memory when deploying
