### PR TITLE
[segment connections] Enable_batching: hides field and defaults to false

### DIFF
--- a/packages/destination-actions/src/destinations/segment/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment/segment-properties.ts
@@ -347,6 +347,8 @@ export const traits: InputField = {
 export const enable_batching: InputField = {
   type: 'boolean',
   label: 'Batch Data to segment',
-  description: 'When enabled, the action will send batch data. Segment accepts batches of up to 225 events.',
-  default: true
+  description:
+    'This is always disabled pending a full removal. When enabled, the action will send batch data. Segment accepts batches of up to 225 events.',
+  default: false,
+  unsafe_hidden: true
 }

--- a/packages/destination-actions/src/destinations/segment/sendGroup/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment/sendGroup/generated-types.ts
@@ -224,7 +224,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * When enabled, the action will send batch data. Segment accepts batches of up to 225 events.
+   * This is always disabled pending a full removal. When enabled, the action will send batch data. Segment accepts batches of up to 225 events.
    */
   enable_batching?: boolean
 }

--- a/packages/destination-actions/src/destinations/segment/sendIdentify/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment/sendIdentify/generated-types.ts
@@ -224,7 +224,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * When enabled, the action will send batch data. Segment accepts batches of up to 225 events.
+   * This is always disabled pending a full removal. When enabled, the action will send batch data. Segment accepts batches of up to 225 events.
    */
   enable_batching?: boolean
 }

--- a/packages/destination-actions/src/destinations/segment/sendPage/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment/sendPage/generated-types.ts
@@ -232,7 +232,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * When enabled, the action will send batch data. Segment accepts batches of up to 225 events.
+   * This is always disabled pending a full removal. When enabled, the action will send batch data. Segment accepts batches of up to 225 events.
    */
   enable_batching?: boolean
 }

--- a/packages/destination-actions/src/destinations/segment/sendScreen/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment/sendScreen/generated-types.ts
@@ -228,7 +228,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * When enabled, the action will send batch data. Segment accepts batches of up to 225 events.
+   * This is always disabled pending a full removal. When enabled, the action will send batch data. Segment accepts batches of up to 225 events.
    */
   enable_batching?: boolean
 }

--- a/packages/destination-actions/src/destinations/segment/sendTrack/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/generated-types.ts
@@ -234,7 +234,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * When enabled, the action will send batch data. Segment accepts batches of up to 225 events.
+   * This is always disabled pending a full removal. When enabled, the action will send batch data. Segment accepts batches of up to 225 events.
    */
   enable_batching?: boolean
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR defaults the `enable_batching` field to false and hides it for the Segment Connections destination. This will result in new instances not being able to use batching for the destination. A migration to move any customers who have the field set to 'true' will follow.

This is in response to sev: https://twilio.enterprise.slack.com/archives/C06NWQVMT8B

## Testing

Testing not required

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
