### PR TITLE
[Snap V3 CAPI] use pixel id for offline events

### DIFF
--- a/packages/destination-actions/src/destinations/snap-conversions-api/_tests_/capiV3tests.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/_tests_/capiV3tests.ts
@@ -200,7 +200,7 @@ export const capiV3tests = () =>
             event_conversion_type: 'MOBILE_APP'
           }
         })
-      ).rejects.toThrowError('If event conversion type is "MOBILE_APP" then Snap App ID and App ID must be defined')
+      ).rejects.toThrowError('If event conversion type is "MOBILE_APP" then Snap App ID must be defined')
     })
 
     it('should handle an offline event conversion type', async () => {

--- a/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-v3.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-v3.ts
@@ -67,7 +67,7 @@ export const formatPayload = (payload: Payload, settings: Settings, isTest = tru
     products.length > 0
       ? {
           content_ids: products.map(({ item_id }) => item_id),
-          content_category: products.map(({ item_category }) => item_category),
+          content_category: products.map(({ item_category }) => item_category ?? ''),
           brands: products.map((product) => product.brand ?? ''),
           num_items: products.length
         }

--- a/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-v3.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-v3.ts
@@ -171,11 +171,26 @@ export const validateAppOrPixelID = (settings: Settings, event_conversion_type: 
 
   // Some configurations specify both a snapPixelID and a snapAppID. In these cases
   // check the conversion type to ensure that the right id is selected and used.
-  const appOrPixelID = event_conversion_type === 'WEB' ? snapPixelID : snapAppID
+  const appOrPixelID = (() => {
+    switch (event_conversion_type) {
+      case 'WEB':
+      case 'OFFLINE':
+        return snapPixelID
+      case 'MOBILE_APP':
+        return snapAppID
+      default:
+        return undefined
+    }
+  })()
+
+  raiseMisconfiguredRequiredFieldErrorIf(
+    event_conversion_type === 'OFFLINE' && isNullOrUndefined(snapPixelID),
+    'If event conversion type is "OFFLINE" then Pixel ID must be defined'
+  )
 
   raiseMisconfiguredRequiredFieldErrorIf(
     event_conversion_type === 'MOBILE_APP' && isNullOrUndefined(snapAppID),
-    'If event conversion type is "MOBILE_APP" then Snap App ID and App ID must be defined'
+    'If event conversion type is "MOBILE_APP" then Snap App ID must be defined'
   )
 
   raiseMisconfiguredRequiredFieldErrorIf(


### PR DESCRIPTION
Update the Snap V3 connector to use the pixel id for offline events, and not fallback to the app id.

## Testing

During production testing, we found one case of AppID being used for OFFLINE conversion events. In this case pixel ID should actually be used.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality