### PR TITLE
[STRATCONN-3673] - Fix release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_PAT }}
-          fetch-depth: 0 # Required as we compute the version based on the number of commits since the last tag
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
@@ -45,6 +44,10 @@ jobs:
       - name: Build
         run: NODE_ENV=production yarn build
 
+      - name: Fetch Latest Tags
+        run: |
+          git fetch --tags
+
       - name: Set NPM Token
         run: |
           npm set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_PUBLISH_TOKEN }}
@@ -54,29 +57,25 @@ jobs:
         run: |
           yarn lerna publish from-git --yes --allowBranch=main --loglevel=verbose --dist-tag latest
 
-      - name: Generate and Push Release Tag
-        id: push-release-tag
+  release:
+    needs: build-and-publish
+    runs-on: ubuntu-20.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for computing changelog
+
+      - name: Get Release tag
+        id: get_release_tag
         run: |
-          git config user.name ${{ github.actor }}
-          git config user.email ${{ github.actor }}@users.noreply.github.com
-
-          commit=${{ github.sha }}
-          if ! n=$(git rev-list --count $commit~ --grep "Publish" --since="00:00"); then
-              echo 'failed to calculate tag'
-              exit 1
+          if ! tag=$(git describe --abbrev=0 --tags --match "release-*"); then
+            echo "No release tag found, skipping release"
+            exit 1
           fi
-
-          case "$n" in
-              0) suffix="" ;; # first commit of the day gets no suffix
-              *) suffix=".$n" ;; # subsequent commits get a suffix, starting with .1
-          esac
-
-          tag=$(printf release-$(date '+%Y-%m-%d%%s') $suffix)
-          git tag -a $tag -m "Release $tag"
-          git push origin $tag
           echo "release-tag=$tag" >> $GITHUB_OUTPUT
 
-      - name: Create Github Release
+      - name: Create Release
         id: create-github-release
         uses: actions/github-script@v7
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,9 +66,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Shallow clones should be disabled for computing changelog
+          fetch-tags: true
 
       - name: Get Release tag
-        id: get_release_tag
+        id: get-release-tag
         run: |
           if ! tag=$(git describe --abbrev=0 --tags --match "release-*"); then
             echo "No release tag found, skipping release"
@@ -80,7 +81,7 @@ jobs:
         id: create-github-release
         uses: actions/github-script@v7
         env:
-          RELEASE_TAG: ${{ steps.push-release-tag.outputs.release-tag }}
+          RELEASE_TAG: ${{ steps.get-release-tag.outputs.release-tag }}
         with:
           script: |
             const script = require('./scripts/create-github-release.js')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,7 +76,7 @@ jobs:
           fi
           echo "release-tag=$tag" >> $GITHUB_OUTPUT
 
-      - name: Create Release
+      - name: Create Github Release
         id: create-github-release
         uses: actions/github-script@v7
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - staging
 
 jobs:
   build-and-publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - staging
 
 jobs:
   build-and-publish:

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "alpha": "lerna version prerelease --allow-branch $(git branch --show-current) --preid $(git branch --show-current) --no-push --no-git-tag-version",
     "release": "bash scripts/release.sh",
     "prepare": "husky install",
+    "postversion": "bash scripts/postversion.sh",
     "clean": "sh scripts/clean.sh"
   },
   "devDependencies": {

--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
-set -e 
+set -e
 sha=$(git rev-parse HEAD);
 branch=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD);
 
 if [[ $branch != "main" ]];
 then
   echo "Skipping release tag generation for non-main branch"
+  exit 0
 fi;
 
 # Generate and push release tag. Release tag format: release-YYYY-MM-DD[.N] e.g. release-2024-01-01
 if ! n=$(git rev-list --count $sha~ --grep "Publish" --since="00:00"); then
-    echo 'Failed to find compute release tag. Please manually tag the release with git tag -a release-YYYY-MM-DD -m "Release release-YYYY-MM-DD" and push the tag with git push origin release-YYYY-MM-DD'
+    echo 'Failed to find compute release tag. Exiting.'
+    exit 1
 else 
     case "$n" in
         0) suffix="" ;; # first commit of the day gets no suffix

--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -14,7 +14,7 @@ fi;
 
 # Generate and push release tag. Release tag format: release-YYYY-MM-DD[.N] e.g. release-2024-01-01
 if ! n=$(git rev-list --count $sha~ --grep "Publish" --since="00:00"); then
-    echo 'Failed to find compute release tag. Exiting.'
+    echo 'Failed to compute release tag. Exiting.'
     exit 1
 else 
     case "$n" in

--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e 
+sha=$(git rev-parse HEAD);
+branch=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD);
+
+if [[ $branch != "main" ]];
+then
+  echo "Skipping release tag generation for non-main branch"
+fi;
+
+# Generate and push release tag. Release tag format: release-YYYY-MM-DD[.N] e.g. release-2024-01-01
+if ! n=$(git rev-list --count $sha~ --grep "Publish" --since="00:00"); then
+    echo 'Failed to find compute release tag. Please manually tag the release with git tag -a release-YYYY-MM-DD -m "Release release-YYYY-MM-DD" and push the tag with git push origin release-YYYY-MM-DD'
+else 
+    case "$n" in
+        0) suffix="" ;; # first commit of the day gets no suffix
+        *) suffix=".$n" ;; # subsequent commits get a suffix, starting with .1
+    esac
+
+    tag=$(printf release-$(date '+%Y-%m-%d%%s') $suffix)
+    echo "Tagging $sha with $tag"
+    git tag -a $tag -m "Release $tag"
+fi

--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+# This script is executed after the version is bumped by lerna. It generates a release tag.
+# The release tag generated will be pushed to the repository by lerna version.
 set -e
 sha=$(git rev-parse HEAD);
 branch=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD);

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e # exit with nonzero exit code if anything fails
 branch=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD);
 sha=$(git rev-parse HEAD);
 
@@ -10,19 +11,20 @@ fi;
 
 git pull --ff-only
 echo "Running lerna version minor..."
-lerna version prerelease --no-private --allow-branch $(git branch --show-current) --preid $(git branch --show-current) --no-push --no-git-tag-version
+lerna version minor --no-private -y
 
-# Generate and add release tag
+# Generate and push release tag
 if ! n=$(git rev-list --count $sha~ --grep "Publish" --since="00:00"); then
     echo 'failed to calculate tag'
     exit 1
 fi
+
 case "$n" in
     0) suffix="" ;; # first commit of the day gets no suffix
     *) suffix=".$n" ;; # subsequent commits get a suffix, starting with .1
 esac
 
 tag=$(printf release-$(date '+%Y-%m-%d%%s') $suffix)
-echo "Tagging release with $tag"
+echo "Tagging $sha with $tag"
 git tag -a $tag -m "Release $tag"
 git push origin $tag

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -9,22 +9,20 @@ then
   exit
 fi;
 
+# Generate and push release tag. Release tag format: release-YYYY-MM-DD[.N] e.g. release-2024-01-01
+if ! n=$(git rev-list --count $sha~ --grep "Publish" --since="00:00"); then
+    echo 'Failed to find compute release tag. Please manually tag the release with git tag -a release-YYYY-MM-DD -m "Release release-YYYY-MM-DD" and push the tag with git push origin release-YYYY-MM-DD'
+else 
+    case "$n" in
+        0) suffix="" ;; # first commit of the day gets no suffix
+        *) suffix=".$n" ;; # subsequent commits get a suffix, starting with .1
+    esac
+
+    tag=$(printf release-$(date '+%Y-%m-%d%%s') $suffix)
+    echo "Tagging $sha with $tag"
+    git tag -a $tag -m "Release $tag"
+fi
+
 git pull --ff-only
 echo "Running lerna version minor..."
 lerna version minor --no-private -y
-
-# Generate and push release tag. Release tag format: release-YYYY-MM-DD[.N] e.g. release-2024-01-01
-if ! n=$(git rev-list --count $sha~ --grep "Publish" --since="00:00"); then
-    echo 'failed to calculate tag'
-    exit 1
-fi
-
-case "$n" in
-    0) suffix="" ;; # first commit of the day gets no suffix
-    *) suffix=".$n" ;; # subsequent commits get a suffix, starting with .1
-esac
-
-tag=$(printf release-$(date '+%Y-%m-%d%%s') $suffix)
-echo "Tagging $sha with $tag"
-git tag -a $tag -m "Release $tag"
-git push origin $tag

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,12 +1,27 @@
 #!/bin/bash
-branch=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD);
-if [[ $branch != "main" ]];
-then
-  echo "You must be on the main branch to release"
-  exit
-fi;
+# branch=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD);
+sha=$(git rev-parse HEAD);
+# if [[ $branch != "main" ]];
+# then
+#   echo "You must be on the main branch to release"
+#   exit
+# fi;
 
 
-git pull --ff-only
-echo "Running lerna version minor..."
-lerna version minor --no-private -y
+# git pull --ff-only
+# echo "Running lerna version minor..."
+# lerna version minor --no-private -y
+
+if ! n=$(git rev-list --count $sha~ --grep "Publish" --since="00:00"); then
+    echo 'failed to calculate tag'
+    exit 1
+fi
+case "$n" in
+    0) suffix="" ;; # first commit of the day gets no suffix
+    *) suffix=".$n" ;; # subsequent commits get a suffix, starting with .1
+esac
+
+tag=$(printf release-$(date '+%Y-%m-%d%%s') $suffix)
+echo "Tagging release with $tag"
+# git tag -a $tag -m "Release $tag"
+# git push origin $tag

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,27 +1,11 @@
 #!/bin/bash
-set -e # exit with nonzero exit code if anything fails
 branch=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD);
-sha=$(git rev-parse HEAD);
 
 if [[ $branch != "main" ]];
 then
   echo "You must be on the main branch to release"
   exit
 fi;
-
-# Generate and push release tag. Release tag format: release-YYYY-MM-DD[.N] e.g. release-2024-01-01
-if ! n=$(git rev-list --count $sha~ --grep "Publish" --since="00:00"); then
-    echo 'Failed to find compute release tag. Please manually tag the release with git tag -a release-YYYY-MM-DD -m "Release release-YYYY-MM-DD" and push the tag with git push origin release-YYYY-MM-DD'
-else 
-    case "$n" in
-        0) suffix="" ;; # first commit of the day gets no suffix
-        *) suffix=".$n" ;; # subsequent commits get a suffix, starting with .1
-    esac
-
-    tag=$(printf release-$(date '+%Y-%m-%d%%s') $suffix)
-    echo "Tagging $sha with $tag"
-    git tag -a $tag -m "Release $tag"
-fi
 
 git pull --ff-only
 echo "Running lerna version minor..."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
-# branch=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD);
+branch=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD);
 sha=$(git rev-parse HEAD);
-# if [[ $branch != "main" ]];
-# then
-#   echo "You must be on the main branch to release"
-#   exit
-# fi;
 
+if [[ $branch != "main" ]];
+then
+  echo "You must be on the main branch to release"
+  exit
+fi;
 
-# git pull --ff-only
-# echo "Running lerna version minor..."
-# lerna version minor --no-private -y
+git pull --ff-only
+echo "Running lerna version minor..."
+lerna version minor --no-private -y
 
+# Generate and add release tag
 if ! n=$(git rev-list --count $sha~ --grep "Publish" --since="00:00"); then
     echo 'failed to calculate tag'
     exit 1
@@ -23,5 +24,5 @@ esac
 
 tag=$(printf release-$(date '+%Y-%m-%d%%s') $suffix)
 echo "Tagging release with $tag"
-# git tag -a $tag -m "Release $tag"
-# git push origin $tag
+git tag -a $tag -m "Release $tag"
+git push origin $tag

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,7 +13,7 @@ git pull --ff-only
 echo "Running lerna version minor..."
 lerna version minor --no-private -y
 
-# Generate and push release tag
+# Generate and push release tag. Release tag format: release-YYYY-MM-DD[.N] e.g. release-2024-01-01
 if ! n=$(git rev-list --count $sha~ --grep "Publish" --since="00:00"); then
     echo 'failed to calculate tag'
     exit 1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -10,7 +10,7 @@ fi;
 
 git pull --ff-only
 echo "Running lerna version minor..."
-lerna version minor --no-private -y
+lerna version prerelease --no-private --allow-branch $(git branch --show-current) --preid $(git branch --show-current) --no-push --no-git-tag-version
 
 # Generate and add release tag
 if ! n=$(git rev-list --count $sha~ --grep "Publish" --since="00:00"); then


### PR DESCRIPTION
This PR attempts to fix the release workflow that is currently failing due to [permission issue](https://github.com/segmentio/action-destinations/actions/runs/8523646318/job/23346389646). 


<img width="1093" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/b7afcff4-53b3-4ea7-abeb-0489e71cf8ed">

The reason for permission issue is we use GH_PAT token in publish workflow which has permissions only to work with control-plane-js-client repo. Since action-destinations is open source, the workflow is able to clone the actions repo. 


This PR makes couple of changes to fix:
- To avoid using GH PAT token with write access to Github repo,  I have moved the release tag computation to the`postversion.sh` script. This script will be executed via postversion hook - only for main branch.
- Extract the release steps to separate job that depends on the build-and-publish job to ensure we don't use GH_PAT token. GH_PAT token contains permissions only to pull data from ctl-plane-js-client.

## Testing

Testing completed successfully with staging branch. No packages were published because I tested by commenting out the `publish` step.

[Success Run](https://github.com/segmentio/action-destinations/actions/runs/8525607521/job/23352968214)

![image](https://github.com/segmentio/action-destinations/assets/109586712/62bab309-ff10-4418-bf94-8c787ebc1bb5)

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
