### PR TITLE
[Segment Profiles] Add SendTrack action

### DIFF
--- a/packages/destination-actions/src/destinations/segment-profiles/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -185,3 +185,47 @@ Object {
   "output": "Action Executed",
 }
 `;
+
+exports[`Testing snapshot for actions-segment-profiles destination: sendTrack action - all fields 1`] = `
+Object {
+  "data": Object {
+    "batch": Array [
+      Object {
+        "anonymousId": "[2uovRzxThJj",
+        "event": "[2uovRzxThJj",
+        "integrations": Object {
+          "All": false,
+        },
+        "properties": Object {
+          "testType": "[2uovRzxThJj",
+        },
+        "timestamp": "2021-02-01T00:00:00.000Z",
+        "type": "track",
+        "userId": "[2uovRzxThJj",
+      },
+    ],
+  },
+  "output": "Action Executed",
+}
+`;
+
+exports[`Testing snapshot for actions-segment-profiles destination: sendTrack action - required fields 1`] = `
+Object {
+  "data": Object {
+    "batch": Array [
+      Object {
+        "anonymousId": "[2uovRzxThJj",
+        "event": "[2uovRzxThJj",
+        "integrations": Object {
+          "All": false,
+        },
+        "properties": Object {},
+        "timestamp": undefined,
+        "type": "track",
+        "userId": "[2uovRzxThJj",
+      },
+    ],
+  },
+  "output": "Action Executed",
+}
+`;

--- a/packages/destination-actions/src/destinations/segment-profiles/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/__tests__/snapshot.test.ts
@@ -8,6 +8,10 @@ const destinationSlug = 'actions-segment-profiles'
 
 describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
   for (const actionSlug in destination.actions) {
+    // skip sendTrack as it doesn't make any API calls
+    if (actionSlug == 'sendTrack') {
+      continue
+    }
     it(`${actionSlug} action - required fields`, async () => {
       const seedName = `${destinationSlug}#${actionSlug}`
       const action = destination.actions[actionSlug]

--- a/packages/destination-actions/src/destinations/segment-profiles/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/__tests__/snapshot.test.ts
@@ -8,10 +8,6 @@ const destinationSlug = 'actions-segment-profiles'
 
 describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
   for (const actionSlug in destination.actions) {
-    // skip sendTrack as it doesn't make any API calls
-    if (actionSlug == 'sendTrack') {
-      continue
-    }
     it(`${actionSlug} action - required fields`, async () => {
       const seedName = `${destinationSlug}#${actionSlug}`
       const action = destination.actions[actionSlug]

--- a/packages/destination-actions/src/destinations/segment-profiles/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/index.ts
@@ -2,10 +2,9 @@ import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
 import sendGroup from './sendGroup'
-
 import sendIdentify from './sendIdentify'
-
 import sendSubscription from './sendSubscription'
+import sendTrack from './sendTrack'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Segment Profiles',
@@ -14,7 +13,8 @@ const destination: DestinationDefinition<Settings> = {
   actions: {
     sendGroup,
     sendIdentify,
-    sendSubscription
+    sendSubscription,
+    sendTrack
   }
 }
 

--- a/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
@@ -54,7 +54,7 @@ export const event_name: InputField = {
 
 export const properties: InputField = {
   label: 'Properties',
-  description: 'Free-form dictionary of properties that describe the screen.',
+  description: 'Free-form dictionary of properties that describe the event.',
   type: 'object',
   defaultObjectUI: 'keyvalue',
   additionalProperties: true

--- a/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
@@ -44,3 +44,18 @@ export const timestamp: InputField = {
     '@path': '$.timestamp'
   }
 }
+
+export const event_name: InputField = {
+  label: 'Event Name',
+  description: 'Name of the action that a user has performed.',
+  type: 'string',
+  required: true
+}
+
+export const properties: InputField = {
+  label: 'Properties',
+  description: 'Free-form dictionary of properties that describe the screen.',
+  type: 'object',
+  defaultObjectUI: 'keyvalue',
+  additionalProperties: true
+}

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/__tests__/__snapshots__/index.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SegmentProfiles.sendTrack Should return transformed segment track event 1`] = `
+Object {
+  "batch": Array [
+    Object {
+      "anonymousId": "arky4h2sh7k",
+      "event": "Test Event",
+      "properties": Object {
+        "plan": "Business",
+      },
+      "timestamp": undefined,
+      "userId": "test-user-ufi5bgkko5",
+    },
+  ],
+}
+`;

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/__tests__/__snapshots__/index.test.ts.snap
@@ -6,10 +6,14 @@ Object {
     Object {
       "anonymousId": "arky4h2sh7k",
       "event": "Test Event",
+      "integrations": Object {
+        "All": false,
+      },
       "properties": Object {
         "plan": "Business",
       },
       "timestamp": undefined,
+      "type": "track",
       "userId": "test-user-ufi5bgkko5",
     },
   ],

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/__tests__/index.test.ts
@@ -1,0 +1,72 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { DEFAULT_SEGMENT_ENDPOINT } from '../../properties'
+import { MissingUserOrAnonymousIdThrowableError } from '../../errors'
+
+const testDestination = createTestIntegration(Destination)
+
+beforeEach(() => nock.cleanAll())
+
+// Default Page Mapping
+const defaultTrackMapping = {
+  event_name: {
+    '@path': '$.event'
+  },
+  user_id: {
+    '@path': '$.userId'
+  },
+  anonymous_id: {
+    '@path': '$.anonymousId'
+  },
+  properties: {
+    '@path': '$.properties'
+  },
+  engage_space: 'engage-space-writekey'
+}
+
+describe('SegmentProfiles.sendTrack', () => {
+  test('Should throw an error if `userId or` `anonymousId` is not defined', async () => {
+    const event = createTestEvent({
+      properties: {
+        plan: 'Business'
+      },
+      event: 'Test Event'
+    })
+
+    await expect(
+      testDestination.testAction('sendTrack', {
+        event,
+        mapping: {
+          event_name: {
+            '@path': '$.event'
+          }
+        }
+      })
+    ).rejects.toThrowError(MissingUserOrAnonymousIdThrowableError)
+  })
+
+  test('Should return transformed segment track event', async () => {
+    const event = createTestEvent({
+      properties: {
+        plan: 'Business'
+      },
+      userId: 'test-user-ufi5bgkko5',
+      anonymousId: 'arky4h2sh7k',
+      event: 'Test Event'
+    })
+
+    const responses = await testDestination.testAction('sendTrack', {
+      event,
+      mapping: defaultTrackMapping,
+      settings: {
+        endpoint: DEFAULT_SEGMENT_ENDPOINT
+      }
+    })
+
+    const results = testDestination.results
+    expect(responses.length).toBe(0)
+    expect(results.length).toBe(3)
+    expect(results[2].data).toMatchSnapshot()
+  })
+})

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/__tests__/index.test.ts
@@ -8,7 +8,7 @@ const testDestination = createTestIntegration(Destination)
 
 beforeEach(() => nock.cleanAll())
 
-// Default Page Mapping
+// Default Track Mapping
 const defaultTrackMapping = {
   event_name: {
     '@path': '$.event'
@@ -22,7 +22,9 @@ const defaultTrackMapping = {
   properties: {
     '@path': '$.properties'
   },
-  engage_space: 'engage-space-writekey'
+  timstamp: {
+    '@path': '$.timestamp'
+  }
 }
 
 describe('SegmentProfiles.sendTrack', () => {
@@ -53,6 +55,7 @@ describe('SegmentProfiles.sendTrack', () => {
       },
       userId: 'test-user-ufi5bgkko5',
       anonymousId: 'arky4h2sh7k',
+      timestamp: '2023-09-26T09:46:28.290Z',
       event: 'Test Event'
     })
 

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/__tests__/index.test.ts
@@ -10,6 +10,7 @@ beforeEach(() => nock.cleanAll())
 
 // Default Track Mapping
 const defaultTrackMapping = {
+  engage_space: 'space-write-key',
   event_name: {
     '@path': '$.event'
   },
@@ -42,7 +43,8 @@ describe('SegmentProfiles.sendTrack', () => {
         mapping: {
           event_name: {
             '@path': '$.event'
-          }
+          },
+          engage_space: 'space-write-key'
         }
       })
     ).rejects.toThrowError(MissingUserOrAnonymousIdThrowableError)

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/generated-types.ts
@@ -1,0 +1,30 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Unique identifier for the user in your database. A userId or an anonymousId is required.
+   */
+  user_id?: string
+  /**
+   * A pseudo-unique substitute for a User ID, for cases when you don’t have an absolutely unique identifier. A userId or an anonymousId is required.
+   */
+  anonymous_id?: string
+  /**
+   * The timestamp of the event.
+   */
+  timestamp?: string | number
+  /**
+   * Name of the action that a user has performed.
+   */
+  event_name: string
+  /**
+   * The group or account ID a user is associated with.
+   */
+  group_id?: string
+  /**
+   * Free-form dictionary of properties that describe the screen.
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/generated-types.ts
@@ -2,6 +2,10 @@
 
 export interface Payload {
   /**
+   * The Profile Space to use for creating a record. *Note: This field shows list of internal sources associated with the Profile Space. Changes made to the Profile Space name in **Settings** will not reflect in this list unless the source associated with the Profile Space is renamed explicitly.*
+   */
+  engage_space: string
+  /**
    * Unique identifier for the user in your database. A userId or an anonymousId is required.
    */
   user_id?: string

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/generated-types.ts
@@ -26,7 +26,7 @@ export interface Payload {
    */
   group_id?: string
   /**
-   * Free-form dictionary of properties that describe the screen.
+   * Free-form dictionary of properties that describe the event.
    */
   properties?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
@@ -1,0 +1,39 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { user_id, anonymous_id, timestamp, event_name, group_id, properties } from '../segment-properties'
+import { MissingUserOrAnonymousIdThrowableError } from '../errors'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Send Track',
+  description: '',
+  fields: {
+    user_id,
+    anonymous_id,
+    timestamp,
+    event_name,
+    group_id,
+    properties
+  },
+  perform: (_, { payload }) => {
+    if (!payload.anonymous_id && !payload.user_id) {
+      throw MissingUserOrAnonymousIdThrowableError
+    }
+
+    return {
+      batch: [
+        {
+          userId: payload?.user_id,
+          anonymousId: payload?.anonymous_id,
+          timestamp: payload?.timestamp,
+          event: payload?.event_name,
+          properties: {
+            ...payload?.properties
+          }
+        }
+      ]
+    }
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
@@ -15,10 +15,11 @@ const action: ActionDefinition<Settings, Payload> = {
     group_id,
     properties
   },
-  perform: (_, { payload }) => {
+  perform: (_, { payload, statsContext }) => {
     if (!payload.anonymous_id && !payload.user_id) {
       throw MissingUserOrAnonymousIdThrowableError
     }
+    statsContext?.statsClient?.incr('tapi_internal', 1, [...statsContext.tags, `action:sendTrack`])
 
     return {
       batch: [

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
@@ -6,7 +6,7 @@ import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Track',
-  description: '',
+  description: 'Send a track call to Segment’s tracking API. This is used to record actions your users perform.',
   fields: {
     user_id,
     anonymous_id,

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
@@ -27,9 +27,15 @@ const action: ActionDefinition<Settings, Payload> = {
           anonymousId: payload?.anonymous_id,
           timestamp: payload?.timestamp,
           event: payload?.event_name,
+          integrations: {
+            // Setting 'integrations.All' to false will ensure that we don't send events
+            // to any destinations which is connected to the Segment Profiles space.
+            All: false
+          },
           properties: {
             ...payload?.properties
-          }
+          },
+          type: 'track'
         }
       ]
     }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
@@ -1,13 +1,14 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { user_id, anonymous_id, timestamp, event_name, group_id, properties } from '../segment-properties'
+import { user_id, anonymous_id, timestamp, event_name, group_id, properties, engage_space } from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Track',
   description: 'Send a track call to Segment’s tracking API. This is used to record actions your users perform.',
   fields: {
+    engage_space,
     user_id,
     anonymous_id,
     timestamp,


### PR DESCRIPTION
This PR adds a new Send Track action to Segment Profiles.
This action was requested by Cloud Sources team for the Segment Unify project.

## Testing

Test results
1. Created New Mapping

<img width="1385" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/cbf8a344-ff3c-44da-93db-0fd7cc4f186d">

2. Confirmed track events are received on the profiles side

<img width="1375" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/551a1546-a11f-4310-986e-318f2d5e5770">

Full demo recording [here](https://drive.google.com/file/d/1vUoE4VwXhtD62ETrPoWESL8Ot3fpdCG0/view?usp=sharing)

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
