### PR TITLE
Add Aggregations.io Destination

### DIFF
--- a/packages/destination-actions/src/destinations/aggregations-io/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/aggregations-io/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for aggregations-io destination: send action - all fields 1`] = `
+Array [
+  Object {
+    "testType": "!80aBDHS1i",
+  },
+]
+`;
+
+exports[`Testing snapshot for aggregations-io destination: send action - required fields 1`] = `
+Array [
+  null,
+]
+`;

--- a/packages/destination-actions/src/destinations/aggregations-io/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/aggregations-io/__tests__/index.test.ts
@@ -1,0 +1,24 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+
+const testDestination = createTestIntegration(Definition)
+const fakeApiKey = 'super-secret-key'
+const fakeIngestId = 'abc456'
+describe('Aggregations Io', () => {
+  describe('testAuthentication', () => {
+    it('should validate authentication inputs', async () => {
+      nock('https://app.aggregations.io')
+        .get(`/api/v1/organization/ping-w?ingest_id=${fakeIngestId}&schema=ARRAY_OF_EVENTS`)
+        .reply(200)
+        .matchHeader('x-api-token', fakeApiKey)
+
+      const authData = {
+        api_key: fakeApiKey,
+        ingest_id: fakeIngestId
+      }
+
+      await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/aggregations-io/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/aggregations-io/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'aggregations-io'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/aggregations-io/generated-types.ts
+++ b/packages/destination-actions/src/destinations/aggregations-io/generated-types.ts
@@ -1,0 +1,12 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your Aggregations.io API Key. This key requires Write permissions.
+   */
+  api_key: string
+  /**
+   * The ID of the ingest you want to send data to. This ingest should be set up as "Array of JSON Objects". Find your ID on the Aggregations.io Organization page.
+   */
+  ingest_id: string
+}

--- a/packages/destination-actions/src/destinations/aggregations-io/index.ts
+++ b/packages/destination-actions/src/destinations/aggregations-io/index.ts
@@ -6,7 +6,7 @@ import { InvalidAuthenticationError } from '@segment/actions-core'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Aggregations Io',
-  slug: 'aggregations-io',
+  slug: 'actions-aggregations-io',
   mode: 'cloud',
   authentication: {
     scheme: 'custom',

--- a/packages/destination-actions/src/destinations/aggregations-io/index.ts
+++ b/packages/destination-actions/src/destinations/aggregations-io/index.ts
@@ -1,0 +1,60 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import send from './send'
+import { InvalidAuthenticationError } from '@segment/actions-core'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Aggregations Io',
+  slug: 'aggregations-io',
+  mode: 'cloud',
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      api_key: {
+        label: 'API Key',
+        description: 'Your Aggregations.io API Key. This key requires Write permissions.',
+        type: 'password',
+        required: true
+      },
+      ingest_id: {
+        label: 'Ingest Id',
+        description:
+          'The ID of the ingest you want to send data to. This ingest should be set up as "Array of JSON Objects". Find your ID on the Aggregations.io Organization page.',
+        type: 'string',
+        required: true
+      }
+    },
+
+    testAuthentication: async (request, settings) => {
+      const resp = await request(
+        `https://app.aggregations.io/api/v1/organization/ping-w?ingest_id=${settings.settings.ingest_id}&schema=ARRAY_OF_EVENTS`,
+        {
+          method: 'get',
+          throwHttpErrors: false,
+          headers: {
+            'x-api-token': settings.settings.api_key
+          }
+        }
+      )
+      if (resp.status === 200) {
+        return resp
+      } else {
+        const err_msg = await resp.json()
+        throw new InvalidAuthenticationError(err_msg.message || 'Error Validating Credentials')
+      }
+    }
+  },
+
+  extendRequest: ({ settings }) => {
+    return {
+      headers: { 'x-api-token': settings.api_key }
+    }
+  },
+
+  actions: {
+    send
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/aggregations-io/index.ts
+++ b/packages/destination-actions/src/destinations/aggregations-io/index.ts
@@ -5,7 +5,7 @@ import send from './send'
 import { InvalidAuthenticationError } from '@segment/actions-core'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Aggregations Io',
+  name: 'Aggregations.io',
   slug: 'actions-aggregations-io',
   mode: 'cloud',
   authentication: {

--- a/packages/destination-actions/src/destinations/aggregations-io/send/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/aggregations-io/send/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for AggregationsIo's send destination action: all fields 1`] = `
+Array [
+  Object {
+    "testType": "#^vP0",
+  },
+]
+`;
+
+exports[`Testing snapshot for AggregationsIo's send destination action: required fields 1`] = `
+Array [
+  null,
+]
+`;

--- a/packages/destination-actions/src/destinations/aggregations-io/send/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/aggregations-io/send/__tests__/index.test.ts
@@ -1,0 +1,60 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { PayloadValidationError } from '@segment/actions-core'
+
+const testDestination = createTestIntegration(Destination)
+const testIngestId = 'abc123'
+const testApiKey = 'super-secret-key'
+const ingestUrl = 'https://ingest.aggregations.io'
+describe('AggregationsIo.send', () => {
+  const event1 = createTestEvent()
+  const event2 = createTestEvent()
+
+  it('should work for single event', async () => {
+    nock(ingestUrl).post(`/${testIngestId}`).reply(200).matchHeader('x-api-token', testApiKey)
+    const response = await testDestination.testAction('send', {
+      event: event1,
+      settings: {
+        api_key: testApiKey,
+        ingest_id: testIngestId
+      },
+      useDefaultMappings: true
+    })
+    expect(response.length).toBe(1)
+    expect(new URL(response[0].url).pathname).toBe('/' + testIngestId)
+    expect(response[0].status).toBe(200)
+  })
+
+  it('should work for batched events', async () => {
+    nock(ingestUrl).post(`/${testIngestId}`).reply(200).matchHeader('x-api-token', testApiKey)
+    const response = await testDestination.testBatchAction('send', {
+      events: [event1, event2],
+      settings: {
+        api_key: testApiKey,
+        ingest_id: testIngestId
+      },
+      useDefaultMappings: true
+    })
+    expect(response.length).toBe(1)
+    expect(new URL(response[0].url).pathname).toBe('/' + testIngestId)
+    expect(response[0].status).toBe(200)
+  })
+
+  it('should not work for batched events when disabled', async () => {
+    nock(ingestUrl).post(`/${testIngestId}`).matchHeader('x-api-token', testApiKey).replyWithError('Batching Disabled')
+    await expect(
+      testDestination.testBatchAction('send', {
+        events: [event1, event2],
+        settings: {
+          api_key: testApiKey,
+          ingest_id: testIngestId
+        },
+        mapping: {
+          enable_batching: false
+        },
+        useDefaultMappings: false
+      })
+    ).rejects.toThrow(PayloadValidationError)
+  })
+})

--- a/packages/destination-actions/src/destinations/aggregations-io/send/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/aggregations-io/send/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'send'
+const destinationSlug = 'AggregationsIo'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/aggregations-io/send/generated-types.ts
+++ b/packages/destination-actions/src/destinations/aggregations-io/send/generated-types.ts
@@ -1,0 +1,18 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Payload to deliver (JSON-encoded).
+   */
+  data?: {
+    [k: string]: unknown
+  }
+  /**
+   * Enabling sending batches of events to Aggregations.io.
+   */
+  enable_batching: boolean
+  /**
+   * Maximum number of events to include in each batch. Actual batch sizes may be lower. If you know your events are large, you may want to tune your batch size down to meet API requirements.
+   */
+  batch_size?: number
+}

--- a/packages/destination-actions/src/destinations/aggregations-io/send/index.ts
+++ b/packages/destination-actions/src/destinations/aggregations-io/send/index.ts
@@ -4,8 +4,7 @@ import type { Payload } from './generated-types'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Events',
-  description: '',
-  defaultSubscription: 'type = "track" or type = "page" or type = "screen"',
+  description: 'Send events to Aggregations.io.',
   fields: {
     data: {
       label: 'Data',
@@ -26,7 +25,8 @@ const action: ActionDefinition<Settings, Payload> = {
         'Maximum number of events to include in each batch. Actual batch sizes may be lower. If you know your events are large, you may want to tune your batch size down to meet API requirements.',
       type: 'number',
       required: false,
-      default: 300
+      default: 300,
+      unsafe_hidden: true
     }
   },
   perform: (request, { settings, payload }) => {

--- a/packages/destination-actions/src/destinations/aggregations-io/send/index.ts
+++ b/packages/destination-actions/src/destinations/aggregations-io/send/index.ts
@@ -1,0 +1,59 @@
+import { ActionDefinition, PayloadValidationError } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Send Events',
+  description: '',
+  defaultSubscription: 'type = "track" or type = "page" or type = "screen"',
+  fields: {
+    data: {
+      label: 'Data',
+      description: 'Payload to deliver (JSON-encoded).',
+      type: 'object',
+      default: { '@path': '$.' }
+    },
+    enable_batching: {
+      label: 'Enable Batching',
+      description: 'Enabling sending batches of events to Aggregations.io.',
+      type: 'boolean',
+      required: true,
+      default: true
+    },
+    batch_size: {
+      label: 'Batch Size',
+      description:
+        'Maximum number of events to include in each batch. Actual batch sizes may be lower. If you know your events are large, you may want to tune your batch size down to meet API requirements.',
+      type: 'number',
+      required: false,
+      default: 300
+    }
+  },
+  perform: (request, { settings, payload }) => {
+    try {
+      return request('https://ingest.aggregations.io/' + settings.ingest_id, {
+        method: 'POST',
+        json: [payload.data]
+      })
+    } catch (error) {
+      if (error instanceof TypeError) throw new PayloadValidationError(error.message)
+      throw error
+    }
+  },
+  performBatch: (request, { settings, payload }) => {
+    try {
+      if (payload[0].enable_batching == false) {
+        throw new PayloadValidationError('Batching Disabled')
+      }
+      return request('https://ingest.aggregations.io/' + settings.ingest_id, {
+        method: 'POST',
+        json: payload.map((x) => x.data)
+      })
+    } catch (error) {
+      if (error instanceof TypeError) throw new PayloadValidationError(error.message)
+      throw error
+    }
+  }
+}
+
+export default action


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Added new destination for [Aggregations.io](https://aggregations.io).  

Aggregations.io doesn't require any special mapping or modifications to events, so the action is a pretty simple "Send Events" action.  User needs to provide their API Key as well as the `Ingest Id` they retrieve from their Aggregations.io dashboard. 

Batching is encouraged, so I defaulted that on with a default batch size of 300 (our max request size is 1MB so with Segment's event size limit of 32KB, seems sensible).

Please let me know if there are any questions or issues! 

## Testing

- Added basic tests for success & failure scenarios for `Send` method.
- Added basic test for auth 
- Ran unit tests locally, worked
- Used actions tester tool, worked
- Tested requests via postman as well, all worked as expected


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
