### PR TITLE
Update user_hash mapping

### DIFF
--- a/packages/browser-destinations/destinations/intercom/src/identifyUser/index.ts
+++ b/packages/browser-destinations/destinations/intercom/src/identifyUser/index.ts
@@ -97,9 +97,9 @@ const action: BrowserActionDefinition<Settings, Intercom, Payload> = {
       required: false,
       default: {
         '@if': {
-          exists: { '@path': '$.context.Intercom.user_hash' },
-          then: { '@path': '$.context.Intercom.user_hash' },
-          else: { '@path': '$.context.Intercom.userHash' }
+          exists: { '@path': '$.integrations.Intercom.user_hash' },
+          then: { '@path': '$.integrations.Intercom.user_hash' },
+          else: { '@path': '$.integrations.Intercom.userHash' }
         }
       }
     },


### PR DESCRIPTION
**Description:** 
Currently our out of the box mapping to user_hash is incorrect. It reads context.Intercom.user_hash when it should be integrations.Intercom._user_hash.

**Is it a bug/defect?** 
Yes
**Is it reproducible?** 
Yes, go to Intercom Web (Actions) and select the Identify User mapping. Scroll down to User Hash and test a payload where the Integrations object looks like: 
`	"integrations": {
		"Intercom": {
			"user_hash": "75ae885f908a8a25f2c88a3ba2f1a40892b0aab7515aa66f6c6e0eea0bdcc861"
		}
	},`
Check your mapping and see this value does not populate with the out of the box mapping. 

**Workaround available?** 
Yes, we are currently asking users to modify their mapping manually.

**Expected Behavior:**
Out of the box mapping should work as Intercom expects to receive this value.

**Actual Behavior:**
This value does not populate unless our mapping is modified. 

**Relevant Slack Thread**
https://twilio.slack.com/archives/C9Z93GW76/p1711388844654799?thread_ts=1711386641.613429&cid=C9Z93GW76


