### PR TITLE
Set intercom destination installation_type to 's' (segment) to identify custom install

### DIFF
--- a/packages/browser-destinations/destinations/intercom/src/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/intercom/src/__tests__/index.test.ts
@@ -39,6 +39,10 @@ describe('Intercom (actions)', () => {
     await event.load(Context.system(), {} as Analytics)
     expect(destination.initialize).toHaveBeenCalled()
 
+    expect(window.intercomSettings).toBeDefined()
+    expect(window.intercomSettings.app_id).toEqual('topSecretKey')
+    expect(window.intercomSettings.installation_type).toEqual('s')
+
     const scripts = window.document.querySelectorAll('script')
     expect(scripts).toMatchInlineSnapshot(`
       NodeList [

--- a/packages/browser-destinations/destinations/intercom/src/index.ts
+++ b/packages/browser-destinations/destinations/intercom/src/index.ts
@@ -1,7 +1,7 @@
 import type { Settings } from './generated-types'
 import type { BrowserDestinationDefinition } from '@segment/browser-destination-runtime/types'
 import { browserDestination } from '@segment/browser-destination-runtime/shim'
-import { initialBoot, initScript } from './init-script'
+import { initialBoot, initScript, initSettings } from './init-script'
 
 import { Intercom } from './api'
 import trackEvent from './trackEvent'
@@ -12,6 +12,10 @@ import { defaultValues } from '@segment/actions-core'
 declare global {
   interface Window {
     Intercom: Intercom
+    intercomSettings: {
+      app_id: string
+      installation_type?: string
+    }
   }
 }
 
@@ -90,6 +94,7 @@ export const destination: BrowserDestinationDefinition<Settings, Intercom> = {
   initialize: async ({ settings }, deps) => {
     //initialize Intercom
     initScript({ appId: settings.appId })
+    initSettings({ appId: settings.appId })
     const preloadedIntercom = window.Intercom
     initialBoot(settings.appId, { api_base: settings.apiBase })
 

--- a/packages/browser-destinations/destinations/intercom/src/init-script.ts
+++ b/packages/browser-destinations/destinations/intercom/src/init-script.ts
@@ -44,6 +44,19 @@ export function initialBoot(appId: string, options = {}) {
     window.Intercom &&
     window.Intercom('boot', {
       app_id: appId,
+      installation_type: 's',
       ...options
     })
+}
+
+export function initSettings({ appId }) {
+  if (window.intercomSettings) {
+    window.intercomSettings.app_id = appId
+    window.intercomSettings.installation_type = 's'
+  } else {
+    window.intercomSettings = {
+      app_id: appId,
+      installation_type: 's'
+    }
+  }
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

At intercom we want to better understand how customers install out Messenger. We currently use `installation_type` attribute that is set in each of the custom integrations we have that save that info and provides it with requests to our API. I've already added the same field to other intercom integrations like Shopify or Wordpress. Segment.io integration was the last one to finish.

## Testing

I added some new attribute check and run the unit tests with: 
![Screenshot 2024-04-02 at 15 37 02](https://github.com/segmentio/action-destinations/assets/4772270/51173b43-9b81-434c-9ecd-9adabb991609)

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
