### PR TITLE
[LinkedIn Conversions] Move Ad Account ID & Campaign ID to hook inputs

### DIFF
--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -49,7 +49,7 @@ export interface BaseActionDefinition {
   fields: Record<string, InputField>
 }
 
-type HookValueTypes = string | boolean | number
+type HookValueTypes = string | boolean | number | Array<string | boolean | number>
 type GenericActionHookValues = Record<string, HookValueTypes>
 
 type GenericActionHookBundle = {

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -152,6 +152,7 @@ export interface ExecuteDynamicFieldInput<Settings, Payload, AudienceSettings = 
   /** For internal Segment/Twilio use only. */
   features?: Features | undefined
   statsContext?: StatsContext | undefined
+  hookInputs?: GenericActionHookValues
 }
 
 interface ExecuteBundle<T = unknown, Data = unknown, AudienceSettings = any, ActionHookValues = any> {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -2,14 +2,42 @@
 
 exports[`Testing snapshot for actions-linkedin-conversions destination: streamConversion action - all fields 1`] = `
 Object {
-  "campaign": "urn:li:sponsoredCampaign:Fuj)Xdj",
   "conversion": "urn:lla:llaPartnerConversion:1234",
+  "conversionHappenedAt": 1710285946348,
+  "conversionValue": Object {
+    "amount": "Fuj)Xdj",
+    "currencyCode": "Fuj)Xdj",
+  },
+  "eventId": "Fuj)Xdj",
+  "user": Object {
+    "userIds": Array [
+      Object {
+        "idType": "SHA256_EMAIL",
+        "idValue": "bad8677b6c86f5d308ee82786c183482a5995f066694246c58c4df37b0cc41f1",
+      },
+    ],
+    "userInfo": Object {
+      "companyName": "Fuj)Xdj",
+      "countryCode": "Fuj)Xdj",
+      "firstName": "Fuj)Xdj",
+      "lastName": "Fuj)Xdj",
+      "title": "Fuj)Xdj",
+    },
+  },
 }
 `;
 
 exports[`Testing snapshot for actions-linkedin-conversions destination: streamConversion action - required fields 1`] = `
 Object {
-  "campaign": "urn:li:sponsoredCampaign:Fuj)Xdj",
   "conversion": "urn:lla:llaPartnerConversion:1234",
+  "conversionHappenedAt": 1710285946318,
+  "user": Object {
+    "userIds": Array [
+      Object {
+        "idType": "SHA256_EMAIL",
+        "idValue": "bad8677b6c86f5d308ee82786c183482a5995f066694246c58c4df37b0cc41f1",
+      },
+    ],
+  },
 }
 `;

--- a/packages/destination-actions/src/destinations/linkedin-conversions/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Testing snapshot for actions-linkedin-conversions destination: streamConversion action - all fields 1`] = `
 Object {
   "conversion": "urn:lla:llaPartnerConversion:1234",
-  "conversionHappenedAt": 1710285946348,
+  "conversionHappenedAt": null,
   "conversionValue": Object {
     "amount": "Fuj)Xdj",
     "currencyCode": "Fuj)Xdj",
@@ -30,7 +30,7 @@ Object {
 exports[`Testing snapshot for actions-linkedin-conversions destination: streamConversion action - required fields 1`] = `
 Object {
   "conversion": "urn:lla:llaPartnerConversion:1234",
-  "conversionHappenedAt": 1710285946318,
+  "conversionHappenedAt": null,
   "user": Object {
     "userIds": Array [
       Object {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/__tests__/snapshot.test.ts
@@ -24,8 +24,6 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
         }
       ]
 
-      eventData.conversionHappenedAt = Date.now()
-
       const event = createTestEvent({
         properties: eventData
       })
@@ -74,8 +72,6 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
           idValue: 'bad8677b6c86f5d308ee82786c183482a5995f066694246c58c4df37b0cc41f1'
         }
       ]
-
-      eventData.conversionHappenedAt = Date.now()
 
       const event = createTestEvent({
         properties: eventData

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/api.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/api.test.ts
@@ -11,6 +11,7 @@ describe('LinkedIn Conversions', () => {
     const linkedIn: LinkedInConversions = new LinkedInConversions(requestClient)
     const adAccountId = 'urn:li:sponsoredAccount:123456'
     const hookInputs: HookBundle['onMappingSave']['inputs'] = {
+      adAccountId,
       name: 'A different name that should trigger an update',
       conversionType: 'PURCHASE',
       attribution_type: 'LAST_TOUCH_BY_CAMPAIGN',
@@ -43,7 +44,7 @@ describe('LinkedIn Conversions', () => {
         })
         .reply(204)
 
-      const updateResult = await linkedIn.updateConversionRule(adAccountId, hookInputs, hookOutputs)
+      const updateResult = await linkedIn.updateConversionRule(hookInputs, hookOutputs)
 
       expect(updateResult).toEqual({
         successMessage: `Conversion rule ${hookOutputs.id} updated successfully!`,
@@ -79,7 +80,7 @@ describe('LinkedIn Conversions', () => {
           postClickAttributionWindowSize: hookInputs.post_click_attribution_window_size,
           viewThroughAttributionWindowSize: hookInputs.view_through_attribution_window_size
         })
-      const createResult = await linkedIn.createConversionRule(adAccountId, hookInputs)
+      const createResult = await linkedIn.createConversionRule(hookInputs)
 
       expect(createResult).toEqual({
         successMessage: `Conversion rule ${mockReturnedId} created successfully!`,
@@ -110,7 +111,6 @@ describe('LinkedIn Conversions', () => {
         .reply(200, existingRule)
 
       const updateResult = await linkedIn.updateConversionRule(
-        adAccountId,
         { ...hookInputs, conversionRuleId: existingRule.id },
         hookOutputs
       )
@@ -144,7 +144,7 @@ describe('LinkedIn Conversions', () => {
         })
         .reply(500)
 
-      const updateResult = await linkedIn.updateConversionRule(adAccountId, hookInputs, hookOutputs)
+      const updateResult = await linkedIn.updateConversionRule(hookInputs, hookOutputs)
 
       expect(updateResult).toEqual({
         error: {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -382,7 +382,12 @@ export class LinkedInConversions {
     })
   }
 
-  async bulkAssociateCampaignToConversion(campaignIds: string[]): Promise<ModifiedResponse> {
+  async bulkAssociateCampaignToConversion(campaignIds?: string[]): Promise<ModifiedResponse | void> {
+    // Associating campaigns is not required to create or update a conversion rule, or to stream a conversion event
+    if (!campaignIds || campaignIds.length === 0) {
+      return
+    }
+
     if (campaignIds.length === 1) {
       return this.associateCampignToConversion(campaignIds[0])
     }

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -72,11 +72,19 @@ export class LinkedInConversions {
   }
 
   createConversionRule = async (
-    adAccount: string,
     hookInputs: HookBundle['onMappingSave']['inputs']
   ): Promise<ActionHookResponse<HookBundle['onMappingSave']['outputs']>> => {
+    if (!hookInputs?.adAccountId) {
+      return {
+        error: {
+          message: `Failed to create conversion rule: No Ad Account selected.`,
+          code: 'CONVERSION_RULE_CREATION_FAILURE'
+        }
+      }
+    }
+
     if (hookInputs?.conversionRuleId) {
-      return this.getConversionRule(adAccount, hookInputs?.conversionRuleId)
+      return this.getConversionRule(hookInputs.adAccountId, hookInputs?.conversionRuleId)
     }
 
     try {
@@ -84,7 +92,7 @@ export class LinkedInConversions {
         method: 'post',
         json: {
           name: hookInputs?.name,
-          account: adAccount,
+          account: hookInputs.adAccountId,
           conversionMethod: 'CONVERSIONS_API',
           postClickAttributionWindowSize:
             hookInputs?.post_click_attribution_window_size || DEFAULT_POST_CLICK_LOOKBACK_WINDOW,
@@ -117,7 +125,6 @@ export class LinkedInConversions {
   }
 
   updateConversionRule = async (
-    adAccount: string,
     hookInputs: HookBundle['onMappingSave']['inputs'],
     hookOutputs: HookBundle['onMappingSave']['outputs']
   ): Promise<ActionHookResponse<HookBundle['onMappingSave']['outputs']>> => {
@@ -130,8 +137,17 @@ export class LinkedInConversions {
       }
     }
 
+    if (!hookInputs?.adAccountId) {
+      return {
+        error: {
+          message: `Failed to update conversion rule: No Ad Account selected.`,
+          code: 'CONVERSION_RULE_UPDATE_FAILURE'
+        }
+      }
+    }
+
     if (hookInputs?.conversionRuleId) {
-      return this.getConversionRule(adAccount, hookInputs?.conversionRuleId)
+      return this.getConversionRule(hookInputs.adAccountId, hookInputs?.conversionRuleId)
     }
 
     const valuesChanged = this.conversionRuleValuesUpdated(hookInputs, hookOutputs)
@@ -162,7 +178,7 @@ export class LinkedInConversions {
       await this.request<ConversionRuleUpdateResponse>(`${BASE_URL}/conversions/${hookOutputs.id}`, {
         method: 'post',
         searchParams: {
-          account: adAccount
+          account: hookInputs.adAccountId
         },
         headers: {
           'X-RestLi-Method': 'PARTIAL_UPDATE',
@@ -237,7 +253,7 @@ export class LinkedInConversions {
     }
   }
 
-  getConversionRulesList = async (adAccountId: string): Promise<DynamicFieldResponse> => {
+  getConversionRulesList = async (adAccountId?: string): Promise<DynamicFieldResponse> => {
     if (!adAccountId || !adAccountId.length) {
       return {
         choices: [],
@@ -289,11 +305,23 @@ export class LinkedInConversions {
     }
   }
 
-  getCampaignsList = async (adAccountUrn: string): Promise<DynamicFieldResponse> => {
-    const parts = adAccountUrn.split(':')
-    const adAccountId = parts.pop()
+  private parseIdFromUrn = (urn?: string): [string, boolean] => {
+    if (!urn) {
+      return ['', true]
+    }
 
-    if (!adAccountId || !adAccountId.length) {
+    const parts = urn.split(':')
+    const id = parts.pop()
+    if (!id) {
+      return ['', true]
+    }
+
+    return [id, false]
+  }
+  getCampaignsList = async (adAccountUrn?: string): Promise<DynamicFieldResponse> => {
+    const [adAccountId, err] = this.parseIdFromUrn(adAccountUrn)
+
+    if (err) {
       return {
         choices: [],
         error: {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -26,8 +26,11 @@ export class LinkedInConversions {
   request: RequestClient
   conversionRuleId?: string
 
-  constructor(request: RequestClient, conversionRuleId?: string) {
+  constructor(request: RequestClient) {
     this.request = request
+  }
+
+  setConversionRuleId(conversionRuleId: string): void {
     this.conversionRuleId = conversionRuleId
   }
 

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -308,23 +308,24 @@ export class LinkedInConversions {
     }
   }
 
-  private parseIdFromUrn = (urn?: string): [string, boolean] => {
+  private parseIdFromUrn = (urn?: string): string | undefined => {
     if (!urn) {
-      return ['', true]
+      return
     }
 
     const parts = urn.split(':')
     const id = parts.pop()
     if (!id) {
-      return ['', true]
+      return
     }
 
-    return [id, false]
+    return id
   }
-  getCampaignsList = async (adAccountUrn?: string): Promise<DynamicFieldResponse> => {
-    const [adAccountId, err] = this.parseIdFromUrn(adAccountUrn)
 
-    if (err) {
+  getCampaignsList = async (adAccountUrn?: string): Promise<DynamicFieldResponse> => {
+    const adAccountId = this.parseIdFromUrn(adAccountUrn)
+
+    if (!adAccountId) {
       return {
         choices: [],
         error: {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Testing snapshot for LinkedinConversions's streamConversion destination action: all fields 1`] = `
 Object {
   "conversion": "urn:lla:llaPartnerConversion:1234",
-  "conversionHappenedAt": 1710285946442,
+  "conversionHappenedAt": null,
   "conversionValue": Object {
     "amount": "RK^DrO",
     "currencyCode": "RK^DrO",
@@ -30,7 +30,7 @@ Object {
 exports[`Testing snapshot for LinkedinConversions's streamConversion destination action: required fields 1`] = `
 Object {
   "conversion": "urn:lla:llaPartnerConversion:1234",
-  "conversionHappenedAt": 1710285946416,
+  "conversionHappenedAt": null,
   "user": Object {
     "userIds": Array [
       Object {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -2,14 +2,42 @@
 
 exports[`Testing snapshot for LinkedinConversions's streamConversion destination action: all fields 1`] = `
 Object {
-  "campaign": "urn:li:sponsoredCampaign:RK^DrO",
   "conversion": "urn:lla:llaPartnerConversion:1234",
+  "conversionHappenedAt": 1710285946442,
+  "conversionValue": Object {
+    "amount": "RK^DrO",
+    "currencyCode": "RK^DrO",
+  },
+  "eventId": "RK^DrO",
+  "user": Object {
+    "userIds": Array [
+      Object {
+        "idType": "SHA256_EMAIL",
+        "idValue": "bad8677b6c86f5d308ee82786c183482a5995f066694246c58c4df37b0cc41f1",
+      },
+    ],
+    "userInfo": Object {
+      "companyName": "RK^DrO",
+      "countryCode": "RK^DrO",
+      "firstName": "RK^DrO",
+      "lastName": "RK^DrO",
+      "title": "RK^DrO",
+    },
+  },
 }
 `;
 
 exports[`Testing snapshot for LinkedinConversions's streamConversion destination action: required fields 1`] = `
 Object {
-  "campaign": "urn:li:sponsoredCampaign:RK^DrO",
   "conversion": "urn:lla:llaPartnerConversion:1234",
+  "conversionHappenedAt": 1710285946416,
+  "user": Object {
+    "userIds": Array [
+      Object {
+        "idType": "SHA256_EMAIL",
+        "idValue": "bad8677b6c86f5d308ee82786c183482a5995f066694246c58c4df37b0cc41f1",
+      },
+    ],
+  },
 }
 `;

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
@@ -46,17 +46,6 @@ const payload = {
 
 describe('LinkedinConversions.streamConversion', () => {
   it('should successfully send the event', async () => {
-    const associateCampignToConversion = JSON.stringify({
-      campaign: 'urn:li:sponsoredCampaign:56789',
-      conversion: 'urn:lla:llaPartnerConversion:789123'
-    })
-
-    nock(
-      `${BASE_URL}/campaignConversions/(campaign:urn%3Ali%3AsponsoredCampaign%3A${payload.campaignId[0]},conversion:urn%3Alla%3AllaPartnerConversion%3A${payload.conversionId})`
-    )
-      .put(/.*/, associateCampignToConversion)
-      .reply(204)
-
     nock(`${BASE_URL}/conversionEvents`).post(/.*/).reply(201)
 
     await expect(
@@ -64,11 +53,9 @@ describe('LinkedinConversions.streamConversion', () => {
         event,
         settings,
         mapping: {
-          adAccountId: payload.adAccountId,
           user: {
             '@path': '$.context.traits.user'
           },
-          campaignId: payload.campaignId,
           conversionHappenedAt: {
             '@path': '$.timestamp'
           },
@@ -83,42 +70,6 @@ describe('LinkedinConversions.streamConversion', () => {
     ).resolves.not.toThrowError()
   })
 
-  it('should bulk associate campaigns and successfully send the event when multiple campaigns are selected', async () => {
-    const multipleCampaigns = payload.campaignId.concat('12345')
-
-    nock(`${BASE_URL}`)
-      .put(
-        `/campaignConversions?ids=List((campaign:urn%3Ali%3AsponsoredCampaign%3A${multipleCampaigns[0]},conversion:urn%3Alla%3AllaPartnerConversion%3A${payload.conversionId}),(campaign:urn%3Ali%3AsponsoredCampaign%3A${multipleCampaigns[1]},conversion:urn%3Alla%3AllaPartnerConversion%3A${payload.conversionId}))`
-      )
-      .reply(200)
-
-    nock(`${BASE_URL}/conversionEvents`).post(/.*/).reply(201)
-
-    await testDestination.testAction('streamConversion', {
-      event,
-      settings,
-      mapping: {
-        adAccountId: payload.adAccountId,
-        userInfo: {
-          firstName: { '@path': '$.context.traits.user.userInfo.firstName' },
-          lastName: { '@path': '$.context.traits.user.userInfo.lastName' },
-          title: { '@path': '$.context.traits.user.userInfo.title' },
-          companyName: { '@path': '$.context.traits.user.userInfo.companyName' },
-          countryCode: { '@path': '$.context.traits.user.userInfo.countryCode' }
-        },
-        userIds: { '@path': '$.context.traits.user.userIds' },
-        campaignId: multipleCampaigns,
-        conversionHappenedAt: currentTimestamp.toString(),
-        onMappingSave: {
-          inputs: {},
-          outputs: {
-            id: payload.conversionId
-          }
-        }
-      }
-    })
-  })
-
   it('should throw an error if timestamp is not within the past 90 days', async () => {
     event.timestamp = '50000000000'
 
@@ -127,11 +78,9 @@ describe('LinkedinConversions.streamConversion', () => {
         event,
         settings,
         mapping: {
-          adAccountId: payload.adAccountId,
           user: {
             '@path': '$.context.traits.user'
           },
-          campaignId: payload.campaignId,
           conversionHappenedAt: {
             '@path': '$.timestamp'
           }
@@ -163,14 +112,12 @@ describe('LinkedinConversions.streamConversion', () => {
         event,
         settings,
         mapping: {
-          adAccountId: payload.adAccountId,
           userIds: {
             '@path': '$.context.traits.userIds'
           },
           userInfo: {
             '@path': '$.context.traits.userInfo'
           },
-          campaignId: payload.campaignId,
           conversionHappenedAt: {
             '@path': '$.timestamp'
           },
@@ -221,10 +168,18 @@ describe('LinkedinConversions.dynamicField', () => {
     const payload = {
       adAccountId: ''
     }
-    const responses = (await testDestination.testDynamicField('streamConversion', 'campaignId', {
-      settings,
-      payload
-    })) as DynamicFieldResponse
+
+    const dynamicFn =
+      testDestination.actions.streamConversion.definition.hooks?.onMappingSave?.inputFields?.campaignId.dynamic
+    const responses = (await testDestination.testDynamicField(
+      'streamConversion',
+      'campaignId',
+      {
+        settings,
+        payload
+      },
+      dynamicFn
+    )) as DynamicFieldResponse
 
     expect(responses).toMatchObject({
       choices: [],
@@ -240,17 +195,6 @@ describe('LinkedinConversions.timestamp', () => {
   it('should convert a human readable date to a unix timestamp', async () => {
     event.timestamp = currentTimestamp.toString()
 
-    const associateCampignToConversion = {
-      campaign: 'urn:li:sponsoredCampaign:56789',
-      conversion: 'urn:lla:llaPartnerConversion:789123'
-    }
-
-    nock(
-      `${BASE_URL}/campaignConversions/(campaign:urn%3Ali%3AsponsoredCampaign%3A${payload.campaignId},conversion:urn%3Alla%3AllaPartnerConversion%3A${payload.conversionId})`
-    )
-      .put(/.*/, associateCampignToConversion)
-      .reply(204)
-
     nock(`${BASE_URL}/conversionEvents`).post(/.*/).reply(201)
 
     await expect(
@@ -258,11 +202,9 @@ describe('LinkedinConversions.timestamp', () => {
         event,
         settings,
         mapping: {
-          adAccountId: payload.adAccountId,
           user: {
             '@path': '$.context.traits.user'
           },
-          campaignId: payload.campaignId,
           conversionHappenedAt: {
             '@path': '$.timestamp'
           },
@@ -280,16 +222,6 @@ describe('LinkedinConversions.timestamp', () => {
   it('should convert a string unix timestamp to a number', async () => {
     event.timestamp = currentTimestamp.toString()
 
-    const associateCampignToConversion = {
-      campaign: 'urn:li:sponsoredCampaign:56789',
-      conversion: 'urn:lla:llaPartnerConversion:789123'
-    }
-
-    nock(
-      `${BASE_URL}/campaignConversions/(campaign:urn%3Ali%3AsponsoredCampaign%3A${payload.campaignId},conversion:urn%3Alla%3AllaPartnerConversion%3A${payload.conversionId})`
-    )
-      .put(/.*/, associateCampignToConversion)
-      .reply(204)
     nock(`${BASE_URL}/conversionEvents`).post(/.*/).reply(201)
 
     await expect(
@@ -297,11 +229,9 @@ describe('LinkedinConversions.timestamp', () => {
         event,
         settings,
         mapping: {
-          adAccountId: payload.adAccountId,
           user: {
             '@path': '$.context.traits.user'
           },
-          campaignId: payload.campaignId,
           conversionHappenedAt: {
             '@path': '$.timestamp'
           },

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/snapshot.test.ts
@@ -24,8 +24,6 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       }
     ]
 
-    eventData.conversionHappenedAt = Date.now() - 20
-
     const event = createTestEvent({
       properties: eventData
     })
@@ -73,8 +71,6 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
         idValue: 'bad8677b6c86f5d308ee82786c183482a5995f066694246c58c4df37b0cc41f1'
       }
     ]
-
-    eventData.conversionHappenedAt = Date.now() - 20
 
     const event = createTestEvent({
       properties: eventData

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
@@ -56,9 +56,9 @@ export interface HookBundle {
        */
       adAccountId: string
       /**
-       * Select one or more advertising campaigns from your ad account to associate with the configured conversion rule.
+       * Select one or more advertising campaigns from your ad account to associate with the configured conversion rule. Segment will only add the selected campaigns to the conversion rule. Deselecting a campaign will not disassociate it from the conversion rule.
        */
-      campaignId: string[]
+      campaignId?: string[]
       /**
        * The ID of an existing conversion rule to stream events to. If defined, we will not create a new conversion rule.
        */

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
@@ -80,7 +80,7 @@ export interface HookBundle {
        */
       post_click_attribution_window_size?: number
       /**
-       * 	Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 7.
+       * Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 7.
        */
       view_through_attribution_window_size?: number
     }

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
@@ -2,10 +2,6 @@
 
 export interface Payload {
   /**
-   * The ad account to use for the conversion event.
-   */
-  adAccountId: string
-  /**
    * Epoch timestamp in milliseconds at which the conversion event happened. If your source records conversion timestamps in second, insert 000 at the end to transform it to milliseconds.
    */
   conversionHappenedAt: string
@@ -49,16 +45,20 @@ export interface Payload {
     title?: string
     countryCode?: string
   }
-  /**
-   * Select one or more advertising campaigns from your ad account to associate with the configured conversion rule.
-   */
-  campaignId: string[]
 }
 // Generated bundle for hooks. DO NOT MODIFY IT BY HAND.
 
 export interface HookBundle {
   onMappingSave: {
     inputs?: {
+      /**
+       * The ad account to use for the conversion event.
+       */
+      adAccountId: string
+      /**
+       * Select one or more advertising campaigns from your ad account to associate with the configured conversion rule.
+       */
+      campaignId: string[]
       /**
        * The ID of an existing conversion rule to stream events to. If defined, we will not create a new conversion rule.
        */

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -115,7 +115,7 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
         view_through_attribution_window_size: {
           label: 'View-Through Attribution Window Size',
           description:
-            '	Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 7.',
+            'Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 7.',
           type: 'number',
           default: 7,
           choices: SUPPORTED_LOOKBACK_WINDOW_CHOICES

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -16,6 +16,28 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
       description:
         'When saving this mapping, we will create a conversion rule in LinkedIn using the fields you provided.',
       inputFields: {
+        adAccountId: {
+          label: 'Ad Account',
+          description: 'The ad account to use for the conversion event.',
+          type: 'string',
+          required: true,
+          dynamic: async (request) => {
+            const linkedIn = new LinkedInConversions(request)
+            return linkedIn.getAdAccounts()
+          }
+        },
+        campaignId: {
+          label: 'Campaigns',
+          description:
+            'Select one or more advertising campaigns from your ad account to associate with the configured conversion rule.',
+          type: 'string',
+          multiple: true,
+          required: true,
+          dynamic: async (request, { payload }) => {
+            const linkedIn = new LinkedInConversions(request)
+            return linkedIn.getCampaignsList(payload.adAccountId)
+          }
+        },
         /**
          * The configuration fields for a LinkedIn CAPI conversion rule.
          * Detailed information on these parameters can be found at
@@ -155,13 +177,6 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
     }
   },
   fields: {
-    adAccountId: {
-      label: 'Ad Account',
-      description: 'The ad account to use for the conversion event.',
-      type: 'string',
-      required: true,
-      dynamic: true
-    },
     conversionHappenedAt: {
       label: 'Timestamp',
       description:
@@ -258,25 +273,6 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
           required: false
         }
       }
-    },
-    campaignId: {
-      label: 'Campaigns',
-      type: 'string',
-      multiple: true,
-      required: true,
-      dynamic: true,
-      description:
-        'Select one or more advertising campaigns from your ad account to associate with the configured conversion rule.'
-    }
-  },
-  dynamicFields: {
-    adAccountId: async (request) => {
-      const linkedIn = new LinkedInConversions(request)
-      return linkedIn.getAdAccounts()
-    },
-    campaignId: async (request, { payload }) => {
-      const linkedIn = new LinkedInConversions(request)
-      return linkedIn.getCampaignsList(payload.adAccountId)
     }
   },
   perform: async (request, { payload, hookOutputs }) => {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -33,9 +33,9 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
           type: 'string',
           multiple: true,
           required: true,
-          dynamic: async (request, { payload }) => {
+          dynamic: async (request, { hookInputs }) => {
             const linkedIn = new LinkedInConversions(request)
-            return linkedIn.getCampaignsList(payload.adAccountId)
+            return linkedIn.getCampaignsList(hookInputs?.adAccountId)
           }
         },
         /**
@@ -49,9 +49,9 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
           description:
             'The ID of an existing conversion rule to stream events to. If defined, we will not create a new conversion rule.',
           required: false,
-          dynamic: async (request, { payload }) => {
+          dynamic: async (request, { hookInputs }) => {
             const linkedIn = new LinkedInConversions(request)
-            return linkedIn.getConversionRulesList(payload.adAccountId)
+            return linkedIn.getConversionRulesList(hookInputs?.adAccountId)
           }
         },
         name: {
@@ -161,18 +161,17 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
           required: true
         }
       },
-      performHook: async (request, { payload, hookInputs, hookOutputs }) => {
+      performHook: async (request, { hookInputs, hookOutputs }) => {
         const linkedIn = new LinkedInConversions(request, hookInputs?.conversionRuleId)
 
         if (hookOutputs?.onMappingSave?.outputs) {
           return await linkedIn.updateConversionRule(
-            payload.adAccountId,
             hookInputs,
             hookOutputs.onMappingSave.outputs as HookBundle['onMappingSave']['outputs']
           )
         }
 
-        return await linkedIn.createConversionRule(payload.adAccountId, hookInputs)
+        return await linkedIn.createConversionRule(hookInputs)
       }
     }
   },


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR moves the existing Ad Account ID and Campaign ID fields from the regular input fields section to the hook input fields section. This section makes more sense since both fields are used to create and update conversion rules, and have no impact on streaming event delivery.

To support this in UI these PRs are needed:
https://github.com/segmentio/app/pull/19870
https://github.com/segmentio/integrations/pull/2834

## Testing

Tested successfully in staging. The fields are shown and their values are correctly used. 


https://github.com/segmentio/action-destinations/assets/27820201/d2a8c4be-f509-4081-8d71-c7e672afa321

The new request succeeding in local:
<img width="1329" alt="Screenshot 2024-03-14 at 2 38 08 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/db88f34c-1e1c-4061-94ab-6c5b1a3d23b9">

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
