### PR TITLE
[Facebook Conversions API]-Updated Default API Version to v18

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-conversions-api/constants.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/constants.ts
@@ -1,4 +1,4 @@
-export const API_VERSION = '16.0'
+export const API_VERSION = '18.0'
 export const CANARY_API_VERSION = '18.0'
 export const CURRENCY_ISO_CODES = new Set([
   'AED',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pull request is to update Default API version from v16 to v18 in Facebook Conversions API.
Jira Ticket :- https://segment.atlassian.net/browse/STRATCONN-3528

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
