### PR TITLE
Adding logic to not double-hash the email when already hashed.

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-audiences/__tests__/functions.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/__tests__/functions.test.ts
@@ -1,0 +1,27 @@
+import { extractUsers } from '../functions'
+
+describe('TikTok Audiences Functions', () => {
+  describe('extractUsers', () => {
+    it('Should hash email address when email is in a plain format', () => {
+      const payload = {
+        email: 'scroogemcduck@disney.com',
+        send_email: true,
+        audience_id: '1234567890'
+      }
+
+      const result: any[][] = extractUsers([payload])
+      expect(result[0][0].id).toEqual('77bc071241f37b4736df28c0c1cb0a99163d1050696134325b99246b2183d408')
+    })
+
+    it('Should NOT hash email address when email is already hashed', () => {
+      const payload = {
+        email: '77bc071241f37b4736df28c0c1cb0a99163d1050696134325b99246b2183d408',
+        send_email: true,
+        audience_id: '1234567890'
+      }
+
+      const result: any[][] = extractUsers([payload])
+      expect(result[0][0].id).toEqual('77bc071241f37b4736df28c0c1cb0a99163d1050696134325b99246b2183d408')
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/tiktok-audiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/__tests__/index.test.ts
@@ -80,7 +80,7 @@ const getAudienceResponse = {
   }
 }
 
-describe('Tik Tok Audiences', () => {
+describe('TikTok Audiences', () => {
   describe('createAudience', () => {
     it('should fail if no audience name is set', async () => {
       await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(IntegrationError)

--- a/packages/destination-actions/src/destinations/tiktok-audiences/functions.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/functions.ts
@@ -99,6 +99,8 @@ export function getIDSchema(payload: GenericPayload): string[] {
   return id_schema
 }
 
+const isHashedEmail = (email: string): boolean => new RegExp(/[0-9abcdef]{64}/gi).test(email)
+
 export function extractUsers(payloads: GenericPayload[]): {}[][] {
   const batch_data: {}[][] = []
 
@@ -126,8 +128,15 @@ export function extractUsers(payloads: GenericPayload[]): {}[][] {
           .replace(/\+.*@/, '@')
           .replace(/\.(?=.*@)/g, '')
           .toLowerCase()
+
+        // If email is already hashed, don't hash it again
+        let hashedEmail = payload.email
+        if (!isHashedEmail(payload.email)) {
+          hashedEmail = createHash('sha256').update(payload.email).digest('hex')
+        }
+
         email_id = {
-          id: createHash('sha256').update(payload.email).digest('hex'),
+          id: hashedEmail,
           audience_ids: [external_audience_id]
         }
       }


### PR DESCRIPTION
Several clients are asking this since they don't send their customers' profile email as plain information.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [X] [Segmenters] Tested in the staging environment
