### PR TITLE
Airship: changes to how tags work to support strings

### DIFF
--- a/packages/destination-actions/src/destinations/airship/utilities.ts
+++ b/packages/destination-actions/src/destinations/airship/utilities.ts
@@ -327,6 +327,12 @@ function _build_tags_object(payload: TagsPayload): object {
       } else {
         tags_to_remove.push(k)
       }
+    } else if (typeof v == 'string' && ['true', 'false'].includes(v.toString().toLowerCase())) {
+      if (v.toLowerCase() === 'true') {
+        tags_to_add.push(k)
+      } else {
+        tags_to_remove.push(k)
+      }
     }
   }
   const airship_payload: { audience: {}; add?: {}; remove?: {} } = { audience: {} }


### PR DESCRIPTION
Change to Airship Destination to support adding or removing tags using string values 'true' and 'false'. 

## Testing

Tested locally using Actions tester. 

![image](https://github.com/segmentio/action-destinations/assets/45374896/24aa0cf9-4248-4993-a1cc-ca55dea55594)

![image](https://github.com/segmentio/action-destinations/assets/45374896/3cde8ce5-208b-4821-8999-90b95a5e01ea)

