### PR TITLE
Add error handling in get Audience

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { IntegrationError, createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { APIError, IntegrationError, createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Definition from '../index'
 
 const testDestination = createTestIntegration(Definition)
@@ -116,7 +116,7 @@ describe('Klaviyo (actions)', () => {
       })
     })
 
-    it('should throw an IntegrationError when the response is not ok', async () => {
+    it('should throw an ApiError when the response is not ok', async () => {
       const errorMessage = 'List not found'
       nock(`${API_URL}/lists`)
         .get(`/${listId}`)
@@ -130,9 +130,9 @@ describe('Klaviyo (actions)', () => {
         })
 
       const audiencePromise = testDestination.getAudience(getAudienceInput)
-      await expect(audiencePromise).rejects.toThrow(IntegrationError)
+      await expect(audiencePromise).rejects.toThrow(APIError)
       await expect(audiencePromise).rejects.toHaveProperty('message', errorMessage)
-      await expect(audiencePromise).rejects.toHaveProperty('code', 'INVALID_REQUEST_DATA')
+      await expect(audiencePromise).rejects.toHaveProperty('status', 404)
     })
   })
 })

--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/index.test.ts
@@ -115,5 +115,24 @@ describe('Klaviyo (actions)', () => {
         externalId: 'XYZABC'
       })
     })
+
+    it('should throw an IntegrationError when the response is not ok', async () => {
+      const errorMessage = 'List not found'
+      nock(`${API_URL}/lists`)
+        .get(`/${listId}`)
+        .reply(404, {
+          success: false,
+          errors: [
+            {
+              detail: errorMessage
+            }
+          ]
+        })
+
+      const audiencePromise = testDestination.getAudience(getAudienceInput)
+      await expect(audiencePromise).rejects.toThrow(IntegrationError)
+      await expect(audiencePromise).rejects.toHaveProperty('message', errorMessage)
+      await expect(audiencePromise).rejects.toHaveProperty('code', 'INVALID_REQUEST_DATA')
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/klaviyo/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/index.ts
@@ -89,8 +89,16 @@ const destination: AudienceDestinationDefinition<Settings> = {
       const apiKey = getAudienceInput.settings.api_key
       const response = await request(`${API_URL}/lists/${listId}`, {
         method: 'GET',
-        headers: buildHeaders(apiKey)
+        headers: buildHeaders(apiKey),
+        throwHttpErrors: false
       })
+
+      if (!response.ok) {
+        const errorResponse = await response.json()
+        const klaviyoErrorDetail = errorResponse.errors[0].detail
+        throw new IntegrationError(klaviyoErrorDetail, 'INVALID_REQUEST_DATA', response.status)
+      }
+
       const r = await response.json()
       const externalId = r.data.id
 

--- a/packages/destination-actions/src/destinations/klaviyo/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/index.ts
@@ -1,4 +1,9 @@
-import { IntegrationError, AudienceDestinationDefinition, PayloadValidationError } from '@segment/actions-core'
+import {
+  IntegrationError,
+  AudienceDestinationDefinition,
+  PayloadValidationError,
+  APIError
+} from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
 import { API_URL } from './config'
@@ -96,7 +101,7 @@ const destination: AudienceDestinationDefinition<Settings> = {
       if (!response.ok) {
         const errorResponse = await response.json()
         const klaviyoErrorDetail = errorResponse.errors[0].detail
-        throw new IntegrationError(klaviyoErrorDetail, 'INVALID_REQUEST_DATA', response.status)
+        throw new APIError(klaviyoErrorDetail, response.status)
       }
 
       const r = await response.json()


### PR DESCRIPTION
This PR adds error handling in get audience because we were receiving Internal server errors in our audience sync in case of failures.
The changes will allow us to understand cause of failures

JIRA -> [STRATCONN-3576](https://segment.atlassian.net/browse/STRATCONN-3576)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

#### Stage Testing
Tested via retool.
<img width="1792" alt="Screenshot 2024-03-08 at 3 28 03 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/f7093e05-4227-4026-8403-95d893714e4a">


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
