### PR TITLE
Adds merge directive

### DIFF
--- a/packages/core/src/mapping-kit/README.md
+++ b/packages/core/src/mapping-kit/README.md
@@ -209,78 +209,6 @@ suite][schema.test.js] is a good source-of-truth for current implementation beha
 
 [schema.test.js]: https://github.com/segmentio/fab-5-engine/blob/master/packages/destination-actions/src/lib/mapping-kit/__tests__
 
-## Options
-
-Options can be passed to the `transform()` function as the third parameter:
-
-```js
-const output = transform(mapping, input, options)
-```
-
-Available options:
-
-```js
-{
-  merge: true // default false
-}
-```
-
-### merge
-
-If true, `merge` will cause the mapped value to be merged onto the input payload. This is useful
-when you only want to map/transform a small number of fields:
-
-```json
-Input:
-
-{
-  "a": {
-    "b": 1
-  },
-  "c": 2
-}
-
-Options:
-
-{
-  "merge": true
-}
-
-Mappings:
-
-{}
-=>
-{
-  "a": {
-    "b": 1
-  },
-  "c": 2
-}
-
-{
-  "a": 3
-}
-=>
-{
-  "a": 3,
-  "c": 2
-}
-
-{
-  "a": {
-    "c": 3
-  }
-}
-=>
-{
-  "a": {
-    "b": 1,
-    "c": 3
-  },
-  "c": 2
-}
-```
-
 ## Removing values from object
 
 `undefined` values in objects are removed from the mapped output while `null` is not:
@@ -637,4 +565,85 @@ Mappings:
 }
 =>
 "just@the-first"
+```
+
+### @merge
+
+The @merge directive accepts a list of one or more objects (either raw objects or directives that
+resolve to objects) and resolves to a single object. The resolved object is built by combining each
+object in turn, overwriting any duplicate keys.
+
+```json
+Input:
+
+{
+  "traits": {
+    "name": "Mr. Rogers",
+    "greeting": "Neighbor",
+    "neighborhood": "Latrobe"
+
+  },
+  "properties": {
+    "neighborhood": "Make Believe"
+  }
+}
+
+Mappings:
+
+{
+  "@merge": [
+    { "@path": "traits" },
+    { "@path": "properties" }
+  ]
+}
+=>
+{
+  "name": "Mr. Rogers",
+  "greeting": "Neighbor",
+  "neighborhood": "Make Believe"
+}
+
+{
+  "@merge": [
+    { "@path": "properties" },
+    { "@path": "traits" }
+  ]
+}
+=>
+{
+  "name": "Mr. Rogers",
+  "greeting": "Neighbor",
+  "neighborhood": "Latrobe"
+}
+```
+
+The @merge directive is especially useful for providing default values:
+
+```json
+Input:
+
+{
+  "traits": {
+    "name": "Mr. Rogers"
+  }
+}
+
+Mapping:
+
+{
+  "@merge": [
+    {
+      "name": "Missing name",
+      "neighborhood": "Missing neighborhood"
+    },
+    { "@path": "traits" }
+  ]
+}
+
+Output:
+
+{
+  "name": "Mr. Rogers",
+  "neighborhood": "Missing neighborhood"
+}
 ```

--- a/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
@@ -879,3 +879,37 @@ describe('remove undefined values in objects', () => {
     })
   })
 })
+
+describe('@merge', () => {
+  test('empty', () => {
+    const output = transform({ '@merge': [] }, {})
+    expect(output).toStrictEqual({})
+  })
+
+  test('one object', () => {
+    const output = transform({ '@merge': [{ cool: true }] }, {})
+    expect(output).toStrictEqual({ cool: true })
+  })
+
+  test('simple overwrite', () => {
+    const output = transform({ '@merge': [{ cool: true }, { cool: 'you bet' }] }, {})
+    expect(output).toStrictEqual({ cool: 'you bet' })
+  })
+
+  test('nested directive', () => {
+    const output = transform({ '@merge': [{ cool: true }, { '@path': 'foo' }] }, { foo: { bar: 'baz' } })
+    expect(output).toStrictEqual({ cool: true, bar: 'baz' })
+  })
+
+  test('invalid type', () => {
+    expect(() => {
+      transform({ '@merge': { oops: true } })
+    }).toThrowError()
+  })
+
+  test('invalid nested type', () => {
+    expect(() => {
+      transform({ '@merge': [{}, 1] })
+    }).toThrowError()
+  })
+})

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -267,6 +267,13 @@ registerDirective('@json', (opts, payload) => {
   }
 })
 
+registerDirective('@merge', (arr, payload) => {
+  if (!Array.isArray(arr)) throw new Error(`@merge: expected array, got ${typeof arr}`)
+
+  const objects = arr.map((v) => resolve(v, payload))
+  return Object.assign({}, ...objects)
+})
+
 /**
  * Resolves a mapping value/object by applying the input payload based on directives
  * @param mapping - the mapping directives or raw values to resolve

--- a/packages/core/src/mapping-kit/validate.ts
+++ b/packages/core/src/mapping-kit/validate.ts
@@ -106,6 +106,21 @@ function validateDirectiveOrString(v: unknown, stack: string[] = []) {
   }
 }
 
+function validateDirectiveOrObject(v: unknown, stack: string[] = []) {
+  const type = realTypeOrDirective(v)
+  switch (type) {
+    case 'directive':
+      return validateDirective(v, stack)
+    case 'object':
+      return validateObject(v, stack)
+    default:
+      throw new ValidationError(
+        `should be a string or a mapping directive but it is ${indefiniteArticle(type)} ${type}`,
+        stack
+      )
+  }
+}
+
 type validator = (v: unknown, stack: string[]) => void
 function chain(...validators: validator[]) {
   return (v: unknown, stack: string[] = []) => {
@@ -316,6 +331,14 @@ directive('@flatten', (v, stack) => {
     },
     stack
   )
+})
+
+directive('@merge', (v, stack) => {
+  const data = v as unknown[]
+  validateArray(data, stack)
+  data.forEach((obj) => {
+    validateDirectiveOrObject(obj)
+  })
 })
 
 directive('@template', (v, stack) => {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

Adds `@merge` directive. Looks like some form of this used to exist, but it is no longer implemented in the code. This PRs adds the directive from scratch and cleans up references to the old `options.merge` in the readme.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
