### PR TITLE
[LinkedIn Conversions] Default mappings for some fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,31 @@ const destination = {
           description: "The person's email address",
           type: 'string',
           default: { '@path': '$.properties.email_address' }
+        },
+        // an object field example. Defaults should be specified on the top level.
+        value: {
+          label: 'Conversion Value',
+          description: 'The monetary value for a conversion. This is an object with shape: {"currencyCode": USD", "amount": "100"}'
+          type: 'object'
+          default: {
+            currencyCode: { '@path': '$.properties.currency' },
+            amount: { '@path': '$.properties.revenue' }
+          },
+          properties: {
+            currencyCode: {
+              label: 'Currency Code',
+              type: 'string',
+              required: true,
+              description: 'ISO format'
+            },
+            amount: {
+              label: 'Amount',
+              type: 'string',
+              required: true,
+              description: 'Value of the conversion in decimal string. Can be dynamically set up or have a fixed value.'
+            }
+          }
+          }
         }
       }
     }

--- a/packages/destination-actions/src/destinations/hyperengage/__tests__/validateInput.test.ts
+++ b/packages/destination-actions/src/destinations/hyperengage/__tests__/validateInput.test.ts
@@ -81,7 +81,7 @@ describe('validateInput', () => {
       expect(payload.traits.industry).toEqual(fakeGroupData.industry)
       expect(payload.traits.website).toEqual(fakeGroupData.website)
       expect(payload.traits).toHaveProperty('required')
-      expect(payload.local_tz_offset).toEqual(60)
+      expect(payload.local_tz_offset).toEqual(120)
     })
   })
 

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
@@ -21,6 +21,13 @@ const event = createTestEvent({
       countryCode: 'US',
       value: 100
     }
+  },
+  traits: {
+    email: 'testing@testing.com'
+  },
+  properties: {
+    currency: 'USD',
+    revenue: 200
   }
 })
 
@@ -115,6 +122,45 @@ describe('LinkedinConversions.streamConversion', () => {
             companyName: { '@path': '$.context.traits.companyName' },
             countryCode: { '@path': '$.context.traits.countryCode' }
           },
+          onMappingSave: {
+            inputs: {},
+            outputs: {
+              id: payload.conversionId
+            }
+          }
+        }
+      })
+    ).resolves.not.toThrowError()
+  })
+
+  it('should successully send the event using default mappings', async () => {
+    nock(`${BASE_URL}/conversionEvents`)
+      .post('', {
+        conversion: 'urn:lla:llaPartnerConversion:789123',
+        conversionHappenedAt: currentTimestamp,
+        conversionValue: {
+          currencyCode: 'USD',
+          amount: '200'
+        },
+        user: {
+          userIds: [
+            {
+              idType: 'SHA256_EMAIL',
+              idValue: '584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777'
+            }
+          ]
+        }
+      })
+      .reply(201)
+
+    await expect(
+      testDestination.testAction('streamConversion', {
+        event,
+        settings,
+        useDefaultMappings: true,
+        mapping: {
+          // Do not map event ID since it is randomly generated
+          eventId: null,
           onMappingSave: {
             inputs: {},
             outputs: {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
@@ -8,6 +8,7 @@ const testDestination = createTestIntegration(Destination)
 const currentTimestamp = Date.now()
 
 const event = createTestEvent({
+  messageId: 'this-is-an-event-id12345',
   event: 'Example Event',
   type: 'track',
   timestamp: currentTimestamp.toString(),
@@ -138,6 +139,7 @@ describe('LinkedinConversions.streamConversion', () => {
       .post('', {
         conversion: 'urn:lla:llaPartnerConversion:789123',
         conversionHappenedAt: currentTimestamp,
+        eventId: 'this-is-an-event-id12345',
         conversionValue: {
           currencyCode: 'USD',
           amount: '200'
@@ -159,8 +161,6 @@ describe('LinkedinConversions.streamConversion', () => {
         settings,
         useDefaultMappings: true,
         mapping: {
-          // Do not map event ID since it is randomly generated
-          eventId: null,
           onMappingSave: {
             inputs: {},
             outputs: {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -188,6 +188,10 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
       type: 'object',
       required: false,
       defaultObjectUI: 'keyvalue:only',
+      default: {
+        currencyCode: { '@path': '$.properties.currency' },
+        amount: { '@path': '$.properties.revenue' }
+      },
       properties: {
         currencyCode: {
           label: 'Currency Code',
@@ -217,7 +221,8 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
       description:
         'Email address of the contact associated with the conversion event. Segment will hash this value before sending it to LinkedIn. One of email or LinkedIn UUID or Axciom ID or Oracle ID is required.',
       type: 'string',
-      required: false
+      required: false,
+      default: { '@path': '$.traits.email' }
     },
     linkedInUUID: {
       label: 'LinkedIn First Party Ads Tracking UUID',


### PR DESCRIPTION
This PR adds default mappings for the `conversionValue` and `email` fields in LinkedIn Conversions API.

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->


## Testing
The defaults are correctly used:
<img width="984" alt="Screenshot 2024-04-01 at 1 48 12 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/ff5cc721-42a2-4813-afb8-2c9d32019f92">


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
