### PR TITLE
Marketo Static Lists Updates

### DIFF
--- a/packages/destination-actions/src/destinations/marketo-static-lists/addToList/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/addToList/__tests__/index.test.ts
@@ -45,7 +45,7 @@ describe('MarketoStaticLists.addToList', () => {
       Content-Disposition: form-data; name=\\"file\\"; filename=\\"leads.csv\\"
       Content-Type: text/csv
 
-      Email
+      email
       testing@testing.com
       ----SEGMENT-DATA----
       "

--- a/packages/destination-actions/src/destinations/marketo-static-lists/addToList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/addToList/generated-types.ts
@@ -29,6 +29,7 @@ export interface Payload {
      * The user's phone number.
      */
     phone?: string
+    [k: string]: unknown
   }
   /**
    * Enable batching of requests.

--- a/packages/destination-actions/src/destinations/marketo-static-lists/addToList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/addToList/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   external_id: string
   /**
-   * Field to use for deduplication. This field must be apart of the lead's info fields.
+   * The lead field to use for deduplication and filtering. This field must be apart of the lead's info fields.
    */
   lookup_field: string
   /**

--- a/packages/destination-actions/src/destinations/marketo-static-lists/addToList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/addToList/generated-types.ts
@@ -6,9 +6,30 @@ export interface Payload {
    */
   external_id: string
   /**
-   * The user's email address to send to Marketo.
+   * Field to use for deduplication. This field must be apart of the lead's info fields.
    */
-  email?: string
+  lookup_field: string
+  /**
+   * The fields that contain data about the lead, such as Email, Last Name, etc. On the left-hand side, input the field name exactly how it appears in Marketo. On the right-hand side, map the Segment field that contains the corresponding value.
+   */
+  data: {
+    /**
+     * The user's email address to send to Marketo.
+     */
+    email?: string
+    /**
+     * The user's first name.
+     */
+    firstName?: string
+    /**
+     * The user's last name.
+     */
+    lastName?: string
+    /**
+     * The user's phone number.
+     */
+    phone?: string
+  }
   /**
    * Enable batching of requests.
    */

--- a/packages/destination-actions/src/destinations/marketo-static-lists/addToList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/addToList/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   external_id: string
   /**
-   * The lead field to use for deduplication and filtering. This field must be apart of the lead's info fields.
+   * The lead field to use for deduplication and filtering. This field must be apart of the field(s) you are sending to Marketo.
    */
   lookup_field: string
   /**

--- a/packages/destination-actions/src/destinations/marketo-static-lists/addToList/index.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/addToList/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { external_id, email, enable_batching, batch_size, event_name } from '../properties'
+import { external_id, lookup_field, data, enable_batching, batch_size, event_name } from '../properties'
 import { addToList } from '../functions'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -10,7 +10,8 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'event = "Audience Entered"',
   fields: {
     external_id: { ...external_id },
-    email: { ...email },
+    lookup_field: { ...lookup_field },
+    data: { ...data },
     enable_batching: { ...enable_batching },
     batch_size: { ...batch_size },
     event_name: { ...event_name }

--- a/packages/destination-actions/src/destinations/marketo-static-lists/constants.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/constants.ts
@@ -6,7 +6,7 @@ const OAUTH_ENDPOINT = 'identity/oauth/token'
 export const GET_FOLDER_ENDPOINT = `/rest/asset/${API_VERSION}/folder/byName.json?name=folderName`
 export const CREATE_LIST_ENDPOINT = `/rest/asset/${API_VERSION}/staticLists.json?folder=folderId&name=listName`
 export const GET_LIST_ENDPOINT = `/rest/asset/${API_VERSION}/staticList/listId.json`
-export const BULK_IMPORT_ENDPOINT = `/bulk/${API_VERSION}/leads.json?format=csv&listId=externalId`
+export const BULK_IMPORT_ENDPOINT = `/bulk/${API_VERSION}/leads.json?format=csv&listId=externalId&lookupField=fieldToLookup`
 export const GET_LEADS_ENDPOINT = `/rest/${API_VERSION}/leads.json?filterType=email&filterValues=emailsToFilter`
 export const REMOVE_USERS_ENDPOINT = `/rest/${API_VERSION}/lists/listId/leads.json?id=idsToDelete`
 

--- a/packages/destination-actions/src/destinations/marketo-static-lists/constants.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/constants.ts
@@ -7,7 +7,7 @@ export const GET_FOLDER_ENDPOINT = `/rest/asset/${API_VERSION}/folder/byName.jso
 export const CREATE_LIST_ENDPOINT = `/rest/asset/${API_VERSION}/staticLists.json?folder=folderId&name=listName`
 export const GET_LIST_ENDPOINT = `/rest/asset/${API_VERSION}/staticList/listId.json`
 export const BULK_IMPORT_ENDPOINT = `/bulk/${API_VERSION}/leads.json?format=csv&listId=externalId&lookupField=fieldToLookup`
-export const GET_LEADS_ENDPOINT = `/rest/${API_VERSION}/leads.json?filterType=email&filterValues=emailsToFilter`
+export const GET_LEADS_ENDPOINT = `/rest/${API_VERSION}/leads.json?filterType=field&filterValues=emailsToFilter`
 export const REMOVE_USERS_ENDPOINT = `/rest/${API_VERSION}/lists/listId/leads.json?id=idsToDelete`
 
 export const CSV_LIMIT = 10000000 // 10MB

--- a/packages/destination-actions/src/destinations/marketo-static-lists/functions.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/functions.ts
@@ -26,8 +26,6 @@ export async function addToList(
   payloads: AddToListPayload[],
   statsContext?: StatsContext
 ) {
-  // Keep only the scheme and host from the endpoint
-  // Marketo shows endpoint with trailing "/rest", which we don't want
   const api_endpoint = formatEndpoint(settings.api_endpoint)
 
   const csvData = formatData(payloads)
@@ -66,12 +64,15 @@ export async function removeFromList(
   payloads: RemoveFromListPayload[],
   statsContext?: StatsContext
 ) {
-  // Keep only the scheme and host from the endpoint
-  // Marketo shows endpoint with trailing "/rest", which we don't want
-  const api_endpoint = settings.api_endpoint.replace('/rest', '')
-  const emailsToRemove = extractEmails(payloads, ',')
+  const api_endpoint = formatEndpoint(settings.api_endpoint)
+  const usersToRemove = extractFilterData(payloads)
 
-  const getLeadsUrl = api_endpoint + GET_LEADS_ENDPOINT.replace('emailsToFilter', encodeURIComponent(emailsToRemove))
+  const getLeadsUrl =
+    api_endpoint +
+    GET_LEADS_ENDPOINT.replace('field', payloads[0].lookup_field).replace(
+      'emailsToFilter',
+      encodeURIComponent(usersToRemove)
+    )
 
   // Get lead ids from Marketo
   const getLeadsResponse = await request<MarketoGetLeadsResponse>(getLeadsUrl, {
@@ -120,17 +121,19 @@ function formatData(payloads: AddToListPayload[]) {
 
   const allKeys = [...new Set(payloads.flatMap((payload) => Object.keys(payload.data)))]
   const header = allKeys.join(',')
-  const csvData = payloads.map((payload) => allKeys.map((key) => payload.data[key] || '').join(',')).join('\n')
+  const csvData = payloads
+    .map((payload) => allKeys.map((key) => payload.data[key as keyof typeof payload.data] || '').join(','))
+    .join('\n')
 
   return `${header}\n${csvData}`
 }
 
-function extractEmails(payloads: AddToListPayload[], separator: string) {
-  const emails = payloads
-    .filter((payload) => payload.data.email !== undefined)
-    .map((payload) => payload.data.email)
-    .join(separator)
-  return emails
+function extractFilterData(payloads: RemoveFromListPayload[]) {
+  const data = payloads
+    .filter((payload) => payload.field_value !== undefined)
+    .map((payload) => payload.field_value)
+    .join(',')
+  return data
 }
 
 function extractLeadIds(leads: MarketoLeads[]) {

--- a/packages/destination-actions/src/destinations/marketo-static-lists/functions.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/functions.ts
@@ -14,6 +14,12 @@ import {
   MarketoResponse
 } from './constants'
 
+// Keep only the scheme and host from the endpoint
+// Marketo UI shows endpoint with trailing "/rest", which we don't want
+export function formatEndpoint(endpoint: string) {
+  return endpoint.replace('/rest', '')
+}
+
 export async function addToList(
   request: RequestClient,
   settings: Settings,
@@ -22,7 +28,7 @@ export async function addToList(
 ) {
   // Keep only the scheme and host from the endpoint
   // Marketo shows endpoint with trailing "/rest", which we don't want
-  const api_endpoint = settings.api_endpoint.replace('/rest', '')
+  const api_endpoint = formatEndpoint(settings.api_endpoint)
 
   const csvData = 'Email\n' + extractEmails(payloads, '\n')
   const csvSize = Buffer.byteLength(csvData, 'utf8')

--- a/packages/destination-actions/src/destinations/marketo-static-lists/index.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/index.ts
@@ -11,6 +11,7 @@ import {
   GET_LIST_ENDPOINT,
   CREATE_LIST_ENDPOINT
 } from './constants'
+import { formatEndpoint } from './functions'
 
 const destination: AudienceDestinationDefinition<Settings> = {
   name: 'Marketo Static Lists (Actions)',
@@ -65,7 +66,7 @@ const destination: AudienceDestinationDefinition<Settings> = {
     async createAudience(request, createAudienceInput) {
       const audienceName = createAudienceInput.audienceName
       const folder = createAudienceInput.settings.folder_name
-      const endpoint = createAudienceInput.settings.api_endpoint
+      const endpoint = formatEndpoint(createAudienceInput.settings.api_endpoint)
       const statsClient = createAudienceInput?.statsContext?.statsClient
       const statsTags = createAudienceInput?.statsContext?.tags
 
@@ -124,7 +125,7 @@ const destination: AudienceDestinationDefinition<Settings> = {
       }
     },
     async getAudience(request, getAudienceInput) {
-      const endpoint = getAudienceInput.settings.api_endpoint
+      const endpoint = formatEndpoint(getAudienceInput.settings.api_endpoint)
       const listId = getAudienceInput.externalId
       const statsClient = getAudienceInput?.statsContext?.statsClient
       const statsTags = getAudienceInput?.statsContext?.tags

--- a/packages/destination-actions/src/destinations/marketo-static-lists/properties.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/properties.ts
@@ -11,14 +11,84 @@ export const external_id: InputField = {
   required: true
 }
 
-export const email: InputField = {
-  label: 'Email',
-  description: `The user's email address to send to Marketo.`,
+export const lookup_field: InputField = {
+  label: 'Lookup Field',
+  description: `Field to use for deduplication. This field must be apart of the lead's info fields.`,
   type: 'string',
-  default: {
-    '@path': '$.context.traits.email'
+  choices: [
+    { label: 'Email', value: 'email' },
+    { label: 'Id', value: 'id' },
+    { label: 'Cookies', value: 'cookies' },
+    { label: 'Twitter ID', value: 'twitterId' },
+    { label: 'Facebook ID', value: 'facebookId' },
+    { label: 'LinkedIn ID', value: 'linkedinId' },
+    { label: 'Salesforce Account ID', value: 'sfdcAccountId' },
+    { label: 'Salesforce Contact ID', value: 'sfdcContactId' },
+    { label: 'Salesforce Lead ID', value: 'sfdcLeadId' },
+    { label: 'Salesforce Opportunity ID', value: 'sfdcOpptyId' }
+  ],
+  default: 'email',
+  required: true
+}
+
+export const data: InputField = {
+  label: 'Lead Info Fields',
+  description:
+    'The fields that contain data about the lead, such as Email, Last Name, etc. On the left-hand side, input the field name exactly how it appears in Marketo. On the right-hand side, map the Segment field that contains the corresponding value.',
+  type: 'object',
+  required: true,
+  properties: {
+    email: {
+      label: 'Email',
+      description: `The user's email address to send to Marketo.`,
+      type: 'string'
+    },
+    firstName: {
+      label: 'First Name',
+      description: `The user's first name.`,
+      type: 'string'
+    },
+    lastName: {
+      label: 'Last Name',
+      description: `The user's last name.`,
+      type: 'string'
+    },
+    phone: {
+      label: 'Phone Number',
+      description: `The user's phone number.`,
+      type: 'string'
+    }
   },
-  readOnly: true
+  default: {
+    email: {
+      '@if': {
+        exists: { '@path': '$.context.traits.email' },
+        then: { '@path': '$.context.traits.email' },
+        else: { '@path': '$.properties.email' }
+      }
+    },
+    firstName: {
+      '@if': {
+        exists: { '@path': '$.context.traits.firstName' },
+        then: { '@path': '$.context.traits.firstName' },
+        else: { '@path': '$.properties.firstName' }
+      }
+    },
+    lastName: {
+      '@if': {
+        exists: { '@path': '$.context.traits.lastName' },
+        then: { '@path': '$.context.traits.lastName' },
+        else: { '@path': '$.properties.lastName' }
+      }
+    },
+    phone: {
+      '@if': {
+        exists: { '@path': '$.context.traits.phoneNumber' },
+        then: { '@path': '$.context.traits.phoneNumber' },
+        else: { '@path': '$.properties.phoneNumber' }
+      }
+    }
+  }
 }
 
 export const enable_batching: InputField = {

--- a/packages/destination-actions/src/destinations/marketo-static-lists/properties.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/properties.ts
@@ -27,7 +27,7 @@ export const field_value: InputField = {
 
 export const lookup_field: InputField = {
   label: 'Lookup Field',
-  description: `The lead field to use for deduplication and filtering. This field must be apart of the lead's info fields.`,
+  description: `The lead field to use for deduplication and filtering. This field must be apart of the field(s) you are sending to Marketo.`,
   type: 'string',
   choices: [
     { label: 'Email', value: 'email' },

--- a/packages/destination-actions/src/destinations/marketo-static-lists/properties.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/properties.ts
@@ -10,10 +10,24 @@ export const external_id: InputField = {
   unsafe_hidden: true,
   required: true
 }
+export const field_value: InputField = {
+  label: 'Field Value',
+  description: 'The value cooresponding to the lookup field.',
+  type: 'string',
+  default: {
+    '@if': {
+      exists: { '@path': '$.context.traits.email' },
+      then: { '@path': '$.context.traits.email' },
+      else: { '@path': '$.properties.email' }
+    }
+  },
+  unsafe_hidden: true,
+  required: true
+}
 
 export const lookup_field: InputField = {
   label: 'Lookup Field',
-  description: `Field to use for deduplication. This field must be apart of the lead's info fields.`,
+  description: `The lead field to use for deduplication and filtering. This field must be apart of the lead's info fields.`,
   type: 'string',
   choices: [
     { label: 'Email', value: 'email' },

--- a/packages/destination-actions/src/destinations/marketo-static-lists/properties.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/properties.ts
@@ -10,6 +10,7 @@ export const external_id: InputField = {
   unsafe_hidden: true,
   required: true
 }
+
 export const field_value: InputField = {
   label: 'Field Value',
   description: 'The value cooresponding to the lookup field.',
@@ -21,7 +22,6 @@ export const field_value: InputField = {
       else: { '@path': '$.properties.email' }
     }
   },
-  unsafe_hidden: true,
   required: true
 }
 
@@ -102,7 +102,8 @@ export const data: InputField = {
         else: { '@path': '$.properties.phoneNumber' }
       }
     }
-  }
+  },
+  additionalProperties: true
 }
 
 export const enable_batching: InputField = {

--- a/packages/destination-actions/src/destinations/marketo-static-lists/removeFromList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/removeFromList/generated-types.ts
@@ -5,9 +5,14 @@ export interface Payload {
    * The ID of the Static List that users will be synced to.
    */
   external_id: string
-  email?: {
-    [k: string]: unknown
-  }
+  /**
+   * The lead field to use for deduplication and filtering. This field must be apart of the lead's info fields.
+   */
+  lookup_field: string
+  /**
+   * The value cooresponding to the lookup field.
+   */
+  field_value: string
   /**
    * Enable batching of requests.
    */

--- a/packages/destination-actions/src/destinations/marketo-static-lists/removeFromList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/removeFromList/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   external_id: string
   /**
-   * The lead field to use for deduplication and filtering. This field must be apart of the lead's info fields.
+   * The lead field to use for deduplication and filtering. This field must be apart of the field(s) you are sending to Marketo.
    */
   lookup_field: string
   /**

--- a/packages/destination-actions/src/destinations/marketo-static-lists/removeFromList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/removeFromList/generated-types.ts
@@ -5,10 +5,9 @@ export interface Payload {
    * The ID of the Static List that users will be synced to.
    */
   external_id: string
-  /**
-   * The user's email address to send to Marketo.
-   */
-  email?: string
+  email?: {
+    [k: string]: unknown
+  }
   /**
    * Enable batching of requests.
    */

--- a/packages/destination-actions/src/destinations/marketo-static-lists/removeFromList/index.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/removeFromList/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { external_id, email, enable_batching, batch_size, event_name } from '../properties'
+import { external_id, lookup_field, field_value, enable_batching, batch_size, event_name } from '../properties'
 import { removeFromList } from '../functions'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -10,7 +10,8 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'event = "Audience Exited"',
   fields: {
     external_id: { ...external_id },
-    email: { ...email },
+    lookup_field: { ...lookup_field },
+    field_value: { ...field_value },
     enable_batching: { ...enable_batching },
     batch_size: { ...batch_size },
     event_name: { ...event_name }


### PR DESCRIPTION
[STRATCONN-3579](https://segment.atlassian.net/browse/STRATCONN-3579) 
In order to support sending multiple identifiers with Trait Enrichment we added some fields to the destination so that customers can configure the data they are sending to Marketo and it is not limited to just email.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
![Screenshot 2024-02-20 at 4 57 02 PM](https://github.com/segmentio/action-destinations/assets/99763167/4c4349d9-0d25-4613-8507-b58ca856395b)
![Screenshot 2024-02-20 at 4 56 39 PM](https://github.com/segmentio/action-destinations/assets/99763167/9f5251e2-e89b-4bab-b1d7-9087cdcae925)


[STRATCONN-3579]: https://segment.atlassian.net/browse/STRATCONN-3579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ