### PR TITLE
Removed flagon from hubspot destination

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
@@ -67,9 +67,8 @@ const action: ActionDefinition<Settings, Payload> = {
       defaultObjectUI: 'keyvalue:only'
     }
   },
-  perform: (request, { payload, settings, features }) => {
-    const shouldTransformEventName = features && features['actions-hubspot-event-name']
-    const eventName = shouldTransformEventName ? transformEventName(payload.eventName) : payload.eventName
+  perform: (request, { payload, settings }) => {
+    const eventName = transformEventName(payload.eventName)
 
     const event: CustomBehavioralEvent = {
       eventName: eventName,


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This pull request is to remove the flagon from hubspot's `transformEventName` function.
JIRA ticket:- https://segment.atlassian.net/browse/STRATCONN-3377

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)

