### PR TITLE
[STRATCONN-3091] - [Segment Profiles] -  Feature gate Cleanup

### DIFF
--- a/packages/destination-actions/src/destinations/segment-profiles/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -2,132 +2,186 @@
 
 exports[`Testing snapshot for actions-segment-profiles destination: sendGroup action - all fields 1`] = `
 Object {
-  "anonymousId": "cZE8HyAL0!BF#)WQb^",
-  "groupId": "cZE8HyAL0!BF#)WQb^",
-  "integrations": Object {
-    "All": false,
+  "data": Object {
+    "batch": Array [
+      Object {
+        "anonymousId": "cZE8HyAL0!BF#)WQb^",
+        "groupId": "cZE8HyAL0!BF#)WQb^",
+        "integrations": Object {
+          "All": false,
+        },
+        "timestamp": "2021-02-01T00:00:00.000Z",
+        "traits": Object {
+          "testType": "cZE8HyAL0!BF#)WQb^",
+        },
+        "type": "group",
+        "userId": "cZE8HyAL0!BF#)WQb^",
+      },
+    ],
   },
-  "timestamp": "2021-02-01T00:00:00.000Z",
-  "traits": Object {
-    "testType": "cZE8HyAL0!BF#)WQb^",
-  },
-  "userId": "cZE8HyAL0!BF#)WQb^",
+  "output": "Action Executed",
 }
 `;
 
 exports[`Testing snapshot for actions-segment-profiles destination: sendGroup action - required fields 1`] = `
 Object {
-  "anonymousId": "cZE8HyAL0!BF#)WQb^",
-  "groupId": "cZE8HyAL0!BF#)WQb^",
-  "integrations": Object {
-    "All": false,
+  "data": Object {
+    "batch": Array [
+      Object {
+        "anonymousId": "cZE8HyAL0!BF#)WQb^",
+        "groupId": "cZE8HyAL0!BF#)WQb^",
+        "integrations": Object {
+          "All": false,
+        },
+        "timestamp": undefined,
+        "traits": Object {},
+        "type": "group",
+        "userId": "cZE8HyAL0!BF#)WQb^",
+      },
+    ],
   },
-  "traits": Object {},
-  "userId": "cZE8HyAL0!BF#)WQb^",
+  "output": "Action Executed",
 }
 `;
 
 exports[`Testing snapshot for actions-segment-profiles destination: sendIdentify action - all fields 1`] = `
 Object {
-  "anonymousId": "hIC1OAmWa[Q!&d%o",
-  "groupId": "hIC1OAmWa[Q!&d%o",
-  "integrations": Object {
-    "All": false,
+  "data": Object {
+    "batch": Array [
+      Object {
+        "anonymousId": "hIC1OAmWa[Q!&d%o",
+        "groupId": "hIC1OAmWa[Q!&d%o",
+        "integrations": Object {
+          "All": false,
+        },
+        "timestamp": "2021-02-01T00:00:00.000Z",
+        "traits": Object {
+          "testType": "hIC1OAmWa[Q!&d%o",
+        },
+        "type": "identify",
+        "userId": "hIC1OAmWa[Q!&d%o",
+      },
+    ],
   },
-  "timestamp": "2021-02-01T00:00:00.000Z",
-  "traits": Object {
-    "testType": "hIC1OAmWa[Q!&d%o",
-  },
-  "userId": "hIC1OAmWa[Q!&d%o",
+  "output": "Action Executed",
 }
 `;
 
 exports[`Testing snapshot for actions-segment-profiles destination: sendIdentify action - required fields 1`] = `
 Object {
-  "anonymousId": "hIC1OAmWa[Q!&d%o",
-  "groupId": "hIC1OAmWa[Q!&d%o",
-  "integrations": Object {
-    "All": false,
+  "data": Object {
+    "batch": Array [
+      Object {
+        "anonymousId": "hIC1OAmWa[Q!&d%o",
+        "groupId": "hIC1OAmWa[Q!&d%o",
+        "integrations": Object {
+          "All": false,
+        },
+        "timestamp": undefined,
+        "traits": Object {},
+        "type": "identify",
+        "userId": "hIC1OAmWa[Q!&d%o",
+      },
+    ],
   },
-  "traits": Object {},
-  "userId": "hIC1OAmWa[Q!&d%o",
+  "output": "Action Executed",
 }
 `;
 
 exports[`Testing snapshot for actions-segment-profiles destination: sendSubscription action - all fields 1`] = `
 Object {
-  "context": Object {
-    "externalIds": Array [
+  "data": Object {
+    "batch": Array [
       Object {
-        "collection": "users",
-        "encoding": "none",
-        "id": "tester11@seg.com",
-        "type": "email",
-      },
-      Object {
-        "collection": "users",
-        "encoding": "none",
-        "id": "+12135618345",
-        "type": "phone",
+        "anonymousId": undefined,
+        "context": Object {
+          "externalIds": Array [
+            Object {
+              "collection": "users",
+              "encoding": "none",
+              "id": "tester11@seg.com",
+              "type": "email",
+            },
+            Object {
+              "collection": "users",
+              "encoding": "none",
+              "id": "+12135618345",
+              "type": "phone",
+            },
+          ],
+          "messaging_subscriptions": Array [
+            Object {
+              "key": "tester11@seg.com",
+              "status": "SUBSCRIBED",
+              "type": "EMAIL",
+            },
+            Object {
+              "key": "+12135618345",
+              "status": "SUBSCRIBED",
+              "type": "SMS",
+            },
+          ],
+          "messaging_subscriptions_retl": true,
+        },
+        "integrations": Object {
+          "All": false,
+        },
+        "timestamp": undefined,
+        "traits": Object {},
+        "type": "identify",
+        "userId": "user12",
       },
     ],
-    "messaging_subscriptions": Array [
-      Object {
-        "key": "tester11@seg.com",
-        "status": "SUBSCRIBED",
-        "type": "EMAIL",
-      },
-      Object {
-        "key": "+12135618345",
-        "status": "SUBSCRIBED",
-        "type": "SMS",
-      },
-    ],
-    "messaging_subscriptions_retl": true,
   },
-  "integrations": Object {
-    "All": false,
-  },
-  "traits": Object {},
-  "userId": "user12",
+  "output": "Action Executed",
 }
 `;
 
 exports[`Testing snapshot for actions-segment-profiles destination: sendSubscription action - required fields 1`] = `
 Object {
-  "context": Object {
-    "externalIds": Array [
+  "data": Object {
+    "batch": Array [
       Object {
-        "collection": "users",
-        "encoding": "none",
-        "id": "tester11@seg.com",
-        "type": "email",
-      },
-      Object {
-        "collection": "users",
-        "encoding": "none",
-        "id": "+12135618345",
-        "type": "phone",
+        "anonymousId": undefined,
+        "context": Object {
+          "externalIds": Array [
+            Object {
+              "collection": "users",
+              "encoding": "none",
+              "id": "tester11@seg.com",
+              "type": "email",
+            },
+            Object {
+              "collection": "users",
+              "encoding": "none",
+              "id": "+12135618345",
+              "type": "phone",
+            },
+          ],
+          "messaging_subscriptions": Array [
+            Object {
+              "key": "tester11@seg.com",
+              "status": "SUBSCRIBED",
+              "type": "EMAIL",
+            },
+            Object {
+              "key": "+12135618345",
+              "status": "SUBSCRIBED",
+              "type": "SMS",
+            },
+          ],
+          "messaging_subscriptions_retl": true,
+        },
+        "integrations": Object {
+          "All": false,
+        },
+        "timestamp": undefined,
+        "traits": Object {},
+        "type": "identify",
+        "userId": "user12",
       },
     ],
-    "messaging_subscriptions": Array [
-      Object {
-        "key": "tester11@seg.com",
-        "status": "SUBSCRIBED",
-        "type": "EMAIL",
-      },
-      Object {
-        "key": "+12135618345",
-        "status": "SUBSCRIBED",
-        "type": "SMS",
-      },
-    ],
-    "messaging_subscriptions_retl": true,
   },
-  "integrations": Object {
-    "All": false,
-  },
-  "traits": Object {},
-  "userId": "user12",
+  "output": "Action Executed",
 }
 `;

--- a/packages/destination-actions/src/destinations/segment-profiles/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/__tests__/snapshot.test.ts
@@ -1,7 +1,6 @@
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import { generateTestData } from '../../../lib/test-data'
 import destination from '../index'
-import { DEFAULT_SEGMENT_ENDPOINT } from '../properties'
 import nock from 'nock'
 
 const testDestination = createTestIntegration(destination)
@@ -14,9 +13,6 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
       const action = destination.actions[actionSlug]
       const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
 
-      nock(/.*/).persist().get(/.*/).reply(200)
-      nock(/.*/).persist().post(/.*/).reply(200)
-      nock(/.*/).persist().put(/.*/).reply(200)
       let event
       if (actionSlug === 'sendSubscription') {
         event = createTestEvent({
@@ -35,25 +31,15 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
         })
       }
 
-      const responses = await testDestination.testAction(actionSlug, {
+      await testDestination.testAction(actionSlug, {
         event: event,
         mapping: event.properties,
-        settings: { ...settingsData, endpoint: DEFAULT_SEGMENT_ENDPOINT },
+        settings: { ...settingsData },
         auth: undefined
       })
 
-      const request = responses[0].request
-      const rawBody = await request.text()
-
-      try {
-        const json = JSON.parse(rawBody)
-        expect(json).toMatchSnapshot()
-        return
-      } catch (err) {
-        expect(rawBody).toMatchSnapshot()
-      }
-
-      expect(request.headers).toMatchSnapshot()
+      const results = testDestination.results
+      expect(results[results.length - 1]).toMatchSnapshot()
     })
 
     it(`${actionSlug} action - all fields`, async () => {
@@ -83,23 +69,15 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
         })
       }
 
-      const responses = await testDestination.testAction(actionSlug, {
+      await testDestination.testAction(actionSlug, {
         event: event,
         mapping: event.properties,
-        settings: { ...settingsData, endpoint: DEFAULT_SEGMENT_ENDPOINT },
+        settings: { ...settingsData },
         auth: undefined
       })
 
-      const request = responses[0].request
-      const rawBody = await request.text()
-
-      try {
-        const json = JSON.parse(rawBody)
-        expect(json).toMatchSnapshot()
-        return
-      } catch (err) {
-        expect(rawBody).toMatchSnapshot()
-      }
+      const results = testDestination.results
+      expect(results[results.length - 1]).toMatchSnapshot()
     })
   }
 })

--- a/packages/destination-actions/src/destinations/segment-profiles/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/generated-types.ts
@@ -1,8 +1,3 @@
 // Generated file. DO NOT MODIFY IT BY HAND.
 
-export interface Settings {
-  /**
-   * The region to send your data.
-   */
-  endpoint: string
-}
+export interface Settings {}

--- a/packages/destination-actions/src/destinations/segment-profiles/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/index.ts
@@ -1,6 +1,5 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
-import { DEFAULT_SEGMENT_ENDPOINT, SEGMENT_ENDPOINTS } from './properties'
 
 import sendGroup from './sendGroup'
 
@@ -12,23 +11,6 @@ const destination: DestinationDefinition<Settings> = {
   name: 'Segment Profiles',
   slug: 'actions-segment-profiles',
   mode: 'cloud',
-  authentication: {
-    scheme: 'custom',
-    fields: {
-      endpoint: {
-        label: 'Endpoint Region',
-        description: 'The region to send your data.',
-        type: 'string',
-        format: 'text',
-        choices: Object.keys(SEGMENT_ENDPOINTS).map((key) => ({
-          label: SEGMENT_ENDPOINTS[key].label,
-          value: key
-        })),
-        default: DEFAULT_SEGMENT_ENDPOINT,
-        required: true
-      }
-    }
-  },
   actions: {
     sendGroup,
     sendIdentify,

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SegmentProfiles.sendGroup Should not send event if actions-segment-profiles-tapi-internal-enabled flag is enabled 1`] = `
+exports[`SegmentProfiles.sendGroup Should return transformed event 1`] = `
 Object {
   "batch": Array [
     Object {
@@ -18,34 +18,5 @@ Object {
       "userId": "test-user-ufi5bgkko5",
     },
   ],
-}
-`;
-
-exports[`SegmentProfiles.sendGroup Should send an group event to Segment 1`] = `
-Headers {
-  Symbol(map): Object {
-    "authorization": Array [
-      "Basic ZW5nYWdlLXNwYWNlLXdyaXRla2V5Og==",
-    ],
-    "user-agent": Array [
-      "Segment (Actions)",
-    ],
-  },
-}
-`;
-
-exports[`SegmentProfiles.sendGroup Should send an group event to Segment 2`] = `
-Object {
-  "anonymousId": "arky4h2sh7k",
-  "groupId": "test-group-ks2i7e",
-  "integrations": Object {
-    "All": false,
-  },
-  "timestamp": "2023-09-26T09:46:28.290Z",
-  "traits": Object {
-    "industry": "Technology",
-    "name": "Example Corp",
-  },
-  "userId": "test-user-ufi5bgkko5",
 }
 `;

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -2,27 +2,44 @@
 
 exports[`Testing snapshot for SegmentProfiles's sendGroup destination action: all fields 1`] = `
 Object {
-  "anonymousId": "tKaa(2A",
-  "groupId": "tKaa(2A",
-  "integrations": Object {
-    "All": false,
+  "data": Object {
+    "batch": Array [
+      Object {
+        "anonymousId": "tKaa(2A",
+        "groupId": "tKaa(2A",
+        "integrations": Object {
+          "All": false,
+        },
+        "timestamp": "2021-02-01T00:00:00.000Z",
+        "traits": Object {
+          "testType": "tKaa(2A",
+        },
+        "type": "group",
+        "userId": "tKaa(2A",
+      },
+    ],
   },
-  "timestamp": "2021-02-01T00:00:00.000Z",
-  "traits": Object {
-    "testType": "tKaa(2A",
-  },
-  "userId": "tKaa(2A",
+  "output": "Action Executed",
 }
 `;
 
 exports[`Testing snapshot for SegmentProfiles's sendGroup destination action: required fields 1`] = `
 Object {
-  "anonymousId": "tKaa(2A",
-  "groupId": "tKaa(2A",
-  "integrations": Object {
-    "All": false,
+  "data": Object {
+    "batch": Array [
+      Object {
+        "anonymousId": "tKaa(2A",
+        "groupId": "tKaa(2A",
+        "integrations": Object {
+          "All": false,
+        },
+        "timestamp": undefined,
+        "traits": Object {},
+        "type": "group",
+        "userId": "tKaa(2A",
+      },
+    ],
   },
-  "traits": Object {},
-  "userId": "tKaa(2A",
+  "output": "Action Executed",
 }
 `;

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/index.test.ts
@@ -1,8 +1,8 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
-import { MissingUserOrAnonymousIdThrowableError, InvalidEndpointSelectedThrowableError } from '../../errors'
-import { SEGMENT_ENDPOINTS, DEFAULT_SEGMENT_ENDPOINT } from '../../properties'
+import { MissingUserOrAnonymousIdThrowableError } from '../../errors'
+import { DEFAULT_SEGMENT_ENDPOINT } from '../../properties'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -50,33 +50,8 @@ describe('SegmentProfiles.sendGroup', () => {
       })
     ).rejects.toThrowError(MissingUserOrAnonymousIdThrowableError)
   })
-  test('Should throw an error if Segment Endpoint is incorrectly defined', async () => {
-    const event = createTestEvent({
-      traits: {
-        name: 'Example Corp',
-        industry: 'Technology'
-      },
-      userId: 'test-user-ufi5bgkko5',
-      anonymousId: 'arky4h2sh7k',
-      groupId: 'test-group-ks2i7e'
-    })
 
-    await expect(
-      testDestination.testAction('sendGroup', {
-        event,
-        mapping: defaultGroupMapping,
-        settings: {
-          endpoint: 'incorrect-endpoint'
-        }
-      })
-    ).rejects.toThrowError(InvalidEndpointSelectedThrowableError)
-  })
-
-  test('Should send an group event to Segment', async () => {
-    // Mock: Segment Group Call
-    const segmentEndpoint = SEGMENT_ENDPOINTS[DEFAULT_SEGMENT_ENDPOINT].url
-    nock(segmentEndpoint).post('/group').reply(200, { success: true })
-
+  test('Should return transformed event', async () => {
     const event = createTestEvent({
       traits: {
         name: 'Example Corp',
@@ -93,35 +68,6 @@ describe('SegmentProfiles.sendGroup', () => {
       mapping: defaultGroupMapping,
       settings: {
         endpoint: DEFAULT_SEGMENT_ENDPOINT
-      }
-    })
-
-    expect(responses.length).toBe(1)
-    expect(responses[0].status).toEqual(200)
-    expect(responses[0].options.headers).toMatchSnapshot()
-    expect(responses[0].options.json).toMatchSnapshot()
-  })
-
-  test('Should not send event if actions-segment-profiles-tapi-internal-enabled flag is enabled', async () => {
-    const event = createTestEvent({
-      traits: {
-        name: 'Example Corp',
-        industry: 'Technology'
-      },
-      userId: 'test-user-ufi5bgkko5',
-      anonymousId: 'arky4h2sh7k',
-      groupId: 'test-group-ks2i7e',
-      timestamp: '2023-09-26T09:46:28.290Z'
-    })
-
-    const responses = await testDestination.testAction('sendGroup', {
-      event,
-      mapping: defaultGroupMapping,
-      settings: {
-        endpoint: DEFAULT_SEGMENT_ENDPOINT
-      },
-      features: {
-        'actions-segment-profiles-tapi-internal-enabled': true
       }
     })
 

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/snapshot.test.ts
@@ -1,8 +1,6 @@
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import { generateTestData } from '../../../../lib/test-data'
 import destination from '../../index'
-import { DEFAULT_SEGMENT_ENDPOINT } from '../../properties'
-import nock from 'nock'
 
 const testDestination = createTestIntegration(destination)
 const actionSlug = 'sendGroup'
@@ -14,63 +12,37 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const action = destination.actions[actionSlug]
     const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
 
-    nock(/.*/).persist().get(/.*/).reply(200)
-    nock(/.*/).persist().post(/.*/).reply(200)
-    nock(/.*/).persist().put(/.*/).reply(200)
-
     const event = createTestEvent({
       properties: eventData
     })
 
-    const responses = await testDestination.testAction(actionSlug, {
+    await testDestination.testAction(actionSlug, {
       event: event,
       mapping: event.properties,
-      settings: { ...settingsData, endpoint: DEFAULT_SEGMENT_ENDPOINT },
+      settings: { ...settingsData },
       auth: undefined
     })
 
-    const request = responses[0].request
-    const rawBody = await request.text()
-
-    try {
-      const json = JSON.parse(rawBody)
-      expect(json).toMatchSnapshot()
-      return
-    } catch (err) {
-      expect(rawBody).toMatchSnapshot()
-    }
-
-    expect(request.headers).toMatchSnapshot()
+    const results = testDestination.results
+    expect(results[results.length - 1]).toMatchSnapshot()
   })
 
   it('all fields', async () => {
     const action = destination.actions[actionSlug]
     const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
 
-    nock(/.*/).persist().get(/.*/).reply(200)
-    nock(/.*/).persist().post(/.*/).reply(200)
-    nock(/.*/).persist().put(/.*/).reply(200)
-
     const event = createTestEvent({
       properties: eventData
     })
 
-    const responses = await testDestination.testAction(actionSlug, {
+    await testDestination.testAction(actionSlug, {
       event: event,
       mapping: event.properties,
-      settings: { ...settingsData, endpoint: DEFAULT_SEGMENT_ENDPOINT },
+      settings: { ...settingsData },
       auth: undefined
     })
 
-    const request = responses[0].request
-    const rawBody = await request.text()
-
-    try {
-      const json = JSON.parse(rawBody)
-      expect(json).toMatchSnapshot()
-      return
-    } catch (err) {
-      expect(rawBody).toMatchSnapshot()
-    }
+    const results = testDestination.results
+    expect(results[results.length - 1]).toMatchSnapshot()
   })
 })

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/index.ts
@@ -2,9 +2,7 @@ import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { user_id, anonymous_id, group_id, traits, engage_space, timestamp } from '../segment-properties'
-import { generateSegmentAPIAuthHeaders } from '../helperFunctions'
-import { SEGMENT_ENDPOINTS } from '../properties'
-import { MissingUserOrAnonymousIdThrowableError, InvalidEndpointSelectedThrowableError } from '../errors'
+import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Group',
@@ -18,7 +16,7 @@ const action: ActionDefinition<Settings, Payload> = {
     traits,
     timestamp
   },
-  perform: (request, { payload, settings, features, statsContext }) => {
+  perform: (_request, { payload, statsContext }) => {
     if (!payload.anonymous_id && !payload.user_id) {
       throw MissingUserOrAnonymousIdThrowableError
     }
@@ -34,28 +32,12 @@ const action: ActionDefinition<Settings, Payload> = {
         // Setting 'integrations.All' to false will ensure that we don't send events
         // to any destinations which is connected to the Segment Profiles space.
         All: false
-      }
+      },
+      type: 'group'
     }
 
-    // Throw an error if endpoint is not defined or invalid
-    if (!settings.endpoint || !(settings.endpoint in SEGMENT_ENDPOINTS)) {
-      throw InvalidEndpointSelectedThrowableError
-    }
-
-    if (features && features['actions-segment-profiles-tapi-internal-enabled']) {
-      statsContext?.statsClient?.incr('tapi_internal', 1, [...statsContext.tags, `action:sendGroup`])
-      const payload = { ...groupPayload, type: 'group' }
-      return { batch: [payload] }
-    }
-
-    const selectedSegmentEndpoint = SEGMENT_ENDPOINTS[settings.endpoint].url
-    return request(`${selectedSegmentEndpoint}/group`, {
-      method: 'POST',
-      json: groupPayload,
-      headers: {
-        authorization: generateSegmentAPIAuthHeaders(payload.engage_space)
-      }
-    })
+    statsContext?.statsClient?.incr('tapi_internal', 1, [...statsContext.tags, `action:sendGroup`])
+    return { batch: [groupPayload] }
   }
 }
 

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Segment.sendIdentify Should not send event if actions-segment-profiles-tapi-internal-enabled flag is enabled 1`] = `
+exports[`Segment.sendIdentify Should return transformed event 1`] = `
 Object {
   "batch": Array [
     Object {
@@ -18,34 +18,5 @@ Object {
       "userId": "test-user-ufi5bgkko5",
     },
   ],
-}
-`;
-
-exports[`Segment.sendIdentify Should send an identify event to Segment 1`] = `
-Headers {
-  Symbol(map): Object {
-    "authorization": Array [
-      "Basic ZW5nYWdlLXNwYWNlLXdyaXRla2V5Og==",
-    ],
-    "user-agent": Array [
-      "Segment (Actions)",
-    ],
-  },
-}
-`;
-
-exports[`Segment.sendIdentify Should send an identify event to Segment 2`] = `
-Object {
-  "anonymousId": "arky4h2sh7k",
-  "groupId": undefined,
-  "integrations": Object {
-    "All": false,
-  },
-  "timestamp": "2023-09-26T09:46:28.290Z",
-  "traits": Object {
-    "email": "test-user@test-company.com",
-    "name": "Test User",
-  },
-  "userId": "test-user-ufi5bgkko5",
 }
 `;

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -2,27 +2,44 @@
 
 exports[`Testing snapshot for SegmentProfiles's sendIdentify destination action: all fields 1`] = `
 Object {
-  "anonymousId": "mV[ZQcEVgZO$MX",
-  "groupId": "mV[ZQcEVgZO$MX",
-  "integrations": Object {
-    "All": false,
+  "data": Object {
+    "batch": Array [
+      Object {
+        "anonymousId": "mV[ZQcEVgZO$MX",
+        "groupId": "mV[ZQcEVgZO$MX",
+        "integrations": Object {
+          "All": false,
+        },
+        "timestamp": "2021-02-01T00:00:00.000Z",
+        "traits": Object {
+          "testType": "mV[ZQcEVgZO$MX",
+        },
+        "type": "identify",
+        "userId": "mV[ZQcEVgZO$MX",
+      },
+    ],
   },
-  "timestamp": "2021-02-01T00:00:00.000Z",
-  "traits": Object {
-    "testType": "mV[ZQcEVgZO$MX",
-  },
-  "userId": "mV[ZQcEVgZO$MX",
+  "output": "Action Executed",
 }
 `;
 
 exports[`Testing snapshot for SegmentProfiles's sendIdentify destination action: required fields 1`] = `
 Object {
-  "anonymousId": "mV[ZQcEVgZO$MX",
-  "groupId": "mV[ZQcEVgZO$MX",
-  "integrations": Object {
-    "All": false,
+  "data": Object {
+    "batch": Array [
+      Object {
+        "anonymousId": "mV[ZQcEVgZO$MX",
+        "groupId": "mV[ZQcEVgZO$MX",
+        "integrations": Object {
+          "All": false,
+        },
+        "timestamp": undefined,
+        "traits": Object {},
+        "type": "identify",
+        "userId": "mV[ZQcEVgZO$MX",
+      },
+    ],
   },
-  "traits": Object {},
-  "userId": "mV[ZQcEVgZO$MX",
+  "output": "Action Executed",
 }
 `;

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/index.test.ts
@@ -1,8 +1,8 @@
 import nock from 'nock'
 import Destination from '../..'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
-import { SEGMENT_ENDPOINTS, DEFAULT_SEGMENT_ENDPOINT } from '../../properties'
-import { MissingUserOrAnonymousIdThrowableError, InvalidEndpointSelectedThrowableError } from '../../errors'
+import { DEFAULT_SEGMENT_ENDPOINT } from '../../properties'
+import { MissingUserOrAnonymousIdThrowableError } from '../../errors'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -45,33 +45,7 @@ describe('Segment.sendIdentify', () => {
     ).rejects.toThrowError(MissingUserOrAnonymousIdThrowableError)
   })
 
-  test('Should throw an error if Segment Endpoint is incorrectly defined', async () => {
-    const event = createTestEvent({
-      type: 'identify',
-      traits: {
-        name: 'Test User',
-        email: 'test-user@test-company.com'
-      },
-      userId: 'test-user-ufi5bgkko5',
-      anonymousId: 'arky4h2sh7k'
-    })
-
-    await expect(
-      testDestination.testAction('sendIdentify', {
-        event,
-        mapping: defaultIdentifyMapping,
-        settings: {
-          endpoint: 'incorrect-endpoint'
-        }
-      })
-    ).rejects.toThrowError(InvalidEndpointSelectedThrowableError)
-  })
-
-  test('Should send an identify event to Segment', async () => {
-    // Mock: Segment Identify Call
-    const segmentEndpoint = SEGMENT_ENDPOINTS[DEFAULT_SEGMENT_ENDPOINT].url
-    nock(segmentEndpoint).post('/identify').reply(200, { success: true })
-
+  test('Should return transformed event', async () => {
     const event = createTestEvent({
       type: 'identify',
       traits: {
@@ -88,35 +62,6 @@ describe('Segment.sendIdentify', () => {
       mapping: defaultIdentifyMapping,
       settings: {
         endpoint: DEFAULT_SEGMENT_ENDPOINT
-      }
-    })
-
-    expect(responses.length).toBe(1)
-    expect(responses[0].status).toEqual(200)
-    expect(responses[0].options.headers).toMatchSnapshot()
-    expect(responses[0].options.json).toMatchSnapshot()
-  })
-
-  test('Should not send event if actions-segment-profiles-tapi-internal-enabled flag is enabled', async () => {
-    const event = createTestEvent({
-      type: 'identify',
-      traits: {
-        name: 'Test User',
-        email: 'test-user@test-company.com'
-      },
-      userId: 'test-user-ufi5bgkko5',
-      anonymousId: 'arky4h2sh7k',
-      timestamp: '2023-09-26T09:46:28.290Z'
-    })
-
-    const responses = await testDestination.testAction('sendIdentify', {
-      event,
-      mapping: defaultIdentifyMapping,
-      settings: {
-        endpoint: DEFAULT_SEGMENT_ENDPOINT
-      },
-      features: {
-        'actions-segment-profiles-tapi-internal-enabled': true
       }
     })
     const results = testDestination.results

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/snapshot.test.ts
@@ -1,8 +1,6 @@
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import { generateTestData } from '../../../../lib/test-data'
 import destination from '../../index'
-import { DEFAULT_SEGMENT_ENDPOINT } from '../../properties'
-import nock from 'nock'
 
 const testDestination = createTestIntegration(destination)
 const actionSlug = 'sendIdentify'
@@ -14,63 +12,37 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const action = destination.actions[actionSlug]
     const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
 
-    nock(/.*/).persist().get(/.*/).reply(200)
-    nock(/.*/).persist().post(/.*/).reply(200)
-    nock(/.*/).persist().put(/.*/).reply(200)
-
     const event = createTestEvent({
       properties: eventData
     })
 
-    const responses = await testDestination.testAction(actionSlug, {
+    await testDestination.testAction(actionSlug, {
       event: event,
       mapping: event.properties,
-      settings: { ...settingsData, endpoint: DEFAULT_SEGMENT_ENDPOINT },
+      settings: { ...settingsData },
       auth: undefined
     })
 
-    const request = responses[0].request
-    const rawBody = await request.text()
-
-    try {
-      const json = JSON.parse(rawBody)
-      expect(json).toMatchSnapshot()
-      return
-    } catch (err) {
-      expect(rawBody).toMatchSnapshot()
-    }
-
-    expect(request.headers).toMatchSnapshot()
+    const results = testDestination.results
+    expect(results[results.length - 1]).toMatchSnapshot()
   })
 
   it('all fields', async () => {
     const action = destination.actions[actionSlug]
     const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
 
-    nock(/.*/).persist().get(/.*/).reply(200)
-    nock(/.*/).persist().post(/.*/).reply(200)
-    nock(/.*/).persist().put(/.*/).reply(200)
-
     const event = createTestEvent({
       properties: eventData
     })
 
-    const responses = await testDestination.testAction(actionSlug, {
+    await testDestination.testAction(actionSlug, {
       event: event,
       mapping: event.properties,
-      settings: { ...settingsData, endpoint: DEFAULT_SEGMENT_ENDPOINT },
+      settings: { ...settingsData },
       auth: undefined
     })
 
-    const request = responses[0].request
-    const rawBody = await request.text()
-
-    try {
-      const json = JSON.parse(rawBody)
-      expect(json).toMatchSnapshot()
-      return
-    } catch (err) {
-      expect(rawBody).toMatchSnapshot()
-    }
+    const results = testDestination.results
+    expect(results[results.length - 1]).toMatchSnapshot()
   })
 })

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
@@ -2,9 +2,7 @@ import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { user_id, anonymous_id, group_id, traits, engage_space, timestamp } from '../segment-properties'
-import { generateSegmentAPIAuthHeaders } from '../helperFunctions'
-import { SEGMENT_ENDPOINTS } from '../properties'
-import { MissingUserOrAnonymousIdThrowableError, InvalidEndpointSelectedThrowableError } from '../errors'
+import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Identify',
@@ -19,7 +17,7 @@ const action: ActionDefinition<Settings, Payload> = {
     traits,
     timestamp
   },
-  perform: (request, { payload, settings, features, statsContext }) => {
+  perform: (_request, { payload, statsContext }) => {
     if (!payload.anonymous_id && !payload.user_id) {
       throw MissingUserOrAnonymousIdThrowableError
     }
@@ -35,28 +33,12 @@ const action: ActionDefinition<Settings, Payload> = {
         // Setting 'integrations.All' to false will ensure that we don't send events
         // to any destinations which is connected to the Segment Profiles space.
         All: false
-      }
+      },
+      type: 'identify'
     }
 
-    // Throw an error if endpoint is not defined or invalid
-    if (!settings.endpoint || !(settings.endpoint in SEGMENT_ENDPOINTS)) {
-      throw InvalidEndpointSelectedThrowableError
-    }
-
-    if (features && features['actions-segment-profiles-tapi-internal-enabled']) {
-      statsContext?.statsClient?.incr('tapi_internal', 1, [...statsContext.tags, `action:sendIdentify`])
-      const payload = { ...identityPayload, type: 'identify' }
-      return { batch: [payload] }
-    }
-
-    const selectedSegmentEndpoint = SEGMENT_ENDPOINTS[settings.endpoint].url
-    return request(`${selectedSegmentEndpoint}/identify`, {
-      method: 'POST',
-      json: identityPayload,
-      headers: {
-        authorization: generateSegmentAPIAuthHeaders(payload.engage_space)
-      }
-    })
+    statsContext?.statsClient?.incr('tapi_internal', 1, [...statsContext.tags, `action:sendIdentify`])
+    return { batch: [identityPayload] }
   }
 }
 

--- a/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/__tests__/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SegmentProfiles.sendSubscription Should not send event if actions-segment-profiles-tapi-internal-enabled flag is enabled 1`] = `
+exports[`SegmentProfiles.sendSubscription Should return transformed event 1`] = `
 Object {
   "batch": Array [
     Object {
@@ -76,143 +76,51 @@ Object {
 }
 `;
 
-exports[`SegmentProfiles.sendSubscription Should send a subscription event to Segment 1`] = `
-Headers {
-  Symbol(map): Object {
-    "authorization": Array [
-      "Basic ZW5nYWdlLXNwYWNlLXdyaXRla2V5Og==",
-    ],
-    "user-agent": Array [
-      "Segment (Actions)",
-    ],
-  },
-}
-`;
-
-exports[`SegmentProfiles.sendSubscription Should send a subscription event to Segment 2`] = `
+exports[`SegmentProfiles.sendSubscription Should return transformed event when subscription groups are defined 1`] = `
 Object {
-  "anonymousId": "anonId1234",
-  "context": Object {
-    "externalIds": Array [
-      Object {
-        "collection": "users",
-        "encoding": "none",
-        "id": "tester11@seg.com",
-        "type": "email",
+  "batch": Array [
+    Object {
+      "anonymousId": "anonId1234",
+      "context": Object {
+        "externalIds": Array [
+          Object {
+            "collection": "users",
+            "encoding": "none",
+            "id": "tester11@seg.com",
+            "type": "email",
+          },
+          Object {
+            "collection": "users",
+            "encoding": "none",
+            "id": "abcd12bbfjfsykdbvbvvvvvv",
+            "type": "ios.push_token",
+          },
+        ],
+        "messaging_subscriptions": Array [
+          Object {
+            "key": "tester11@seg.com",
+            "status": "SUBSCRIBED",
+            "type": "EMAIL",
+          },
+          Object {
+            "key": "abcd12bbfjfsykdbvbvvvvvv",
+            "status": "SUBSCRIBED",
+            "type": "IOS_PUSH",
+          },
+        ],
+        "messaging_subscriptions_retl": true,
       },
-      Object {
-        "collection": "users",
-        "encoding": "none",
-        "id": "+12135618345",
-        "type": "phone",
+      "integrations": Object {
+        "All": false,
       },
-      Object {
-        "collection": "users",
-        "encoding": "none",
-        "id": "abcd12bbfygdbvbvvvv",
-        "type": "android.push_token",
+      "timestamp": "2023-10-10T07:24:07.036Z",
+      "traits": Object {
+        "email": "test-user@test-company.com",
+        "name": "Test User",
       },
-      Object {
-        "collection": "users",
-        "encoding": "none",
-        "id": "abcd12bbfjfsykdbvbvvvvvv",
-        "type": "ios.push_token",
-      },
-    ],
-    "messaging_subscriptions": Array [
-      Object {
-        "key": "tester11@seg.com",
-        "status": "SUBSCRIBED",
-        "type": "EMAIL",
-      },
-      Object {
-        "key": "+12135618345",
-        "status": "SUBSCRIBED",
-        "type": "SMS",
-      },
-      Object {
-        "key": "+12135618345",
-        "status": "SUBSCRIBED",
-        "type": "WHATSAPP",
-      },
-      Object {
-        "key": "abcd12bbfygdbvbvvvv",
-        "status": "UNSUBSCRIBED",
-        "type": "ANDROID_PUSH",
-      },
-      Object {
-        "key": "abcd12bbfjfsykdbvbvvvvvv",
-        "status": "SUBSCRIBED",
-        "type": "IOS_PUSH",
-      },
-    ],
-    "messaging_subscriptions_retl": true,
-  },
-  "integrations": Object {
-    "All": false,
-  },
-  "timestamp": "2023-10-10T07:24:07.036Z",
-  "traits": Object {
-    "email": "test-user@test-company.com",
-    "name": "Test User",
-  },
-  "userId": "user1234",
-}
-`;
-
-exports[`SegmentProfiles.sendSubscription Should send a subscription event to Segment when subscription groups are defined 1`] = `
-Headers {
-  Symbol(map): Object {
-    "authorization": Array [
-      "Basic ZW5nYWdlLXNwYWNlLXdyaXRla2V5Og==",
-    ],
-    "user-agent": Array [
-      "Segment (Actions)",
-    ],
-  },
-}
-`;
-
-exports[`SegmentProfiles.sendSubscription Should send a subscription event to Segment when subscription groups are defined 2`] = `
-Object {
-  "anonymousId": "anonId1234",
-  "context": Object {
-    "externalIds": Array [
-      Object {
-        "collection": "users",
-        "encoding": "none",
-        "id": "tester11@seg.com",
-        "type": "email",
-      },
-      Object {
-        "collection": "users",
-        "encoding": "none",
-        "id": "abcd12bbfjfsykdbvbvvvvvv",
-        "type": "ios.push_token",
-      },
-    ],
-    "messaging_subscriptions": Array [
-      Object {
-        "key": "tester11@seg.com",
-        "status": "SUBSCRIBED",
-        "type": "EMAIL",
-      },
-      Object {
-        "key": "abcd12bbfjfsykdbvbvvvvvv",
-        "status": "SUBSCRIBED",
-        "type": "IOS_PUSH",
-      },
-    ],
-    "messaging_subscriptions_retl": true,
-  },
-  "integrations": Object {
-    "All": false,
-  },
-  "timestamp": "2023-10-10T07:24:07.036Z",
-  "traits": Object {
-    "email": "test-user@test-company.com",
-    "name": "Test User",
-  },
-  "userId": "user1234",
+      "type": "identify",
+      "userId": "user1234",
+    },
+  ],
 }
 `;

--- a/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -2,118 +2,139 @@
 
 exports[`Testing snapshot for SegmentProfiles's sendSubscription destination action: all fields 1`] = `
 Object {
-  "context": Object {
-    "externalIds": Array [
+  "data": Object {
+    "batch": Array [
       Object {
-        "collection": "users",
-        "encoding": "none",
-        "id": "tester11@seg.com",
-        "type": "email",
-      },
-      Object {
-        "collection": "users",
-        "encoding": "none",
-        "id": "+12135618345",
-        "type": "phone",
-      },
-      Object {
-        "collection": "users",
-        "encoding": "none",
-        "id": "abcd12bbfygdbvbvvvv",
-        "type": "android.push_token",
-      },
-      Object {
-        "collection": "users",
-        "encoding": "none",
-        "id": "abcd12bbfjfsykdbvbvvvvvv",
-        "type": "ios.push_token",
+        "anonymousId": undefined,
+        "context": Object {
+          "externalIds": Array [
+            Object {
+              "collection": "users",
+              "encoding": "none",
+              "id": "tester11@seg.com",
+              "type": "email",
+            },
+            Object {
+              "collection": "users",
+              "encoding": "none",
+              "id": "+12135618345",
+              "type": "phone",
+            },
+            Object {
+              "collection": "users",
+              "encoding": "none",
+              "id": "abcd12bbfygdbvbvvvv",
+              "type": "android.push_token",
+            },
+            Object {
+              "collection": "users",
+              "encoding": "none",
+              "id": "abcd12bbfjfsykdbvbvvvvvv",
+              "type": "ios.push_token",
+            },
+          ],
+          "messaging_subscriptions": Array [
+            Object {
+              "groups": Array [
+                Object {
+                  "name": "marketing",
+                  "status": "SUBSCRIBED",
+                },
+                Object {
+                  "name": "ProductUpdates",
+                  "status": undefined,
+                },
+                Object {
+                  "name": "newsletter",
+                  "status": "UNSUBSCRIBED",
+                },
+              ],
+              "key": "tester11@seg.com",
+              "status": "SUBSCRIBED",
+              "type": "EMAIL",
+            },
+            Object {
+              "key": "+12135618345",
+              "status": "SUBSCRIBED",
+              "type": "SMS",
+            },
+            Object {
+              "key": "+12135618345",
+              "status": "SUBSCRIBED",
+              "type": "WHATSAPP",
+            },
+            Object {
+              "key": "abcd12bbfygdbvbvvvv",
+              "status": "UNSUBSCRIBED",
+              "type": "ANDROID_PUSH",
+            },
+            Object {
+              "key": "abcd12bbfjfsykdbvbvvvvvv",
+              "status": "SUBSCRIBED",
+              "type": "IOS_PUSH",
+            },
+          ],
+          "messaging_subscriptions_retl": true,
+        },
+        "integrations": Object {
+          "All": false,
+        },
+        "timestamp": undefined,
+        "traits": Object {},
+        "type": "identify",
+        "userId": "user1234",
       },
     ],
-    "messaging_subscriptions": Array [
-      Object {
-        "groups": Array [
-          Object {
-            "name": "marketing",
-            "status": "SUBSCRIBED",
-          },
-          Object {
-            "name": "ProductUpdates",
-          },
-          Object {
-            "name": "newsletter",
-            "status": "UNSUBSCRIBED",
-          },
-        ],
-        "key": "tester11@seg.com",
-        "status": "SUBSCRIBED",
-        "type": "EMAIL",
-      },
-      Object {
-        "key": "+12135618345",
-        "status": "SUBSCRIBED",
-        "type": "SMS",
-      },
-      Object {
-        "key": "+12135618345",
-        "status": "SUBSCRIBED",
-        "type": "WHATSAPP",
-      },
-      Object {
-        "key": "abcd12bbfygdbvbvvvv",
-        "status": "UNSUBSCRIBED",
-        "type": "ANDROID_PUSH",
-      },
-      Object {
-        "key": "abcd12bbfjfsykdbvbvvvvvv",
-        "status": "SUBSCRIBED",
-        "type": "IOS_PUSH",
-      },
-    ],
-    "messaging_subscriptions_retl": true,
   },
-  "integrations": Object {
-    "All": false,
-  },
-  "traits": Object {},
-  "userId": "user1234",
+  "output": "Action Executed",
 }
 `;
 
 exports[`Testing snapshot for SegmentProfiles's sendSubscription destination action: required fields 1`] = `
 Object {
-  "context": Object {
-    "externalIds": Array [
+  "data": Object {
+    "batch": Array [
       Object {
-        "collection": "users",
-        "encoding": "none",
-        "id": "tester11@seg.com",
-        "type": "email",
-      },
-      Object {
-        "collection": "users",
-        "encoding": "none",
-        "id": "+12135618345",
-        "type": "phone",
+        "anonymousId": undefined,
+        "context": Object {
+          "externalIds": Array [
+            Object {
+              "collection": "users",
+              "encoding": "none",
+              "id": "tester11@seg.com",
+              "type": "email",
+            },
+            Object {
+              "collection": "users",
+              "encoding": "none",
+              "id": "+12135618345",
+              "type": "phone",
+            },
+          ],
+          "messaging_subscriptions": Array [
+            Object {
+              "key": "tester11@seg.com",
+              "status": "SUBSCRIBED",
+              "type": "EMAIL",
+            },
+            Object {
+              "key": "+12135618345",
+              "status": "SUBSCRIBED",
+              "type": "SMS",
+            },
+          ],
+          "messaging_subscriptions_retl": true,
+        },
+        "integrations": Object {
+          "All": false,
+        },
+        "timestamp": undefined,
+        "traits": Object {},
+        "type": "identify",
+        "userId": "user12",
       },
     ],
-    "messaging_subscriptions": Array [
-      Object {
-        "key": "tester11@seg.com",
-        "status": "SUBSCRIBED",
-        "type": "EMAIL",
-      },
-      Object {
-        "key": "+12135618345",
-        "status": "SUBSCRIBED",
-        "type": "SMS",
-      },
-    ],
-    "messaging_subscriptions_retl": true,
   },
-  "integrations": Object {
-    "All": false,
-  },
-  "traits": Object {},
-  "userId": "user12",
+  "output": "Action Executed",
 }
 `;

--- a/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/__tests__/index.test.ts
@@ -2,12 +2,11 @@ import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 import {
-  InvalidEndpointSelectedThrowableError,
   MissingExternalIdsError,
   MissingIosPushTokenIfIosPushSubscriptionIsPresentError,
   MissingSubscriptionStatusesError
 } from '../../errors'
-import { DEFAULT_SEGMENT_ENDPOINT, SEGMENT_ENDPOINTS } from '../../properties'
+import { DEFAULT_SEGMENT_ENDPOINT } from '../../properties'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -86,30 +85,6 @@ describe('SegmentProfiles.sendSubscription', () => {
     ).rejects.toThrowError(MissingExternalIdsError)
   })
 
-  test('Should throw an error if Segment Endpoint is incorrectly defined', async () => {
-    const event = createTestEvent({
-      type: 'identify',
-      traits: {
-        name: 'Test User',
-        email: 'test-user@test-company.com'
-      },
-      properties: {
-        email: 'tester11@seg.com',
-        email_subscription_status: 'unsubscribed'
-      }
-    })
-
-    await expect(
-      testDestination.testAction('sendSubscription', {
-        event,
-        mapping: defaultSubscriptionMapping,
-        settings: {
-          endpoint: 'incorrect-endpoint'
-        }
-      })
-    ).rejects.toThrowError(InvalidEndpointSelectedThrowableError)
-  })
-
   test('Should throw an error if `email` or `phone` or `Android_Push_Token` or `Ios_Push_Token` is not defined', async () => {
     const event = createTestEvent({
       traits: {
@@ -178,10 +153,7 @@ describe('SegmentProfiles.sendSubscription', () => {
     ).rejects.toThrowError(MissingIosPushTokenIfIosPushSubscriptionIsPresentError)
   })
 
-  test('Should send a subscription event to Segment when subscription groups are defined', async () => {
-    // Mock: Segment Identify Call
-    const segmentEndpoint = SEGMENT_ENDPOINTS[DEFAULT_SEGMENT_ENDPOINT].url
-    nock(segmentEndpoint).post('/identify').reply(200, { success: true })
+  test('Should return transformed event when subscription groups are defined', async () => {
     const event = createTestEvent({
       traits: {
         name: 'Test User',
@@ -209,56 +181,14 @@ describe('SegmentProfiles.sendSubscription', () => {
       }
     })
 
-    expect(responses.length).toBe(1)
-    expect(responses[0].status).toEqual(200)
-    expect(responses[0].options.headers).toMatchSnapshot()
-    expect(responses[0].options.json).toMatchSnapshot()
+    const results = testDestination.results
+
+    expect(responses.length).toBe(0)
+    expect(results.length).toBe(3)
+    expect(results[2].data).toMatchSnapshot()
   })
 
-  test('Should send a subscription event to Segment', async () => {
-    // Mock: Segment Identify Call
-    const segmentEndpoint = SEGMENT_ENDPOINTS[DEFAULT_SEGMENT_ENDPOINT].url
-    nock(segmentEndpoint).post('/identify').reply(200, { success: true })
-
-    const event = createTestEvent({
-      traits: {
-        name: 'Test User',
-        email: 'test-user@test-company.com'
-      },
-      timestamp: '2023-10-10T07:24:07.036Z',
-      properties: {
-        email: 'tester11@seg.com',
-        email_subscription_status: 'true',
-        phone: '+12135618345',
-        sms_subscription_status: 'true',
-        whatsapp_subscription_status: 'true',
-        subscription_groups: {
-          marketing: 'true',
-          ProductUpdates: '',
-          newsletter: 'false'
-        },
-        android_push_token: 'abcd12bbfygdbvbvvvv',
-        android_push_subscription_status: 'false',
-        ios_push_token: 'abcd12bbfjfsykdbvbvvvvvv',
-        ios_push_subscription_status: 'true'
-      }
-    })
-
-    const responses = await testDestination.testAction('sendSubscription', {
-      event,
-      mapping: defaultSubscriptionMapping,
-      settings: {
-        endpoint: DEFAULT_SEGMENT_ENDPOINT
-      }
-    })
-
-    expect(responses.length).toBe(1)
-    expect(responses[0].status).toEqual(200)
-    expect(responses[0].options.headers).toMatchSnapshot()
-    expect(responses[0].options.json).toMatchSnapshot()
-  })
-
-  test('Should not send event if actions-segment-profiles-tapi-internal-enabled flag is enabled', async () => {
+  test('Should return transformed event', async () => {
     const event = createTestEvent({
       traits: {
         name: 'Test User',

--- a/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/__tests__/snapshot.test.ts
@@ -1,8 +1,6 @@
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import { generateTestData } from '../../../../lib/test-data'
 import destination from '../../index'
-import nock from 'nock'
-import { DEFAULT_SEGMENT_ENDPOINT } from '../../properties'
 
 const testDestination = createTestIntegration(destination)
 const actionSlug = 'sendSubscription'
@@ -14,10 +12,6 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const action = destination.actions[actionSlug]
     const [settingsData] = generateTestData(seedName, destination, action, true)
 
-    nock(/.*/).persist().get(/.*/).reply(200)
-    nock(/.*/).persist().post(/.*/).reply(200)
-    nock(/.*/).persist().put(/.*/).reply(200)
-
     const event = createTestEvent({
       properties: {
         email: 'tester11@seg.com',
@@ -28,34 +22,21 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
         user_id: 'user12'
       }
     })
-    const responses = await testDestination.testAction(actionSlug, {
+
+    await testDestination.testAction(actionSlug, {
       event: event,
       mapping: event.properties,
-      settings: { ...settingsData, endpoint: DEFAULT_SEGMENT_ENDPOINT },
+      settings: { ...settingsData },
       auth: undefined
     })
 
-    const request = responses[0].request
-    const rawBody = await request.text()
-
-    try {
-      const json = JSON.parse(rawBody)
-      expect(json).toMatchSnapshot()
-      return
-    } catch (err) {
-      expect(rawBody).toMatchSnapshot()
-    }
-
-    expect(request.headers).toMatchSnapshot()
+    const results = testDestination.results
+    expect(results[results.length - 1]).toMatchSnapshot()
   })
 
   it('all fields', async () => {
     const action = destination.actions[actionSlug]
     const [settingsData] = generateTestData(seedName, destination, action, false)
-
-    nock(/.*/).persist().get(/.*/).reply(200)
-    nock(/.*/).persist().post(/.*/).reply(200)
-    nock(/.*/).persist().put(/.*/).reply(200)
 
     const event = createTestEvent({
       properties: {
@@ -78,22 +59,14 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       }
     })
 
-    const responses = await testDestination.testAction(actionSlug, {
+    await testDestination.testAction(actionSlug, {
       event: event,
       mapping: event.properties,
-      settings: { ...settingsData, endpoint: DEFAULT_SEGMENT_ENDPOINT },
+      settings: { ...settingsData },
       auth: undefined
     })
 
-    const request = responses[0].request
-    const rawBody = await request.text()
-
-    try {
-      const json = JSON.parse(rawBody)
-      expect(json).toMatchSnapshot()
-      return
-    } catch (err) {
-      expect(rawBody).toMatchSnapshot()
-    }
+    const results = testDestination.results
+    expect(results[results.length - 1]).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
This PR
- Cleans up flags introduced to faciliate internal TAPI rollout for Segment Destination
- Also removes endpoint settings as it is no longer relevant.

Old PR that introduced the flagon gate - https://github.com/segmentio/action-destinations/pull/1507
Relevant [RFC](https://docs.google.com/document/d/19uKcgtbNE9TJZHUYIPWqE9i0QwunkYPpBIDqP8vMeHw/edit#heading=h.2qwax5f5kf78)

## Testing

Testing completed successfully in staging. Test results can be found [here](https://docs.google.com/document/d/11zZzx8LB4z6rCFUyZjSNMN3ZjswVXejC2D7LoaAIpV4/edit#heading=h.nbna6gu1cdzp)

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
