### PR TITLE
feat(Jimo/Actions): sendTrackEvent

### DIFF
--- a/packages/browser-destinations/destinations/jimo/src/index.ts
+++ b/packages/browser-destinations/destinations/jimo/src/index.ts
@@ -3,6 +3,7 @@ import { browserDestination } from '@segment/browser-destination-runtime/shim'
 import type { BrowserDestinationDefinition } from '@segment/browser-destination-runtime/types'
 import type { Settings } from './generated-types'
 import { initScript } from './init-script'
+import sendTrackEvent from './sendTrackEvent'
 import sendUserData from './sendUserData'
 import { JimoSDK } from './types'
 
@@ -38,6 +39,13 @@ export const destination: BrowserDestinationDefinition<Settings, JimoSDK> = {
       partnerAction: 'sendUserData',
       mapping: defaultValues(sendUserData.fields),
       type: 'automatic'
+    },
+    {
+      name: 'Send Track Event',
+      subscribe: 'type = "track"',
+      partnerAction: 'sendTrackEvent',
+      mapping: defaultValues(sendTrackEvent.fields),
+      type: 'automatic'
     }
   ],
   initialize: async ({ settings }, deps) => {
@@ -50,7 +58,8 @@ export const destination: BrowserDestinationDefinition<Settings, JimoSDK> = {
     return window.jimo as JimoSDK
   },
   actions: {
-    sendUserData
+    sendUserData,
+    sendTrackEvent
   }
 }
 

--- a/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/__tests__/index.test.ts
@@ -20,7 +20,6 @@ describe('Jimo - Send Track Event', () => {
       payload: {
         messageId: '42',
         timestamp: 'timestamp-as-iso-string',
-        receivedAt: 'receivedAt-as-iso-string',
         userId: 'u1',
         anonymousId: 'a1',
         event_name: 'foo',

--- a/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/__tests__/index.test.ts
@@ -1,0 +1,52 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import sendTrackEvent from '..'
+import { JimoSDK } from '../../types'
+import { Payload } from '../generated-types'
+
+describe('Jimo - Send Track Event', () => {
+  test('do:segmentio:track is called', async () => {
+    const client = {
+      push: jest.fn()
+    } as any as JimoSDK
+
+    const context = new Context({
+      type: 'track'
+    })
+
+    await sendTrackEvent.perform(client as any as JimoSDK, {
+      settings: { projectId: 'unk' },
+      analytics: jest.fn() as any as Analytics,
+      context: context,
+      payload: {
+        messageId: '42',
+        timestamp: 'timestamp-as-iso-string',
+        receivedAt: 'receivedAt-as-iso-string',
+        userId: 'u1',
+        anonymousId: 'a1',
+        event_name: 'foo',
+        properties: {
+          foo: 'bar'
+        }
+      } as Payload
+    })
+
+    expect(client.push).toHaveBeenCalled()
+    expect(client.push).toHaveBeenCalledWith([
+      'do',
+      'segmentio:track',
+      [
+        {
+          event: 'foo',
+          messageId: '42',
+          timestamp: 'timestamp-as-iso-string',
+          receivedAt: 'timestamp-as-iso-string',
+          userId: 'u1',
+          anonymousId: 'a1',
+          properties: {
+            foo: 'bar'
+          }
+        }
+      ]
+    ])
+  })
+})

--- a/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/generated-types.ts
+++ b/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/generated-types.ts
@@ -10,10 +10,6 @@ export interface Payload {
    */
   timestamp: string
   /**
-   * The reception date of the event.
-   */
-  receivedAt: string
-  /**
    * The name of the event.
    */
   event_name: string

--- a/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/generated-types.ts
+++ b/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/generated-types.ts
@@ -1,0 +1,34 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The internal id of the message.
+   */
+  messageId: string
+  /**
+   * The timestamp of the event.
+   */
+  timestamp: string
+  /**
+   * The reception date of the event.
+   */
+  receivedAt: string
+  /**
+   * The name of the event.
+   */
+  event_name: string
+  /**
+   * A unique identifier for the user.
+   */
+  userId?: string
+  /**
+   * An anonymous identifier for the user.
+   */
+  anonymousId?: string
+  /**
+   * Information associated with the event
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/index.ts
+++ b/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/index.ts
@@ -1,0 +1,96 @@
+import type { BrowserActionDefinition } from '@segment/browser-destination-runtime/types'
+import { JimoSDK } from 'src/types'
+import type { Settings } from '../generated-types'
+import { Payload } from './generated-types'
+
+const action: BrowserActionDefinition<Settings, JimoSDK, Payload> = {
+  title: 'Send Track Event',
+  description: 'Submit an event to Jimo',
+  defaultSubscription: 'type = "track"',
+  platform: 'web',
+  fields: {
+    messageId: {
+      description: 'The internal id of the message.',
+      label: 'Message Id',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.messageId'
+      }
+    },
+    timestamp: {
+      description: 'The timestamp of the event.',
+      label: 'Timestamp',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.timestamp'
+      }
+    },
+    receivedAt: {
+      description: 'The reception date of the event.',
+      label: 'Received at',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.receivedAt'
+      }
+    },
+    event_name: {
+      description: 'The name of the event.',
+      label: 'Event Name',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.event'
+      }
+    },
+    userId: {
+      description: 'A unique identifier for the user.',
+      label: 'User ID',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    anonymousId: {
+      description: 'An anonymous identifier for the user.',
+      label: 'Anonymous ID',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.anonymousId'
+      }
+    },
+    properties: {
+      description: 'Information associated with the event',
+      label: 'Event Properties',
+      type: 'object',
+      required: false,
+      default: {
+        '@path': '$.properties'
+      }
+    }
+  },
+  perform: (jimo, { payload }) => {
+    const {
+      event_name,
+      userId,
+      anonymousId,
+      timestamp,
+      /* receivedAt, (for some reason, receivedAt is undefined) */
+      messageId,
+      properties
+    } = payload
+    const receivedAt = timestamp
+
+    jimo.push([
+      'do',
+      'segmentio:track',
+      [{ event: event_name, userId, anonymousId, messageId, timestamp, receivedAt, properties }]
+    ])
+  }
+}
+
+export default action

--- a/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/index.ts
+++ b/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/index.ts
@@ -90,6 +90,7 @@ const action: BrowserActionDefinition<Settings, JimoSDK, Payload> = {
       'segmentio:track',
       [{ event: event_name, userId, anonymousId, messageId, timestamp, receivedAt, properties }]
     ])
+    window.dispatchEvent(new CustomEvent(`jimo-segmentio-track:${event_name}`))
   }
 }
 

--- a/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/index.ts
+++ b/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/index.ts
@@ -27,15 +27,6 @@ const action: BrowserActionDefinition<Settings, JimoSDK, Payload> = {
         '@path': '$.timestamp'
       }
     },
-    receivedAt: {
-      description: 'The reception date of the event.',
-      label: 'Received at',
-      type: 'string',
-      required: true,
-      default: {
-        '@path': '$.receivedAt'
-      }
-    },
     event_name: {
       description: 'The name of the event.',
       label: 'Event Name',
@@ -74,15 +65,7 @@ const action: BrowserActionDefinition<Settings, JimoSDK, Payload> = {
     }
   },
   perform: (jimo, { payload }) => {
-    const {
-      event_name,
-      userId,
-      anonymousId,
-      timestamp,
-      /* receivedAt, (for some reason, receivedAt is undefined) */
-      messageId,
-      properties
-    } = payload
+    const { event_name, userId, anonymousId, timestamp, messageId, properties } = payload
     const receivedAt = timestamp
 
     jimo.push([


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Adding an action for track events

## Testing

Nothing too hard or specific, we basically subscribe to track events and call a method of our SDK.
That said, I saw that we were not able to access the `receivedAt` property of the event payload. Not sure why because in the testing tool, we do see the mapping happening, yet, the field is undefined.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
