### PR TITLE
Pass eventOccurredTS value to the custom_args of the sendgrid/twilio body

### DIFF
--- a/packages/destination-actions/src/destinations/engage/sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/engage/sendgrid/__tests__/send-email.test.ts
@@ -82,6 +82,7 @@ describe.each([
           source_id: 'sourceId',
           space_id: 'spaceId',
           user_id: userData.userId,
+          event_ocurred_ts: '2024-03-23T23:02:40.563Z',
           __segment_internal_external_id_key__: 'email',
           __segment_internal_external_id_value__: userData.email
         }
@@ -304,6 +305,7 @@ describe.each([
               journey_id: 'journeyId',
               journey_state_id: 'journeyStateId',
               audience_id: 'audienceId',
+              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -359,7 +361,8 @@ describe.each([
           customArgs: {
             journey_id: 'journeyId',
             journey_state_id: 'journeyStateId',
-            audience_id: 'audienceId'
+            audience_id: 'audienceId',
+            event_ocurred_ts: '2024-03-23T23:02:40.563Z'
           },
           previewText: 'unused',
           subject: 'Test email with metadata',
@@ -423,6 +426,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
+              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -505,6 +509,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
+              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -603,6 +608,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
+              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -682,6 +688,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
+              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -782,6 +789,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
+              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -869,6 +877,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
+              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -956,6 +965,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
+              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -1043,6 +1053,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
+              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -1126,6 +1137,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
+              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -1212,6 +1224,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
+              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -2265,6 +2278,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
+              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }

--- a/packages/destination-actions/src/destinations/engage/sendgrid/__tests__/send-email.test.ts
+++ b/packages/destination-actions/src/destinations/engage/sendgrid/__tests__/send-email.test.ts
@@ -82,7 +82,7 @@ describe.each([
           source_id: 'sourceId',
           space_id: 'spaceId',
           user_id: userData.userId,
-          event_ocurred_ts: '2024-03-23T23:02:40.563Z',
+          event_occurred_ts: '2024-03-23T23:02:40.563Z',
           __segment_internal_external_id_key__: 'email',
           __segment_internal_external_id_value__: userData.email
         }
@@ -162,7 +162,7 @@ describe.each([
         ]
       },
       traits: { '@path': '$.properties' },
-      eventOccurredTS: { '@path': '$.timestamp' },
+      eventOccurredTS: '2024-03-23T23:02:40.563Z',
       ...overrides
     }
   }
@@ -305,7 +305,7 @@ describe.each([
               journey_id: 'journeyId',
               journey_state_id: 'journeyStateId',
               audience_id: 'audienceId',
-              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
+              event_occurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -362,7 +362,7 @@ describe.each([
             journey_id: 'journeyId',
             journey_state_id: 'journeyStateId',
             audience_id: 'audienceId',
-            event_ocurred_ts: '2024-03-23T23:02:40.563Z'
+            event_occurred_ts: '2024-03-23T23:02:40.563Z'
           },
           previewText: 'unused',
           subject: 'Test email with metadata',
@@ -376,7 +376,7 @@ describe.each([
             { id: userData.phone, type: 'phone', subscriptionStatus: 'true', channelType: 'sms' }
           ],
           traits: { '@path': '$.properties' },
-          eventOccurredTS: { '@path': '$.timestamp' }
+          eventOccurredTS: '2024-03-23T23:02:40.563Z'
         }
       })
 
@@ -426,7 +426,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
-              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
+              event_occurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -509,7 +509,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
-              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
+              event_occurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -608,7 +608,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
-              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
+              event_occurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -688,7 +688,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
-              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
+              event_occurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -789,7 +789,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
-              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
+              event_occurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -877,7 +877,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
-              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
+              event_occurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -965,7 +965,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
-              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
+              event_occurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -1053,7 +1053,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
-              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
+              event_occurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -1137,7 +1137,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
-              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
+              event_occurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -1224,7 +1224,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
-              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
+              event_occurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }
@@ -2278,7 +2278,7 @@ describe.each([
               source_id: 'sourceId',
               space_id: 'spaceId',
               user_id: userData.userId,
-              event_ocurred_ts: '2024-03-23T23:02:40.563Z',
+              event_occurred_ts: '2024-03-23T23:02:40.563Z',
               __segment_internal_external_id_key__: 'email',
               __segment_internal_external_id_value__: userData.email
             }

--- a/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
+++ b/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
@@ -167,6 +167,7 @@ export class SendEmailPerformer extends MessageSendPerformer<Settings, Payload> 
             source_id: this.settings.sourceId,
             space_id: this.settings.spaceId,
             user_id: this.payload.userId ?? undefined,
+            event_occurred_ts: this.payload?.eventOccurredTS,
             __segment_internal_external_id_key__: EXTERNAL_ID_KEY,
             __segment_internal_external_id_value__: profile[EXTERNAL_ID_KEY]
           }

--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-mobile-push.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-mobile-push.test.ts
@@ -44,7 +44,8 @@ const testAction = createTestAction({
       badgeStrategy: null,
       ttl: null,
       tapActionButtons: null
-    }
+    },
+    eventOccurredTS: '2024-03-23'
   })
 })
 
@@ -112,7 +113,7 @@ describe('sendMobilePush action', () => {
       const notifyReqBody = getDefaultExpectedNotifyApiReq(externalId)
       notifyReqBody.append(
         'DeliveryCallbackUrl',
-        `http://localhost.com/?space_id=spaceid&__segment_internal_external_id_key__=${externalId.type}&__segment_internal_external_id_value__=${externalId.id}#rp=all&rc=600`
+        `http://localhost.com/?space_id=spaceid&event_occurred_ts=2024-03-23&__segment_internal_external_id_key__=${externalId.type}&__segment_internal_external_id_value__=${externalId.id}#rp=all&rc=600`
       )
 
       nock(`https://content.twilio.com`).get(`/v1/Content/${contentSid}`).reply(200, defaultTemplate)

--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-mobile-push.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-mobile-push.test.ts
@@ -45,7 +45,7 @@ const testAction = createTestAction({
       ttl: null,
       tapActionButtons: null
     },
-    eventOccurredTS: '2024-03-23'
+    eventOccurredTS: '2024-03-23T23:02:40.563Z'
   })
 })
 
@@ -113,7 +113,7 @@ describe('sendMobilePush action', () => {
       const notifyReqBody = getDefaultExpectedNotifyApiReq(externalId)
       notifyReqBody.append(
         'DeliveryCallbackUrl',
-        `http://localhost.com/?space_id=spaceid&event_occurred_ts=2024-03-23&__segment_internal_external_id_key__=${externalId.type}&__segment_internal_external_id_value__=${externalId.id}#rp=all&rc=600`
+        `http://localhost.com/?space_id=spaceid&event_occurred_ts=2024-03-23T23%3A02%3A40.563Z&__segment_internal_external_id_key__=${externalId.type}&__segment_internal_external_id_value__=${externalId.id}#rp=all&rc=600`
       )
 
       nock(`https://content.twilio.com`).get(`/v1/Content/${contentSid}`).reply(200, defaultTemplate)

--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
@@ -26,7 +26,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         { type: 'phone', id: phoneNumber, subscriptionStatus: 'true', channelType: 'sms' }
       ],
       sendBasedOnOptOut: false,
-      eventOccurredTS: '2024-03-23T23:02:40.563Z'
+      eventOccurredTS: '2024-03-23'
     })
   })
 
@@ -402,7 +402,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         ShortenUrls: 'true',
         Tags: defaultTags,
         StatusCallback:
-          'http://localhost/?foo=bar&space_id=d&__segment_internal_external_id_key__=phone&__segment_internal_external_id_value__=%2B1234567891#rp=all&rc=5'
+          'http://localhost/?foo=bar&space_id=d&event_occurred_ts=2024-03-23&__segment_internal_external_id_key__=phone&__segment_internal_external_id_value__=%2B1234567891#rp=all&rc=5'
       })
       const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
         .post('/Messages.json', expectedTwilioRequest.toString())

--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
@@ -25,7 +25,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         { type: 'email', id: 'test@twilio.com', subscriptionStatus: 'true' },
         { type: 'phone', id: phoneNumber, subscriptionStatus: 'true', channelType: 'sms' }
       ],
-      sendBasedOnOptOut: false
+      sendBasedOnOptOut: false,
+      eventOccurredTS: '2024-03-23T23:02:40.563Z'
     })
   })
 
@@ -781,8 +782,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           campaign_name: 'c-3',
           campaign_key: '4',
           user_id: 'u-5',
-          message_id: 'm-6',
-          event_ocurred_ts: '2024-03-23T23:02:40.563Z'
+          message_id: 'm-6'
         }
       }
     })

--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
@@ -26,7 +26,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         { type: 'phone', id: phoneNumber, subscriptionStatus: 'true', channelType: 'sms' }
       ],
       sendBasedOnOptOut: false,
-      eventOccurredTS: '2024-03-23'
+      eventOccurredTS: '2024-03-23T23:02:40.563Z'
     })
   })
 
@@ -402,7 +402,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         ShortenUrls: 'true',
         Tags: defaultTags,
         StatusCallback:
-          'http://localhost/?foo=bar&space_id=d&event_occurred_ts=2024-03-23&__segment_internal_external_id_key__=phone&__segment_internal_external_id_value__=%2B1234567891#rp=all&rc=5'
+          'http://localhost/?foo=bar&space_id=d&event_occurred_ts=2024-03-23T23%3A02%3A40.563Z&__segment_internal_external_id_key__=phone&__segment_internal_external_id_value__=%2B1234567891#rp=all&rc=5'
       })
       const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
         .post('/Messages.json', expectedTwilioRequest.toString())

--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
@@ -781,7 +781,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
           campaign_name: 'c-3',
           campaign_key: '4',
           user_id: 'u-5',
-          message_id: 'm-6'
+          message_id: 'm-6',
+          event_ocurred_ts: '2024-03-23T23:02:40.563Z'
         }
       }
     })

--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-sms.test.ts
@@ -4,6 +4,7 @@ import { FLAGON_NAME_LOG_ERROR, FLAGON_NAME_LOG_INFO, SendabilityStatus } from '
 
 const phoneNumber = '+1234567891'
 const defaultTags = JSON.stringify({
+  event_occurred_ts: '2024-03-23T23:02:40.563Z',
   external_id_type: 'phone',
   external_id_value: phoneNumber
 })
@@ -371,6 +372,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         To: '+1 (505) 555-4555',
         ShortenUrls: 'true',
         Tags: JSON.stringify({
+          event_occurred_ts: '2024-03-23T23:02:40.563Z',
           external_id_type: 'phone',
           external_id_value: '+1 (505) 555-4555'
         })
@@ -766,7 +768,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       From: 'MG1111222233334444',
       To: phoneNumber,
       ShortenUrls: 'true',
-      Tags: '{"audience_id":"1","correlation_id":"1","journey_name":"j-1","step_name":"2","campaign_name":"c-3","campaign_key":"4","user_id":"u-5","message_id":"m-6","external_id_type":"phone","external_id_value":"+1234567891"}'
+      Tags: '{"audience_id":"1","correlation_id":"1","step_name":"2","campaign_name":"c-3","campaign_key":"4","user_id":"u-5","message_id":"m-6","event_occurred_ts":"2024-03-23T23:02:40.563Z","external_id_type":"phone","external_id_value":"+1234567891"}'
     })
     const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
       .post('/Messages.json', expectedTwilioRequest.toString())
@@ -777,13 +779,13 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         customArgs: {
           audience_id: '1',
           correlation_id: '1',
-          journey_name: 'j-1',
           step_name: '2',
           campaign_name: 'c-3',
           campaign_key: '4',
           user_id: 'u-5',
           message_id: 'm-6'
-        }
+        },
+        eventOccurredTS: '2024-03-23T23:02:40.563Z'
       }
     })
 

--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-whatsapp.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-whatsapp.test.ts
@@ -25,7 +25,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         { type: 'email', id: 'test@twilio.com', subscriptionStatus: 'subscribed' },
         { type: 'phone', id: phoneNumber, subscriptionStatus: 'subscribed', channelType: 'whatsapp' }
       ],
-      eventOccurredTS: '2024-03-23'
+      eventOccurredTS: '2024-03-23T23:02:40.563Z'
     })
   })
 
@@ -270,7 +270,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         To: defaultTo,
         Tags: defaultTags,
         StatusCallback:
-          'http://localhost/?foo=bar&space_id=d&event_occurred_ts=2024-03-23&__segment_internal_external_id_key__=phone&__segment_internal_external_id_value__=%2B1234567891#rp=all&rc=5'
+          'http://localhost/?foo=bar&space_id=d&event_occurred_ts=2024-03-23T23%3A02%3A40.563Z&__segment_internal_external_id_key__=phone&__segment_internal_external_id_value__=%2B1234567891#rp=all&rc=5'
       })
       const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
         .post('/Messages.json', expectedTwilioRequest.toString())

--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-whatsapp.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-whatsapp.test.ts
@@ -5,6 +5,7 @@ const defaultTemplateSid = 'my_template'
 const phoneNumber = '+1234567891'
 const defaultTo = `whatsapp:${phoneNumber}`
 const defaultTags = JSON.stringify({
+  event_occurred_ts: '2024-03-23T23:02:40.563Z',
   external_id_type: 'phone',
   external_id_value: phoneNumber
 })
@@ -107,6 +108,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         From: 'MG1111222233334444',
         To: `whatsapp:+${phone}`,
         Tags: JSON.stringify({
+          event_occurred_ts: '2024-03-23T23:02:40.563Z',
           external_id_type: 'phone',
           external_id_value: phone // expect external id to stay the same.. without "+"
         })
@@ -138,6 +140,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         From: 'MG1111222233334444',
         To: `whatsapp:${phone}`,
         Tags: JSON.stringify({
+          event_occurred_ts: '2024-03-23T23:02:40.563Z',
           external_id_type: 'phone',
           external_id_value: phone
         })
@@ -168,6 +171,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         From: 'MG1111222233334444',
         To: `whatsapp:+${phone}`,
         Tags: JSON.stringify({
+          event_occurred_ts: '2024-03-23T23:02:40.563Z',
           external_id_type: 'phone',
           external_id_value: phone
         })
@@ -195,6 +199,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         From: 'MG1111222233334444',
         To: `whatsapp:${phone}`,
         Tags: JSON.stringify({
+          event_occurred_ts: '2024-03-23T23:02:40.563Z',
           external_id_type: 'phone',
           external_id_value: phone
         })
@@ -222,6 +227,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         From: 'MG1111222233334444',
         To: `whatsapp:${phone}`,
         Tags: JSON.stringify({
+          event_occurred_ts: '2024-03-23T23:02:40.563Z',
           external_id_type: 'phone',
           external_id_value: phone
         })
@@ -384,6 +390,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         From: from,
         To: 'whatsapp:+19195551234',
         Tags: JSON.stringify({
+          event_occurred_ts: '2024-03-23T23:02:40.563Z',
           external_id_type: 'phone',
           external_id_value: '(919) 555 1234'
         })

--- a/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-whatsapp.test.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/__tests__/send-whatsapp.test.ts
@@ -24,7 +24,8 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
       externalIds: [
         { type: 'email', id: 'test@twilio.com', subscriptionStatus: 'subscribed' },
         { type: 'phone', id: phoneNumber, subscriptionStatus: 'subscribed', channelType: 'whatsapp' }
-      ]
+      ],
+      eventOccurredTS: '2024-03-23'
     })
   })
 
@@ -269,7 +270,7 @@ describe.each(['stage', 'production'])('%s environment', (environment) => {
         To: defaultTo,
         Tags: defaultTags,
         StatusCallback:
-          'http://localhost/?foo=bar&space_id=d&__segment_internal_external_id_key__=phone&__segment_internal_external_id_value__=%2B1234567891#rp=all&rc=5'
+          'http://localhost/?foo=bar&space_id=d&event_occurred_ts=2024-03-23&__segment_internal_external_id_key__=phone&__segment_internal_external_id_value__=%2B1234567891#rp=all&rc=5'
       })
       const twilioRequest = nock('https://api.twilio.com/2010-04-01/Accounts/a')
         .post('/Messages.json', expectedTwilioRequest.toString())

--- a/packages/destination-actions/src/destinations/engage/twilio/utils/PhoneMessageSender.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/utils/PhoneMessageSender.ts
@@ -49,7 +49,6 @@ export abstract class PhoneMessageSender<Payload extends PhoneMessagePayload> ex
       campaign_key: this.payload.customArgs && this.payload.customArgs['campaign_key'],
       user_id: this.payload.customArgs && this.payload.customArgs['user_id'],
       message_id: this.payload.customArgs && this.payload.customArgs['message_id'],
-      event_occurred_ts: this.payload.customArgs && this.payload.customArgs['event_occurred_ts'],
       external_id_type: recepient.type,
       external_id_value: phone
     }

--- a/packages/destination-actions/src/destinations/engage/twilio/utils/PhoneMessageSender.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/utils/PhoneMessageSender.ts
@@ -49,6 +49,7 @@ export abstract class PhoneMessageSender<Payload extends PhoneMessagePayload> ex
       campaign_key: this.payload.customArgs && this.payload.customArgs['campaign_key'],
       user_id: this.payload.customArgs && this.payload.customArgs['user_id'],
       message_id: this.payload.customArgs && this.payload.customArgs['message_id'],
+      event_occurred_ts: this.payload.customArgs && this.payload.customArgs['event_occurred_ts'],
       external_id_type: recepient.type,
       external_id_value: phone
     }

--- a/packages/destination-actions/src/destinations/engage/twilio/utils/PhoneMessageSender.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/utils/PhoneMessageSender.ts
@@ -43,12 +43,12 @@ export abstract class PhoneMessageSender<Payload extends PhoneMessagePayload> ex
     const tags = {
       audience_id: this.payload.customArgs && this.payload.customArgs['audience_id'],
       correlation_id: this.payload.customArgs && this.payload.customArgs['correlation_id'],
-      journey_name: this.payload.customArgs && this.payload.customArgs['journey_name'],
       step_name: this.payload.customArgs && this.payload.customArgs['step_name'],
       campaign_name: this.payload.customArgs && this.payload.customArgs['campaign_name'],
       campaign_key: this.payload.customArgs && this.payload.customArgs['campaign_key'],
       user_id: this.payload.customArgs && this.payload.customArgs['user_id'],
       message_id: this.payload.customArgs && this.payload.customArgs['message_id'],
+      event_occurred_ts: this.payload && this.payload?.eventOccurredTS,
       external_id_type: recepient.type,
       external_id_value: phone
     }

--- a/packages/destination-actions/src/destinations/engage/twilio/utils/TwilioMessageSender.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/utils/TwilioMessageSender.ts
@@ -12,6 +12,7 @@ const Liquid = new LiquidJs()
 
 export interface TwilioPayloadBase extends MessagePayloadBase {
   contentSid?: string
+  eventOccurredTS?: string
 }
 
 export abstract class TwilioMessageSender<TPayload extends TwilioPayloadBase> extends MessageSendPerformer<
@@ -121,7 +122,7 @@ export abstract class TwilioMessageSender<TPayload extends TwilioPayloadBase> ex
     const customArgs: Record<string, string | undefined> = {
       ...this.payload.customArgs,
       space_id: this.settings.spaceId,
-      event_occurred_ts: (this.payload as any)?.eventOccurredTS,
+      event_occurred_ts: this.payload?.eventOccurredTS,
       __segment_internal_external_id_key__: externalIdType,
       __segment_internal_external_id_value__: externalIdValue
     }

--- a/packages/destination-actions/src/destinations/engage/twilio/utils/TwilioMessageSender.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/utils/TwilioMessageSender.ts
@@ -121,6 +121,7 @@ export abstract class TwilioMessageSender<TPayload extends TwilioPayloadBase> ex
     const customArgs: Record<string, string | undefined> = {
       ...this.payload.customArgs,
       space_id: this.settings.spaceId,
+      event_occurred_ts: (this.payload as any)?.eventOccurredTS,
       __segment_internal_external_id_key__: externalIdType,
       __segment_internal_external_id_value__: externalIdValue
     }

--- a/packages/destination-actions/src/destinations/engage/twilio/utils/TwilioMessageSender.ts
+++ b/packages/destination-actions/src/destinations/engage/twilio/utils/TwilioMessageSender.ts
@@ -121,7 +121,6 @@ export abstract class TwilioMessageSender<TPayload extends TwilioPayloadBase> ex
     const customArgs: Record<string, string | undefined> = {
       ...this.payload.customArgs,
       space_id: this.settings.spaceId,
-      event_occurred_ts: (this.payload as any)?.eventOccurredTS,
       __segment_internal_external_id_key__: externalIdType,
       __segment_internal_external_id_value__: externalIdValue
     }


### PR DESCRIPTION
In the DestinationAction payload we receive eventOccurredTS, which we use to stats event delivery latency which is for some reason called [eventDeliveryTS](https://github.com/segmentio/action-destinations/blob/0a761433021e6310fff08b361debf479a38a9fb0/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts#L202-L208). Regardless of confusing name - this metric helps to understand how much time it took from the event creation till the end of event processing by Destination Action.

It would be helpful to pass that eventOccurredTS value to the [custom_args](https://github.com/segmentio/action-destinations/blob/0a761433021e6310fff08b361debf479a38a9fb0/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts#L146) of the sendgrid/twilio body, so it will be returned to a webhook call after email/sms is delivered and we can add that [twilio|sendgrid]_eventDeliveryDuration metric to [engage-events-ingest service](https://github.com/segmentio/engage-events-ingest/blob/be6cbc49d70c49a644ef410ee3a2f4b9f60dac52/internal/eventconsumer/eventconsumer.go#L265C4-L265C4) (supplying all the tags that twilio_total and sendgrid_total have) to track how much time it takes for email/sms to be delivered from the moment of placing it to centrifuge to the moment of delivering it to the user.

## Testing

Updated unit tests
