### PR TITLE
bucket-web: Allow init options and sdk version overrides

### DIFF
--- a/packages/browser-destinations/destinations/bucket/src/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/bucket/src/__tests__/index.test.ts
@@ -70,9 +70,53 @@ describe('Bucket', () => {
     analyticsInstance.reset()
 
     expect(getBucketCallLog()).toStrictEqual([
-      { method: 'init', args: ['testTrackingKey'] },
+      { method: 'init', args: ['testTrackingKey', {}] },
       { method: 'reset', args: [] }
     ])
+  })
+
+  it('passes options to bucket.init()', async () => {
+    const [instance] = await bucketWebDestination({
+      trackingKey: 'testTrackingKey',
+      host: 'http://localhost:3200',
+      subscriptions: subscriptions as unknown as JSONArray
+    })
+
+    const analyticsInstance = new Analytics({ writeKey: 'test-writekey' })
+
+    await instance.load(Context.system(), analyticsInstance)
+
+    expect(getBucketCallLog()).toStrictEqual([
+      { method: 'init', args: ['testTrackingKey', { host: 'http://localhost:3200' }] }
+    ])
+  })
+
+  it('allows sdkVersion override', async () => {
+    const [instance] = await bucketWebDestination({
+      trackingKey: 'testTrackingKey',
+      sdkVersion: 'latest',
+      subscriptions: subscriptions as unknown as JSONArray
+    })
+
+    const analyticsInstance = new Analytics({ writeKey: 'test-writekey' })
+
+    await instance.load(Context.system(), analyticsInstance)
+
+    const scripts = Array.from(window.document.querySelectorAll('script'))
+    expect(scripts).toMatchInlineSnapshot(`
+      Array [
+        <script
+          src="https://cdn.jsdelivr.net/npm/@bucketco/tracking-sdk@latest"
+          status="loaded"
+          type="text/javascript"
+        />,
+        <script>
+          // the emptiness
+        </script>,
+      ]
+    `)
+
+    expect(getBucketCallLog()).toStrictEqual([{ method: 'init', args: ['testTrackingKey', {}] }])
   })
 
   describe('when not logged in', () => {
@@ -86,7 +130,7 @@ describe('Bucket', () => {
 
       await instance.load(Context.system(), analyticsInstance)
 
-      expect(getBucketCallLog()).toStrictEqual([{ method: 'init', args: ['testTrackingKey'] }])
+      expect(getBucketCallLog()).toStrictEqual([{ method: 'init', args: ['testTrackingKey', {}] }])
     })
   })
 
@@ -108,7 +152,7 @@ describe('Bucket', () => {
       await instance.load(Context.system(), analyticsInstance)
 
       expect(getBucketCallLog()).toStrictEqual([
-        { method: 'init', args: ['testTrackingKey'] },
+        { method: 'init', args: ['testTrackingKey', {}] },
         { method: 'user', args: ['test-user-id-1', {}, { active: false }] }
       ])
     })

--- a/packages/browser-destinations/destinations/bucket/src/group/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/bucket/src/group/__tests__/index.test.ts
@@ -71,7 +71,7 @@ describe('Bucket.company', () => {
         )
 
         expect(getBucketCallLog()).toStrictEqual([
-          { method: 'init', args: ['testTrackingKey'] },
+          { method: 'init', args: ['testTrackingKey', {}] },
           {
             method: 'user',
             args: ['user-id-1', {}, { active: false }]
@@ -129,7 +129,7 @@ describe('Bucket.company', () => {
         )
 
         expect(getBucketCallLog()).toStrictEqual([
-          { method: 'init', args: ['testTrackingKey'] },
+          { method: 'init', args: ['testTrackingKey', {}] },
           {
             method: 'user',
             args: ['user-id-1']
@@ -180,7 +180,7 @@ describe('Bucket.company', () => {
       // and then trigger the full flow trhough analytics.group() with only an anonymous ID
       // expect(destination.actions.group.perform).not.toHaveBeenCalled()
 
-      expect(getBucketCallLog()).toStrictEqual([{ method: 'init', args: ['testTrackingKey'] }])
+      expect(getBucketCallLog()).toStrictEqual([{ method: 'init', args: ['testTrackingKey', {}] }])
     })
   })
 })

--- a/packages/browser-destinations/destinations/bucket/src/identifyUser/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/bucket/src/identifyUser/__tests__/index.test.ts
@@ -61,7 +61,7 @@ describe('Bucket.user', () => {
     )
 
     expect(getBucketCallLog()).toStrictEqual([
-      { method: 'init', args: ['testTrackingKey'] },
+      { method: 'init', args: ['testTrackingKey', {}] },
       {
         method: 'user',
         args: [

--- a/packages/browser-destinations/destinations/bucket/src/index.ts
+++ b/packages/browser-destinations/destinations/bucket/src/index.ts
@@ -60,10 +60,21 @@ export const destination: BrowserDestinationDefinition<Settings, Bucket> = {
   },
 
   initialize: async ({ settings, analytics }, deps) => {
-    await deps.loadScript('https://cdn.jsdelivr.net/npm/@bucketco/tracking-sdk@2')
+    const {
+      // @ts-expect-error versionSettings is not part of the settings object but they are injected by Analytics 2.0, making Braze SDK raise a warning when we initialize it.
+      versionSettings,
+      // @ts-expect-error same as above.
+      subscriptions,
+
+      trackingKey,
+      // @ts-expect-error Code-only SDK version override. Can be set via analytics.load() integrations overrides
+      sdkVersion = '2',
+      ...options
+    } = settings
+    await deps.loadScript(`https://cdn.jsdelivr.net/npm/@bucketco/tracking-sdk@${sdkVersion}`)
     await deps.resolveWhen(() => window.bucket != undefined, 100)
 
-    window.bucket.init(settings.trackingKey)
+    window.bucket.init(settings.trackingKey, options)
 
     // If the analytics client already has a logged in user from a
     // previous session or page, consider the user logged in.

--- a/packages/browser-destinations/destinations/bucket/src/test-utils.ts
+++ b/packages/browser-destinations/destinations/bucket/src/test-utils.ts
@@ -38,7 +38,9 @@ export function bucketTestHooks() {
   })
 
   beforeEach(() => {
-    nock('https://cdn.jsdelivr.net').get('/npm/@bucketco/tracking-sdk@2').reply(200, bucketTestMock)
+    nock('https://cdn.jsdelivr.net')
+      .get((uri) => uri.startsWith('/npm/@bucketco/tracking-sdk@'))
+      .reply(200, bucketTestMock)
   })
 
   afterEach(function () {
@@ -46,8 +48,9 @@ export function bucketTestHooks() {
       // @ts-expect-error no-unsafe-call
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       this.test.error(new Error('Not all nock interceptors were used!'))
-      nock.cleanAll()
     }
+
+    nock.cleanAll()
   })
 
   afterAll(() => {

--- a/packages/browser-destinations/destinations/bucket/src/trackEvent/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/bucket/src/trackEvent/__tests__/index.test.ts
@@ -64,7 +64,7 @@ describe('trackEvent', () => {
         )
 
         expect(getBucketCallLog()).toStrictEqual([
-          { method: 'init', args: ['testTrackingKey'] },
+          { method: 'init', args: ['testTrackingKey', {}] },
           {
             method: 'user',
             args: ['user-id-1', {}, { active: false }]
@@ -109,7 +109,7 @@ describe('trackEvent', () => {
         )
 
         expect(getBucketCallLog()).toStrictEqual([
-          { method: 'init', args: ['testTrackingKey'] },
+          { method: 'init', args: ['testTrackingKey', {}] },
           {
             method: 'user',
             args: ['user-id-1']
@@ -153,7 +153,7 @@ describe('trackEvent', () => {
       // and then trigger the full flow trhough analytics.track() with only an anonymous ID
       // expect(destination.actions.trackEvent.perform).not.toHaveBeenCalled()
 
-      expect(getBucketCallLog()).toStrictEqual([{ method: 'init', args: ['testTrackingKey'] }])
+      expect(getBucketCallLog()).toStrictEqual([{ method: 'init', args: ['testTrackingKey', {}] }])
     })
   })
 })


### PR DESCRIPTION
Addition of initialization options and SDK version override for Bucket Web (Actions).

During early beta testing it became clear that it would be very useful to be able to pass init options via the integrations configuration for Analytics.js, in order to allow passing Bucket SDK [initialization options](https://github.com/bucketco/bucket-tracking-sdk?tab=readme-ov-file#init-options) and [feedback UI configuration](https://github.com/bucketco/bucket-tracking-sdk/blob/main/FEEDBACK.md#global-feedback-configuration)

We're still working under the assumption that less is more in terms of configuration exposed via the segment UI, which is why we're holding back a bit with adding all of the configuration options as structured fields. We'll add the ones we see the greatest need for eventually when we have more customer feedback. In the mean time, this allows for all the flexibiliy of the bucket SDK itself, given you can make code additions

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
