### PR TITLE
Update linkedin API version to 202311

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -13,7 +13,7 @@ Headers {
       "Bearer undefined",
     ],
     "linkedin-version": Array [
-      "202307",
+      "202311",
     ],
     "user-agent": Array [
       "Segment (Actions)",

--- a/packages/destination-actions/src/destinations/linkedin-audiences/constants.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/constants.ts
@@ -1,3 +1,3 @@
-export const LINKEDIN_API_VERSION = '202307'
+export const LINKEDIN_API_VERSION = '202311'
 export const BASE_URL = 'https://api.linkedin.com/rest'
 export const LINKEDIN_SOURCE_PLATFORM = 'SEGMENT'

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -13,7 +13,7 @@ Headers {
       "Bearer undefined",
     ],
     "linkedin-version": Array [
-      "202307",
+      "202311",
     ],
     "user-agent": Array [
       "Segment (Actions)",


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR upgrades the API version for linkedin.

JIRA -> [STRATCONN-3071](https://segment.atlassian.net/browse/STRATCONN-3071)
## Testing

<img width="1537" alt="Screenshot 2023-12-25 at 4 53 13 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/9357b294-51b4-4df1-9341-2858103a4014">

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment


[STRATCONN-3071]: https://segment.atlassian.net/browse/STRATCONN-3071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ