### PR TITLE
[STRATCONN-3575] Updates salesforce enable_batch field to reflect accurate batch sizes

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   operation: string
   /**
-   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
   enable_batching?: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   recordMatcherOperator?: string
   /**
-   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
   enable_batching?: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   recordMatcherOperator?: string
   /**
-   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
   enable_batching?: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   recordMatcherOperator?: string
   /**
-   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
   enable_batching?: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   recordMatcherOperator?: string
   /**
-   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
   enable_batching?: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   recordMatcherOperator?: string
   /**
-   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
    */
   enable_batching?: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -18,7 +18,7 @@ export const operation: InputField = {
 export const enable_batching: InputField = {
   label: 'Use Salesforce Bulk API',
   description:
-    'If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 1000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.',
+    'If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.',
   type: 'boolean',
   default: false
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This ticket corrects a minor documentation error in the Salesforce `enable_batch` field. 
https://segment.atlassian.net/browse/STRATCONN-3575
## Testing
Testing not required since this is a docs update.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
