### PR TITLE
Changes to trackey added by Partner

### DIFF
--- a/packages/destination-actions/src/destinations/trackey/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/trackey/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,69 +1,62 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing snapshot for actions-trackey destination: group action - all fields 1`] = `
+exports[`Testing snapshot for actions-trackey destination: identifyUser action - all fields 1`] = `
 Object {
-  "groupId": Object {
-    "testType": "^Vvf$jtvC",
-  },
-  "messageId": "^Vvf$jtvC",
-  "timestamp": "^Vvf$jtvC",
+  "messageId": "4lC*xBPj6Zf^iE3J1PF",
+  "timestamp": "4lC*xBPj6Zf^iE3J1PF",
   "traits": Object {
-    "testType": "^Vvf$jtvC",
+    "testType": "4lC*xBPj6Zf^iE3J1PF",
   },
-  "userId": "^Vvf$jtvC",
+  "userId": "4lC*xBPj6Zf^iE3J1PF",
 }
 `;
 
-exports[`Testing snapshot for actions-trackey destination: group action - required fields 1`] = `
+exports[`Testing snapshot for actions-trackey destination: identifyUser action - required fields 1`] = `
 Object {
-  "groupId": Object {
-    "testType": "^Vvf$jtvC",
-  },
-  "timestamp": "^Vvf$jtvC",
-  "userId": "^Vvf$jtvC",
+  "timestamp": "4lC*xBPj6Zf^iE3J1PF",
+  "userId": "4lC*xBPj6Zf^iE3J1PF",
 }
 `;
 
-exports[`Testing snapshot for actions-trackey destination: identify action - all fields 1`] = `
+exports[`Testing snapshot for actions-trackey destination: registerCompany action - all fields 1`] = `
 Object {
-  "groupId": Object {
-    "testType": "6aniX&1",
-  },
-  "messageId": "6aniX&1",
-  "timestamp": "6aniX&1",
+  "groupId": "dv8xxzqiX16YI!L#st",
+  "messageId": "dv8xxzqiX16YI!L#st",
+  "timestamp": "dv8xxzqiX16YI!L#st",
   "traits": Object {
-    "testType": "6aniX&1",
+    "testType": "dv8xxzqiX16YI!L#st",
   },
-  "userId": "6aniX&1",
+  "userId": "dv8xxzqiX16YI!L#st",
 }
 `;
 
-exports[`Testing snapshot for actions-trackey destination: identify action - required fields 1`] = `
+exports[`Testing snapshot for actions-trackey destination: registerCompany action - required fields 1`] = `
 Object {
-  "timestamp": "6aniX&1",
-  "userId": "6aniX&1",
+  "groupId": "dv8xxzqiX16YI!L#st",
+  "timestamp": "dv8xxzqiX16YI!L#st",
+  "userId": "dv8xxzqiX16YI!L#st",
 }
 `;
 
-exports[`Testing snapshot for actions-trackey destination: track action - all fields 1`] = `
+exports[`Testing snapshot for actions-trackey destination: trackEvent action - all fields 1`] = `
 Object {
-  "event": "eT[K8ft@uBryp",
+  "event": "qnx]3%$)][Qxz",
   "groupId": Object {
-    "testType": "eT[K8ft@uBryp",
+    "testType": "qnx]3%$)][Qxz",
   },
-  "messageId": "eT[K8ft@uBryp",
+  "messageId": "qnx]3%$)][Qxz",
   "properties": Object {
-    "testType": "eT[K8ft@uBryp",
+    "testType": "qnx]3%$)][Qxz",
   },
-  "timestamp": "eT[K8ft@uBryp",
-  "userId": "eT[K8ft@uBryp",
+  "timestamp": "qnx]3%$)][Qxz",
+  "userId": "qnx]3%$)][Qxz",
 }
 `;
 
-exports[`Testing snapshot for actions-trackey destination: track action - required fields 1`] = `
+exports[`Testing snapshot for actions-trackey destination: trackEvent action - required fields 1`] = `
 Object {
-  "event": "eT[K8ft@uBryp",
-  "timestamp": "eT[K8ft@uBryp",
-  "userId": "eT[K8ft@uBryp",
+  "event": "qnx]3%$)][Qxz",
+  "timestamp": "qnx]3%$)][Qxz",
+  "userId": "qnx]3%$)][Qxz",
 }
 `;

--- a/packages/destination-actions/src/destinations/trackey/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/trackey/__tests__/index.test.ts
@@ -1,22 +1,24 @@
-import nock from 'nock'
 import { createTestIntegration } from '@segment/actions-core'
+import nock from 'nock'
+import { baseUrl } from '../constants'
 import Definition from '../index'
 
 const testDestination = createTestIntegration(Definition)
-const base = 'https://app.trackey.io'
-const url = '/public-api/integrations/segment/webhook'
 
 describe('Trackey', () => {
-  it('should validate api key', async () => {
-    nock(base).get(url).reply(200, {
-      status: 'success',
-      data: 'Test client'
+  describe('testAuthentication', () => {
+    it('should validate api key', async () => {
+      nock(baseUrl).get('/auth/me').reply(200, {
+        status: 'SUCCESS',
+        data: 'Test client'
+      })
+
+      // This should match your authentication.fields
+      const authData = {
+        apiKey: 'test-api-key'
+      }
+
+      await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
     })
-
-    const authData = {
-      apiKey: 'test-api-key'
-    }
-
-    await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
   })
 })

--- a/packages/destination-actions/src/destinations/trackey/constants.ts
+++ b/packages/destination-actions/src/destinations/trackey/constants.ts
@@ -1,0 +1,2 @@
+const base = 'https://app.trackey.io'
+export const baseUrl = base + '/public-api/integrations/segment/webhook'

--- a/packages/destination-actions/src/destinations/trackey/group/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/trackey/group/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Trackey's registerCompany destination action: all fields 1`] = `
+Object {
+  "groupId": "XKWTBCZ%QyH",
+  "messageId": "XKWTBCZ%QyH",
+  "timestamp": "XKWTBCZ%QyH",
+  "traits": Object {
+    "testType": "XKWTBCZ%QyH",
+  },
+  "userId": "XKWTBCZ%QyH",
+}
+`;
+
+exports[`Testing snapshot for Trackey's registerCompany destination action: required fields 1`] = `
+Object {
+  "groupId": "XKWTBCZ%QyH",
+  "timestamp": "XKWTBCZ%QyH",
+  "userId": "XKWTBCZ%QyH",
+}
+`;

--- a/packages/destination-actions/src/destinations/trackey/group/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/trackey/group/__tests__/index.test.ts
@@ -1,0 +1,45 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import nock from 'nock'
+import { baseUrl } from '../../constants'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+const timestamp = '2023-02-22T15:21:15.449Z'
+
+describe('Trackey.registerCompany', () => {
+  it('Sends company data correctly', async () => {
+    const event = createTestEvent({
+      type: 'group',
+      userId: 'test-user-id',
+      timestamp,
+      groupId: 'test-group-id',
+      traits: { 'company-property-1': 'test-value', 'company-property-2': 'test-value-2' }
+    })
+
+    nock(baseUrl)
+      .post('')
+      .reply(202, {
+        status: 'SUCCESS',
+        data: {
+          message: 'Account registered'
+        }
+      })
+
+    const response = await testDestination.testAction('registerCompany', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        apiKey: 'test-api-key'
+      }
+    })
+
+    expect(response[0].status).toBe(202)
+    expect(response[0].data).toMatchObject({
+      status: 'SUCCESS',
+      data: {
+        message: 'Account registered'
+      }
+    })
+    expect(response.length).toBe(1)
+  })
+})

--- a/packages/destination-actions/src/destinations/trackey/group/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/trackey/group/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'registerCompany'
+const destinationSlug = 'Trackey'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/trackey/group/generated-types.ts
+++ b/packages/destination-actions/src/destinations/trackey/group/generated-types.ts
@@ -1,0 +1,26 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The user identifier to associate the event with
+   */
+  userId: string
+  /**
+   * A unique value for each event.
+   */
+  messageId?: string
+  /**
+   * Timestamp that the event took place, in ISO 8601 format. e.g. 2019-06-12T19:11:01.152Z
+   */
+  timestamp: string
+  /**
+   * Company profile information
+   */
+  traits?: {
+    [k: string]: unknown
+  }
+  /**
+   * Company ID associated with the event
+   */
+  groupId: string
+}

--- a/packages/destination-actions/src/destinations/trackey/group/index.ts
+++ b/packages/destination-actions/src/destinations/trackey/group/index.ts
@@ -1,0 +1,62 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { baseUrl } from '../constants'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Register Company',
+  description: 'Register a user in a company',
+  defaultSubscription: 'type = "group"',
+  fields: {
+    userId: {
+      label: 'User ID',
+      type: 'string',
+      required: true,
+      description: 'The user identifier to associate the event with',
+      default: { '@path': '$.userId' }
+    },
+    messageId: {
+      label: 'Message ID',
+      type: 'string',
+      description: 'A unique value for each event.',
+      default: {
+        '@path': '$.messageId'
+      }
+    },
+    timestamp: {
+      label: 'Event Timestamp',
+      type: 'string',
+      required: true,
+      description: 'Timestamp that the event took place, in ISO 8601 format. e.g. 2019-06-12T19:11:01.152Z',
+      default: { '@path': '$.timestamp' }
+    },
+    traits: {
+      label: 'COmpany Traits',
+      type: 'object',
+      required: false,
+      description: 'Company profile information',
+      default: { '@path': '$.traits' }
+    },
+    groupId: {
+      label: 'Group ID',
+      type: 'string',
+      required: true,
+      description: 'Company ID associated with the event',
+      default: { '@path': '$.groupId' }
+    }
+  },
+  perform: (request, { payload }) => {
+    return request(baseUrl, {
+      method: 'POST',
+      json: {
+        userId: payload.userId,
+        messageId: payload.messageId,
+        timestamp: payload.timestamp,
+        traits: payload.traits,
+        groupId: payload.groupId
+      }
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/trackey/identify/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/trackey/identify/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Trackey's identifyUser destination action: all fields 1`] = `
+Object {
+  "messageId": "C(l]qexukkH*z",
+  "timestamp": "C(l]qexukkH*z",
+  "traits": Object {
+    "testType": "C(l]qexukkH*z",
+  },
+  "userId": "C(l]qexukkH*z",
+}
+`;
+
+exports[`Testing snapshot for Trackey's identifyUser destination action: required fields 1`] = `
+Object {
+  "timestamp": "C(l]qexukkH*z",
+  "userId": "C(l]qexukkH*z",
+}
+`;

--- a/packages/destination-actions/src/destinations/trackey/identify/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/trackey/identify/__tests__/index.test.ts
@@ -1,0 +1,44 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import nock from 'nock'
+import { baseUrl } from '../../constants'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+const timestamp = '2023-02-22T15:21:15.449Z'
+
+describe('Trackey.identifyUser', () => {
+  it('Sends an account profile succesfully', async () => {
+    const event = createTestEvent({
+      type: 'identify',
+      userId: 'test-user-id',
+      timestamp,
+      traits: { 'test-property': 'test-value', 'test-property-2': 'test-value-2' }
+    })
+
+    nock(baseUrl)
+      .post('')
+      .reply(202, {
+        status: 'SUCCESS',
+        data: {
+          message: 'User identified'
+        }
+      })
+
+    const response = await testDestination.testAction('identifyUser', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        apiKey: 'test-api-key'
+      }
+    })
+
+    expect(response[0].status).toBe(202)
+    expect(response[0].data).toMatchObject({
+      status: 'SUCCESS',
+      data: {
+        message: 'User identified'
+      }
+    })
+    expect(response.length).toBe(1)
+  })
+})

--- a/packages/destination-actions/src/destinations/trackey/identify/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/trackey/identify/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'identifyUser'
+const destinationSlug = 'Trackey'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/trackey/identify/generated-types.ts
+++ b/packages/destination-actions/src/destinations/trackey/identify/generated-types.ts
@@ -1,0 +1,22 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The user identifier to associate the event with
+   */
+  userId: string
+  /**
+   * A unique value for each event.
+   */
+  messageId?: string
+  /**
+   * Timestamp that the event took place, in ISO 8601 format. e.g. 2019-06-12T19:11:01.152Z
+   */
+  timestamp: string
+  /**
+   * User profile information
+   */
+  traits?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/trackey/identify/index.ts
+++ b/packages/destination-actions/src/destinations/trackey/identify/index.ts
@@ -1,0 +1,54 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { baseUrl } from '../constants'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Identify User',
+  description: 'Identify a user',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    userId: {
+      label: 'User ID',
+      type: 'string',
+      required: true,
+      description: 'The user identifier to associate the event with',
+      default: { '@path': '$.userId' }
+    },
+    messageId: {
+      label: 'Message ID',
+      type: 'string',
+      description: 'A unique value for each event.',
+      default: {
+        '@path': '$.messageId'
+      }
+    },
+    timestamp: {
+      label: 'Event Timestamp',
+      type: 'string',
+      required: true,
+      description: 'Timestamp that the event took place, in ISO 8601 format. e.g. 2019-06-12T19:11:01.152Z',
+      default: { '@path': '$.timestamp' }
+    },
+    traits: {
+      label: 'User Traits',
+      type: 'object',
+      required: false,
+      description: 'User profile information',
+      default: { '@path': '$.traits' }
+    }
+  },
+  perform: (request, { payload }) => {
+    return request(baseUrl, {
+      method: 'POST',
+      json: {
+        userId: payload.userId,
+        messageId: payload.messageId,
+        timestamp: payload.timestamp,
+        traits: payload.traits
+      }
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/trackey/index.ts
+++ b/packages/destination-actions/src/destinations/trackey/index.ts
@@ -1,9 +1,8 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
-
-//const base = 'https://6550-2-139-22-73.ngrok-free.app/';
-const base = 'https://eo493p73oqjeket.m.pipedream.net/'
-const endpoint = base + 'public-api/integrations/segment/webhook'
+import identifyUser from './identify'
+import trackEvent from './track'
+import registerCompany from './group'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Trackey',
@@ -24,185 +23,15 @@ const destination: DestinationDefinition<Settings> = {
   extendRequest: ({ settings }) => {
     return {
       headers: {
-        'api-key': settings.apiKey,
+        api_key: settings.apiKey,
         'Content-Type': 'application/json'
       }
     }
   },
   actions: {
-    track: {
-      title: 'track',
-      description: 'Track an event',
-      defaultSubscription: 'type = "track"',
-      fields: {
-        userId: {
-          label: 'User ID',
-          type: 'string',
-          required: true,
-          description: 'The user identifier to associate the event with',
-          default: { '@path': '$.userId' }
-        },
-        event: {
-          label: 'Event Name',
-          type: 'string',
-          required: true,
-          description: 'Name of the Segment track() event',
-          default: { '@path': '$.event' }
-        },
-        messageId: {
-          label: 'Message ID',
-          type: 'string',
-          description: 'A unique value for each event.',
-          default: {
-            '@path': '$.messageId'
-          }
-        },
-        timestamp: {
-          label: 'Event Timestamp',
-          type: 'string',
-          required: true,
-          description: 'Timestamp that the event took place, in ISO 8601 format. e.g. 2019-06-12T19:11:01.152Z',
-          default: { '@path': '$.timestamp' }
-        },
-        properties: {
-          label: 'Event Properties',
-          type: 'object',
-          required: false,
-          description: 'Additional information associated with the track() event',
-          default: { '@path': '$.properties' }
-        },
-        groupId: {
-          label: 'Group ID',
-          type: 'object',
-          required: false,
-          description: 'Company ID associated with the event',
-          default: { '@path': '$.context.group_id' }
-        }
-      },
-      perform: (request, { payload }) => {
-        return request(endpoint, {
-          method: 'POST',
-          json: {
-            userId: payload.userId,
-            event: payload.event,
-            messageId: payload.messageId,
-            timestamp: payload.timestamp,
-            properties: payload.properties,
-            groupId: payload.groupId
-          }
-        })
-      }
-    },
-    identify: {
-      title: 'Identify',
-      description: 'Identify a user',
-      defaultSubscription: 'type = "identify"',
-      fields: {
-        userId: {
-          label: 'User ID',
-          type: 'string',
-          required: true,
-          description: 'The user identifier to associate the event with',
-          default: { '@path': '$.userId' }
-        },
-        messageId: {
-          label: 'Message ID',
-          type: 'string',
-          description: 'A unique value for each event.',
-          default: {
-            '@path': '$.messageId'
-          }
-        },
-        timestamp: {
-          label: 'Event Timestamp',
-          type: 'string',
-          required: true,
-          description: 'Timestamp that the event took place, in ISO 8601 format. e.g. 2019-06-12T19:11:01.152Z',
-          default: { '@path': '$.timestamp' }
-        },
-        traits: {
-          label: 'User Traits',
-          type: 'object',
-          required: false,
-          description: 'User profile information',
-          default: { '@path': '$.traits' }
-        },
-        groupId: {
-          label: 'Group ID',
-          type: 'object',
-          required: false,
-          description: 'Company ID associated with the event',
-          default: { '@path': '$.context.group_id' }
-        }
-      },
-      perform: (request, { payload }) => {
-        return request(endpoint, {
-          method: 'POST',
-          json: {
-            userId: payload.userId,
-            messageId: payload.messageId,
-            timestamp: payload.timestamp,
-            traits: payload.traits,
-            groupId: payload.groupId
-          }
-        })
-      }
-    },
-    group: {
-      title: 'Group',
-      description: 'Group a user',
-      defaultSubscription: 'type = "group"',
-      fields: {
-        userId: {
-          label: 'User ID',
-          type: 'string',
-          required: true,
-          description: 'The user identifier to associate the event with',
-          default: { '@path': '$.userId' }
-        },
-        messageId: {
-          label: 'Message ID',
-          type: 'string',
-          description: 'A unique value for each event.',
-          default: {
-            '@path': '$.messageId'
-          }
-        },
-        timestamp: {
-          label: 'Event Timestamp',
-          type: 'string',
-          required: true,
-          description: 'Timestamp that the event took place, in ISO 8601 format. e.g. 2019-06-12T19:11:01.152Z',
-          default: { '@path': '$.timestamp' }
-        },
-        traits: {
-          label: 'Company Traits',
-          type: 'object',
-          required: false,
-          description: 'Company profile information',
-          default: { '@path': '$.traits' }
-        },
-        groupId: {
-          label: 'Group ID',
-          type: 'object',
-          required: true,
-          description: 'Company ID associated with the event',
-          default: { '@path': '$.groupId' }
-        }
-      },
-      perform: (request, { payload }) => {
-        return request(endpoint, {
-          method: 'POST',
-          json: {
-            userId: payload.userId,
-            messageId: payload.messageId,
-            timestamp: payload.timestamp,
-            traits: payload.traits,
-            groupId: payload.groupId
-          }
-        })
-      }
-    }
+    identifyUser,
+    trackEvent,
+    registerCompany
   }
 }
 

--- a/packages/destination-actions/src/destinations/trackey/track/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/trackey/track/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Trackey's trackEvent destination action: all fields 1`] = `
+Object {
+  "event": ")6YuL#JK44tb69K",
+  "groupId": Object {
+    "testType": ")6YuL#JK44tb69K",
+  },
+  "messageId": ")6YuL#JK44tb69K",
+  "properties": Object {
+    "testType": ")6YuL#JK44tb69K",
+  },
+  "timestamp": ")6YuL#JK44tb69K",
+  "userId": ")6YuL#JK44tb69K",
+}
+`;
+
+exports[`Testing snapshot for Trackey's trackEvent destination action: required fields 1`] = `
+Object {
+  "event": ")6YuL#JK44tb69K",
+  "timestamp": ")6YuL#JK44tb69K",
+  "userId": ")6YuL#JK44tb69K",
+}
+`;

--- a/packages/destination-actions/src/destinations/trackey/track/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/trackey/track/__tests__/index.test.ts
@@ -1,0 +1,46 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import nock from 'nock'
+import { baseUrl } from '../../constants'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+const timestamp = '2023-02-22T15:21:15.449Z'
+
+describe('Trackey.trackEvent', () => {
+  it('Sends the tracked events data correctly', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      userId: 'test-user-id',
+      event: 'test-event',
+      timestamp,
+      groupId: 'test-group-id',
+      properties: { 'event-prop-1': 'test-value', 'event-prop-2': 'test-value-2' }
+    })
+
+    nock(baseUrl)
+      .post('')
+      .reply(202, {
+        status: 'SUCCESS',
+        data: {
+          message: 'Event tracked'
+        }
+      })
+
+    const response = await testDestination.testAction('registerCompany', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        apiKey: 'test-api-key'
+      }
+    })
+
+    expect(response[0].status).toBe(202)
+    expect(response[0].data).toMatchObject({
+      status: 'SUCCESS',
+      data: {
+        message: 'Event tracked'
+      }
+    })
+    expect(response.length).toBe(1)
+  })
+})

--- a/packages/destination-actions/src/destinations/trackey/track/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/trackey/track/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'trackEvent'
+const destinationSlug = 'Trackey'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/trackey/track/generated-types.ts
+++ b/packages/destination-actions/src/destinations/trackey/track/generated-types.ts
@@ -1,0 +1,32 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The user identifier to associate the event with
+   */
+  userId: string
+  /**
+   * Name of the Segment track() event
+   */
+  event: string
+  /**
+   * A unique value for each event.
+   */
+  messageId?: string
+  /**
+   * Timestamp that the event took place, in ISO 8601 format. e.g. 2019-06-12T19:11:01.152Z
+   */
+  timestamp: string
+  /**
+   * Additional information associated with the track() event
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+  /**
+   * Company ID associated with the event
+   */
+  groupId?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/trackey/track/index.ts
+++ b/packages/destination-actions/src/destinations/trackey/track/index.ts
@@ -1,0 +1,70 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { baseUrl } from '../constants'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Track Event',
+  description: 'Track an event',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    userId: {
+      label: 'User ID',
+      type: 'string',
+      required: true,
+      description: 'The user identifier to associate the event with',
+      default: { '@path': '$.userId' }
+    },
+    event: {
+      label: 'Event Name',
+      type: 'string',
+      required: true,
+      description: 'Name of the Segment track() event',
+      default: { '@path': '$.event' }
+    },
+    messageId: {
+      label: 'Message ID',
+      type: 'string',
+      description: 'A unique value for each event.',
+      default: {
+        '@path': '$.messageId'
+      }
+    },
+    timestamp: {
+      label: 'Event Timestamp',
+      type: 'string',
+      required: true,
+      description: 'Timestamp that the event took place, in ISO 8601 format. e.g. 2019-06-12T19:11:01.152Z',
+      default: { '@path': '$.timestamp' }
+    },
+    properties: {
+      label: 'Event Properties',
+      type: 'object',
+      required: false,
+      description: 'Additional information associated with the track() event',
+      default: { '@path': '$.properties' }
+    },
+    groupId: {
+      label: 'Group ID',
+      type: 'object',
+      required: false,
+      description: 'Company ID associated with the event',
+      default: { '@path': '$.context.group_id' }
+    }
+  },
+  perform: (request, { payload }) => {
+    return request(baseUrl, {
+      method: 'POST',
+      json: {
+        userId: payload.userId,
+        event: payload.event,
+        messageId: payload.messageId,
+        timestamp: payload.timestamp,
+        properties: payload.properties,
+        groupId: payload.groupId
+      }
+    })
+  }
+}
+
+export default action


### PR DESCRIPTION
Trackey is not yet in use by customers. 

Partner has refactored out the Actions into separate folders so that tests could be created. 

The original PR is [here](https://github.com/segmentio/action-destinations/pull/1711), however I created this PR to ensure we keep the Action folder names the same so that we can avoid having to do a DB migration. 

## Testing

Purpose of this PR was to refactor and add tests. 