### PR TITLE
Update name of AppFit destination

### DIFF
--- a/packages/destination-actions/src/destinations/app-fit/index.ts
+++ b/packages/destination-actions/src/destinations/app-fit/index.ts
@@ -5,7 +5,7 @@ import AppFitConfig from './config'
 import track from './track'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'App Fit',
+  name: 'AppFit',
   slug: 'actions-app-fit',
   mode: 'cloud',
 


### PR DESCRIPTION
Update name of AppFit destination from "App Fit" to "Appfit"

Context: Customer has requested to update the name of their integration from "App Fit" to "AppFit" everywhere we can. We can't make the change to the slug but name can be updated - Ref: https://github.com/segmentio/segment-docs/pull/6027 & [ZenDesk Partner Support Ticket](https://segment.zendesk.com/agent/tickets/534723)

## Testing

N/A as this is simply a name change


