### PR TITLE
fix for jimo initialize issue

### DIFF
--- a/packages/browser-destinations/destinations/jimo/src/index.ts
+++ b/packages/browser-destinations/destinations/jimo/src/index.ts
@@ -53,6 +53,8 @@ export const destination: BrowserDestinationDefinition<Settings, JimoSDK> = {
 
     await deps.loadScript(`${ENDPOINT_UNDERCITY}`)
 
+    await deps.resolveWhen(() => typeof window.jimo.push === 'function', 100)
+
     return window.jimo as JimoSDK
   },
   actions: {


### PR DESCRIPTION
Fix for Jimo Web Destination. 

window.jimo is not being resolved correctly as the initialize function is returning a stub object instead of waiting for the jimo library to initialize. 

## Testing

No customers using this integration yet