### PR TITLE
Algolia Insightes - adding 2 new fields

### DIFF
--- a/packages/destination-actions/src/destinations/algolia-insights/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,8 +4,8 @@ exports[`Testing snapshot for actions-algolia-insights destination: conversionEv
 Object {
   "events": Array [
     Object {
-      "eventName": "Conversion Event",
-      "eventType": "conversion",
+      "eventName": "U[ABpE$k",
+      "eventType": "view",
       "index": "U[ABpE$k",
       "objectIDs": Array [
         "U[ABpE$k",
@@ -23,8 +23,8 @@ exports[`Testing snapshot for actions-algolia-insights destination: conversionEv
 Object {
   "events": Array [
     Object {
-      "eventName": "Conversion Event",
-      "eventType": "conversion",
+      "eventName": "U[ABpE$k",
+      "eventType": "view",
       "index": "U[ABpE$k",
       "objectIDs": Array [
         "U[ABpE$k",
@@ -39,8 +39,8 @@ exports[`Testing snapshot for actions-algolia-insights destination: productAdded
 Object {
   "events": Array [
     Object {
-      "eventName": "Add to cart",
-      "eventType": "conversion",
+      "eventName": "g)$f*TeM",
+      "eventType": "view",
       "index": "g)$f*TeM",
       "objectIDs": Array [
         "g)$f*TeM",
@@ -58,8 +58,8 @@ exports[`Testing snapshot for actions-algolia-insights destination: productAdded
 Object {
   "events": Array [
     Object {
-      "eventName": "Add to cart",
-      "eventType": "conversion",
+      "eventName": "g)$f*TeM",
+      "eventType": "view",
       "index": "g)$f*TeM",
       "objectIDs": Array [
         "g)$f*TeM",
@@ -74,8 +74,8 @@ exports[`Testing snapshot for actions-algolia-insights destination: productClick
 Object {
   "events": Array [
     Object {
-      "eventName": "Product Clicked",
-      "eventType": "click",
+      "eventName": "LLjxSD^^GnH",
+      "eventType": "conversion",
       "index": "LLjxSD^^GnH",
       "objectIDs": Array [
         "LLjxSD^^GnH",
@@ -96,8 +96,8 @@ exports[`Testing snapshot for actions-algolia-insights destination: productClick
 Object {
   "events": Array [
     Object {
-      "eventName": "Product Clicked",
-      "eventType": "click",
+      "eventName": "LLjxSD^^GnH",
+      "eventType": "conversion",
       "index": "LLjxSD^^GnH",
       "objectIDs": Array [
         "LLjxSD^^GnH",
@@ -112,8 +112,8 @@ exports[`Testing snapshot for actions-algolia-insights destination: productListF
 Object {
   "events": Array [
     Object {
-      "eventName": "Product List Filtered",
-      "eventType": "click",
+      "eventName": "6O0djra",
+      "eventType": "view",
       "filters": Array [
         "6O0djra:6O0djra",
       ],
@@ -131,8 +131,8 @@ exports[`Testing snapshot for actions-algolia-insights destination: productListF
 Object {
   "events": Array [
     Object {
-      "eventName": "Product List Filtered",
-      "eventType": "click",
+      "eventName": "6O0djra",
+      "eventType": "view",
       "filters": Array [
         "6O0djra:6O0djra",
       ],
@@ -147,7 +147,7 @@ exports[`Testing snapshot for actions-algolia-insights destination: productViewe
 Object {
   "events": Array [
     Object {
-      "eventName": "Product Viewed",
+      "eventName": "BLFCPcmz",
       "eventType": "view",
       "index": "BLFCPcmz",
       "objectIDs": Array [
@@ -166,7 +166,7 @@ exports[`Testing snapshot for actions-algolia-insights destination: productViewe
 Object {
   "events": Array [
     Object {
-      "eventName": "Product Viewed",
+      "eventName": "BLFCPcmz",
       "eventType": "view",
       "index": "BLFCPcmz",
       "objectIDs": Array [

--- a/packages/destination-actions/src/destinations/algolia-insights/algolia-insight-api.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/algolia-insight-api.ts
@@ -4,32 +4,31 @@ export const AlgoliaBehaviourURL = BaseAlgoliaInsightsURL + '/1/events'
 export const algoliaApiPermissionsUrl = (settings: Settings) =>
   `https://${settings.appId}.algolia.net/1/keys/${settings.apiKey}`
 
+export type AlgoliaEventType = 'view' | 'click' | 'conversion'
+
 type EventCommon = {
   eventName: string
   index: string
   userToken: string
   timestamp?: number
   queryID?: string
+  eventType: AlgoliaEventType
 }
 
 export type AlgoliaProductViewedEvent = EventCommon & {
-  eventType: 'view'
   objectIDs: string[]
 }
 
 export type AlgoliaProductClickedEvent = EventCommon & {
-  eventType: 'click'
   positions?: number[]
   objectIDs: string[]
 }
 
 export type AlgoliaFilterClickedEvent = EventCommon & {
-  eventType: 'click'
   filters: string[]
 }
 
 export type AlgoliaConversionEvent = EventCommon & {
-  eventType: 'conversion'
   objectIDs: string[]
 }
 

--- a/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,8 +4,8 @@ exports[`Testing snapshot for AlgoliaInsights's conversionEvents destination act
 Object {
   "events": Array [
     Object {
-      "eventName": "Conversion Event",
-      "eventType": "conversion",
+      "eventName": ")j)vR5%1AP*epuo8A%R",
+      "eventType": "click",
       "index": ")j)vR5%1AP*epuo8A%R",
       "objectIDs": Array [
         ")j)vR5%1AP*epuo8A%R",
@@ -23,8 +23,8 @@ exports[`Testing snapshot for AlgoliaInsights's conversionEvents destination act
 Object {
   "events": Array [
     Object {
-      "eventName": "Conversion Event",
-      "eventType": "conversion",
+      "eventName": ")j)vR5%1AP*epuo8A%R",
+      "eventType": "click",
       "index": ")j)vR5%1AP*epuo8A%R",
       "objectIDs": Array [
         ")j)vR5%1AP*epuo8A%R",

--- a/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/generated-types.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/generated-types.ts
@@ -29,4 +29,12 @@ export interface Payload {
   extraProperties?: {
     [k: string]: unknown
   }
+  /**
+   * The name of the event to be send to Algolia. Defaults to 'Conversion Event'
+   */
+  eventName: string
+  /**
+   * The type of event to send to Algolia. Defaults to 'conversion'
+   */
+  eventType: string
 }

--- a/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/index.ts
@@ -1,6 +1,6 @@
 import type { ActionDefinition, Preset } from '@segment/actions-core'
 import { defaultValues } from '@segment/actions-core'
-import { AlgoliaBehaviourURL, AlgoliaConversionEvent } from '../algolia-insight-api'
+import { AlgoliaBehaviourURL, AlgoliaConversionEvent, AlgoliaEventType } from '../algolia-insight-api'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
@@ -68,14 +68,33 @@ export const conversionEvents: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.properties'
       }
+    },
+    eventName: {
+      label: 'Event Name',
+      description: "The name of the event to be send to Algolia. Defaults to 'Conversion Event'",
+      type: 'string',
+      required: true,
+      default: 'Conversion Event'
+    },
+    eventType: {
+      label: 'Event Type',
+      description: "The type of event to send to Algolia. Defaults to 'conversion'",
+      type: 'string',
+      required: true,
+      default: 'conversion',
+      choices: [
+        { label: 'view', value: 'view' },
+        { label: 'conversion', value: 'conversion' },
+        { label: 'click', value: 'click' }
+      ]
     }
   },
   defaultSubscription: 'type = "track" and event = "Order Completed"',
   perform: (request, data) => {
     const insightEvent: AlgoliaConversionEvent = {
       ...data.payload.extraProperties,
-      eventName: 'Conversion Event',
-      eventType: 'conversion',
+      eventName: data.payload.eventName ?? 'Conversion Event',
+      eventType: (data.payload.eventType as AlgoliaEventType) ?? ('conversion' as AlgoliaEventType),
       index: data.payload.index,
       queryID: data.payload.queryID,
       objectIDs: data.payload.products.map((product) => product.product_id),

--- a/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,8 +4,8 @@ exports[`Testing snapshot for AlgoliaInsights's productAddedEvents destination a
 Object {
   "events": Array [
     Object {
-      "eventName": "Add to cart",
-      "eventType": "conversion",
+      "eventName": "D9W&9sjJ$g9LNBPqU",
+      "eventType": "click",
       "index": "D9W&9sjJ$g9LNBPqU",
       "objectIDs": Array [
         "D9W&9sjJ$g9LNBPqU",
@@ -23,8 +23,8 @@ exports[`Testing snapshot for AlgoliaInsights's productAddedEvents destination a
 Object {
   "events": Array [
     Object {
-      "eventName": "Add to cart",
-      "eventType": "conversion",
+      "eventName": "D9W&9sjJ$g9LNBPqU",
+      "eventType": "click",
       "index": "D9W&9sjJ$g9LNBPqU",
       "objectIDs": Array [
         "D9W&9sjJ$g9LNBPqU",

--- a/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/generated-types.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/generated-types.ts
@@ -27,4 +27,12 @@ export interface Payload {
   extraProperties?: {
     [k: string]: unknown
   }
+  /**
+   * The name of the event to be send to Algolia. Defaults to 'Add to cart'
+   */
+  eventName: string
+  /**
+   * The type of event to send to Algolia. Defaults to 'conversion'
+   */
+  eventType: string
 }

--- a/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/index.ts
@@ -2,7 +2,7 @@ import type { ActionDefinition, Preset } from '@segment/actions-core'
 import { defaultValues } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { AlgoliaBehaviourURL, AlgoliaConversionEvent } from '../algolia-insight-api'
+import { AlgoliaBehaviourURL, AlgoliaConversionEvent, AlgoliaEventType } from '../algolia-insight-api'
 
 export const productAddedEvents: ActionDefinition<Settings, Payload> = {
   title: 'Product Added Events',
@@ -66,14 +66,33 @@ export const productAddedEvents: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.properties'
       }
+    },
+    eventName: {
+      label: 'Event Name',
+      description: "The name of the event to be send to Algolia. Defaults to 'Add to cart'",
+      type: 'string',
+      required: true,
+      default: 'Add to cart'
+    },
+    eventType: {
+      label: 'Event Type',
+      description: "The type of event to send to Algolia. Defaults to 'conversion'",
+      type: 'string',
+      required: true,
+      default: 'conversion',
+      choices: [
+        { label: 'view', value: 'view' },
+        { label: 'conversion', value: 'conversion' },
+        { label: 'click', value: 'click' }
+      ]
     }
   },
   defaultSubscription: 'type = "track" and event = "Product Added"',
   perform: (request, data) => {
     const insightEvent: AlgoliaConversionEvent = {
       ...data.payload.extraProperties,
-      eventName: 'Add to cart',
-      eventType: 'conversion',
+      eventName: data.payload.eventName ?? 'Add to cart',
+      eventType: (data.payload.eventType as AlgoliaEventType) ?? ('conversion' as AlgoliaEventType),
       index: data.payload.index,
       queryID: data.payload.queryID,
       objectIDs: [data.payload.product],

--- a/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,8 +4,8 @@ exports[`Testing snapshot for AlgoliaInsights's productClickedEvents destination
 Object {
   "events": Array [
     Object {
-      "eventName": "Product Clicked",
-      "eventType": "click",
+      "eventName": "tTO6#",
+      "eventType": "view",
       "index": "tTO6#",
       "objectIDs": Array [
         "tTO6#",
@@ -26,8 +26,8 @@ exports[`Testing snapshot for AlgoliaInsights's productClickedEvents destination
 Object {
   "events": Array [
     Object {
-      "eventName": "Product Clicked",
-      "eventType": "click",
+      "eventName": "tTO6#",
+      "eventType": "view",
       "index": "tTO6#",
       "objectID": "tTO6#",
       "objectIDs": Array [

--- a/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/generated-types.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/generated-types.ts
@@ -31,4 +31,12 @@ export interface Payload {
   extraProperties?: {
     [k: string]: unknown
   }
+  /**
+   * The name of the event to be send to Algolia. Defaults to 'Product Clicked'
+   */
+  eventName: string
+  /**
+   * The type of event to send to Algolia. Defaults to 'click'
+   */
+  eventType: string
 }

--- a/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productClickedEvents/index.ts
@@ -1,6 +1,6 @@
 import type { ActionDefinition, Preset } from '@segment/actions-core'
 import { defaultValues } from '@segment/actions-core'
-import { AlgoliaBehaviourURL, AlgoliaProductClickedEvent } from '../algolia-insight-api'
+import { AlgoliaBehaviourURL, AlgoliaProductClickedEvent, AlgoliaEventType } from '../algolia-insight-api'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
@@ -73,14 +73,33 @@ export const productClickedEvents: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.properties'
       }
+    },
+    eventName: {
+      label: 'Event Name',
+      description: "The name of the event to be send to Algolia. Defaults to 'Product Clicked'",
+      type: 'string',
+      required: true,
+      default: 'Product Clicked'
+    },
+    eventType: {
+      label: 'Event Type',
+      description: "The type of event to send to Algolia. Defaults to 'click'",
+      type: 'string',
+      required: true,
+      default: 'click',
+      choices: [
+        { label: 'view', value: 'view' },
+        { label: 'conversion', value: 'conversion' },
+        { label: 'click', value: 'click' }
+      ]
     }
   },
   defaultSubscription: 'type = "track" and event = "Product Clicked"',
   perform: (request, data) => {
     const insightEvent: AlgoliaProductClickedEvent = {
       ...data.payload.extraProperties,
-      eventName: 'Product Clicked',
-      eventType: 'click',
+      eventName: data.payload.eventName ?? 'Product Clicked',
+      eventType: (data.payload.eventType as AlgoliaEventType) ?? ('click' as AlgoliaEventType),
       index: data.payload.index,
       queryID: data.payload.queryID,
       objectIDs: [data.payload.objectID],

--- a/packages/destination-actions/src/destinations/algolia-insights/productListFilteredEvents/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/productListFilteredEvents/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,8 +4,8 @@ exports[`Testing snapshot for AlgoliaInsights's productListFilteredEvents destin
 Object {
   "events": Array [
     Object {
-      "eventName": "Product List Filtered",
-      "eventType": "click",
+      "eventName": "E625IsTOULbrg8",
+      "eventType": "conversion",
       "filters": Array [
         "E625IsTOULbrg8:E625IsTOULbrg8",
       ],
@@ -23,8 +23,8 @@ exports[`Testing snapshot for AlgoliaInsights's productListFilteredEvents destin
 Object {
   "events": Array [
     Object {
-      "eventName": "Product List Filtered",
-      "eventType": "click",
+      "eventName": "E625IsTOULbrg8",
+      "eventType": "conversion",
       "filters": Array [
         "E625IsTOULbrg8:E625IsTOULbrg8",
       ],

--- a/packages/destination-actions/src/destinations/algolia-insights/productListFilteredEvents/generated-types.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productListFilteredEvents/generated-types.ts
@@ -36,4 +36,12 @@ export interface Payload {
   extraProperties?: {
     [k: string]: unknown
   }
+  /**
+   * The name of the event to be send to Algolia. Defaults to 'Product List Filtered'
+   */
+  eventName: string
+  /**
+   * The type of event to send to Algolia. Defaults to 'click'
+   */
+  eventType: string
 }

--- a/packages/destination-actions/src/destinations/algolia-insights/productListFilteredEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productListFilteredEvents/index.ts
@@ -1,6 +1,6 @@
 import type { ActionDefinition, Preset } from '@segment/actions-core'
 import { defaultValues } from '@segment/actions-core'
-import { AlgoliaBehaviourURL, AlgoliaFilterClickedEvent } from '../algolia-insight-api'
+import { AlgoliaBehaviourURL, AlgoliaFilterClickedEvent, AlgoliaEventType } from '../algolia-insight-api'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
@@ -72,6 +72,25 @@ export const productListFilteredEvents: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.properties'
       }
+    },
+    eventName: {
+      label: 'Event Name',
+      description: "The name of the event to be send to Algolia. Defaults to 'Product List Filtered'",
+      type: 'string',
+      required: true,
+      default: 'Product List Filtered'
+    },
+    eventType: {
+      label: 'Event Type',
+      description: "The type of event to send to Algolia. Defaults to 'click'",
+      type: 'string',
+      required: true,
+      default: 'click',
+      choices: [
+        { label: 'view', value: 'view' },
+        { label: 'conversion', value: 'conversion' },
+        { label: 'click', value: 'click' }
+      ]
     }
   },
   defaultSubscription: 'type = "track" and event = "Product List Filtered"',
@@ -79,8 +98,8 @@ export const productListFilteredEvents: ActionDefinition<Settings, Payload> = {
     const filters: string[] = data.payload.filters.map(({ attribute, value }) => `${attribute}:${value}`)
     const insightEvent: AlgoliaFilterClickedEvent = {
       ...data.payload.extraProperties,
-      eventName: 'Product List Filtered',
-      eventType: 'click',
+      eventName: data.payload.eventName ?? 'Product List Filtered',
+      eventType: (data.payload.eventType as AlgoliaEventType) ?? ('click' as AlgoliaEventType),
       index: data.payload.index,
       queryID: data.payload.queryID,
       filters,

--- a/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,8 +4,8 @@ exports[`Testing snapshot for AlgoliaInsights's productViewedEvents destination 
 Object {
   "events": Array [
     Object {
-      "eventName": "Product Viewed",
-      "eventType": "view",
+      "eventName": "og&DCP)aINw@qxe)",
+      "eventType": "click",
       "index": "og&DCP)aINw@qxe)",
       "objectIDs": Array [
         "og&DCP)aINw@qxe)",
@@ -23,8 +23,8 @@ exports[`Testing snapshot for AlgoliaInsights's productViewedEvents destination 
 Object {
   "events": Array [
     Object {
-      "eventName": "Product Viewed",
-      "eventType": "view",
+      "eventName": "og&DCP)aINw@qxe)",
+      "eventType": "click",
       "index": "og&DCP)aINw@qxe)",
       "objectID": "og&DCP)aINw@qxe)",
       "objectIDs": Array [

--- a/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/generated-types.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/generated-types.ts
@@ -27,4 +27,12 @@ export interface Payload {
   extraProperties?: {
     [k: string]: unknown
   }
+  /**
+   * The name of the event to be send to Algolia. Defaults to 'Product Viewed'
+   */
+  eventName: string
+  /**
+   * The type of event to send to Algolia. Defaults to 'view'
+   */
+  eventType: string
 }

--- a/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productViewedEvents/index.ts
@@ -1,6 +1,6 @@
 import type { ActionDefinition, Preset } from '@segment/actions-core'
 import { defaultValues } from '@segment/actions-core'
-import { AlgoliaBehaviourURL, AlgoliaProductViewedEvent } from '../algolia-insight-api'
+import { AlgoliaBehaviourURL, AlgoliaProductViewedEvent, AlgoliaEventType } from '../algolia-insight-api'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
@@ -65,14 +65,33 @@ export const productViewedEvents: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.properties'
       }
+    },
+    eventName: {
+      label: 'Event Name',
+      description: "The name of the event to be send to Algolia. Defaults to 'Product Viewed'",
+      type: 'string',
+      required: true,
+      default: 'Product Viewed'
+    },
+    eventType: {
+      label: 'Event Type',
+      description: "The type of event to send to Algolia. Defaults to 'view'",
+      type: 'string',
+      required: true,
+      default: 'view',
+      choices: [
+        { label: 'view', value: 'view' },
+        { label: 'conversion', value: 'conversion' },
+        { label: 'click', value: 'click' }
+      ]
     }
   },
   defaultSubscription: 'type = "track" and event = "Product Viewed"',
   perform: (request, data) => {
     const insightEvent: AlgoliaProductViewedEvent = {
       ...data.payload.extraProperties,
-      eventName: 'Product Viewed',
-      eventType: 'view',
+      eventName: data.payload.eventName ?? 'Product Viewed',
+      eventType: (data.payload.eventType as AlgoliaEventType) ?? ('view' as AlgoliaEventType),
       index: data.payload.index,
       queryID: data.payload.queryID,
       objectIDs: [data.payload.objectID],


### PR DESCRIPTION
Update allows customers to select the name of the event and type of event to send to Algolia for each Action. 

Default values will remain in place. 

## Testing

Tested with Actions Tester locally