### PR TITLE
[DV360] - Adds `refreshAccessToken`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,6 +39,17 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Run CLI Serve without UI",
+      "program": "${workspaceFolder}/bin/run",
+      "restart": true,
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "port": 47082,
+      "args": ["serve", "-n"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Run CLI",
       "program": "${workspaceFolder}/bin/run",
       "args": [

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -57,7 +57,7 @@ export default class Serve extends Command {
       })
 
       const { selectedDestination } = await autoPrompt<{ selectedDestination: { name: string } }>(flags, {
-        type: 'select',
+        type: 'autocomplete',
         name: 'selectedDestination',
         message: 'Which destination?',
         choices: integrationDirs.map((integrationPath) => {

--- a/packages/destination-actions/src/destinations/display-video-360/index.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/index.ts
@@ -17,7 +17,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   authentication: {
     scheme: 'oauth2',
     fields: {
-      // TODO: Fields is required, but I don't think we need anything here
+      //Fields is required, so this is left empty
     },
     refreshAccessToken: async (request, { auth }) => {
       const { data } = await request<RefreshTokenResponse>('https://accounts.google.com/o/oauth2/token', {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR implements `refreshAccessToken` for the new DV360 destination. 

## Testing

Tested with the local server `/refreshAccessToken` route:
<img width="1213" alt="Screenshot 2023-10-31 at 5 09 23 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/5a3983bc-1b7c-4f0f-aff9-26ff5aa21aaa">

Pending Stage testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
