### PR TITLE
Marketo Access Token Expired 

### DIFF
--- a/packages/destination-actions/src/destinations/marketo-static-lists/functions.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/functions.ts
@@ -116,7 +116,7 @@ function extractLeadIds(leads: MarketoLeads[]) {
 }
 
 function parseErrorResponse(response: MarketoResponse) {
-  if (response.errors[0].code === '601') {
+  if (response.errors[0].code === '601' || response.errors[0].code === '602') {
     throw new IntegrationError(response.errors[0].message, 'INVALID_OAUTH_TOKEN', 401)
   }
   if (response.errors[0].code === '1019') {


### PR DESCRIPTION
Marketo has 2 error codes for invalid/ expired tokens. We currently only address one. This PR is to add the other so the token gets refreshed and the batch is sent again instead of all the events failing.

![Screenshot 2024-01-10 at 4 23 01 PM](https://github.com/segmentio/action-destinations/assets/99763167/c18a6310-f2c7-4fc3-93f9-0b7af751357d)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
