### PR TITLE
Added preset for Customer.io jsm step event

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/__tests__/trackEvent.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/trackEvent.test.ts
@@ -114,11 +114,11 @@ describe('CustomerIO', () => {
         await testDestination.testAction('trackEvent', { event, settings, useDefaultMappings: true })
         fail('This test should have thrown an error')
       } catch (e) {
-        expect(e.message).toBe("The root value is missing the required field 'name'.")
+        expect(e.message).toBe('The root value is missing the required field \'name\'.')
       }
     })
 
-    it("should not convert timestamp if it's invalid", async () => {
+    it('should not convert timestamp if it\'s invalid', async () => {
       const settings: Settings = {
         siteId: '12345',
         apiKey: 'abcde',
@@ -320,6 +320,71 @@ describe('CustomerIO', () => {
           over18: true,
           identification: 'valid',
           birthdate
+        }
+      }
+
+      trackEventService.post(`/customers/${userId}/events`).reply(200, {}, { 'x-customerio-region': 'US' })
+
+      const event = createTestEvent({
+        event: name,
+        userId,
+        properties: data,
+        timestamp
+      })
+
+      const responses = await testDestination.testAction('trackEvent', {
+        event,
+        settings,
+        // Using the mapping of presets with event type 'track'
+        mapping: {
+          data: {
+            '@path': '$.properties'
+          }
+        },
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+    })
+
+    it('should succeed with mapping of preset and Journeys Step Transition event(presets) ', async () => {
+      const settings: Settings = {
+        siteId: '12345',
+        apiKey: 'abcde',
+        accountRegion: AccountRegion.US
+      }
+      const userId = 'abc123'
+      const name = 'Journeys Step Transition Track'
+      const timestamp = dayjs.utc().toISOString()
+      const data = {
+        journey_metadata: {
+          journey_id: 'test-journey-id',
+          journey_name: 'test-journey-name',
+          step_id: 'test-step-id',
+          step_name: 'test-step-name'
+        },
+        journey_context: {
+          appointment_booked: {
+            type: 'track',
+            event: 'Appointment Booked',
+            timestamp: '2021-09-01T00:00:00.000Z',
+            properties: {
+              appointment_id: 'test-appointment-id',
+              appointment_date: '2021-09-01T00:00:00.000Z',
+              appointment_type: 'test-appointment-type'
+            }
+          },
+          appointment_confirmed: {
+            type: 'track',
+            event: 'Appointment Confirmed',
+            timestamp: '2021-09-01T00:00:00.000Z',
+            properties: {
+              appointment_id: 'test-appointment-id',
+              appointment_date: '2021-09-01T00:00:00.000Z',
+              appointment_type: 'test-appointment-type'
+            }
+          }
         }
       }
 

--- a/packages/destination-actions/src/destinations/customerio/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/index.ts
@@ -176,7 +176,7 @@ const destination: DestinationDefinition<Settings> = {
       partnerAction: 'trackEvent',
       mapping: {
         ...defaultValues(trackEvent.fields),
-        properties: {
+        data: {
           '@path': '$.properties'
         }
       },

--- a/packages/destination-actions/src/destinations/customerio/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/index.ts
@@ -170,6 +170,18 @@ const destination: DestinationDefinition<Settings> = {
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
+    },
+    {
+      name: 'Journeys Step Transition Track',
+      partnerAction: 'trackEvent',
+      mapping: {
+        ...defaultValues(trackEvent.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ],
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

- Adding mapping for new Journeys Step Transition track event for JSM

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
