### PR TITLE
New action destination for StackAdapt

### DIFF
--- a/packages/destination-actions/src/destinations/stackadapt/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/stackadapt/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-stackadapt destination: forwardEvent action - all fields 1`] = `""`;
+
+exports[`Testing snapshot for actions-stackadapt destination: forwardEvent action - required fields 1`] = `""`;
+
+exports[`Testing snapshot for actions-stackadapt destination: forwardEvent action - required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "",
+    ],
+    "x-forwarded-for": Array [
+      "",
+    ],
+  },
+}
+`;

--- a/packages/destination-actions/src/destinations/stackadapt/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/__tests__/index.test.ts
@@ -1,4 +1,209 @@
-describe('Stackadapt', () => {
-  // Temporary empty test to prevent failure due to spec file having no tests
-  it.skip('dummy test', () => {});
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+import { SegmentEvent } from '@segment/actions-core/*'
+
+const testDestination = createTestIntegration(Definition)
+const pixelHostUrl = 'https://tags.srv.stackadapt.com'
+const pixelPath = '/saq_pxl'
+const mockFirstName = 'John'
+const mockLastName = 'Doe'
+const mockEmail = 'admin@stackadapt.com'
+const mockPhone = '1234567890'
+const mockPageTitle = 'Test Page Title'
+const mockPageUrl = 'https://www.example.com/example.html'
+const mockReferrer = 'https://www.example.net/page.html'
+const mockUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36'
+const mockIpAddress = '172.0.0.1'
+const mockUtmSource = 'stackadapt'
+const mockUserId = 'user-id'
+const mockAnonymousId = 'anonymous-id'
+const mockPixelId = 'sqHQa3Ob1hiF__2EcY3VZg1'
+const mockProduct = {
+  price: 10.51,
+  quantity: 1,
+  category: 'Test Category',
+  product_id: 'Test Product Id',
+  name: 'Test Product Name'
+}
+const mockRevenue = 8.72
+const mockOrderId = 'Test Order Id'
+const mockSingleProductAction = 'Product Added'
+const mockMultiProductAction = 'Order Completed'
+
+const expectedProduct = {
+  product_price: mockProduct.price,
+  product_quantity: mockProduct.quantity,
+  product_id: mockProduct.product_id,
+  product_category: mockProduct.category,
+  product_name: mockProduct.name
+}
+
+const defaultExpectedParams = {
+  segment_ss: '1',
+  event_type: 'identify',
+  title: mockPageTitle,
+  url: mockPageUrl,
+  ref: mockReferrer,
+  ip_fwd: mockIpAddress,
+  utm_source: mockUtmSource,
+  first_name: mockFirstName,
+  last_name: mockLastName,
+  email: mockEmail,
+  phone: mockPhone,
+  user_id: mockUserId,
+  uid: mockPixelId
+}
+
+const defaultEventPayload: Partial<SegmentEvent> = {
+  anonymousId: mockAnonymousId,
+  userId: mockUserId,
+  type: 'identify',
+  traits: {
+    firstName: mockFirstName,
+    lastName: mockLastName,
+    email: mockEmail,
+    phone: mockPhone
+  },
+  context: {
+    ip: mockIpAddress,
+    userAgent: mockUserAgent,
+    page: {
+      title: mockPageTitle,
+      url: mockPageUrl,
+      referrer: mockReferrer
+    },
+    campaign: {
+      name: 'Campaign',
+      term: 'Term',
+      content: 'Content',
+      source: mockUtmSource,
+      medium: 'Medium'
+    }
+  }
+}
+
+describe('StackAdapt', () => {
+  describe('forwardEvent', () => {
+    it('should validate action fields', async () => {
+      try {
+        await testDestination.testAction('createOrUpdateContact', {
+          settings: { pixelId: mockPixelId }
+        })
+      } catch (err) {
+        expect(err.message).toContain("missing the required field 'userId'.")
+      }
+    })
+
+    it('Sends event data to pixel endpoint in expected format with expected headers', async () => {
+      nock(pixelHostUrl).get(pixelPath).query(defaultExpectedParams).reply(200, {})
+
+      const event = createTestEvent(defaultEventPayload)
+      const responses = await testDestination.testAction('forwardEvent', {
+        event,
+        useDefaultMappings: true,
+        settings: {
+          pixelId: mockPixelId
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].request.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "content-type": Array [
+              "application/json",
+            ],
+            "user-agent": Array [
+              "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+            ],
+            "x-forwarded-for": Array [
+              "172.0.0.1",
+            ],
+          },
+        }
+      `)
+    })
+
+    it('Serializes product data for single product event', async () => {
+      nock(pixelHostUrl).get(pixelPath).query(true).reply(200, {})
+
+      const eventPayload: Partial<SegmentEvent> = {
+        ...defaultEventPayload,
+        type: 'track',
+        event: mockSingleProductAction,
+        properties: {
+          revenue: mockRevenue,
+          order_id: mockOrderId,
+          ...mockProduct
+        }
+      }
+      const event = createTestEvent(eventPayload)
+      const responses = await testDestination.testAction('forwardEvent', {
+        event,
+        useDefaultMappings: true,
+        settings: {
+          pixelId: mockPixelId
+        }
+      })
+
+      const expectedParams = {
+        ...defaultExpectedParams,
+        event_type: 'track',
+        args: expect.any(String)
+      }
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      const requestParams = Object.fromEntries(new URL(responses[0].request.url).searchParams)
+      expect(requestParams).toMatchObject(expectedParams)
+      expect(JSON.parse(requestParams.args)).toEqual({
+        action: mockSingleProductAction,
+        revenue: mockRevenue,
+        order_id: mockOrderId,
+        ...expectedProduct
+      })
+    })
+
+    it('Serializes product data for product array event', async () => {
+      nock(pixelHostUrl).get(pixelPath).query(true).reply(200, {})
+
+      const eventPayload: Partial<SegmentEvent> = {
+        ...defaultEventPayload,
+        type: 'track',
+        event: mockMultiProductAction,
+        properties: {
+          revenue: mockRevenue,
+          order_id: mockOrderId,
+          products: [mockProduct]
+        }
+      }
+      const event = createTestEvent(eventPayload)
+      const responses = await testDestination.testAction('forwardEvent', {
+        event,
+        useDefaultMappings: true,
+        settings: {
+          pixelId: mockPixelId
+        }
+      })
+
+      const expectedParams = {
+        ...defaultExpectedParams,
+        event_type: 'track',
+        args: expect.any(String)
+      }
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      const requestParams = Object.fromEntries(new URL(responses[0].request.url).searchParams)
+      expect(requestParams).toMatchObject(expectedParams)
+      expect(JSON.parse(requestParams.args)).toEqual({
+        action: mockMultiProductAction,
+        revenue: mockRevenue,
+        order_id: mockOrderId,
+        products: [expectedProduct]
+      })
+    })
+  })
 })

--- a/packages/destination-actions/src/destinations/stackadapt/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/__tests__/index.test.ts
@@ -63,8 +63,8 @@ const defaultEventPayload: Partial<SegmentEvent> = {
   userId: mockUserId,
   type: 'identify',
   traits: {
-    firstName: mockFirstName,
-    lastName: mockLastName,
+    first_name: mockFirstName,
+    last_name: mockLastName,
     email: mockEmail,
     phone: mockPhone
   },
@@ -100,7 +100,7 @@ describe('StackAdapt', () => {
 
     it('Sends event data to pixel endpoint in expected format with expected headers', async () => {
       const expectedParams = { ...defaultExpectedParams, ...defaultIdentifyParams }
-      nock(pixelHostUrl).get(pixelPath).query(expectedParams).reply(200, {})
+      nock(pixelHostUrl).get(pixelPath).query(true).reply(200, {})
 
       const event = createTestEvent(defaultEventPayload)
       const responses = await testDestination.testAction('forwardEvent', {
@@ -113,6 +113,8 @@ describe('StackAdapt', () => {
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
+      const requestParams = Object.fromEntries(new URL(responses[0].request.url).searchParams)
+      expect(requestParams).toMatchObject(expectedParams)
       expect(responses[0].request.headers).toMatchInlineSnapshot(`
         Headers {
           Symbol(map): Object {

--- a/packages/destination-actions/src/destinations/stackadapt/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/__tests__/index.test.ts
@@ -47,12 +47,15 @@ const defaultExpectedParams = {
   ref: mockReferrer,
   ip_fwd: mockIpAddress,
   utm_source: mockUtmSource,
+  user_id: mockUserId,
+  uid: mockPixelId
+}
+
+const defaultIdentifyParams = {
   first_name: mockFirstName,
   last_name: mockLastName,
   email: mockEmail,
-  phone: mockPhone,
-  user_id: mockUserId,
-  uid: mockPixelId
+  phone: mockPhone
 }
 
 const defaultEventPayload: Partial<SegmentEvent> = {
@@ -96,7 +99,8 @@ describe('StackAdapt', () => {
     })
 
     it('Sends event data to pixel endpoint in expected format with expected headers', async () => {
-      nock(pixelHostUrl).get(pixelPath).query(defaultExpectedParams).reply(200, {})
+      const expectedParams = { ...defaultExpectedParams, ...defaultIdentifyParams }
+      nock(pixelHostUrl).get(pixelPath).query(expectedParams).reply(200, {})
 
       const event = createTestEvent(defaultEventPayload)
       const responses = await testDestination.testAction('forwardEvent', {

--- a/packages/destination-actions/src/destinations/stackadapt/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/__tests__/index.test.ts
@@ -1,0 +1,4 @@
+describe('Stackadapt', () => {
+  // Temporary empty test to prevent failure due to spec file having no tests
+  it.skip('dummy test', () => {});
+})

--- a/packages/destination-actions/src/destinations/stackadapt/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/__tests__/index.test.ts
@@ -48,14 +48,12 @@ const defaultExpectedParams = {
   ip_fwd: mockIpAddress,
   utm_source: mockUtmSource,
   user_id: mockUserId,
-  uid: mockPixelId
-}
-
-const defaultIdentifyParams = {
   first_name: mockFirstName,
   last_name: mockLastName,
   email: mockEmail,
-  phone: mockPhone
+  phone: mockPhone,
+  uid: mockPixelId,
+  args: `{"action":"Test Event"}`
 }
 
 const defaultEventPayload: Partial<SegmentEvent> = {
@@ -99,7 +97,6 @@ describe('StackAdapt', () => {
     })
 
     it('Sends event data to pixel endpoint in expected format with expected headers', async () => {
-      const expectedParams = { ...defaultExpectedParams, ...defaultIdentifyParams }
       nock(pixelHostUrl).get(pixelPath).query(true).reply(200, {})
 
       const event = createTestEvent(defaultEventPayload)
@@ -114,7 +111,7 @@ describe('StackAdapt', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       const requestParams = Object.fromEntries(new URL(responses[0].request.url).searchParams)
-      expect(requestParams).toMatchObject(expectedParams)
+      expect(requestParams).toEqual(defaultExpectedParams)
       expect(responses[0].request.headers).toMatchInlineSnapshot(`
         Headers {
           Symbol(map): Object {
@@ -163,7 +160,7 @@ describe('StackAdapt', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       const requestParams = Object.fromEntries(new URL(responses[0].request.url).searchParams)
-      expect(requestParams).toMatchObject(expectedParams)
+      expect(requestParams).toEqual(expectedParams)
       expect(JSON.parse(requestParams.args)).toEqual({
         action: mockSingleProductAction,
         revenue: mockRevenue,
@@ -203,7 +200,7 @@ describe('StackAdapt', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       const requestParams = Object.fromEntries(new URL(responses[0].request.url).searchParams)
-      expect(requestParams).toMatchObject(expectedParams)
+      expect(requestParams).toEqual(expectedParams)
       expect(JSON.parse(requestParams.args)).toEqual({
         action: mockMultiProductAction,
         revenue: mockRevenue,

--- a/packages/destination-actions/src/destinations/stackadapt/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/__tests__/snapshot.test.ts
@@ -7,9 +7,6 @@ const testDestination = createTestIntegration(destination)
 const destinationSlug = 'actions-stackadapt'
 
 describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
-  // Temporary empty test to prevent failure due to spec file having no tests
-  it.skip('dummy test', () => {})
-
   for (const actionSlug in destination.actions) {
     it(`${actionSlug} action - required fields`, async () => {
       const seedName = `${destinationSlug}#${actionSlug}`

--- a/packages/destination-actions/src/destinations/stackadapt/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/__tests__/snapshot.test.ts
@@ -1,0 +1,80 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-stackadapt'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  // Temporary empty test to prevent failure due to spec file having no tests
+  it.skip('dummy test', () => {})
+
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/stackadapt/forwardEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/stackadapt/forwardEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Stackadapt's forwardEvent destination action: all fields 1`] = `""`;
+
+exports[`Testing snapshot for Stackadapt's forwardEvent destination action: required fields 1`] = `""`;
+
+exports[`Testing snapshot for Stackadapt's forwardEvent destination action: required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "",
+    ],
+    "x-forwarded-for": Array [
+      "",
+    ],
+  },
+}
+`;

--- a/packages/destination-actions/src/destinations/stackadapt/forwardEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/forwardEvent/__tests__/index.test.ts
@@ -1,0 +1,4 @@
+describe('Stackadapt.forwardEvent', () => {
+  // Temporary empty test to prevent failure due to spec file having no tests
+  it.skip('dummy test', () => {})
+})

--- a/packages/destination-actions/src/destinations/stackadapt/forwardEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/forwardEvent/__tests__/index.test.ts
@@ -1,4 +1,0 @@
-describe('Stackadapt.forwardEvent', () => {
-  // Temporary empty test to prevent failure due to spec file having no tests
-  it.skip('dummy test', () => {})
-})

--- a/packages/destination-actions/src/destinations/stackadapt/forwardEvent/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/forwardEvent/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'forwardEvent'
+const destinationSlug = 'Stackadapt'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it.skip('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/stackadapt/forwardEvent/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/forwardEvent/__tests__/snapshot.test.ts
@@ -9,7 +9,7 @@ const destinationSlug = 'Stackadapt'
 const seedName = `${destinationSlug}#${actionSlug}`
 
 describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
-  it.skip('required fields', async () => {
+  it('required fields', async () => {
     const action = destination.actions[actionSlug]
     const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
 

--- a/packages/destination-actions/src/destinations/stackadapt/forwardEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/forwardEvent/generated-types.ts
@@ -2,23 +2,17 @@
 
 export interface Payload {
   /**
+   * The ID of the user in Segment
+   */
+  user_id: string
+  /**
    * The Segment event type (page, track, etc.)
    */
-  eventType?: string
+  event_type?: string
   /**
    * IP address of the user
    */
-  ip?: string
-  /**
-   * User-Agent of the user
-   */
-  userAgent?: string
-  /**
-   * Additional properties associated with the event.
-   */
-  eventProperties?: {
-    [k: string]: unknown
-  }
+  ip_fwd?: string
   /**
    * The title of the page where the event occurred.
    */
@@ -32,9 +26,13 @@ export interface Payload {
    */
   referrer?: string
   /**
-   * UTM source parameter associated with even
+   * UTM source parameter associated with event
    */
-  utmSource?: string
+  utm_source?: string
+  /**
+   * User-Agent of the user
+   */
+  user_agent?: string
   /**
    * Email address of the individual who triggered the conversion event.
    */
@@ -46,39 +44,73 @@ export interface Payload {
   /**
    * First name of the individual who triggered the conversion event.
    */
-  firstName?: string
+  first_name?: string
   /**
    * Last name of the individual who triggered the conversion event.
    */
-  lastName?: string
+  last_name?: string
   /**
-   * The revenue generated from the event.
+   * Additional ecommerce fields that are included in the pixel payload.
    */
-  revenue?: number
-  /**
-   * The ID of the order.
-   */
-  orderId?: string
-  /**
-   * The list of products purchased.
-   */
-  products?: {
+  ecommerce_data?: {
     /**
-     * The price of the item purchased.
+     * The event name (e.g. Order Completed)
      */
-    price?: number
+    action?: string
     /**
-     * The quantity of the item purchased.
+     * The revenue generated from the event.
      */
-    quantity?: number
+    revenue?: number
     /**
-     * An identifier for the item purchased.
+     * The ID of the order.
      */
-    productId?: string
+    order_id?: string
+    /**
+     * The price of the product.
+     */
+    product_price?: number
+    /**
+     * The quantity of the product.
+     */
+    product_quantity?: number
+    /**
+     * An identifier for the product.
+     */
+    product_id?: string
+    /**
+     * A category for the product.
+     */
+    product_category?: string
+    /**
+     * The name of the product.
+     */
+    product_name?: string
+    /**
+     * The list of products associated with the event (for events with multiple products, such as order completed)
+     */
+    products?: {
+      /**
+       * The price of the product.
+       */
+      product_price?: number
+      /**
+       * The quantity of the product.
+       */
+      product_quantity?: number
+      /**
+       * An identifier for the product.
+       */
+      product_id?: string
+      /**
+       * A category for the product.
+       */
+      product_category?: string
+      /**
+       * The name of the product.
+       */
+      product_name?: string
+      [k: string]: unknown
+    }[]
     [k: string]: unknown
-  }[]
-  /**
-   * The ID of the user in Segment
-   */
-  userId: string
+  }
 }

--- a/packages/destination-actions/src/destinations/stackadapt/forwardEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/forwardEvent/generated-types.ts
@@ -34,19 +34,19 @@ export interface Payload {
    */
   user_agent?: string
   /**
-   * Email address of the individual who triggered the conversion event.
+   * Email address of the individual who triggered the event.
    */
   email?: string
   /**
-   * Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000.
+   * Phone number of the individual who triggered the event
    */
   phone?: string
   /**
-   * First name of the individual who triggered the conversion event.
+   * First name of the individual who triggered the event.
    */
   first_name?: string
   /**
-   * Last name of the individual who triggered the conversion event.
+   * Last name of the individual who triggered the event.
    */
   last_name?: string
   /**

--- a/packages/destination-actions/src/destinations/stackadapt/forwardEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/forwardEvent/generated-types.ts
@@ -85,32 +85,32 @@ export interface Payload {
      * The name of the product.
      */
     product_name?: string
-    /**
-     * The list of products associated with the event (for events with multiple products, such as order completed)
-     */
-    products?: {
-      /**
-       * The price of the product.
-       */
-      product_price?: number
-      /**
-       * The quantity of the product.
-       */
-      product_quantity?: number
-      /**
-       * An identifier for the product.
-       */
-      product_id?: string
-      /**
-       * A category for the product.
-       */
-      product_category?: string
-      /**
-       * The name of the product.
-       */
-      product_name?: string
-      [k: string]: unknown
-    }[]
     [k: string]: unknown
   }
+  /**
+   * The list of products associated with the event (for events with multiple products, such as order completed)
+   */
+  ecommerce_products?: {
+    /**
+     * The price of the product.
+     */
+    product_price?: number
+    /**
+     * The quantity of the product.
+     */
+    product_quantity?: number
+    /**
+     * An identifier for the product.
+     */
+    product_id?: string
+    /**
+     * A category for the product.
+     */
+    product_category?: string
+    /**
+     * The name of the product.
+     */
+    product_name?: string
+    [k: string]: unknown
+  }[]
 }

--- a/packages/destination-actions/src/destinations/stackadapt/forwardEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/forwardEvent/generated-types.ts
@@ -1,0 +1,84 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The Segment event type (page, track, etc.)
+   */
+  eventType?: string
+  /**
+   * IP address of the user
+   */
+  ip?: string
+  /**
+   * User-Agent of the user
+   */
+  userAgent?: string
+  /**
+   * Additional properties associated with the event.
+   */
+  eventProperties?: {
+    [k: string]: unknown
+  }
+  /**
+   * The title of the page where the event occurred.
+   */
+  title?: string
+  /**
+   * The URL of the page where the event occurred.
+   */
+  url?: string
+  /**
+   * The referrer of the page where the event occurred.
+   */
+  referrer?: string
+  /**
+   * UTM source parameter associated with even
+   */
+  utmSource?: string
+  /**
+   * Email address of the individual who triggered the conversion event.
+   */
+  email?: string
+  /**
+   * Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000.
+   */
+  phone?: string
+  /**
+   * First name of the individual who triggered the conversion event.
+   */
+  firstName?: string
+  /**
+   * Last name of the individual who triggered the conversion event.
+   */
+  lastName?: string
+  /**
+   * The revenue generated from the event.
+   */
+  revenue?: number
+  /**
+   * The ID of the order.
+   */
+  orderId?: string
+  /**
+   * The list of products purchased.
+   */
+  products?: {
+    /**
+     * The price of the item purchased.
+     */
+    price?: number
+    /**
+     * The quantity of the item purchased.
+     */
+    quantity?: number
+    /**
+     * An identifier for the item purchased.
+     */
+    productId?: string
+    [k: string]: unknown
+  }[]
+  /**
+   * The ID of the user in Segment
+   */
+  userId: string
+}

--- a/packages/destination-actions/src/destinations/stackadapt/forwardEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/forwardEvent/generated-types.ts
@@ -88,7 +88,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * The list of products associated with the event (for events with multiple products, such as order completed)
+   * The list of products associated with the event (for events with multiple products, such as Order Completed)
    */
   ecommerce_products?: {
     /**

--- a/packages/destination-actions/src/destinations/stackadapt/forwardEvent/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/forwardEvent/index.ts
@@ -1,0 +1,251 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Forward Event',
+  description: 'Forward Segment events to StackAdapt for conversion tracking',
+  defaultSubscription: 'type = "identify" or type = "page" or type = "screen" or type = "track"',
+  fields: {
+    eventType: {
+      label: 'Event Type',
+      description: 'The Segment event type (page, track, etc.)',
+      type: 'string',
+      default: {
+        '@path': '$.type'
+      }
+    },
+    ip: {
+      description: 'IP address of the user',
+      label: 'IP Address',
+      required: false,
+      type: 'string',
+      default: {
+        '@path': '$.context.ip'
+      }
+    },
+    userAgent: {
+      description: 'User-Agent of the user',
+      label: 'User Agent',
+      required: false,
+      type: 'string',
+      default: {
+        '@path': '$.context.userAgent'
+      }
+    },
+    eventProperties: {
+      label: 'Event Properties',
+      description: 'Additional properties associated with the event.',
+      type: 'object',
+      required: false,
+      default: { '@path': '$.properties' }
+    },
+    title: {
+      type: 'string',
+      required: false,
+      description: 'The title of the page where the event occurred.',
+      label: 'Page Title',
+      default: { '@path': '$.context.page.title' }
+    },
+    url: {
+      type: 'string',
+      required: false,
+      description: 'The URL of the page where the event occurred.',
+      label: 'URL',
+      default: { '@path': '$.context.page.url' }
+    },
+    referrer: {
+      type: 'string',
+      required: false,
+      description: 'The referrer of the page where the event occurred.',
+      label: 'Referrer',
+      default: { '@path': '$.context.page.referrer' }
+    },
+    utmSource: {
+      type: 'string',
+      format: 'text',
+      label: 'UTM Source',
+      description: 'UTM source parameter associated with even',
+      required: false,
+      default: { '@path': '$.context.campaign.source' }
+    },
+    email: {
+      label: 'Email',
+      description: 'Email address of the individual who triggered the conversion event.',
+      type: 'string',
+      format: 'email',
+      default: {
+        '@if': {
+          exists: { '@path': '$.properties.email' },
+          then: { '@path': '$.properties.email' },
+          else: { '@path': '$.traits.email' }
+        }
+      }
+    },
+    phone: {
+      label: 'Phone Number',
+      description:
+        'Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000.',
+      type: 'string',
+      default: {
+        '@if': {
+          exists: { '@path': '$.properties.phone' },
+          then: { '@path': '$.properties.phone' },
+          else: { '@path': '$.traits.phone' }
+        }
+      }
+    },
+    firstName: {
+      label: 'First Name',
+      description: 'First name of the individual who triggered the conversion event.',
+      type: 'string',
+      default: {
+        '@if': {
+          exists: { '@path': '$.properties.firstName' },
+          then: { '@path': '$.properties.firstName' },
+          else: { '@path': '$.traits.firstName' }
+        }
+      }
+    },
+    lastName: {
+      label: 'Last Name',
+      description: 'Last name of the individual who triggered the conversion event.',
+      type: 'string',
+      default: {
+        '@if': {
+          exists: { '@path': '$.properties.lastName' },
+          then: { '@path': '$.properties.lastName' },
+          else: { '@path': '$.traits.lastName' }
+        }
+      }
+    },
+    revenue: {
+      label: 'Revenue',
+      type: 'number',
+      description: 'The revenue generated from the event.',
+      required: false,
+      default: {
+        '@path': '$.properties.revenue'
+      }
+    },
+    orderId: {
+      label: 'Order ID',
+      type: 'string',
+      description: 'The ID of the order.',
+      required: false,
+      default: {
+        '@path': '$.properties.orderId'
+      }
+    },
+    products: {
+      label: 'Products',
+      description: 'The list of products purchased.',
+      type: 'object',
+      multiple: true,
+      additionalProperties: true,
+      properties: {
+        price: {
+          label: 'Price',
+          type: 'number',
+          description: 'The price of the item purchased.'
+        },
+        quantity: {
+          label: 'Quantity',
+          type: 'integer',
+          description: 'The quantity of the item purchased.'
+        },
+        productId: {
+          label: 'Product ID',
+          type: 'string',
+          description: 'An identifier for the item purchased.'
+        }
+      },
+      default: {
+        '@arrayPath': [
+          '$.properties.products',
+          {
+            price: {
+              '@path': 'price'
+            },
+            quantity: {
+              '@path': 'quantity'
+            },
+            productId: {
+              '@path': 'product_id'
+            }
+          }
+        ]
+      }
+    },
+    userId: {
+      label: 'Segment User ID',
+      description: 'The ID of the user in Segment',
+      type: 'string',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      }
+    }
+  },
+  perform: async (request, { payload, settings }) => {
+    const queryStr = new URLSearchParams(getAvailableData(payload, settings)).toString()
+    return request(`https://tags.srv.stackadapt.com/saq_pxl?${queryStr}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Forwarded-For': payload.ip ?? '',
+        'User-Agent': payload.userAgent ?? ''
+      }
+    })
+  }
+}
+
+function getAvailableData(payload: Payload, settings: Settings) {
+  const data = {
+    segment_ss: '1',
+    event_type: payload.eventType ?? '',
+    title: payload.title ?? '',
+    url: payload.url ?? '',
+    ref: payload.referrer ?? '',
+    ip_fwd: payload.ip ?? '',
+    utm_source: payload.utmSource ?? '',
+    /**
+     * By default we want to use the permanent user id that's consistent across a customer's lifetime.
+     * But if we don't have that we can fall back to the anonymous id
+     *
+     * See: https://segment.com/docs/connections/spec/identify/#user-id
+     */
+    first_name: payload.firstName ?? '',
+    last_name: payload.lastName ?? '',
+    email: payload.email ?? '',
+    phone: payload.phone ?? '',
+    user_id: payload.userId,
+    uid: settings.pixelId,
+    args: getProductJson(payload)
+  }
+  const { args, ...dataMinusProducts } = data
+  return data.args === '{}' ? dataMinusProducts : data
+}
+
+function getProductJson(payload: Payload) {
+  const productData = {
+    revenue: payload.revenue ?? undefined,
+    order_id: payload.orderId ?? undefined,
+    products: payload.products
+      ? payload.products.map((product) => {
+          return {
+            product_id: product.productId,
+            product_price: product.price,
+            product_quantity: product.quantity
+          }
+        })
+      : undefined
+  }
+  return JSON.stringify(productData)
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/stackadapt/forwardEvent/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/forwardEvent/index.ts
@@ -2,7 +2,6 @@ import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import isEmpty from 'lodash/isEmpty'
-import isEqual from 'lodash/isEqual'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Forward Event',
@@ -267,8 +266,7 @@ function getAvailableData(payload: Payload, settings: Settings) {
     utm_source: payload.utm_source ?? '',
     user_id: payload.user_id,
     uid: settings.pixelId,
-    ...(!isEmpty(ecommerceData) &&
-      !isEqual(Object.keys(ecommerceData), ['action']) && { args: JSON.stringify(ecommerceData) })
+    ...(!isEmpty(ecommerceData) && { args: JSON.stringify(ecommerceData) })
   }
   if (payload.event_type === 'identify') {
     data = {

--- a/packages/destination-actions/src/destinations/stackadapt/forwardEvent/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/forwardEvent/index.ts
@@ -182,7 +182,7 @@ const action: ActionDefinition<Settings, Payload> = {
     ecommerce_products: {
       label: 'Products',
       description:
-        'The list of products associated with the event (for events with multiple products, such as order completed)',
+        'The list of products associated with the event (for events with multiple products, such as Order Completed)',
       type: 'object',
       multiple: true,
       additionalProperties: true,
@@ -256,7 +256,7 @@ function getAvailableData(payload: Payload, settings: Settings) {
     ...payload.ecommerce_data,
     ...(!isEmpty(payload.ecommerce_products) && { products: payload.ecommerce_products })
   }
-  let data: Record<string, string> = {
+  return {
     segment_ss: '1',
     event_type: payload.event_type ?? '',
     title: payload.title ?? '',
@@ -266,18 +266,12 @@ function getAvailableData(payload: Payload, settings: Settings) {
     utm_source: payload.utm_source ?? '',
     user_id: payload.user_id,
     uid: settings.pixelId,
+    first_name: payload.first_name ?? '',
+    last_name: payload.last_name ?? '',
+    email: payload.email ?? '',
+    phone: payload.phone ?? '',
     ...(!isEmpty(ecommerceData) && { args: JSON.stringify(ecommerceData) })
   }
-  if (payload.event_type === 'identify') {
-    data = {
-      ...data,
-      first_name: payload.first_name ?? '',
-      last_name: payload.last_name ?? '',
-      email: payload.email ?? '',
-      phone: payload.phone ?? ''
-    }
-  }
-  return data
 }
 
 export default action

--- a/packages/destination-actions/src/destinations/stackadapt/forwardEvent/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/forwardEvent/index.ts
@@ -288,7 +288,7 @@ const action: ActionDefinition<Settings, Payload> = {
 }
 
 function getAvailableData(payload: Payload, settings: Settings) {
-  const data = {
+  const data: Record<string, string> = {
     segment_ss: '1',
     event_type: payload.event_type ?? '',
     title: payload.title ?? '',
@@ -304,8 +304,8 @@ function getAvailableData(payload: Payload, settings: Settings) {
     uid: settings.pixelId,
     args: JSON.stringify(payload.ecommerce_data)
   }
-  const { args, ...dataMinusArgs } = data
-  return !data.args ? dataMinusArgs : data
+  if (!data.args) delete data.args
+  return data
 }
 
 export default action

--- a/packages/destination-actions/src/destinations/stackadapt/generated-types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your StackAdapt Universal Pixel ID
+   */
+  pixelId: string
+}

--- a/packages/destination-actions/src/destinations/stackadapt/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/index.ts
@@ -1,0 +1,24 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'StackAdapt',
+  slug: 'actions-stackadapt',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      pixelId: {
+        label: 'Universal Pixel ID',
+        description: 'Your StackAdapt Universal Pixel ID',
+        type: 'string',
+        required: true
+      }
+    }
+  },
+
+  actions: {}
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/stackadapt/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/index.ts
@@ -9,7 +9,7 @@ const destination: DestinationDefinition<Settings> = {
   slug: 'actions-stackadapt',
   mode: 'cloud',
   description:
-    'Forward Segment events to StackAdapt for tracking ad conversions, and generating lookalike and retargeting audiences',
+    'Forward Segment events to StackAdapt for tracking ad conversions, and generating lookalike and retargeting Audiences',
   authentication: {
     scheme: 'custom',
     fields: {

--- a/packages/destination-actions/src/destinations/stackadapt/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/index.ts
@@ -1,13 +1,15 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
+import { defaultValues } from '@segment/actions-core'
 import forwardEvent from './forwardEvent'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'StackAdapt',
   slug: 'actions-stackadapt',
   mode: 'cloud',
-
+  description:
+    'Forward Segment events to StackAdapt for tracking ad conversions, and generating lookalike and retargeting audiences',
   authentication: {
     scheme: 'custom',
     fields: {
@@ -19,6 +21,15 @@ const destination: DestinationDefinition<Settings> = {
       }
     }
   },
+  presets: [
+    {
+      name: 'Forward Event',
+      subscribe: 'type = "identify" or type = "page" or type = "screen" or type = "track"',
+      partnerAction: 'forwardEvent',
+      mapping: defaultValues(forwardEvent.fields),
+      type: 'automatic'
+    }
+  ],
   actions: {
     forwardEvent
   }

--- a/packages/destination-actions/src/destinations/stackadapt/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/index.ts
@@ -1,6 +1,8 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
+import forwardEvent from './forwardEvent'
+
 const destination: DestinationDefinition<Settings> = {
   name: 'StackAdapt',
   slug: 'actions-stackadapt',
@@ -17,8 +19,9 @@ const destination: DestinationDefinition<Settings> = {
       }
     }
   },
-
-  actions: {}
+  actions: {
+    forwardEvent
+  }
 }
 
 export default destination


### PR DESCRIPTION
This pull request adds a new action destination for StackAdapt. StackAdapt is a demand-side platform customers use to run targeted programmatic ad campaigns. An important part of the programmatic advertising process (and advertising in general) is tracking conversions. This destination forwards Segment events to StackAdapt in order to enable StackAdapt customers who also use Segment to track conversion events based on their own definitions without needing to install the StackAdapt pixel or other tracking tools on their website.

## Testing

I have added unit tests that validate that the expected request is sent to StackAdapt given different Segment event data.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
