### PR TITLE
Added test to validate moving parentAccount property

### DIFF
--- a/packages/browser-destinations/destinations/pendo-web-actions/src/group/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/group/__tests__/index.test.ts
@@ -18,6 +18,9 @@ const subscriptions: Subscription[] = [
       },
       accountData: {
         '@path': '$.traits'
+      },
+      parentAccountData: {
+        '@path': '$.traits.parentAccount'
       }
     }
   }
@@ -68,6 +71,31 @@ describe('Pendo.group', () => {
     expect(mockPendo.identify).toHaveBeenCalledWith({
       account: { id: 'company_id_1', company_name: 'Megacorp 2000' },
       visitor: { id: 'testUserId' }
+    })
+  })
+
+  test('moves the parentAccount property up a level, off the account, to be a sibling property ', async () => {
+    const context = new Context({
+      type: 'group',
+      userId: 'testUserId',
+      traits: {
+        company_name: 'Megacorp 2000',
+        parentAccount: {
+          id: 'abc123',
+          company_name: 'Umbrella corp'
+        }
+      },
+      groupId: 'company_id_1'
+    })
+    await groupAction.group?.(context)
+
+    expect(mockPendo.identify).toHaveBeenCalledWith({
+      account: { id: 'company_id_1', company_name: 'Megacorp 2000' },
+      visitor: { id: 'testUserId' },
+      parentAccount: {
+        id: 'abc123',
+        company_name: 'Umbrella corp'
+      }
     })
   })
 })


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This is a unit test for the logic added to the pendo actions destination for pulling a specific property off of the group.traits because we are including it elsewhere in the payload

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
