### PR TITLE
Add mantle action destination

### DIFF
--- a/packages/destination-actions/src/destinations/mantle/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/mantle/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-mantle destination: identify action - all fields 1`] = `
+Object {
+  "customFields": Object {
+    "testType": "f$gKO(@kXal",
+  },
+  "email": "cothe@kogufo.as",
+  "myshopifyDomain": "f$gKO(@kXal",
+  "name": "f$gKO(@kXal",
+  "platform": "shopify",
+  "platformId": "f$gKO(@kXal",
+}
+`;
+
+exports[`Testing snapshot for actions-mantle destination: identify action - required fields 1`] = `
+Object {
+  "myshopifyDomain": "f$gKO(@kXal",
+  "platform": "shopify",
+  "platformId": "f$gKO(@kXal",
+}
+`;
+
+exports[`Testing snapshot for actions-mantle destination: pushEvent action - all fields 1`] = `
+Object {
+  "customerId": "1ebNi5n[1Ax",
+  "event_id": "1ebNi5n[1Ax",
+  "event_name": "1ebNi5n[1Ax",
+  "properties": Object {
+    "testType": "1ebNi5n[1Ax",
+  },
+  "timestamp": "2021-02-01T00:00:00.000Z",
+}
+`;
+
+exports[`Testing snapshot for actions-mantle destination: pushEvent action - required fields 1`] = `
+Object {
+  "customerId": "1ebNi5n[1Ax",
+  "event_name": "1ebNi5n[1Ax",
+  "properties": Object {},
+}
+`;

--- a/packages/destination-actions/src/destinations/mantle/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mantle/__tests__/index.test.ts
@@ -1,0 +1,32 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+
+import { API_URL } from '../config'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Mantle', () => {
+  describe('testAuthentication', () => {
+    it('should validate authentication inputs', async () => {
+      nock(API_URL).get('/app').reply(200, {})
+
+      const authData = {
+        appId: 'fake-app-id',
+        apiKey: 'fake-api-key'
+      }
+
+      await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
+    })
+    it('should fail on invalid authentication inputs', async () => {
+      nock(API_URL).get('/app').reply(401, {})
+
+      const authData = {
+        appId: 'fake-app-id',
+        apiKey: ''
+      }
+
+      await expect(testDestination.testAuthentication(authData)).rejects.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/mantle/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/mantle/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-mantle'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/mantle/config.ts
+++ b/packages/destination-actions/src/destinations/mantle/config.ts
@@ -1,0 +1,1 @@
+export const API_URL = 'https://appapi.heymantle.com/v1'

--- a/packages/destination-actions/src/destinations/mantle/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mantle/generated-types.ts
@@ -1,0 +1,12 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * The unique identifier for the app in Mantle. Get this from the API Keys section for your app in Mantle.
+   */
+  appId: string
+  /**
+   * The API key for the app in Mantle. Get this from the API Keys section for your app in Mantle.
+   */
+  apiKey: string
+}

--- a/packages/destination-actions/src/destinations/mantle/identify/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/mantle/identify/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for MantleRevOps's identify destination action: all fields 1`] = `
+Object {
+  "customFields": Object {
+    "testType": "P%L*#Z]I@",
+  },
+  "email": "faacogad@wazjanom.nr",
+  "myshopifyDomain": "P%L*#Z]I@",
+  "name": "P%L*#Z]I@",
+  "platform": "shopify",
+  "platformId": "P%L*#Z]I@",
+}
+`;
+
+exports[`Testing snapshot for MantleRevOps's identify destination action: required fields 1`] = `
+Object {
+  "myshopifyDomain": "P%L*#Z]I@",
+  "platform": "shopify",
+  "platformId": "P%L*#Z]I@",
+}
+`;

--- a/packages/destination-actions/src/destinations/mantle/identify/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mantle/identify/__tests__/index.test.ts
@@ -1,0 +1,55 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+import { API_URL } from '../../config'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('MantleRevOps.identify', () => {
+  it('should identify a customer in mantle', async () => {
+    nock(API_URL).post('/identify').reply(200, {})
+
+    const responses = await testDestination.testAction('identify', {
+      event: createTestEvent({
+        type: 'identify',
+        userId: 'test-user-id',
+        traits: {
+          email: 'test@example.com',
+          name: 'test-name',
+          platformId: 'test-platform-id',
+          myshopifyDomain: 'test-shopify-domain'
+        }
+      }),
+      settings: {
+        appId: 'fake-app-id',
+        apiKey: 'fake-api-key'
+      },
+      mapping: {
+        email: {
+          '@path': '$.traits.email'
+        },
+        name: {
+          '@path': '$.traits.name'
+        },
+        platformId: {
+          '@path': '$.traits.platformId'
+        },
+        myshopifyDomain: {
+          '@path': '$.traits.myshopifyDomain'
+        },
+        useDefaultMappings: true
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.json).toMatchObject({
+      platform: 'shopify',
+      platformId: 'test-platform-id',
+      myshopifyDomain: 'test-shopify-domain',
+      email: 'test@example.com',
+      name: 'test-name'
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/mantle/identify/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/mantle/identify/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'identify'
+const destinationSlug = 'MantleRevOps'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/mantle/identify/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mantle/identify/generated-types.ts
@@ -1,0 +1,26 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The unique identifier for the Shopify shop. This is used to associate the customer with a Shopify shop in Mantle
+   */
+  platformId: string
+  /**
+   * The unique .myshopify.com domain of the Shopify shop. This is used to associate the customer with a Shopify shop in Mantle
+   */
+  myshopifyDomain: string
+  /**
+   * The name of the customer / shop
+   */
+  name?: string
+  /**
+   * The email of the customer
+   */
+  email?: string
+  /**
+   * The custom fields of the customer / shop
+   */
+  customFields?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/mantle/identify/index.ts
+++ b/packages/destination-actions/src/destinations/mantle/identify/index.ts
@@ -15,32 +15,40 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'The unique identifier for the Shopify shop. This is used to associate the customer with a Shopify shop in Mantle',
       type: 'string',
-      required: true
+      required: true,
+      default: { '@path': '$.traits.shopId' }
     },
     myshopifyDomain: {
       label: 'Shopify Shop Domain',
       description:
         'The unique .myshopify.com domain of the Shopify shop. This is used to associate the customer with a Shopify shop in Mantle',
       type: 'string',
-      required: true
+      required: true,
+      default: { '@path': '$.traits.shopifyDomain' }
     },
     name: {
       label: 'Name',
       description: 'The name of the customer / shop',
       type: 'string',
-      required: false
+      required: false,
+      default: { '@path': '$.traits.name' }
     },
     email: {
       label: 'Email',
       description: 'The email of the customer',
       type: 'string',
-      required: false
+      required: false,
+      default: { '@path': '$.traits.email' }
     },
     customFields: {
       label: 'Custom Fields',
       description: 'The custom fields of the customer / shop',
       type: 'object',
-      required: false
+      required: false,
+      defaultObjectUI: 'keyvalue',
+      default: {
+        '@path': '$.traits'
+      }
     }
   },
   perform: (request, data) => {

--- a/packages/destination-actions/src/destinations/mantle/identify/index.ts
+++ b/packages/destination-actions/src/destinations/mantle/identify/index.ts
@@ -1,0 +1,61 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+import { API_URL } from '../config'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Identify',
+  description:
+    'Identify (create or update) a customer for your app in Mantle, including any additional information about the customer',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    platformId: {
+      label: 'Shopify Shop ID',
+      description:
+        'The unique identifier for the Shopify shop. This is used to associate the customer with a Shopify shop in Mantle',
+      type: 'string',
+      required: true
+    },
+    myshopifyDomain: {
+      label: 'Shopify Shop Domain',
+      description:
+        'The unique .myshopify.com domain of the Shopify shop. This is used to associate the customer with a Shopify shop in Mantle',
+      type: 'string',
+      required: true
+    },
+    name: {
+      label: 'Name',
+      description: 'The name of the customer / shop',
+      type: 'string',
+      required: false
+    },
+    email: {
+      label: 'Email',
+      description: 'The email of the customer',
+      type: 'string',
+      required: false
+    },
+    customFields: {
+      label: 'Custom Fields',
+      description: 'The custom fields of the customer / shop',
+      type: 'object',
+      required: false
+    }
+  },
+  perform: (request, data) => {
+    return request(`${API_URL}/identify`, {
+      method: 'post',
+      json: {
+        platform: 'shopify',
+        platformId: data.payload.platformId,
+        myshopifyDomain: data.payload.myshopifyDomain,
+        name: data.payload.name,
+        email: data.payload.email,
+        ...(data.payload.customFields ? { customFields: data.payload.customFields } : {})
+      }
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/mantle/index.ts
+++ b/packages/destination-actions/src/destinations/mantle/index.ts
@@ -1,0 +1,52 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import pushEvent from './pushEvent'
+import identify from './identify'
+import { API_URL } from './config'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Mantle (Actions)',
+  slug: 'actions-mantle',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      appId: {
+        label: 'App ID',
+        description:
+          'The unique identifier for the app in Mantle. Get this from the API Keys section for your app in Mantle.',
+        type: 'string',
+        required: true
+      },
+      apiKey: {
+        label: 'API Key',
+        description: 'The API key for the app in Mantle. Get this from the API Keys section for your app in Mantle.',
+        type: 'string',
+        required: true
+      }
+    },
+    testAuthentication: (request) => {
+      return request(`${API_URL}/app`, {
+        method: 'GET'
+      })
+    }
+  },
+
+  extendRequest: ({ settings }) => {
+    return {
+      headers: {
+        'x-mantle-app-id': settings.appId,
+        'x-mantle-app-api-key': settings.apiKey
+      }
+    }
+  },
+
+  actions: {
+    pushEvent,
+    identify
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/mantle/index.ts
+++ b/packages/destination-actions/src/destinations/mantle/index.ts
@@ -7,6 +7,8 @@ import { API_URL } from './config'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Mantle (Actions)',
+  description:
+    'Track important revenue metrics for your Shopify apps. Manage plans and pricing. Improve customer relationships. Focus on growing your business.',
   slug: 'actions-mantle',
   mode: 'cloud',
 

--- a/packages/destination-actions/src/destinations/mantle/pushEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/mantle/pushEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for MantleRevOps's pushEvent destination action: all fields 1`] = `
+Object {
+  "customerId": "vgsl(VF]C@p@66ob",
+  "event_id": "vgsl(VF]C@p@66ob",
+  "event_name": "vgsl(VF]C@p@66ob",
+  "properties": Object {
+    "testType": "vgsl(VF]C@p@66ob",
+  },
+  "timestamp": "2021-02-01T00:00:00.000Z",
+}
+`;
+
+exports[`Testing snapshot for MantleRevOps's pushEvent destination action: required fields 1`] = `
+Object {
+  "customerId": "vgsl(VF]C@p@66ob",
+  "event_name": "vgsl(VF]C@p@66ob",
+  "properties": Object {},
+}
+`;

--- a/packages/destination-actions/src/destinations/mantle/pushEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mantle/pushEvent/__tests__/index.test.ts
@@ -1,0 +1,63 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+import { API_URL } from '../../config'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('MantleRevOps.pushEvent', () => {
+  it('should push usage event to mantle', async () => {
+    nock(API_URL).post('/usage_events').reply(200, {})
+
+    const event = createTestEvent({
+      type: 'track',
+      userId: 'test-user-id',
+      event: 'test-event',
+      timestamp: '2022-03-07T17:02:44.000Z',
+      properties: {
+        test: 'test',
+        customerId: 'test-customer-id',
+        eventId: 'test-event-id'
+      }
+    })
+    const responses = await testDestination.testAction('pushEvent', {
+      event,
+      settings: {
+        appId: 'fake-app-id',
+        apiKey: 'fake-api-key'
+      },
+      mapping: {
+        eventName: {
+          '@path': '$.event'
+        },
+        eventId: {
+          '@path': '$.properties.eventId'
+        },
+        customerId: {
+          '@path': '$.properties.customerId'
+        },
+        properties: {
+          '@path': '$.properties'
+        },
+        timestamp: {
+          '@path': '$.timestamp'
+        },
+        useDefaultMappings: true
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.json).toMatchObject({
+      event_name: 'test-event',
+      customerId: 'test-customer-id',
+      properties: {
+        test: 'test',
+        customerId: 'test-customer-id',
+        eventId: 'test-event-id'
+      },
+      timestamp: '2022-03-07T17:02:44.000Z'
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/mantle/pushEvent/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/mantle/pushEvent/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'pushEvent'
+const destinationSlug = 'MantleRevOps'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/mantle/pushEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mantle/pushEvent/generated-types.ts
@@ -1,0 +1,26 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The name of the event you want to push to Mantle
+   */
+  eventName: string
+  /**
+   * The unique identifier for the event. This is used to deduplicate events in Mantle
+   */
+  eventId?: string
+  /**
+   * The unique identifier for the customer. This is used to associate the event with a customer in Mantle. It can be the internal customer ID, API token, Shopify shop ID, or Shopify shop domain
+   */
+  customerId: string
+  /**
+   * The properties of the event. This is the extra data you want to attach to the event
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+  /**
+   * The timestamp of the event, defaults to the current time
+   */
+  timestamp?: string | number
+}

--- a/packages/destination-actions/src/destinations/mantle/pushEvent/index.ts
+++ b/packages/destination-actions/src/destinations/mantle/pushEvent/index.ts
@@ -1,0 +1,74 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+import { API_URL } from '../config'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Push Event',
+  description: 'Push event to your app in Mantle',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    eventName: {
+      label: 'Event Name',
+      description: 'The name of the event you want to push to Mantle',
+      type: 'string',
+      required: true
+    },
+    eventId: {
+      label: 'Event ID',
+      description: 'The unique identifier for the event. This is used to deduplicate events in Mantle',
+      type: 'string',
+      required: false
+    },
+    customerId: {
+      label: 'Customer ID',
+      description:
+        'The unique identifier for the customer. This is used to associate the event with a customer in Mantle. It can be the internal customer ID, API token, Shopify shop ID, or Shopify shop domain',
+      type: 'string',
+      required: true
+    },
+    properties: {
+      label: 'Event Properties',
+      description: 'The properties of the event. This is the extra data you want to attach to the event',
+      type: 'object',
+      required: false
+    },
+    timestamp: {
+      label: 'Event timestamp',
+      description: 'The timestamp of the event, defaults to the current time',
+      type: 'datetime',
+      required: false
+    }
+  },
+  perform: (request, data) => {
+    const payload = {
+      event_name: data.payload.eventName,
+      ...(data.payload.eventId ? { event_id: data.payload.eventId } : {}),
+      customerId: data.payload.customerId,
+      properties: data.payload.properties || {},
+      ...(data.payload.timestamp ? { timestamp: data.payload.timestamp } : {})
+    }
+    return request(`${API_URL}/usage_events`, {
+      method: 'post',
+      json: payload
+    })
+  },
+  performBatch: (request, data) => {
+    const events = data.payload.map((payload) => ({
+      event_name: payload.eventName,
+      ...(payload.eventId ? { event_id: payload.eventId } : {}),
+      customerId: payload.customerId,
+      properties: payload.properties || {},
+      ...(payload.timestamp ? { timestamp: payload.timestamp } : {})
+    }))
+    return request(`${API_URL}/usage_events`, {
+      method: 'post',
+      json: {
+        events
+      }
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/mantle/pushEvent/index.ts
+++ b/packages/destination-actions/src/destinations/mantle/pushEvent/index.ts
@@ -13,32 +13,37 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Event Name',
       description: 'The name of the event you want to push to Mantle',
       type: 'string',
-      required: true
+      required: true,
+      default: { '@path': '$.event' }
     },
     eventId: {
       label: 'Event ID',
       description: 'The unique identifier for the event. This is used to deduplicate events in Mantle',
       type: 'string',
-      required: false
+      required: false,
+      default: { '@path': '$.messageId' }
     },
     customerId: {
       label: 'Customer ID',
       description:
         'The unique identifier for the customer. This is used to associate the event with a customer in Mantle. It can be the internal customer ID, API token, Shopify shop ID, or Shopify shop domain',
       type: 'string',
-      required: true
+      required: true,
+      default: { '@path': '$.properties.shopifyDomain' }
     },
     properties: {
       label: 'Event Properties',
       description: 'The properties of the event. This is the extra data you want to attach to the event',
       type: 'object',
-      required: false
+      required: false,
+      default: { '@path': '$.properties' }
     },
     timestamp: {
       label: 'Event timestamp',
       description: 'The timestamp of the event, defaults to the current time',
       type: 'datetime',
-      required: false
+      required: false,
+      default: { '@path': '$.timestamp' }
     }
   },
   perform: (request, data) => {


### PR DESCRIPTION
Adds the [Mantle](https://heymantle.com) destination with `identify` and `pushEvent` actions.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
