### PR TITLE
[linkedin-conversions] Correctly throw IntegrationErrors when there is an error response in `perform`

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
@@ -5,11 +5,12 @@ import { BASE_URL } from '../../constants'
 import Destination from '../../index'
 
 const testDestination = createTestIntegration(Destination)
+const currentTimestamp = Date.now()
 
 const event = createTestEvent({
   event: 'Example Event',
   type: 'track',
-  timestamp: `${Date.now()}`,
+  timestamp: currentTimestamp.toString(),
   context: {
     traits: {
       email: 'testing@testing.com',
@@ -45,41 +46,18 @@ const payload = {
 
 describe('LinkedinConversions.streamConversion', () => {
   it('should successfully send the event', async () => {
-    const associateCampignToConversion = {
-      campaign: 'urn:li:sponsoredCampaign:123456`',
+    const associateCampignToConversion = JSON.stringify({
+      campaign: 'urn:li:sponsoredCampaign:56789',
       conversion: 'urn:lla:llaPartnerConversion:789123'
-    }
-
-    const streamConversionEvent = {
-      conversion: `urn:lla:llaPartnerConversion:${payload.conversionId}`,
-      conversionHappenedAt: Date.now(),
-      user: {
-        userIds: [
-          {
-            idType: 'SHA256_EMAIL',
-            idValue: 'bad8677b6c86f5d308ee82786c183482a5995f066694246c58c4df37b0cc41f1'
-          },
-          {
-            idType: 'LINKEDIN_FIRST_PARTY_ADS_TRACKING_UUID',
-            idValue: 'df5gf5-gh6t7-ph4j7h-fgf6n1'
-          }
-        ],
-        userInfo: {
-          firstName: 'mike',
-          lastName: 'smith',
-          title: 'software engineer',
-          companyName: 'microsoft',
-          countryCode: 'US'
-        }
-      }
-    }
+    })
 
     nock(
       `${BASE_URL}/campaignConversions/(campaign:urn%3Ali%3AsponsoredCampaign%3A${payload.campaignId[0]},conversion:urn%3Alla%3AllaPartnerConversion%3A${payload.conversionId})`
     )
-      .post(/.*/, associateCampignToConversion)
+      .put(/.*/, associateCampignToConversion)
       .reply(204)
-    nock(`${BASE_URL}/conversionEvents`).post(/.*/, streamConversionEvent).reply(201)
+
+    nock(`${BASE_URL}/conversionEvents`).post(/.*/).reply(201)
 
     await expect(
       testDestination.testAction('streamConversion', {
@@ -105,52 +83,32 @@ describe('LinkedinConversions.streamConversion', () => {
     ).resolves.not.toThrowError()
   })
 
-  it.only('should bulk associate campaigns and successfully send the event when multiple campaigns are selected', async () => {
-    const multipleCampaigns = payload.campaignId.concat('56789')
-
-    const streamConversionEvent = {
-      conversion: `urn:lla:llaPartnerConversion:${payload.conversionId}`,
-      conversionHappenedAt: Date.now(),
-      user: {
-        userIds: [
-          {
-            idType: 'SHA256_EMAIL',
-            idValue: 'bad8677b6c86f5d308ee82786c183482a5995f066694246c58c4df37b0cc41f1'
-          },
-          {
-            idType: 'LINKEDIN_FIRST_PARTY_ADS_TRACKING_UUID',
-            idValue: 'df5gf5-gh6t7-ph4j7h-fgf6n1'
-          }
-        ],
-        userInfo: {
-          firstName: 'mike',
-          lastName: 'smith',
-          title: 'software engineer',
-          companyName: 'microsoft',
-          countryCode: 'US'
-        }
-      }
-    }
+  it('should bulk associate campaigns and successfully send the event when multiple campaigns are selected', async () => {
+    const multipleCampaigns = payload.campaignId.concat('12345')
 
     nock(`${BASE_URL}`)
-      .post(
-        '/campaignConversions?ids=List((campaign:urn%3Ali%3AsponsoredCampaign%3A${multipleCampaigns[0]},conversion:urn%3Alla%3AllaPartnerConversion%3A${payload.conversionId}),(campaign:urn%3Ali%3AsponsoredCampaign%3A${multipleCampaigns[1]},conversion:urn%3Alla%3AllaPartnerConversion%3A${payload.conversionId}))'
+      .put(
+        `/campaignConversions?ids=List((campaign:urn%3Ali%3AsponsoredCampaign%3A${multipleCampaigns[0]},conversion:urn%3Alla%3AllaPartnerConversion%3A${payload.conversionId}),(campaign:urn%3Ali%3AsponsoredCampaign%3A${multipleCampaigns[1]},conversion:urn%3Alla%3AllaPartnerConversion%3A${payload.conversionId}))`
       )
       .reply(200)
-    nock(`${BASE_URL}/conversionEvents`).post(/.*/, streamConversionEvent).reply(201)
+
+    nock(`${BASE_URL}/conversionEvents`).post(/.*/).reply(201)
 
     await testDestination.testAction('streamConversion', {
       event,
       settings,
       mapping: {
         adAccountId: payload.adAccountId,
-        user: {
-          '@path': '$.context.traits.user'
+        userInfo: {
+          firstName: { '@path': '$.context.traits.user.userInfo.firstName' },
+          lastName: { '@path': '$.context.traits.user.userInfo.lastName' },
+          title: { '@path': '$.context.traits.user.userInfo.title' },
+          companyName: { '@path': '$.context.traits.user.userInfo.companyName' },
+          countryCode: { '@path': '$.context.traits.user.userInfo.countryCode' }
         },
+        userIds: { '@path': '$.context.traits.user.userIds' },
         campaignId: multipleCampaigns,
-        conversionHappenedAt: {
-          '@path': '$.timestamp'
-        },
+        conversionHappenedAt: currentTimestamp.toString(),
         onMappingSave: {
           inputs: {},
           outputs: {
@@ -280,43 +238,20 @@ describe('LinkedinConversions.dynamicField', () => {
 
 describe('LinkedinConversions.timestamp', () => {
   it('should convert a human readable date to a unix timestamp', async () => {
-    event.timestamp = new Date().toISOString()
+    event.timestamp = currentTimestamp.toString()
 
     const associateCampignToConversion = {
-      campaign: 'urn:li:sponsoredCampaign:123456`',
+      campaign: 'urn:li:sponsoredCampaign:56789',
       conversion: 'urn:lla:llaPartnerConversion:789123'
-    }
-
-    const streamConversionEvent = {
-      conversion: `urn:lla:llaPartnerConversion:${payload.conversionId}`,
-      conversionHappenedAt: 1698840732125,
-      user: {
-        userIds: [
-          {
-            idType: 'SHA256_EMAIL',
-            idValue: 'bad8677b6c86f5d308ee82786c183482a5995f066694246c58c4df37b0cc41f1'
-          },
-          {
-            idType: 'LINKEDIN_FIRST_PARTY_ADS_TRACKING_UUID',
-            idValue: 'df5gf5-gh6t7-ph4j7h-fgf6n1'
-          }
-        ],
-        userInfo: {
-          firstName: 'mike',
-          lastName: 'smith',
-          title: 'software engineer',
-          companyName: 'microsoft',
-          countryCode: 'US'
-        }
-      }
     }
 
     nock(
       `${BASE_URL}/campaignConversions/(campaign:urn%3Ali%3AsponsoredCampaign%3A${payload.campaignId},conversion:urn%3Alla%3AllaPartnerConversion%3A${payload.conversionId})`
     )
-      .post(/.*/, associateCampignToConversion)
+      .put(/.*/, associateCampignToConversion)
       .reply(204)
-    nock(`${BASE_URL}/conversionEvents`).post(/.*/, streamConversionEvent).reply(201)
+
+    nock(`${BASE_URL}/conversionEvents`).post(/.*/).reply(201)
 
     await expect(
       testDestination.testAction('streamConversion', {
@@ -343,43 +278,19 @@ describe('LinkedinConversions.timestamp', () => {
   })
 
   it('should convert a string unix timestamp to a number', async () => {
-    event.timestamp = Date.now().toString()
+    event.timestamp = currentTimestamp.toString()
 
     const associateCampignToConversion = {
-      campaign: 'urn:li:sponsoredCampaign:123456`',
+      campaign: 'urn:li:sponsoredCampaign:56789',
       conversion: 'urn:lla:llaPartnerConversion:789123'
-    }
-
-    const streamConversionEvent = {
-      conversion: `urn:lla:llaPartnerConversion:${payload.conversionId}`,
-      conversionHappenedAt: 1698840732125,
-      user: {
-        userIds: [
-          {
-            idType: 'SHA256_EMAIL',
-            idValue: 'bad8677b6c86f5d308ee82786c183482a5995f066694246c58c4df37b0cc41f1'
-          },
-          {
-            idType: 'LINKEDIN_FIRST_PARTY_ADS_TRACKING_UUID',
-            idValue: 'df5gf5-gh6t7-ph4j7h-fgf6n1'
-          }
-        ],
-        userInfo: {
-          firstName: 'mike',
-          lastName: 'smith',
-          title: 'software engineer',
-          companyName: 'microsoft',
-          countryCode: 'US'
-        }
-      }
     }
 
     nock(
       `${BASE_URL}/campaignConversions/(campaign:urn%3Ali%3AsponsoredCampaign%3A${payload.campaignId},conversion:urn%3Alla%3AllaPartnerConversion%3A${payload.conversionId})`
     )
-      .post(/.*/, associateCampignToConversion)
+      .put(/.*/, associateCampignToConversion)
       .reply(204)
-    nock(`${BASE_URL}/conversionEvents`).post(/.*/, streamConversionEvent).reply(201)
+    nock(`${BASE_URL}/conversionEvents`).post(/.*/).reply(201)
 
     await expect(
       testDestination.testAction('streamConversion', {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
@@ -105,12 +105,8 @@ describe('LinkedinConversions.streamConversion', () => {
     ).resolves.not.toThrowError()
   })
 
-  it('should bulk associate campaigns and successfully send the event when multiple campaigns are selected', async () => {
+  it.only('should bulk associate campaigns and successfully send the event when multiple campaigns are selected', async () => {
     const multipleCampaigns = payload.campaignId.concat('56789')
-    // const associateCampignToConversion = {
-    //   campaign: 'urn:li:sponsoredCampaign:123456`',
-    //   conversion: 'urn:lla:llaPartnerConversion:789123'
-    // }
 
     const streamConversionEvent = {
       conversion: `urn:lla:llaPartnerConversion:${payload.conversionId}`,
@@ -143,7 +139,7 @@ describe('LinkedinConversions.streamConversion', () => {
       .reply(200)
     nock(`${BASE_URL}/conversionEvents`).post(/.*/, streamConversionEvent).reply(201)
 
-    const responses = await testDestination.testAction('streamConversion', {
+    await testDestination.testAction('streamConversion', {
       event,
       settings,
       mapping: {
@@ -163,8 +159,6 @@ describe('LinkedinConversions.streamConversion', () => {
         }
       }
     })
-
-    console.log('responses', responses)
   })
 
   it('should throw an error if timestamp is not within the past 90 days', async () => {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -236,6 +236,7 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
       await linkedinApiClient.bulkAssociateCampaignToConversion(payload.campaignId)
       return linkedinApiClient.streamConversionEvent(payload, conversionTime)
     } catch (error) {
+      console.log('Error:', error)
       throw handleRequestError(error)
     }
   }

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -1,9 +1,10 @@
 import type { ActionDefinition } from '@segment/actions-core'
-import { PayloadValidationError } from '@segment/actions-core'
+import { IntegrationError, PayloadValidationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import { LinkedInConversions } from '../api'
 import { SUPPORTED_ID_TYPE } from '../constants'
 import type { Payload, HookBundle } from './generated-types'
+import { LinkedInError } from '../types'
 
 const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
   title: 'Stream Conversion Event',
@@ -235,7 +236,12 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
       await linkedinApiClient.bulkAssociateCampaignToConversion(payload.campaignId)
       return linkedinApiClient.streamConversionEvent(payload, conversionTime)
     } catch (error) {
-      return error
+      const asLinkedInError = error as LinkedInError
+      throw new IntegrationError(
+        asLinkedInError.response.data.message ?? 'Unknown Error',
+        asLinkedInError.response.data.code ?? 'UNKNOWN',
+        asLinkedInError.response.data.status ?? 500
+      )
     }
   }
 }

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -236,7 +236,6 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
       await linkedinApiClient.bulkAssociateCampaignToConversion(payload.campaignId)
       return linkedinApiClient.streamConversionEvent(payload, conversionTime)
     } catch (error) {
-      console.log('Error:', error)
       throw handleRequestError(error)
     }
   }

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -1,5 +1,5 @@
 import type { ActionDefinition } from '@segment/actions-core'
-import { IntegrationError, PayloadValidationError } from '@segment/actions-core'
+import { ErrorCodes, IntegrationError, PayloadValidationError, InvalidAuthenticationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import { LinkedInConversions } from '../api'
 import { SUPPORTED_ID_TYPE } from '../constants'
@@ -236,14 +236,33 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
       await linkedinApiClient.bulkAssociateCampaignToConversion(payload.campaignId)
       return linkedinApiClient.streamConversionEvent(payload, conversionTime)
     } catch (error) {
-      const asLinkedInError = error as LinkedInError
-      throw new IntegrationError(
-        asLinkedInError.response.data.message ?? 'Unknown Error',
-        asLinkedInError.response.data.code ?? 'UNKNOWN',
-        asLinkedInError.response.data.status ?? 500
-      )
+      throw handleRequestError(error)
     }
   }
+}
+
+function handleRequestError(error: unknown) {
+  const asLinkedInError = error as LinkedInError
+
+  if (!asLinkedInError) {
+    return new IntegrationError('Unknown error', 'UNKNOWN_ERROR', 500)
+  }
+
+  const status = asLinkedInError.response.data.status
+
+  if (status === 401) {
+    return new InvalidAuthenticationError(asLinkedInError.response.data.message, ErrorCodes.INVALID_AUTHENTICATION)
+  }
+
+  if (status === 501) {
+    return new IntegrationError(asLinkedInError.response.data.message, 'INTEGRATION_ERROR', 501)
+  }
+
+  if (status === 408 || status === 423 || status === 429 || status >= 500) {
+    return new IntegrationError(asLinkedInError.response.data.message, 'RETRYABLE_ERROR', status)
+  }
+
+  return new IntegrationError(asLinkedInError.response.data.message, 'INTEGRATION_ERROR', status)
 }
 
 function validate(payload: Payload, conversionTime: number) {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/types.ts
@@ -11,6 +11,16 @@ export interface ProfileAPIResponse {
   id: string
 }
 
+export interface LinkedInError {
+  response: {
+    data: {
+      message: string
+      code: string
+      status: number
+    }
+  }
+}
+
 export class LinkedInTestAuthenticationError extends HTTPError {
   response: Response & {
     data: {


### PR DESCRIPTION
This PR resolves an issue in LinkedIn Conversions where 401 errors in the `perform` block were incorrectly returned as `200` successful responses. 

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->
## Testing
Tested in staging by revoking an active access token. The events correctly fail with `401`.
<img width="1298" alt="Screenshot 2024-02-09 at 3 01 12 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/c64f4bb3-7ac3-4fb6-866d-b6ea379f61f2">


<img width="1286" alt="Screenshot 2024-02-09 at 3 00 58 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/23a921fa-dcea-4bd6-baab-02a3aa4f4469">

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
