### PR TITLE
GA4 - Fix page_view parameter loading

### DIFF
--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/setConfigurationFields/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/setConfigurationFields/index.ts
@@ -170,6 +170,10 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     if (payload.campaign_content) {
       config.campaign_content = payload.campaign_content
     }
+    if (settings.pageView != true) {
+      config.send_page_view = settings.pageView
+    }
+
     gtag('config', settings.measurementID, config)
   }
 }


### PR DESCRIPTION
This change fixes the page_view parameter loading sequence that's causing duplicate pageView events in GA4 web.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
