### PR TITLE
[LinkedIn CAPI] Addresses socket hangup issues

### DIFF
--- a/packages/destination-actions/src/destinations/aggregations-io/send/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/aggregations-io/send/__tests__/index.test.ts
@@ -1,7 +1,6 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
-import { PayloadValidationError } from '@segment/actions-core'
 
 const testDestination = createTestIntegration(Destination)
 const testIngestId = 'abc123'
@@ -40,5 +39,4 @@ describe('AggregationsIo.send', () => {
     expect(new URL(response[0].url).pathname).toBe('/' + testIngestId)
     expect(response[0].status).toBe(200)
   })
-
 })


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

LinkedIn destinations run into a 'socket hangup' error when executing requests against certain endpoints. This PR is a fix to that issue, and is copied from the LinkedIn Audiences destination which had previously ran into the issue.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

Tested successfully in staging, the socket hang up is resolved and event delivery works as expected.

<img width="1273" alt="Screenshot 2024-01-10 at 5 01 31 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/45ef51cf-0f0a-4f46-b3a8-e9cbb5cfd687">

<img width="1266" alt="Screenshot 2024-01-10 at 5 01 43 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/680721a5-cb8e-42a1-9b38-b476c9cd8e5e">



- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
