### PR TITLE
Add FullStory Browser destination version 2

### DIFF
--- a/packages/browser-destinations/destinations/fullstory/package.json
+++ b/packages/browser-destinations/destinations/fullstory/package.json
@@ -15,7 +15,7 @@
   },
   "typings": "./dist/esm",
   "dependencies": {
-    "@fullstory/browser": "^1.4.9",
+    "@fullstory/browser": "^2.0.0",
     "@segment/actions-core": "^3.97.0",
     "@segment/browser-destination-runtime": "^1.27.0"
   },

--- a/packages/browser-destinations/destinations/fullstory/package.json
+++ b/packages/browser-destinations/destinations/fullstory/package.json
@@ -15,7 +15,7 @@
   },
   "typings": "./dist/esm",
   "dependencies": {
-    "@fullstory/browser": "^2.0.2",
+    "@fullstory/browser": "^2.0.3",
     "@segment/actions-core": "^3.97.0",
     "@segment/browser-destination-runtime": "^1.27.0"
   },

--- a/packages/browser-destinations/destinations/fullstory/package.json
+++ b/packages/browser-destinations/destinations/fullstory/package.json
@@ -15,7 +15,7 @@
   },
   "typings": "./dist/esm",
   "dependencies": {
-    "@fullstory/browser": "^2.0.0",
+    "@fullstory/browser": "^2.0.2",
     "@segment/actions-core": "^3.97.0",
     "@segment/browser-destination-runtime": "^1.27.0"
   },

--- a/packages/browser-destinations/destinations/fullstory/src/__tests__/initialization.test.ts
+++ b/packages/browser-destinations/destinations/fullstory/src/__tests__/initialization.test.ts
@@ -1,0 +1,81 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import fullstory, { destination } from '..'
+import { Subscription } from '@segment/browser-destination-runtime/types'
+
+const example: Subscription[] = [
+  {
+    partnerAction: 'trackEvent',
+    name: 'Track Event',
+    enabled: true,
+    subscribe: 'type = "track"',
+    mapping: {
+      name: {
+        '@path': '$.name'
+      },
+      properties: {
+        '@path': '$.properties'
+      }
+    }
+  },
+  {
+    partnerAction: 'identifyUser',
+    name: 'Identify User',
+    enabled: true,
+    subscribe: 'type = "identify"',
+    mapping: {
+      anonymousId: {
+        '@path': '$.anonymousId'
+      },
+      userId: {
+        '@path': '$.userId'
+      },
+      email: {
+        '@path': '$.traits.email'
+      },
+      traits: {
+        '@path': '$.traits'
+      },
+      displayName: {
+        '@path': '$.traits.name'
+      }
+    }
+  }
+]
+
+test('can load fullstory', async () => {
+  const [event] = await fullstory({
+    orgId: 'thefullstory.com',
+    subscriptions: example
+  })
+
+  jest.spyOn(destination.actions.trackEvent, 'perform')
+  jest.spyOn(destination, 'initialize')
+
+  await event.load(Context.system(), {} as Analytics)
+  expect(destination.initialize).toHaveBeenCalled()
+
+  const ctx = await event.track?.(
+    new Context({
+      type: 'track',
+      properties: {
+        banana: '📞'
+      }
+    })
+  )
+
+  expect(destination.actions.trackEvent.perform).toHaveBeenCalled()
+  expect(ctx).not.toBeUndefined()
+
+  const scripts = window.document.querySelectorAll('script')
+  expect(scripts).toMatchInlineSnapshot(`
+    NodeList [
+      <script
+        crossorigin="anonymous"
+        src="https://edge.fullstory.com/s/fs.js"
+      />,
+      <script>
+        // the emptiness
+      </script>,
+    ]
+  `)
+})

--- a/packages/browser-destinations/destinations/fullstory/src/identifyUserV2/generated-types.ts
+++ b/packages/browser-destinations/destinations/fullstory/src/identifyUserV2/generated-types.ts
@@ -1,0 +1,26 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The user's id
+   */
+  userId?: string
+  /**
+   * The user's anonymous id
+   */
+  anonymousId?: string
+  /**
+   * The user's display name
+   */
+  displayName?: string
+  /**
+   * The user's email
+   */
+  email?: string
+  /**
+   * The Segment traits to be forwarded to FullStory
+   */
+  traits?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/destinations/fullstory/src/identifyUserV2/index.ts
+++ b/packages/browser-destinations/destinations/fullstory/src/identifyUserV2/index.ts
@@ -1,0 +1,95 @@
+import type { BrowserActionDefinition } from '@segment/browser-destination-runtime/types'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import type { FS } from '../types'
+import { segmentEventSource } from '..'
+
+// Change from unknown to the partner SDK types
+const action: BrowserActionDefinition<Settings, FS, Payload> = {
+  title: 'Identify User V2',
+  description: 'Sets user identity variables',
+  platform: 'web',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    userId: {
+      type: 'string',
+      required: false,
+      description: "The user's id",
+      label: 'User ID',
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    anonymousId: {
+      type: 'string',
+      required: false,
+      description: "The user's anonymous id",
+      label: 'Anonymous ID',
+      default: {
+        '@path': '$.anonymousId'
+      }
+    },
+    displayName: {
+      type: 'string',
+      required: false,
+      description: "The user's display name",
+      label: 'Display Name',
+      default: {
+        '@path': '$.traits.name'
+      }
+    },
+    email: {
+      type: 'string',
+      required: false,
+      description: "The user's email",
+      label: 'Email',
+      default: {
+        '@path': '$.traits.email'
+      }
+    },
+    traits: {
+      type: 'object',
+      required: false,
+      description: 'The Segment traits to be forwarded to FullStory',
+      label: 'Traits',
+      default: {
+        '@path': '$.traits'
+      }
+    }
+  },
+  perform: (FS, event) => {
+    const newTraits: Record<string, unknown> = event.payload.traits || {}
+
+    if (event.payload.anonymousId) {
+      newTraits.segmentAnonymousId = event.payload.anonymousId
+    }
+
+    const userProperties = {
+      ...newTraits,
+      ...(event.payload.email !== undefined && { email: event.payload.email }),
+      ...(event.payload.displayName !== undefined && { displayName: event.payload.displayName })
+    }
+
+    if (event.payload.userId) {
+      FS(
+        'setIdentity',
+        {
+          uid: event.payload.userId,
+          properties: userProperties
+        },
+        segmentEventSource
+      )
+    } else {
+      FS(
+        'setProperties',
+        {
+          type: 'user',
+          properties: userProperties
+        },
+        segmentEventSource
+      )
+    }
+  }
+}
+
+export default action

--- a/packages/browser-destinations/destinations/fullstory/src/index.ts
+++ b/packages/browser-destinations/destinations/fullstory/src/index.ts
@@ -1,11 +1,14 @@
 import type { FS } from './types'
 import type { BrowserDestinationDefinition } from '@segment/browser-destination-runtime/types'
-import { FSPackage } from './types'
+import { initFullStory } from './types'
 import { browserDestination } from '@segment/browser-destination-runtime/shim'
 import type { Settings } from './generated-types'
 import trackEvent from './trackEvent'
+import trackEventV2 from './trackEventV2'
 import identifyUser from './identifyUser'
+import identifyUserV2 from './identifyUserV2'
 import viewedPage from './viewedPage'
+import viewedPageV2 from './viewedPageV2'
 import { defaultValues } from '@segment/actions-core'
 
 declare global {
@@ -24,15 +27,22 @@ export const destination: BrowserDestinationDefinition<Settings, FS> = {
     {
       name: 'Track Event',
       subscribe: 'type = "track"',
-      partnerAction: 'trackEvent',
-      mapping: defaultValues(trackEvent.fields),
+      partnerAction: 'trackEventV2',
+      mapping: defaultValues(trackEventV2.fields),
       type: 'automatic'
     },
     {
       name: 'Identify User',
       subscribe: 'type = "identify"',
-      partnerAction: 'identifyUser',
-      mapping: defaultValues(identifyUser.fields),
+      partnerAction: 'identifyUserV2',
+      mapping: defaultValues(identifyUserV2.fields),
+      type: 'automatic'
+    },
+    {
+      name: 'Viewed Page',
+      subscribe: 'type = "page"',
+      partnerAction: 'viewedPageV2',
+      mapping: defaultValues(viewedPageV2.fields),
       type: 'automatic'
     }
   ],
@@ -60,11 +70,14 @@ export const destination: BrowserDestinationDefinition<Settings, FS> = {
   },
   actions: {
     trackEvent,
+    trackEventV2,
     identifyUser,
-    viewedPage
+    identifyUserV2,
+    viewedPage,
+    viewedPageV2
   },
   initialize: async ({ settings }, dependencies) => {
-    FSPackage.init(settings)
+    initFullStory(settings)
     await dependencies.resolveWhen(() => Object.prototype.hasOwnProperty.call(window, 'FS'), 100)
     return window.FS
   }

--- a/packages/browser-destinations/destinations/fullstory/src/trackEventV2/generated-types.ts
+++ b/packages/browser-destinations/destinations/fullstory/src/trackEventV2/generated-types.ts
@@ -1,0 +1,14 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The name of the event.
+   */
+  name: string
+  /**
+   * A JSON object containing additional information about the event that will be indexed by FullStory.
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/destinations/fullstory/src/trackEventV2/index.ts
+++ b/packages/browser-destinations/destinations/fullstory/src/trackEventV2/index.ts
@@ -1,0 +1,44 @@
+import type { BrowserActionDefinition } from '@segment/browser-destination-runtime/types'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import type { FS } from '../types'
+import { segmentEventSource } from '..'
+
+const action: BrowserActionDefinition<Settings, FS, Payload> = {
+  title: 'Track Event V2',
+  description: 'Track events',
+  platform: 'web',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    name: {
+      description: 'The name of the event.',
+      label: 'Name',
+      required: true,
+      type: 'string',
+      default: {
+        '@path': '$.event'
+      }
+    },
+    properties: {
+      description: 'A JSON object containing additional information about the event that will be indexed by FullStory.',
+      label: 'Properties',
+      required: false,
+      type: 'object',
+      default: {
+        '@path': '$.properties'
+      }
+    }
+  },
+  perform: (FS, event) => {
+    FS(
+      'trackEvent',
+      {
+        name: event.payload.name,
+        properties: event.payload.properties ?? {}
+      },
+      segmentEventSource
+    )
+  }
+}
+
+export default action

--- a/packages/browser-destinations/destinations/fullstory/src/types.ts
+++ b/packages/browser-destinations/destinations/fullstory/src/types.ts
@@ -1,10 +1,4 @@
-import * as FullStory from '@fullstory/browser'
+import { FullStory, init as initFullStory } from '@fullstory/browser'
 
-export const FSPackage = FullStory
-export type FS = typeof FullStory & {
-  // setVars is not available on the FS client yet.
-  setVars: (eventName: string, eventProperties: object, source: string) => {}
-  setUserVars: (eventProperties: object, source: string) => void
-  event: (eventName: string, eventProperties: { [key: string]: unknown }, source: string) => void
-  identify: (uid: string, customVars: FullStory.UserVars, source: string) => void
-}
+export type FS = typeof FullStory
+export { FullStory, initFullStory }

--- a/packages/browser-destinations/destinations/fullstory/src/viewedPageV2/generated-types.ts
+++ b/packages/browser-destinations/destinations/fullstory/src/viewedPageV2/generated-types.ts
@@ -1,0 +1,14 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The name of the page that was viewed.
+   */
+  pageName?: string
+  /**
+   * The properties of the page that was viewed.
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/destinations/fullstory/src/viewedPageV2/index.ts
+++ b/packages/browser-destinations/destinations/fullstory/src/viewedPageV2/index.ts
@@ -1,0 +1,62 @@
+import type { BrowserActionDefinition } from '@segment/browser-destination-runtime/types'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import type { FS } from '../types'
+import { segmentEventSource } from '..'
+
+const action: BrowserActionDefinition<Settings, FS, Payload> = {
+  title: 'Viewed Page V2',
+  description: 'Sets page properties events',
+  defaultSubscription: 'type = "page"',
+  platform: 'web',
+  fields: {
+    pageName: {
+      type: 'string',
+      required: false,
+      description: 'The name of the page that was viewed.',
+      label: 'Page Name',
+      default: {
+        '@if': {
+          exists: { '@path': '$.category' },
+          then: { '@path': '$.category' },
+          else: { '@path': '$.name' }
+        }
+      }
+    },
+    properties: {
+      type: 'object',
+      required: false,
+      description: 'The properties of the page that was viewed.',
+      label: 'Properties',
+      default: {
+        '@path': '$.properties'
+      }
+    }
+  },
+  perform: (FS, event) => {
+    if (event.payload.pageName) {
+      FS(
+        'setProperties',
+        {
+          type: 'page',
+          properties: {
+            pageName: event.payload.pageName,
+            ...event.payload.properties
+          }
+        },
+        segmentEventSource
+      )
+    } else if (event.payload.properties) {
+      FS(
+        'setProperties',
+        {
+          type: 'page',
+          properties: event.payload.properties
+        },
+        segmentEventSource
+      )
+    }
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/fullstory/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/index.ts
@@ -15,15 +15,15 @@ const destination: DestinationDefinition<Settings> = {
     {
       name: 'Track Event',
       subscribe: 'type = "track"',
-      partnerAction: 'trackEvent',
-      mapping: defaultValues(trackEvent.fields),
+      partnerAction: 'trackEventV2',
+      mapping: defaultValues(trackEventV2.fields),
       type: 'automatic'
     },
     {
       name: 'Identify User',
       subscribe: 'type = "identify"',
-      partnerAction: 'identifyUser',
-      mapping: defaultValues(identifyUser.fields),
+      partnerAction: 'identifyUserV2',
+      mapping: defaultValues(identifyUserV2.fields),
       type: 'automatic'
     }
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1256,17 +1256,17 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
   integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
 
-"@fullstory/browser@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@fullstory/browser/-/browser-2.0.0.tgz#43228edafd3fa7828d4a21c5023b426ab1c3782e"
-  integrity sha512-TcHEDORY/xBDEZD2SC6nLBoiZDGMKTD/8568A9NBf7ufPkDlJh5zuKHu81dv40M/GPG/kcFCD2RooLDUILRkMw==
+"@fullstory/browser@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@fullstory/browser/-/browser-2.0.2.tgz#cf503097979c016cb014c335f85447e213658b1a"
+  integrity sha512-zFpkdwuVoFR9Yz3v+PilkYG61VI37+EcT27pw/t7K/1YK5HczCGpGAjQa1rmDV1IUL51kH0Z/Zx6Se5+KdammA==
   dependencies:
-    "@fullstory/snippet" "2.0.0"
+    "@fullstory/snippet" "2.0.2"
 
-"@fullstory/snippet@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@fullstory/snippet/-/snippet-2.0.0.tgz#77d6fc6fc304f09708512971168701b5d88052e0"
-  integrity sha512-rAEPt5mCBXnJfPsD9lY7N4/5QWNiMj1vczn31B7B8mBDop/EzJsVHXeRA8ExhaRW2Oe87bZvmOoUIRoOrx5R+w==
+"@fullstory/snippet@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@fullstory/snippet/-/snippet-2.0.2.tgz#e344c9e8ca340899fa70764916788bb7852e1b11"
+  integrity sha512-k5Cx0VrVbFfIg4CgGkx2ND/vCfNCj+25H4l0IRsbN1chSc2/2cLBR6nMKlUiOvsn5gQTKcGsrrKEXNWKgMe7HQ==
 
 "@gar/promisify@^1.1.3":
   version "1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1256,17 +1256,17 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
   integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
 
-"@fullstory/browser@^1.4.9":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@fullstory/browser/-/browser-1.7.1.tgz#eb94fcb5e21b13a1b30de58951480ac344e61cdd"
-  integrity sha512-IBPisG+xRyTHHX8XkZJkQRbP2hVYNMZUYW8R3YiB582dl/VZImkFN+LopIAfPqB97FAZgUTofi7flkrHT4Qmtg==
+"@fullstory/browser@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@fullstory/browser/-/browser-2.0.0.tgz#43228edafd3fa7828d4a21c5023b426ab1c3782e"
+  integrity sha512-TcHEDORY/xBDEZD2SC6nLBoiZDGMKTD/8568A9NBf7ufPkDlJh5zuKHu81dv40M/GPG/kcFCD2RooLDUILRkMw==
   dependencies:
-    "@fullstory/snippet" "1.3.1"
+    "@fullstory/snippet" "2.0.0"
 
-"@fullstory/snippet@1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@fullstory/snippet/-/snippet-1.3.1.tgz#6817ea94601e071e630b25262e703ca356a5f537"
-  integrity sha512-NgrBWGHH5i8zejlRFSyJNhovkNqHAXsWKrcXIWaABrgESwbkdGETjOU7BD7d1ZeT0X+QXL/2yr/1y4xnWfVkwQ==
+"@fullstory/snippet@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@fullstory/snippet/-/snippet-2.0.0.tgz#77d6fc6fc304f09708512971168701b5d88052e0"
+  integrity sha512-rAEPt5mCBXnJfPsD9lY7N4/5QWNiMj1vczn31B7B8mBDop/EzJsVHXeRA8ExhaRW2Oe87bZvmOoUIRoOrx5R+w==
 
 "@gar/promisify@^1.1.3":
   version "1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1256,17 +1256,17 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
   integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
 
-"@fullstory/browser@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@fullstory/browser/-/browser-2.0.2.tgz#cf503097979c016cb014c335f85447e213658b1a"
-  integrity sha512-zFpkdwuVoFR9Yz3v+PilkYG61VI37+EcT27pw/t7K/1YK5HczCGpGAjQa1rmDV1IUL51kH0Z/Zx6Se5+KdammA==
+"@fullstory/browser@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@fullstory/browser/-/browser-2.0.3.tgz#09c0b590d81a8098f8fd85d160a44e4f73e15bfb"
+  integrity sha512-usjH8FB1O2LiSWoblsuKhFhlYDGpIPuyQVOx4JXtxm9QmQARdKZdNq1vPijxuDvOGjhwtVZa4JmhvByRRuDPnQ==
   dependencies:
-    "@fullstory/snippet" "2.0.2"
+    "@fullstory/snippet" "2.0.3"
 
-"@fullstory/snippet@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@fullstory/snippet/-/snippet-2.0.2.tgz#e344c9e8ca340899fa70764916788bb7852e1b11"
-  integrity sha512-k5Cx0VrVbFfIg4CgGkx2ND/vCfNCj+25H4l0IRsbN1chSc2/2cLBR6nMKlUiOvsn5gQTKcGsrrKEXNWKgMe7HQ==
+"@fullstory/snippet@2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@fullstory/snippet/-/snippet-2.0.3.tgz#d5410132becc3d0115bb129b57461d228c73b5f0"
+  integrity sha512-EaCuTQSLv5FvnjHLbTxErn3sS1+nLqf1p6sA/c4PV49stBtkUakA0eLhJJdaw0WLdXyEzZXf86lRNsjEzrgGPw==
 
 "@gar/promisify@^1.1.3":
   version "1.1.3"


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

FullStory recently released a v2 of their browser api. The changes are different enough to warrant a second set of actions (`trackEvent`, `trackEventV2` etc...) I set these new actions to the default presets. I also set the server destination presets to point to version 2 now that the integration is in general availability. 

## Testing

Unit tests updated for browser v1 (adding `viewdPage` tests) as well as a second set of tests for the v2 actions.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
