### PR TITLE
PE-90 - Customer.io - adding app_version field to a single Action

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/createUpdateDevice/generated-types.ts
+++ b/packages/destination-actions/src/destinations/customerio/createUpdateDevice/generated-types.ts
@@ -10,6 +10,10 @@ export interface Payload {
    */
   device_id: string
   /**
+   * The version of the App
+   */
+  app_version?: string
+  /**
    * The mobile device's platform. ("ios" or "android")
    */
   platform: string

--- a/packages/destination-actions/src/destinations/customerio/createUpdateDevice/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/createUpdateDevice/index.ts
@@ -26,6 +26,14 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.context.device.token'
       }
     },
+    app_version: {
+      label: 'App Version',
+      description: 'The version of the App',
+      type: 'string',
+      default: {
+        '@path': '$.context.app.version'
+      }
+    },
     platform: {
       label: 'Platform',
       description: `The mobile device's platform. ("ios" or "android")`,
@@ -64,7 +72,8 @@ const action: ActionDefinition<Settings, Payload> = {
         device: {
           id: payload.device_id,
           platform: payload.platform,
-          last_used: lastUsed
+          last_used: lastUsed,
+          ...(payload.app_version ? { attributes: { app_version: payload.app_version } } : {})
         }
       }
     })


### PR DESCRIPTION
Add a new field to collect and send app_version in the createUpdateDevice Action only. 

## Testing

Tested locally and added unit test. 