### PR TITLE
feat(Jimo/sendUserData): handle traits

### DIFF
--- a/packages/browser-destinations/destinations/jimo/src/sendUserData/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/jimo/src/sendUserData/__tests__/index.test.ts
@@ -47,4 +47,41 @@ describe('Jimo - Send User Data', () => {
     expect(client.push).toHaveBeenCalled()
     expect(client.push).toHaveBeenCalledWith(['set', 'user:email', ['foo@bar.com']])
   })
+  test('user traits', async () => {
+    const client = {
+      push: jest.fn()
+    } as any as JimoSDK
+
+    const context = new Context({
+      type: 'identify'
+    })
+
+    await sendUserData.perform(client as any as JimoSDK, {
+      settings: { projectId: 'unk' },
+      analytics: jest.fn() as any as Analytics,
+      context: context,
+      payload: {
+        traits: {
+          trait1: true,
+          trait2: 'foo',
+          trait3: 1
+        }
+      } as Payload
+    })
+
+    expect(client.push).toHaveBeenCalled()
+    expect(client.push).toHaveBeenCalledWith([
+      'set',
+      'user:attributes',
+      [
+        {
+          trait1: true,
+          trait2: 'foo',
+          trait3: 1
+        },
+        false,
+        true
+      ]
+    ])
+  })
 })

--- a/packages/browser-destinations/destinations/jimo/src/sendUserData/generated-types.ts
+++ b/packages/browser-destinations/destinations/jimo/src/sendUserData/generated-types.ts
@@ -9,4 +9,10 @@ export interface Payload {
    * The email of the user
    */
   email?: string | null
+  /**
+   * A list of attributes coming from segment traits
+   */
+  traits?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/browser-destinations/destinations/jimo/src/sendUserData/index.ts
+++ b/packages/browser-destinations/destinations/jimo/src/sendUserData/index.ts
@@ -39,10 +39,7 @@ const action: BrowserActionDefinition<Settings, JimoSDK, Payload> = {
   },
   defaultSubscription: 'type = "identify"',
   perform: (jimo, { payload }) => {
-    console.log(payload)
-    console.log(window.jimo)
     if (payload.userId != null) {
-      console.log('coucou')
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       jimo.push(['set', 'user:id', [payload.userId]])
     }

--- a/packages/browser-destinations/destinations/jimo/src/sendUserData/index.ts
+++ b/packages/browser-destinations/destinations/jimo/src/sendUserData/index.ts
@@ -48,6 +48,7 @@ const action: BrowserActionDefinition<Settings, JimoSDK, Payload> = {
       jimo.push(['set', 'user:email', [payload.email]])
     }
     if (payload.traits != null) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       jimo.push(['set', 'user:attributes', [payload.traits, false, true]])
     }
   }

--- a/packages/browser-destinations/destinations/jimo/src/sendUserData/index.ts
+++ b/packages/browser-destinations/destinations/jimo/src/sendUserData/index.ts
@@ -27,17 +27,31 @@ const action: BrowserActionDefinition<Settings, JimoSDK, Payload> = {
       default: {
         '@path': '$.traits.email'
       }
+    },
+    traits: {
+      label: 'User Traits',
+      description: 'A list of attributes coming from segment traits',
+      type: 'object',
+      default: {
+        '@path': '$.traits'
+      }
     }
   },
   defaultSubscription: 'type = "identify"',
   perform: (jimo, { payload }) => {
+    console.log(payload)
+    console.log(window.jimo)
     if (payload.userId != null) {
+      console.log('coucou')
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       jimo.push(['set', 'user:id', [payload.userId]])
     }
     if (payload.email != null) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       jimo.push(['set', 'user:email', [payload.email]])
+    }
+    if (payload.traits != null) {
+      jimo.push(['set', 'user:attributes', [payload.traits, false, true]])
     }
   }
 }

--- a/packages/browser-destinations/destinations/jimo/src/types.ts
+++ b/packages/browser-destinations/destinations/jimo/src/types.ts
@@ -1,3 +1,3 @@
 export interface JimoSDK {
-  push: (params: Array<string | string[]>) => Promise<void>
+  push: (params: Array<string | (string | { [k: string]: unknown } | boolean)[]>) => Promise<void>
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

We'd like to handle the `traits` object in the identify call.
At the moment, we only handle the user id and email, but our customers would like to also see the traits being sent to Jimo.

Therefore, this PR make sure we handle the `traits` object of the `Identify` event.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
