### PR TITLE
fix for empty string in setting

### DIFF
--- a/packages/browser-destinations/destinations/pendo-web-actions/src/loadScript.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/loadScript.ts
@@ -16,7 +16,7 @@ export function loadPendo(apiKey, region, cnameContentHost) {
       })(v[w])
     y = e.createElement(n)
     y.async = !0
-    y.src = `${cnameContentHost ?? region}/agent/static/${apiKey}/pendo.js`
+    y.src = `${cnameContentHost || region}/agent/static/${apiKey}/pendo.js`
     z = e.getElementsByTagName(n)[0]
     z.parentNode.insertBefore(y, z)
   })(window, document, 'script', 'pendo')


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Swapping out a nullish coalescing operator for a plain old `||` because the optional field `cnameContentHost` passes through as an empty string if left blank.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
