### PR TITLE
[STRATCONN-3673] - Fetch all commits in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,10 +45,6 @@ jobs:
       - name: Build
         run: NODE_ENV=production yarn build
 
-      - name: Fetch Latest Tags
-        run: |
-          git fetch --tags
-
       - name: Set NPM Token
         run: |
           npm set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_PAT }}
+          fetch-depth: 0 # Required as we compute the version based on the number of commits since the last tag
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3


### PR DESCRIPTION
Publish workflow failed during last week's deploy with the following error. This was because the publish workflow doesn't clone all the commits and hence it wasn't able to process commits beyond the current HEAD commit. Since we are generating changelog as part of the pulbish workflow, we fetch all commits instead of just the current HEAD. This PR updates the checkout action to fetch all [commits](https://github.com/actions/checkout?tab=readme-ov-file#checkout-v4).

<img width="1105" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/1c375286-a59a-4793-92e6-ae486ee7c63f">


## Testing

Testing completed successfully in local.

Shallow cloned the github repo with `git clone --branch=main git@github.com:segmentio/action-destinations.git --depth 1` 

<img width="982" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/4ee6770c-f8d0-472d-a4fb-5cbc728edd2b">


Ran `git rev-list --count HEAD~ --grep "Publish" --since="00:00"` - This resulted in an error

<img width="891" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/1630edad-3436-41a5-adbb-45c9fab9ec3d">


On cloning the entire repo, the error went away

<img width="860" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/8f4ab07e-2e82-4abc-8895-476038109073">
