### PR TITLE
DV360 - Support no-auth endpoint for legacy destinations

### DIFF
--- a/packages/destination-actions/src/destinations/display-video-360/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/__tests__/index.test.ts
@@ -160,5 +160,20 @@ describe('Display Video 360', () => {
         externalId: expectedExternalID
       })
     })
+
+    it('should succeed when Destination is flagged as migration', async () => {
+      const migrationGetAudienceInput = {
+        ...getAudienceInput,
+        settings: { oauth: {} },
+        externalId: 'iWasHereInTheBeforeTimes'
+      }
+
+      nock(advertiserGetAudienceUrl).post(/.*/).reply(200, getAudienceResponse)
+
+      const r = await testDestination.getAudience(migrationGetAudienceInput)
+      expect(r).toEqual({
+        externalId: 'iWasHereInTheBeforeTimes'
+      })
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/display-video-360/shared.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/shared.ts
@@ -13,8 +13,18 @@ import {
 
 import { ListOperation, UpdateHandlerPayload, UserOperation } from './types'
 import type { AudienceSettings, Settings } from './generated-types'
+import { GetAudienceInput } from '@segment/actions-core/destination-kit/execute'
 
 type SettingsWithOauth = Settings & { oauth: OAuth2ClientCredentials }
+
+export const isLegacyDestinationMigration = (
+  getAudienceInput: GetAudienceInput,
+  authSettings: OAuth2ClientCredentials
+): boolean => {
+  const noOAuth = !authSettings.clientId || !authSettings.clientSecret
+  const hasExternalAudienceId = getAudienceInput.externalId !== undefined
+  return noOAuth && hasExternalAudienceId
+}
 
 export const getAuthSettings = (settings: SettingsWithOauth): OAuth2ClientCredentials => {
   const { oauth } = settings


### PR DESCRIPTION
Legacy destinations don't have an oauth object until customers authenticate into the new destination. However, the bulkUploader API does not require an OAuth object to function; it can continue to relay data by verifying ownership through the externalId. Only legacy destinations will have an externalId and no auth object. While we preserve the security benefits of OAuth, we also ensure that current users can maintain uninterrupted data flow without needing to take any action.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
