### PR TITLE
Update default Ripe cloud mode endpoint

### DIFF
--- a/packages/destination-actions/src/destinations/ripe/group/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/ripe/group/__tests__/index.test.ts
@@ -16,11 +16,11 @@ describe('Ripe', () => {
     })
 
     it('should work', async () => {
-      nock('https://api.getripe.com/core-backend').post('/group').reply(200, {})
+      nock('https://api.getripe.com/event').post('/group').reply(200, {})
 
       const responses = await testDestination.testAction('group', {
         mapping: { anonymousId: 'my-anonymous-id', groupId: 'my-group-id' },
-        settings: { apiKey: 'api-key', endpoint: 'https://api.getripe.com/core-backend' }
+        settings: { apiKey: 'api-key', endpoint: 'https://api.getripe.com/event' }
       })
 
       expect(responses.length).toBe(1)

--- a/packages/destination-actions/src/destinations/ripe/identify/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/ripe/identify/__tests__/index.test.ts
@@ -17,11 +17,11 @@ describe('Ripe', () => {
     })
 
     it('should work', async () => {
-      nock('https://api.getripe.com/core-backend').post('/identify').reply(200, {})
+      nock('https://api.getripe.com/event').post('/identify').reply(200, {})
 
       const responses = await testDestination.testAction('identify', {
         mapping: { anonymousId: 'my-id', traits: {} },
-        settings: { apiKey: 'api-key', endpoint: 'https://api.getripe.com/core-backend' }
+        settings: { apiKey: 'api-key', endpoint: 'https://api.getripe.com/event' }
       })
 
       expect(responses.length).toBe(1)

--- a/packages/destination-actions/src/destinations/ripe/index.ts
+++ b/packages/destination-actions/src/destinations/ripe/index.ts
@@ -29,7 +29,7 @@ const destination: DestinationDefinition<Settings> = {
         description: `The Ripe API endpoint (do not change this unless you know what you're doing)`,
         type: 'string',
         format: 'uri',
-        default: 'https://api.getripe.com/core-backend'
+        default: 'https://api.getripe.com/event'
       }
     },
 

--- a/packages/destination-actions/src/destinations/ripe/page/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/ripe/page/__tests__/index.test.ts
@@ -7,10 +7,10 @@ const testDestination = createTestIntegration(Ripe)
 describe('Ripe', () => {
   describe('page', () => {
     it('should validate action fields', async () => {
-      nock('https://api.getripe.com/core-backend').post('/page').reply(200, {})
+      nock('https://api.getripe.com/event').post('/page').reply(200, {})
       try {
         await testDestination.testAction('page', {
-          settings: { apiKey: 'api-key', endpoint: 'https://api.getripe.com/core-backend' }
+          settings: { apiKey: 'api-key', endpoint: 'https://api.getripe.com/event' }
         })
       } catch (err) {
         expect(err.message).toContain("missing the required field 'properties'.")
@@ -19,11 +19,11 @@ describe('Ripe', () => {
     })
 
     it('should work', async () => {
-      nock('https://api.getripe.com/core-backend').post('/page').reply(200, {})
+      nock('https://api.getripe.com/event').post('/page').reply(200, {})
 
       const responses = await testDestination.testAction('page', {
         mapping: { anonymousId: 'my-id', properties: {}, name: 'page-name' },
-        settings: { apiKey: 'api-key', endpoint: 'https://api.getripe.com/core-backend' }
+        settings: { apiKey: 'api-key', endpoint: 'https://api.getripe.com/event' }
       })
 
       expect(responses.length).toBe(1)

--- a/packages/destination-actions/src/destinations/ripe/track/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/ripe/track/__tests__/index.test.ts
@@ -17,11 +17,11 @@ describe('Ripe', () => {
     })
 
     it('should work', async () => {
-      nock('https://api.getripe.com/core-backend').post('/track').reply(200, {})
+      nock('https://api.getripe.com/event').post('/track').reply(200, {})
 
       const responses = await testDestination.testAction('track', {
         mapping: { anonymousId: 'my-id', event: 'event-name' },
-        settings: { apiKey: 'api-key', endpoint: 'https://api.getripe.com/core-backend' }
+        settings: { apiKey: 'api-key', endpoint: 'https://api.getripe.com/event' }
       })
 
       expect(responses.length).toBe(1)


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Updating the default endpoint of the Ripe cloud mode destination.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
