### PR TITLE
[MAIN] [STRATCONN] send to field is added in GA4 web actions

### DIFF
--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/addPaymentInfo.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/addPaymentInfo.test.ts
@@ -18,6 +18,9 @@ const subscriptions: Subscription[] = [
       coupon: {
         '@path': '$.properties.coupon'
       },
+      send_to: {
+        '@path': '$.properties.send_to'
+      },
       items: [
         {
           item_name: {
@@ -64,7 +67,7 @@ describe('GoogleAnalytics4Web.addPaymentInfo', () => {
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
 
-  test('GA4 addPaymentInfo Event', async () => {
+  test('GA4 addPaymentInfo Event when send to is false', async () => {
     const context = new Context({
       event: 'Payment Info Entered',
       type: 'track',
@@ -73,6 +76,7 @@ describe('GoogleAnalytics4Web.addPaymentInfo', () => {
         value: 10,
         coupon: 'SUMMER_123',
         payment_method: 'Credit Card',
+        send_to: false,
         products: [
           {
             product_id: '12345',
@@ -91,7 +95,42 @@ describe('GoogleAnalytics4Web.addPaymentInfo', () => {
         coupon: 'SUMMER_123',
         currency: 'USD',
         items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
-        value: 10
+        value: 10,
+        send_to: 'default'
+      })
+    )
+  })
+
+  test('GA4 addPaymentInfo Event when send to is true', async () => {
+    const context = new Context({
+      event: 'Payment Info Entered',
+      type: 'track',
+      properties: {
+        currency: 'USD',
+        value: 10,
+        coupon: 'SUMMER_123',
+        payment_method: 'Credit Card',
+        send_to: true,
+        products: [
+          {
+            product_id: '12345',
+            name: 'Monopoly: 3rd Edition',
+            currency: 'USD'
+          }
+        ]
+      }
+    })
+    await addPaymentInfoEvent.track?.(context)
+
+    expect(mockGA4).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('add_payment_info'),
+      expect.objectContaining({
+        coupon: 'SUMMER_123',
+        currency: 'USD',
+        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
+        value: 10,
+        send_to: settings.measurementID
       })
     )
   })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/addToCart.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/addToCart.test.ts
@@ -15,6 +15,9 @@ const subscriptions: Subscription[] = [
       value: {
         '@path': '$.properties.value'
       },
+      send_to: {
+        '@path': '$.properties.send_to'
+      },
       items: [
         {
           item_name: {
@@ -61,13 +64,14 @@ describe('GoogleAnalytics4Web.addToCart', () => {
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
 
-  test('GA4 addToCart Event', async () => {
+  test('GA4 addToCart Event when send to is false', async () => {
     const context = new Context({
       event: 'Add To Cart',
       type: 'track',
       properties: {
         currency: 'USD',
         value: 10,
+        send_to: false,
         products: [
           {
             product_id: '12345',
@@ -85,7 +89,38 @@ describe('GoogleAnalytics4Web.addToCart', () => {
       expect.objectContaining({
         currency: 'USD',
         items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
-        value: 10
+        value: 10,
+        send_to: 'default'
+      })
+    )
+  })
+  test('GA4 addToCart Event when send to is true', async () => {
+    const context = new Context({
+      event: 'Add To Cart',
+      type: 'track',
+      properties: {
+        currency: 'USD',
+        value: 10,
+        send_to: true,
+        products: [
+          {
+            product_id: '12345',
+            name: 'Monopoly: 3rd Edition',
+            currency: 'USD'
+          }
+        ]
+      }
+    })
+    await addToCartEvent.track?.(context)
+
+    expect(mockGA4).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('add_to_cart'),
+      expect.objectContaining({
+        currency: 'USD',
+        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
+        value: 10,
+        send_to: settings.measurementID
       })
     )
   })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/addToWishlist.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/addToWishlist.test.ts
@@ -15,6 +15,9 @@ const subscriptions: Subscription[] = [
       value: {
         '@path': '$.properties.value'
       },
+      send_to: {
+        '@path': '$.properties.send_to'
+      },
       items: [
         {
           item_name: {
@@ -61,13 +64,14 @@ describe('GoogleAnalytics4Web.addToWishlist', () => {
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
 
-  test('Track call without parameters', async () => {
+  test('Track call without parameters when send to is false', async () => {
     const context = new Context({
       event: 'Add To Wishlist',
       type: 'track',
       properties: {
         currency: 'USD',
         value: 10,
+        send_to: false,
         products: [
           {
             product_id: '12345',
@@ -85,7 +89,39 @@ describe('GoogleAnalytics4Web.addToWishlist', () => {
       expect.objectContaining({
         currency: 'USD',
         items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
-        value: 10
+        value: 10,
+        send_to: 'default'
+      })
+    )
+  })
+
+  test('Track call without parameters when send to is true', async () => {
+    const context = new Context({
+      event: 'Add To Wishlist',
+      type: 'track',
+      properties: {
+        currency: 'USD',
+        value: 10,
+        send_to: true,
+        products: [
+          {
+            product_id: '12345',
+            name: 'Monopoly: 3rd Edition',
+            currency: 'USD'
+          }
+        ]
+      }
+    })
+    await addToWishlistEvent.track?.(context)
+
+    expect(mockGA4).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('add_to_wishlist'),
+      expect.objectContaining({
+        currency: 'USD',
+        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
+        value: 10,
+        send_to: settings.measurementID
       })
     )
   })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/beginCheckout.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/beginCheckout.test.ts
@@ -18,6 +18,9 @@ const subscriptions: Subscription[] = [
       coupon: {
         '@path': '$.properties.coupon'
       },
+      send_to: {
+        '@path': '$.properties.send_to'
+      },
       items: [
         {
           item_name: {
@@ -64,7 +67,7 @@ describe('GoogleAnalytics4Web.beginCheckout', () => {
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
 
-  test('GA4 beginCheckout Event', async () => {
+  test('GA4 beginCheckout Event when send to is false', async () => {
     const context = new Context({
       event: 'Begin Checkout',
       type: 'track',
@@ -73,6 +76,7 @@ describe('GoogleAnalytics4Web.beginCheckout', () => {
         value: 10,
         coupon: 'SUMMER_123',
         payment_method: 'Credit Card',
+        send_to: false,
         products: [
           {
             product_id: '12345',
@@ -91,7 +95,41 @@ describe('GoogleAnalytics4Web.beginCheckout', () => {
         coupon: 'SUMMER_123',
         currency: 'USD',
         items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
-        value: 10
+        value: 10,
+        send_to: 'default'
+      })
+    )
+  })
+  test('GA4 beginCheckout Event when send to is true', async () => {
+    const context = new Context({
+      event: 'Begin Checkout',
+      type: 'track',
+      properties: {
+        currency: 'USD',
+        value: 10,
+        coupon: 'SUMMER_123',
+        payment_method: 'Credit Card',
+        send_to: true,
+        products: [
+          {
+            product_id: '12345',
+            name: 'Monopoly: 3rd Edition',
+            currency: 'USD'
+          }
+        ]
+      }
+    })
+    await beginCheckoutEvent.track?.(context)
+
+    expect(mockGA4).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('begin_checkout'),
+      expect.objectContaining({
+        coupon: 'SUMMER_123',
+        currency: 'USD',
+        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
+        value: 10,
+        send_to: settings.measurementID
       })
     )
   })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/customEvent.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/customEvent.test.ts
@@ -12,6 +12,9 @@ const subscriptions: Subscription[] = [
       name: {
         '@path': '$.event'
       },
+      send_to: {
+        '@path': '$.properties.send_to'
+      },
       params: {
         '@path': '$.properties.params'
       }
@@ -42,7 +45,34 @@ describe('GoogleAnalytics4Web.customEvent', () => {
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
 
-  test('GA4 customEvent Event', async () => {
+  test('GA4 customEvent Event when send_to is false', async () => {
+    const context = new Context({
+      event: 'Custom Event',
+      type: 'track',
+      properties: {
+        send_to: false,
+        params: [
+          {
+            paramOne: 'test123',
+            paramTwo: 'test123',
+            paramThree: 123
+          }
+        ]
+      }
+    })
+    await customEvent.track?.(context)
+
+    expect(mockGA4).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('Custom_Event'),
+      expect.objectContaining({
+        send_to: 'default',
+        ...[{ paramOne: 'test123', paramThree: 123, paramTwo: 'test123' }]
+      })
+    )
+  })
+
+  test('GA4 customEvent Event when send_to is undefined', async () => {
     const context = new Context({
       event: 'Custom Event',
       type: 'track',
@@ -61,7 +91,37 @@ describe('GoogleAnalytics4Web.customEvent', () => {
     expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('Custom_Event'),
-      expect.objectContaining([{ paramOne: 'test123', paramThree: 123, paramTwo: 'test123' }])
+      expect.objectContaining({
+        send_to: 'default',
+        ...[{ paramOne: 'test123', paramThree: 123, paramTwo: 'test123' }]
+      })
+    )
+  })
+
+  test('GA4 customEvent Event when send_to is true', async () => {
+    const context = new Context({
+      event: 'Custom Event',
+      type: 'track',
+      properties: {
+        params: [
+          {
+            paramOne: 'test123',
+            paramTwo: 'test123',
+            paramThree: 123
+          }
+        ],
+        send_to: true
+      }
+    })
+    await customEvent.track?.(context)
+
+    expect(mockGA4).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('Custom_Event'),
+      expect.objectContaining({
+        send_to: settings.measurementID,
+        ...[{ paramOne: 'test123', paramThree: 123, paramTwo: 'test123' }]
+      })
     )
   })
 })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/generateLead.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/generateLead.test.ts
@@ -14,6 +14,9 @@ const subscriptions: Subscription[] = [
       },
       value: {
         '@path': '$.properties.value'
+      },
+      send_to: {
+        '@path': '$.properties.send_to'
       }
     }
   }
@@ -42,13 +45,14 @@ describe('GoogleAnalytics4Web.generateLead', () => {
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
 
-  test('GA4 generateLead Event', async () => {
+  test('GA4 generateLead Event when send to is false', async () => {
     const context = new Context({
       event: 'Generate Lead',
       type: 'track',
       properties: {
         currency: 'USD',
-        value: 10
+        value: 10,
+        send_to: false
       }
     })
     await generateLeadEvent.track?.(context)
@@ -58,7 +62,30 @@ describe('GoogleAnalytics4Web.generateLead', () => {
       expect.stringContaining('generate_lead'),
       expect.objectContaining({
         currency: 'USD',
-        value: 10
+        value: 10,
+        send_to: 'default'
+      })
+    )
+  })
+  test('GA4 generateLead Event when send to is true', async () => {
+    const context = new Context({
+      event: 'Generate Lead',
+      type: 'track',
+      properties: {
+        currency: 'USD',
+        value: 10,
+        send_to: true
+      }
+    })
+    await generateLeadEvent.track?.(context)
+
+    expect(mockGA4).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('generate_lead'),
+      expect.objectContaining({
+        currency: 'USD',
+        value: 10,
+        send_to: settings.measurementID
       })
     )
   })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/login.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/login.test.ts
@@ -11,6 +11,9 @@ const subscriptions: Subscription[] = [
     mapping: {
       method: {
         '@path': '$.properties.method'
+      },
+      send_to: {
+        '@path': '$.properties.send_to'
       }
     }
   }
@@ -39,12 +42,13 @@ describe('GoogleAnalytics4Web.login', () => {
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
 
-  test('GA4 login Event', async () => {
+  test('GA4 login Event when send to is false', async () => {
     const context = new Context({
       event: 'Login',
       type: 'track',
       properties: {
-        method: 'Google'
+        method: 'Google',
+        send_to: false
       }
     })
     await loginEvent.track?.(context)
@@ -53,7 +57,28 @@ describe('GoogleAnalytics4Web.login', () => {
       expect.anything(),
       expect.stringContaining('login'),
       expect.objectContaining({
-        method: 'Google'
+        method: 'Google',
+        send_to: 'default'
+      })
+    )
+  })
+  test('GA4 login Event when send to is true', async () => {
+    const context = new Context({
+      event: 'Login',
+      type: 'track',
+      properties: {
+        method: 'Google',
+        send_to: true
+      }
+    })
+    await loginEvent.track?.(context)
+
+    expect(mockGA4).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('login'),
+      expect.objectContaining({
+        method: 'Google',
+        send_to: settings.measurementID
       })
     )
   })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/purchase.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/purchase.test.ts
@@ -21,6 +21,9 @@ const subscriptions: Subscription[] = [
       transaction_id: {
         '@path': '$.properties.transaction_id'
       },
+      send_to: {
+        '@path': '$.properties.send_to'
+      },
       items: [
         {
           item_name: {
@@ -67,7 +70,7 @@ describe('GoogleAnalytics4Web.purchase', () => {
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
 
-  test('GA4 purchase Event', async () => {
+  test('GA4 purchase Event when send to is false', async () => {
     const context = new Context({
       event: 'Purchase',
       type: 'track',
@@ -75,6 +78,7 @@ describe('GoogleAnalytics4Web.purchase', () => {
         currency: 'USD',
         value: 10,
         transaction_id: 12321,
+        send_to: false,
         products: [
           {
             product_id: '12345',
@@ -93,7 +97,40 @@ describe('GoogleAnalytics4Web.purchase', () => {
         currency: 'USD',
         transaction_id: 12321,
         items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
-        value: 10
+        value: 10,
+        send_to: 'default'
+      })
+    )
+  })
+  test('GA4 purchase Event when send to is true', async () => {
+    const context = new Context({
+      event: 'Purchase',
+      type: 'track',
+      properties: {
+        currency: 'USD',
+        value: 10,
+        transaction_id: 12321,
+        send_to: true,
+        products: [
+          {
+            product_id: '12345',
+            name: 'Monopoly: 3rd Edition',
+            currency: 'USD'
+          }
+        ]
+      }
+    })
+    await purchaseEvent.track?.(context)
+
+    expect(mockGA4).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('purchase'),
+      expect.objectContaining({
+        currency: 'USD',
+        transaction_id: 12321,
+        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
+        value: 10,
+        send_to: settings.measurementID
       })
     )
   })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/refund.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/refund.test.ts
@@ -15,6 +15,9 @@ const subscriptions: Subscription[] = [
       value: {
         '@path': '$.properties.value'
       },
+      send_to: {
+        '@path': '$.properties.send_to'
+      },
       coupon: {
         '@path': '$.properties.coupon'
       },
@@ -67,7 +70,7 @@ describe('GoogleAnalytics4Web.refund', () => {
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
 
-  test('GA4 Refund Event', async () => {
+  test('GA4 Refund Event when send to is false', async () => {
     const context = new Context({
       event: 'Refund',
       type: 'track',
@@ -75,6 +78,7 @@ describe('GoogleAnalytics4Web.refund', () => {
         currency: 'USD',
         value: 10,
         transaction_id: 12321,
+        send_to: false,
         products: [
           {
             product_id: '12345',
@@ -93,7 +97,40 @@ describe('GoogleAnalytics4Web.refund', () => {
         currency: 'USD',
         transaction_id: 12321,
         items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
-        value: 10
+        value: 10,
+        send_to: 'default'
+      })
+    )
+  })
+  test('GA4 Refund Event when send to is true', async () => {
+    const context = new Context({
+      event: 'Refund',
+      type: 'track',
+      properties: {
+        currency: 'USD',
+        value: 10,
+        transaction_id: 12321,
+        send_to: true,
+        products: [
+          {
+            product_id: '12345',
+            name: 'Monopoly: 3rd Edition',
+            currency: 'USD'
+          }
+        ]
+      }
+    })
+    await refundEvent.track?.(context)
+
+    expect(mockGA4).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('refund'),
+      expect.objectContaining({
+        currency: 'USD',
+        transaction_id: 12321,
+        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
+        value: 10,
+        send_to: settings.measurementID
       })
     )
   })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/removeFromCart.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/removeFromCart.test.ts
@@ -18,6 +18,9 @@ const subscriptions: Subscription[] = [
       coupon: {
         '@path': '$.properties.coupon'
       },
+      send_to: {
+        '@path': '$.properties.send_to'
+      },
       items: [
         {
           item_name: {
@@ -64,13 +67,14 @@ describe('GoogleAnalytics4Web.removeFromCart', () => {
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
 
-  test('GA4 removeFromCart Event', async () => {
+  test('GA4 removeFromCart Event when send to is false', async () => {
     const context = new Context({
       event: 'Remove from Cart',
       type: 'track',
       properties: {
         currency: 'USD',
         value: 10,
+        send_to: false,
         products: [
           {
             product_id: '12345',
@@ -89,7 +93,39 @@ describe('GoogleAnalytics4Web.removeFromCart', () => {
       expect.objectContaining({
         currency: 'USD',
         items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
-        value: 10
+        value: 10,
+        send_to: 'default'
+      })
+    )
+  })
+  test('GA4 removeFromCart Event when send to is true', async () => {
+    const context = new Context({
+      event: 'Remove from Cart',
+      type: 'track',
+      properties: {
+        currency: 'USD',
+        value: 10,
+        send_to: true,
+        products: [
+          {
+            product_id: '12345',
+            name: 'Monopoly: 3rd Edition',
+            currency: 'USD'
+          }
+        ]
+      }
+    })
+
+    await removeFromCartEvent.track?.(context)
+
+    expect(mockGA4).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('remove_from_cart'),
+      expect.objectContaining({
+        currency: 'USD',
+        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
+        value: 10,
+        send_to: settings.measurementID
       })
     )
   })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/search.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/search.test.ts
@@ -11,6 +11,9 @@ const subscriptions: Subscription[] = [
     mapping: {
       search_term: {
         '@path': '$.properties.search_term'
+      },
+      send_to: {
+        '@path': '$.properties.send_to'
       }
     }
   }
@@ -39,12 +42,13 @@ describe('GoogleAnalytics4Web.search', () => {
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
 
-  test('GA4 search Event', async () => {
+  test('GA4 search Event when send to is false', async () => {
     const context = new Context({
       event: 'search',
       type: 'track',
       properties: {
-        search_term: 'Monopoly: 3rd Edition'
+        search_term: 'Monopoly: 3rd Edition',
+        send_to: false
       }
     })
 
@@ -54,7 +58,29 @@ describe('GoogleAnalytics4Web.search', () => {
       expect.anything(),
       expect.stringContaining('search'),
       expect.objectContaining({
-        search_term: 'Monopoly: 3rd Edition'
+        search_term: 'Monopoly: 3rd Edition',
+        send_to: 'default'
+      })
+    )
+  })
+  test('GA4 search Event when send to is true', async () => {
+    const context = new Context({
+      event: 'search',
+      type: 'track',
+      properties: {
+        search_term: 'Monopoly: 3rd Edition',
+        send_to: true
+      }
+    })
+
+    await searchEvent.track?.(context)
+
+    expect(mockGA4).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('search'),
+      expect.objectContaining({
+        search_term: 'Monopoly: 3rd Edition',
+        send_to: settings.measurementID
       })
     )
   })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/selectItem.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/selectItem.test.ts
@@ -15,6 +15,9 @@ const subscriptions: Subscription[] = [
       item_list_name: {
         '@path': '$.properties.item_list_name'
       },
+      send_to: {
+        '@path': '$.properties.send_to'
+      },
       items: [
         {
           item_name: {
@@ -61,13 +64,14 @@ describe('GoogleAnalytics4Web.selectItem', () => {
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
 
-  test('GA4 selectItem Event', async () => {
+  test('GA4 selectItem Event when send to is false', async () => {
     const context = new Context({
       event: 'Select Item',
       type: 'track',
       properties: {
         item_list_id: 12321,
         item_list_name: 'Monopoly: 3rd Edition',
+        send_to: false,
         products: [
           {
             product_id: '12345',
@@ -86,7 +90,39 @@ describe('GoogleAnalytics4Web.selectItem', () => {
       expect.objectContaining({
         item_list_id: 12321,
         item_list_name: 'Monopoly: 3rd Edition',
-        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }]
+        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
+        send_to: 'default'
+      })
+    )
+  })
+  test('GA4 selectItem Event when send to is true', async () => {
+    const context = new Context({
+      event: 'Select Item',
+      type: 'track',
+      properties: {
+        item_list_id: 12321,
+        item_list_name: 'Monopoly: 3rd Edition',
+        send_to: true,
+        products: [
+          {
+            product_id: '12345',
+            name: 'Monopoly: 3rd Edition',
+            currency: 'USD'
+          }
+        ]
+      }
+    })
+
+    await selectItemEvent.track?.(context)
+
+    expect(mockGA4).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('select_item'),
+      expect.objectContaining({
+        item_list_id: 12321,
+        item_list_name: 'Monopoly: 3rd Edition',
+        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
+        send_to: settings.measurementID
       })
     )
   })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/selectPromotion.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/selectPromotion.test.ts
@@ -24,6 +24,9 @@ const subscriptions: Subscription[] = [
       promotion_name: {
         '@path': '$.properties.promotion_name'
       },
+      send_to: {
+        '@path': '$.properties.send_to'
+      },
       items: [
         {
           item_name: {
@@ -70,7 +73,7 @@ describe('GoogleAnalytics4Web.selectPromotion', () => {
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
 
-  test('GA4 selectPromotion Event', async () => {
+  test('GA4 selectPromotion Event when send to is false', async () => {
     const context = new Context({
       event: 'Select Promotion',
       type: 'track',
@@ -80,6 +83,7 @@ describe('GoogleAnalytics4Web.selectPromotion', () => {
         location_id: 'ChIJIQBpAG2ahYAR_6128GcTUEo',
         promotion_id: 'P_12345',
         promotion_name: 'Summer Sale',
+        send_to: false,
         products: [
           {
             product_id: '12345',
@@ -101,7 +105,45 @@ describe('GoogleAnalytics4Web.selectPromotion', () => {
         location_id: 'ChIJIQBpAG2ahYAR_6128GcTUEo',
         promotion_id: 'P_12345',
         promotion_name: 'Summer Sale',
-        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }]
+        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
+        send_to: 'default'
+      })
+    )
+  })
+  test('GA4 selectPromotion Event when send to is true', async () => {
+    const context = new Context({
+      event: 'Select Promotion',
+      type: 'track',
+      properties: {
+        creative_name: 'summer_banner2',
+        creative_slot: 'featured_app_1',
+        location_id: 'ChIJIQBpAG2ahYAR_6128GcTUEo',
+        promotion_id: 'P_12345',
+        promotion_name: 'Summer Sale',
+        send_to: true,
+        products: [
+          {
+            product_id: '12345',
+            name: 'Monopoly: 3rd Edition',
+            currency: 'USD'
+          }
+        ]
+      }
+    })
+
+    await selectPromotionEvent.track?.(context)
+
+    expect(mockGA4).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('select_promotion'),
+      expect.objectContaining({
+        creative_name: 'summer_banner2',
+        creative_slot: 'featured_app_1',
+        location_id: 'ChIJIQBpAG2ahYAR_6128GcTUEo',
+        promotion_id: 'P_12345',
+        promotion_name: 'Summer Sale',
+        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
+        send_to: settings.measurementID
       })
     )
   })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/signUp.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/signUp.test.ts
@@ -11,6 +11,9 @@ const subscriptions: Subscription[] = [
     mapping: {
       method: {
         '@path': '$.properties.method'
+      },
+      send_to: {
+        '@path': '$.properties.send_to'
       }
     }
   }
@@ -39,12 +42,13 @@ describe('GoogleAnalytics4Web.signUp', () => {
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
 
-  test('GA4 signUp Event', async () => {
+  test('GA4 signUp Event when send to is false', async () => {
     const context = new Context({
       event: 'signUp',
       type: 'track',
       properties: {
-        method: 'Google'
+        method: 'Google',
+        send_to: false
       }
     })
 
@@ -53,7 +57,25 @@ describe('GoogleAnalytics4Web.signUp', () => {
     expect(mockGA4).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('sign_up'),
-      expect.objectContaining({ method: 'Google' })
+      expect.objectContaining({ method: 'Google', send_to: 'default' })
+    )
+  })
+  test('GA4 signUp Event when send to is true', async () => {
+    const context = new Context({
+      event: 'signUp',
+      type: 'track',
+      properties: {
+        method: 'Google',
+        send_to: true
+      }
+    })
+
+    await signUpEvent.track?.(context)
+
+    expect(mockGA4).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('sign_up'),
+      expect.objectContaining({ method: 'Google', send_to: settings.measurementID })
     )
   })
 })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/viewCart.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/viewCart.test.ts
@@ -15,6 +15,9 @@ const subscriptions: Subscription[] = [
       value: {
         '@path': '$.properties.value'
       },
+      send_to: {
+        '@path': '$.properties.send_to'
+      },
       items: [
         {
           item_name: {
@@ -61,13 +64,14 @@ describe('GoogleAnalytics4Web.viewCart', () => {
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
 
-  test('GA4 viewCart Event', async () => {
+  test('GA4 viewCart Event when send to is false', async () => {
     const context = new Context({
       event: 'View Cart',
       type: 'track',
       properties: {
         currency: 'USD',
         value: 10,
+        send_to: false,
         products: [
           {
             product_id: '12345',
@@ -86,7 +90,39 @@ describe('GoogleAnalytics4Web.viewCart', () => {
       expect.objectContaining({
         currency: 'USD',
         items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
-        value: 10
+        value: 10,
+        send_to: 'default'
+      })
+    )
+  })
+  test('GA4 viewCart Event when send to is true', async () => {
+    const context = new Context({
+      event: 'View Cart',
+      type: 'track',
+      properties: {
+        currency: 'USD',
+        value: 10,
+        send_to: true,
+        products: [
+          {
+            product_id: '12345',
+            name: 'Monopoly: 3rd Edition',
+            currency: 'USD'
+          }
+        ]
+      }
+    })
+
+    await viewCartEvent.track?.(context)
+
+    expect(mockGA4).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('view_cart'),
+      expect.objectContaining({
+        currency: 'USD',
+        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
+        value: 10,
+        send_to: settings.measurementID
       })
     )
   })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/viewItem.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/viewItem.test.ts
@@ -15,6 +15,9 @@ const subscriptions: Subscription[] = [
       value: {
         '@path': '$.properties.value'
       },
+      send_to: {
+        '@path': '$.properties.send_to'
+      },
       items: [
         {
           item_name: {
@@ -61,13 +64,14 @@ describe('GoogleAnalytics4Web.viewItem', () => {
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
 
-  test('GA4 viewItem Event', async () => {
+  test('GA4 viewItem Event when send to is false', async () => {
     const context = new Context({
       event: 'View Item',
       type: 'track',
       properties: {
         currency: 'USD',
         value: 10,
+        send_to: false,
         products: [
           {
             product_id: '12345',
@@ -86,7 +90,39 @@ describe('GoogleAnalytics4Web.viewItem', () => {
       expect.objectContaining({
         currency: 'USD',
         items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
-        value: 10
+        value: 10,
+        send_to: 'default'
+      })
+    )
+  })
+  test('GA4 viewItem Event when send to is true', async () => {
+    const context = new Context({
+      event: 'View Item',
+      type: 'track',
+      properties: {
+        currency: 'USD',
+        value: 10,
+        send_to: true,
+        products: [
+          {
+            product_id: '12345',
+            name: 'Monopoly: 3rd Edition',
+            currency: 'USD'
+          }
+        ]
+      }
+    })
+
+    await viewItemEvent.track?.(context)
+
+    expect(mockGA4).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('view_item'),
+      expect.objectContaining({
+        currency: 'USD',
+        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
+        value: 10,
+        send_to: settings.measurementID
       })
     )
   })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/viewItemList.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/viewItemList.test.ts
@@ -15,6 +15,9 @@ const subscriptions: Subscription[] = [
       item_list_name: {
         '@path': '$.properties.item_list_name'
       },
+      send_to: {
+        '@path': '$.properties.send_to'
+      },
       items: [
         {
           item_name: {
@@ -61,13 +64,14 @@ describe('GoogleAnalytics4Web.viewItemList', () => {
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
 
-  test('GA4 viewItemList Event', async () => {
+  test('GA4 viewItemList Event when send to is false', async () => {
     const context = new Context({
       event: 'View Item List',
       type: 'track',
       properties: {
         item_list_id: 12321,
         item_list_name: 'Monopoly: 3rd Edition',
+        send_to: false,
         products: [
           {
             product_id: '12345',
@@ -86,7 +90,40 @@ describe('GoogleAnalytics4Web.viewItemList', () => {
       expect.objectContaining({
         item_list_id: 12321,
         item_list_name: 'Monopoly: 3rd Edition',
-        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }]
+        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
+        send_to: 'default'
+      })
+    )
+  })
+
+  test('GA4 viewItemList Event when send to is true', async () => {
+    const context = new Context({
+      event: 'View Item List',
+      type: 'track',
+      properties: {
+        item_list_id: 12321,
+        item_list_name: 'Monopoly: 3rd Edition',
+        send_to: true,
+        products: [
+          {
+            product_id: '12345',
+            name: 'Monopoly: 3rd Edition',
+            currency: 'USD'
+          }
+        ]
+      }
+    })
+
+    await viewItemListEvent.track?.(context)
+
+    expect(mockGA4).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('view_item_list'),
+      expect.objectContaining({
+        item_list_id: 12321,
+        item_list_name: 'Monopoly: 3rd Edition',
+        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
+        send_to: settings.measurementID
       })
     )
   })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/viewPromotion.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/viewPromotion.test.ts
@@ -24,6 +24,9 @@ const subscriptions: Subscription[] = [
       promotion_name: {
         '@path': '$.properties.promotion_name'
       },
+      send_to: {
+        '@path': '$.properties.send_to'
+      },
       items: [
         {
           item_name: {
@@ -70,7 +73,7 @@ describe('GoogleAnalytics4Web.viewPromotion', () => {
     await trackEventPlugin.load(Context.system(), {} as Analytics)
   })
 
-  test('GA4 viewPromotion Event', async () => {
+  test('GA4 viewPromotion Event when send to is false', async () => {
     const context = new Context({
       event: 'Select Promotion',
       type: 'track',
@@ -80,6 +83,7 @@ describe('GoogleAnalytics4Web.viewPromotion', () => {
         location_id: 'ChIJIQBpAG2ahYAR_6128GcTUEo',
         promotion_id: 'P_12345',
         promotion_name: 'Summer Sale',
+        send_to: false,
         products: [
           {
             product_id: '12345',
@@ -101,7 +105,45 @@ describe('GoogleAnalytics4Web.viewPromotion', () => {
         location_id: 'ChIJIQBpAG2ahYAR_6128GcTUEo',
         promotion_id: 'P_12345',
         promotion_name: 'Summer Sale',
-        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }]
+        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
+        send_to: 'default'
+      })
+    )
+  })
+  test('GA4 viewPromotion Event when send to is true', async () => {
+    const context = new Context({
+      event: 'Select Promotion',
+      type: 'track',
+      properties: {
+        creative_name: 'summer_banner2',
+        creative_slot: 'featured_app_1',
+        location_id: 'ChIJIQBpAG2ahYAR_6128GcTUEo',
+        promotion_id: 'P_12345',
+        promotion_name: 'Summer Sale',
+        send_to: true,
+        products: [
+          {
+            product_id: '12345',
+            name: 'Monopoly: 3rd Edition',
+            currency: 'USD'
+          }
+        ]
+      }
+    })
+
+    await viewPromotionEvent.track?.(context)
+
+    expect(mockGA4).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('view_promotion'),
+      expect.objectContaining({
+        creative_name: 'summer_banner2',
+        creative_slot: 'featured_app_1',
+        location_id: 'ChIJIQBpAG2ahYAR_6128GcTUEo',
+        promotion_id: 'P_12345',
+        promotion_name: 'Summer Sale',
+        items: [{ currency: 'USD', item_id: '12345', item_name: 'Monopoly: 3rd Edition' }],
+        send_to: settings.measurementID
       })
     )
   })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/addPaymentInfo/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/addPaymentInfo/generated-types.ts
@@ -115,4 +115,8 @@ export interface Payload {
   params?: {
     [k: string]: unknown
   }
+  /**
+   * If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag
+   */
+  send_to?: boolean
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/addPaymentInfo/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/addPaymentInfo/index.ts
@@ -9,7 +9,8 @@ import {
   coupon,
   payment_type,
   items_multi_products,
-  params
+  params,
+  send_to
 } from '../ga4-properties'
 
 // Change from unknown to the partner SDK types
@@ -29,9 +30,10 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
       required: true
     },
     user_properties: user_properties,
-    params: params
+    params: params,
+    send_to: send_to
   },
-  perform: (gtag, { payload }) => {
+  perform: (gtag, { payload, settings }) => {
     gtag('event', 'add_payment_info', {
       currency: payload.currency,
       value: payload.value,
@@ -40,6 +42,7 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
       items: payload.items,
       user_id: payload.user_id ?? undefined,
       user_properties: payload.user_properties,
+      send_to: payload.send_to == true ? settings.measurementID : 'default',
       ...payload.params
     })
   }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/addToCart/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/addToCart/generated-types.ts
@@ -107,4 +107,8 @@ export interface Payload {
   params?: {
     [k: string]: unknown
   }
+  /**
+   * If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag
+   */
+  send_to?: boolean
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/addToCart/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/addToCart/index.ts
@@ -2,7 +2,7 @@ import type { BrowserActionDefinition } from '@segment/browser-destination-runti
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
-import { user_properties, params, value, currency, items_single_products, user_id } from '../ga4-properties'
+import { user_properties, params, value, currency, items_single_products, user_id, send_to } from '../ga4-properties'
 
 const action: BrowserActionDefinition<Settings, Function, Payload> = {
   title: 'Add to Cart',
@@ -18,15 +18,17 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     },
     value: value,
     user_properties: user_properties,
-    params: params
+    params: params,
+    send_to: send_to
   },
-  perform: (gtag, { payload }) => {
+  perform: (gtag, { payload, settings }) => {
     gtag('event', 'add_to_cart', {
       currency: payload.currency,
       value: payload.value,
       items: payload.items,
       user_id: payload.user_id ?? undefined,
       user_properties: payload.user_properties,
+      send_to: payload.send_to == true ? settings.measurementID : 'default',
       ...payload.params
     })
   }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/addToWishlist/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/addToWishlist/generated-types.ts
@@ -107,4 +107,8 @@ export interface Payload {
   params?: {
     [k: string]: unknown
   }
+  /**
+   * If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag
+   */
+  send_to?: boolean
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/addToWishlist/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/addToWishlist/index.ts
@@ -2,7 +2,7 @@ import type { BrowserActionDefinition } from '@segment/browser-destination-runti
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
-import { user_properties, params, value, currency, items_single_products, user_id } from '../ga4-properties'
+import { user_properties, params, value, currency, items_single_products, user_id, send_to } from '../ga4-properties'
 
 // Change from unknown to the partner SDK types
 const action: BrowserActionDefinition<Settings, Function, Payload> = {
@@ -20,15 +20,17 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
       required: true
     },
     user_properties: user_properties,
-    params: params
+    params: params,
+    send_to: send_to
   },
-  perform: (gtag, { payload }) => {
+  perform: (gtag, { payload, settings }) => {
     gtag('event', 'add_to_wishlist', {
       currency: payload.currency,
       value: payload.value,
       items: payload.items,
       user_id: payload.user_id ?? undefined,
       user_properties: payload.user_properties,
+      send_to: payload.send_to == true ? settings.measurementID : 'default',
       ...payload.params
     })
   }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/beginCheckout/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/beginCheckout/generated-types.ts
@@ -111,4 +111,8 @@ export interface Payload {
   user_properties?: {
     [k: string]: unknown
   }
+  /**
+   * If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag
+   */
+  send_to?: boolean
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/beginCheckout/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/beginCheckout/index.ts
@@ -2,7 +2,16 @@ import type { BrowserActionDefinition } from '@segment/browser-destination-runti
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
-import { params, coupon, currency, value, items_multi_products, user_id, user_properties } from '../ga4-properties'
+import {
+  params,
+  coupon,
+  currency,
+  value,
+  items_multi_products,
+  user_id,
+  user_properties,
+  send_to
+} from '../ga4-properties'
 
 const action: BrowserActionDefinition<Settings, Function, Payload> = {
   title: 'Begin Checkout',
@@ -19,9 +28,10 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     },
     value: value,
     params: params,
-    user_properties: user_properties
+    user_properties: user_properties,
+    send_to: send_to
   },
-  perform: (gtag, { payload }) => {
+  perform: (gtag, { payload, settings }) => {
     gtag('event', 'begin_checkout', {
       currency: payload.currency,
       value: payload.value,
@@ -29,6 +39,7 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
       items: payload.items,
       user_id: payload.user_id ?? undefined,
       user_properties: payload.user_properties,
+      send_to: payload.send_to == true ? settings.measurementID : 'default',
       ...payload.params
     })
   }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/customEvent/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/customEvent/generated-types.ts
@@ -25,4 +25,8 @@ export interface Payload {
   params?: {
     [k: string]: unknown
   }
+  /**
+   * If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag
+   */
+  send_to?: boolean
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/customEvent/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/customEvent/index.ts
@@ -1,7 +1,7 @@
 import type { BrowserActionDefinition } from '@segment/browser-destination-runtime/types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { user_id, user_properties, params } from '../ga4-properties'
+import { user_id, user_properties, params, send_to } from '../ga4-properties'
 
 const normalizeEventName = (name: string, lowercase: boolean | undefined): string => {
   name = name.trim()
@@ -38,14 +38,16 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     },
     user_id: { ...user_id },
     user_properties: user_properties,
-    params: params
+    params: params,
+    send_to: send_to
   },
-  perform: (gtag, { payload }) => {
+  perform: (gtag, { payload, settings }) => {
     const event_name = normalizeEventName(payload.name, payload.lowercase)
 
     gtag('event', event_name, {
       user_id: payload.user_id ?? undefined,
       user_properties: payload.user_properties,
+      send_to: payload.send_to == true ? settings.measurementID : 'default',
       ...payload.params
     })
   }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/ga4-properties.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/ga4-properties.ts
@@ -367,3 +367,10 @@ export const items_multi_products: InputField = {
     ]
   }
 }
+export const send_to: InputField = {
+  label: 'Send To',
+  type: 'boolean',
+  default: true,
+  description:
+    'If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag'
+}

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/generateLead/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/generateLead/generated-types.ts
@@ -25,4 +25,8 @@ export interface Payload {
   params?: {
     [k: string]: unknown
   }
+  /**
+   * If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag
+   */
+  send_to?: boolean
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/generateLead/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/generateLead/index.ts
@@ -2,7 +2,7 @@ import type { BrowserActionDefinition } from '@segment/browser-destination-runti
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
-import { user_properties, params, user_id, currency, value } from '../ga4-properties'
+import { user_properties, params, user_id, currency, value, send_to } from '../ga4-properties'
 
 const action: BrowserActionDefinition<Settings, Function, Payload> = {
   title: 'Generate Lead',
@@ -15,14 +15,16 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     currency: currency,
     value: value,
     user_properties: user_properties,
-    params: params
+    params: params,
+    send_to: send_to
   },
-  perform: (gtag, { payload }) => {
+  perform: (gtag, { payload, settings }) => {
     gtag('event', 'generate_lead', {
       currency: payload.currency,
       value: payload.value,
       user_id: payload.user_id ?? undefined,
       user_properties: payload.user_properties,
+      send_to: payload.send_to == true ? settings.measurementID : 'default',
       ...payload.params
     })
   }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/login/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/login/generated-types.ts
@@ -21,4 +21,8 @@ export interface Payload {
   params?: {
     [k: string]: unknown
   }
+  /**
+   * If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag
+   */
+  send_to?: boolean
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/login/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/login/index.ts
@@ -2,7 +2,7 @@ import type { BrowserActionDefinition } from '@segment/browser-destination-runti
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
-import { user_properties, params, user_id, method } from '../ga4-properties'
+import { user_properties, params, user_id, method, send_to } from '../ga4-properties'
 
 // Change from unknown to the partner SDK types
 const action: BrowserActionDefinition<Settings, Function, Payload> = {
@@ -14,14 +14,16 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     user_id: user_id,
     method: method,
     user_properties: user_properties,
-    params: params
+    params: params,
+    send_to: send_to
   },
 
-  perform: (gtag, { payload }) => {
+  perform: (gtag, { payload, settings }) => {
     gtag('event', 'login', {
       method: payload.method,
       user_id: payload.user_id ?? undefined,
       user_properties: payload.user_properties,
+      send_to: payload.send_to == true ? settings.measurementID : 'default',
       ...payload.params
     })
   }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/purchase/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/purchase/generated-types.ts
@@ -123,4 +123,8 @@ export interface Payload {
   params?: {
     [k: string]: unknown
   }
+  /**
+   * If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag
+   */
+  send_to?: boolean
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/purchase/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/purchase/index.ts
@@ -11,7 +11,8 @@ import {
   tax,
   items_multi_products,
   params,
-  user_properties
+  user_properties,
+  send_to
 } from '../ga4-properties'
 
 const action: BrowserActionDefinition<Settings, Function, Payload> = {
@@ -32,9 +33,10 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     tax: tax,
     value: { ...value, default: { '@path': '$.properties.total' } },
     user_properties: user_properties,
-    params: params
+    params: params,
+    send_to: send_to
   },
-  perform: (gtag, { payload }) => {
+  perform: (gtag, { payload, settings }) => {
     gtag('event', 'purchase', {
       currency: payload.currency,
       transaction_id: payload.transaction_id,
@@ -45,6 +47,7 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
       items: payload.items,
       user_id: payload.user_id ?? undefined,
       user_properties: payload.user_properties,
+      send_to: payload.send_to == true ? settings.measurementID : 'default',
       ...payload.params
     })
   }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/refund/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/refund/generated-types.ts
@@ -127,4 +127,8 @@ export interface Payload {
   params?: {
     [k: string]: unknown
   }
+  /**
+   * If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag
+   */
+  send_to?: boolean
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/refund/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/refund/index.ts
@@ -13,7 +13,8 @@ import {
   items_multi_products,
   params,
   user_properties,
-  tax
+  tax,
+  send_to
 } from '../ga4-properties'
 
 const action: BrowserActionDefinition<Settings, Function, Payload> = {
@@ -34,9 +35,10 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
       ...items_multi_products
     },
     user_properties: user_properties,
-    params: params
+    params: params,
+    send_to: send_to
   },
-  perform: (gtag, { payload }) => {
+  perform: (gtag, { payload, settings }) => {
     gtag('event', 'refund', {
       currency: payload.currency,
       transaction_id: payload.transaction_id, // Transaction ID. Required for purchases and refunds.
@@ -48,6 +50,7 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
       items: payload.items,
       user_id: payload.user_id ?? undefined,
       user_properties: payload.user_properties,
+      send_to: payload.send_to == true ? settings.measurementID : 'default',
       ...payload.params
     })
   }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/removeFromCart/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/removeFromCart/generated-types.ts
@@ -107,4 +107,8 @@ export interface Payload {
   params?: {
     [k: string]: unknown
   }
+  /**
+   * If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag
+   */
+  send_to?: boolean
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/removeFromCart/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/removeFromCart/index.ts
@@ -2,7 +2,7 @@ import type { BrowserActionDefinition } from '@segment/browser-destination-runti
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
-import { user_properties, params, value, user_id, currency, items_single_products } from '../ga4-properties'
+import { user_properties, params, value, user_id, currency, items_single_products, send_to } from '../ga4-properties'
 
 // Change from unknown to the partner SDK types
 const action: BrowserActionDefinition<Settings, Function, Payload> = {
@@ -19,15 +19,17 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
       required: true
     },
     user_properties: user_properties,
-    params: params
+    params: params,
+    send_to: send_to
   },
-  perform: (gtag, { payload }) => {
+  perform: (gtag, { payload, settings }) => {
     gtag('event', 'remove_from_cart', {
       currency: payload.currency,
       value: payload.value,
       items: payload.items,
       user_id: payload.user_id ?? undefined,
       user_properties: payload.user_properties,
+      send_to: payload.send_to == true ? settings.measurementID : 'default',
       ...payload.params
     })
   }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/search/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/search/generated-types.ts
@@ -21,4 +21,8 @@ export interface Payload {
    * The term that was searched for.
    */
   search_term?: string
+  /**
+   * If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag
+   */
+  send_to?: boolean
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/search/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/search/index.ts
@@ -2,7 +2,7 @@ import type { BrowserActionDefinition } from '@segment/browser-destination-runti
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
-import { user_properties, params, user_id, search_term } from '../ga4-properties'
+import { user_properties, params, user_id, search_term, send_to } from '../ga4-properties'
 
 // Change from unknown to the partner SDK types
 const action: BrowserActionDefinition<Settings, Function, Payload> = {
@@ -14,13 +14,15 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     user_id: user_id,
     user_properties: user_properties,
     params: params,
-    search_term: search_term
+    search_term: search_term,
+    send_to: send_to
   },
-  perform: (gtag, { payload }) => {
+  perform: (gtag, { payload, settings }) => {
     gtag('event', 'search', {
       search_term: payload.search_term,
       user_id: payload.user_id ?? undefined,
       user_properties: payload.user_properties,
+      send_to: payload.send_to == true ? settings.measurementID : 'default',
       ...payload.params
     })
   }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/selectItem/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/selectItem/generated-types.ts
@@ -107,4 +107,8 @@ export interface Payload {
   params?: {
     [k: string]: unknown
   }
+  /**
+   * If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag
+   */
+  send_to?: boolean
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/selectItem/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/selectItem/index.ts
@@ -8,7 +8,8 @@ import {
   user_id,
   items_single_products,
   item_list_name,
-  item_list_id
+  item_list_id,
+  send_to
 } from '../ga4-properties'
 
 const action: BrowserActionDefinition<Settings, Function, Payload> = {
@@ -25,15 +26,17 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
       required: true
     },
     user_properties: user_properties,
-    params: params
+    params: params,
+    send_to: send_to
   },
-  perform: (gtag, { payload }) => {
+  perform: (gtag, { payload, settings }) => {
     gtag('event', 'select_item', {
       item_list_id: payload.item_list_id,
       item_list_name: payload.item_list_name,
       items: payload.items,
       user_id: payload.user_id ?? undefined,
       user_properties: payload.user_properties,
+      send_to: payload.send_to == true ? settings.measurementID : 'default',
       ...payload.params
     })
   }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/selectPromotion/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/selectPromotion/generated-types.ts
@@ -135,4 +135,8 @@ export interface Payload {
   params?: {
     [k: string]: unknown
   }
+  /**
+   * If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag
+   */
+  send_to?: boolean
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/selectPromotion/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/selectPromotion/index.ts
@@ -12,7 +12,8 @@ import {
   items_single_products,
   params,
   user_properties,
-  location_id
+  location_id,
+  send_to
 } from '../ga4-properties'
 const action: BrowserActionDefinition<Settings, Function, Payload> = {
   title: 'Select Promotion',
@@ -45,9 +46,10 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
       }
     },
     user_properties: user_properties,
-    params: params
+    params: params,
+    send_to: send_to
   },
-  perform: (gtag, { payload }) => {
+  perform: (gtag, { payload, settings }) => {
     gtag('event', 'select_promotion', {
       creative_name: payload.creative_name,
       creative_slot: payload.creative_slot,
@@ -57,6 +59,7 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
       items: payload.items,
       user_id: payload.user_id ?? undefined,
       user_properties: payload.user_properties,
+      send_to: payload.send_to == true ? settings.measurementID : 'default',
       ...payload.params
     })
   }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/signUp/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/signUp/generated-types.ts
@@ -21,4 +21,8 @@ export interface Payload {
   params?: {
     [k: string]: unknown
   }
+  /**
+   * If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag
+   */
+  send_to?: boolean
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/signUp/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/signUp/index.ts
@@ -2,7 +2,7 @@ import type { BrowserActionDefinition } from '@segment/browser-destination-runti
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
-import { user_properties, params, user_id, method } from '../ga4-properties'
+import { user_properties, params, user_id, method, send_to } from '../ga4-properties'
 
 const action: BrowserActionDefinition<Settings, Function, Payload> = {
   title: 'Sign Up',
@@ -13,13 +13,15 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     user_id: user_id,
     method: method,
     user_properties: user_properties,
-    params: params
+    params: params,
+    send_to: send_to
   },
-  perform: (gtag, { payload }) => {
+  perform: (gtag, { payload, settings }) => {
     gtag('event', 'sign_up', {
       method: payload.method,
       user_id: payload.user_id ?? undefined,
       user_properties: payload.user_properties,
+      send_to: payload.send_to == true ? settings.measurementID : 'default',
       ...payload.params
     })
   }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/viewCart/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/viewCart/generated-types.ts
@@ -107,4 +107,8 @@ export interface Payload {
   params?: {
     [k: string]: unknown
   }
+  /**
+   * If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag
+   */
+  send_to?: boolean
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/viewCart/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/viewCart/index.ts
@@ -2,7 +2,7 @@ import type { BrowserActionDefinition } from '@segment/browser-destination-runti
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
-import { user_properties, params, currency, value, user_id, items_multi_products } from '../ga4-properties'
+import { user_properties, params, currency, value, user_id, items_multi_products, send_to } from '../ga4-properties'
 
 const action: BrowserActionDefinition<Settings, Function, Payload> = {
   title: 'View Cart',
@@ -18,15 +18,17 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
       required: true
     },
     user_properties: user_properties,
-    params: params
+    params: params,
+    send_to: send_to
   },
-  perform: (gtag, { payload }) => {
+  perform: (gtag, { payload, settings }) => {
     gtag('event', 'view_cart', {
       currency: payload.currency,
       value: payload.value,
       items: payload.items,
       user_id: payload.user_id ?? undefined,
       user_properties: payload.user_properties,
+      send_to: payload.send_to == true ? settings.measurementID : 'default',
       ...payload.params
     })
   }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/viewItem/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/viewItem/generated-types.ts
@@ -107,4 +107,8 @@ export interface Payload {
   params?: {
     [k: string]: unknown
   }
+  /**
+   * If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag
+   */
+  send_to?: boolean
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/viewItem/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/viewItem/index.ts
@@ -2,7 +2,7 @@ import type { BrowserActionDefinition } from '@segment/browser-destination-runti
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
-import { user_properties, params, currency, user_id, value, items_single_products } from '../ga4-properties'
+import { user_properties, params, currency, user_id, value, items_single_products, send_to } from '../ga4-properties'
 
 const action: BrowserActionDefinition<Settings, Function, Payload> = {
   title: 'View Item',
@@ -19,15 +19,17 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
       required: true
     },
     user_properties: user_properties,
-    params: params
+    params: params,
+    send_to: send_to
   },
-  perform: (gtag, { payload }) => {
+  perform: (gtag, { payload, settings }) => {
     gtag('event', 'view_item', {
       currency: payload.currency,
       value: payload.value,
       items: payload.items,
       user_id: payload.user_id ?? undefined,
       user_properties: payload.user_properties,
+      send_to: payload.send_to == true ? settings.measurementID : 'default',
       ...payload.params
     })
   }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/viewItemList/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/viewItemList/generated-types.ts
@@ -107,4 +107,8 @@ export interface Payload {
   params?: {
     [k: string]: unknown
   }
+  /**
+   * If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag
+   */
+  send_to?: boolean
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/viewItemList/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/viewItemList/index.ts
@@ -2,7 +2,15 @@ import type { BrowserActionDefinition } from '@segment/browser-destination-runti
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
-import { user_properties, params, user_id, items_multi_products, item_list_name, item_list_id } from '../ga4-properties'
+import {
+  user_properties,
+  params,
+  user_id,
+  items_multi_products,
+  item_list_name,
+  item_list_id,
+  send_to
+} from '../ga4-properties'
 
 const action: BrowserActionDefinition<Settings, Function, Payload> = {
   title: 'View Item List',
@@ -18,15 +26,17 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
       required: true
     },
     user_properties: user_properties,
-    params: params
+    params: params,
+    send_to: send_to
   },
-  perform: (gtag, { payload }) => {
+  perform: (gtag, { payload, settings }) => {
     gtag('event', 'view_item_list', {
       item_list_id: payload.item_list_id,
       item_list_name: payload.item_list_name,
       items: payload.items,
       user_id: payload.user_id ?? undefined,
       user_properties: payload.user_properties,
+      send_to: payload.send_to == true ? settings.measurementID : 'default',
       ...payload.params
     })
   }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/viewPromotion/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/viewPromotion/generated-types.ts
@@ -135,4 +135,8 @@ export interface Payload {
   params?: {
     [k: string]: unknown
   }
+  /**
+   * If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag
+   */
+  send_to?: boolean
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/viewPromotion/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/viewPromotion/index.ts
@@ -11,7 +11,8 @@ import {
   items_single_products,
   params,
   user_properties,
-  location_id
+  location_id,
+  send_to
 } from '../ga4-properties'
 
 const action: BrowserActionDefinition<Settings, Function, Payload> = {
@@ -46,9 +47,10 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
       }
     },
     user_properties: user_properties,
-    params: params
+    params: params,
+    send_to: send_to
   },
-  perform: (gtag, { payload }) => {
+  perform: (gtag, { payload, settings }) => {
     gtag('event', 'view_promotion', {
       creative_name: payload.creative_name,
       creative_slot: payload.creative_slot,
@@ -58,6 +60,7 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
       items: payload.items,
       user_id: payload.user_id ?? undefined,
       user_properties: payload.user_properties,
+      send_to: payload.send_to == true ? settings.measurementID : 'default',
       ...payload.params
     })
   }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

In this PR added new field ( send_to ) in GA4 actions 

<img width="856" alt="Screenshot 2024-01-25 at 6 07 35 PM" src="https://github.com/segmentio/action-destinations/assets/139338151/a5181d3c-3318-49ce-a7ac-9e5ff5148e0c">

<img width="689" alt="Screenshot 2024-01-08 at 10 28 20 PM" src="https://github.com/segmentio/action-destinations/assets/139338151/5655bba4-14a8-411e-acdb-20b54b529a4c">

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [X] [Segmenters] Tested in the staging environment
