### PR TITLE
Switch to main url

### DIFF
--- a/packages/browser-destinations/destinations/koala/src/index.ts
+++ b/packages/browser-destinations/destinations/koala/src/index.ts
@@ -1,11 +1,11 @@
-import type { Settings } from './generated-types'
-import type { BrowserDestinationDefinition } from '@segment/browser-destination-runtime/types'
-import type { KoalaSDK, Koala } from './types'
 import { defaultValues } from '@segment/actions-core'
 import { browserDestination } from '@segment/browser-destination-runtime/shim'
+import type { BrowserDestinationDefinition } from '@segment/browser-destination-runtime/types'
+import type { Settings } from './generated-types'
+import identifyVisitor from './identifyVisitor'
 import { initScript } from './init-script'
 import trackEvent from './trackEvent'
-import identifyVisitor from './identifyVisitor'
+import type { Koala, KoalaSDK } from './types'
 
 declare global {
   interface Window {
@@ -30,7 +30,7 @@ export const destination: BrowserDestinationDefinition<Settings, Koala> = {
 
   initialize: async ({ settings, analytics }, deps) => {
     initScript()
-    await deps.loadScript(`https://cdn.koala.live/v1/${settings.project_slug}/umd.js`)
+    await deps.loadScript(`https://cdn.getkoala.com/v1/${settings.project_slug}/umd.js`)
 
     const ko = await window.KoalaSDK.load({
       project: settings.project_slug,

--- a/packages/browser-destinations/destinations/koala/src/index.ts
+++ b/packages/browser-destinations/destinations/koala/src/index.ts
@@ -1,11 +1,11 @@
+import type { Settings } from './generated-types'
+import type { BrowserDestinationDefinition } from '@segment/browser-destination-runtime/types'
+import type { KoalaSDK, Koala } from './types'
 import { defaultValues } from '@segment/actions-core'
 import { browserDestination } from '@segment/browser-destination-runtime/shim'
-import type { BrowserDestinationDefinition } from '@segment/browser-destination-runtime/types'
-import type { Settings } from './generated-types'
-import identifyVisitor from './identifyVisitor'
 import { initScript } from './init-script'
 import trackEvent from './trackEvent'
-import type { Koala, KoalaSDK } from './types'
+import identifyVisitor from './identifyVisitor'
 
 declare global {
   interface Window {


### PR DESCRIPTION
Hello!

This is very small change that switches off of our old cdn domain (still works though) to the current domain. 🙏 Hopefully this small change is fairly trivial to release – thanks!

## Testing

I've verified this is working identically as before.

- [-] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
