### PR TITLE
Enhance @replace directive

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/actions-core",
   "description": "Core runtime for Destinations Actions.",
-  "version": "3.100.0-staging.0",
+  "version": "3.100.0-staging.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/fab-5-engine",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/actions-core",
   "description": "Core runtime for Destinations Actions.",
-  "version": "3.99.0",
+  "version": "3.100.0-staging.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/fab-5-engine",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/actions-core",
   "description": "Core runtime for Destinations Actions.",
-  "version": "3.100.0-staging.1",
+  "version": "3.99.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/fab-5-engine",

--- a/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
@@ -803,6 +803,42 @@ describe('@replace', () => {
     )
     expect(output).toStrictEqual('granted')
   })
+  test('replace 2 values', () => {
+    const payload = {
+      a: 'something-great!'
+    }
+    const output = transform(
+      {
+        '@replace': {
+          pattern: '-',
+          replacement: ' ',
+          pattern2: 'great',
+          replacement2: 'awesome',
+          value: { '@path': '$.a' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual('something awesome!')
+  })
+  test('replace with 2 values but only second one exists', () => {
+    const payload = {
+      a: false
+    }
+    const output = transform(
+      {
+        '@replace': {
+          pattern: 'true',
+          replacement: 'granted',
+          pattern2: 'false',
+          replacement2: 'denied',
+          value: { '@path': '$.a' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual('denied')
+  })
 })
 
 describe('remove undefined values in objects', () => {

--- a/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
@@ -771,6 +771,38 @@ describe('@replace', () => {
     )
     expect(output).toStrictEqual('different+things')
   })
+  test('replace boolean', () => {
+    const payload = {
+      a: true
+    }
+    const output = transform(
+      {
+        '@replace': {
+          pattern: 'true',
+          replacement: 'granted',
+          value: { '@path': '$.a' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual('granted')
+  })
+  test('replace number', () => {
+    const payload = {
+      a: 1
+    }
+    const output = transform(
+      {
+        '@replace': {
+          pattern: '1',
+          replacement: 'granted',
+          value: { '@path': '$.a' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual('granted')
+  })
 })
 
 describe('remove undefined values in objects', () => {

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -102,6 +102,23 @@ registerDirective('@case', (opts, payload) => {
 
 export const MAX_PATTERN_LENGTH = 10
 export const MAX_REPLACEMENT_LENGTH = 10
+
+function performReplace(value: string, pattern: string, replacement: string, flags: string) {
+  if (pattern.length > MAX_PATTERN_LENGTH) {
+    throw new Error(`@replace requires a "pattern" less than ${MAX_PATTERN_LENGTH} characters`)
+  }
+
+  if (replacement.length > MAX_REPLACEMENT_LENGTH) {
+    throw new Error(`@replace requires a "replacement" less than ${MAX_REPLACEMENT_LENGTH} characters`)
+  }
+
+  // We don't want users providing regular expressions for the pattern (for now)
+  // https://stackoverflow.com/questions/F3115150/how-to-escape-regular-expression-special-characters-using-javascript
+  pattern = pattern.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
+
+  return value.replace(new RegExp(pattern, flags), replacement)
+}
+
 registerDirective('@replace', (opts, payload) => {
   if (!isObject(opts)) {
     throw new Error('@replace requires an object with a "pattern" key')
@@ -117,6 +134,12 @@ registerDirective('@replace', (opts, payload) => {
     opts.replacement = ''
   }
 
+  // Assume null/missing replacement means empty for pattern2 if exists
+  if (opts.pattern2 && opts.replacement2 == null) {
+    // Empty replacement string is ok
+    opts.replacement2 = ''
+  }
+
   // case sensitive by default if this key is missing
   if (opts.ignorecase == null) {
     opts.ignorecase = false
@@ -127,12 +150,13 @@ registerDirective('@replace', (opts, payload) => {
     opts.global = true
   }
 
-  let pattern = opts.pattern
+  const pattern = opts.pattern
   const replacement = opts.replacement
   const ignorecase = opts.ignorecase
   const isGlobal = opts.global
   if (opts.value) {
     let value = resolve(opts.value, payload)
+    let new_value = ''
 
     // We want to be able to replace values that are boolean or numbers
     if (typeof value === 'boolean' || typeof value === 'number') {
@@ -146,17 +170,6 @@ registerDirective('@replace', (opts, payload) => {
       typeof ignorecase === 'boolean' &&
       typeof isGlobal === 'boolean'
     ) {
-      if (pattern.length > MAX_PATTERN_LENGTH) {
-        throw new Error(`@replace requires a "pattern" less than ${MAX_PATTERN_LENGTH} characters`)
-      }
-
-      if (replacement.length > MAX_REPLACEMENT_LENGTH) {
-        throw new Error(`@replace requires a "replacement" less than ${MAX_REPLACEMENT_LENGTH} characters`)
-      }
-
-      // We don't want users providing regular expressions for the pattern (for now)
-      // https://stackoverflow.com/questions/F3115150/how-to-escape-regular-expression-special-characters-using-javascript
-      pattern = pattern.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
       let flags = ''
       if (isGlobal) {
         flags += 'g'
@@ -164,8 +177,16 @@ registerDirective('@replace', (opts, payload) => {
       if (ignorecase) {
         flags += 'i'
       }
-      return value.replace(new RegExp(pattern, flags), replacement)
+
+      new_value = performReplace(value, pattern, replacement, flags)
+
+      // If pattern2 exists, replace the new_value with replacement2
+      if (opts.pattern2 && typeof opts.pattern2 === 'string' && typeof opts.replacement2 === 'string') {
+        new_value = performReplace(new_value, opts.pattern2, opts.replacement2, flags)
+      }
     }
+
+    return new_value
   }
 })
 

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -132,7 +132,13 @@ registerDirective('@replace', (opts, payload) => {
   const ignorecase = opts.ignorecase
   const isGlobal = opts.global
   if (opts.value) {
-    const value = String(resolve(opts.value, payload))
+    let value = resolve(opts.value, payload)
+
+    // We want to be able to replace values that are boolean or numbers
+    if (typeof value === 'boolean' || typeof value === 'number') {
+      value = String(value)
+    }
+
     if (
       typeof value === 'string' &&
       typeof pattern === 'string' &&

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -132,7 +132,7 @@ registerDirective('@replace', (opts, payload) => {
   const ignorecase = opts.ignorecase
   const isGlobal = opts.global
   if (opts.value) {
-    const value = resolve(opts.value, payload)
+    const value = String(resolve(opts.value, payload))
     if (
       typeof value === 'string' &&
       typeof pattern === 'string' &&

--- a/packages/core/src/mapping-kit/value-keys.ts
+++ b/packages/core/src/mapping-kit/value-keys.ts
@@ -110,6 +110,8 @@ export interface ReplaceDirective extends DirectiveMetadata {
     ignorecase: PrimitiveValue
     pattern: string
     replacement: string
+    pattern2: string
+    replacement2: string
     value?: FieldValue
   }
 }


### PR DESCRIPTION
This PR addresses [STRATCONN-3627](https://segment.atlassian.net/browse/STRATCONN-3627) to enhance the `@replace` directive to allow customers to replace 2 different patterns and also allow values that are of `number` or `boolean` type. 

App PR: https://github.com/segmentio/app/pull/19728


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment (See [app PR](https://github.com/segmentio/app/pull/19728) for details)
