### PR TITLE
Channels-1075: fix partially formatted E164 numbers failing to send

### DIFF
--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-whatsapp.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-whatsapp.test.ts
@@ -39,6 +39,36 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       expect(responses.length).toEqual(0)
     })
 
+    it('should abort when there are no external IDs in the payload', async () => {
+      const responses = await testAction({
+        mappingOverrides: {
+          externalIds: []
+        }
+      })
+
+      expect(responses.length).toEqual(0)
+    })
+
+    it('should abort when there is an empty `phone` external ID in the payload', async () => {
+      const responses = await testAction({
+        mappingOverrides: {
+          externalIds: [{ type: 'phone', id: '', subscriptionStatus: 'subscribed' }]
+        }
+      })
+
+      expect(responses.length).toEqual(0)
+    })
+
+    it('should abort when there is a null `phone` external ID in the payload', async () => {
+      const responses = await testAction({
+        mappingOverrides: {
+          externalIds: [{ type: 'phone', id: null, subscriptionStatus: 'subscribed' }]
+        }
+      })
+
+      expect(responses.length).toEqual(0)
+    })
+
     it('should abort when there is no `channelType` in the external ID payload', async () => {
       const responses = await testAction({
         mappingOverrides: {

--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-whatsapp.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-whatsapp.test.ts
@@ -70,7 +70,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
 
     it('should send WhatsApp for partially formatted E164 number in non-default region', async () => {
       // EU number without "+"
-      const phone = '447720376181'
+      const phone = '441112276181'
       const expectedTwilioRequest = new URLSearchParams({
         ContentSid: defaultTemplateSid,
         From: 'MG1111222233334444',
@@ -101,7 +101,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
 
     it('should send WhatsApp for fully formatted E164 number in non-default region', async () => {
       // EU number with "+"
-      const phone = '+447720376181'
+      const phone = '+441112276181'
       const expectedTwilioRequest = new URLSearchParams({
         ContentSid: defaultTemplateSid,
         From: 'MG1111222233334444',
@@ -131,7 +131,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
     })
 
     it('should send WhatsApp for partially formatted E164 number in default region "US"', async () => {
-      const phone = '16146369373'
+      const phone = '11116369373'
       const expectedTwilioRequest = new URLSearchParams({
         ContentSid: defaultTemplateSid,
         From: 'MG1111222233334444',
@@ -158,7 +158,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
     })
 
     it('should send WhatsApp for fully formatted E164 number in default region "US"', async () => {
-      const phone = '+11231233212'
+      const phone = '+11116369373'
       const expectedTwilioRequest = new URLSearchParams({
         ContentSid: defaultTemplateSid,
         From: 'MG1111222233334444',


### PR DESCRIPTION
[CHANNELS-1075](https://segment.atlassian.net/browse/CHANNELS-1075)

Customers were having issues receiving messages when given a phone number that included a country code without a "+" in front. This PR fixes that.


<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment


[CHANNELS-1075]: https://segment.atlassian.net/browse/CHANNELS-1075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ