### PR TITLE
Gleap cloud action

### DIFF
--- a/packages/destination-actions/src/destinations/gleap/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/gleap/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,56 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-gleap destination: identifyContact action - all fields 1`] = `
+Object {
+  "companyId": "5(nuZw&pud4S",
+  "companyName": "5(nuZw&pud4S",
+  "createdAt": "2021-02-01T00:00:00.000Z",
+  "email": "perum@rakunar.dm",
+  "lang": "5(nuzw&pud4s",
+  "lastActivity": "2021-02-01T00:00:00.000Z",
+  "lastPageView": Object {
+    "date": "2021-02-01T00:00:00.000Z",
+    "page": "5(nuZw&pud4S",
+  },
+  "name": "5(nuZw&pud4S",
+  "phone": "5(nuZw&pud4S",
+  "plan": "5(nuZw&pud4S",
+  "testType": "5(nuZw&pud4S",
+  "userId": "5(nuZw&pud4S",
+  "value": -3360299155456,
+}
+`;
+
+exports[`Testing snapshot for actions-gleap destination: identifyContact action - required fields 1`] = `
+Object {
+  "lang": "en",
+  "userId": "5(nuZw&pud4S",
+}
+`;
+
+exports[`Testing snapshot for actions-gleap destination: trackEvent action - all fields 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "data": Object {
+        "testType": "5h*@HiWdC&Q2#9YhdZ&0",
+      },
+      "date": "2021-02-01T00:00:00.000Z",
+      "name": "5h*@HiWdC&Q2#9YhdZ&0",
+      "userId": "5h*@HiWdC&Q2#9YhdZ&0",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for actions-gleap destination: trackEvent action - required fields 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "date": "2021-02-01T00:00:00.000Z",
+      "name": "5h*@HiWdC&Q2#9YhdZ&0",
+      "userId": "5h*@HiWdC&Q2#9YhdZ&0",
+    },
+  ],
+}
+`;

--- a/packages/destination-actions/src/destinations/gleap/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gleap/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { createTestEvent, createTestIntegration, DecoratedResponse } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import nock from 'nock'
 import Definition from '../index'
 
@@ -38,9 +38,8 @@ describe('Gleap (actions)', () => {
         const response = await testDestination.onDelete(event, {
           apiToken: '1234'
         })
-        const resp = response as DecoratedResponse
-        expect(resp.status).toBe(200)
-        expect(resp.data).toMatchObject({})
+        expect(response.status).toBe(200)
+        expect(response.data).toMatchObject({})
       }
     })
   })

--- a/packages/destination-actions/src/destinations/gleap/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gleap/__tests__/index.test.ts
@@ -1,0 +1,47 @@
+import { createTestEvent, createTestIntegration, DecoratedResponse } from '@segment/actions-core'
+import nock from 'nock'
+import Definition from '../index'
+
+const testDestination = createTestIntegration(Definition)
+const endpoint = 'https://api.gleap.io'
+
+describe('Gleap (actions)', () => {
+  describe('testAuthentication', () => {
+    it('should validate authentication inputs', async () => {
+      nock(endpoint).get('/admin/auth').reply(200, {})
+      const authData = {
+        apiToken: '1234'
+      }
+
+      await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
+    })
+
+    it('should fail on authentication failure', async () => {
+      nock(endpoint).get('/admin/auth').reply(404, {})
+      const authData = {
+        apiToken: '1234'
+      }
+
+      await expect(testDestination.testAuthentication(authData)).rejects.toThrowError(
+        new Error('Credentials are invalid:  Test authentication failed')
+      )
+    })
+  })
+
+  describe('onDelete', () => {
+    it('should delete a user with a given userId', async () => {
+      const userId = '9999'
+      const event = createTestEvent({ userId: '9999' })
+      nock(endpoint).delete(`/admin/contacts/${userId}`).reply(200, {})
+
+      if (testDestination.onDelete) {
+        const response = await testDestination.onDelete(event, {
+          apiToken: '1234'
+        })
+        const resp = response as DecoratedResponse
+        expect(resp.status).toBe(200)
+        expect(resp.data).toMatchObject({})
+      }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/gleap/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/gleap/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-gleap'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/gleap/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gleap/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Found in `Project settings` -> `Secret API token`.
+   */
+  apiToken: string
+}

--- a/packages/destination-actions/src/destinations/gleap/identifyContact/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gleap/identifyContact/__tests__/index.test.ts
@@ -1,0 +1,23 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import nock from 'nock'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+const endpoint = 'https://api.gleap.io'
+
+describe('Gleap.identifyContact', () => {
+  it('should identify a user', async () => {
+    const event = createTestEvent({
+      traits: { name: 'example user', email: 'user@example.com', userId: 'example-129394' }
+    })
+
+    nock(`${endpoint}`).post(`/admin/identify`).reply(200, {})
+
+    const responses = await testDestination.testAction('identifyContact', {
+      event,
+      useDefaultMappings: true
+    })
+
+    expect(responses[0].status).toBe(200)
+  })
+})

--- a/packages/destination-actions/src/destinations/gleap/identifyContact/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gleap/identifyContact/generated-types.ts
@@ -1,0 +1,58 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * A unique identifier for the contact.
+   */
+  userId: string
+  /**
+   * The contact's name.
+   */
+  name?: string
+  /**
+   * The contact's email address.
+   */
+  email?: string
+  /**
+   * The contact's phone number.
+   */
+  phone?: string
+  /**
+   * The contact's company name.
+   */
+  companyName?: string
+  /**
+   * The contact's compan ID
+   */
+  companyId?: string
+  /**
+   * The user's language.
+   */
+  lang?: string
+  /**
+   * The user's subscription plan.
+   */
+  plan?: string
+  /**
+   * The user's value.
+   */
+  value?: number
+  /**
+   * The page where the contact was last seen.
+   */
+  lastPageView?: string
+  /**
+   * The time specified for when a contact signed up.
+   */
+  createdAt?: string | number
+  /**
+   * The time when the contact was last seen.
+   */
+  lastActivity?: string | number
+  /**
+   * The custom attributes which are set for the contact.
+   */
+  customAttributes?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/gleap/identifyContact/index.ts
+++ b/packages/destination-actions/src/destinations/gleap/identifyContact/index.ts
@@ -1,0 +1,144 @@
+import { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Identify Contact',
+  description: 'Create or update a contact in Gleap',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    userId: {
+      type: 'string',
+      required: true,
+      description: 'A unique identifier for the contact.',
+      label: 'User ID',
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    name: {
+      type: 'string',
+      description: "The contact's name.",
+      label: 'Name',
+      default: {
+        '@path': '$.traits.name'
+      }
+    },
+    email: {
+      type: 'string',
+      description: "The contact's email address.",
+      label: 'Email Address',
+      format: 'email',
+      default: {
+        '@if': {
+          exists: { '@path': '$.email' },
+          then: { '@path': '$.email' },
+          else: { '@path': '$.traits.email' }
+        }
+      }
+    },
+    phone: {
+      label: 'Phone Number',
+      description: "The contact's phone number.",
+      type: 'string',
+      default: {
+        '@path': '$.traits.phone'
+      }
+    },
+    companyName: {
+      label: 'Company Name',
+      description: "The contact's company name.",
+      type: 'string',
+      default: {
+        '@path': '$.traits.company.name'
+      }
+    },
+    companyId: {
+      label: 'Company ID',
+      description: "The contact's compan ID",
+      type: 'string',
+      default: {
+        '@path': '$.traits.company.id'
+      }
+    },
+    lang: {
+      label: 'Language',
+      description: "The user's language.",
+      type: 'string',
+      required: false,
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.language' },
+          then: { '@path': '$.traits.language' },
+          else: 'en'
+        }
+      }
+    },
+    plan: {
+      label: 'Subscription Plan',
+      description: "The user's subscription plan.",
+      type: 'string',
+      required: false,
+      default: { '@path': '$.traits.plan' }
+    },
+    value: {
+      label: 'User Value',
+      description: "The user's value.",
+      type: 'number',
+      required: false
+    },
+    lastPageView: {
+      label: 'Last Page View',
+      type: 'string',
+      description: 'The page where the contact was last seen.',
+      default: {
+        '@path': '$.context.page.url'
+      }
+    },
+    createdAt: {
+      label: 'Signed Up Timestamp',
+      type: 'datetime',
+      description: 'The time specified for when a contact signed up.'
+    },
+    lastActivity: {
+      label: 'Last Seen Timestamp',
+      type: 'datetime',
+      description: 'The time when the contact was last seen.',
+      default: {
+        '@path': '$.timestamp'
+      }
+    },
+    customAttributes: {
+      label: 'Custom Attributes',
+      description: 'The custom attributes which are set for the contact.',
+      type: 'object',
+      defaultObjectUI: 'keyvalue'
+    }
+  },
+  perform: async (request, { payload }) => {
+    // Map the payload to the correct format.
+    payload = {
+      ...payload,
+      lang: payload.lang ? payload.lang.toLowerCase() : 'en',
+      ...payload.customAttributes
+    }
+
+    // Remove the customAttributes field from the payload.
+    delete payload.customAttributes
+
+    // Map the lastPageView and lastActivity to the correct format.
+    if (payload.lastPageView) {
+      payload.lastPageView = {
+        page: payload.lastPageView,
+        date: payload.lastActivity
+      }
+    }
+
+    return request('https://api.gleap.io/admin/identify', {
+      method: 'POST',
+      json: payload
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/gleap/index.ts
+++ b/packages/destination-actions/src/destinations/gleap/index.ts
@@ -1,0 +1,60 @@
+import { DestinationDefinition, IntegrationError } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+import identifyContact from './identifyContact'
+import trackEvent from './trackEvent'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Gleap',
+  slug: 'gleap',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      apiToken: {
+        type: 'string',
+        label: 'Secret API token',
+        description: 'Found in `Project settings` -> `Secret API token`.',
+        required: true
+      }
+    },
+    testAuthentication: async (request) => {
+      // The auth endpoint checks if the API token is valid
+      // https://api.gleap.io/admin/auth.
+
+      try {
+        return await request('https://api.gleap.io/admin/auth')
+      } catch (error) {
+        throw new Error('Test authentication failed')
+      }
+    }
+  },
+  extendRequest({ settings }) {
+    return {
+      headers: {
+        'Api-Token': settings?.apiToken
+      }
+    }
+  },
+
+  /**
+   * Delete a contact from Gleap when a user is deleted in Segment. Use the `userId` to find the contact in Gleap.
+   */
+  onDelete: async (request, { payload }) => {
+    const external_id = payload.userId as string
+    if (external_id) {
+      return request(`https://api.gleap.io/admin/contacts/${external_id}`, {
+        method: 'DELETE'
+      })
+    } else {
+      throw new IntegrationError('No unique contact found', 'Contact not found', 404)
+    }
+  },
+
+  actions: {
+    identifyContact,
+    trackEvent
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/gleap/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gleap/trackEvent/__tests__/index.test.ts
@@ -1,0 +1,21 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import nock from 'nock'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+const endpoint = 'https://api.gleap.io'
+
+describe('Gleap.trackEvent', () => {
+  it('should create an event with name and userId', async () => {
+    const event = createTestEvent({ event: 'Segment Test Event Name 3', userId: 'user1234' })
+
+    nock(`${endpoint}`).post(`/admin/track`).reply(200, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      useDefaultMappings: true
+    })
+
+    expect(responses[0].status).toBe(200)
+  })
+})

--- a/packages/destination-actions/src/destinations/gleap/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gleap/trackEvent/generated-types.ts
@@ -1,0 +1,22 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The name of the event that occurred. Names are treated as case insensitive. Periods and dollar signs in event names are replaced with hyphens.
+   */
+  eventName: string
+  /**
+   * The time the event occurred as a UTC Unix timestamp. Segment will convert to Unix if not already converted.
+   */
+  date: string | number
+  /**
+   * Your identifier for the user who performed the event. User ID is required.
+   */
+  userId: string
+  /**
+   * Optional metadata describing the event. Each event can contain up to ten metadata key-value pairs. If you send more than ten keys, Gleap will ignore the rest.
+   */
+  data?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/gleap/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/gleap/trackEvent/index.ts
@@ -1,0 +1,66 @@
+import { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Track Event',
+  description: 'Submit an event to Gleap.',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    eventName: {
+      type: 'string',
+      required: true,
+      description:
+        'The name of the event that occurred. Names are treated as case insensitive. Periods and dollar signs in event names are replaced with hyphens.',
+      label: 'Event Name',
+      default: {
+        '@path': '$.event'
+      }
+    },
+    date: {
+      type: 'datetime',
+      required: true,
+      description:
+        'The time the event occurred as a UTC Unix timestamp. Segment will convert to Unix if not already converted.',
+      label: 'Event Timestamp',
+      default: {
+        '@path': '$.timestamp'
+      }
+    },
+    userId: {
+      type: 'string',
+      required: true,
+      description: 'Your identifier for the user who performed the event. User ID is required.',
+      label: 'User ID',
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    data: {
+      type: 'object',
+      description:
+        'Optional metadata describing the event. Each event can contain up to ten metadata key-value pairs. If you send more than ten keys, Gleap will ignore the rest.',
+      label: 'Event Metadata',
+      default: {
+        '@path': '$.properties'
+      }
+    }
+  },
+  perform: async (request, { payload }) => {
+    const event = {
+      name: payload.eventName,
+      date: payload.date,
+      data: payload.data,
+      userId: payload.userId
+    }
+
+    return request('https://api.gleap.io/admin/track', {
+      method: 'POST',
+      json: {
+        events: [event]
+      }
+    })
+  }
+}
+
+export default action


### PR DESCRIPTION
This PR adds Gleap as a cloud destination, allowing mutual customers to identify users and forward events from Segment to Gleap.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [] [Segmenters] Tested in the staging environment