### PR TITLE
fix(google-analytics-4-web): scope user updates to the relevant measurement ID

### DIFF
--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/addPaymentInfo/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/addPaymentInfo/index.ts
@@ -32,8 +32,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     user_properties: user_properties,
     params: params
   },
-  perform: (gtag, { payload }) => {
-    updateUser(payload.user_id, payload.user_properties, gtag)
+  perform: (gtag, { payload, settings }) => {
+    updateUser(payload.user_id, payload.user_properties, gtag, settings.measurementID)
     gtag('event', 'add_payment_info', {
       currency: payload.currency,
       value: payload.value,

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/addToCart/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/addToCart/index.ts
@@ -21,8 +21,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     user_properties: user_properties,
     params: params
   },
-  perform: (gtag, { payload }) => {
-    updateUser(payload.user_id, payload.user_properties, gtag)
+  perform: (gtag, { payload, settings }) => {
+    updateUser(payload.user_id, payload.user_properties, gtag, settings.measurementID)
 
     gtag('event', 'add_to_cart', {
       currency: payload.currency,

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/addToWishlist/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/addToWishlist/index.ts
@@ -23,8 +23,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     user_properties: user_properties,
     params: params
   },
-  perform: (gtag, { payload }) => {
-    updateUser(payload.user_id, payload.user_properties, gtag)
+  perform: (gtag, { payload, settings }) => {
+    updateUser(payload.user_id, payload.user_properties, gtag, settings.measurementID)
 
     gtag('event', 'add_to_wishlist', {
       currency: payload.currency,

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/beginCheckout/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/beginCheckout/index.ts
@@ -22,8 +22,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     params: params,
     user_properties: user_properties
   },
-  perform: (gtag, { payload }) => {
-    updateUser(payload.user_id, payload.user_properties, gtag)
+  perform: (gtag, { payload, settings }) => {
+    updateUser(payload.user_id, payload.user_properties, gtag, settings.measurementID)
 
     gtag('event', 'begin_checkout', {
       currency: payload.currency,

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/customEvent/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/customEvent/index.ts
@@ -41,8 +41,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     user_properties: user_properties,
     params: params
   },
-  perform: (gtag, { payload }) => {
-    updateUser(payload.user_id, payload.user_properties, gtag)
+  perform: (gtag, { payload, settings }) => {
+    updateUser(payload.user_id, payload.user_properties, gtag, settings.measurementID)
     const event_name = normalizeEventName(payload.name, payload.lowercase)
 
     gtag('event', event_name, payload.params)

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/ga4-functions.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/ga4-functions.ts
@@ -1,8 +1,8 @@
-export function updateUser(userID: string | undefined, userProps: object | undefined, gtag: Function): void {
+export function updateUser(userID: string | undefined, userProps: object | undefined, gtag: Function, measurementId: string): void {
   if (userID) {
-    gtag('set', { user_id: userID })
+    gtag('config', measurementId, { user_id: userID })
   }
   if (userProps) {
-    gtag('set', { user_properties: userProps })
+    gtag('config', measurementId, { user_properties: userProps })
   }
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/generateLead/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/generateLead/index.ts
@@ -18,8 +18,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     user_properties: user_properties,
     params: params
   },
-  perform: (gtag, { payload }) => {
-    updateUser(payload.user_id, payload.user_properties, gtag)
+  perform: (gtag, { payload, settings }) => {
+    updateUser(payload.user_id, payload.user_properties, gtag, settings.measurementID)
 
     gtag('event', 'generate_lead', {
       currency: payload.currency,

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/login/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/login/index.ts
@@ -18,8 +18,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     params: params
   },
 
-  perform: (gtag, { payload }) => {
-    updateUser(payload.user_id, payload.user_properties, gtag)
+  perform: (gtag, { payload, settings }) => {
+    updateUser(payload.user_id, payload.user_properties, gtag, settings.measurementID)
 
     gtag('event', 'login', {
       method: payload.method,

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/purchase/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/purchase/index.ts
@@ -35,8 +35,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     user_properties: user_properties,
     params: params
   },
-  perform: (gtag, { payload }) => {
-    updateUser(payload.user_id, payload.user_properties, gtag)
+  perform: (gtag, { payload, settings }) => {
+    updateUser(payload.user_id, payload.user_properties, gtag, settings.measurementID)
 
     gtag('event', 'purchase', {
       currency: payload.currency,

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/refund/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/refund/index.ts
@@ -37,8 +37,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     user_properties: user_properties,
     params: params
   },
-  perform: (gtag, { payload }) => {
-    updateUser(payload.user_id, payload.user_properties, gtag)
+  perform: (gtag, { payload, settings }) => {
+    updateUser(payload.user_id, payload.user_properties, gtag, settings.measurementID)
 
     gtag('event', 'refund', {
       currency: payload.currency,

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/removeFromCart/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/removeFromCart/index.ts
@@ -22,8 +22,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     user_properties: user_properties,
     params: params
   },
-  perform: (gtag, { payload }) => {
-    updateUser(payload.user_id, payload.user_properties, gtag)
+  perform: (gtag, { payload, settings }) => {
+    updateUser(payload.user_id, payload.user_properties, gtag, settings.measurementID)
 
     gtag('event', 'remove_from_cart', {
       currency: payload.currency,

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/search/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/search/index.ts
@@ -17,8 +17,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     params: params,
     search_term: search_term
   },
-  perform: (gtag, { payload }) => {
-    updateUser(payload.user_id, payload.user_properties, gtag)
+  perform: (gtag, { payload, settings }) => {
+    updateUser(payload.user_id, payload.user_properties, gtag, settings.measurementID)
 
     gtag('event', 'search', {
       search_term: payload.search_term,

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/selectItem/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/selectItem/index.ts
@@ -28,8 +28,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     user_properties: user_properties,
     params: params
   },
-  perform: (gtag, { payload }) => {
-    updateUser(payload.user_id, payload.user_properties, gtag)
+  perform: (gtag, { payload, settings }) => {
+    updateUser(payload.user_id, payload.user_properties, gtag, settings.measurementID)
 
     gtag('event', 'select_item', {
       item_list_id: payload.item_list_id,

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/selectPromotion/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/selectPromotion/index.ts
@@ -49,8 +49,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     user_properties: user_properties,
     params: params
   },
-  perform: (gtag, { payload }) => {
-    updateUser(payload.user_id, payload.user_properties, gtag)
+  perform: (gtag, { payload, settings }) => {
+    updateUser(payload.user_id, payload.user_properties, gtag, settings.measurementID)
 
     gtag('event', 'select_promotion', {
       creative_name: payload.creative_name,

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/setConfigurationFields/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/setConfigurationFields/index.ts
@@ -96,7 +96,7 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     }
   },
   perform: (gtag, { payload, settings }) => {
-    updateUser(payload.user_id, payload.user_properties, gtag)
+    updateUser(payload.user_id, payload.user_properties, gtag, settings.measurementID)
     if (settings.enableConsentMode) {
       window.gtag('consent', 'update', {
         ad_storage: payload.ads_storage_consent_state as ConsentParamsArg,

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/signUp/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/signUp/index.ts
@@ -16,8 +16,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     user_properties: user_properties,
     params: params
   },
-  perform: (gtag, { payload }) => {
-    updateUser(payload.user_id, payload.user_properties, gtag)
+  perform: (gtag, { payload, settings }) => {
+    updateUser(payload.user_id, payload.user_properties, gtag, settings.measurementID)
 
     gtag('event', 'sign_up', {
       method: payload.method,

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/viewCart/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/viewCart/index.ts
@@ -21,8 +21,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     user_properties: user_properties,
     params: params
   },
-  perform: (gtag, { payload }) => {
-    updateUser(payload.user_id, payload.user_properties, gtag)
+  perform: (gtag, { payload, settings }) => {
+    updateUser(payload.user_id, payload.user_properties, gtag, settings.measurementID)
 
     gtag('event', 'view_cart', {
       currency: payload.currency,

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/viewItem/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/viewItem/index.ts
@@ -22,8 +22,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     user_properties: user_properties,
     params: params
   },
-  perform: (gtag, { payload }) => {
-    updateUser(payload.user_id, payload.user_properties, gtag)
+  perform: (gtag, { payload, settings }) => {
+    updateUser(payload.user_id, payload.user_properties, gtag, settings.measurementID)
 
     gtag('event', 'view_item', {
       currency: payload.currency,

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/viewItemList/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/viewItemList/index.ts
@@ -21,8 +21,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     user_properties: user_properties,
     params: params
   },
-  perform: (gtag, { payload }) => {
-    updateUser(payload.user_id, payload.user_properties, gtag)
+  perform: (gtag, { payload, settings }) => {
+    updateUser(payload.user_id, payload.user_properties, gtag, settings.measurementID)
 
     gtag('event', 'view_item_list', {
       item_list_id: payload.item_list_id,

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/viewPromotion/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/viewPromotion/index.ts
@@ -49,8 +49,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     user_properties: user_properties,
     params: params
   },
-  perform: (gtag, { payload }) => {
-    updateUser(payload.user_id, payload.user_properties, gtag)
+  perform: (gtag, { payload, settings }) => {
+    updateUser(payload.user_id, payload.user_properties, gtag, settings.measurementID)
 
     gtag('event', 'view_promotion', {
       creative_name: payload.creative_name,


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

This PR fixes what I believe to be a bug in the GA4 Web Destination. The GA4 Web Destination in Segment requires configuration of a Measurement ID, implying that it is scoped to a single measurement. Currently, however, changes to the user_id and user_properties are 'leaking' into other measurements that are not being managed by Segment. Per the [gTag docs](https://developers.google.com/tag-platform/gtagjs/reference#parameter_scope), the 'set' operation sets for all measurements. To properly scope the user_id and user_properties, this PR updates the problematic usage of 'set' to use 'config' and passed in the relevant measurement ID to ensure that it is scoped. 


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
