### PR TITLE
[linkedin conversions] Adds lookback window fields to hook inputs + adds new conversion type options

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/api.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/api.test.ts
@@ -13,14 +13,18 @@ describe('LinkedIn Conversions', () => {
     const hookInputs: HookBundle['onMappingSave']['inputs'] = {
       name: 'A different name that should trigger an update',
       conversionType: 'PURCHASE',
-      attribution_type: 'LAST_TOUCH_BY_CAMPAIGN'
+      attribution_type: 'LAST_TOUCH_BY_CAMPAIGN',
+      post_click_attribution_window_size: 30,
+      view_through_attribution_window_size: 7
     }
 
     const hookOutputs: HookBundle['onMappingSave']['outputs'] = {
       id: '56789',
       name: 'The original name',
       conversionType: 'LEAD',
-      attribution_type: 'LAST_TOUCH_BY_CONVERSION'
+      attribution_type: 'LAST_TOUCH_BY_CONVERSION',
+      post_click_attribution_window_size: 30,
+      view_through_attribution_window_size: 7
     }
 
     it('should update a conversion rule', async () => {
@@ -47,7 +51,9 @@ describe('LinkedIn Conversions', () => {
           id: hookOutputs.id,
           name: hookInputs.name,
           conversionType: hookInputs.conversionType,
-          attribution_type: hookInputs.attribution_type
+          attribution_type: hookInputs.attribution_type,
+          post_click_attribution_window_size: hookOutputs.post_click_attribution_window_size,
+          view_through_attribution_window_size: hookOutputs.view_through_attribution_window_size
         }
       })
     })
@@ -60,15 +66,18 @@ describe('LinkedIn Conversions', () => {
           name: hookInputs.name,
           account: adAccountId,
           conversionMethod: 'CONVERSIONS_API',
-          postClickAttributionWindowSize: 30,
-          viewThroughAttributionWindowSize: 7,
+          postClickAttributionWindowSize: hookInputs.post_click_attribution_window_size,
+          viewThroughAttributionWindowSize: hookInputs.view_through_attribution_window_size,
           attributionType: hookInputs.attribution_type,
           type: hookInputs.conversionType
         })
         .reply(201, {
           id: mockReturnedId,
           name: hookInputs.name,
-          type: hookInputs.conversionType
+          type: hookInputs.conversionType,
+          attributionType: hookInputs.attribution_type,
+          postClickAttributionWindowSize: hookInputs.post_click_attribution_window_size,
+          viewThroughAttributionWindowSize: hookInputs.view_through_attribution_window_size
         })
       const createResult = await linkedIn.createConversionRule(adAccountId, hookInputs)
 
@@ -78,7 +87,9 @@ describe('LinkedIn Conversions', () => {
           id: mockReturnedId,
           name: hookInputs.name,
           conversionType: hookInputs.conversionType,
-          attribution_type: hookInputs.attribution_type
+          attribution_type: hookInputs.attribution_type,
+          post_click_attribution_window_size: hookInputs.post_click_attribution_window_size,
+          view_through_attribution_window_size: hookInputs.view_through_attribution_window_size
         }
       })
     })
@@ -88,7 +99,9 @@ describe('LinkedIn Conversions', () => {
         id: '5678',
         name: 'Exists already',
         type: 'PURCHASE',
-        attributionType: 'LAST_TOUCH_BY_CAMPAIGN'
+        attributionType: 'LAST_TOUCH_BY_CAMPAIGN',
+        postClickAttributionWindowSize: 1,
+        viewThroughAttributionWindowSize: 1
       }
 
       nock(`${BASE_URL}`)
@@ -108,7 +121,9 @@ describe('LinkedIn Conversions', () => {
           id: existingRule.id,
           name: existingRule.name,
           conversionType: existingRule.type,
-          attribution_type: existingRule.attributionType
+          attribution_type: existingRule.attributionType,
+          post_click_attribution_window_size: existingRule.postClickAttributionWindowSize,
+          view_through_attribution_window_size: existingRule.viewThroughAttributionWindowSize
         }
       })
     })
@@ -140,7 +155,9 @@ describe('LinkedIn Conversions', () => {
           id: hookOutputs.id,
           name: hookOutputs.name,
           conversionType: hookOutputs.conversionType,
-          attribution_type: hookOutputs.attribution_type
+          attribution_type: hookOutputs.attribution_type,
+          post_click_attribution_window_size: hookOutputs.post_click_attribution_window_size,
+          view_through_attribution_window_size: hookOutputs.view_through_attribution_window_size
         }
       })
     })

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -81,8 +81,8 @@ export class LinkedInConversions {
           name: hookInputs?.name,
           account: adAccount,
           conversionMethod: 'CONVERSIONS_API',
-          postClickAttributionWindowSize: 30,
-          viewThroughAttributionWindowSize: 7,
+          postClickAttributionWindowSize: hookInputs?.post_click_attribution_window_size || 30,
+          viewThroughAttributionWindowSize: hookInputs?.view_through_attribution_window_size || 7,
           attributionType: hookInputs?.attribution_type,
           type: hookInputs?.conversionType
         }

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -1,5 +1,5 @@
 import { RequestClient, ModifiedResponse, DynamicFieldResponse, ActionHookResponse } from '@segment/actions-core'
-import { BASE_URL } from '../constants'
+import { BASE_URL, DEFAULT_POST_CLICK_LOOKBACK_WINDOW, DEFAULT_VIEW_THROUGH_LOOKBACK_WINDOW } from '../constants'
 import type {
   ProfileAPIResponse,
   GetAdAccountsAPIResponse,
@@ -56,8 +56,9 @@ export class LinkedInConversions {
           name: data.name || `No name returned for rule: ${conversionRuleId}`,
           conversionType: data.type || `No type returned for rule: ${conversionRuleId}`,
           attribution_type: data.attributionType || `No attribution type returned for rule: ${conversionRuleId}`,
-          post_click_attribution_window_size: data.postClickAttributionWindowSize || 30,
-          view_through_attribution_window_size: data.viewThroughAttributionWindowSize || 7
+          post_click_attribution_window_size: data.postClickAttributionWindowSize || DEFAULT_POST_CLICK_LOOKBACK_WINDOW,
+          view_through_attribution_window_size:
+            data.viewThroughAttributionWindowSize || DEFAULT_VIEW_THROUGH_LOOKBACK_WINDOW
         }
       }
     } catch (e) {
@@ -85,8 +86,10 @@ export class LinkedInConversions {
           name: hookInputs?.name,
           account: adAccount,
           conversionMethod: 'CONVERSIONS_API',
-          postClickAttributionWindowSize: hookInputs?.post_click_attribution_window_size || 30,
-          viewThroughAttributionWindowSize: hookInputs?.view_through_attribution_window_size || 7,
+          postClickAttributionWindowSize:
+            hookInputs?.post_click_attribution_window_size || DEFAULT_POST_CLICK_LOOKBACK_WINDOW,
+          viewThroughAttributionWindowSize:
+            hookInputs?.view_through_attribution_window_size || DEFAULT_VIEW_THROUGH_LOOKBACK_WINDOW,
           attributionType: hookInputs?.attribution_type,
           type: hookInputs?.conversionType
         }

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -18,6 +18,8 @@ interface ConversionRuleUpdateValues {
   name?: string
   type?: string
   attributionType?: string
+  postClickAttributionWindowSize?: number
+  viewThroughAttributionWindowSize?: number
 }
 
 export class LinkedInConversions {
@@ -53,7 +55,9 @@ export class LinkedInConversions {
           id: conversionRuleId,
           name: data.name || `No name returned for rule: ${conversionRuleId}`,
           conversionType: data.type || `No type returned for rule: ${conversionRuleId}`,
-          attribution_type: data.attributionType || `No attribution type returned for rule: ${conversionRuleId}`
+          attribution_type: data.attributionType || `No attribution type returned for rule: ${conversionRuleId}`,
+          post_click_attribution_window_size: data.postClickAttributionWindowSize || 30,
+          view_through_attribution_window_size: data.viewThroughAttributionWindowSize || 7
         }
       }
     } catch (e) {
@@ -94,7 +98,9 @@ export class LinkedInConversions {
           id: data.id,
           name: data.name,
           conversionType: data.type,
-          attribution_type: hookInputs?.attribution_type || 'UNKNOWN'
+          attribution_type: data.attributionType || 'UNKNOWN',
+          post_click_attribution_window_size: data.postClickAttributionWindowSize,
+          view_through_attribution_window_size: data.viewThroughAttributionWindowSize
         }
       }
     } catch (e) {
@@ -142,7 +148,9 @@ export class LinkedInConversions {
           id: hookOutputs.id,
           name: hookOutputs.name,
           conversionType: hookOutputs.conversionType,
-          attribution_type: hookOutputs.attribution_type
+          attribution_type: hookOutputs.attribution_type,
+          post_click_attribution_window_size: hookOutputs.post_click_attribution_window_size,
+          view_through_attribution_window_size: hookOutputs.view_through_attribution_window_size
         }
       }
     }
@@ -170,7 +178,11 @@ export class LinkedInConversions {
           id: hookOutputs.id,
           name: valuesChanged?.name || hookOutputs.name,
           conversionType: valuesChanged?.type || hookOutputs.conversionType,
-          attribution_type: valuesChanged?.attributionType || hookOutputs.attribution_type
+          attribution_type: valuesChanged?.attributionType || hookOutputs.attribution_type,
+          post_click_attribution_window_size:
+            valuesChanged?.postClickAttributionWindowSize || hookOutputs.post_click_attribution_window_size,
+          view_through_attribution_window_size:
+            valuesChanged?.viewThroughAttributionWindowSize || hookOutputs.view_through_attribution_window_size
         }
       }
     } catch (e) {
@@ -179,7 +191,9 @@ export class LinkedInConversions {
           id: hookOutputs.id,
           name: hookOutputs.name,
           conversionType: hookOutputs.conversionType,
-          attribution_type: hookOutputs.attribution_type
+          attribution_type: hookOutputs.attribution_type,
+          post_click_attribution_window_size: hookOutputs.post_click_attribution_window_size,
+          view_through_attribution_window_size: hookOutputs.view_through_attribution_window_size
         },
         error: {
           message: `Failed to update conversion rule: ${(e as { message: string })?.message ?? JSON.stringify(e)}`,
@@ -419,6 +433,20 @@ export class LinkedInConversions {
 
     if (hookInputs?.attribution_type && hookInputs?.attribution_type !== hookOutputs?.attribution_type) {
       valuesChanged.attributionType = hookInputs?.attribution_type
+    }
+
+    if (
+      hookInputs?.post_click_attribution_window_size &&
+      hookInputs?.post_click_attribution_window_size !== hookOutputs?.post_click_attribution_window_size
+    ) {
+      valuesChanged.postClickAttributionWindowSize = hookInputs?.post_click_attribution_window_size
+    }
+
+    if (
+      hookInputs?.view_through_attribution_window_size &&
+      hookInputs?.view_through_attribution_window_size !== hookOutputs?.view_through_attribution_window_size
+    ) {
+      valuesChanged.viewThroughAttributionWindowSize = hookInputs?.view_through_attribution_window_size
     }
 
     return valuesChanged

--- a/packages/destination-actions/src/destinations/linkedin-conversions/constants.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/constants.ts
@@ -8,3 +8,47 @@ export const SUPPORTED_ID_TYPE = [
   'ACXIOM_ID',
   'ORACLE_MOAT_ID'
 ]
+
+interface Choice {
+  value: string
+  label: string
+}
+
+export const CONVERSION_TYPE_OPTIONS: Choice[] = [
+  { label: 'Add to Cart', value: 'ADD_TO_CART' },
+  { label: 'Download', value: 'DOWNLOAD' },
+  { label: 'Install', value: 'INSTALL' },
+  { label: 'Key Page View', value: 'KEY_PAGE_VIEW' },
+  { label: 'Lead', value: 'LEAD' },
+  { label: 'Purchase', value: 'PURCHASE' },
+  { label: 'Sign Up', value: 'SIGN_UP' },
+  { label: 'Other', value: 'OTHER' },
+  { label: 'Talent Lead', value: 'TALENT_LEAD' },
+  { label: 'Job Apply', value: 'JOB_APPLY' },
+  { label: 'Save', value: 'SAVE' },
+  { label: 'Start Checkout', value: 'START_CHECKOUT' },
+  { label: 'Schedule', value: 'SCHEDULE' },
+  { label: 'View Content', value: 'VIEW_CONTENT' },
+  { label: 'View Video', value: 'VIEW_VIDEO' },
+  { label: 'Add Billing Info', value: 'ADD_BILLING_INFO' },
+  { label: 'Book Appointment', value: 'BOOK_APPOINTMENT' },
+  { label: 'Request Quote', value: 'REQUEST_QUOTE' },
+  { label: 'Search', value: 'SEARCH' },
+  { label: 'Subscribe', value: 'SUBSCRIBE' },
+  { label: 'Ad Click', value: 'AD_CLICK' },
+  { label: 'Ad View', value: 'AD_VIEW' },
+  { label: 'Complete Signup', value: 'COMPLETE_SIGNUP' },
+  { label: 'Submit Application', value: 'SUBMIT_APPLICATION' },
+  { label: 'Phone Call', value: 'PHONE_CALL' },
+  { label: 'Invite', value: 'INVITE' },
+  { label: 'Login', value: 'LOGIN' },
+  { label: 'Share', value: 'SHARE' },
+  { label: 'Donate', value: 'DONATE' },
+  { label: 'Add to List', value: 'ADD_TO_LIST' },
+  { label: 'Rate', value: 'RATE' },
+  { label: 'Start Trial', value: 'START_TRIAL' },
+  { label: 'Outbound Click', value: 'OUTBOUND_CLICK' },
+  { label: 'Contact', value: 'CONTACT' },
+  { label: 'Marketing Qualified Lead', value: 'MARKETING_QUALIFIED_LEAD' },
+  { label: 'Sales Qualified Lead', value: 'SALES_QUALIFIED_LEAD' }
+]

--- a/packages/destination-actions/src/destinations/linkedin-conversions/constants.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/constants.ts
@@ -59,3 +59,6 @@ export const SUPPORTED_LOOKBACK_WINDOW_CHOICES: Choice[] = [
   { label: '30 days', value: 30 },
   { label: '90 days', value: 90 }
 ]
+
+export const DEFAULT_POST_CLICK_LOOKBACK_WINDOW = 30
+export const DEFAULT_VIEW_THROUGH_LOOKBACK_WINDOW = 7

--- a/packages/destination-actions/src/destinations/linkedin-conversions/constants.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/constants.ts
@@ -10,7 +10,7 @@ export const SUPPORTED_ID_TYPE = [
 ]
 
 interface Choice {
-  value: string
+  value: string | number
   label: string
 }
 
@@ -51,4 +51,11 @@ export const CONVERSION_TYPE_OPTIONS: Choice[] = [
   { label: 'Contact', value: 'CONTACT' },
   { label: 'Marketing Qualified Lead', value: 'MARKETING_QUALIFIED_LEAD' },
   { label: 'Sales Qualified Lead', value: 'SALES_QUALIFIED_LEAD' }
+]
+
+export const SUPPORTED_LOOKBACK_WINDOW_CHOICES: Choice[] = [
+  { label: '1 day', value: 1 },
+  { label: '7 days', value: 7 },
+  { label: '30 days', value: 30 },
+  { label: '90 days', value: 90 }
 ]

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
@@ -101,6 +101,14 @@ export interface HookBundle {
        * The attribution type for the conversion rule.
        */
       attribution_type: string
+      /**
+       * Conversion window timeframe (in days) of a member clicking on a LinkedIn Ad (a post-click conversion) within which conversions will be attributed to a LinkedIn ad.
+       */
+      post_click_attribution_window_size: number
+      /**
+       * 	Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad.
+       */
+      view_through_attribution_window_size: number
     }
   }
 }

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
@@ -106,7 +106,7 @@ export interface HookBundle {
        */
       post_click_attribution_window_size: number
       /**
-       * 	Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad.
+       * Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 7.
        */
       view_through_attribution_window_size: number
     }

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
@@ -75,6 +75,14 @@ export interface HookBundle {
        * The attribution type for the conversion rule.
        */
       attribution_type?: string
+      /**
+       * Conversion window timeframe (in days) of a member clicking on a LinkedIn Ad (a post-click conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 30.
+       */
+      post_click_attribution_window_size?: number
+      /**
+       * 	Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 7.
+       */
+      view_through_attribution_window_size?: number
     }
     outputs?: {
       /**

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -134,7 +134,7 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
         view_through_attribution_window_size: {
           label: 'View-Through Attribution Window Size',
           description:
-            '	Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad.',
+            'Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 7.',
           type: 'number',
           required: true
         }

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -123,6 +123,20 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
           description: 'The attribution type for the conversion rule.',
           type: 'string',
           required: true
+        },
+        post_click_attribution_window_size: {
+          label: 'Post-Click Attribution Window Size',
+          description:
+            'Conversion window timeframe (in days) of a member clicking on a LinkedIn Ad (a post-click conversion) within which conversions will be attributed to a LinkedIn ad.',
+          type: 'number',
+          required: true
+        },
+        view_through_attribution_window_size: {
+          label: 'View-Through Attribution Window Size',
+          description:
+            '	Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad.',
+          type: 'number',
+          required: true
         }
       },
       performHook: async (request, { payload, hookInputs, hookOutputs }) => {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -2,7 +2,7 @@ import type { ActionDefinition } from '@segment/actions-core'
 import { ErrorCodes, IntegrationError, PayloadValidationError, InvalidAuthenticationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import { LinkedInConversions } from '../api'
-import { SUPPORTED_ID_TYPE } from '../constants'
+import { SUPPORTED_ID_TYPE, CONVERSION_TYPE_OPTIONS } from '../constants'
 import type { Payload, HookBundle } from './generated-types'
 import { LinkedInError } from '../types'
 
@@ -51,16 +51,7 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
           type: 'string',
           label: 'Conversion Type',
           description: 'The type of conversion rule.',
-          choices: [
-            { label: 'Add to Cart', value: 'ADD_TO_CART' },
-            { label: 'Download', value: 'DOWNLOAD' },
-            { label: 'Install', value: 'INSTALL' },
-            { label: 'Key Page View', value: 'KEY_PAGE_VIEW' },
-            { label: 'Lead', value: 'LEAD' },
-            { label: 'Purchase', value: 'PURCHASE' },
-            { label: 'Sign Up', value: 'SIGN_UP' },
-            { label: 'Other', value: 'OTHER' }
-          ],
+          choices: CONVERSION_TYPE_OPTIONS,
           depends_on: {
             match: 'all',
             conditions: [

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -2,7 +2,7 @@ import type { ActionDefinition } from '@segment/actions-core'
 import { ErrorCodes, IntegrationError, PayloadValidationError, InvalidAuthenticationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import { LinkedInConversions } from '../api'
-import { SUPPORTED_ID_TYPE, CONVERSION_TYPE_OPTIONS } from '../constants'
+import { SUPPORTED_ID_TYPE, CONVERSION_TYPE_OPTIONS, SUPPORTED_LOOKBACK_WINDOW_CHOICES } from '../constants'
 import type { Payload, HookBundle } from './generated-types'
 import { LinkedInError } from '../types'
 
@@ -81,6 +81,22 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
               }
             ]
           }
+        },
+        post_click_attribution_window_size: {
+          label: 'Post-Click Attribution Window Size',
+          description:
+            'Conversion window timeframe (in days) of a member clicking on a LinkedIn Ad (a post-click conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 30.',
+          type: 'number',
+          default: 30,
+          choices: SUPPORTED_LOOKBACK_WINDOW_CHOICES
+        },
+        view_through_attribution_window_size: {
+          label: 'View-Through Attribution Window Size',
+          description:
+            '	Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 7.',
+          type: 'number',
+          default: 7,
+          choices: SUPPORTED_LOOKBACK_WINDOW_CHOICES
         }
       },
       outputTypes: {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/types.ts
@@ -98,6 +98,9 @@ export interface ConversionRuleCreationResponse {
   id: string
   name: string
   type: string
+  attributionType: string
+  postClickAttributionWindowSize: number
+  viewThroughAttributionWindowSize: number
 }
 
 /** This request returns 204 no content */
@@ -115,4 +118,6 @@ export interface GetConversionRuleResponse {
   id?: string
   attributionType?: string
   account?: string
+  postClickAttributionWindowSize?: number
+  viewThroughAttributionWindowSize?: number
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR updates the LinkedIn Conversions API destination with new hook input fields that are required to create a conversion rule. It also adds all possible options for the existing conversion type field so that users can select them from the dropdown.

## Testing
Tested successfully in local + staging.

Conversion Rule created:
<img width="1186" alt="Screenshot 2024-03-11 at 12 14 47 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/87a76a3c-f7e3-4cf3-ba72-5be6466bc60c">

Conversion Rule in LinkedIn manager:
<img width="832" alt="Screenshot 2024-03-11 at 2 37 24 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/c793a417-efa9-405e-9b94-5d26dfa84bee">

### Staging
Conversion Type fields correctly displayed:
<img width="864" alt="Screenshot 2024-03-11 at 3 15 27 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/929c4356-dc74-4ad5-8607-519dfad9a3d0">

The newly added fields:
<img width="947" alt="Screenshot 2024-03-11 at 3 32 58 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/6b0c30b7-4354-46c0-9b2a-9d3314d11c88">

The conversion rule is successfully created with the lookback window params:
<img width="967" alt="Screenshot 2024-03-11 at 3 35 45 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/d2665bf6-f5a3-4b15-8039-b83fe7524c8c">

That same rule in LinkedIn:
<img width="837" alt="Screenshot 2024-03-11 at 3 36 00 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/b916ea1c-390f-45c2-9aa1-985f46ec096a">


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
