### PR TITLE
[Aggregations.io] Add error handling for auth

### DIFF
--- a/packages/destination-actions/src/destinations/aggregations-io/types.ts
+++ b/packages/destination-actions/src/destinations/aggregations-io/types.ts
@@ -1,0 +1,9 @@
+import { HTTPError } from '@segment/actions-core'
+
+export class AggregationsAuthError extends HTTPError {
+  response: Response & {
+    data: {
+      message: string
+    }
+  }
+}


### PR DESCRIPTION
Currently, when `testAuthentication` fails we see a non-descriptive error in Segment UI: 

![Screenshot 2024-01-17 at 10 43 03 AM](https://github.com/segmentio/action-destinations/assets/64277654/b8fd07bb-0076-4308-971a-21b3c57a692d)

This PR corrects for that

## Testing

Tested in Actions Tester: 

![Screenshot 2024-01-17 at 11 23 45 AM](https://github.com/segmentio/action-destinations/assets/64277654/e66d2b0f-0169-4cb1-a290-dc01142bb8af)

