### PR TITLE
[github] Adds Strategic Connections team as codeowner for all packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,11 +6,11 @@
 
 # Actions common lib folder
 
-actions-shared/ @segmentio/build-experience-team
+actions-shared/ @segmentio/build-experience-team @segmentio/strategic-connections-team
 
 # AJV utils
 
-ajv-human-errors/ @segmentio/build-experience-team
+ajv-human-errors/ @segmentio/build-experience-team @segmentio/strategic-connections-team
 
 # Browser destinations
 
@@ -18,15 +18,15 @@ browser-destinations/ @segmentio/libraries-web-team @segmentio/strategic-connect
 
 # CLI private libs
 
-cli-internal/ @segmentio/build-experience-team
+cli-internal/ @segmentio/build-experience-team @segmentio/strategic-connections-team
 
 # CLI binary
 
-cli/ @segmentio/build-experience-team
+cli/ @segmentio/build-experience-team @segmentio/strategic-connections-team
 
 # Core actions runtime
 
-core/ @segmentio/build-experience-team
+core/ @segmentio/build-experience-team @segmentio/strategic-connections-team
 
 # Destination definitions and their actions
 
@@ -34,4 +34,4 @@ destination-actions/ @segmentio/strategic-connections-team @segmentio/build-expe
 
 # Utilities for event payload validation against an action's subscription AST.
 
-destination-subscriptions/ @segmentio/build-experience-team
+destination-subscriptions/ @segmentio/build-experience-team @segmentio/strategic-connections-team


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR adds the strategic connections team as a codeowner on all repos. This will allow the team to approve core/cli/etc changes without requiring the Build Experience team to take a look.

## Testing

Not required, github config change

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
