### PR TITLE
Channels-973: parse text field of action buttons

### DIFF
--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-mobile-push.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-mobile-push.test.ts
@@ -350,7 +350,7 @@ describe('sendMobilePush action', () => {
       expect(responses[0].data).toMatchObject(externalIds[0])
     })
 
-    it('parses links in tapActionButtons', async () => {
+    it('parses links and titles in tapActionButtons', async () => {
       const title = 'buy'
       const body = 'now'
       const tapAction = 'OPEN_DEEP_LINK'
@@ -365,7 +365,7 @@ describe('sendMobilePush action', () => {
         tapActionButtons: [
           {
             id: '1',
-            text: 'open',
+            text: 'open{{profile.traits.fav_color}}',
             onTap: 'deep_link',
             link: 'app://buy-now/{{profile.traits.fav_color}}'
           },
@@ -414,7 +414,7 @@ describe('sendMobilePush action', () => {
           tapActionButtons: [
             {
               id: '1',
-              text: 'open',
+              text: 'openmantis_green',
               onTap: 'deep_link',
               link: 'app://buy-now/mantis_green'
             },

--- a/packages/destination-actions/src/destinations/engage/twilio/sendMobilePush/PushSender.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/sendMobilePush/PushSender.ts
@@ -120,7 +120,7 @@ export class PushSender extends TwilioMessageSender<PushPayload> {
         return {
           ...button,
           onTap: this.getTapActionPreset(button.onTap, button.link),
-          ...(await this.parseContent({ link: button.link }, profile))
+          ...(await this.parseContent({ link: button.link, text: button.text }, profile))
         }
       })
     )


### PR DESCRIPTION
[Channels-973](https://segment.atlassian.net/browse/CHANNELS-973)

This PR adds liquid trait parsing to the text field of action buttons

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
