### PR TITLE
Yahoo audiences 5

### DIFF
--- a/packages/destination-actions/src/destinations/yahoo-audiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/__tests__/index.test.ts
@@ -19,8 +19,10 @@ const createAudienceInput = {
   },
   audienceName: '',
   audienceSettings: {
-    audience_key: AUDIENCE_KEY,
-    audience_id: AUDIENCE_ID
+    personas: {
+      computation_key: AUDIENCE_KEY,
+      computation_id: AUDIENCE_ID
+    }
   }
 }
 
@@ -28,7 +30,6 @@ describe('Yahoo Audiences', () => {
   describe('createAudience() function', () => {
     let testDestination: any
     const OLD_ENV = process.env
-
     beforeEach(() => {
       jest.resetModules() // Most important - it clears the cache
       process.env = { ...OLD_ENV } // Make a copy
@@ -53,24 +54,8 @@ describe('Yahoo Audiences', () => {
       })
     })
     describe('Failure cases', () => {
-      it('should throw an error when audience_id setting is missing', async () => {
-        createAudienceInput.settings.engage_space_id = 'acme_corp_engage_space'
-        createAudienceInput.audienceSettings.audience_key = 'sneakeres_buyers'
-        createAudienceInput.audienceSettings.audience_id = ''
-        await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(IntegrationError)
-      })
-
-      it('should throw an error when audience_key setting is missing', async () => {
-        createAudienceInput.settings.engage_space_id = 'acme_corp_engage_space'
-        createAudienceInput.audienceSettings.audience_key = ''
-        createAudienceInput.audienceSettings.audience_id = 'aud_12345'
-        await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(IntegrationError)
-      })
-
       it('should throw an error when engage_space_id setting is missing', async () => {
         createAudienceInput.settings.engage_space_id = ''
-        createAudienceInput.audienceSettings.audience_key = 'sneakeres_buyers'
-        createAudienceInput.audienceSettings.audience_id = 'aud_123456789012345678901234567'
         await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(IntegrationError)
       })
     })

--- a/packages/destination-actions/src/destinations/yahoo-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/generated-types.ts
@@ -18,11 +18,7 @@ export interface Settings {
 
 export interface AudienceSettings {
   /**
-   * Segment Audience Id (aud_...)
+   * Placeholder field to allow the audience to be created. Do not change this
    */
-  audience_id: string
-  /**
-   * Segment Audience Key
-   */
-  audience_key: string
+  placeholder?: boolean
 }

--- a/packages/destination-actions/src/destinations/yahoo-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/index.ts
@@ -55,7 +55,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
 
       const body_form_data = gen_customer_taxonomy_payload(settings)
       // The last 2 params are undefined because we don't have statsContext.statsClient and statsContext.tags in testAuthentication()
-      await update_taxonomy('', tx_creds, request, body_form_data, undefined, undefined)
+      return await update_taxonomy('', tx_creds, request, body_form_data, undefined, undefined)
     },
     refreshAccessToken: async (request, { auth }) => {
       // Refresh Realtime API token (Oauth2 client_credentials)
@@ -112,7 +112,6 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       const audience_id = personas.computation_id
       const audience_key = personas.computation_key
 
-      console.log(audience_id, audience_key)
       const statsClient = createAudienceInput?.statsContext?.statsClient
       const statsTags = createAudienceInput?.statsContext?.tags
 

--- a/packages/destination-actions/src/destinations/yahoo-audiences/updateSegment/generated-types.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/updateSegment/generated-types.ts
@@ -20,6 +20,10 @@ export interface Payload {
    */
   segment_computation_action: string
   /**
+   * Phone number of a user
+   */
+  phone?: string
+  /**
    * Email address of a user
    */
   email?: string
@@ -28,13 +32,17 @@ export interface Payload {
    */
   advertising_id?: string
   /**
-   * Phone number of a user
-   */
-  phone?: string
-  /**
    * User's mobile device type
    */
   device_type?: string
+  /**
+   * User iOS advertising Id
+   */
+  ios_advertising_id?: string
+  /**
+   * User Android advertising Id
+   */
+  android_advertising_id?: string
   /**
    * Set to true to indicate that audience data is subject to GDPR regulations
    */

--- a/packages/destination-actions/src/destinations/yahoo-audiences/updateSegment/generated-types.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/updateSegment/generated-types.ts
@@ -36,14 +36,6 @@ export interface Payload {
    */
   device_type?: string
   /**
-   * User iOS advertising Id
-   */
-  ios_advertising_id?: string
-  /**
-   * User Android advertising Id
-   */
-  android_advertising_id?: string
-  /**
    * Set to true to indicate that audience data is subject to GDPR regulations
    */
   gdpr_flag: boolean

--- a/packages/destination-actions/src/destinations/yahoo-audiences/updateSegment/index.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/updateSegment/index.ts
@@ -60,7 +60,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'User Phone',
       description: 'Phone number of a user',
       type: 'string',
-      unsafe_hidden: true,
+      unsafe_hidden: false,
       required: false,
       default: {
         '@if': {
@@ -74,7 +74,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'User Email',
       description: 'Email address of a user',
       type: 'string',
-      unsafe_hidden: true,
+      unsafe_hidden: false,
       required: false,
       default: {
         '@if': {
@@ -88,46 +88,20 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'User Mobile Advertising ID',
       description: "User's mobile advertising Id",
       type: 'string',
-      unsafe_hidden: true,
+      unsafe_hidden: false,
+      required: false,
       default: {
         '@path': '$.context.device.advertisingId'
-      },
-      required: false
+      }
     },
     device_type: {
       label: 'User Mobile Device Type', // This field is required to determine the type of the advertising Id: IDFA or GAID
       description: "User's mobile device type",
       type: 'string',
-      unsafe_hidden: true,
+      unsafe_hidden: false,
+      required: false,
       default: {
         '@path': '$.context.device.type'
-      },
-      required: false
-    },
-    ios_advertising_id: {
-      label: 'User iOS Advertising ID', // This field is used with trait enrichment for iOS advertising Id
-      description: 'User iOS advertising Id',
-      type: 'string',
-      unsafe_hidden: true,
-      default: {
-        '@if': {
-          exists: { '@path': '$.traits.ios_advertising_id' },
-          then: { '@path': '$.traits.ios_advertising_id' },
-          else: { '@path': '$.properties.ios_advertising_id' }
-        }
-      }
-    },
-    android_advertising_id: {
-      label: 'User Android Advertising ID', // This field is used with trait enrichment for Android advertising Id
-      description: 'User Android advertising Id',
-      type: 'string',
-      unsafe_hidden: true,
-      default: {
-        '@if': {
-          exists: { '@path': '$.traits.android_advertising_id' },
-          then: { '@path': '$.traits.android_advertising_id' },
-          else: { '@path': '$.properties.android_advertising_id' }
-        }
       }
     },
     gdpr_flag: {
@@ -148,12 +122,10 @@ const action: ActionDefinition<Settings, Payload> = {
 
   perform: (request, { payload, auth, statsContext }) => {
     const rt_access_token = auth?.accessToken
-    //const rt_access_token = 'cc606d91-1786-47a0-87fd-6f48ee70fa7c'
     return process_payload(request, [payload], rt_access_token, statsContext)
   },
   performBatch: (request, { payload, auth, statsContext }) => {
     const rt_access_token = auth?.accessToken
-    //const rt_access_token = 'cc606d91-1786-47a0-87fd-6f48ee70fa7c'
     return process_payload(request, payload, rt_access_token, statsContext)
   }
 }

--- a/packages/destination-actions/src/destinations/yahoo-audiences/utils-rt.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/utils-rt.ts
@@ -52,52 +52,7 @@ export function generate_jwt(client_id: string, client_secret: string): string {
  * @param payload The payload.
  * @returns {{ maid: boolean; email: boolean }} The definitions object (id_schema).
  */
-/*
-// TODO: remove this function. We inherit the id_schema from the payload. Once a user has mapped an 
-// identifier in Configurable Id sync, we can use the identifier from the payload.
-export function get_id_schema(
-  payload: Payload,
-  audienceSettings: AudienceSettings
-): { maid: boolean; email: boolean; phone: boolean } {
-  const schema = {
-    email: false,
-    maid: false,
-    phone: false
-  }
-  let id_type
-  audienceSettings.identifier ? (id_type = audienceSettings.identifier) : (id_type = payload.identifier)
-  switch (id_type) {
-    case 'email':
-      schema.email = true
-      break
-    case 'maid':
-      schema.maid = true
-      break
-    case 'phone':
-      schema.phone = true
-      break
-    case 'email_maid':
-      schema.maid = true
-      schema.email = true
-      break
-    case 'email_maid_phone':
-      schema.maid = true
-      schema.email = true
-      schema.phone = true
-      break
-    case 'email_phone':
-      schema.email = true
-      schema.phone = true
-      break
-    case 'phone_maid':
-      schema.phone = true
-      schema.maid = true
-      break
-  }
 
-  return schema
-}
-*/
 export function validate_phone(phone: string) {
   /*
   Phone must match E.164 format: a number up to 15 digits in length starting with a ‘+’
@@ -138,13 +93,22 @@ export function gen_update_segment_payload(payloads: Payload[]): YahooPayload {
     let idfa: string | undefined = ''
     let gpsaid: string | undefined = ''
     if (event.advertising_id) {
-      switch (event.device_type) {
-        case 'ios':
+      if (event.device_type) {
+        switch (event.device_type) {
+          case 'ios':
+            idfa = event.advertising_id
+            break
+          case 'android':
+            gpsaid = event.advertising_id
+            break
+        }
+      } else {
+        if (event.advertising_id === event.advertising_id.toUpperCase()) {
+          // Apple IDFA is always uppercase
           idfa = event.advertising_id
-          break
-        case 'android':
+        } else {
           gpsaid = event.advertising_id
-          break
+        }
       }
     }
     let hashed_phone: string | undefined = ''

--- a/packages/destination-actions/src/destinations/yahoo-audiences/utils-tax.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/utils-tax.ts
@@ -89,14 +89,13 @@ export async function update_taxonomy(
       }
     })
     if (statsClient && statsTags) {
-      statsClient.incr('update_taxonomy_success', 1, statsTags)
+      statsClient.incr('update_taxonomy.success', 1, statsTags)
     }
     return await add_segment_node.json()
   } catch (error) {
     const _error = error as { response: { data: unknown; status: string } }
     if (statsClient && statsTags) {
-      // TODO Incapsulate error codes into severar stats
-      statsClient.incr('util:update_taxonomy.error', 1, statsTags)
+      statsClient.incr('update_taxonomy.error', 1, statsTags)
     }
     // If Taxonomy API returned 401, throw Integration error w/status 400 to prevent refreshAccessToken from firing
     // Otherwise throw the original error

--- a/packages/destination-actions/src/destinations/yahoo-audiences/utils-tax.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/utils-tax.ts
@@ -89,13 +89,14 @@ export async function update_taxonomy(
       }
     })
     if (statsClient && statsTags) {
-      statsClient.incr('yahoo_audiences', 1, [...statsTags, 'util:update_taxonomy.success'])
+      statsClient.incr('update_taxonomy_success', 1, statsTags)
     }
     return await add_segment_node.json()
   } catch (error) {
     const _error = error as { response: { data: unknown; status: string } }
     if (statsClient && statsTags) {
-      statsClient.incr('yahoo_audiences', 1, [...statsTags, `util:update_taxonomy.error_${_error.response.status}`])
+      // TODO Incapsulate error codes into severar stats
+      statsClient.incr('util:update_taxonomy.error', 1, statsTags)
     }
     // If Taxonomy API returned 401, throw Integration error w/status 400 to prevent refreshAccessToken from firing
     // Otherwise throw the original error


### PR DESCRIPTION

## Description

This PR adds the following changes:
- adds code to account for https://github.com/segmentio/integrations/pull/2757
- improves DD logging
- makes email, phone, advertisingId and device_type mappings visible so that users can map arbitrary traits when using Trait Enrichment

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
