### PR TITLE
Channels: Support both legacy and v1 FCM formats

### DIFF
--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush.types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush.types.ts
@@ -124,4 +124,8 @@ export interface Payload {
    * Time of when the actual event happened.
    */
   eventOccurredTS?: string
+  /**
+   * Controls the notification payload format
+   */
+  googleApiVersion?: string
 }

--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-mobile-push.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-mobile-push.test.ts
@@ -858,7 +858,7 @@ describe('sendMobilePush action', () => {
       expect(responses[1].data).toMatchObject(externalId)
     })
 
-    it('should format FCM overrides with v1 format when googleApiVersion field is not provided', async () => {
+    it('should format FCM overrides with v1 format when googleApiVersion field is v1', async () => {
       const externalId = {
         type: 'android.push_token',
         id: 'android-token-1',

--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-mobile-push.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-mobile-push.test.ts
@@ -758,4 +758,128 @@ describe('sendMobilePush action', () => {
       expect(responses[1].data).toMatchObject(externalIds[0])
     })
   })
+
+  describe('Google Api Formatting', () => {
+    const externalId = {
+      type: 'android.push_token',
+      id: 'android-token-1',
+      channelType: 'ANDROID_PUSH',
+      subscriptionStatus: 'subscribed'
+    }
+
+    const androidLegacyReq = new URLSearchParams({
+      Body: defaultTemplate.types['twilio/text'].body,
+      Title: customizationTitle,
+      FcmPayload: JSON.stringify({
+        mutable_content: true,
+        notification: {
+          badge: 1
+        }
+      }),
+      ApnPayload: JSON.stringify({
+        aps: {
+          'mutable-content': 1,
+          badge: 1
+        }
+      }),
+      Recipients: JSON.stringify({
+        fcm: [{ addr: externalId.id }]
+      }),
+      CustomData: JSON.stringify({
+        space_id: spaceId,
+        badgeAmount: 1,
+        badgeStrategy: 'inc',
+        __segment_internal_external_id_key__: externalId.type,
+        __segment_internal_external_id_value__: externalId.id
+      })
+    })
+
+    const androidV1Req = new URLSearchParams({
+      Body: defaultTemplate.types['twilio/text'].body,
+      Title: customizationTitle,
+      FcmPayload: JSON.stringify({
+        android: {
+          mutable_content: true,
+          notification: {
+            badge: 1
+          }
+        }
+      }),
+      ApnPayload: JSON.stringify({
+        aps: {
+          'mutable-content': 1,
+          badge: 1
+        }
+      }),
+      Recipients: JSON.stringify({
+        fcm: [{ addr: externalId.id }]
+      }),
+      CustomData: JSON.stringify({
+        space_id: spaceId,
+        badgeAmount: 1,
+        badgeStrategy: 'inc',
+        __segment_internal_external_id_key__: externalId.type,
+        __segment_internal_external_id_value__: externalId.id
+      })
+    })
+
+    it('should format FCM overrides with legacy format when googleApiVersion field is not provided', async () => {
+      const notifyReqUrl = `https://push.ashburn.us1.twilio.com/v1/Services/${pushServiceSid}/Notifications`
+      const notifyReqBody = androidLegacyReq
+
+      nock(`https://content.twilio.com`).get(`/v1/Content/${contentSid}`).reply(200, defaultTemplate)
+      nock(notifyReqUrl).post('', notifyReqBody.toString()).reply(201, externalId)
+
+      const responses = await testAction({
+        mappingOverrides: {
+          externalIds: [externalId]
+        }
+      })
+      expect(responses[1].url).toStrictEqual(notifyReqUrl)
+      expect(responses[1].status).toEqual(201)
+      expect(responses[1].data).toMatchObject(externalId)
+    })
+
+    it('should format FCM overrides with legacy format when googleApiVersion field is set to legacy', async () => {
+      const notifyReqUrl = `https://push.ashburn.us1.twilio.com/v1/Services/${pushServiceSid}/Notifications`
+      const notifyReqBody = androidLegacyReq
+
+      nock(`https://content.twilio.com`).get(`/v1/Content/${contentSid}`).reply(200, defaultTemplate)
+      nock(notifyReqUrl).post('', notifyReqBody.toString()).reply(201, externalId)
+
+      const responses = await testAction({
+        mappingOverrides: {
+          googleApiVersion: 'legacy',
+          externalIds: [externalId]
+        }
+      })
+      expect(responses[1].url).toStrictEqual(notifyReqUrl)
+      expect(responses[1].status).toEqual(201)
+      expect(responses[1].data).toMatchObject(externalId)
+    })
+
+    it('should format FCM overrides with v1 format when googleApiVersion field is not provided', async () => {
+      const externalId = {
+        type: 'android.push_token',
+        id: 'android-token-1',
+        channelType: 'ANDROID_PUSH',
+        subscriptionStatus: 'subscribed'
+      }
+      const notifyReqUrl = `https://push.ashburn.us1.twilio.com/v1/Services/${pushServiceSid}/Notifications`
+      const notifyReqBody = androidV1Req
+
+      nock(`https://content.twilio.com`).get(`/v1/Content/${contentSid}`).reply(200, defaultTemplate)
+      nock(notifyReqUrl).post('', notifyReqBody.toString()).reply(201, externalId)
+
+      const responses = await testAction({
+        mappingOverrides: {
+          googleApiVersion: 'v1',
+          externalIds: [externalId]
+        }
+      })
+      expect(responses[1].url).toStrictEqual(notifyReqUrl)
+      expect(responses[1].status).toEqual(201)
+      expect(responses[1].data).toMatchObject(externalId)
+    })
+  })
 })

--- a/packages/destination-actions/src/destinations/engage/twilio/sendMobilePush/PushSender.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/sendMobilePush/PushSender.ts
@@ -146,12 +146,7 @@ export class PushSender extends TwilioMessageSender<PushPayload> {
         Sound: this.payload.customizations?.sound,
         Priority: this.payload.customizations?.priority,
         TimeToLive: this.payload.customizations?.ttl,
-        FcmPayload: {
-          mutable_content: true,
-          notification: {
-            badge: badgeAmount
-          }
-        },
+        FcmPayload: this.getFcmNotificationOverrides(badgeAmount),
         ApnPayload: {
           aps: {
             'mutable-content': 1,
@@ -169,6 +164,27 @@ export class PushSender extends TwilioMessageSender<PushPayload> {
       return { requestBody, customData }
     } catch (error: unknown) {
       this.rethrowIntegrationError(error, () => new PayloadValidationError('Unable to construct Push API request body'))
+    }
+  }
+
+  private getFcmNotificationOverrides(badgeAmount: number) {
+    // FCM V1 format
+    if (this.payload.googleApiVersion === 'v1') {
+      return {
+        android: {
+          mutable_content: true,
+          notification: {
+            badge: badgeAmount
+          }
+        }
+      }
+    }
+    // FCM legacy format
+    return {
+      mutable_content: true,
+      notification: {
+        badge: badgeAmount
+      }
     }
   }
 

--- a/packages/destination-actions/src/destinations/engage/twilio/sendMobilePush/actionDefinition.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/sendMobilePush/actionDefinition.ts
@@ -234,6 +234,13 @@ export const actionDefinition: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.timestamp'
       }
+    },
+    googleApiVersion: {
+      label: 'Google Api Version',
+      description: 'Controls the notification payload format',
+      type: 'string',
+      required: false,
+      choices: ['legacy', 'v1']
     }
   },
   perform: async (request, data) => {


### PR DESCRIPTION
https://docs.google.com/document/d/1WyKmymTRsCdeRdp4p3H3BhLH5jFqoK14-vwJ97r9bBc/

This PR adds support for legacy & v1 push notification formats for FCM.

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
