### PR TITLE
Inc-7055 long term fix: add external ids to message tags

### DIFF
--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
@@ -278,9 +278,12 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       const expectedTwilioRequest = new URLSearchParams({
         Body: 'Hello world, jane!',
         From: 'MG1111222233334444',
-        To: phoneNumber,
+        To: '+1 (505) 555-4555',
         ShortenUrls: 'true',
-        Tags: defaultTags
+        Tags: JSON.stringify({
+          external_id_type: 'phone',
+          external_id_value: '+1 (505) 555-4555'
+        })
       })
 
       const twilioHostname = 'api.nottwilio.com'
@@ -289,7 +292,12 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         .post('/Messages.json', expectedTwilioRequest.toString())
         .reply(201, {})
 
-      const responses = await testAction({ settingsOverrides: { twilioHostname } })
+      const responses = await testAction({
+        settingsOverrides: { twilioHostname },
+        mappingOverrides: {
+          externalIds: [{ type: 'phone', id: '+1 (505) 555-4555', subscriptionStatus: true, channelType: 'sms' }]
+        }
+      })
       expect(responses.map((response) => response.url)).toStrictEqual([
         `https://${twilioHostname}/2010-04-01/Accounts/a/Messages.json`
       ])

--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
@@ -2,7 +2,11 @@ import nock from 'nock'
 import { createTestAction, expectErrorLogged, expectInfoLogged, loggerMock as logger } from './__helpers__/test-utils'
 import { FLAGON_NAME_LOG_ERROR, FLAGON_NAME_LOG_INFO, SendabilityStatus } from '../../utils'
 
-const defaultTags = JSON.stringify({})
+const phoneNumber = '+1234567891'
+const defaultTags = JSON.stringify({
+  external_id_type: 'phone',
+  external_id_value: phoneNumber
+})
 
 describe.each(['stage', 'production'])('%s environment', (environment) => {
   const contentSid = 'g'
@@ -19,7 +23,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       traitEnrichment: true,
       externalIds: [
         { type: 'email', id: 'test@twilio.com', subscriptionStatus: 'true' },
-        { type: 'phone', id: '+1234567891', subscriptionStatus: 'true', channelType: 'sms' }
+        { type: 'phone', id: phoneNumber, subscriptionStatus: 'true', channelType: 'sms' }
       ],
       sendBasedOnOptOut: false
     })
@@ -158,7 +162,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       const expectedTwilioRequest = new URLSearchParams({
         Body: 'Hello world, jane!',
         From: 'MG1111222233334444',
-        To: '+1234567891',
+        To: phoneNumber,
         ShortenUrls: 'true',
         Tags: defaultTags
       })
@@ -205,7 +209,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       const expectedTwilioRequest = new URLSearchParams({
         Body: 'Hello world, jane!',
         From: 'MG1111222233334444',
-        To: '+1234567891',
+        To: phoneNumber,
         ShortenUrls: 'true',
         MediaUrl: 'http://myimg.com',
         Tags: defaultTags
@@ -239,7 +243,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       const expectedTwilioRequest = new URLSearchParams({
         Body: 'Hello world, jane!',
         From: 'MG1111222233334444',
-        To: '+1234567891',
+        To: phoneNumber,
         ShortenUrls: 'true'
       })
 
@@ -274,7 +278,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       const expectedTwilioRequest = new URLSearchParams({
         Body: 'Hello world, jane!',
         From: 'MG1111222233334444',
-        To: '+1234567891',
+        To: phoneNumber,
         ShortenUrls: 'true',
         Tags: defaultTags
       })
@@ -296,7 +300,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       const expectedTwilioRequest = new URLSearchParams({
         Body: 'Hello world, jane!',
         From: 'MG1111222233334444',
-        To: '+1234567891',
+        To: phoneNumber,
         ShortenUrls: 'true',
         Tags: defaultTags,
         StatusCallback:
@@ -351,7 +355,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       const expectedTwilioRequest = new URLSearchParams({
         Body: 'Hello world, jane!',
         From: 'MG1111222233334444',
-        To: '+1234567891',
+        To: phoneNumber,
         ShortenUrls: 'true',
         Tags: defaultTags
       })
@@ -381,7 +385,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       const expectedTwilioRequest = new URLSearchParams({
         Body: 'Hello world, jane!',
         From: 'MG1111222233334444',
-        To: '+1234567891',
+        To: phoneNumber,
         ShortenUrls: 'true',
         Tags: defaultTags
       })
@@ -392,7 +396,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
 
       const responses = await testAction({
         mappingOverrides: {
-          externalIds: [{ type: 'phone', id: '+1234567891', subscriptionStatus, channelType: 'sms' }]
+          externalIds: [{ type: 'phone', id: phoneNumber, subscriptionStatus, channelType: 'sms' }]
         }
       })
       expect(responses.map((response) => response.url)).toStrictEqual([
@@ -407,7 +411,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         const expectedTwilioRequest = new URLSearchParams({
           Body: 'Hello world, jane!',
           From: 'MG1111222233334444',
-          To: '+1234567891',
+          To: phoneNumber,
           ShortenUrls: 'true',
           Tags: defaultTags
         })
@@ -418,7 +422,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
 
         const responses = await testAction({
           mappingOverrides: {
-            externalIds: [{ type: 'phone', id: '+1234567891', subscriptionStatus, channelType: 'sms' }],
+            externalIds: [{ type: 'phone', id: phoneNumber, subscriptionStatus, channelType: 'sms' }],
             sendBasedOnOptOut: true
           }
         })
@@ -435,7 +439,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         const expectedTwilioRequest = new URLSearchParams({
           Body: 'Hello world, jane!',
           From: 'MG1111222233334444',
-          To: '+1234567891',
+          To: phoneNumber,
           ShortenUrls: 'true',
           Tags: defaultTags
         })
@@ -446,7 +450,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
 
         const responses = await testAction({
           mappingOverrides: {
-            externalIds: [{ type: 'phone', id: '+1234567891', subscriptionStatus, channelType: 'sms' }],
+            externalIds: [{ type: 'phone', id: phoneNumber, subscriptionStatus, channelType: 'sms' }],
             sendBasedOnOptOut: undefined
           }
         })
@@ -463,7 +467,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         const expectedTwilioRequest = new URLSearchParams({
           Body: 'Hello world, jane!',
           From: 'MG1111222233334444',
-          To: '+1234567891',
+          To: phoneNumber,
           ShortenUrls: 'true',
           Tags: defaultTags
         })
@@ -474,7 +478,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
 
         const responses = await testAction({
           mappingOverrides: {
-            externalIds: [{ type: 'phone', id: '+1234567891', subscriptionStatus, channelType: 'sms' }]
+            externalIds: [{ type: 'phone', id: phoneNumber, subscriptionStatus, channelType: 'sms' }]
           }
         })
         expect(responses).toHaveLength(0)
@@ -488,7 +492,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         const expectedTwilioRequest = new URLSearchParams({
           Body: 'Hello world, jane!',
           From: 'MG1111222233334444',
-          To: '+1234567891',
+          To: phoneNumber,
           ShortenUrls: 'true',
           Tags: defaultTags
         })
@@ -499,7 +503,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
 
         const responses = await testAction({
           mappingOverrides: {
-            externalIds: [{ type: 'phone', id: '+1234567891', subscriptionStatus, channelType: 'sms' }],
+            externalIds: [{ type: 'phone', id: phoneNumber, subscriptionStatus, channelType: 'sms' }],
             sendBasedOnOptOut: undefined
           }
         })
@@ -515,7 +519,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       const expectedTwilioRequest = new URLSearchParams({
         Body: 'Hello world, jane!',
         From: 'MG1111222233334444',
-        To: '+1234567891',
+        To: phoneNumber,
         ShortenUrls: 'true',
         Tags: defaultTags
       })
@@ -526,7 +530,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
 
       const responses = await testAction({
         mappingOverrides: {
-          externalIds: [{ type: 'phone', id: '+1234567891', subscriptionStatus, channelType: 'sms' }],
+          externalIds: [{ type: 'phone', id: phoneNumber, subscriptionStatus, channelType: 'sms' }],
           sendBasedOnOptOut: true
         }
       })
@@ -541,7 +545,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
     const expectedTwilioRequest = new URLSearchParams({
       Body: 'Hello world, jane!',
       From: 'MG1111222233334444',
-      To: '+1234567891',
+      To: phoneNumber,
       ShortenUrls: 'true',
       Tags: defaultTags
     })
@@ -552,7 +556,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
 
     const responses = await testAction({
       mappingOverrides: {
-        externalIds: [{ type: 'phone', id: '+1234567891', subscriptionStatus: randomSubscriptionStatusPhrase }]
+        externalIds: [{ type: 'phone', id: phoneNumber, subscriptionStatus: randomSubscriptionStatusPhrase }]
       }
     })
     expect(responses).toHaveLength(0)
@@ -636,7 +640,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         const expectedTwilioRequest = new URLSearchParams({
           Body: 'Hello world, jane!',
           From: 'MG1111222233334444',
-          To: '+1234567891',
+          To: phoneNumber,
           ShortenUrls: 'true',
           Tags: defaultTags
         })
@@ -662,9 +666,9 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
     const expectedTwilioRequest = new URLSearchParams({
       Body: 'Hello world, jane!',
       From: 'MG1111222233334444',
-      To: '+1234567891',
+      To: phoneNumber,
       ShortenUrls: 'true',
-      Tags: '{"audience_id":"1","correlation_id":"1","journey_name":"j-1","step_name":"2","campaign_name":"c-3","campaign_key":"4","user_id":"u-5","message_id":"m-6"}'
+      Tags: '{"audience_id":"1","correlation_id":"1","journey_name":"j-1","step_name":"2","campaign_name":"c-3","campaign_key":"4","user_id":"u-5","message_id":"m-6","external_id_type":"phone","external_id_value":"+1234567891"}'
     })
     const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
       .post('/Messages.json', expectedTwilioRequest.toString())

--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-whatsapp.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-whatsapp.test.ts
@@ -3,7 +3,11 @@ import { createTestAction, expectErrorLogged, expectInfoLogged } from './__helpe
 
 const defaultTemplateSid = 'my_template'
 const defaultTo = 'whatsapp:+1234567891'
-const defaultTags = JSON.stringify({})
+const phoneNumber = '+1234567891'
+const defaultTags = JSON.stringify({
+  external_id_type: 'phone',
+  external_id_value: phoneNumber
+})
 
 describe.each(['stage', 'production'])('%s environment', (environment) => {
   const spaceId = 'd'
@@ -19,7 +23,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       traitEnrichment: true,
       externalIds: [
         { type: 'email', id: 'test@twilio.com', subscriptionStatus: 'subscribed' },
-        { type: 'phone', id: '+1234567891', subscriptionStatus: 'subscribed', channelType: 'whatsapp' }
+        { type: 'phone', id: phoneNumber, subscriptionStatus: 'subscribed', channelType: 'whatsapp' }
       ]
     })
   })
@@ -38,7 +42,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
     it('should abort when there is no `channelType` in the external ID payload', async () => {
       const responses = await testAction({
         mappingOverrides: {
-          externalIds: [{ type: 'phone', id: '+1234567891', subscriptionStatus: 'subscribed' }]
+          externalIds: [{ type: 'phone', id: phoneNumber, subscriptionStatus: 'subscribed' }]
         }
       })
 
@@ -137,7 +141,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
 
       const responses = await testAction({
         mappingOverrides: {
-          externalIds: [{ type: 'phone', id: '+1234567891', subscriptionStatus, channelType: 'whatsapp' }]
+          externalIds: [{ type: 'phone', id: phoneNumber, subscriptionStatus, channelType: 'whatsapp' }]
         }
       })
       expect(responses.map((response) => response.url)).toStrictEqual([
@@ -162,7 +166,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
 
         const responses = await testAction({
           mappingOverrides: {
-            externalIds: [{ type: 'phone', id: '+1234567891', subscriptionStatus, channelType: 'whatsapp' }]
+            externalIds: [{ type: 'phone', id: phoneNumber, subscriptionStatus, channelType: 'whatsapp' }]
           }
         })
         expect(responses).toHaveLength(0)
@@ -188,7 +192,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           externalIds: [
             {
               type: 'phone',
-              id: '+1234567891',
+              id: phoneNumber,
               subscriptionStatus: randomSubscriptionStatusPhrase,
               channelType: 'whatsapp'
             }
@@ -205,7 +209,10 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         ContentSid: defaultTemplateSid,
         From: from,
         To: 'whatsapp:+19195551234',
-        Tags: defaultTags
+        Tags: JSON.stringify({
+          external_id_type: 'phone',
+          external_id_value: '(919) 555 1234'
+        })
       })
 
       const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')

--- a/packages/destination-actions/src/destinations/engage/twilio/utils/PhoneMessageSender.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/utils/PhoneMessageSender.ts
@@ -48,7 +48,9 @@ export abstract class PhoneMessageSender<Payload extends PhoneMessagePayload> ex
       campaign_name: this.payload.customArgs && this.payload.customArgs['campaign_name'],
       campaign_key: this.payload.customArgs && this.payload.customArgs['campaign_key'],
       user_id: this.payload.customArgs && this.payload.customArgs['user_id'],
-      message_id: this.payload.customArgs && this.payload.customArgs['message_id']
+      message_id: this.payload.customArgs && this.payload.customArgs['message_id'],
+      external_id_type: recepient.type,
+      external_id_value: phone
     }
     body.append('Tags', JSON.stringify(tags))
 


### PR DESCRIPTION
[SEV Betterment](https://twilio.enterprise.slack.com/archives/C067L6S9BEY)

This PR adds external id metadata to message tags. This is to be consumed by marketing analytics.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
