### PR TITLE
Update request based on latest data contract

### DIFF
--- a/packages/destination-actions/src/destinations/stackadapt/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/__tests__/index.test.ts
@@ -39,6 +39,16 @@ const expectedProduct = {
   product_name: mockProduct.name
 }
 
+const defaultExpectedConversionArgs = {
+  action: 'Test Event',
+  utm_source: mockUtmSource,
+  user_id: mockUserId,
+  first_name: mockFirstName,
+  last_name: mockLastName,
+  email: mockEmail,
+  phone: mockPhone
+}
+
 const defaultExpectedParams = {
   segment_ss: '1',
   event_type: 'identify',
@@ -46,14 +56,9 @@ const defaultExpectedParams = {
   url: mockPageUrl,
   ref: mockReferrer,
   ip_fwd: mockIpAddress,
-  utm_source: mockUtmSource,
-  user_id: mockUserId,
-  first_name: mockFirstName,
-  last_name: mockLastName,
-  email: mockEmail,
-  phone: mockPhone,
+  ua_fwd: mockUserAgent,
   uid: mockPixelId,
-  args: `{"action":"Test Event"}`
+  args: JSON.stringify(defaultExpectedConversionArgs)
 }
 
 const defaultEventPayload: Partial<SegmentEvent> = {
@@ -162,6 +167,7 @@ describe('StackAdapt', () => {
       const requestParams = Object.fromEntries(new URL(responses[0].request.url).searchParams)
       expect(requestParams).toEqual(expectedParams)
       expect(JSON.parse(requestParams.args)).toEqual({
+        ...defaultExpectedConversionArgs,
         action: mockSingleProductAction,
         revenue: mockRevenue,
         order_id: mockOrderId,
@@ -202,6 +208,7 @@ describe('StackAdapt', () => {
       const requestParams = Object.fromEntries(new URL(responses[0].request.url).searchParams)
       expect(requestParams).toEqual(expectedParams)
       expect(JSON.parse(requestParams.args)).toEqual({
+        ...defaultExpectedConversionArgs,
         action: mockMultiProductAction,
         revenue: mockRevenue,
         order_id: mockOrderId,

--- a/packages/destination-actions/src/destinations/stackadapt/forwardEvent/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/forwardEvent/index.ts
@@ -252,9 +252,15 @@ const action: ActionDefinition<Settings, Payload> = {
 }
 
 function getAvailableData(payload: Payload, settings: Settings) {
-  const ecommerceData = {
+  const conversionArgs = {
     ...payload.ecommerce_data,
-    ...(!isEmpty(payload.ecommerce_products) && { products: payload.ecommerce_products })
+    ...(!isEmpty(payload.ecommerce_products) && { products: payload.ecommerce_products }),
+    utm_source: payload.utm_source ?? '',
+    user_id: payload.user_id,
+    first_name: payload.first_name,
+    last_name: payload.last_name,
+    email: payload.email,
+    phone: payload.phone
   }
   return {
     segment_ss: '1',
@@ -263,14 +269,9 @@ function getAvailableData(payload: Payload, settings: Settings) {
     url: payload.url ?? '',
     ref: payload.referrer ?? '',
     ip_fwd: payload.ip_fwd ?? '',
-    utm_source: payload.utm_source ?? '',
-    user_id: payload.user_id,
+    ua_fwd: payload.user_agent ?? '',
     uid: settings.pixelId,
-    first_name: payload.first_name ?? '',
-    last_name: payload.last_name ?? '',
-    email: payload.email ?? '',
-    phone: payload.phone ?? '',
-    ...(!isEmpty(ecommerceData) && { args: JSON.stringify(ecommerceData) })
+    ...(!isEmpty(conversionArgs) && { args: JSON.stringify(conversionArgs) })
   }
 }
 


### PR DESCRIPTION
After testing our Segment destination and reviewing our use cases, we have made changes to our backend server which change the data contract between the destination:

- Added `ua_fwd` URL parameter which is populated with the user agent string.
- Moved PII fields to the the `args` parameter.

## Testing

- Modified existing unit tests based on the new data contract
- Manually tested that expected parameters are sent to our backend server

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
