### PR TITLE
Make InputFieldJSONSchema.properties work with specialized types

### DIFF
--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -132,7 +132,7 @@ export interface InputFieldJSONSchema {
    * Note: this part of the schema is not persisted outside the code
    * but is used for validation and typedefs
    */
-  properties?: Record<string, Optional<InputField, 'description'>>
+  properties?: Record<string, Optional<this, 'description'>>
   /**
    * Format option to specify more nuanced 'string' types
    * @see {@link https://github.com/ajv-validator/ajv/tree/v6#formats}


### PR DESCRIPTION
`InputFieldJSONSchema` is a base type that can be specialized. E.g. `InputField` specializes it.

However, in the base type, `properties` is defined in terms of a specialized type.

This makes it hard to correctly type `properties`. For example, specializing `InputField` with, say, `EditableInputField` means that `properties` would be defined in terms of `InputField`, not `EditableInputField`.

Instead, we can use TypeScript's [polymorphic this type] to define `properties`.

[polymorphic this type]: https://stackoverflow.com/a/67307495

## Testing

Let's define some sample input field arrays to demonstrate:

```
const xs: InputFieldJSONSchema[] = [
  {
    label: 'l',
    type: 'string',
    description: 'd',
    properties: {
      a: {
        label: 'a',
      }
    },
  }
];

const ys: InputField[] = [
  {
    label: 'l',
    type: 'string',
    description: 'd',
    properties: {
      a: {
        label: 'a',
      }
    },
  }
];
```

Compare how TS sees these two arrays of input fields.

**Old code**

TS only understands that `properties` is a map of `InputField`, which makes sense because it's hard coded.

For `xs`:

<img width="848" alt="image" src="https://github.com/segmentio/action-destinations/assets/626664/7b99496c-4bfc-4b09-b438-37d876b11a6b">

And `ys`:

<img width="790" alt="image" src="https://github.com/segmentio/action-destinations/assets/626664/ca159f8f-8add-4e99-bbea-68c58b42cdda">

**New code**

TS uses the specialized type for the `properties` map.

For `xs`:

<img width="794" alt="image" src="https://github.com/segmentio/action-destinations/assets/626664/0cec1a97-04de-4e5f-903e-f46dda250ee4">

For `ys`:

<img width="789" alt="image" src="https://github.com/segmentio/action-destinations/assets/626664/78fe18cc-3511-491b-a147-3f3d118ec846">

Add a new specialized type `EditableInputField`:

```
interface EditableInputField extends InputField {
  value: FieldValue;
}
```

And a test array for this:

```
const zs: EditableInputField[] = [
  {
    label: 'l',
    type: 'string',
    description: 'd',
    value: {
      '@path': '$.l'
    },
    properties: {
      a: {
        label: 'a',
      }
    },
  }
];
```

And we can see that TS also correctly understands that `properties` is now this specialized type:

<img width="798" alt="image" src="https://github.com/segmentio/action-destinations/assets/626664/291a0752-98ea-46ef-a252-4cabd3e78dab">

