### PR TITLE
Added option mapping field for messageId in segment profiles

### DIFF
--- a/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
@@ -44,3 +44,9 @@ export const timestamp: InputField = {
     '@path': '$.timestamp'
   }
 }
+
+export const message_id: InputField = {
+  type: 'string',
+  label: 'MessageId',
+  description: 'The Segment messageId.'
+}

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/generated-types.ts
@@ -27,4 +27,8 @@ export interface Payload {
    * The timestamp of the event.
    */
   timestamp?: string | number
+  /**
+   * The Segment messageId.
+   */
+  message_id?: string
 }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { user_id, anonymous_id, group_id, traits, engage_space, timestamp } from '../segment-properties'
+import { user_id, anonymous_id, group_id, traits, engage_space, timestamp, message_id } from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -14,7 +14,8 @@ const action: ActionDefinition<Settings, Payload> = {
     anonymous_id,
     group_id: { ...group_id, required: true },
     traits,
-    timestamp
+    timestamp,
+    message_id
   },
   perform: (_request, { payload, statsContext }) => {
     if (!payload.anonymous_id && !payload.user_id) {
@@ -24,6 +25,7 @@ const action: ActionDefinition<Settings, Payload> = {
       userId: payload?.user_id,
       anonymousId: payload?.anonymous_id,
       groupId: payload?.group_id,
+      messageId: payload?.message_id,
       traits: {
         ...payload?.traits
       },

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/generated-types.ts
@@ -27,4 +27,8 @@ export interface Payload {
    * The timestamp of the event.
    */
   timestamp?: string | number
+  /**
+   * The Segment messageId.
+   */
+  message_id?: string
 }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { user_id, anonymous_id, group_id, traits, engage_space, timestamp } from '../segment-properties'
+import { user_id, anonymous_id, group_id, traits, engage_space, timestamp, message_id } from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -15,7 +15,8 @@ const action: ActionDefinition<Settings, Payload> = {
     anonymous_id,
     group_id,
     traits,
-    timestamp
+    timestamp,
+    message_id
   },
   perform: (_request, { payload, statsContext }) => {
     if (!payload.anonymous_id && !payload.user_id) {
@@ -25,6 +26,7 @@ const action: ActionDefinition<Settings, Payload> = {
       userId: payload?.user_id,
       anonymousId: payload?.anonymous_id,
       groupId: payload?.group_id,
+      messageId: payload?.message_id,
       traits: {
         ...payload?.traits
       },

--- a/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/generated-types.ts
@@ -65,4 +65,8 @@ export interface Payload {
    * The timestamp of the event.
    */
   timestamp?: string | number
+  /**
+   * The Segment messageId.
+   */
+  message_id?: string
 }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/index.ts
@@ -15,7 +15,8 @@ import {
   android_push_token,
   android_push_subscription_status,
   ios_push_subscription_status,
-  ios_push_token
+  ios_push_token,
+  message_id
 } from './subscription-properties'
 import {
   InvalidSubscriptionStatusError,
@@ -278,7 +279,8 @@ const action: ActionDefinition<Settings, Payload> = {
     ios_push_token,
     ios_push_subscription_status,
     traits,
-    timestamp
+    timestamp,
+    message_id
   },
   perform: (_request, { payload, statsContext }) => {
     const statsClient = statsContext?.statsClient
@@ -308,6 +310,7 @@ const action: ActionDefinition<Settings, Payload> = {
         // to any destinations which is connected to the Segment Profiles space
         All: false
       },
+      messageId: payload?.message_id,
       type: 'identify'
     }
 

--- a/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/subscription-properties.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/subscription-properties.ts
@@ -102,3 +102,9 @@ export const subscription_groups: InputField = {
   additionalProperties: true,
   defaultObjectUI: 'keyvalue'
 }
+
+export const message_id: InputField = {
+  type: 'string',
+  label: 'MessageId',
+  description: 'The Segment messageId.'
+}


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Added support for optionally mapping messageId in all actions in the Segment profiles destination.
JIRA Ticket:- https://segment.atlassian.net/browse/STRATCONN-3665

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] [Segmenters] Tested in the staging environment

<img width="918" alt="Screenshot 2024-03-20 at 6 43 01 AM" src="https://github.com/segmentio/action-destinations/assets/117922634/425ba2ff-1b9e-43a6-9dcb-ba894b684005">

