### PR TITLE
Refactor ordered product event request handling

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/index.test.ts
@@ -102,7 +102,7 @@ describe('Order Completed', () => {
     const products = [
       {
         value: 10,
-        properties: { key: 'value' }
+        properties: { productKey: 'productValue' }
       }
     ]
 
@@ -129,7 +129,7 @@ describe('Order Completed', () => {
     nock(`${API_URL}`).post(`/events/`, requestBodyForEvent).reply(202, {})
 
     const requestBodyForProduct = createRequestBody(
-      products[0].properties,
+      { ...products[0].properties, ...properties },
       products[0].value,
       'Ordered Product',
       profile


### PR DESCRIPTION
This PR fixes an issue with klaviyo's ordered product event not sending top level properties.
Refactored the function to send properties of order complete event in ordered product event.

JIRA -> [STRATCONN-3590](https://segment.atlassian.net/browse/STRATCONN-3590)

## Testing

Tested locally via action tester and in staging via event tester.

#### Local testing

<img width="1792" alt="Screenshot 2024-02-19 at 6 21 01 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/639645f4-0f42-4310-b893-6e9a67f77778">

<img width="1792" alt="Screenshot 2024-02-19 at 6 21 38 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/a183b7bb-2954-431b-bbbc-32bff22c6368">

#### Stage Testing

<img width="1554" alt="Screenshot 2024-02-19 at 10 26 19 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/a898e244-2160-47d7-90ae-04c282a06dc7">

<img width="1580" alt="Screenshot 2024-02-19 at 10 26 44 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/1bc298dc-7fea-4db8-b897-16673395ef2d">


_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment


[STRATCONN-3590]: https://segment.atlassian.net/browse/STRATCONN-3590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ