### PR TITLE
[LinkedIn CAPI] Batch create a campaign conversion

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -271,6 +271,64 @@ export class LinkedInConversions {
     return await this.associateCampignToConversion(campaignIds[campaignIds.length - 1])
   }
 
+  async bulkAssociateCampaignToConversion(campaignIds: string[]): Promise<ModifiedResponse> {
+    if (campaignIds.length === 1) {
+      return this.associateCampignToConversion(campaignIds[0])
+    }
+    
+    /**
+     * campaign[0]: "(campaign:urn%3Ali%3AsponsoredCampaign%3A<campaign0>,conversion:urn%3Alla%3AllaPartnerConversion%3A<this.conversionRuleId>)"
+     * ...
+     * campaign[n]: "(campaign:urn%3Ali%3AsponsoredCampaign%3A<campaignn>,conversion:urn%3Alla%3AllaPartnerConversion%3A<this.conversionRuleId>)"
+     */
+    const campaignConversions = new Map<string, string>(
+      campaignIds.map((campaignId) => {
+        return [
+          campaignId,
+          `(campaign:${encodeURIComponent(`urn:li:sponsoredCampaign:${campaignId}`)},conversion:${encodeURIComponent(
+            `urn:lla:llaPartnerConversion:${this.conversionRuleId})`
+          )}`
+        ]
+      })
+    )
+
+    /**
+     * {
+     *  campaignConversions.get(campaignIds[0]): {
+     *    campaign: `urn:li:sponsoredCampaign:${campaignIds[0]}`,
+     *    conversion: `urn:lla:llaPartnerConversion:${this.conversionRuleId}`
+     *  },
+     * ...
+     * campaignConversions.get(campaignIds[n]): {
+     *   campaign: `urn:li:sponsoredCampaign:${campaignIds[n]}`,
+     *  conversion: `urn:lla:llaPartnerConversion:${this.conversionRuleId}`
+     * }
+     */
+    const entities = Object.fromEntries(
+      Array.from(campaignConversions, ([id, value]) => [
+        value,
+        {
+          campaign: `urn:li:sponsoredCampaign:${id}`,
+          conversion: `urn:lla:llaPartnerConversion:${this.conversionRuleId}`
+        }
+      ])
+    )
+
+    const listString = Array.from(campaignConversions, ([_, value]) => value).join(',')
+
+    return this.request(`${BASE_URL}/campaignConversions?ids=List(${listString})`, {
+      method: 'PUT',
+      json: {
+        entities
+      },
+      headers: {
+        'X-RestLi-Method': 'BATCH_CREATE',
+        'content-type': 'application/json',
+        'X-Restli-Protocol-Version': '2.0.0'
+      }
+    })
+  }
+
   async associateCampignToConversion(campaignId: string): Promise<ModifiedResponse> {
     return this.request(
       `${BASE_URL}/campaignConversions/(campaign:urn%3Ali%3AsponsoredCampaign%3A${campaignId},conversion:urn%3Alla%3AllaPartnerConversion%3A${this.conversionRuleId})`,

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -1,10 +1,4 @@
-import {
-  RequestClient,
-  ModifiedResponse,
-  DynamicFieldResponse,
-  ActionHookResponse,
-  IntegrationError
-} from '@segment/actions-core'
+import { RequestClient, ModifiedResponse, DynamicFieldResponse, ActionHookResponse } from '@segment/actions-core'
 import { BASE_URL } from '../constants'
 import type {
   ProfileAPIResponse,
@@ -247,35 +241,11 @@ export class LinkedInConversions {
     })
   }
 
-  /**
-   * As a temporary workaround this method will associate campaign IDs to the conversion rule with a loop.
-   * This is because the LinkedIn API Bulk Create Campaign Conversions endpoint is not working.
-   * This may cause timeouts if there are too many campaigns to associate.
-   * This issue is tracked in: https://segment.atlassian.net/browse/STRATCONN-3510
-   */
-  async temp_bulkAssociateCampignToConversion(campaignIds: string[]): Promise<ModifiedResponse> {
-    for (let i = 0; i < campaignIds.length - 1; i++) {
-      const campaignId = campaignIds[i]
-      if (campaignId) {
-        try {
-          await this.associateCampignToConversion(campaignId)
-        } catch (e) {
-          throw new IntegrationError(
-            `Campaign ID ${campaignId} err: ${(e as { message: string })?.message ?? JSON.stringify(e)}`,
-            JSON.stringify((e as { status: string | number }).status) ?? 'ASSOCIATE_CAMPAIGN_TO_CONVERSION_ERROR',
-            500
-          )
-        }
-      }
-    }
-    return await this.associateCampignToConversion(campaignIds[campaignIds.length - 1])
-  }
-
   async bulkAssociateCampaignToConversion(campaignIds: string[]): Promise<ModifiedResponse> {
     if (campaignIds.length === 1) {
       return this.associateCampignToConversion(campaignIds[0])
     }
-    
+
     /**
      * campaign[0]: "(campaign:urn%3Ali%3AsponsoredCampaign%3A<campaign0>,conversion:urn%3Alla%3AllaPartnerConversion%3A<this.conversionRuleId>)"
      * ...
@@ -320,11 +290,6 @@ export class LinkedInConversions {
       method: 'PUT',
       json: {
         entities
-      },
-      headers: {
-        'X-RestLi-Method': 'BATCH_CREATE',
-        'content-type': 'application/json',
-        'X-Restli-Protocol-Version': '2.0.0'
       }
     })
   }

--- a/packages/destination-actions/src/destinations/linkedin-conversions/constants.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/constants.ts
@@ -1,4 +1,4 @@
-export const LINKEDIN_API_VERSION = '202309'
+export const LINKEDIN_API_VERSION = '202401'
 export const BASE_URL = 'https://api.linkedin.com/rest'
 export const LINKEDIN_SOURCE_PLATFORM = 'SEGMENT'
 

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
@@ -105,7 +105,7 @@ describe('LinkedinConversions.streamConversion', () => {
     ).resolves.not.toThrowError()
   })
 
-  it.only('should bulk associate campaigns and successfully send the event when multiple campaigns are selected', async () => {
+  it('should bulk associate campaigns and successfully send the event when multiple campaigns are selected', async () => {
     const multipleCampaigns = payload.campaignId.concat('56789')
     // const associateCampignToConversion = {
     //   campaign: 'urn:li:sponsoredCampaign:123456`',

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * A dynamic field dropdown which fetches all adAccounts.
+   * The ad account to use for the conversion event.
    */
   adAccountId: string
   /**
@@ -23,7 +23,7 @@ export interface Payload {
     amount: string
   }
   /**
-   * Will be used for deduplication in future.
+   * The unique id for each event. This field is optional and is used for deduplication.
    */
   eventId?: string
   /**
@@ -50,7 +50,7 @@ export interface Payload {
     countryCode?: string
   }
   /**
-   * A dynamic field dropdown which fetches all active campaigns.
+   * Select one or more advertising campaigns from your ad account to associate with the configured conversion rule.
    */
   campaignId: string[]
 }

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -228,7 +228,7 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
 
     const linkedinApiClient: LinkedInConversions = new LinkedInConversions(request, conversionRuleId)
     try {
-      await linkedinApiClient.temp_bulkAssociateCampignToConversion(payload.campaignId)
+      await linkedinApiClient.bulkAssociateCampaignToConversion(payload.campaignId)
       return linkedinApiClient.streamConversionEvent(payload, conversionTime)
     } catch (error) {
       return error

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -113,6 +113,7 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
       description: 'The monetary value for this conversion. Example: {“currencyCode”: “USD”, “amount”: “50.0”}.',
       type: 'object',
       required: false,
+      defaultObjectUI: 'keyvalue:only',
       properties: {
         currencyCode: {
           label: 'Currency Code',
@@ -143,6 +144,7 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
         'Either userIds or userInfo is required. List of one or more identifiers to match the conversion user with objects containing "idType" and "idValue".',
       type: 'object',
       multiple: true,
+      defaultObjectUI: 'keyvalue',
       properties: {
         idType: {
           label: 'ID Type',
@@ -163,6 +165,7 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
       label: 'User Info',
       description: 'Object containing additional fields for user matching.',
       type: 'object',
+      defaultObjectUI: 'keyvalue',
       required: false,
       properties: {
         firstName: {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -93,7 +93,7 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
   fields: {
     adAccountId: {
       label: 'Ad Account',
-      description: 'A dynamic field dropdown which fetches all adAccounts.',
+      description: 'The ad account to use for the conversion event.',
       type: 'string',
       required: true,
       dynamic: true
@@ -131,7 +131,7 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
     },
     eventId: {
       label: 'Event ID',
-      description: 'Will be used for deduplication in future.',
+      description: 'The unique id for each event. This field is optional and is used for deduplication.',
       type: 'string',
       required: false,
       default: {
@@ -196,12 +196,13 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
       }
     },
     campaignId: {
-      label: 'Campaign',
+      label: 'Campaigns',
       type: 'string',
       multiple: true,
       required: true,
       dynamic: true,
-      description: 'A dynamic field dropdown which fetches all active campaigns.'
+      description:
+        'Select one or more advertising campaigns from your ad account to associate with the configured conversion rule.'
     }
   },
   dynamicFields: {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR adds support for associating multiple LinkedIn advertising campaigns to a single 'conversion' value. A [previous PR](https://github.com/segmentio/action-destinations/pull/1840) updated the `campaignId` field to be an array. This PR replaces the temporary for loop in that PR with a more efficient, single, batch create request.

It also updates the API version to `202401` supporting the bulk create request. I've tested all dynamic fields and streamed an event through, no further updates were needed to support this new API version.

## Testing
Local Request with multiple campaigns:
<img width="791" alt="Screenshot 2024-02-01 at 4 07 05 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/0f823b48-b857-41f8-88d9-9a69926685a1">

Stream Conversion triggers the bulk associate request with successful response:
<img width="708" alt="Screenshot 2024-02-02 at 4 41 35 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/9cfd42fd-2f6a-4185-b8b3-b22712be0530">

Conversion streamed successfully:
<img width="711" alt="Screenshot 2024-02-02 at 4 41 45 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/d08665e7-3e07-46a5-93d7-9d3ea67fbd50">

Bulk request in staging:
<img width="648" alt="Screenshot 2024-02-02 at 4 27 48 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/9313d8f2-b915-45db-8252-62017393f634">

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
