### PR TITLE
DV360 - Fix 403 Errors in Data Syncs

### DIFF
--- a/packages/destination-actions/src/destinations/display-video-360/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/__tests__/index.test.ts
@@ -161,10 +161,10 @@ describe('Display Video 360', () => {
       })
     })
 
-    it('should succeed when Destination is flagged as migration', async () => {
+    it('should succeed when the destination instance is flagged as a migration instance', async () => {
       const migrationGetAudienceInput = {
         ...getAudienceInput,
-        settings: { oauth: {} },
+        settings: {}, // Settings for migration instances are set as {} in the migration script.
         externalId: 'iWasHereInTheBeforeTimes'
       }
 

--- a/packages/destination-actions/src/destinations/display-video-360/errors.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/errors.ts
@@ -1,5 +1,5 @@
 import { ErrorCodes, IntegrationError, InvalidAuthenticationError } from '@segment/actions-core'
-import { StatsClient } from '@segment/actions-core/destination-kit'
+import { StatsContext } from '@segment/actions-core/destination-kit'
 
 import { GoogleAPIError } from './types'
 
@@ -20,10 +20,13 @@ const isGoogleAPIError = (error: unknown): error is GoogleAPIError => {
 }
 
 // This method follows the retry logic defined in IntegrationError in the actions-core package
-export const handleRequestError = (error: unknown, statsName: string, statsClient: StatsClient | undefined) => {
+export const handleRequestError = (error: unknown, statsName: string, statsContext: StatsContext | undefined) => {
+  const { statsClient, tags: statsTags } = statsContext || {}
+
   if (!isGoogleAPIError(error)) {
     if (!error) {
-      statsClient?.incr(`${statsName}.error.UNKNOWN_ERROR`, 1)
+      statsTags?.push('error:unknown')
+      statsClient?.incr(`${statsName}.error`, 1, statsTags)
       return new IntegrationError('Unknown error', 'UNKNOWN_ERROR', 500)
     }
   }
@@ -33,20 +36,24 @@ export const handleRequestError = (error: unknown, statsName: string, statsClien
   const message = gError.response?.data?.error?.message
 
   if (code === 401) {
-    statsClient?.incr(`${statsName}.error.INVALID_AUTHENTICATION`, 1)
+    statsTags?.push('error:invalid-authentication')
+    statsClient?.incr(`${statsName}.error`, 1, statsTags)
     return new InvalidAuthenticationError(message, ErrorCodes.INVALID_AUTHENTICATION)
   }
 
   if (code === 501) {
-    statsClient?.incr(`${statsName}.error.INTEGRATION_ERROR`, 1)
+    statsTags?.push('error:integration-error')
+    statsClient?.incr(`${statsName}.error`, 1, statsTags)
     return new IntegrationError(message, 'INTEGRATION_ERROR', 501)
   }
 
   if (code === 408 || code === 423 || code === 429 || code >= 500) {
-    statsClient?.incr(`${statsName}.error.RETRYABLE_ERROR`, 1)
+    statsTags?.push('error:retryable-error')
+    statsClient?.incr(`${statsName}.error`, 1, statsTags)
     return new IntegrationError(message, 'RETRYABLE_ERROR', code)
   }
 
-  statsClient?.incr(`${statsName}.error.INTEGRATION_ERROR`, 1)
+  statsTags?.push('error:generic-error')
+  statsClient?.incr(`${statsName}.error`, 1, statsTags)
   return new IntegrationError(message, 'INTEGRATION_ERROR', code)
 }

--- a/packages/destination-actions/src/destinations/display-video-360/shared.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/shared.ts
@@ -27,10 +27,13 @@ export const isLegacyDestinationMigration = (
 }
 
 export const getAuthSettings = (settings: SettingsWithOauth): OAuth2ClientCredentials => {
-  const { oauth } = settings
+  if (!settings.oauth) {
+    return {} as OAuth2ClientCredentials
+  }
+
   return {
-    clientId: oauth.clientId,
-    clientSecret: oauth.clientSecret
+    clientId: settings.oauth.clientId,
+    clientSecret: settings.oauth.clientSecret
   } as OAuth2ClientCredentials
 }
 


### PR DESCRIPTION
The 403 errors are being caused by the wrong expectation that settings for migrated objects would receive an empty `oauth` object. They don't; the sync is failing because of that.
This PR fixes the issue and also refactors some of the DD metrics that were hidden/lost because of how tags were being used.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
