### PR TITLE
[Snap CAPI v3] Add missing IDFV and app-id fields

### DIFF
--- a/packages/destination-actions/src/destinations/snap-conversions-api/_tests_/capiV3tests.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/_tests_/capiV3tests.ts
@@ -82,6 +82,7 @@ export const capiV3tests = () =>
       const { integration, event_name, event_time, user_data, custom_data, action_source, app_data } = data[0]
       const { em, ph } = user_data
       const { brands, content_category, content_ids, currency, num_items, value } = custom_data
+      const { app_id } = app_data
 
       expect(integration).toBe('segment')
       expect(event_name).toBe('PURCHASE')
@@ -92,7 +93,7 @@ export const capiV3tests = () =>
       expect(currency).toBe('USD')
       expect(value).toBe(15)
       expect(action_source).toBe('website')
-      expect(app_data).toBeUndefined()
+      expect(app_id).toBe('test123')
 
       expect(brands).toEqual(['Hasbro', 'Mattel'])
       expect(content_category).toEqual(['games', 'games'])
@@ -132,6 +133,7 @@ export const capiV3tests = () =>
         data[0]
       const { client_ip_address, client_user_agent, em, ph } = user_data
       const { currency, value } = custom_data
+      const { app_id } = app_data
 
       expect(integration).toBe('segment')
       expect(event_name).toBe('PURCHASE')
@@ -146,7 +148,7 @@ export const capiV3tests = () =>
       expect(currency).toBe('USD')
       expect(value).toBe(15)
       expect(action_source).toBe('website')
-      expect(app_data).toBeUndefined()
+      expect(app_id).toBe('test123')
     })
 
     it('should fail web event without pixel_id', async () => {
@@ -232,6 +234,7 @@ export const capiV3tests = () =>
         data[0]
       const { client_ip_address, client_user_agent, em, ph } = user_data
       const { currency, value } = custom_data
+      const { app_id } = app_data
 
       expect(integration).toBe('segment')
       expect(event_name).toBe('SAVE')
@@ -246,7 +249,7 @@ export const capiV3tests = () =>
       expect(currency).toBe('USD')
       expect(value).toBe(15)
       expect(action_source).toBe('other')
-      expect(app_data).toBeUndefined()
+      expect(app_id).toBe('test123')
     })
 
     it('should handle a mobile app event conversion type', async () => {
@@ -390,6 +393,7 @@ export const capiV3tests = () =>
         data[0]
       const { client_ip_address, client_user_agent, em, ph } = user_data
       const { currency, value } = custom_data
+      const { app_id } = app_data
 
       expect(integration).toBe('segment')
       expect(event_name).toBe('CUSTOM_EVENT_5')
@@ -404,7 +408,7 @@ export const capiV3tests = () =>
       expect(currency).toBe('USD')
       expect(value).toBe(15)
       expect(action_source).toBe('app')
-      expect(app_data).toBeUndefined()
+      expect(app_id).toBe('123')
     })
 
     it('should fail event missing all Snap identifiers', async () => {

--- a/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-v3.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-v3.ts
@@ -70,7 +70,8 @@ export const formatPayload = (payload: Payload, settings: Settings, isTest = tru
           num_items: payload.number_items
         }
 
-  const extInfoVersion = iosAppIDRegex.test((settings.app_id ?? '').trim()) ? 'i2' : 'a2'
+  const { app_id } = settings
+  const extInfoVersion = iosAppIDRegex.test((app_id ?? '').trim()) ? 'i2' : 'a2'
 
   const result = {
     data: [
@@ -87,8 +88,8 @@ export const formatPayload = (payload: Payload, settings: Settings, isTest = tru
           client_ip_address: payload.ip_address,
           client_user_agent: payload.user_agent,
           em: box(email),
+          idfv: payload.idfv,
           madid,
-
           ph: box(phone_number),
           sc_click_id: payload.click_id,
           sc_cookie1: payload.uuid_c1
@@ -107,9 +108,10 @@ export const formatPayload = (payload: Payload, settings: Settings, isTest = tru
 
         action_source,
 
-        app_data: !isNullOrUndefined(payload.os_version ?? payload.device_model)
-          ? {
-              extinfo: [
+        app_data: emptyObjectToUndefined({
+          app_id,
+          extinfo: !isNullOrUndefined(payload.os_version ?? payload.device_model)
+            ? [
                 extInfoVersion, // required per spec version must be a2 for Android, must be i2 for iOS
                 '', // app package name
                 '', // short version
@@ -127,8 +129,8 @@ export const formatPayload = (payload: Payload, settings: Settings, isTest = tru
                 '', // freespace in external storage size
                 '' // device time zone
               ]
-            }
-          : undefined
+            : undefined
+        })
       }
     ],
     ...(isTest ? { test_event_code: 'segment_test' } : {})


### PR DESCRIPTION
This PR adds support for passing IDFV and app_id to the SNAPv3 CAPI endpoint. These fields were not previously supported. This only impacts the v3 implementation

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
