### PR TITLE
[Label workflow] - Changes trigger from pull_request to pull_request_target

### DIFF
--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -3,7 +3,8 @@
 
 name: Label PRs
 on:
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 jobs:
   pr-labeler:


### PR DESCRIPTION
This PR updates the label workflow to trigger on pull_request_target event instead of pull_request_event event. 
This should help fix the github-secret problem we are facing with label workflows for PRs from forks.

More info [here](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks).

## Testing

Not applicable.
- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
