### PR TITLE
Update Attio action to link User<>Workspace and append values

### DIFF
--- a/packages/destination-actions/src/destinations/attio/api/index.ts
+++ b/packages/destination-actions/src/destinations/attio/api/index.ts
@@ -30,7 +30,8 @@ export class AttioClient {
   }
 
   /**
-   * Either create or update a Record in the Attio system.
+   * Either create or update a Record in the Attio system. Multi-select attribute values
+   * are always appended, never replaced.
    *
    * @param matching_attribute The Attribute to match the Record on (e.g. an email address)
    * @param object The Attio Object (id / api_slug) that this Record should belong to (e.g. "people")
@@ -49,7 +50,7 @@ export class AttioClient {
     requestOptions?: Partial<RequestOptions>
   }): Promise<ModifiedResponse<AssertResponse>> {
     return await this.request(
-      `${this.api_url}/v2/objects/${object}/records/simple?matching_attribute=${matching_attribute}`,
+      `${this.api_url}/v2/objects/${object}/records/simple?matching_attribute=${matching_attribute}&append_to_existing_values=true`,
       {
         method: 'put',
         json: { data: { values } },

--- a/packages/destination-actions/src/destinations/attio/assertRecord/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/attio/assertRecord/__tests__/index.test.ts
@@ -32,7 +32,7 @@ const mapping = {
 describe('Attio.assertRecord', () => {
   it('asserts a Record', async () => {
     nock('https://api.attio.com')
-      .put('/v2/objects/vehicles/records/simple?matching_attribute=name', {
+      .put('/v2/objects/vehicles/records/simple?matching_attribute=name&append_to_existing_values=true', {
         data: {
           values: {
             name: 'Stair car',

--- a/packages/destination-actions/src/destinations/attio/groupWorkspace/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/attio/groupWorkspace/__tests__/index.test.ts
@@ -17,11 +17,103 @@ const event = createTestEvent({
 
 const mapping = {
   domain: { '@path': '$.traits.domain' },
-  workspace_id: { '@path': '$.traits.id' }
+  workspace_id: { '@path': '$.traits.id' },
+  user_id: { '@path': '$.userId' }
 }
 
 describe('Attio.groupWorkspace', () => {
   it('asserts a Company and then a Workspace', async () => {
+    const companyResponse: AssertResponse = {
+      data: {
+        id: {
+          workspace_id: 'workspace_id',
+          object_id: 'object_id',
+          record_id: 'record_id'
+        },
+        created_at: new Date().toISOString(),
+        values: {}
+      }
+    }
+
+    nock('https://api.attio.com')
+      .put('/v2/objects/companies/records/simple?matching_attribute=domains', {
+        data: {
+          values: {
+            domains: domain
+          }
+        }
+      })
+      .reply(200, companyResponse)
+
+    nock('https://api.attio.com')
+      .put('/v2/objects/workspaces/records/simple?matching_attribute=workspace_id', {
+        data: {
+          values: {
+            company: 'record_id',
+            workspace_id: '42',
+            users: ['user1234']
+          }
+        }
+      })
+      .reply(200, {})
+
+    const responses = await testDestination.testAction('groupWorkspace', {
+      event,
+      mapping,
+      settings: {}
+    })
+
+    expect(responses.length).toBe(2)
+    expect(responses[0].status).toBe(200)
+    expect(responses[1].status).toBe(200)
+  })
+
+  it('does not set a `users` property if missing from event', async () => {
+    const companyResponse: AssertResponse = {
+      data: {
+        id: {
+          workspace_id: 'workspace_id',
+          object_id: 'object_id',
+          record_id: 'record_id'
+        },
+        created_at: new Date().toISOString(),
+        values: {}
+      }
+    }
+
+    nock('https://api.attio.com')
+      .put('/v2/objects/companies/records/simple?matching_attribute=domains', {
+        data: {
+          values: {
+            domains: domain
+          }
+        }
+      })
+      .reply(200, companyResponse)
+
+    nock('https://api.attio.com')
+      .put('/v2/objects/workspaces/records/simple?matching_attribute=workspace_id', {
+        data: {
+          values: {
+            company: 'record_id',
+            workspace_id: '42'
+          }
+        }
+      })
+      .reply(200, {})
+
+    const responses = await testDestination.testAction('groupWorkspace', {
+      event: { ...event, userId: null },
+      mapping,
+      settings: {}
+    })
+
+    expect(responses.length).toBe(2)
+    expect(responses[0].status).toBe(200)
+    expect(responses[1].status).toBe(200)
+  })
+
+  it('does not set a `users` property if mapping is blank', async () => {
     const companyResponse: AssertResponse = {
       data: {
         id: {
@@ -57,7 +149,10 @@ describe('Attio.groupWorkspace', () => {
 
     const responses = await testDestination.testAction('groupWorkspace', {
       event,
-      mapping,
+      mapping: {
+        ...mapping,
+        user_id: ''
+      },
       settings: {}
     })
 

--- a/packages/destination-actions/src/destinations/attio/groupWorkspace/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/attio/groupWorkspace/__tests__/index.test.ts
@@ -36,7 +36,7 @@ describe('Attio.groupWorkspace', () => {
     }
 
     nock('https://api.attio.com')
-      .put('/v2/objects/companies/records/simple?matching_attribute=domains', {
+      .put('/v2/objects/companies/records/simple?matching_attribute=domains&append_to_existing_values=true', {
         data: {
           values: {
             domains: domain
@@ -46,7 +46,7 @@ describe('Attio.groupWorkspace', () => {
       .reply(200, companyResponse)
 
     nock('https://api.attio.com')
-      .put('/v2/objects/workspaces/records/simple?matching_attribute=workspace_id', {
+      .put('/v2/objects/workspaces/records/simple?matching_attribute=workspace_id&append_to_existing_values=true', {
         data: {
           values: {
             company: 'record_id',
@@ -82,7 +82,7 @@ describe('Attio.groupWorkspace', () => {
     }
 
     nock('https://api.attio.com')
-      .put('/v2/objects/companies/records/simple?matching_attribute=domains', {
+      .put('/v2/objects/companies/records/simple?matching_attribute=domains&append_to_existing_values=true', {
         data: {
           values: {
             domains: domain
@@ -92,7 +92,7 @@ describe('Attio.groupWorkspace', () => {
       .reply(200, companyResponse)
 
     nock('https://api.attio.com')
-      .put('/v2/objects/workspaces/records/simple?matching_attribute=workspace_id', {
+      .put('/v2/objects/workspaces/records/simple?matching_attribute=workspace_id&append_to_existing_values=true', {
         data: {
           values: {
             company: 'record_id',
@@ -127,7 +127,7 @@ describe('Attio.groupWorkspace', () => {
     }
 
     nock('https://api.attio.com')
-      .put('/v2/objects/companies/records/simple?matching_attribute=domains', {
+      .put('/v2/objects/companies/records/simple?matching_attribute=domains&append_to_existing_values=true', {
         data: {
           values: {
             domains: domain
@@ -137,7 +137,7 @@ describe('Attio.groupWorkspace', () => {
       .reply(200, companyResponse)
 
     nock('https://api.attio.com')
-      .put('/v2/objects/workspaces/records/simple?matching_attribute=workspace_id', {
+      .put('/v2/objects/workspaces/records/simple?matching_attribute=workspace_id&append_to_existing_values=true', {
         data: {
           values: {
             company: 'record_id',
@@ -163,7 +163,7 @@ describe('Attio.groupWorkspace', () => {
 
   it('fails to assert a Company and returns', async () => {
     nock('https://api.attio.com')
-      .put('/v2/objects/companies/records/simple?matching_attribute=domains', {
+      .put('/v2/objects/companies/records/simple?matching_attribute=domains&append_to_existing_values=true', {
         data: {
           values: {
             domains: domain

--- a/packages/destination-actions/src/destinations/attio/groupWorkspace/generated-types.ts
+++ b/packages/destination-actions/src/destinations/attio/groupWorkspace/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   workspace_id: string
   /**
+   * The ID of the User, if you'd like to link them to this Workspace (leave blank to skip). This assumes you will have already called the Attio identifyUser action: unrecognised Users will fail this action otherwise.
+   */
+  user_id?: string
+  /**
    * Additional attributes to either set or update on the Attio Company Record. The values on the left should be Segment attributes or custom text, and the values on the right are Attio Attribute IDs or Slugs. For example: traits.name → name
    */
   company_attributes?: {

--- a/packages/destination-actions/src/destinations/attio/groupWorkspace/index.ts
+++ b/packages/destination-actions/src/destinations/attio/groupWorkspace/index.ts
@@ -34,6 +34,17 @@ const workspace_id: InputField = {
   }
 }
 
+const user_id: InputField = {
+  type: 'string',
+  label: 'ID',
+  description:
+    "The ID of the User, if you'd like to link them to this Workspace (leave blank to skip). " +
+    'This assumes you will have already called the Attio identifyUser action: unrecognised Users will fail this action otherwise.',
+  format: 'text',
+  required: false,
+  default: { '@path': '$.userId' }
+}
+
 const company_attributes: InputField = {
   type: 'object',
   label: 'Additional Company attributes',
@@ -63,6 +74,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     domain,
     workspace_id,
+    user_id,
     company_attributes,
     workspace_attributes
   },
@@ -85,6 +97,7 @@ const action: ActionDefinition<Settings, Payload> = {
       values: {
         workspace_id: payload.workspace_id,
         company: company.data.data.id.record_id,
+        ...(payload.user_id ? { users: [payload.user_id] } : {}),
         ...(payload.workspace_attributes ?? {})
       }
     })

--- a/packages/destination-actions/src/destinations/attio/identifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/attio/identifyUser/__tests__/index.test.ts
@@ -28,7 +28,7 @@ const mapping = {
 describe('Attio.identifyUser', () => {
   it('asserts a Person and then a User', async () => {
     nock('https://api.attio.com')
-      .put('/v2/objects/people/records/simple?matching_attribute=email_addresses', {
+      .put('/v2/objects/people/records/simple?matching_attribute=email_addresses&append_to_existing_values=true', {
         data: {
           values: {
             email_addresses: email
@@ -38,7 +38,7 @@ describe('Attio.identifyUser', () => {
       .reply(200, {})
 
     nock('https://api.attio.com')
-      .put('/v2/objects/users/records/simple?matching_attribute=user_id', {
+      .put('/v2/objects/users/records/simple?matching_attribute=user_id&append_to_existing_values=true', {
         data: {
           values: {
             user_id: '9',
@@ -63,7 +63,7 @@ describe('Attio.identifyUser', () => {
 
   it('fails to assert a Person and returns', async () => {
     nock('https://api.attio.com')
-      .put('/v2/objects/people/records/simple?matching_attribute=email_addresses', {
+      .put('/v2/objects/people/records/simple?matching_attribute=email_addresses&append_to_existing_values=true', {
         data: {
           values: {
             email_addresses: email


### PR DESCRIPTION
Thanks Segment team for all of your help so far. We've got a few customers using our action now, the biggest being Attio itself. Overall we're quite happy with the stability of this feature. There are two minor changes in this PR that we hope will complete our journey.

  1. **Update the handler for the `group` events so that it actually links Users and Workspaces together**. We always intended to do this but the designs of these objects were still in flux, it's ready now. With this change when calling the `groupWorkspace` action now (and having opted-in on the field) it will find an existing User and link it to the Workspace. This change is non-breaking (I believe!)

  2. **Pass an extra parameter in the API call to append values**. A subtle one this, the Attio API was overwriting one-to-many relationship attributes whenever updated, so you could only ever set a single User for a Workspace at a time. Very annoying. Our API has already been updated to support this new flag so it's safe to roll out at your leisure.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
