### PR TITLE
[STRATCONN-3673] Adds github release workflow

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   root: true,
-  ignorePatterns: ['node_modules', 'dist', 'templates', '**/node_modules'],
+  ignorePatterns: ['node_modules', 'dist', 'templates', 'scripts', '**/node_modules'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 2019,

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,3 +56,32 @@ jobs:
       - name: Publish
         run: |
           yarn lerna publish from-git --yes --allowBranch=main --loglevel=verbose --dist-tag latest
+
+      - name: Push Release Tag
+        run: |
+          git config user.name ${{ github.actor }}
+          git config user.email ${{ github.actor }}@users.noreply.github.com
+
+          commit=${{ github.sha }}
+          if ! n=$(git rev-list --count $commit~ --since="00:00"); then
+              echo 'failed to calculate tag'
+              exit 1
+          fi
+
+          case "$n" in
+              0) suffix="" ;; # first commit of the day gets no suffix
+              *) suffix=".$n" ;; # subsequent commits get a suffix, starting with .1
+          esac
+
+          tag=$(printf release-$(date '+%Y-%m-%d%%s') $suffix)
+
+          git tag -a $tag -m "Release $tag"
+          git push origin $tag
+
+      - name: Create Release
+        id: create-release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./scripts/create-github-release.js')
+            await script({github, context, core, exec})

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,7 @@ jobs:
           yarn lerna publish from-git --yes --allowBranch=main --loglevel=verbose --dist-tag latest
 
       - name: Push Release Tag
+        id: push-release-tag
         run: |
           git config user.name ${{ github.actor }}
           git config user.email ${{ github.actor }}@users.noreply.github.com
@@ -74,13 +75,15 @@ jobs:
           esac
 
           tag=$(printf release-$(date '+%Y-%m-%d%%s') $suffix)
-
           git tag -a $tag -m "Release $tag"
           git push origin $tag
+          echo "release-tag=$tag" >> $GITHUB_OUTPUT
 
       - name: Create Release
         id: create-release
         uses: actions/github-script@v7
+        env:
+          RELEASE_TAG: ${{ steps.push-release-tag.outputs.release-tag }}
         with:
           script: |
             const script = require('./scripts/create-github-release.js')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           yarn lerna publish from-git --yes --allowBranch=main --loglevel=verbose --dist-tag latest
 
-      - name: Push Release Tag
+      - name: Generate and Push Release Tag
         id: push-release-tag
         run: |
           git config user.name ${{ github.actor }}
@@ -79,8 +79,8 @@ jobs:
           git push origin $tag
           echo "release-tag=$tag" >> $GITHUB_OUTPUT
 
-      - name: Create Release
-        id: create-release
+      - name: Create Github Release
+        id: create-github-release
         uses: actions/github-script@v7
         env:
           RELEASE_TAG: ${{ steps.push-release-tag.outputs.release-tag }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
           git config user.email ${{ github.actor }}@users.noreply.github.com
 
           commit=${{ github.sha }}
-          if ! n=$(git rev-list --count $commit~ --since="00:00"); then
+          if ! n=$(git rev-list --count $commit~ --grep "Publish" --since="00:00"); then
               echo 'failed to calculate tag'
               exit 1
           fi

--- a/scripts/compute-labels.js
+++ b/scripts/compute-labels.js
@@ -1,5 +1,5 @@
-// This is a github action script and can be run only from github actions. It is not possible to run this script locally.
-module.exports = async ({ github, context, core }) => {
+// This is a github action script and can be run only from github actions. To run this script locally, you need to mock the github object and context object.
+export default async ({ github, context, core }) => {
   const authorLabels = await computeAuthorLabels(github, context, core)
   const { add, remove } = await computeFileBasedLabels(github, context, core)
   core.setOutput('add', [...authorLabels, ...add].join(','))

--- a/scripts/create-github-release.js
+++ b/scripts/create-github-release.js
@@ -1,6 +1,6 @@
 // This is a github action script and can be run only from github actions. It is not possible to run this script locally.
 module.exports = async ({ github, context, core, exec }) => {
-  const { GITHUB_RUN_NUMBER, GITHUB_SHA } = process.env
+  const { GITHUB_SHA, RELEASE_TAG } = process.env
   const { data } = await github.rest.search.commits({
     q: `Publish repo:${context.repo.owner}/action-destinations`,
     per_page: 2,
@@ -13,7 +13,7 @@ module.exports = async ({ github, context, core, exec }) => {
   const lastCommit = data.items[1]
   const prs = await getPRsBetweenCommits(github, context, core, lastCommit, currentCommit)
 
-  const currentReleaseTag = `v${GITHUB_RUN_NUMBER}`
+  const currentReleaseTag = RELEASE_TAG
   const latestRelease = await github.rest.repos
     .getLatestRelease({
       owner: context.repo.owner,
@@ -134,7 +134,7 @@ function formatChangeLog(prs, currentRelease, prevRelease, packageTags) {
 
   const packageURLs = packageTags
     .filter((tag) => tag.includes('@segment/'))
-    .map((tag) => `- [${tag}](https://www.npmjs.com/package/${formatNPMPackageURL(tag)})`)
+    .map((tag) => `- ${formatNPMPackageURL(tag)}`)
     .join('\n')
 
   const changelog = `

--- a/scripts/create-github-release.js
+++ b/scripts/create-github-release.js
@@ -56,7 +56,11 @@ async function extractPackageTags(sha, exec, core) {
   if (exitCode !== 0) {
     core.error(`Failed to extract package tags: ${stderr}`)
   }
-  return stdout.split('\n').filter(Boolean)
+  // filter out only the tags that are related to segment packages
+  return stdout
+    .split('\n')
+    .filter(Boolean)
+    .filter((tag) => tag.includes('@segment/') && !tag.includes('staging'))
 }
 
 async function getPRsBetweenCommits(github, context, core, lastCommit, currentCommit) {
@@ -149,7 +153,6 @@ function formatChangeLog(prs, tagsContext, context) {
   const releaseDiff = prevRelease ? `${prevRelease}...${currentRelease}` : currentRelease
 
   const formattedPackageTags = packageTags
-    .filter((tag) => tag.includes('@segment/'))
     .map((tag) => `- [${tag}](https://www.npmjs.com/package/${formatNPMPackageURL(tag)})`)
     .join('\n')
 
@@ -181,8 +184,9 @@ function formatChangeLog(prs, tagsContext, context) {
         return `|${tableConfig.map((config) => pr[config.value]).join('|')}|`
       })
       .join('\n')}
-    `.replace(/  +/g, '')
-  return changelog
+    `
+  // trim double spaces and return the changelog
+  return changelog.replace(/  +/g, '')
 }
 
 function mapPRWithAffectedDestinations(pr) {

--- a/scripts/create-github-release.js
+++ b/scripts/create-github-release.js
@@ -1,0 +1,203 @@
+// This is a github action script and can be run only from github actions. It is not possible to run this script locally.
+module.exports = async ({ github, context, core, exec }) => {
+  const { GITHUB_RUN_NUMBER, GITHUB_SHA } = process.env
+  const { data } = await github.rest.search.commits({
+    q: `Publish repo:${context.repo.owner}/action-destinations`,
+    per_page: 2,
+    sort: 'committer-date'
+  })
+  if (data.items.length < 2) {
+    core.error(`No previous release commits found`)
+  }
+  const currentCommit = data.items[0]
+  const lastCommit = data.items[1]
+  const prs = await getPRsBetweenCommits(github, context, core, lastCommit, currentCommit)
+
+  const currentReleaseTag = `v${GITHUB_RUN_NUMBER}`
+  const latestRelease = await github.rest.repos
+    .getLatestRelease({
+      owner: context.repo.owner,
+      repo: context.repo.repo
+    })
+    .catch((e) => {
+      core.info(`No previous release found: ${e.message}`)
+      return null
+    })
+
+  const latestReleaseTag = latestRelease ? latestRelease.data.tag_name : null
+  const packageTags = await extractPackageTags(GITHUB_SHA, exec, core)
+  const changeLog = formatChangeLog(prs, currentReleaseTag, latestReleaseTag, packageTags)
+
+  await github.rest.repos.createRelease({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    tag_name: currentReleaseTag,
+    name: currentReleaseTag,
+    body: changeLog
+  })
+
+  return
+}
+
+// Extracts the package tags from the commit SHA
+async function extractPackageTags(sha, exec, core) {
+  const { stdout, stderr, exitCode } = await exec.getExecOutput('git', ['tag', '--points-at', sha])
+  if (exitCode !== 0) {
+    core.error(`Failed to extract package tags: ${stderr}`)
+  }
+  return stdout.split('\n').filter(Boolean)
+}
+
+// Fetches the PRs between two commits
+async function getPRsBetweenCommits(github, context, core, lastCommit, currentCommit) {
+  const lastCommitDate = new Date(lastCommit.commit.committer.date)
+  const currentCommitDate = new Date(currentCommit.commit.committer.date)
+  // GraphQL query to get PRs between two commits
+  try {
+    const prsMerged = await github.graphql(`{
+      search(first:100, type: ISSUE, query: "repo:segmentio/action-destinations is:pr merged:${lastCommitDate.toISOString()}..${currentCommitDate.toISOString()}") {
+        issueCount
+        nodes {
+          ... on PullRequest {
+            number
+            title
+            url
+            author {
+              login
+            }
+            files(first: 100) {
+              nodes {
+                path
+              }
+            }
+            labels(first: 10, orderBy: {direction: DESC, field: CREATED_AT}) {
+              nodes {
+                name
+              }
+            }
+          }
+        }
+      }
+       }`)
+
+    core.info(`Found ${prsMerged.search.issueCount} PRs between commits`)
+
+    return prsMerged.search.nodes.map((pr) => ({
+      number: `[#${pr.number}](${pr.url})`,
+      title: pr.title,
+      url: pr.url,
+      files: pr.files.nodes.map((file) => file.path),
+      author: `@${pr.author.login}`,
+      labels: pr.labels.nodes.map((label) => label.name),
+      requiresPush: pr.labels.nodes.some((label) => label.name === 'deploy:push') ? 'Yes' : 'No',
+      requiresRegistration: pr.labels.nodes.some((label) => label.name === 'deploy:registration') ? 'Yes' : 'No'
+    }))
+  } catch (e) {
+    core.error(`Unable to fetch PRs between commits: ${e.message}`)
+  }
+}
+
+// Formats the changelog
+function formatChangeLog(prs, currentRelease, prevRelease, packageTags) {
+  const prsWithAffectedDestinations = prs.map(mapPRWithAffectedDestinations)
+  const internalPRS = prsWithAffectedDestinations.filter(
+    (pr) => pr.labels.includes('team:segment-core') || pr.labels.includes('team:segment')
+  )
+  const externalPRs = prsWithAffectedDestinations.filter((pr) => pr.labels.includes('team:external'))
+
+  const tableConfig = [
+    {
+      label: 'PR',
+      value: 'number'
+    },
+    {
+      label: 'Title',
+      value: 'title'
+    },
+    {
+      label: 'Author',
+      value: 'author'
+    },
+    {
+      label: 'Affected Destinations',
+      value: 'affectedDestinations'
+    },
+    {
+      label: 'Requires Push',
+      value: 'requiresPush'
+    },
+    {
+      label: 'Requires Registration',
+      value: 'requiresRegistration'
+    }
+  ]
+
+  const packageURLs = packageTags
+    .filter((tag) => tag.includes('@segment/'))
+    .map((tag) => `- [${tag}](https://www.npmjs.com/package/${formatNPMPackageURL(tag)})`)
+    .join('\n')
+
+  const changelog = `
+      # What's Changed
+      
+      [Commits](https://github.com/segmentio/action-destinations-deploy-automation/compare/${prevRelease}...${currentRelease})
+  
+      ## Packages Published
+  
+      ${packageURLs}
+  
+      ## Internal PRs
+      
+      |${tableConfig.map((config) => config.label).join('|')}|
+      |${tableConfig.map(() => '---').join('|')}|
+      ${internalPRS
+        .map((pr) => {
+          return `|${tableConfig.map((config) => pr[config.value]).join('|')}|`
+        })
+        .join('\n')}
+          
+      ## External PRs
+      
+      |${tableConfig.map((config) => config.label).join('|')}|
+      |${tableConfig.map(() => '---').join('|')}|
+      ${externalPRs
+        .map((pr) => {
+          return `|${tableConfig.map((config) => pr[config.value]).join('|')}|`
+        })
+        .join('\n')}
+      `.replace(/  +/g, '')
+  return changelog
+}
+
+function mapPRWithAffectedDestinations(pr) {
+  let affectedDestinations = []
+  if (pr.labels.includes('mode:cloud')) {
+    pr.files
+      .filter((file) => file.includes('packages/destination-actions/src/destinations'))
+      .forEach((file) => {
+        const match = file.match(/packages\/destination-actions\/src\/destinations\/([^\/]+)\/*/)
+        if (match && !affectedDestinations.includes(match[1])) {
+          affectedDestinations.push(match[1])
+        }
+      })
+  }
+  if (pr.labels.includes('mode:device')) {
+    pr.files
+      .filter((file) => file.includes('packages/browser-destinations/destinations'))
+      .forEach((file) => {
+        const match = file.match(/packages\/browser-destinations\/([^\/]+)\/*/)
+        if (match && !affectedDestinations.includes(match[1])) {
+          affectedDestinations.push(match[1])
+        }
+      })
+  }
+  return {
+    ...pr,
+    affectedDestinations: affectedDestinations.join(', ')
+  }
+}
+
+function formatNPMPackageURL(tag) {
+  const [name, version] = tag.split(/@(\d.*)/)
+  return `[${tag}](https://www.npmjs.com/package/${name}/v/${version})`
+}

--- a/scripts/create-github-release.js
+++ b/scripts/create-github-release.js
@@ -1,4 +1,5 @@
-module.exports = async ({ github, context, core, exec }) => {
+// This is a github action script and can be run only from github actions. To run this script locally, you need to mock the github object and context object.
+export default async ({ github, context, core, exec }) => {
   const { GITHUB_SHA, RELEASE_TAG } = process.env
   const { data } = await github.rest.search.commits({
     q: `Publish repo:${context.repo.owner}/${context.repo.repo}`,

--- a/scripts/create-github-release.js
+++ b/scripts/create-github-release.js
@@ -169,21 +169,13 @@ function formatChangeLog(prs, tagsContext, context) {
     
     |${tableConfig.map((config) => config.label).join('|')}|
     |${tableConfig.map(() => '---').join('|')}|
-    ${internalPRS
-      .map((pr) => {
-        return `|${tableConfig.map((config) => pr[config.value]).join('|')}|`
-      })
-      .join('\n')}
+    ${internalPRS.map((pr) => `|${tableConfig.map((config) => pr[config.value]).join('|')}|`).join('\n')}
         
     ## External PRs
     
     |${tableConfig.map((config) => config.label).join('|')}|
     |${tableConfig.map(() => '---').join('|')}|
-    ${externalPRs
-      .map((pr) => {
-        return `|${tableConfig.map((config) => pr[config.value]).join('|')}|`
-      })
-      .join('\n')}
+    ${externalPRs.map((pr) => `|${tableConfig.map((config) => pr[config.value]).join('|')}|`).join('\n')}
     `
   // trim double spaces and return the changelog
   return changelog.replace(/  +/g, '')

--- a/scripts/create-github-release.js
+++ b/scripts/create-github-release.js
@@ -2,7 +2,7 @@
 module.exports = async ({ github, context, core, exec }) => {
   const { GITHUB_SHA, RELEASE_TAG } = process.env
   const { data } = await github.rest.search.commits({
-    q: `Publish repo:${context.repo.owner}/action-destinations`,
+    q: `Publish repo:${context.repo.owner}/${context.repo.repo}`,
     per_page: 2,
     sort: 'committer-date'
   })
@@ -55,7 +55,7 @@ async function getPRsBetweenCommits(github, context, core, lastCommit, currentCo
   // GraphQL query to get PRs between two commits
   try {
     const prsMerged = await github.graphql(`{
-      search(first:100, type: ISSUE, query: "repo:segmentio/action-destinations is:pr merged:${lastCommitDate.toISOString()}..${currentCommitDate.toISOString()}") {
+      search(first:100, type: ISSUE, query: "repo:${context.repo.owner}/${context.repo.repo} is:pr merged:${lastCommitDate.toISOString()}..${currentCommitDate.toISOString()}") {
         issueCount
         nodes {
           ... on PullRequest {
@@ -140,7 +140,7 @@ function formatChangeLog(prs, currentRelease, prevRelease, packageTags) {
   const changelog = `
       # What's Changed
       
-      [Commits](https://github.com/segmentio/action-destinations-deploy-automation/compare/${prevRelease}...${currentRelease})
+      [Commits](https://github.com/segmentio/action-destinations/compare/${prevRelease}...${currentRelease})
   
       ## Packages Published
   

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "experimentalDecorators": true,
     "skipLibCheck": true
   },
-  "exclude": ["dist", "templates"],
+  "exclude": ["dist", "templates", "scripts"],
   "references": [
     { "path": "./packages/ajv-human-errors/tsconfig.build.json" },
     { "path": "./packages/browser-destinations/tsconfig.build.json" },


### PR DESCRIPTION
This PR adds github release workflow. After packages are published, the two new steps added will create a new release tag of the format `release-{YYYY-MM-DD}.{count}` and publish a github release.


## Testing

Testing completed successfully using an internal fork of the actions repo.

### Sample Release

https://github.com/segmentio/action-destinations-deploy-automation/releases/tag/release-2024-03-22.33

![image](https://github.com/segmentio/action-destinations/assets/109586712/238c5cfd-d4dd-47e4-b0c4-6086dcbfbb1d)



