### PR TITLE
[LinkedIn CAPI] - Multiple campaign conversions (temporary workaround)

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-conversions/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/__tests__/snapshot.test.ts
@@ -24,7 +24,7 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
         }
       ]
 
-      eventData.conversionHappenedAt = '1698764171467'
+      eventData.conversionHappenedAt = Date.now()
 
       const event = createTestEvent({
         properties: eventData
@@ -75,7 +75,7 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
         }
       ]
 
-      eventData.conversionHappenedAt = '1698764171467'
+      eventData.conversionHappenedAt = Date.now()
 
       const event = createTestEvent({
         properties: eventData

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/api.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/api.test.ts
@@ -99,7 +99,7 @@ describe('LinkedIn Conversions', () => {
       }
       nock(`${BASE_URL}`)
         .get(`/conversions`)
-        .query({ q: 'account', account: payload.adAccountId })
+        .query({ q: 'account', account: payload.adAccountId, start: 0, count: 100 })
         .reply(200, {
           elements: [
             {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -139,14 +139,19 @@ export class LinkedInConversions {
       const response: Array<Conversions> = []
       const result = await this.request<GetConversionListAPIResponse>(`${BASE_URL}/conversions`, {
         method: 'GET',
+        skipResponseCloning: true,
         searchParams: {
           q: 'account',
-          account: adAccountId
+          account: adAccountId,
+          start: 0,
+          count: 100
         }
       })
 
       result.data.elements.forEach((item) => {
-        response.push(item)
+        if (item.enabled && item.conversionMethod === 'CONVERSIONS_API') {
+          response.push(item)
+        }
       })
 
       const choices = response?.map((item) => {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -243,13 +243,12 @@ export class LinkedInConversions {
   }
 
   /**
-   * As a temporary workaround this method will associate the first 5 campaign IDs to the conversion rule.
+   * As a temporary workaround this method will associate campaign IDs to the conversion rule with a loop.
    * This is because the LinkedIn API Bulk Create Campaign Conversions endpoint is not working.
-   * This is limited to 5 because of the integrations timeout.
+   * This may cause timeouts if there are too many campaigns to associate.
    * This issue is tracked in: https://segment.atlassian.net/browse/STRATCONN-3510
    */
   async temp_bulkAssociateCampignToConversion(campaignIds: string[]): Promise<ModifiedResponse> {
-    campaignIds = campaignIds.slice(0, 5)
     for (let i = 0; i < campaignIds.length - 1; i++) {
       const campaignId = campaignIds[i]
       if (campaignId) {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -249,7 +249,8 @@ export class LinkedInConversions {
    * This issue is tracked in: https://segment.atlassian.net/browse/STRATCONN-3510
    */
   async temp_bulkAssociateCampignToConversion(campaignIds: string[]): Promise<ModifiedResponse> {
-    for (let i = 0; i < 4; i++) {
+    campaignIds = campaignIds.slice(0, 5)
+    for (let i = 0; i < campaignIds.length - 1; i++) {
       const campaignId = campaignIds[i]
       if (campaignId) {
         try {
@@ -263,7 +264,7 @@ export class LinkedInConversions {
         }
       }
     }
-    return await this.associateCampignToConversion(campaignIds[4])
+    return await this.associateCampignToConversion(campaignIds[campaignIds.length - 1])
   }
 
   async associateCampignToConversion(campaignId: string): Promise<ModifiedResponse> {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -12,6 +12,7 @@ import type {
   GetConversionRuleResponse
 } from '../types'
 import type { Payload, HookBundle } from '../streamConversion/generated-types'
+import { IntegrationError } from '@segment/actions-core/*'
 export class LinkedInConversions {
   request: RequestClient
   conversionRuleId?: string
@@ -241,13 +242,37 @@ export class LinkedInConversions {
     })
   }
 
-  async associateCampignToConversion(payload: Payload): Promise<ModifiedResponse> {
+  /**
+   * As a temporary workaround this method will associate the first 5 campaign IDs to the conversion rule.
+   * This is because the LinkedIn API Bulk Create Campaign Conversions endpoint is not working.
+   * This is limited to 5 because of the integrations timeout.
+   * This issue is tracked in: https://segment.atlassian.net/browse/STRATCONN-3510
+   */
+  async temp_bulkAssociateCampignToConversion(campaignIds: string[]): Promise<ModifiedResponse> {
+    for (let i = 0; i < 4; i++) {
+      const campaignId = campaignIds[i]
+      if (campaignId) {
+        try {
+          await this.associateCampignToConversion(campaignId)
+        } catch (e) {
+          throw new IntegrationError(
+            `Campaign ID ${campaignId} err: ${(e as { message: string })?.message ?? JSON.stringify(e)}`,
+            JSON.stringify((e as { status: string | number }).status) ?? 'ASSOCIATE_CAMPAIGN_TO_CONVERSION_ERROR',
+            500
+          )
+        }
+      }
+    }
+    return await this.associateCampignToConversion(campaignIds[4])
+  }
+
+  async associateCampignToConversion(campaignId: string): Promise<ModifiedResponse> {
     return this.request(
-      `${BASE_URL}/campaignConversions/(campaign:urn%3Ali%3AsponsoredCampaign%3A${payload.campaignId},conversion:urn%3Alla%3AllaPartnerConversion%3A${this.conversionRuleId})`,
+      `${BASE_URL}/campaignConversions/(campaign:urn%3Ali%3AsponsoredCampaign%3A${campaignId},conversion:urn%3Alla%3AllaPartnerConversion%3A${this.conversionRuleId})`,
       {
         method: 'PUT',
         body: JSON.stringify({
-          campaign: `urn:li:sponsoredCampaign:${payload.campaignId}`,
+          campaign: `urn:li:sponsoredCampaign:${campaignId}`,
           conversion: `urn:lla:llaPartnerConversion:${this.conversionRuleId}`
         })
       }

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -1,4 +1,10 @@
-import type { RequestClient, ModifiedResponse, DynamicFieldResponse, ActionHookResponse } from '@segment/actions-core'
+import {
+  RequestClient,
+  ModifiedResponse,
+  DynamicFieldResponse,
+  ActionHookResponse,
+  IntegrationError
+} from '@segment/actions-core'
 import { BASE_URL } from '../constants'
 import type {
   ProfileAPIResponse,
@@ -12,7 +18,6 @@ import type {
   GetConversionRuleResponse
 } from '../types'
 import type { Payload, HookBundle } from '../streamConversion/generated-types'
-import { IntegrationError } from '@segment/actions-core/*'
 export class LinkedInConversions {
   request: RequestClient
   conversionRuleId?: string

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/snapshot.test.ts
@@ -24,7 +24,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       }
     ]
 
-    eventData.conversionHappenedAt = '1698764171467'
+    eventData.conversionHappenedAt = Date.now() - 20
 
     const event = createTestEvent({
       properties: eventData
@@ -74,7 +74,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       }
     ]
 
-    eventData.conversionHappenedAt = '1698764171467'
+    eventData.conversionHappenedAt = Date.now() - 20
 
     const event = createTestEvent({
       properties: eventData

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
@@ -52,7 +52,7 @@ export interface Payload {
   /**
    * A dynamic field dropdown which fetches all active campaigns.
    */
-  campaignId: string
+  campaignId: string[]
 }
 // Generated bundle for hooks. DO NOT MODIFY IT BY HAND.
 

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -195,6 +195,7 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
     campaignId: {
       label: 'Campaign',
       type: 'string',
+      multiple: true,
       required: true,
       dynamic: true,
       description: 'A dynamic field dropdown which fetches all active campaigns.'
@@ -227,7 +228,7 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
 
     const linkedinApiClient: LinkedInConversions = new LinkedInConversions(request, conversionRuleId)
     try {
-      await linkedinApiClient.associateCampignToConversion(payload)
+      await linkedinApiClient.temp_bulkAssociateCampignToConversion(payload.campaignId)
       return linkedinApiClient.streamConversionEvent(payload, conversionTime)
     } catch (error) {
       return error

--- a/packages/destination-actions/src/destinations/linkedin-conversions/types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/types.ts
@@ -65,6 +65,8 @@ export interface GetConversionListAPIResponse {
 export interface Conversions {
   name: string
   id: string
+  enabled: boolean
+  conversionMethod: string
 }
 
 export interface GetCampaignsListAPIResponse {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR makes the following changes which were requested by LinkedIn:
* Allows users to select multiple 'campaign IDs' to associate with a 'conversion rule'. This has been implemented as a for loop temporarily.
* Only shows enabled conversion rules on a users account.
* Only shows `CONVERSIONS_API` conversion rules on a users account.

## Testing
Tested successfully locally. 
Request with multiple campaign IDs:
<img width="875" alt="Screenshot 2024-01-29 at 5 09 25 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/cbaf2721-a01f-417c-a4c9-a8a089d33bee">

Two requests made, one for each campaign:
<img width="872" alt="Screenshot 2024-01-29 at 5 09 46 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/4f44cd5c-2c9d-40f6-abfc-ed7fb6c7a7e6">

Conversion successfully sent:
<img width="870" alt="Screenshot 2024-01-29 at 5 09 54 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/eeb5c9e9-64c8-4441-8728-061d2f0d47e8">


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
