### PR TITLE
Channels-1034 Set google Api version for Push

### DIFF
--- a/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush.types.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-twilio/sendMobilePush.types.ts
@@ -124,4 +124,8 @@ export interface Payload {
    * Time of when the actual event happened.
    */
   eventOccurredTS?: string
+  /**
+   * Controls the notification payload format
+   */
+  googleApiVersion?: string
 }

--- a/packages/destination-actions/src/destinations/engage/twilio/sendMobilePush/PushSender.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/sendMobilePush/PushSender.ts
@@ -146,12 +146,7 @@ export class PushSender extends TwilioMessageSender<PushPayload> {
         Sound: this.payload.customizations?.sound,
         Priority: this.payload.customizations?.priority,
         TimeToLive: this.payload.customizations?.ttl,
-        FcmPayload: {
-          mutable_content: true,
-          notification: {
-            badge: badgeAmount
-          }
-        },
+        FcmPayload: this.getFcmNotificationOverrides(badgeAmount),
         ApnPayload: {
           aps: {
             'mutable-content': 1,
@@ -169,6 +164,27 @@ export class PushSender extends TwilioMessageSender<PushPayload> {
       return { requestBody, customData }
     } catch (error: unknown) {
       this.rethrowIntegrationError(error, () => new PayloadValidationError('Unable to construct Push API request body'))
+    }
+  }
+
+  private getFcmNotificationOverrides(badgeAmount: number) {
+    // FCM V1 format
+    if (this.payload.googleApiVersion === 'v1') {
+      return {
+        android: {
+          mutable_content: true,
+          notification: {
+            badge: badgeAmount
+          }
+        }
+      }
+    }
+    // FCM legacy format
+    return {
+      mutable_content: true,
+      notification: {
+        badge: badgeAmount
+      }
     }
   }
 

--- a/packages/destination-actions/src/destinations/engage/twilio/sendMobilePush/actionDefinition.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/sendMobilePush/actionDefinition.ts
@@ -240,7 +240,10 @@ export const actionDefinition: ActionDefinition<Settings, Payload> = {
       description: 'Controls the notification payload format',
       type: 'string',
       required: false,
-      choices: ['legacy', 'v1'],
+      choices: [
+        { label: 'legacy', value: 'legacy' },
+        { label: 'v1', value: 'v1' }
+      ],
       default: 'legacy'
     }
   },

--- a/packages/destination-actions/src/destinations/engage/twilio/sendMobilePush/actionDefinition.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/sendMobilePush/actionDefinition.ts
@@ -234,6 +234,14 @@ export const actionDefinition: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.timestamp'
       }
+    },
+    googleApiVersion: {
+      label: 'Google Api Version',
+      description: 'Controls the notification payload format',
+      type: 'string',
+      required: false,
+      choices: ['legacy', 'v1'],
+      default: 'legacy'
     }
   },
   perform: async (request, data) => {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

[Channels-1034](https://segment.atlassian.net/browse/CHANNELS-1034) - This PR sets google API version for Push

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
