### PR TITLE
Add @flatten directive

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export {
   PrimitiveValue,
   ReplaceDirective,
   TemplateDirective,
+  JSONDirective,
   getFieldValue,
   getFieldValueKeys,
   isArrayPathDirective,
@@ -22,7 +23,8 @@ export {
   isLiteralDirective,
   isPathDirective,
   isReplaceDirective,
-  isTemplateDirective
+  isTemplateDirective,
+  isJSONDirective
 } from './mapping-kit/value-keys'
 export { createTestEvent } from './create-test-event'
 export { createTestIntegration } from './create-test-integration'

--- a/packages/core/src/mapping-kit/__tests__/flatten.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/flatten.test.ts
@@ -1,0 +1,134 @@
+import { flattenObject } from '../flatten'
+
+describe('flatten', () => {
+  it('flattens an object', () => {
+    const obj = {
+      a: {
+        b: {
+          c: 1
+        },
+        d: 2
+      }
+    }
+    expect(flattenObject(obj)).toEqual({
+      'a.b.c': 1,
+      'a.d': 2
+    })
+  })
+  it('flattens an object with a custom separator', () => {
+    const obj = {
+      a: {
+        b: {
+          c: 1
+        },
+        d: 2
+      }
+    }
+    expect(flattenObject(obj, '', '/')).toEqual({
+      'a/b/c': 1,
+      'a/d': 2
+    })
+  })
+  it('flattens an array', () => {
+    const obj = {
+      a: [
+        {
+          b: 1
+        },
+        {
+          c: 2
+        }
+      ]
+    }
+    expect(flattenObject(obj)).toEqual({
+      'a.0.b': 1,
+      'a.1.c': 2
+    })
+  })
+  it('flattens a deep nested structure', () => {
+    const obj = {
+      a: {
+        b: {
+          c: {
+            d: {
+              e: {
+                f: {
+                  g: {
+                    h: {
+                      i: 1
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    expect(flattenObject(obj)).toEqual({
+      'a.b.c.d.e.f.g.h.i': 1
+    })
+  })
+  it('flattens a deep nested structure with deep nested arrays', () => {
+    const obj = {
+      a: {
+        b: {
+          c: [
+            {
+              d: [
+                {
+                  e: [
+                    {
+                      f: [
+                        {
+                          g: [
+                            {
+                              h: [
+                                {
+                                  i: 1
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+    expect(flattenObject(obj)).toEqual({
+      'a.b.c.0.d.0.e.0.f.0.g.0.h.0.i': 1
+    })
+  })
+  it('flattens a structure starting with arrays of objects', () => {
+    const obj = [
+      {
+        a: [
+          {
+            b: [
+              {
+                c: 1
+              }
+            ]
+          },
+          {
+            d: [
+              {
+                e: 2
+              }
+            ]
+          }
+        ]
+      }
+    ]
+    expect(flattenObject(obj)).toEqual({
+      '0.a.0.b.0.c': 1,
+      '0.a.1.d.0.e': 2
+    })
+  })
+})

--- a/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
@@ -531,6 +531,23 @@ describe('@json', () => {
   })
 })
 
+describe.only('@flatten', () => {
+  test('simple', () => {
+    const output = transform(
+      { neat: { '@flatten': { value: { '@path': '$.foo' } } } },
+      { foo: { bar: 'baz', aces: { a: 1, b: 2 } } }
+    )
+    expect(output).toStrictEqual({ neat: { bar: 'baz', 'aces.a': 1, 'aces.b': 2 } })
+  })
+  test('array value first', () => {
+    const output = transform(
+      { result: { '@flatten': { value: { '@path': '$.foo' } } } },
+      { foo: [{ fazz: 'bar', fizz: 'baz' }] }
+    )
+    expect(output).toStrictEqual({ result: { '0.fazz': 'bar', '0.fizz': 'baz' } })
+  })
+})
+
 describe('@path', () => {
   test('simple', () => {
     const output = transform({ neat: { '@path': '$.foo' } }, { foo: 'bar' })

--- a/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
@@ -531,17 +531,17 @@ describe('@json', () => {
   })
 })
 
-describe.only('@flatten', () => {
+describe('@flatten', () => {
   test('simple', () => {
     const output = transform(
-      { neat: { '@flatten': { value: { '@path': '$.foo' } } } },
+      { neat: { '@flatten': { value: { '@path': '$.foo' }, separator: '.' } } },
       { foo: { bar: 'baz', aces: { a: 1, b: 2 } } }
     )
     expect(output).toStrictEqual({ neat: { bar: 'baz', 'aces.a': 1, 'aces.b': 2 } })
   })
   test('array value first', () => {
     const output = transform(
-      { result: { '@flatten': { value: { '@path': '$.foo' } } } },
+      { result: { '@flatten': { value: { '@path': '$.foo' }, separator: '.' } } },
       { foo: [{ fazz: 'bar', fizz: 'baz' }] }
     )
     expect(output).toStrictEqual({ result: { '0.fazz': 'bar', '0.fizz': 'baz' } })

--- a/packages/core/src/mapping-kit/flatten.ts
+++ b/packages/core/src/mapping-kit/flatten.ts
@@ -1,18 +1,16 @@
-import { JSONLikeObject } from '../json-object'
-import { isObject } from '../real-type-of'
+import { JSONLike, JSONLikeObject } from '../json-object'
+import { isArray, isObject } from '../real-type-of'
 
-export const flattenObject = (obj: JSONLikeObject, prefix = '', separator = '.'): JSONLikeObject => {
-  const newObj: JSONLikeObject = {}
-
-  for (const key of Object.keys(obj)) {
-    const value = obj[key]
-
-    if (isObject(value)) {
-      Object.assign(newObj, flattenObject(value, `${prefix}${key}${separator}`, separator))
-    } else {
-      newObj[`${prefix}${key}`] = value
-    }
+export const flattenObject = (input: JSONLike, prefix = '', separator = '.'): JSONLikeObject => {
+  //input may be a primitive value, object, or array
+  if (isObject(input) || isArray(input)) {
+    return Object.entries(input).reduce((acc, [key, value]) => {
+      const newKey = prefix ? `${prefix}${separator}${key}` : key
+      return {
+        ...acc,
+        ...flattenObject(value, newKey, separator)
+      }
+    }, {})
   }
-
-  return newObj
+  return { [prefix]: input }
 }

--- a/packages/core/src/mapping-kit/flatten.ts
+++ b/packages/core/src/mapping-kit/flatten.ts
@@ -1,0 +1,18 @@
+import { JSONLikeObject } from '../json-object'
+import { isObject } from '../real-type-of'
+
+export const flattenObject = (obj: JSONLikeObject, prefix = '', separator = '.'): JSONLikeObject => {
+  const newObj: JSONLikeObject = {}
+
+  for (const key of Object.keys(obj)) {
+    const value = obj[key]
+
+    if (isObject(value)) {
+      Object.assign(newObj, flattenObject(value, `${prefix}${key}${separator}`, separator))
+    } else {
+      newObj[`${prefix}${key}`] = value
+    }
+  }
+
+  return newObj
+}

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -6,6 +6,7 @@ import { realTypeOf, isObject, isArray } from '../real-type-of'
 import { removeUndefined } from '../remove-undefined'
 import validate from './validate'
 import { arrify } from '../arrify'
+import { flattenObject } from './flatten'
 
 export type InputData = { [key: string]: unknown }
 export type Features = { [key: string]: boolean }
@@ -221,6 +222,23 @@ registerStringDirective('@template', (template: string, payload) => {
 // Literal should be used in place of 'empty' template strings as they will not resolve correctly
 registerDirective('@literal', (value, payload) => {
   return resolve(value, payload)
+})
+
+registerDirective('@flatten', (opts, payload) => {
+  if (!isObject(opts)) {
+    throw new Error('@flatten requires an object with a "separator" key')
+  }
+
+  if (!opts.separator) {
+    throw new Error('@flatten requires a "separator" key')
+  }
+
+  const separator = resolve(opts.separator, payload)
+  if (typeof separator !== 'string') {
+    throw new Error('@flatten requires a string separator')
+  }
+
+  return flattenObject(payload, '', separator)
 })
 
 registerDirective('@json', (opts, payload) => {

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -238,7 +238,9 @@ registerDirective('@flatten', (opts, payload) => {
     throw new Error('@flatten requires a string separator')
   }
 
-  return flattenObject(payload, '', separator)
+  const value = resolve(opts.value, payload)
+
+  return flattenObject(value, '', separator)
 })
 
 registerDirective('@json', (opts, payload) => {

--- a/packages/core/src/mapping-kit/validate.ts
+++ b/packages/core/src/mapping-kit/validate.ts
@@ -176,7 +176,7 @@ function validateObject(value: unknown, stack: string[] = []) {
     try {
       validate(obj[k], [...stack, k])
     } catch (e) {
-      errors.push(e)
+      errors.push(e as Error)
     }
   })
 
@@ -211,7 +211,7 @@ function validateObjectWithFields(input: unknown, fields: ValidateFields, stack:
         }
       }
     } catch (error) {
-      errors.push(error)
+      errors.push(error as Error)
     }
   })
 
@@ -237,11 +237,12 @@ function directive(names: string[] | string, fn: DirectiveValidator): void {
       try {
         fn(v, [...stack, name])
       } catch (e) {
+        const err: Error = e as Error
         if (e instanceof ValidationError || e instanceof AggregateError) {
           throw e
         }
 
-        throw new ValidationError(e.message, stack)
+        throw new ValidationError(err.message, stack)
       }
     }
   })
@@ -301,6 +302,17 @@ directive('@json', (v, stack) => {
     {
       value: { required: validateDirectiveOrRaw },
       mode: { required: validateAllowedStrings('encode', 'decode') }
+    },
+    stack
+  )
+})
+
+directive('@flatten', (v, stack) => {
+  validateObjectWithFields(
+    v,
+    {
+      separator: { optional: validateString },
+      value: { required: validateDirectiveOrRaw }
     },
     stack
   )


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This pull request adds a new @flatten directive to mapping kit. This directive will take a nested object or array context and reduce it to a single object with keys composed from the nested values. 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
