### PR TITLE
Add '<nil>' as needing a default value

### DIFF
--- a/packages/destination-actions/src/destinations/engage/twilio/utils/TwilioMessageSender.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/utils/TwilioMessageSender.ts
@@ -40,7 +40,7 @@ export abstract class TwilioMessageSender<TPayload extends TwilioPayloadBase> ex
   ): Promise<R> {
     const parsedEntries = await Promise.all(
       Object.entries(content).map(async ([key, val]) => {
-        if (val == null) {
+        if (val == null || val === '<nil>') {
           return [key, val]
         }
 


### PR DESCRIPTION
Fixes Broadcasts returning NIL for merge tags in SMS/MMS messages when there is no value for the trait. In order to compensate for the compute service sending `“<nil>”` for non existent profile traits, we have to exclude that value from profile traits, replacing it with null before parsing liquid js.

Jira ticket: https://segment.atlassian.net/browse/CHANNELS-1020