### PR TITLE
[LinkedIn CAPI] Update the adAccountId dynamic field to return account name as the label

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/api.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/api.test.ts
@@ -11,49 +11,67 @@ describe('LinkedIn Conversions', () => {
 
     it('should fetch a list of ad accounts, with their names', async () => {
       nock(`${BASE_URL}`)
-        .get(`/adAccountUsers`)
-        .query({ q: 'authenticatedUser' })
+        .get(`/adAccounts`)
+        .query({ q: 'search' })
         .reply(200, {
           elements: [
             {
-              account: 'urn:li:sponsoredAccount:516413367',
+              test: false,
+              notifiedOnCreativeRejection: true,
+              notifiedOnNewFeaturesEnabled: true,
+              notifiedOnEndOfCampaign: true,
+              notifiedOnCampaignOptimization: true,
+              type: 'BUSINESS',
+              version: {
+                versionTag: '6'
+              },
+              reference: 'urn:li:organization:1122334',
+              notifiedOnCreativeApproval: false,
               changeAuditStamps: {
                 created: {
                   actor: 'urn:li:unknown:0',
-                  time: 1500331577000
+                  time: 1498178296000
                 },
                 lastModified: {
                   actor: 'urn:li:unknown:0',
-                  time: 1505328748000
+                  time: 1696277984515
                 }
               },
-              role: 'ACCOUNT_BILLING_ADMIN',
-              user: 'urn:li:person:K1RwyVNukt',
-              version: {
-                versionTag: '89'
-              }
+              name: 'Test Ad Account',
+              currency: 'USD',
+              id: 101100090,
+              status: 'ACTIVE'
             },
             {
-              account: 'urn:li:sponsoredAccount:516880883',
+              test: false,
+              notifiedOnCreativeRejection: false,
+              notifiedOnNewFeaturesEnabled: false,
+              notifiedOnEndOfCampaign: false,
+              notifiedOnCampaignOptimization: false,
+              type: 'BUSINESS',
+              version: {
+                versionTag: '4'
+              },
+              reference: 'urn:li:organization:1122334',
+              notifiedOnCreativeApproval: false,
               changeAuditStamps: {
                 created: {
                   actor: 'urn:li:unknown:0',
-                  time: 1505326590000
+                  time: 1687394995000
                 },
                 lastModified: {
                   actor: 'urn:li:unknown:0',
-                  time: 1505326615000
+                  time: 1694040316291
                 }
               },
-              role: 'ACCOUNT_BILLING_ADMIN',
-              user: 'urn:li:person:K1RwyVNukt',
-              version: {
-                versionTag: '3'
-              }
+              name: 'Krusty Krab Ads',
+              currency: 'USD',
+              id: 998877665,
+              status: 'ACTIVE'
             }
           ],
           paging: {
-            count: 2,
+            count: 1000,
             links: [],
             start: 0,
             total: 2
@@ -64,12 +82,12 @@ describe('LinkedIn Conversions', () => {
       expect(getAdAccountsRes).toEqual({
         choices: [
           {
-            label: 'urn:li:person:K1RwyVNukt',
-            value: 'urn:li:sponsoredAccount:516413367'
+            label: 'Test Ad Account',
+            value: 'urn:li:sponsoredAccount:101100090'
           },
           {
-            label: 'urn:li:person:K1RwyVNukt',
-            value: 'urn:li:sponsoredAccount:516880883'
+            label: 'Krusty Krab Ads',
+            value: 'urn:li:sponsoredAccount:998877665'
           }
         ]
       })
@@ -133,7 +151,7 @@ describe('LinkedIn Conversions', () => {
         adAccountId: '123456'
       }
       nock(`${BASE_URL}`)
-        .get(`/adAccounts/${payload.adAccountId}/adCampaigns?q=search&search=(status:(values:List(ACTIVE)))`)
+        .get(`/adAccounts/${payload.adAccountId}/adCampaigns?q=search&search=(status:(values:List(ACTIVE,DRAFT)))`)
         .reply(200, {
           paging: {
             start: 0,

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -3,7 +3,6 @@ import { BASE_URL } from '../constants'
 import type {
   ProfileAPIResponse,
   GetAdAccountsAPIResponse,
-  Accounts,
   AccountsErrorInfo,
   GetConversionListAPIResponse,
   Conversions,
@@ -96,22 +95,17 @@ export class LinkedInConversions {
 
   getAdAccounts = async (): Promise<DynamicFieldResponse> => {
     try {
-      const response: Array<Accounts> = []
-      const result = await this.request<GetAdAccountsAPIResponse>(`${BASE_URL}/adAccountUsers`, {
+      const allAdAccountsResponse = await this.request<GetAdAccountsAPIResponse>(`${BASE_URL}/adAccounts`, {
         method: 'GET',
         searchParams: {
-          q: 'authenticatedUser'
+          q: 'search'
         }
       })
 
-      result.data.elements.forEach((item) => {
-        response.push(item)
-      })
-
-      const choices = response?.map((item) => {
+      const choices = allAdAccountsResponse.data.elements.map((item) => {
         return {
-          label: item.user,
-          value: item.account
+          label: item.name,
+          value: `urn:li:sponsoredAccount:${item.id}`
         }
       })
 
@@ -194,7 +188,7 @@ export class LinkedInConversions {
     try {
       const response: Array<Campaigns> = []
       const result = await this.request<GetCampaignsListAPIResponse>(
-        `${BASE_URL}/adAccounts/${adAccountId}/adCampaigns?q=search&search=(status:(values:List(ACTIVE)))`,
+        `${BASE_URL}/adAccounts/${adAccountId}/adCampaigns?q=search&search=(status:(values:List(ACTIVE,DRAFT)))`,
         {
           method: 'GET'
         }

--- a/packages/destination-actions/src/destinations/linkedin-conversions/types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/types.ts
@@ -35,15 +35,12 @@ export interface GetAdAccountsAPIResponse {
     start: number
     total: number
   }
-  elements: [Accounts]
+  elements: [Account]
 }
 
-export interface Accounts {
-  account: string
-  changeAuditStamps: object
-  role: string
-  user: string
-  version: object
+export interface Account {
+  name: string
+  id: string
 }
 
 export interface AccountsErrorInfo {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR updates the `adAccountId` dynamic field. Previously it was returning a 'person URN' as the label. For example: `{label: urn:li:person:ab83923, value: <adAccountId>`. It now uses a new endpoint that provides a human readable name and returns values such as: `{label: 'Segment's Ad Account', value: <adAccountId>}`.

## Testing
Tested successfully in local: The ad account name is populated.

<img width="990" alt="Screenshot 2024-01-18 at 2 59 17 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/e4f79091-a08e-47bb-8040-d625b6d75070">

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
