### PR TITLE
[conditional-fields] Rollout to LinkedIn + Google Enhanced Conversions

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
@@ -75,13 +75,31 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Restatement Value',
       description:
         'The restated conversion value. This is the value of the conversion after restatement. For example, to change the value of a conversion from 100 to 70, an adjusted value of 70 should be reported. Required for RESTATEMENT adjustments.',
-      type: 'number'
+      type: 'number',
+      depends_on: {
+        conditions: [
+          {
+            fieldKey: 'adjustment_type',
+            operator: 'is_not',
+            value: ['RETRACTION']
+          }
+        ]
+      }
     },
     restatement_currency_code: {
       label: 'Restatement Currency Code',
       description:
         'The currency of the restated value. If not provided, then the default currency from the conversion action is used, and if that is not set then the account currency is used. This is the ISO 4217 3-character currency code, e.g. USD or EUR.',
-      type: 'string'
+      type: 'string',
+      depends_on: {
+        conditions: [
+          {
+            fieldKey: 'adjustment_type',
+            operator: 'is_not',
+            value: ['RETRACTION']
+          }
+        ]
+      }
     },
     email_address: {
       label: 'Email Address',

--- a/packages/destination-actions/src/destinations/intercom/identifyContact/index.ts
+++ b/packages/destination-actions/src/destinations/intercom/identifyContact/index.ts
@@ -25,15 +25,6 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'External ID',
       default: {
         '@path': '$.userId'
-      },
-      depends_on: {
-        conditions: [
-          {
-            fieldKey: 'role',
-            operator: 'is_not',
-            value: 'lead'
-          }
-        ]
       }
     },
     email: {

--- a/packages/destination-actions/src/destinations/intercom/identifyContact/index.ts
+++ b/packages/destination-actions/src/destinations/intercom/identifyContact/index.ts
@@ -25,6 +25,15 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'External ID',
       default: {
         '@path': '$.userId'
+      },
+      depends_on: {
+        conditions: [
+          {
+            fieldKey: 'role',
+            operator: 'is_not',
+            value: 'lead'
+          }
+        ]
       }
     },
     email: {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/constants.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/constants.ts
@@ -1,3 +1,5 @@
+import { DependsOnConditions } from '@segment/actions-core/destination-kit/types'
+
 export const LINKEDIN_API_VERSION = '202401'
 export const BASE_URL = 'https://api.linkedin.com/rest'
 export const LINKEDIN_SOURCE_PLATFORM = 'SEGMENT'
@@ -62,3 +64,14 @@ export const SUPPORTED_LOOKBACK_WINDOW_CHOICES: Choice[] = [
 
 export const DEFAULT_POST_CLICK_LOOKBACK_WINDOW = 30
 export const DEFAULT_VIEW_THROUGH_LOOKBACK_WINDOW = 7
+
+export const DEPENDS_ON_CONVERSION_RULE_ID: DependsOnConditions = {
+  match: 'all',
+  conditions: [
+    {
+      fieldKey: 'conversionRuleId',
+      operator: 'is_not',
+      value: undefined
+    }
+  ]
+}

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
@@ -80,7 +80,7 @@ export interface HookBundle {
        */
       post_click_attribution_window_size?: number
       /**
-       * 	Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 7.
+       * Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 7.
        */
       view_through_attribution_window_size?: number
     }

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -2,7 +2,12 @@ import type { ActionDefinition } from '@segment/actions-core'
 import { ErrorCodes, IntegrationError, PayloadValidationError, InvalidAuthenticationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import { LinkedInConversions } from '../api'
-import { SUPPORTED_ID_TYPE, CONVERSION_TYPE_OPTIONS, SUPPORTED_LOOKBACK_WINDOW_CHOICES } from '../constants'
+import {
+  SUPPORTED_ID_TYPE,
+  CONVERSION_TYPE_OPTIONS,
+  SUPPORTED_LOOKBACK_WINDOW_CHOICES,
+  DEPENDS_ON_CONVERSION_RULE_ID
+} from '../constants'
 import type { Payload, HookBundle } from './generated-types'
 import { LinkedInError } from '../types'
 
@@ -36,32 +41,14 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
           type: 'string',
           label: 'Name',
           description: 'The name of the conversion rule.',
-          depends_on: {
-            match: 'all',
-            conditions: [
-              {
-                fieldKey: 'conversionRuleId',
-                operator: 'is_not',
-                value: undefined
-              }
-            ]
-          }
+          depends_on: DEPENDS_ON_CONVERSION_RULE_ID
         },
         conversionType: {
           type: 'string',
           label: 'Conversion Type',
           description: 'The type of conversion rule.',
           choices: CONVERSION_TYPE_OPTIONS,
-          depends_on: {
-            match: 'all',
-            conditions: [
-              {
-                fieldKey: 'conversionRuleId',
-                operator: 'is_not',
-                value: undefined
-              }
-            ]
-          }
+          depends_on: DEPENDS_ON_CONVERSION_RULE_ID
         },
         attribution_type: {
           label: 'Attribution Type',
@@ -71,16 +58,7 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
             { label: 'Each Campaign', value: 'LAST_TOUCH_BY_CAMPAIGN' },
             { label: 'Single Campaign', value: 'LAST_TOUCH_BY_CONVERSION' }
           ],
-          depends_on: {
-            match: 'all',
-            conditions: [
-              {
-                fieldKey: 'conversionRuleId',
-                operator: 'is_not',
-                value: undefined
-              }
-            ]
-          }
+          depends_on: DEPENDS_ON_CONVERSION_RULE_ID
         },
         post_click_attribution_window_size: {
           label: 'Post-Click Attribution Window Size',
@@ -88,15 +66,17 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
             'Conversion window timeframe (in days) of a member clicking on a LinkedIn Ad (a post-click conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 30.',
           type: 'number',
           default: 30,
-          choices: SUPPORTED_LOOKBACK_WINDOW_CHOICES
+          choices: SUPPORTED_LOOKBACK_WINDOW_CHOICES,
+          depends_on: DEPENDS_ON_CONVERSION_RULE_ID
         },
         view_through_attribution_window_size: {
           label: 'View-Through Attribution Window Size',
           description:
-            '	Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 7.',
+            'Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 7.',
           type: 'number',
           default: 7,
-          choices: SUPPORTED_LOOKBACK_WINDOW_CHOICES
+          choices: SUPPORTED_LOOKBACK_WINDOW_CHOICES,
+          depends_on: DEPENDS_ON_CONVERSION_RULE_ID
         }
       },
       outputTypes: {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR adds conditions for fields in two actions:
* LinkedIn: streamConversion
The new lookback window fields are hidden when a user selects an existing conversion rule ID. In this case these fields are ignored. 

* Google Enhanced Conversions: uploadConversionAdjustment
The `restatement_value` and `restatement_currency_code` fields are hidden when `adjustment_type` is `RETRACTION`. In this case these fields are ignored by the `perform` block.

## Testing
Tested successfully in stage

https://github.com/segmentio/action-destinations/assets/27820201/c1136a7a-3a26-4578-966d-b078df8f3505

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
