### PR TITLE
Update avo with presets for the action.

### DIFF
--- a/packages/destination-actions/src/destinations/avo/index.ts
+++ b/packages/destination-actions/src/destinations/avo/index.ts
@@ -1,9 +1,20 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { DestinationDefinition } from '@segment/actions-core'
+import { defaultValues } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import sendSchemaAction from './sendSchemaToInspector'
 import { Environment } from './sendSchemaToInspector/avo-types'
+
+const presets: DestinationDefinition['presets'] = [
+  {
+    name: 'Track schema From Event',
+    subscribe: 'type = "track"',
+    partnerAction: 'sendSchemaToInspector',
+    mapping: defaultValues(sendSchemaAction.fields),
+    type: 'automatic'
+  }
+]
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Avo',
@@ -50,7 +61,7 @@ const destination: DestinationDefinition<Settings> = {
       return resp
     }
   },
-
+  presets,
   actions: {
     sendSchemaToInspector: sendSchemaAction // Add your action here
   }

--- a/packages/destination-actions/src/destinations/avo/sendSchemaToInspector/avo.ts
+++ b/packages/destination-actions/src/destinations/avo/sendSchemaToInspector/avo.ts
@@ -26,7 +26,7 @@ function generateBaseBody(event: Payload, appVersionPropertyName: string | undef
     libVersion: '1.0.0',
     libPlatform: 'Segment',
     messageId: event.messageId,
-    createdAt: event.receivedAt,
+    createdAt: event.createdAt,
     sessionId: '_'
   }
 }

--- a/packages/destination-actions/src/destinations/avo/sendSchemaToInspector/generated-types.ts
+++ b/packages/destination-actions/src/destinations/avo/sendSchemaToInspector/generated-types.ts
@@ -16,9 +16,9 @@ export interface Payload {
    */
   messageId: string
   /**
-   * Timestamp of when the event was received
+   * Timestamp of when the event was sent
    */
-  receivedAt: string
+  createdAt: string
   /**
    * Version of the app that sent the event
    */

--- a/packages/destination-actions/src/destinations/avo/sendSchemaToInspector/index.ts
+++ b/packages/destination-actions/src/destinations/avo/sendSchemaToInspector/index.ts
@@ -22,7 +22,7 @@ const processEvents = async (request: RequestClient, settings: Settings, payload
 }
 
 const sendSchemaAction: ActionDefinition<Settings, Payload> = {
-  title: 'Send Schema',
+  title: 'Track Schema From Event',
   description: 'Sends event schema to the Avo Inspector API',
   defaultSubscription: 'type = "track"',
   fields: {
@@ -54,10 +54,10 @@ const sendSchemaAction: ActionDefinition<Settings, Payload> = {
         '@path': '$.messageId'
       }
     },
-    receivedAt: {
-      label: 'Received At',
+    createdAt: {
+      label: 'Created At',
       type: 'string',
-      description: 'Timestamp of when the event was received',
+      description: 'Timestamp of when the event was sent',
       required: true,
       default: {
         '@path': '$.timestamp'


### PR DESCRIPTION

Adding presets for my action so that users setting up the destination do not have to remember to do it themselves.
- This came up when setting up the destination with one of our customers, and of course it makes sense that we do by default 🙌

@joe-ayoub-segment I based it of your PR so we don't have to have 2 PR's with changes for us 🙈 hope that is ok!

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
