### PR TITLE
Add profile to list in upsertProfile

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/snapshot.test.ts
@@ -14,7 +14,10 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
       const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
 
       nock(/.*/).persist().get(/.*/).reply(200)
-      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/)
+        .persist()
+        .post(/.*/)
+        .reply(200, { data: { id: 'fake-id' } })
       nock(/.*/).persist().put(/.*/).reply(200)
 
       const event = createTestEvent({

--- a/packages/destination-actions/src/destinations/klaviyo/functions.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/functions.ts
@@ -1,0 +1,54 @@
+import { RequestClient, DynamicFieldResponse, APIError } from '@segment/actions-core'
+import { API_URL, REVISION_DATE } from './config'
+import { GetListResultContent } from './types'
+import { Settings } from './generated-types'
+
+export async function getListIdDynamicData(request: RequestClient, settings: Settings): Promise<DynamicFieldResponse> {
+  try {
+    const result = await request(`${API_URL}/lists/`, {
+      method: 'get',
+      headers: {
+        Authorization: `Klaviyo-API-Key ${settings.api_key}`,
+        Accept: 'application/json',
+        revision: REVISION_DATE
+      },
+      skipResponseCloning: true
+    })
+    const parsedContent = JSON.parse(result.content) as GetListResultContent
+    const choices = parsedContent.data.map((list: { id: string; attributes: { name: string } }) => {
+      return { value: list.id, label: list.attributes.name }
+    })
+    return {
+      choices
+    }
+  } catch (err) {
+    return {
+      choices: [],
+      nextPage: '',
+      error: {
+        message: (err as APIError).message ?? 'Unknown error',
+        code: (err as APIError).status + '' ?? 'Unknown error'
+      }
+    }
+  }
+}
+
+export async function addProfileToList(request: RequestClient, profileId: string, listId: string) {
+  const listData = {
+    data: [
+      {
+        type: 'profile',
+        id: profileId
+      }
+    ]
+  }
+
+  try {
+    await request(`${API_URL}/lists/${listId}/relationships/profiles/`, {
+      method: 'POST',
+      json: listData
+    })
+  } catch (error) {
+    throw new APIError('An error occurred while processing the request', 400)
+  }
+}

--- a/packages/destination-actions/src/destinations/klaviyo/functions.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/functions.ts
@@ -43,12 +43,8 @@ export async function addProfileToList(request: RequestClient, profileId: string
     ]
   }
 
-  try {
-    await request(`${API_URL}/lists/${listId}/relationships/profiles/`, {
-      method: 'POST',
-      json: listData
-    })
-  } catch (error) {
-    throw new APIError('An error occurred while processing the request', 400)
-  }
+  await request(`${API_URL}/lists/${listId}/relationships/profiles/`, {
+    method: 'POST',
+    json: listData
+  })
 }

--- a/packages/destination-actions/src/destinations/klaviyo/types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/types.ts
@@ -62,3 +62,12 @@ export interface EventData {
     }
   }
 }
+
+export interface GetListResultContent {
+  data: {
+    id: string
+    attributes: {
+      name: string
+    }
+  }[]
+}

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import nock from 'nock'
 import { IntegrationError, createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Definition from '../../index'
 import { API_URL } from '../../config'
+import * as Functions from '../../functions'
 
 const testDestination = createTestIntegration(Definition)
 
@@ -11,7 +12,16 @@ export const settings = {
   api_key: apiKey
 }
 
+jest.mock('../../functions', () => ({
+  ...jest.requireActual('../../functions'),
+  addProfileToList: jest.fn(() => Promise.resolve())
+}))
+
 describe('Upsert Profile', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
   it('should throw error if no email, phone_number, or external_id is provided', async () => {
     const event = createTestEvent({
       type: 'track',
@@ -137,5 +147,119 @@ describe('Upsert Profile', () => {
     await expect(
       testDestination.testAction('upsertProfile', { event, settings, useDefaultMappings: true })
     ).rejects.toThrowError('An error occurred while processing the request')
+  })
+
+  it('should add a profile to a list if list_id is provided', async () => {
+    const listId = 'abc123'
+    const profileId = '123'
+    const mapping = { list_id: 'abc123' }
+
+    const requestBody = {
+      data: {
+        type: 'profile',
+        attributes: {
+          email: 'test@example.com',
+          first_name: 'John',
+          last_name: 'Doe',
+          location: {},
+          properties: {}
+        }
+      }
+    }
+
+    nock(`${API_URL}`)
+      .post('/profiles/', requestBody)
+      .reply(
+        200,
+        JSON.stringify({
+          data: {
+            id: profileId
+          }
+        })
+      )
+
+    nock(`${API_URL}`).post(`/lists/${listId}/relationships/profiles/`).reply(200)
+
+    const event = createTestEvent({
+      type: 'track',
+      userId: '123',
+      traits: {
+        email: 'test@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+        list_id: listId
+      }
+    })
+
+    await expect(
+      testDestination.testAction('upsertProfile', { event, mapping, settings, useDefaultMappings: true })
+    ).resolves.not.toThrowError()
+
+    expect(Functions.addProfileToList).toHaveBeenCalledWith(expect.anything(), profileId, listId)
+  })
+
+  it('should add an existing profile to a list if list_id is provided', async () => {
+    const listId = 'abc123'
+    const profileId = '123'
+    const mapping = { list_id: 'abc123' }
+
+    const requestBody = {
+      data: {
+        type: 'profile',
+        attributes: {
+          email: 'test@example.com',
+          first_name: 'John',
+          last_name: 'Doe',
+          location: {},
+          properties: {}
+        }
+      }
+    }
+
+    const errorResponse = JSON.stringify({
+      errors: [
+        {
+          meta: {
+            duplicate_profile_id: profileId
+          }
+        }
+      ]
+    })
+
+    nock(`${API_URL}`).post('/profiles/', requestBody).reply(409, errorResponse)
+
+    const updateRequestBody = {
+      data: {
+        type: 'profile',
+        id: profileId,
+        attributes: {
+          email: 'test@example.com',
+          first_name: 'John',
+          last_name: 'Doe',
+          location: {},
+          properties: {}
+        }
+      }
+    }
+    nock(`${API_URL}`).patch(`/profiles/${profileId}`, updateRequestBody).reply(200, {})
+
+    nock(`${API_URL}`).post(`/lists/${listId}/relationships/profiles/`).reply(200)
+
+    const event = createTestEvent({
+      type: 'track',
+      userId: '123',
+      traits: {
+        email: 'test@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+        list_id: listId
+      }
+    })
+
+    await expect(
+      testDestination.testAction('upsertProfile', { event, mapping, settings, useDefaultMappings: true })
+    ).resolves.not.toThrowError()
+
+    expect(Functions.addProfileToList).toHaveBeenCalledWith(expect.anything(), profileId, listId)
   })
 })

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/__tests__/snapshot.test.ts
@@ -14,7 +14,10 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
 
     nock(/.*/).persist().get(/.*/).reply(200)
-    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/)
+      .persist()
+      .post(/.*/)
+      .reply(200, { data: { id: 'fake-id' } })
     nock(/.*/).persist().put(/.*/).reply(200)
 
     const event = createTestEvent({

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/generated-types.ts
@@ -53,7 +53,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * 'Insert the ID of the default list that you'd like to subscribe users to when you call .identify().'
+   * Insert the ID of the default list that you'd like to subscribe users to when you call .identify().
    */
   list_id?: string
 }

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/generated-types.ts
@@ -53,7 +53,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * Insert the ID of the default list that you'd like to subscribe users to when you call .identify().
+   * The Klaviyo list to add the profile to.
    */
   list_id?: string
 }

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/generated-types.ts
@@ -52,4 +52,8 @@ export interface Payload {
   properties?: {
     [k: string]: unknown
   }
+  /**
+   * 'Insert the ID of the default list that you'd like to subscribe users to when you call .identify().'
+   */
+  list_id?: string
 }

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
@@ -124,7 +124,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     list_id: {
       label: 'List Id',
-      description: `'Insert the ID of the default list that you'd like to subscribe users to when you call .identify().'`,
+      description: `Insert the ID of the default list that you'd like to subscribe users to when you call .identify().`,
       type: 'string',
       dynamic: true
     }

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
@@ -123,8 +123,8 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     list_id: {
-      label: 'List Id',
-      description: `Insert the ID of the default list that you'd like to subscribe users to when you call .identify().`,
+      label: 'List',
+      description: `The Klaviyo list to add the profile to.`,
       type: 'string',
       dynamic: true
     }

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
@@ -1,10 +1,11 @@
-import type { ActionDefinition } from '@segment/actions-core'
+import type { ActionDefinition, DynamicFieldResponse } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
 import { API_URL } from '../config'
 import { APIError, PayloadValidationError } from '@segment/actions-core'
 import { KlaviyoAPIError, ProfileData } from '../types'
+import { addProfileToList, getListIdDynamicData } from '../functions'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Upsert Profile',
@@ -120,10 +121,21 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.properties'
       }
+    },
+    list_id: {
+      label: 'List Id',
+      description: `'Insert the ID of the default list that you'd like to subscribe users to when you call .identify().'`,
+      type: 'string',
+      dynamic: true
+    }
+  },
+  dynamicFields: {
+    list_id: async (request, { settings }): Promise<DynamicFieldResponse> => {
+      return getListIdDynamicData(request, settings)
     }
   },
   perform: async (request, { payload }) => {
-    const { email, external_id, phone_number, ...otherAttributes } = payload
+    const { email, external_id, phone_number, list_id, ...otherAttributes } = payload
 
     if (!email && !phone_number && !external_id) {
       throw new PayloadValidationError('One of External ID, Phone Number and Email is required.')
@@ -146,6 +158,11 @@ const action: ActionDefinition<Settings, Payload> = {
         method: 'POST',
         json: profileData
       })
+      if (list_id) {
+        const content = JSON.parse(profile?.content)
+        const id = content.data.id
+        await addProfileToList(request, id, list_id)
+      }
       return profile
     } catch (error) {
       const { response } = error as KlaviyoAPIError
@@ -161,6 +178,10 @@ const action: ActionDefinition<Settings, Payload> = {
             method: 'PATCH',
             json: profileData
           })
+
+          if (list_id) {
+            await addProfileToList(request, id, list_id)
+          }
           return profile
         }
       }


### PR DESCRIPTION
This PR 

- Adds list Id mapping in upsertProfile action
- Adds profile to list if list Id is provided
- Updates unit tests

JIRA -> [STRATCONN-3358](https://segment.atlassian.net/browse/STRATCONN-3358)

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

## Testing

### Testing in stage (running locally via stage)
<img width="1434" alt="Screenshot 2023-11-03 at 10 42 58 AM" src="https://github.com/segmentio/action-destinations/assets/129737395/94b229ff-302c-45e5-bbce-0bee31fa8aff">
<img width="1574" alt="Screenshot 2023-11-03 at 10 47 25 AM" src="https://github.com/segmentio/action-destinations/assets/129737395/ef79f4e4-e0bc-4407-934b-8e98443387c4">
<img width="1574" alt="Screenshot 2023-11-03 at 10 47 57 AM" src="https://github.com/segmentio/action-destinations/assets/129737395/93b5555d-00c0-4159-bb0e-39160d115786">


_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment


[STRATCONN-3358]: https://segment.atlassian.net/browse/STRATCONN-3358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ