### PR TITLE
Add more Fullstory settings

### DIFF
--- a/packages/browser-destinations/destinations/fullstory/src/index.ts
+++ b/packages/browser-destinations/destinations/fullstory/src/index.ts
@@ -88,6 +88,13 @@ export const destination: BrowserDestinationDefinition<Settings, FS> = {
       required: false,
       default: false
     },
+    appHost: {
+      description: "Use this to set the app host for displaying session urls.",
+      label: 'App Host',
+      type: 'string',
+      required: false,
+      default: 'app.fullstory.com'
+    },
     debug: {
       description: 'Enables FullStory debug mode.',
       label: 'Debug mode',

--- a/packages/browser-destinations/destinations/fullstory/src/index.ts
+++ b/packages/browser-destinations/destinations/fullstory/src/index.ts
@@ -53,9 +53,29 @@ export const destination: BrowserDestinationDefinition<Settings, FS> = {
       type: 'string',
       required: true
     },
-    debug: {
-      description: 'Enables FullStory debug mode.',
-      label: 'Debug mode',
+    host: {
+      description: 'The recording server host domain.',
+      label: 'Host',
+      type: 'string',
+      required: false,
+      default: 'fullstory.com'
+    },
+    script: {
+      description: 'FullStory script host domain.',
+      label: 'Script',
+      type: 'string',
+      required: false,
+      default: 'edge.fullstory.com'
+    },
+    cookieDomain: {
+      description: 'Overrides the cookie domain.',
+      label: 'Cookie Domain',
+      type: 'string',
+      required: false
+    },
+    recordCrossDomainIFrames: {
+      description: 'Allows recording cross-domain iFrames.',
+      label: 'Cookie Domain',
       type: 'boolean',
       required: false,
       default: false
@@ -63,6 +83,20 @@ export const destination: BrowserDestinationDefinition<Settings, FS> = {
     recordOnlyThisIFrame: {
       description: 'Enables FullStory inside an iframe.',
       label: 'Capture only this iFrame',
+      type: 'boolean',
+      required: false,
+      default: false
+    },
+    startCaptureManually: {
+      description: "Allow starting Fullstory capture using FS('start').",
+      label: 'Start capture manually',
+      type: 'boolean',
+      required: false,
+      default: false
+    },
+    debug: {
+      description: 'Enables FullStory debug mode.',
+      label: 'Debug mode',
       type: 'boolean',
       required: false,
       default: false

--- a/packages/browser-destinations/destinations/fullstory/src/index.ts
+++ b/packages/browser-destinations/destinations/fullstory/src/index.ts
@@ -67,12 +67,6 @@ export const destination: BrowserDestinationDefinition<Settings, FS> = {
       required: false,
       default: 'edge.fullstory.com'
     },
-    cookieDomain: {
-      description: 'Overrides the cookie domain.',
-      label: 'Cookie Domain',
-      type: 'string',
-      required: false
-    },
     recordCrossDomainIFrames: {
       description: 'Allows recording cross-domain iFrames.',
       label: 'Cookie Domain',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Adds other Fullstory settings for configuring the `fullstory-browser-sdk` to allow for custom domain specification and other features supported by the SDK.
https://github.com/fullstorydev/fullstory-browser-sdk?tab=readme-ov-file#initialize-the-sdk
https://help.fullstory.com/hc/en-us/articles/18612999473175-How-to-send-captured-traffic-to-FullStory-using-Custom-Endpoints

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
