### PR TITLE
Common parsing util

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,29 @@
 export { Destination, fieldsToJsonSchema } from './destination-kit'
 export { getAuthData } from './destination-kit/parse-settings'
 export { transform } from './mapping-kit'
-export * from './mapping-kit/value-keys'
+export {
+  ArrayPathDirective,
+  CaseDirective,
+  Directive,
+  DirectiveMetadata,
+  FieldValue,
+  IfDirective,
+  LiteralDirective,
+  PathDirective,
+  PrimitiveValue,
+  ReplaceDirective,
+  TemplateDirective,
+  getFieldValue,
+  getFieldValueKeys,
+  isArrayPathDirective,
+  isCaseDirective,
+  isDirective,
+  isIfDirective,
+  isLiteralDirective,
+  isPathDirective,
+  isReplaceDirective,
+  isTemplateDirective
+} from './mapping-kit/value-keys'
 export { createTestEvent } from './create-test-event'
 export { createTestIntegration } from './create-test-integration'
 export { default as createInstance } from './request-client'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export { Destination, fieldsToJsonSchema } from './destination-kit'
 export { getAuthData } from './destination-kit/parse-settings'
-export { transform, getFieldValueKeys } from './mapping-kit'
+export { transform } from './mapping-kit'
+export * from './mapping-kit/value-keys'
 export { createTestEvent } from './create-test-event'
 export { createTestIntegration } from './create-test-integration'
 export { default as createInstance } from './request-client'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 export { Destination, fieldsToJsonSchema } from './destination-kit'
 export { getAuthData } from './destination-kit/parse-settings'
-export { transform } from './mapping-kit'
+export { transform, getFieldValueKeys } from './mapping-kit'
 export { createTestEvent } from './create-test-event'
 export { createTestIntegration } from './create-test-integration'
 export { default as createInstance } from './request-client'

--- a/packages/core/src/mapping-kit/__tests__/value-keys.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/value-keys.test.ts
@@ -1,0 +1,87 @@
+import { getFieldValueKeys } from '../value-keys'
+
+describe('getFieldValueKeys', () => {
+  it('should return empty [] for strings', () => {
+    const value = 'https://webhook.site/very-legit'
+
+    const keys = getFieldValueKeys(value)
+
+    expect(keys).toEqual([])
+  })
+
+  it('should return empty [] for booleans', () => {
+    const value = false
+
+    const keys = getFieldValueKeys(value)
+
+    expect(keys).toEqual([])
+  })
+
+  it('should return empty [] for empty objects', () => {
+    const value = {}
+
+    const keys = getFieldValueKeys(value)
+
+    expect(keys).toEqual([])
+  })
+
+  it('should return correct keys for single @path', () => {
+    const value = {
+      '@path': '$.properties.string'
+    }
+
+    const keys = getFieldValueKeys(value)
+
+    expect(keys).toEqual(['$.properties.string'])
+  })
+
+  it('should return correct keys for single @templates', () => {
+    const value = {
+      value: {
+        '@template': '{{__segment_entities.log-test-1.ENTITIES_TEST.PRODUCTS.NAME}}'
+      }
+    }
+
+    const keys = getFieldValueKeys(value)
+
+    expect(keys).toEqual(['__segment_entities.log-test-1.ENTITIES_TEST.PRODUCTS.NAME'])
+  })
+
+  it('should return correct keys for multiple @templates', () => {
+    const value = {
+      value: {
+        '@template': '{{__segment_entities.log-test-1.ENTITIES_TEST.PRODUCTS.NAME}}-{{test}}'
+      }
+    }
+
+    const keys = getFieldValueKeys(value)
+
+    expect(keys).toEqual(['__segment_entities.log-test-1.ENTITIES_TEST.PRODUCTS.NAME', 'test'])
+  })
+
+  it('should return correct keys for objects', () => {
+    const value = {
+      Category: {
+        '@template': '{{__segment_entities.log-test-1.ENTITIES_TEST.PRODUCTS.CATEGORY}}'
+      },
+      Enriched_ID: 'test',
+      Name: {
+        '@path': '$.properties.string'
+      }
+    }
+
+    const keys = getFieldValueKeys(value)
+
+    expect(keys).toEqual(['__segment_entities.log-test-1.ENTITIES_TEST.PRODUCTS.CATEGORY', '$.properties.string'])
+  })
+
+  it('should return correct keys for @arrayPath (not yet supported for enrichments)', () => {
+    const value = {
+      '@arrayPath': [{ '@template': '{{properties.products}}' }, { productId: { '@template': '{{productId}}' } }]
+    }
+
+    const keys = getFieldValueKeys(value)
+
+    expect(keys).toEqual(['properties.products', 'productId'])
+  })
+})

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -6,6 +6,7 @@ import { realTypeOf, isObject, isArray } from '../real-type-of'
 import { removeUndefined } from '../remove-undefined'
 import validate from './validate'
 import { arrify } from '../arrify'
+import { getFieldValueKeys } from './value-keys'
 
 export type InputData = { [key: string]: unknown }
 export type Features = { [key: string]: boolean }
@@ -230,7 +231,7 @@ function resolve(mapping: JSONLike, payload: JSONObject): JSONLike {
  * @param mapping - the directives and raw values
  * @param data - the input data to apply to directives
  */
-export function transform(mapping: JSONLikeObject, data: InputData | undefined = {}): JSONObject {
+function transform(mapping: JSONLikeObject, data: InputData | undefined = {}): JSONObject {
   const realType = realTypeOf(data)
   if (realType !== 'object') {
     throw new Error(`data must be an object, got ${realType}`)
@@ -251,7 +252,7 @@ export function transform(mapping: JSONLikeObject, data: InputData | undefined =
  * @param mapping - the directives and raw values
  * @param data - the array input data to apply to directives
  */
-export function transformBatch(mapping: JSONLikeObject, data: Array<InputData> | undefined = []): JSONObject[] {
+function transformBatch(mapping: JSONLikeObject, data: Array<InputData> | undefined = []): JSONObject[] {
   const realType = realTypeOf(data)
   if (!isArray(data)) {
     throw new Error(`data must be an array, got ${realType}`)
@@ -265,3 +266,5 @@ export function transformBatch(mapping: JSONLikeObject, data: Array<InputData> |
   // Cast because we know there are no `undefined` values after `removeUndefined`
   return removeUndefined(resolved) as JSONObject[]
 }
+
+export { transform, transformBatch, getFieldValueKeys }

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -6,7 +6,6 @@ import { realTypeOf, isObject, isArray } from '../real-type-of'
 import { removeUndefined } from '../remove-undefined'
 import validate from './validate'
 import { arrify } from '../arrify'
-import { getFieldValueKeys } from './value-keys'
 
 export type InputData = { [key: string]: unknown }
 export type Features = { [key: string]: boolean }
@@ -267,4 +266,4 @@ function transformBatch(mapping: JSONLikeObject, data: Array<InputData> | undefi
   return removeUndefined(resolved) as JSONObject[]
 }
 
-export { transform, transformBatch, getFieldValueKeys }
+export { transform, transformBatch }

--- a/packages/core/src/mapping-kit/value-keys.ts
+++ b/packages/core/src/mapping-kit/value-keys.ts
@@ -4,14 +4,14 @@ import _ from 'lodash'
 
 type ValueType = 'enrichment' | 'function' | 'literal' | 'variable'
 
-interface DirectiveMetadata {
+export interface DirectiveMetadata {
   _metadata?: {
     label?: string
     type: ValueType
   }
 }
 
-function isDirective(value: FieldValue): value is Directive {
+export function isDirective(value: FieldValue): value is Directive {
   return (
     value !== null &&
     typeof value === 'object' &&
@@ -21,26 +21,34 @@ function isDirective(value: FieldValue): value is Directive {
   )
 }
 
-interface LiteralDirective extends DirectiveMetadata {
+export interface LiteralDirective extends DirectiveMetadata {
   '@literal': PrimitiveValue | Record<string, FieldValue>
 }
 
-function isLiteralDirective(value: FieldValue): value is LiteralDirective {
+export function isLiteralDirective(value: FieldValue): value is LiteralDirective {
   return isDirective(value) && '@literal' in value
 }
-interface TemplateDirective extends DirectiveMetadata {
+export interface TemplateDirective extends DirectiveMetadata {
   '@template': string
 }
 
-function isTemplateDirective(value: FieldValue): value is TemplateDirective {
+export function isTemplateDirective(value: FieldValue): value is TemplateDirective {
   return isDirective(value) && '@template' in value
 }
 
-interface PathDirective extends DirectiveMetadata {
+export function getFieldValue(value: FieldValue): any {
+  if (isTemplateDirective(value)) {
+    return value['@template']
+  }
+
+  return value
+}
+
+export interface PathDirective extends DirectiveMetadata {
   '@path': string
 }
 
-function isPathDirective(value: FieldValue): value is PathDirective {
+export function isPathDirective(value: FieldValue): value is PathDirective {
   return isDirective(value) && '@path' in value
 }
 
@@ -49,7 +57,7 @@ type RequireOnlyOne<T, Keys extends keyof T = keyof T> = {
 }[Keys] &
   Pick<T, Exclude<keyof T, Keys>>
 
-interface IfDirective extends DirectiveMetadata {
+export interface IfDirective extends DirectiveMetadata {
   '@if': RequireOnlyOne<
     {
       blank?: FieldValue
@@ -61,7 +69,7 @@ interface IfDirective extends DirectiveMetadata {
   >
 }
 
-function isIfDirective(value: FieldValue): value is IfDirective {
+export function isIfDirective(value: FieldValue): value is IfDirective {
   return (
     isDirective(value) &&
     '@if' in value &&
@@ -71,22 +79,22 @@ function isIfDirective(value: FieldValue): value is IfDirective {
   )
 }
 
-interface ArrayPathDirective extends DirectiveMetadata {
+export interface ArrayPathDirective extends DirectiveMetadata {
   '@arrayPath': [Directive | string, { [key: string]: FieldValue } | undefined] | [Directive | string]
 }
 
-function isArrayPathDirective(value: FieldValue): value is ArrayPathDirective {
+export function isArrayPathDirective(value: FieldValue): value is ArrayPathDirective {
   return isDirective(value) && '@arrayPath' in value && Array.isArray(value['@arrayPath'])
 }
 
-interface CaseDirective extends DirectiveMetadata {
+export interface CaseDirective extends DirectiveMetadata {
   '@case': {
     operator: string
     value?: FieldValue
   }
 }
 
-function isCaseDirective(value: FieldValue): value is CaseDirective {
+export function isCaseDirective(value: FieldValue): value is CaseDirective {
   return (
     isDirective(value) &&
     '@case' in value &&
@@ -96,7 +104,7 @@ function isCaseDirective(value: FieldValue): value is CaseDirective {
   )
 }
 
-interface ReplaceDirective extends DirectiveMetadata {
+export interface ReplaceDirective extends DirectiveMetadata {
   '@replace': {
     global: PrimitiveValue
     ignorecase: PrimitiveValue
@@ -106,7 +114,7 @@ interface ReplaceDirective extends DirectiveMetadata {
   }
 }
 
-function isReplaceDirective(value: FieldValue): value is ReplaceDirective {
+export function isReplaceDirective(value: FieldValue): value is ReplaceDirective {
   return (
     isDirective(value) &&
     '@replace' in value &&
@@ -150,7 +158,7 @@ function directiveType<T>(directive: Directive, checker: DirectiveKeysToType<T>)
   return null
 }
 
-type Directive =
+export type Directive =
   | ArrayPathDirective
   | CaseDirective
   | IfDirective
@@ -158,8 +166,8 @@ type Directive =
   | PathDirective
   | ReplaceDirective
   | TemplateDirective
-type PrimitiveValue = boolean | number | string | null
-type FieldValue = Directive | PrimitiveValue | { [key: string]: FieldValue } | FieldValue[] | undefined
+export type PrimitiveValue = boolean | number | string | null
+export type FieldValue = Directive | PrimitiveValue | { [key: string]: FieldValue } | FieldValue[] | undefined
 
 /**
  * @param value

--- a/packages/core/src/mapping-kit/value-keys.ts
+++ b/packages/core/src/mapping-kit/value-keys.ts
@@ -197,7 +197,10 @@ export function getFieldValueKeys(value: FieldValue): string[] {
   return []
 }
 
-function getRawKeys(input: FieldValue): string[] {
+/**
+ * Function to get raw keys from a FieldValue
+ */
+export function getRawKeys(input: FieldValue): string[] {
   if (isDirective(input)) {
     return getFieldValueKeys(input)
   } else if (_.isObject(input)) {
@@ -209,7 +212,7 @@ function getRawKeys(input: FieldValue): string[] {
 /**
  * Function to grab all values between any set of {{}} in a string
  */
-function getTemplateKeys(input: string): string[] {
+export function getTemplateKeys(input: string): string[] {
   const regex = /{{(.*?)}}/g
   return Array.from(input.matchAll(regex), (m) => m[1])
 }

--- a/packages/core/src/mapping-kit/value-keys.ts
+++ b/packages/core/src/mapping-kit/value-keys.ts
@@ -1,0 +1,207 @@
+// import { isDirective } from './is-directive'
+// eslint-disable-next-line lodash/import-scope
+import _ from 'lodash'
+
+type ValueType = 'enrichment' | 'function' | 'literal' | 'variable'
+
+interface DirectiveMetadata {
+  _metadata?: {
+    label?: string
+    type: ValueType
+  }
+}
+
+function isDirective(value: FieldValue): value is Directive {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    Object.keys(value).some((key) =>
+      ['@if', '@path', '@template', '@literal', '@arrayPath', '@case', '@replace'].includes(key)
+    )
+  )
+}
+
+interface LiteralDirective extends DirectiveMetadata {
+  '@literal': PrimitiveValue | Record<string, FieldValue>
+}
+
+function isLiteralDirective(value: FieldValue): value is LiteralDirective {
+  return isDirective(value) && '@literal' in value
+}
+interface TemplateDirective extends DirectiveMetadata {
+  '@template': string
+}
+
+function isTemplateDirective(value: FieldValue): value is TemplateDirective {
+  return isDirective(value) && '@template' in value
+}
+
+interface PathDirective extends DirectiveMetadata {
+  '@path': string
+}
+
+function isPathDirective(value: FieldValue): value is PathDirective {
+  return isDirective(value) && '@path' in value
+}
+
+type RequireOnlyOne<T, Keys extends keyof T = keyof T> = {
+  [K in Keys]-?: Partial<Record<Exclude<Keys, K>, undefined>> & Required<Pick<T, K>>
+}[Keys] &
+  Pick<T, Exclude<keyof T, Keys>>
+
+interface IfDirective extends DirectiveMetadata {
+  '@if': RequireOnlyOne<
+    {
+      blank?: FieldValue
+      else?: FieldValue
+      exists?: FieldValue
+      then: FieldValue
+    },
+    'blank' | 'exists'
+  >
+}
+
+function isIfDirective(value: FieldValue): value is IfDirective {
+  return (
+    isDirective(value) &&
+    '@if' in value &&
+    value['@if'] !== null &&
+    typeof value['@if'] === 'object' &&
+    ('exists' in value['@if'] || 'blank' in value['@if'])
+  )
+}
+
+interface ArrayPathDirective extends DirectiveMetadata {
+  '@arrayPath': [Directive | string, { [key: string]: FieldValue } | undefined] | [Directive | string]
+}
+
+function isArrayPathDirective(value: FieldValue): value is ArrayPathDirective {
+  return isDirective(value) && '@arrayPath' in value && Array.isArray(value['@arrayPath'])
+}
+
+interface CaseDirective extends DirectiveMetadata {
+  '@case': {
+    operator: string
+    value?: FieldValue
+  }
+}
+
+function isCaseDirective(value: FieldValue): value is CaseDirective {
+  return (
+    isDirective(value) &&
+    '@case' in value &&
+    value['@case'] !== null &&
+    typeof value['@case'] === 'object' &&
+    'operator' in value['@case']
+  )
+}
+
+interface ReplaceDirective extends DirectiveMetadata {
+  '@replace': {
+    global: PrimitiveValue
+    ignorecase: PrimitiveValue
+    pattern: string
+    replacement: string
+    value?: FieldValue
+  }
+}
+
+function isReplaceDirective(value: FieldValue): value is ReplaceDirective {
+  return (
+    isDirective(value) &&
+    '@replace' in value &&
+    value['@replace'] !== null &&
+    typeof value['@replace'] === 'object' &&
+    'pattern' in value['@replace']
+  )
+}
+type DirectiveKeysToType<T> = {
+  ['@arrayPath']: (input: ArrayPathDirective) => T
+  ['@case']: (input: CaseDirective) => T
+  ['@if']: (input: IfDirective) => T
+  ['@literal']: (input: LiteralDirective) => T
+  ['@path']: (input: PathDirective) => T
+  ['@replace']: (input: ReplaceDirective) => T
+  ['@template']: (input: TemplateDirective) => T
+}
+
+function directiveType<T>(directive: Directive, checker: DirectiveKeysToType<T>): T | null {
+  if (isArrayPathDirective(directive)) {
+    return checker['@arrayPath'](directive)
+  }
+  if (isCaseDirective(directive)) {
+    return checker['@case'](directive)
+  }
+  if (isIfDirective(directive)) {
+    return checker['@if'](directive)
+  }
+  if (isLiteralDirective(directive)) {
+    return checker['@literal'](directive)
+  }
+  if (isPathDirective(directive)) {
+    return checker['@path'](directive)
+  }
+  if (isReplaceDirective(directive)) {
+    return checker['@replace'](directive)
+  }
+  if (isTemplateDirective(directive)) {
+    return checker['@template'](directive)
+  }
+  return null
+}
+
+type Directive =
+  | ArrayPathDirective
+  | CaseDirective
+  | IfDirective
+  | LiteralDirective
+  | PathDirective
+  | ReplaceDirective
+  | TemplateDirective
+type PrimitiveValue = boolean | number | string | null
+type FieldValue = Directive | PrimitiveValue | { [key: string]: FieldValue } | FieldValue[] | undefined
+
+/**
+ * @param value
+ * @returns an array containing all keys of nested @directives
+ */
+export function getFieldValueKeys(value: FieldValue): string[] {
+  if (isDirective(value)) {
+    return (
+      directiveType<string[]>(value, {
+        '@arrayPath': (input: ArrayPathDirective) => input['@arrayPath'].flatMap(getRawKeys),
+        '@case': (input: CaseDirective) => getRawKeys(input['@case'].value),
+        '@if': (input: IfDirective) => [
+          ...getRawKeys(input['@if'].blank),
+          ...getRawKeys(input['@if'].exists),
+          ...getRawKeys(input['@if'].then),
+          ...getRawKeys(input['@if'].else)
+        ],
+        '@literal': (_: LiteralDirective) => [''],
+        '@path': (input: PathDirective) => [input['@path']],
+        '@replace': (input: ReplaceDirective) => getRawKeys(input['@replace'].value),
+        '@template': (input: TemplateDirective) => getTemplateKeys(input['@template'])
+      })?.filter((k) => k) ?? []
+    )
+  } else if (_.isObject(value)) {
+    return Object.values(value).flatMap(getFieldValueKeys)
+  }
+  return []
+}
+
+function getRawKeys(input: FieldValue): string[] {
+  if (isDirective(input)) {
+    return getFieldValueKeys(input)
+  } else if (_.isObject(input)) {
+    return Object.values(input).flatMap(getFieldValueKeys)
+  }
+  return []
+}
+
+/**
+ * Function to grab all values between any set of {{}} in a string
+ */
+function getTemplateKeys(input: string): string[] {
+  const regex = /{{(.*?)}}/g
+  return Array.from(input.matchAll(regex), (m) => m[1])
+}


### PR DESCRIPTION
This PR addresses JIRA [EN-586](https://segment.atlassian.net/browse/EN-586)

In it we create a common parsing method for the values of an action mapping to correctly parse out any `@template` & `@path` key values. This will later be used in CPS to update all mappings of a user with keys that match a certain format.

Needed for https://segment.atlassian.net/browse/EN-562

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment


[EN-586]: https://segment.atlassian.net/browse/EN-586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ