### PR TITLE
Schematic destination - updates to trackEvent

### DIFF
--- a/packages/destination-actions/src/destinations/schematic/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/schematic/trackEvent/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * Name of event
+   * Name of event (this will be snake cased in request)
    */
   event_name: string
   /**
@@ -25,6 +25,10 @@ export interface Payload {
    * Additional properties to send with event
    */
   traits?: {
+    /**
+     * Event name
+     */
+    raw_event_name?: string
     [k: string]: unknown
   }
 }

--- a/packages/destination-actions/src/destinations/schematic/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/schematic/trackEvent/index.ts
@@ -2,7 +2,7 @@ import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
-function snakeCase(str) {
+function snakeCase(str: string) {
   const result = str.replace(/([A-Z])/g, '$1')
   return result.split(' ').join('_').toLowerCase()
 }

--- a/packages/destination-actions/src/destinations/schematic/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/schematic/trackEvent/index.ts
@@ -2,6 +2,11 @@ import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
+function snakeCase(str) {
+  const result = str.replace(/([A-Z])/g, '$1')
+  return result.split(' ').join('_').toLowerCase()
+}
+
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track Event',
   description: 'Send track events to Schematic',
@@ -9,7 +14,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     event_name: {
       label: 'Event name',
-      description: 'Name of event',
+      description: 'Name of event (this will be snake cased in request)',
       type: 'string',
       required: true,
       default: { '@path': '$.event' }
@@ -46,7 +51,19 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'Additional properties to send with event',
       type: 'object',
       defaultObjectUI: 'keyvalue',
-      required: false
+      required: false,
+      additionalProperties: true,
+      properties: {
+        raw_event_name: {
+          label: 'Raw Event Name',
+          description: 'Event name',
+          type: 'string',
+          required: false
+        }
+      },
+      default: {
+        raw_event_name: { '@path': '$.event' }
+      }
     }
   },
 
@@ -59,7 +76,7 @@ const action: ActionDefinition<Settings, Payload> = {
           company: payload.company_keys,
           user: payload.user_keys,
           traits: payload.traits,
-          event: payload.event_name
+          event: snakeCase(payload.event_name)
         },
         event_type: 'track'
       }


### PR DESCRIPTION
@joe-ayoub-segment here's the PR with a couple more changes. These do the following (both the trackEvent):
1. Adds pre-processing to snake case event name when sending to Schematic (our system requires that the actual even name has no spaces)
2. Adds a default trait with raw event name (to preserve a reference to the raw name)

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ X ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ X ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
