### PR TITLE
Fix SMS/MMS and email with <nil> traits to display default

### DIFF
--- a/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
+++ b/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
@@ -90,15 +90,14 @@ export class SendEmailPerformer extends MessageSendPerformer<Settings, Payload> 
     },
     contentType: string
   ) {
-    for (const trait of Object.keys(liquidData.profile.traits || {})) {
-      if (
-        liquidData.profile.traits &&
-        (liquidData.profile.traits[trait] === '<nil>' || liquidData.profile.traits[trait].trim() === '')
-      ) {
-        liquidData.profile.traits[trait] = ''
+    const profileCopy = { ...liquidData.profile }
+    for (const trait of Object.keys(profileCopy.traits || {})) {
+      if (profileCopy.traits && (profileCopy.traits[trait] === '<nil>' || profileCopy.traits[trait].trim() === '')) {
+        profileCopy.traits[trait] = ''
       }
     }
-    const parsedContent = content == null ? content : await Liquid.parseAndRender(content, liquidData)
+    const parsedContent =
+      content == null ? content : await Liquid.parseAndRender(content, { ...liquidData, profile: profileCopy })
     this.logOnError(() => 'Content type: ' + contentType)
     return parsedContent
   }

--- a/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
+++ b/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
@@ -90,10 +90,15 @@ export class SendEmailPerformer extends MessageSendPerformer<Settings, Payload> 
     },
     contentType: string
   ) {
-    const parsedContent =
-      content == null || content === '<nil>' || content.trim() === ''
-        ? content
-        : await Liquid.parseAndRender(content, liquidData)
+    for (const trait of Object.keys(liquidData.profile.traits || {})) {
+      if (
+        liquidData.profile.traits &&
+        (liquidData.profile.traits[trait] === '<nil>' || liquidData.profile.traits[trait].trim() === '')
+      ) {
+        liquidData.profile.traits[trait] = ''
+      }
+    }
+    const parsedContent = content == null ? content : await Liquid.parseAndRender(content, liquidData)
     this.logOnError(() => 'Content type: ' + contentType)
     return parsedContent
   }

--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
@@ -232,6 +232,38 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       expect(twilioContentRequest.isDone()).toEqual(true)
     })
 
+    it('should send SMS with content sid and <nil> trait', async () => {
+      const twilioMessagingRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
+        .post('/Messages.json')
+        .reply(201, {})
+
+      const twilioContentResponse = {
+        types: {
+          'twilio/text': {
+            body: 'Hi {{profile.traits.firstName | default: "Person"}}'
+          }
+        }
+      }
+
+      const twilioContentRequest = nock('https://content.twilio.com')
+        .get(`/v1/Content/${contentSid}`)
+        .reply(200, twilioContentResponse)
+
+      const responses = await testAction({
+        mappingOverrides: {
+          contentSid,
+          traits: {
+            firstName: '<nil>'
+          }
+        }
+      })
+      expect(twilioMessagingRequest.isDone()).toEqual(true)
+      expect(twilioContentRequest.isDone()).toEqual(true)
+      expect(
+        responses.map((response) => response.options.body?.toString().includes('Hi+Person')).some((item) => item)
+      ).toEqual(true)
+    })
+
     it('should send MMS with media in payload', async () => {
       const expectedTwilioRequest = new URLSearchParams({
         Body: 'Hello world, jane!',

--- a/packages/destination-actions/src/destinations/engage/twilio/utils/TwilioMessageSender.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/utils/TwilioMessageSender.ts
@@ -38,9 +38,10 @@ export abstract class TwilioMessageSender<TPayload extends TwilioPayloadBase> ex
     content: R,
     profile: Profile
   ): Promise<R> {
-    for (const trait of Object.keys(profile.traits || {})) {
-      if (profile.traits && profile.traits[trait] === '<nil>') {
-        profile.traits[trait] = ''
+    const profileCopy = { ...profile }
+    for (const trait of Object.keys(profileCopy.traits || {})) {
+      if (profileCopy.traits && profileCopy.traits[trait] === '<nil>') {
+        profileCopy.traits[trait] = ''
       }
     }
 
@@ -51,9 +52,9 @@ export abstract class TwilioMessageSender<TPayload extends TwilioPayloadBase> ex
         }
 
         if (Array.isArray(val)) {
-          val = await Promise.all(val.map((item) => Liquid.parseAndRender(item, { profile })))
+          val = await Promise.all(val.map((item) => Liquid.parseAndRender(item, { profile: profileCopy })))
         } else {
-          val = await Liquid.parseAndRender(val, { profile })
+          val = await Liquid.parseAndRender(val, { profile: profileCopy })
         }
         return [key, val]
       })

--- a/packages/destination-actions/src/destinations/engage/twilio/utils/TwilioMessageSender.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/utils/TwilioMessageSender.ts
@@ -38,9 +38,15 @@ export abstract class TwilioMessageSender<TPayload extends TwilioPayloadBase> ex
     content: R,
     profile: Profile
   ): Promise<R> {
+    for (const trait of Object.keys(profile.traits || {})) {
+      if (profile.traits && profile.traits[trait] === '<nil>') {
+        profile.traits[trait] = ''
+      }
+    }
+
     const parsedEntries = await Promise.all(
       Object.entries(content).map(async ([key, val]) => {
-        if (val == null || val === '<nil>') {
+        if (val == null) {
           return [key, val]
         }
 


### PR DESCRIPTION
Fixes Broadcasts returning NIL for merge tags in SMS/MMS messages when there is no value for the trait. In order to compensate for the compute service sending “<nil>” for non existent profile traits, we have to exclude that value from profile traits, replacing it with null before parsing liquid js.

## Testing

- [x ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
