### PR TITLE
[Userpilot] Add Group method to presets 

### DIFF
--- a/packages/browser-destinations/destinations/userpilot/src/index.ts
+++ b/packages/browser-destinations/destinations/userpilot/src/index.ts
@@ -31,6 +31,12 @@ export const destination: BrowserDestinationDefinition<Settings, Userpilot> = {
       mapping: defaultValues(identifyUser.fields)
     },
     {
+      name: 'Identify Company',
+      subscribe: 'type = "group"',
+      partnerAction: 'identifyCompany',
+      mapping: defaultValues(identifyCompany.fields)
+    },
+    {
       name: 'Track Event',
       subscribe: 'type = "track"',
       partnerAction: 'trackEvent',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

Currently, for users to use the Group functionality with Userpilot, it is required for them to add it in the mappings manually. The method is already supported and works without any issues; just missing the preset. 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
