### PR TITLE
[DevRev]: Add event_id to streamEvent

### DIFF
--- a/packages/destination-actions/src/destinations/devrev/streamEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/devrev/streamEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Testing snapshot for Devrev's streamEvent destination action: all field
 Object {
   "events_list": Array [
     Object {
-      "event_id": "test-event-id",
+      "event_id": "sZcTM%n(kDC3tsz4iK5h",
       "event_time": "2021-02-01T00:00:00.000Z",
       "name": "sZcTM%n(kDC3tsz4iK5h",
       "payload": Object {

--- a/packages/destination-actions/src/destinations/devrev/streamEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/devrev/streamEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,6 +4,7 @@ exports[`Testing snapshot for Devrev's streamEvent destination action: all field
 Object {
   "events_list": Array [
     Object {
+      "event_id": "test-event-id",
       "event_time": "2021-02-01T00:00:00.000Z",
       "name": "sZcTM%n(kDC3tsz4iK5h",
       "payload": Object {
@@ -33,6 +34,7 @@ exports[`Testing snapshot for Devrev's streamEvent destination action: required 
 Object {
   "events_list": Array [
     Object {
+      "event_id": "test-event-id",
       "event_time": "2021-02-01T00:00:00.000Z",
       "name": "sZcTM%n(kDC3tsz4iK5h",
       "payload": Object {

--- a/packages/destination-actions/src/destinations/devrev/streamEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/devrev/streamEvent/__tests__/index.test.ts
@@ -14,10 +14,6 @@ import {
   testWorkspaceRef
 } from '../../mocks'
 
-jest.mock('@lukeed/uuid', () => ({
-  v4: jest.fn(() => 'test-event-id')
-}))
-
 const testDestination = createTestIntegration(Destination)
 
 describe('Devrev.streamEvent', () => {
@@ -60,7 +56,7 @@ describe('Devrev.streamEvent', () => {
       events_list: [
         {
           name: testEventPayload.event as string,
-          event_id: 'test-event-id',
+          event_id: testMessageId,
           event_time: testEventPayload.timestamp as string,
           payload: {
             eventName: testEventPayload.event,

--- a/packages/destination-actions/src/destinations/devrev/streamEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/devrev/streamEvent/__tests__/index.test.ts
@@ -14,6 +14,10 @@ import {
   testWorkspaceRef
 } from '../../mocks'
 
+jest.mock('@lukeed/uuid', () => ({
+  v4: jest.fn(() => 'test-event-id')
+}))
+
 const testDestination = createTestIntegration(Destination)
 
 describe('Devrev.streamEvent', () => {
@@ -56,6 +60,7 @@ describe('Devrev.streamEvent', () => {
       events_list: [
         {
           name: testEventPayload.event as string,
+          event_id: 'test-event-id',
           event_time: testEventPayload.timestamp as string,
           payload: {
             eventName: testEventPayload.event,

--- a/packages/destination-actions/src/destinations/devrev/streamEvent/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/devrev/streamEvent/__tests__/snapshot.test.ts
@@ -3,6 +3,10 @@ import { generateTestData } from '../../../../lib/test-data'
 import destination from '../../index'
 import nock from 'nock'
 
+jest.mock('@lukeed/uuid', () => ({
+  v4: jest.fn(() => 'test-event-id')
+}))
+
 const testDestination = createTestIntegration(destination)
 const actionSlug = 'streamEvent'
 const destinationSlug = 'Devrev'

--- a/packages/destination-actions/src/destinations/devrev/streamEvent/index.ts
+++ b/packages/destination-actions/src/destinations/devrev/streamEvent/index.ts
@@ -3,6 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { TrackEventsPublishBody, devrevApiPaths, getBaseUrl } from '../utils'
 import { RequestOptions } from '@segment/actions-core'
+import { v4 as uuidv4 } from '@lukeed/uuid'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Stream Event',
@@ -122,6 +123,7 @@ const action: ActionDefinition<Settings, Payload> = {
         {
           name: eventName,
           event_time: timestamp.toString(),
+          event_id: uuidv4(),
           payload: {
             // add mapped data to payload
             ...payload,

--- a/packages/destination-actions/src/destinations/devrev/streamEvent/index.ts
+++ b/packages/destination-actions/src/destinations/devrev/streamEvent/index.ts
@@ -123,7 +123,7 @@ const action: ActionDefinition<Settings, Payload> = {
         {
           name: eventName,
           event_time: timestamp.toString(),
-          event_id: uuidv4(),
+          event_id: payload.messageId || uuidv4(),
           payload: {
             // add mapped data to payload
             ...payload,

--- a/packages/destination-actions/src/destinations/devrev/utils/types.ts
+++ b/packages/destination-actions/src/destinations/devrev/utils/types.ts
@@ -120,6 +120,7 @@ export interface CreateAccountBody {
 }
 
 export interface TraceEvent {
+  event_id: string
   event_time: string
   name: string
   payload: object


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Adds a field `event_id`  which is a UUID to uniquely identify an event in `streamEvent`

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
