### PR TITLE
Add Window object change unit test

### DIFF
--- a/packages/browser-destinations/__tests__/window.test.ts
+++ b/packages/browser-destinations/__tests__/window.test.ts
@@ -1,5 +1,5 @@
 import { Analytics, Context } from '@segment/analytics-next'
-import segmentUtilitiesDestination from '../segment-utilities-web/src/index'
+import segmentUtilitiesDestination from '../destinations/segment-utilities-web/src/index'
 
 it('window object shouldnt be changed by actions core', async () => {
   const windowBefore = Object.keys(window)

--- a/packages/browser-destinations/destinations/__tests__/indext.test.ts
+++ b/packages/browser-destinations/destinations/__tests__/indext.test.ts
@@ -1,0 +1,29 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import segmentUtilitiesDestination from '../segment-utilities-web'
+
+it('window object shouldnt be changed by actions core', async () => {
+  const windowBefore = Object.keys(window)
+
+  // load a plugin that doesn't alter window object
+  const [plugin] = await segmentUtilitiesDestination({
+    throttleWindow: 3000,
+    passThroughCount: 1,
+    subscriptions: [
+      {
+        partnerAction: 'throttle',
+        name: 'Throttle',
+        enabled: true,
+        subscribe: 'type = "track"',
+        mapping: {}
+      }
+    ]
+  })
+
+  await plugin.load(Context.system(), {} as Analytics)
+
+  const windowAfter = Object.keys(window)
+  const diff = windowAfter.filter((element) => !windowBefore.includes(element))
+
+  // window object shouldn't change as long as actions-core isn't changing it
+  expect(diff.length).toBe(0)
+})

--- a/packages/browser-destinations/destinations/__tests__/indext.test.ts
+++ b/packages/browser-destinations/destinations/__tests__/indext.test.ts
@@ -22,8 +22,7 @@ it('window object shouldnt be changed by actions core', async () => {
   await plugin.load(Context.system(), {} as Analytics)
 
   const windowAfter = Object.keys(window)
-  const diff = windowAfter.filter((element) => !windowBefore.includes(element))
 
   // window object shouldn't change as long as actions-core isn't changing it
-  expect(diff.length).toBe(0)
+  expect(windowBefore.sort()).toEqual(windowAfter.sort())
 })

--- a/packages/browser-destinations/destinations/__tests__/indext.test.ts
+++ b/packages/browser-destinations/destinations/__tests__/indext.test.ts
@@ -1,5 +1,5 @@
 import { Analytics, Context } from '@segment/analytics-next'
-import segmentUtilitiesDestination from '../segment-utilities-web'
+import segmentUtilitiesDestination from '../segment-utilities-web/src/index'
 
 it('window object shouldnt be changed by actions core', async () => {
   const windowBefore = Object.keys(window)


### PR DESCRIPTION
This PR adds a unit test that loads a web destination that doesn't alter the Window object and then checks for Window changes to confirm that our actions core isn't making unintended changes to Window

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
