### PR TITLE
Yahoo: removed Identifier setting and mapping

### DIFF
--- a/packages/destination-actions/src/destinations/yahoo-audiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/__tests__/index.test.ts
@@ -20,8 +20,7 @@ const createAudienceInput = {
   audienceName: '',
   audienceSettings: {
     audience_key: AUDIENCE_KEY,
-    audience_id: AUDIENCE_ID,
-    identifier: ''
+    audience_id: AUDIENCE_ID
   }
 }
 
@@ -48,7 +47,7 @@ describe('Yahoo Audiences', () => {
           anything: '123'
         })
 
-        createAudienceInput.audienceSettings.identifier = 'anything'
+        //createAudienceInput.audienceSettings.identifier = 'anything'
         const result = await testDestination.createAudience(createAudienceInput)
         expect(result.externalId).toBe(AUDIENCE_ID)
       })
@@ -79,18 +78,12 @@ describe('Yahoo Audiences', () => {
 
   describe('gen_update_segment_payload() function', () => {
     describe('Success cases', () => {
-      const audienceSettings = {
-        audience_key: AUDIENCE_KEY,
-        audience_id: AUDIENCE_ID,
-        identifier: 'email'
-      }
-
       it('trivial', () => {
         // Given
         const payloads: Payload[] = [{ gdpr_flag: false } as Payload]
 
         // When
-        const result = gen_update_segment_payload(payloads, audienceSettings)
+        const result = gen_update_segment_payload(payloads)
 
         // Then
         expect(result).toBeTruthy()
@@ -141,7 +134,7 @@ describe('Yahoo Audiences', () => {
         ]
 
         // When
-        const result = gen_update_segment_payload(payloads, audienceSettings)
+        const result = gen_update_segment_payload(payloads)
 
         // Then
         expect(result).toBeTruthy()

--- a/packages/destination-actions/src/destinations/yahoo-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/generated-types.ts
@@ -25,8 +25,4 @@ export interface AudienceSettings {
    * Segment Audience Key
    */
   audience_key: string
-  /**
-   * Specify the identifier(s) to send to Yahoo
-   */
-  identifier: string
 }

--- a/packages/destination-actions/src/destinations/yahoo-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/index.ts
@@ -96,7 +96,8 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       description: 'Segment Audience Key',
       type: 'string',
       required: true
-    },
+    }
+    /*,
     identifier: {
       label: 'User Identifier',
       description: 'Specify the identifier(s) to send to Yahoo',
@@ -112,7 +113,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         { value: 'email_phone', label: 'Send email and/or phone' },
         { value: 'phone_maid', label: 'Send phone and/or MAID' }
       ]
-    }
+    }*/
   },
   audienceConfig: {
     mode: {
@@ -130,7 +131,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       const audience_id = createAudienceInput.audienceSettings?.audience_id
       const audience_key = createAudienceInput.audienceSettings?.audience_key
       const engage_space_id = createAudienceInput.settings?.engage_space_id
-      const identifier = createAudienceInput.audienceSettings?.identifier
+      //const identifier = createAudienceInput.audienceSettings?.identifier
       const statsClient = createAudienceInput?.statsContext?.statsClient
       const statsTags = createAudienceInput?.statsContext?.tags
       // The 3 errors below will be removed once we have Payload accessible by createAudience()
@@ -153,14 +154,14 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       if (!engage_space_id) {
         throw new IntegrationError('Create Audience: missing setting "Engage space Id" ', 'MISSING_REQUIRED_FIELD', 400)
       }
-
-      if (!identifier) {
-        throw new IntegrationError(
-          'Create Audience: missing audience setting "Identifier"',
-          'MISSING_REQUIRED_FIELD',
-          400
-        )
-      }
+      // Removed since identifier is inherited from the payload. Required Ids are sent when they're mapped in Configurable Id sync
+      // if (!identifier) {
+      //   throw new IntegrationError(
+      //     'Create Audience: missing audience setting "Identifier"',
+      //     'MISSING_REQUIRED_FIELD',
+      //     400
+      //   )
+      // }
 
       if (!process.env.ACTIONS_YAHOO_AUDIENCES_TAXONOMY_CLIENT_SECRET) {
         throw new IntegrationError('Missing Taxonomy API client secret', 'MISSING_REQUIRED_FIELD', 400)
@@ -172,8 +173,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       const input = {
         segment_audience_id: audience_id,
         segment_audience_key: audience_key,
-        engage_space_id: engage_space_id,
-        identifier: identifier
+        engage_space_id: engage_space_id
       }
 
       const body_form_data = gen_segment_subtaxonomy_payload(input)

--- a/packages/destination-actions/src/destinations/yahoo-audiences/types.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/types.ts
@@ -30,5 +30,5 @@ export interface YahooSubTaxonomy {
   segment_audience_id: string
   segment_audience_key: string
   engage_space_id: string
-  identifier: string
+  //identifier: string
 }

--- a/packages/destination-actions/src/destinations/yahoo-audiences/updateSegment/generated-types.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/updateSegment/generated-types.ts
@@ -36,10 +36,6 @@ export interface Payload {
    */
   device_type?: string
   /**
-   * Specify the identifier(s) to send to Yahoo
-   */
-  identifier: string
-  /**
    * Set to true to indicate that audience data is subject to GDPR regulations
    */
   gdpr_flag: boolean

--- a/packages/destination-actions/src/destinations/yahoo-audiences/updateSegment/index.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/updateSegment/index.ts
@@ -1,10 +1,10 @@
 import type { ActionDefinition, RequestClient, StatsContext } from '@segment/actions-core'
-import { IntegrationError, PayloadValidationError } from '@segment/actions-core'
-import type { Settings, AudienceSettings } from '../generated-types'
+import { PayloadValidationError } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { gen_update_segment_payload } from '../utils-rt'
 
-const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
+const action: ActionDefinition<Settings, Payload> = {
   title: 'Sync To Yahoo Ads Segment',
   description: 'Sync Segment Audience to Yahoo Ads Segment',
   defaultSubscription: 'type = "identify" or type = "track"',
@@ -66,7 +66,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
         '@if': {
           exists: { '@path': '$.traits.email' },
           then: { '@path': '$.traits.email' },
-          else: { '@path': '$.context.traits.email' }
+          else: { '@path': '$.context.traits.email' } // Phone is sent as identify's trait or track's context.trait
         }
       }
     },
@@ -89,8 +89,8 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
       default: {
         '@if': {
           exists: { '@path': '$.traits.phone' },
-          then: { '@path': '$.traits.phone' },
-          else: { '@path': '$.context.traits.phone' }
+          then: { '@path': '$.traits.phone' }, // Phone is sent as identify's trait or track's property
+          else: { '@path': '$.properties.phone' }
         }
       }
     },
@@ -104,22 +104,22 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
       },
       required: false
     },
-    identifier: {
-      label: 'User Identifier',
-      description: 'Specify the identifier(s) to send to Yahoo',
-      type: 'string',
-      required: true,
-      default: 'email',
-      choices: [
-        { value: 'email', label: 'Send email' },
-        { value: 'maid', label: 'Send MAID' },
-        { value: 'phone', label: 'Send phone' },
-        { value: 'email_maid', label: 'Send email and/or MAID' },
-        { value: 'email_maid_phone', label: 'Send email, MAID and/or phone' },
-        { value: 'email_phone', label: 'Send email and/or phone' },
-        { value: 'phone_maid', label: 'Send phone and/or MAID' }
-      ]
-    },
+    // identifier: {
+    //   label: 'User Identifier',
+    //   description: 'Specify the identifier(s) to send to Yahoo',
+    //   type: 'string',
+    //   required: true,
+    //   default: 'email',
+    //   choices: [
+    //     { value: 'email', label: 'Send email' },
+    //     { value: 'maid', label: 'Send MAID' },
+    //     { value: 'phone', label: 'Send phone' },
+    //     { value: 'email_maid', label: 'Send email and/or MAID' },
+    //     { value: 'email_maid_phone', label: 'Send email, MAID and/or phone' },
+    //     { value: 'email_phone', label: 'Send email and/or phone' },
+    //     { value: 'phone_maid', label: 'Send phone and/or MAID' }
+    //   ]
+    // },
     gdpr_flag: {
       label: 'GDPR Flag',
       description: 'Set to true to indicate that audience data is subject to GDPR regulations',
@@ -136,30 +136,26 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     }
   },
 
-  perform: (request, { payload, auth, audienceSettings, statsContext }) => {
+  perform: (request, { payload, auth, statsContext }) => {
     const rt_access_token = auth?.accessToken
-    if (!audienceSettings) {
-      throw new IntegrationError('Bad Request: no audienceSettings found.', 'INVALID_REQUEST_DATA', 400)
-    }
-    return process_payload(request, [payload], rt_access_token, audienceSettings, statsContext)
+    //const rt_access_token = 'cc606d91-1786-47a0-87fd-6f48ee70fa7c'
+    return process_payload(request, [payload], rt_access_token, statsContext)
   },
-  performBatch: (request, { payload, audienceSettings, auth, statsContext }) => {
+  performBatch: (request, { payload, auth, statsContext }) => {
     const rt_access_token = auth?.accessToken
-    if (!audienceSettings) {
-      throw new IntegrationError('Bad Request: no audienceSettings found.', 'INVALID_REQUEST_DATA', 400)
-    }
-    return process_payload(request, payload, rt_access_token, audienceSettings, statsContext)
+    //const rt_access_token = 'cc606d91-1786-47a0-87fd-6f48ee70fa7c'
+    return process_payload(request, payload, rt_access_token, statsContext)
   }
 }
 
+// Makes a request to Yahoo Realtime API to populate an audience
 async function process_payload(
   request: RequestClient,
   payload: Payload[],
   token: string | undefined,
-  audienceSettings: AudienceSettings,
   statsContext: StatsContext | undefined
 ) {
-  const body = gen_update_segment_payload(payload, audienceSettings)
+  const body = gen_update_segment_payload(payload)
   const statsClient = statsContext?.statsClient
   const statsTag = statsContext?.tags
   // Send request to Yahoo only when all events in the batch include selected Ids

--- a/packages/destination-actions/src/destinations/yahoo-audiences/utils-rt.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/utils-rt.ts
@@ -2,7 +2,6 @@ import { createHmac, createHash } from 'crypto'
 import { Payload } from './updateSegment/generated-types'
 import { YahooPayload } from './types'
 import { gen_random_id } from './utils-tax'
-import { AudienceSettings } from './generated-types'
 
 /**
  * Creates a SHA256 hash from the input
@@ -53,6 +52,9 @@ export function generate_jwt(client_id: string, client_secret: string): string {
  * @param payload The payload.
  * @returns {{ maid: boolean; email: boolean }} The definitions object (id_schema).
  */
+/*
+// TODO: remove this function. We inherit the id_schema from the payload. Once a user has mapped an 
+// identifier in Configurable Id sync, we can use the identifier from the payload.
 export function get_id_schema(
   payload: Payload,
   audienceSettings: AudienceSettings
@@ -95,7 +97,7 @@ export function get_id_schema(
 
   return schema
 }
-
+*/
 export function validate_phone(phone: string) {
   /*
   Phone must match E.164 format: a number up to 15 digits in length starting with a ‘+’
@@ -117,8 +119,8 @@ export function validate_phone(phone: string) {
  * @param payloads
  * @returns {YahooPayload} The Yahoo payload.
  */
-export function gen_update_segment_payload(payloads: Payload[], audienceSettings: AudienceSettings): YahooPayload {
-  const schema = get_id_schema(payloads[0], audienceSettings)
+export function gen_update_segment_payload(payloads: Payload[]): YahooPayload {
+  //const schema = get_id_schema(payloads[0], audienceSettings)
   const data_groups: {
     [hashed_email: string]: {
       exp: string
@@ -130,12 +132,12 @@ export function gen_update_segment_payload(payloads: Payload[], audienceSettings
   //
   for (const event of payloads) {
     let hashed_email: string | undefined = ''
-    if (schema.email === true && event.email) {
+    if (event.email) {
       hashed_email = create_hash(event.email.toLowerCase())
     }
     let idfa: string | undefined = ''
     let gpsaid: string | undefined = ''
-    if (schema.maid === true && event.advertising_id) {
+    if (event.advertising_id) {
       switch (event.device_type) {
         case 'ios':
           idfa = event.advertising_id
@@ -146,7 +148,7 @@ export function gen_update_segment_payload(payloads: Payload[], audienceSettings
       }
     }
     let hashed_phone: string | undefined = ''
-    if (schema.phone === true && event.phone) {
+    if (event.phone) {
       const phone = validate_phone(event.phone)
       if (phone !== '') {
         hashed_phone = create_hash(phone)


### PR DESCRIPTION
Remover Identifier audience setting and action mapping. We inherit identifiers from the Configurable ID sync: IDs mapped in the Configurable ID sync setting will be sent to the destination.
