### PR TITLE
Revert github action scripts to commonJS export

### DIFF
--- a/scripts/compute-labels.js
+++ b/scripts/compute-labels.js
@@ -1,5 +1,5 @@
 // This is a github action script and can be run only from github actions. To run this script locally, you need to mock the github object and context object.
-export default async ({ github, context, core }) => {
+module.exports = async ({ github, context, core }) => {
   const authorLabels = await computeAuthorLabels(github, context, core)
   const { add, remove } = await computeFileBasedLabels(github, context, core)
   core.setOutput('add', [...authorLabels, ...add].join(','))

--- a/scripts/create-github-release.js
+++ b/scripts/create-github-release.js
@@ -1,5 +1,5 @@
 // This is a github action script and can be run only from github actions. To run this script locally, you need to mock the github object and context object.
-export default async ({ github, context, core, exec }) => {
+module.exports = async ({ github, context, core, exec }) => {
   const { GITHUB_SHA, RELEASE_TAG } = process.env
   const { data } = await github.rest.search.commits({
     q: `Publish repo:${context.repo.owner}/${context.repo.repo}`,


### PR DESCRIPTION
Revert github action scripts to commonJS export.

https://github.com/segmentio/action-destinations/actions/runs/8420753470

## Testing


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
