### PR TITLE
correcting Yotpo auth scheme

### DIFF
--- a/packages/destination-actions/src/destinations/yotpo/index.ts
+++ b/packages/destination-actions/src/destinations/yotpo/index.ts
@@ -15,7 +15,7 @@ const destination: DestinationDefinition<Settings> = {
   description: 'Send data to Yotpo',
 
   authentication: {
-    scheme: 'oauth2',
+    scheme: 'oauth-managed',
     fields: {
       store_id: {
         label: 'Store ID',


### PR DESCRIPTION
Correcting yotpo auth mechanism to oauth-managed. 

## Testing
Not needed - Yotpo is in Private Betae. 