### PR TITLE
Disable full syncs for DV360

### DIFF
--- a/packages/destination-actions/src/destinations/display-video-360/index.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/index.ts
@@ -53,7 +53,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   audienceConfig: {
     mode: {
       type: 'synced',
-      full_audience_sync: true
+      full_audience_sync: false
     },
     async createAudience(request, createAudienceInput) {
       const { audienceName, audienceSettings, statsContext, settings } = createAudienceInput


### PR DESCRIPTION
I had some wrong assumptions regarding the `mode` object defined in the Audience Action Destination definition (see [here](https://github.com/segmentio/action-destinations/blob/1b3abba826c940dbd79f21414c884fbe12f91dd0/packages/destination-actions/src/destinations/display-video-360/index.ts#L54)). This change comes to address that.

- The `force_full_sync` variable **does** have an effect on the way data is prepared. It causes our audience data to be sent whole instead of incrementally. Think of `>` (append) vs `>>` (overwrite) but for an audience. 

- The `type` variable **does not** hav an effect as synced vs realtime are not handled by this part of the backend anymore and both settings are actively supported.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
