### PR TITLE
update preset & new offline conversions action name

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-conversions-sandbox/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions-sandbox/index.ts
@@ -100,7 +100,7 @@ const destination: DestinationDefinition<Settings> = {
   presets: [
     {
       name: 'Complete Payment',
-      subscribe: 'event = "Payment Completed"',
+      subscribe: 'event = "Order Completed"',
       partnerAction: 'reportWebEvent',
       mapping: {
         ...multiProductContents,
@@ -220,7 +220,7 @@ const destination: DestinationDefinition<Settings> = {
     },
     {
       name: 'Place an Order',
-      subscribe: 'event = "Order Completed"',
+      subscribe: 'event = "Order Placed"',
       partnerAction: 'reportWebEvent',
       mapping: {
         ...multiProductContents,

--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions-sandbox/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions-sandbox/index.ts
@@ -95,7 +95,7 @@ const destination: DestinationDefinition<Settings> = {
   presets: [
     {
       name: 'Complete Payment',
-      subscribe: 'event = "Payment Completed"',
+      subscribe: 'event = "Order Completed"',
       partnerAction: 'reportOfflineEvent',
       mapping: {
         ...multiProductContents,
@@ -215,7 +215,7 @@ const destination: DestinationDefinition<Settings> = {
     },
     {
       name: 'Place an Order',
-      subscribe: 'event = "Order Completed"',
+      subscribe: 'event = "Order Placed"',
       partnerAction: 'reportOfflineEvent',
       mapping: {
         ...multiProductContents,

--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions-sandbox/reportOfflineEvent/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions-sandbox/reportOfflineEvent/index.ts
@@ -5,7 +5,7 @@ import { commonFields } from '../common_fields'
 import { performOfflineEvent } from '../utils'
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Track Payment Offline Conversion',
+  title: 'Track Offline Conversion',
   description: 'Send details of an in-store purchase or console purchase to the Tiktok Offline Events API',
   fields: {
     ...commonFields


### PR DESCRIPTION
Updated preset for "Order Completed" Segment event to be mapped to "Complete Payment" TikTok event.

Updated the new Offline conversions action name.

