### PR TITLE
[GA4 Web] Page View defaults

### DIFF
--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/setConfigurationFields.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/setConfigurationFields.test.ts
@@ -642,7 +642,7 @@ describe('Set Configuration Fields action', () => {
     expect(mockGtag).toHaveBeenCalledWith('config', 'G-XXXXXXXXXX', {
       allow_ad_personalization_signals: false,
       allow_google_signals: false,
-      send_page_view: false
+      send_page_view: true
     })
   })
 

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/setConfigurationFields.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/setConfigurationFields.test.ts
@@ -475,7 +475,7 @@ describe('Set Configuration Fields action', () => {
     })
   })
 
-  it('pageView is true and pageView is true -> nothing', async () => {
+  it('pageView is true and send_page_view is true -> nothing', async () => {
     const settings = {
       ...defaultSettings,
       pageView: true
@@ -584,7 +584,7 @@ describe('Set Configuration Fields action', () => {
     expect(mockGtag).toHaveBeenCalledWith('config', 'G-XXXXXXXXXX', {
       allow_ad_personalization_signals: false,
       allow_google_signals: false,
-      send_page_view: false
+      send_page_view: true
     })
   })
 
@@ -617,7 +617,7 @@ describe('Set Configuration Fields action', () => {
     })
   })
 
-  it('pageView is false and send_page_view is true -> true', async () => {
+  it('pageView is false and send_page_view is undefined -> false', async () => {
     const settings = {
       ...defaultSettings,
       pageView: false
@@ -642,7 +642,7 @@ describe('Set Configuration Fields action', () => {
     expect(mockGtag).toHaveBeenCalledWith('config', 'G-XXXXXXXXXX', {
       allow_ad_personalization_signals: false,
       allow_google_signals: false,
-      send_page_view: true
+      send_page_view: false
     })
   })
 

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/setConfigurationFields.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/setConfigurationFields.test.ts
@@ -524,7 +524,7 @@ describe('Set Configuration Fields action', () => {
     expect(mockGtag).toHaveBeenCalledWith('config', 'G-XXXXXXXXXX', {
       allow_ad_personalization_signals: false,
       allow_google_signals: false,
-      send_page_view: true
+      send_page_view: false
     })
   })
   it('should update config if payload has send_page_view is undefined', async () => {
@@ -543,7 +543,9 @@ describe('Set Configuration Fields action', () => {
     const context = new Context({
       event: 'setConfigurationFields',
       type: 'page',
-      properties: {}
+      properties: {
+        send_page_view: undefined
+      }
     })
 
     setConfigurationEvent.page?.(context)
@@ -551,6 +553,35 @@ describe('Set Configuration Fields action', () => {
       allow_ad_personalization_signals: false,
       allow_google_signals: false,
       send_page_view: true
+    })
+  })
+
+  it('should fallback to settings.pageView send_page_view is undefined', async () => {
+    const settings = {
+      ...defaultSettings,
+      pageView: false
+    }
+
+    const [setConfigurationEventPlugin] = await googleAnalytics4Web({
+      ...settings,
+      subscriptions
+    })
+    setConfigurationEvent = setConfigurationEventPlugin
+    await setConfigurationEventPlugin.load(Context.system(), {} as Analytics)
+
+    const context = new Context({
+      event: 'setConfigurationFields',
+      type: 'page',
+      properties: {
+        send_page_view: undefined
+      }
+    })
+
+    setConfigurationEvent.page?.(context)
+    expect(mockGtag).toHaveBeenCalledWith('config', 'G-XXXXXXXXXX', {
+      allow_ad_personalization_signals: false,
+      allow_google_signals: false,
+      send_page_view: false
     })
   })
 

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/setConfigurationFields.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/setConfigurationFields.test.ts
@@ -475,7 +475,7 @@ describe('Set Configuration Fields action', () => {
     })
   })
 
-  it('should update config if payload has send_page_view is true', async () => {
+  it('pageView is true and pageView is true -> nothing', async () => {
     const settings = {
       ...defaultSettings,
       pageView: true
@@ -491,7 +491,64 @@ describe('Set Configuration Fields action', () => {
     const context = new Context({
       event: 'setConfigurationFields',
       type: 'page',
-      properties: {}
+      properties: {
+        send_page_view: true
+      }
+    })
+
+    setConfigurationEvent.page?.(context)
+    expect(mockGtag).toHaveBeenCalledWith('config', 'G-XXXXXXXXXX', {
+      allow_ad_personalization_signals: false,
+      allow_google_signals: false
+    })
+  })
+  it('pageView is true and send_page_view is false -> false', async () => {
+    const settings = {
+      ...defaultSettings,
+      pageView: true
+    }
+
+    const [setConfigurationEventPlugin] = await googleAnalytics4Web({
+      ...settings,
+      subscriptions
+    })
+    setConfigurationEvent = setConfigurationEventPlugin
+    await setConfigurationEventPlugin.load(Context.system(), {} as Analytics)
+
+    const context = new Context({
+      event: 'setConfigurationFields',
+      type: 'page',
+      properties: {
+        send_page_view: false
+      }
+    })
+
+    setConfigurationEvent.page?.(context)
+    expect(mockGtag).toHaveBeenCalledWith('config', 'G-XXXXXXXXXX', {
+      allow_ad_personalization_signals: false,
+      allow_google_signals: false,
+      send_page_view: false
+    })
+  })
+  it('pageView is true and send_page_view is undefined -> true', async () => {
+    const settings = {
+      ...defaultSettings,
+      pageView: true
+    }
+
+    const [setConfigurationEventPlugin] = await googleAnalytics4Web({
+      ...settings,
+      subscriptions
+    })
+    setConfigurationEvent = setConfigurationEventPlugin
+    await setConfigurationEventPlugin.load(Context.system(), {} as Analytics)
+
+    const context = new Context({
+      event: 'setConfigurationFields',
+      type: 'page',
+      properties: {
+        send_page_view: undefined
+      }
     })
 
     setConfigurationEvent.page?.(context)
@@ -501,7 +558,8 @@ describe('Set Configuration Fields action', () => {
       send_page_view: true
     })
   })
-  it('should update config if payload has send_page_view is false', async () => {
+
+  it('pageView is false and send_page_view is true -> true', async () => {
     const settings = {
       ...defaultSettings,
       pageView: false
@@ -517,7 +575,9 @@ describe('Set Configuration Fields action', () => {
     const context = new Context({
       event: 'setConfigurationFields',
       type: 'page',
-      properties: {}
+      properties: {
+        send_page_view: true
+      }
     })
 
     setConfigurationEvent.page?.(context)
@@ -527,7 +587,66 @@ describe('Set Configuration Fields action', () => {
       send_page_view: false
     })
   })
-  it('should update config if payload has send_page_view is undefined', async () => {
+
+  it('pageView is false and send_page_view is false -> false', async () => {
+    const settings = {
+      ...defaultSettings,
+      pageView: false
+    }
+
+    const [setConfigurationEventPlugin] = await googleAnalytics4Web({
+      ...settings,
+      subscriptions
+    })
+    setConfigurationEvent = setConfigurationEventPlugin
+    await setConfigurationEventPlugin.load(Context.system(), {} as Analytics)
+
+    const context = new Context({
+      event: 'setConfigurationFields',
+      type: 'page',
+      properties: {
+        send_page_view: false
+      }
+    })
+
+    setConfigurationEvent.page?.(context)
+    expect(mockGtag).toHaveBeenCalledWith('config', 'G-XXXXXXXXXX', {
+      allow_ad_personalization_signals: false,
+      allow_google_signals: false,
+      send_page_view: false
+    })
+  })
+
+  it('pageView is false and send_page_view is true -> true', async () => {
+    const settings = {
+      ...defaultSettings,
+      pageView: false
+    }
+
+    const [setConfigurationEventPlugin] = await googleAnalytics4Web({
+      ...settings,
+      subscriptions
+    })
+    setConfigurationEvent = setConfigurationEventPlugin
+    await setConfigurationEventPlugin.load(Context.system(), {} as Analytics)
+
+    const context = new Context({
+      event: 'setConfigurationFields',
+      type: 'page',
+      properties: {
+        send_page_view: undefined
+      }
+    })
+
+    setConfigurationEvent.page?.(context)
+    expect(mockGtag).toHaveBeenCalledWith('config', 'G-XXXXXXXXXX', {
+      allow_ad_personalization_signals: false,
+      allow_google_signals: false,
+      send_page_view: false
+    })
+  })
+
+  it('pageView is undefined and send_page_view is undefined -> true', async () => {
     const settings = {
       ...defaultSettings,
       pageView: undefined
@@ -553,35 +672,6 @@ describe('Set Configuration Fields action', () => {
       allow_ad_personalization_signals: false,
       allow_google_signals: false,
       send_page_view: true
-    })
-  })
-
-  it('should fallback to settings.pageView send_page_view is undefined', async () => {
-    const settings = {
-      ...defaultSettings,
-      pageView: false
-    }
-
-    const [setConfigurationEventPlugin] = await googleAnalytics4Web({
-      ...settings,
-      subscriptions
-    })
-    setConfigurationEvent = setConfigurationEventPlugin
-    await setConfigurationEventPlugin.load(Context.system(), {} as Analytics)
-
-    const context = new Context({
-      event: 'setConfigurationFields',
-      type: 'page',
-      properties: {
-        send_page_view: undefined
-      }
-    })
-
-    setConfigurationEvent.page?.(context)
-    expect(mockGtag).toHaveBeenCalledWith('config', 'G-XXXXXXXXXX', {
-      allow_ad_personalization_signals: false,
-      allow_google_signals: false,
-      send_page_view: false
     })
   })
 

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/setConfigurationFields/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/setConfigurationFields/generated-types.ts
@@ -76,7 +76,7 @@ export interface Payload {
    */
   screen_resolution?: string
   /**
-   * Set to false to prevent sending a page_view.
+   * Selection overrides toggled value set within Settings
    */
   send_page_view?: boolean
   /**

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/setConfigurationFields/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/setConfigurationFields/index.ts
@@ -117,7 +117,7 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
       type: 'string'
     },
     send_page_view: {
-      description: 'Set to false to prevent sending a page_view.',
+      description: 'Selection overrides toggled value set within Settings',
       label: 'Send Page Views',
       type: 'boolean',
       choices: [
@@ -176,11 +176,8 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     if (checkCookiePathDefaultValue) {
       config.cookie_path = settings.cookiePath
     }
-    if (settings.pageView != true) {
-      config.send_page_view = settings.pageView ?? true
-    }
 
-    if (payload.send_page_view != true) {
+    if (payload.send_page_view != true || settings.pageView != true) {
       config.send_page_view = payload.send_page_view ?? settings.pageView ?? true
     }
     if (settings.cookieFlags) {

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/setConfigurationFields/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/setConfigurationFields/index.ts
@@ -181,7 +181,7 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
     }
 
     if (payload.send_page_view != true) {
-      config.send_page_view = payload.send_page_view ?? true
+      config.send_page_view = payload.send_page_view ?? settings.pageView ?? true
     }
     if (settings.cookieFlags) {
       config.cookie_flags = settings.cookieFlags


### PR DESCRIPTION
According to: https://github.com/segmentio/action-destinations/pull/1904#discussion_r1518239574. If `send_page_view` is undefined we should fall back to `settings.pageView` before defaulting to `true`.

Stage Tests
:white_check_mark: Test 1 - Setting true, Action Config false
Config called with send_page_view : false
:white_check_mark:Test 2 - Setting true, Action  Config undefined
Config called with send_page_view : true
:white_check_mark:Test 3- Setting true, Action Config true
 Config called no parameter marked, this is default to send page view
:white_check_mark:Test 4 - Settings false, Action  Config false
Config called with send_page_view : false
:white_check_mark:Test 5 - Settings false, Action  Config true
Config called with send_page_view : true
:white_check_mark:Test 6 - Setting false, Action Config undefined
Config called with send_page_view : false

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
