### PR TITLE
Add computation id and audience id to engage stats

### DIFF
--- a/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/actionDefinition.ts
+++ b/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/actionDefinition.ts
@@ -138,6 +138,16 @@ export const actionDefinition: ActionDefinition<Settings, Payload> = {
       multiple: true,
       properties: apiLookupActionFields
     },
+    segmentComputationId: {
+      label: 'Segment Computation ID',
+      description: 'Segment computation ID',
+      type: 'string',
+      unsafe_hidden: true,
+      required: true,
+      default: {
+        '@path': '$.context.personas.computation_id'
+      }
+    },
     externalIds: {
       label: 'External IDs',
       description: 'An array of user profile identity information.',

--- a/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/actionDefinition.ts
+++ b/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/actionDefinition.ts
@@ -142,8 +142,7 @@ export const actionDefinition: ActionDefinition<Settings, Payload> = {
       label: 'Segment Computation ID',
       description: 'Segment computation ID',
       type: 'string',
-      unsafe_hidden: true,
-      required: true,
+      required: false,
       default: {
         '@path': '$.context.personas.computation_id'
       }

--- a/packages/destination-actions/src/destinations/engage/twilio/sendMobilePush/actionDefinition.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/sendMobilePush/actionDefinition.ts
@@ -167,8 +167,7 @@ export const actionDefinition: ActionDefinition<Settings, Payload> = {
       label: 'Segment Computation ID',
       description: 'Segment computation ID',
       type: 'string',
-      unsafe_hidden: true,
-      required: true,
+      required: false,
       default: {
         '@path': '$.context.personas.computation_id'
       }

--- a/packages/destination-actions/src/destinations/engage/twilio/sendMobilePush/actionDefinition.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/sendMobilePush/actionDefinition.ts
@@ -163,6 +163,16 @@ export const actionDefinition: ActionDefinition<Settings, Payload> = {
       required: false,
       default: false
     },
+    segmentComputationId: {
+      label: 'Segment Computation ID',
+      description: 'Segment computation ID',
+      type: 'string',
+      unsafe_hidden: true,
+      required: true,
+      default: {
+        '@path': '$.context.personas.computation_id'
+      }
+    },
     externalIds: {
       label: 'External IDs',
       description: 'An array of user profile identity information.',

--- a/packages/destination-actions/src/destinations/engage/twilio/sendSms/actionDefinition.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/sendSms/actionDefinition.ts
@@ -82,8 +82,7 @@ export const actionDefinition: ActionDefinition<Settings, Payload> = {
       label: 'Segment Computation ID',
       description: 'Segment computation ID',
       type: 'string',
-      unsafe_hidden: true,
-      required: true,
+      required: false,
       default: {
         '@path': '$.context.personas.computation_id'
       }

--- a/packages/destination-actions/src/destinations/engage/twilio/sendSms/actionDefinition.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/sendSms/actionDefinition.ts
@@ -78,6 +78,16 @@ export const actionDefinition: ActionDefinition<Settings, Payload> = {
       type: 'boolean',
       default: false
     },
+    segmentComputationId: {
+      label: 'Segment Computation ID',
+      description: 'Segment computation ID',
+      type: 'string',
+      unsafe_hidden: true,
+      required: true,
+      default: {
+        '@path': '$.context.personas.computation_id'
+      }
+    },
     externalIds: {
       label: 'External IDs',
       description: 'An array of user profile identity information.',

--- a/packages/destination-actions/src/destinations/engage/twilio/sendWhatsApp/actionDefinition.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/sendWhatsApp/actionDefinition.ts
@@ -63,8 +63,7 @@ export const actionDefinition: ActionDefinition<Settings, Payload> = {
       label: 'Segment Computation ID',
       description: 'Segment computation ID',
       type: 'string',
-      unsafe_hidden: true,
-      required: true,
+      required: false,
       default: {
         '@path': '$.context.personas.computation_id'
       }

--- a/packages/destination-actions/src/destinations/engage/twilio/sendWhatsApp/actionDefinition.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/sendWhatsApp/actionDefinition.ts
@@ -59,6 +59,16 @@ export const actionDefinition: ActionDefinition<Settings, Payload> = {
       required: false,
       default: true
     },
+    segmentComputationId: {
+      label: 'Segment Computation ID',
+      description: 'Segment computation ID',
+      type: 'string',
+      unsafe_hidden: true,
+      required: true,
+      default: {
+        '@path': '$.context.personas.computation_id'
+      }
+    },
     externalIds: {
       label: 'External IDs',
       description: 'An array of user profile identity information.',

--- a/packages/destination-actions/src/destinations/engage/utils/EngageStats.ts
+++ b/packages/destination-actions/src/destinations/engage/utils/EngageStats.ts
@@ -26,6 +26,7 @@ export class EngageStats extends OperationStats {
     ctx.sharedContext.tags.push(
       `space_id:${this.actionPerformer.settings.spaceId}`,
       `projectid:${this.actionPerformer.settings.sourceId}`,
+      `computation_id:${this.actionPerformer.payload.segmentComputationId}`,
       `settings_region:${this.actionPerformer.settings.region}`,
       `channel:${this.actionPerformer.getChannelType()}`
     )


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
