### PR TITLE
STRATCONN-3420 - Support Tiktok offline conversions limited data use

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -15,6 +15,7 @@ Object {
   "event": "fQ92^RLkQyhJ8TU3nYnh",
   "event_id": "fQ92^RLkQyhJ8TU3nYnh",
   "event_set_id": "fQ92^RLkQyhJ8TU3nYnh",
+  "limited_data_use": false,
   "partner_name": "Segment",
   "properties": Object {
     "event_channel": "other",
@@ -40,6 +41,7 @@ Object {
   "event": "fQ92^RLkQyhJ8TU3nYnh",
   "event_id": "fQ92^RLkQyhJ8TU3nYnh",
   "event_set_id": "fQ92^RLkQyhJ8TU3nYnh",
+  "limited_data_use": false,
   "partner_name": "Segment",
   "properties": Object {
     "event_channel": "other",
@@ -63,6 +65,7 @@ Object {
   "event": "fQ92^RLkQyhJ8TU3nYnh",
   "event_id": "fQ92^RLkQyhJ8TU3nYnh",
   "event_set_id": "fQ92^RLkQyhJ8TU3nYnh",
+  "limited_data_use": false,
   "partner_name": "Segment",
   "properties": Object {
     "order_id": "fQ92^RLkQyhJ8TU3nYnh",
@@ -85,6 +88,7 @@ Object {
   "event": "fQ92^RLkQyhJ8TU3nYnh",
   "event_id": "fQ92^RLkQyhJ8TU3nYnh",
   "event_set_id": "fQ92^RLkQyhJ8TU3nYnh",
+  "limited_data_use": false,
   "partner_name": "Segment",
   "properties": Object {
     "order_id": "fQ92^RLkQyhJ8TU3nYnh",
@@ -109,6 +113,7 @@ Object {
   "event": "BkRZ5",
   "event_id": "BkRZ5",
   "event_set_id": "BkRZ5",
+  "limited_data_use": true,
   "partner_name": "Segment",
   "properties": Object {
     "contents": Array [
@@ -146,6 +151,7 @@ Object {
   "event": "BkRZ5",
   "event_id": "BkRZ5",
   "event_set_id": "BkRZ5",
+  "limited_data_use": true,
   "partner_name": "Segment",
   "properties": Object {
     "contents": Array [
@@ -181,6 +187,7 @@ Object {
   "event": "BkRZ5",
   "event_id": "BkRZ5",
   "event_set_id": "BkRZ5",
+  "limited_data_use": true,
   "partner_name": "Segment",
   "properties": Object {
     "currency": "DZD",
@@ -204,6 +211,7 @@ Object {
   "event": "BkRZ5",
   "event_id": "BkRZ5",
   "event_set_id": "BkRZ5",
+  "limited_data_use": true,
   "partner_name": "Segment",
   "properties": Object {
     "currency": "DZD",

--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions/__tests__/index.test.ts
@@ -178,6 +178,63 @@ describe('TikTok Offline Conversions', () => {
         }
       })
     })
+
+    it("should default limited_data_use setting to false in payload for 'trackNonPaymentOfflineConversion'", async () => {
+      const event = createTestEvent({
+        timestamp: timestamp,
+        event: 'User Contacted Call Center',
+        messageId: 'test-message-id-contact',
+        type: 'track',
+        properties: {
+          email: ['testsegmentintegration1@tiktok.com', 'testsegmentintegration2@tiktok.com'],
+          phone: ['+1555-555-5555', '+1555-555-5556'],
+          ttclid: 'test-ttclid-contact',
+          order_id: 'test-order-id-contact',
+          shop_id: 'test-shop-id-contact',
+          event_channel: 'in_store'
+        },
+        userId: 'testId123-contact'
+      })
+
+      nock('https://business-api.tiktok.com/open_api/v1.3/offline/track/').post('/').reply(200, {})
+
+      const responses = await testDestination.testAction('trackNonPaymentOfflineConversion', {
+        event,
+        settings,
+        useDefaultMappings: true,
+        mapping: {
+          event: 'Contact'
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        event_set_id: settings.eventSetID,
+        event: 'Contact',
+        event_id: event.messageId,
+        timestamp: timestamp,
+        limited_data_use: false,
+        partner_name: 'Segment',
+        context: {
+          user: {
+            emails: [
+              '522a233963af49ceac13a2f68719d86a0b4cfb306b9a7959db697e1d7a52676a',
+              'c4821c6d488a9a27653e59b7c1f576e1434ed3e11cd0b6b86440fe56ea6c2d97'
+            ],
+            phone_numbers: [
+              '910a625c4ba147b544e6bd2f267e130ae14c591b6ba9c25cb8573322dedbebd0',
+              '46563a86074ccb92653d9f0666885030f5e921563bfa19c423b60a8c9ef7f85e'
+            ]
+          }
+        },
+        properties: {
+          order_id: 'test-order-id-contact',
+          shop_id: 'test-shop-id-contact',
+          event_channel: 'in_store'
+        }
+      })
+    })
   })
 
   describe('testTrackPaymentOfflineConversion', () => {
@@ -238,6 +295,95 @@ describe('TikTok Offline Conversions', () => {
         event: 'CompletePayment',
         event_id: event.messageId,
         timestamp: timestamp,
+        partner_name: 'Segment',
+        context: {
+          user: {
+            emails: [
+              '522a233963af49ceac13a2f68719d86a0b4cfb306b9a7959db697e1d7a52676a',
+              'c4821c6d488a9a27653e59b7c1f576e1434ed3e11cd0b6b86440fe56ea6c2d97'
+            ],
+            phone_numbers: [
+              '910a625c4ba147b544e6bd2f267e130ae14c591b6ba9c25cb8573322dedbebd0',
+              '46563a86074ccb92653d9f0666885030f5e921563bfa19c423b60a8c9ef7f85e'
+            ]
+          }
+        },
+        properties: {
+          order_id: 'test-order-id-complete-payment',
+          shop_id: 'test-shop-id-complete-payment',
+          event_channel: 'in_store',
+          contents: [
+            {
+              price: 100,
+              quantity: 2,
+              content_type: 'Air Force One (Size S)',
+              content_id: 'abc123'
+            }
+          ],
+          currency: 'USD',
+          value: 100
+        }
+      })
+    })
+
+    it("should default limited_data_use setting to false in payload for 'trackPaymentOfflineConversion'", async () => {
+      const event = createTestEvent({
+        timestamp: timestamp,
+        event: 'Order Completed',
+        messageId: 'test-message-id-complete-payment',
+        type: 'track',
+        properties: {
+          email: ['testsegmentintegration1@tiktok.com', 'testsegmentintegration2@tiktok.com'],
+          phone: ['+1555-555-5555', '+1555-555-5556'],
+          order_id: 'test-order-id-complete-payment',
+          shop_id: 'test-shop-id-complete-payment',
+          event_channel: 'in_store',
+          currency: 'USD',
+          value: 100,
+          query: 'shoes',
+          products: [{ price: 100, quantity: 2, category: 'Air Force One (Size S)', product_id: 'abc123' }]
+        },
+        userId: 'testId123-complete-payment'
+      })
+
+      nock('https://business-api.tiktok.com/open_api/v1.3/offline/track/').post('/').reply(200, {})
+
+      const responses = await testDestination.testAction('trackPaymentOfflineConversion', {
+        event,
+        settings,
+        useDefaultMappings: true,
+        mapping: {
+          event: 'CompletePayment',
+          contents: {
+            '@arrayPath': [
+              '$.properties.products',
+              {
+                price: {
+                  '@path': '$.price'
+                },
+                quantity: {
+                  '@path': '$.quantity'
+                },
+                content_type: {
+                  '@path': '$.category'
+                },
+                content_id: {
+                  '@path': '$.product_id'
+                }
+              }
+            ]
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        event_set_id: settings.eventSetID,
+        event: 'CompletePayment',
+        event_id: event.messageId,
+        timestamp: timestamp,
+        limited_data_use: false,
         partner_name: 'Segment',
         context: {
           user: {

--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions/common_fields.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions/common_fields.ts
@@ -84,5 +84,11 @@ export const commonFields: Record<string, InputField> = {
       { label: 'Other', value: 'other' }
     ],
     default: 'in_store'
+  },
+  limited_data_use: {
+    label: 'Enable Limited Data Use',
+    type: 'boolean',
+    description: "Enables TikTok's Limited Data Use feature. This field overrides the global setting of the same name.",
+    default: false
   }
 }

--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions/generated-types.ts
@@ -9,4 +9,8 @@ export interface Settings {
    * Your TikTok Offline Event Set ID. Please see TikTok’s [Events API documentation](https://ads.tiktok.com/marketing_api/docs?rid=mcxl4tclmfa&id=1758051319816193) for information on how to find this value.
    */
   eventSetID: string
+  /**
+   * Enables TikTok's Limited Data Use feature on all events sent from this Destination to TikTok.
+   */
+  limited_data_use?: boolean
 }

--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions/index.ts
@@ -24,6 +24,13 @@ const destination: DestinationDefinition<Settings> = {
         description:
           'Your TikTok Offline Event Set ID. Please see TikTok’s [Events API documentation](https://ads.tiktok.com/marketing_api/docs?rid=mcxl4tclmfa&id=1758051319816193) for information on how to find this value.',
         required: true
+      },
+      limited_data_use: {
+        label: 'Enable Limited Data Use',
+        type: 'boolean',
+        description: "Enables TikTok's Limited Data Use feature on all events sent from this Destination to TikTok.",
+        default: false,
+        required: false
       }
     },
     testAuthentication: (request, { settings }) => {

--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions/trackNonPaymentOfflineConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions/trackNonPaymentOfflineConversion/generated-types.ts
@@ -33,4 +33,8 @@ export interface Payload {
    * Event channel of the offline conversion event. Accepted values are: email, website, phone_call, in_store, crm, other. Any other value will be rejected
    */
   event_channel?: string
+  /**
+   * Enables TikTok's Limited Data Use feature. This field overrides the global setting of the same name.
+   */
+  limited_data_use?: boolean
 }

--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions/trackNonPaymentOfflineConversion/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions/trackNonPaymentOfflineConversion/index.ts
@@ -24,6 +24,7 @@ const action: ActionDefinition<Settings, Payload> = {
         event: payload.event,
         event_id: payload.event_id ? `${payload.event_id}` : undefined,
         timestamp: payload.timestamp,
+        limited_data_use: payload.limited_data_use ?? settings.limited_data_use ?? false,
         context: {
           user: {
             phone_numbers,

--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions/trackPaymentOfflineConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions/trackPaymentOfflineConversion/generated-types.ts
@@ -34,6 +34,10 @@ export interface Payload {
    */
   event_channel?: string
   /**
+   * Enables TikTok's Limited Data Use feature. This field overrides the global setting of the same name.
+   */
+  limited_data_use?: boolean
+  /**
    * Array of product or content items for the offline event.
    */
   contents?: {

--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions/trackPaymentOfflineConversion/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions/trackPaymentOfflineConversion/index.ts
@@ -121,6 +121,7 @@ const action: ActionDefinition<Settings, Payload> = {
         event: payload.event,
         event_id: payload.event_id ? `${payload.event_id}` : undefined,
         timestamp: payload.timestamp,
+        limited_data_use: payload.limited_data_use ?? settings.limited_data_use ?? false,
         context: {
           user: {
             phone_numbers,


### PR DESCRIPTION
Description: 

Associated JIRA ticket: https://segment.atlassian.net/browse/STRATCONN-3420

TikTok offers a Limited Data Use feature for their Events and Pixel APIs that help customer comply with U.S. state privacy laws. To implement this feature for destinations using the Events API, such as the TikTok Offline Conversion destination, customers need to add the limited_data_use parameter to the root of event payloads.

Relevant TikTok Events API doc: https://business-api.tiktok.com/portal/docs?rid=oyn7lhbo6ar&id=1770091656601602 

![image](https://github.com/segmentio/action-destinations/assets/45374896/30aee038-ff67-43cc-9fe5-91dcae6a5396)

This change introduces 1 new setting and 1 new field (for each Action). The Action level fields override the global setting. 

## Testing

Test locally with Actions Tester. To be approved by TikTok Partner before being merged. 
