### PR TITLE
retlOnMappingSave Hook

### DIFF
--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -53,7 +53,7 @@ type HookValueTypes = string | boolean | number | Array<string | boolean | numbe
 type GenericActionHookValues = Record<string, HookValueTypes>
 
 type GenericActionHookBundle = {
-  [K in ActionHookType]: {
+  [K in ActionHookType]?: {
     inputs?: GenericActionHookValues
     outputs?: GenericActionHookValues
   }
@@ -85,17 +85,17 @@ export interface ActionDefinition<
    * in the mapping for later use in the action.
    */
   hooks?: {
-    [K in ActionHookType]: ActionHookDefinition<
+    [K in ActionHookType]?: ActionHookDefinition<
       Settings,
       Payload,
       AudienceSettings,
-      GeneratedActionHookBundle[K]['outputs'],
-      GeneratedActionHookBundle[K]['inputs']
+      NonNullable<GeneratedActionHookBundle[K]>['outputs'],
+      NonNullable<GeneratedActionHookBundle[K]>['inputs']
     >
   }
 }
 
-export const hookTypeStrings = ['onMappingSave'] as const
+export const hookTypeStrings = ['onMappingSave', 'retlOnMappingSave'] as const
 /**
  * The supported actions hooks.
  * on-mapping-save: Called when a mapping is saved by the user. The return from this method is then stored in the mapping.
@@ -207,7 +207,7 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
     if (definition.hooks) {
       for (const hookName in definition.hooks) {
         const hook = definition.hooks[hookName as ActionHookType]
-        if (hook.inputFields) {
+        if (hook?.inputFields) {
           if (!this.hookSchemas) {
             this.hookSchemas = {}
           }
@@ -313,6 +313,17 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
         .filter((payload) => validateSchema(payload, schema, validationOptions))
     }
 
+    let hookOutputs = {}
+    if (this.definition.hooks) {
+      for (const hookType in this.definition.hooks) {
+        const hookOutputValues = bundle.mapping?.[hookType]
+
+        if (hookOutputValues) {
+          hookOutputs = { ...hookOutputs, [hookType]: hookOutputValues }
+        }
+      }
+    }
+
     if (payloads.length === 0) {
       return results
     }
@@ -330,7 +341,8 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
         logger: bundle.logger,
         dataFeedCache: bundle.dataFeedCache,
         transactionContext: bundle.transactionContext,
-        stateContext: bundle.stateContext
+        stateContext: bundle.stateContext,
+        hookOutputs
       }
       const output = await this.performRequest(this.definition.performBatch, data)
       results[0].data = output as JSONObject

--- a/packages/destination-actions/src/destinations/marketo-static-lists/addToList/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/addToList/__tests__/index.test.ts
@@ -28,6 +28,38 @@ const event = createTestEvent({
   }
 })
 
+const audienceName = 'The Best Test Audience'
+const folderName = 'Test Folder'
+const clientId = 'test_client_id'
+const clientSecret = 'test_client_secret'
+const apiEndpoint = 'https://123-ABC-456.mktorest.com'
+
+const hookInputNew = {
+  settings: {
+    folder_name: folderName,
+    client_id: clientId,
+    client_secret: clientSecret,
+    api_endpoint: apiEndpoint
+  },
+  hookInputs: {
+    list_name: audienceName
+  },
+  payload: {}
+}
+
+const hookInputExisting = {
+  settings: {
+    folder_name: folderName,
+    client_id: clientId,
+    client_secret: clientSecret,
+    api_endpoint: apiEndpoint
+  },
+  hookInputs: {
+    list_id: '782'
+  },
+  payload: {}
+}
+
 describe('MarketoStaticLists.addToList', () => {
   it('should succeed if response from Marketo is successful', async () => {
     const bulkImport = API_ENDPOINT + BULK_IMPORT_ENDPOINT.replace('externalId', EXTERNAL_AUDIENCE_ID)
@@ -65,5 +97,96 @@ describe('MarketoStaticLists.addToList', () => {
         useDefaultMappings: true
       })
     ).rejects.toThrow('Static list not found')
+  })
+
+  it('create a new list with hook', async () => {
+    nock(
+      `${apiEndpoint}/identity/oauth/token?grant_type=client_credentials&client_id=${clientId}&client_secret=${clientSecret}`
+    )
+      .post(/.*/)
+      .reply(200, {
+        access_token: 'access_token'
+      })
+
+    nock(`${apiEndpoint}/rest/asset/v1/folder/byName.json?name=${encodeURIComponent(folderName)}`)
+      .get(/.*/)
+      .reply(200, {
+        success: true,
+        result: [
+          {
+            name: folderName,
+            id: 12
+          }
+        ]
+      })
+
+    nock(`${apiEndpoint}/rest/asset/v1/staticLists.json?folder=12&name=${encodeURIComponent(audienceName)}`)
+      .post(/.*/)
+      .reply(200, {
+        success: true,
+        result: [
+          {
+            name: audienceName,
+            id: 782
+          }
+        ]
+      })
+
+    const r = await testDestination.actions.addToList.executeHook('retlOnMappingSave', hookInputNew)
+
+    expect(r.savedData).toMatchObject({
+      id: '782',
+      name: 'The Best Test Audience'
+    })
+    expect(r.successMessage).toMatchInlineSnapshot(`"List 782 created successfully!"`)
+  })
+
+  it('verify the existing list', async () => {
+    nock(
+      `${apiEndpoint}/identity/oauth/token?grant_type=client_credentials&client_id=${clientId}&client_secret=${clientSecret}`
+    )
+      .post(/.*/)
+      .reply(200, {
+        access_token: 'access_token'
+      })
+    nock(`${apiEndpoint}/rest/asset/v1/staticList/782.json`)
+      .get(/.*/)
+      .reply(200, {
+        success: true,
+        result: [
+          {
+            name: folderName,
+            id: 782
+          }
+        ]
+      })
+
+    const r = await testDestination.actions.addToList.executeHook('retlOnMappingSave', hookInputExisting)
+
+    expect(r.savedData).toMatchObject({
+      id: '782',
+      name: 'Test Folder'
+    })
+    expect(r.successMessage).toMatchInlineSnapshot(`"Using existing list 782."`)
+  })
+
+  it('fail if list id does not exist', async () => {
+    nock(
+      `${apiEndpoint}/identity/oauth/token?grant_type=client_credentials&client_id=${clientId}&client_secret=${clientSecret}`
+    )
+      .post(/.*/)
+      .reply(200, {
+        access_token: 'access_token'
+      })
+    nock(`${apiEndpoint}/rest/asset/v1/staticList/782.json`)
+      .get(/.*/)
+      .reply(200, {
+        success: false,
+        errors: [{ code: 1013, message: 'Static list not found' }]
+      })
+
+    const r = await testDestination.actions.addToList.executeHook('retlOnMappingSave', hookInputExisting)
+
+    expect(r).toMatchObject({ error: { code: 'LIST_ID_VERIFICATION_FAILURE', message: 'Static list not found' } })
   })
 })

--- a/packages/destination-actions/src/destinations/marketo-static-lists/addToList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/addToList/generated-types.ts
@@ -4,9 +4,9 @@ export interface Payload {
   /**
    * The ID of the Static List that users will be synced to.
    */
-  external_id: string
+  external_id?: string
   /**
-   * The lead field to use for deduplication and filtering. This field must be apart of the field(s) you are sending to Marketo.
+   * The lead field to use for deduplication and filtering. This field must be apart of the Lead Info Fields below.
    */
   lookup_field: string
   /**
@@ -17,18 +17,6 @@ export interface Payload {
      * The user's email address to send to Marketo.
      */
     email?: string
-    /**
-     * The user's first name.
-     */
-    firstName?: string
-    /**
-     * The user's last name.
-     */
-    lastName?: string
-    /**
-     * The user's phone number.
-     */
-    phone?: string
     [k: string]: unknown
   }
   /**
@@ -43,4 +31,30 @@ export interface Payload {
    * The name of the current Segment event.
    */
   event_name: string
+}
+// Generated bundle for hooks. DO NOT MODIFY IT BY HAND.
+
+export interface HookBundle {
+  retlOnMappingSave: {
+    inputs?: {
+      /**
+       * The ID of the Marketo Static List that users will be synced to. If defined, we will not create a new list.
+       */
+      list_id?: string
+      /**
+       * The name of the Marketo Static List that you would like to create.
+       */
+      list_name?: string
+    }
+    outputs?: {
+      /**
+       * The ID of the created Marketo Static List that users will be synced to.
+       */
+      id?: string
+      /**
+       * The name of the created Marketo Static List that users will be synced to.
+       */
+      name?: string
+    }
+  }
 }

--- a/packages/destination-actions/src/destinations/marketo-static-lists/addToList/index.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/addToList/index.ts
@@ -2,7 +2,7 @@ import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { external_id, lookup_field, data, enable_batching, batch_size, event_name } from '../properties'
-import { addToList } from '../functions'
+import { addToList, createList, getList } from '../functions'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Add to List',
@@ -16,13 +16,76 @@ const action: ActionDefinition<Settings, Payload> = {
     batch_size: { ...batch_size },
     event_name: { ...event_name }
   },
-  perform: async (request, { settings, payload, statsContext }) => {
-    statsContext?.statsClient?.incr('addToAudience', 1, statsContext?.tags)
-    return addToList(request, settings, [payload], statsContext)
+  hooks: {
+    retlOnMappingSave: {
+      label: 'Create a new static list in Marketo',
+      description: 'When saving this mapping, we will create a static list in Marketo using the fields you provided.',
+      inputFields: {
+        list_id: {
+          type: 'string',
+          label: 'List ID',
+          description:
+            'The ID of the Marketo Static List that users will be synced to. If defined, we will not create a new list.',
+          required: false
+        },
+        list_name: {
+          type: 'string',
+          label: 'List Name',
+          description: 'The name of the Marketo Static List that you would like to create.',
+          required: false
+        }
+      },
+      outputTypes: {
+        id: {
+          type: 'string',
+          label: 'ID',
+          description: 'The ID of the created Marketo Static List that users will be synced to.',
+          required: false
+        },
+        name: {
+          type: 'string',
+          label: 'List Name',
+          description: 'The name of the created Marketo Static List that users will be synced to.',
+          required: false
+        }
+      },
+      performHook: async (request, { settings, hookInputs, statsContext }) => {
+        if (hookInputs.list_id) {
+          return getList(request, settings, hookInputs.list_id)
+        }
+
+        try {
+          const input = {
+            audienceName: hookInputs.list_name,
+            settings: settings
+          }
+          const listId = await createList(request, input, statsContext)
+
+          return {
+            successMessage: `List ${listId} created successfully!`,
+            savedData: {
+              id: listId,
+              name: hookInputs.list_name
+            }
+          }
+        } catch (e) {
+          return {
+            error: {
+              message: 'Failed to create list',
+              code: 'CREATE_LIST_FAILURE'
+            }
+          }
+        }
+      }
+    }
   },
-  performBatch: async (request, { settings, payload, statsContext }) => {
+  perform: async (request, { settings, payload, statsContext, hookOutputs }) => {
+    statsContext?.statsClient?.incr('addToAudience', 1, statsContext?.tags)
+    return addToList(request, settings, [payload], statsContext, hookOutputs?.retlOnMappingSave?.outputs)
+  },
+  performBatch: async (request, { settings, payload, statsContext, hookOutputs }) => {
     statsContext?.statsClient?.incr('addToAudience.batch', 1, statsContext?.tags)
-    return addToList(request, settings, payload, statsContext)
+    return addToList(request, settings, payload, statsContext, hookOutputs?.retlOnMappingSave?.outputs)
   }
 }
 

--- a/packages/destination-actions/src/destinations/marketo-static-lists/addToList/index.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/addToList/index.ts
@@ -18,12 +18,12 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   hooks: {
     retlOnMappingSave: {
-      label: 'Create a new static list in Marketo',
+      label: 'Connect to a static list in Marketo',
       description: 'When saving this mapping, we will create a static list in Marketo using the fields you provided.',
       inputFields: {
         list_id: {
           type: 'string',
-          label: 'List ID',
+          label: 'Existing List ID',
           description:
             'The ID of the Marketo Static List that users will be synced to. If defined, we will not create a new list.',
           required: false
@@ -62,7 +62,7 @@ const action: ActionDefinition<Settings, Payload> = {
           const listId = await createList(request, input, statsContext)
 
           return {
-            successMessage: `List ${listId} created successfully!`,
+            successMessage: `List '${hookInputs.list_name}' (id: ${listId}) created successfully!`,
             savedData: {
               id: listId,
               name: hookInputs.list_name

--- a/packages/destination-actions/src/destinations/marketo-static-lists/constants.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/constants.ts
@@ -1,8 +1,5 @@
-import { RequestClient } from '@segment/actions-core'
-import { Settings } from './generated-types'
-
 const API_VERSION = 'v1'
-const OAUTH_ENDPOINT = 'identity/oauth/token'
+export const OAUTH_ENDPOINT = 'identity/oauth/token'
 export const GET_FOLDER_ENDPOINT = `/rest/asset/${API_VERSION}/folder/byName.json?name=folderName`
 export const CREATE_LIST_ENDPOINT = `/rest/asset/${API_VERSION}/staticLists.json?folder=folderId&name=listName`
 export const GET_LIST_ENDPOINT = `/rest/asset/${API_VERSION}/staticList/listId.json`
@@ -67,15 +64,12 @@ export interface MarketoLeads {
   createdAt: string
 }
 
-export async function getAccessToken(request: RequestClient, settings: Settings) {
-  const res = await request<RefreshTokenResponse>(`${settings.api_endpoint}/${OAUTH_ENDPOINT}`, {
-    method: 'POST',
-    body: new URLSearchParams({
-      client_id: settings.client_id,
-      client_secret: settings.client_secret,
-      grant_type: 'client_credentials'
-    })
-  })
-
-  return res.data.access_token
+export interface CreateListInput {
+  audienceName: string
+  settings: {
+    client_id: string
+    client_secret: string
+    api_endpoint: string
+    folder_name: string
+  }
 }

--- a/packages/destination-actions/src/destinations/marketo-static-lists/functions.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/functions.ts
@@ -206,7 +206,7 @@ export async function getList(request: RequestClient, settings: Settings, id: st
   }
 
   return {
-    successMessage: `Using existing list ${id}.`,
+    successMessage: `Using existing list '${getListResponse.data.result[0].name}' (id: ${id})`,
     savedData: {
       id: id,
       name: getListResponse.data.result[0].name

--- a/packages/destination-actions/src/destinations/marketo-static-lists/functions.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/functions.ts
@@ -7,11 +7,18 @@ import {
   BULK_IMPORT_ENDPOINT,
   MarketoBulkImportResponse,
   GET_LEADS_ENDPOINT,
+  GET_FOLDER_ENDPOINT,
   MarketoGetLeadsResponse,
   MarketoLeads,
   MarketoDeleteLeadsResponse,
   REMOVE_USERS_ENDPOINT,
-  MarketoResponse
+  MarketoResponse,
+  CreateListInput,
+  OAUTH_ENDPOINT,
+  RefreshTokenResponse,
+  MarketoListResponse,
+  CREATE_LIST_ENDPOINT,
+  GET_LIST_ENDPOINT
 } from './constants'
 
 // Keep only the scheme and host from the endpoint
@@ -24,8 +31,16 @@ export async function addToList(
   request: RequestClient,
   settings: Settings,
   payloads: AddToListPayload[],
-  statsContext?: StatsContext
+  statsContext?: StatsContext,
+  hookOutputs?: { id: string; name: string }
 ) {
+  // If the list ID is provided in the hook outputs, use it
+  const list_id = hookOutputs?.id ?? payloads[0].external_id
+
+  if (!list_id) {
+    throw new IntegrationError('No list ID found in payload', 'INVALID_REQUEST_DATA', 400)
+  }
+
   const api_endpoint = formatEndpoint(settings.api_endpoint)
 
   const csvData = formatData(payloads)
@@ -37,10 +52,7 @@ export async function addToList(
 
   const url =
     api_endpoint +
-    BULK_IMPORT_ENDPOINT.replace('externalId', payloads[0].external_id).replace(
-      'fieldToLookup',
-      payloads[0].lookup_field
-    )
+    BULK_IMPORT_ENDPOINT.replace('externalId', list_id).replace('fieldToLookup', payloads[0].lookup_field)
 
   const response = await request<MarketoBulkImportResponse>(url, {
     method: 'POST',
@@ -64,6 +76,10 @@ export async function removeFromList(
   payloads: RemoveFromListPayload[],
   statsContext?: StatsContext
 ) {
+  if (!payloads[0].external_id) {
+    throw new IntegrationError('No external_id found in payload', 'INVALID_REQUEST_DATA', 400)
+  }
+
   const api_endpoint = formatEndpoint(settings.api_endpoint)
   const usersToRemove = extractFilterData(payloads)
 
@@ -151,4 +167,114 @@ function parseErrorResponse(response: MarketoResponse) {
     )
   }
   throw new IntegrationError(response.errors[0].message, 'INVALID_RESPONSE', 400)
+}
+
+export async function getAccessToken(request: RequestClient, settings: Settings) {
+  const api_endpoint = formatEndpoint(settings.api_endpoint)
+  const res = await request<RefreshTokenResponse>(`${api_endpoint}/${OAUTH_ENDPOINT}`, {
+    method: 'POST',
+    body: new URLSearchParams({
+      client_id: settings.client_id,
+      client_secret: settings.client_secret,
+      grant_type: 'client_credentials'
+    })
+  })
+
+  return res.data.access_token
+}
+
+export async function getList(request: RequestClient, settings: Settings, id: string) {
+  const accessToken = await getAccessToken(request, settings)
+  const endpoint = formatEndpoint(settings.api_endpoint)
+
+  const getListUrl = endpoint + GET_LIST_ENDPOINT.replace('listId', id)
+
+  const getListResponse = await request<MarketoListResponse>(getListUrl, {
+    method: 'GET',
+    headers: {
+      authorization: `Bearer ${accessToken}`
+    }
+  })
+
+  if (!getListResponse.data.success && getListResponse.data.errors) {
+    return {
+      error: {
+        message: getListResponse.data.errors[0].message,
+        code: 'LIST_ID_VERIFICATION_FAILURE'
+      }
+    }
+  }
+
+  return {
+    successMessage: `Using existing list ${id}.`,
+    savedData: {
+      id: id,
+      name: getListResponse.data.result[0].name
+    }
+  }
+}
+
+export async function createList(request: RequestClient, input: CreateListInput, statsContext?: StatsContext) {
+  const statsClient = statsContext?.statsClient
+  const statsTags = statsContext?.tags
+
+  if (!input.audienceName) {
+    throw new IntegrationError('Missing audience name value', 'MISSING_REQUIRED_FIELD', 400)
+  }
+
+  // Format Marketo base endpoint
+  const endpoint = formatEndpoint(input.settings.api_endpoint)
+
+  // Get access token
+  const accessToken = await getAccessToken(request, input.settings)
+
+  const getFolderUrl =
+    endpoint + GET_FOLDER_ENDPOINT.replace('folderName', encodeURIComponent(input.settings.folder_name))
+
+  // Get folder ID by name
+  const getFolderResponse = await request<MarketoListResponse>(getFolderUrl, {
+    method: 'GET',
+    headers: {
+      authorization: `Bearer ${accessToken}`
+    }
+  })
+
+  // Since the API will return 200 we need to parse the response to see if it failed.
+  if (!getFolderResponse.data.success && getFolderResponse.data.errors) {
+    statsClient?.incr('createAudience.error', 1, statsTags)
+    throw new IntegrationError(`${getFolderResponse.data.errors[0].message}`, 'INVALID_RESPONSE', 400)
+  }
+
+  if (!getFolderResponse.data.result) {
+    statsClient?.incr('createAudience.error', 1, statsTags)
+    throw new IntegrationError(
+      `A folder with the name ${input.settings.folder_name} not found`,
+      'INVALID_REQUEST_DATA',
+      400
+    )
+  }
+
+  const folderId = getFolderResponse.data.result[0].id.toString()
+
+  const createListUrl =
+    endpoint +
+    CREATE_LIST_ENDPOINT.replace('folderId', folderId).replace('listName', encodeURIComponent(input.audienceName))
+
+  // Create list in given folder
+  const createListResponse = await request<MarketoListResponse>(createListUrl, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${accessToken}`
+    }
+  })
+
+  if (!createListResponse.data.success && createListResponse.data.errors) {
+    statsClient?.incr('createAudience.error', 1, statsTags)
+    throw new IntegrationError(`${createListResponse.data.errors[0].message}`, 'INVALID_RESPONSE', 400)
+  }
+
+  const listId = createListResponse.data.result[0].id.toString()
+  statsClient?.incr('createAudience.success', 1, statsTags)
+
+  return listId
 }

--- a/packages/destination-actions/src/destinations/marketo-static-lists/index.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/index.ts
@@ -4,14 +4,8 @@ import type { Settings } from './generated-types'
 
 import addToList from './addToList'
 import removeFromList from './removeFromList'
-import {
-  MarketoListResponse,
-  getAccessToken,
-  GET_FOLDER_ENDPOINT,
-  GET_LIST_ENDPOINT,
-  CREATE_LIST_ENDPOINT
-} from './constants'
-import { formatEndpoint } from './functions'
+import { MarketoListResponse, GET_LIST_ENDPOINT } from './constants'
+import { createList, formatEndpoint, getAccessToken } from './functions'
 
 const destination: AudienceDestinationDefinition<Settings> = {
   name: 'Marketo Static Lists (Actions)',
@@ -64,64 +58,10 @@ const destination: AudienceDestinationDefinition<Settings> = {
       full_audience_sync: false // If true, we send the entire audience. If false, we just send the delta.
     },
     async createAudience(request, createAudienceInput) {
-      const audienceName = createAudienceInput.audienceName
-      const folder = createAudienceInput.settings.folder_name
-      const endpoint = formatEndpoint(createAudienceInput.settings.api_endpoint)
-      const statsClient = createAudienceInput?.statsContext?.statsClient
-      const statsTags = createAudienceInput?.statsContext?.tags
-
-      if (!audienceName) {
-        throw new IntegrationError('Missing audience name value', 'MISSING_REQUIRED_FIELD', 400)
-      }
-
-      // Get access token
-      const accessToken = await getAccessToken(request, createAudienceInput.settings)
-
-      const getFolderUrl = endpoint + GET_FOLDER_ENDPOINT.replace('folderName', encodeURIComponent(folder))
-
-      // Get folder ID by name
-      const getFolderResponse = await request<MarketoListResponse>(getFolderUrl, {
-        method: 'GET',
-        headers: {
-          authorization: `Bearer ${accessToken}`
-        }
-      })
-
-      // Since the API will return 200 we need to parse the response to see if it failed.
-      if (!getFolderResponse.data.success && getFolderResponse.data.errors) {
-        statsClient?.incr('createAudience.error', 1, statsTags)
-        throw new IntegrationError(`${getFolderResponse.data.errors[0].message}`, 'INVALID_RESPONSE', 400)
-      }
-
-      if (!getFolderResponse.data.result) {
-        statsClient?.incr('createAudience.error', 1, statsTags)
-        throw new IntegrationError(`A folder with the name ${folder} not found`, 'INVALID_REQUEST_DATA', 400)
-      }
-
-      const folderId = getFolderResponse.data.result[0].id.toString()
-
-      const createListUrl =
-        endpoint +
-        CREATE_LIST_ENDPOINT.replace('folderId', folderId).replace('listName', encodeURIComponent(audienceName))
-
-      // Create list in given folder
-      const createListResponse = await request<MarketoListResponse>(createListUrl, {
-        method: 'POST',
-        headers: {
-          authorization: `Bearer ${accessToken}`
-        }
-      })
-
-      if (!createListResponse.data.success && createListResponse.data.errors) {
-        statsClient?.incr('createAudience.error', 1, statsTags)
-        throw new IntegrationError(`${createListResponse.data.errors[0].message}`, 'INVALID_RESPONSE', 400)
-      }
-
-      const externalId = createListResponse.data.result[0].id.toString()
-      statsClient?.incr('createAudience.success', 1, statsTags)
+      const listId = await createList(request, createAudienceInput, createAudienceInput.statsContext)
 
       return {
-        externalId: externalId
+        externalId: listId
       }
     },
     async getAudience(request, getAudienceInput) {

--- a/packages/destination-actions/src/destinations/marketo-static-lists/properties.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/properties.ts
@@ -7,8 +7,7 @@ export const external_id: InputField = {
   default: {
     '@path': '$.context.personas.external_audience_id'
   },
-  unsafe_hidden: true,
-  required: true
+  unsafe_hidden: true
 }
 
 export const field_value: InputField = {
@@ -27,7 +26,7 @@ export const field_value: InputField = {
 
 export const lookup_field: InputField = {
   label: 'Lookup Field',
-  description: `The lead field to use for deduplication and filtering. This field must be apart of the field(s) you are sending to Marketo.`,
+  description: `The lead field to use for deduplication and filtering. This field must be apart of the Lead Info Fields below.`,
   type: 'string',
   choices: [
     { label: 'Email', value: 'email' },
@@ -56,21 +55,6 @@ export const data: InputField = {
       label: 'Email',
       description: `The user's email address to send to Marketo.`,
       type: 'string'
-    },
-    firstName: {
-      label: 'First Name',
-      description: `The user's first name.`,
-      type: 'string'
-    },
-    lastName: {
-      label: 'Last Name',
-      description: `The user's last name.`,
-      type: 'string'
-    },
-    phone: {
-      label: 'Phone Number',
-      description: `The user's phone number.`,
-      type: 'string'
     }
   },
   default: {
@@ -79,27 +63,6 @@ export const data: InputField = {
         exists: { '@path': '$.context.traits.email' },
         then: { '@path': '$.context.traits.email' },
         else: { '@path': '$.properties.email' }
-      }
-    },
-    firstName: {
-      '@if': {
-        exists: { '@path': '$.context.traits.firstName' },
-        then: { '@path': '$.context.traits.firstName' },
-        else: { '@path': '$.properties.firstName' }
-      }
-    },
-    lastName: {
-      '@if': {
-        exists: { '@path': '$.context.traits.lastName' },
-        then: { '@path': '$.context.traits.lastName' },
-        else: { '@path': '$.properties.lastName' }
-      }
-    },
-    phone: {
-      '@if': {
-        exists: { '@path': '$.context.traits.phoneNumber' },
-        then: { '@path': '$.context.traits.phoneNumber' },
-        else: { '@path': '$.properties.phoneNumber' }
       }
     }
   },

--- a/packages/destination-actions/src/destinations/marketo-static-lists/removeFromList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/removeFromList/generated-types.ts
@@ -4,9 +4,9 @@ export interface Payload {
   /**
    * The ID of the Static List that users will be synced to.
    */
-  external_id: string
+  external_id?: string
   /**
-   * The lead field to use for deduplication and filtering. This field must be apart of the field(s) you are sending to Marketo.
+   * The lead field to use for deduplication and filtering. This field must be apart of the Lead Info Fields below.
    */
   lookup_field: string
   /**


### PR DESCRIPTION
This PR introduces a _new_ hook `retlOnMappingSave` that will be used for RETL only. 

[SDD](https://docs.google.com/document/d/1b6URV6z-KbqgxWxBZw1eTTXDyS0WGxFZzHSRM_rmL3A/edit#heading=h.6o5vd076j404)

This hook will create a list in Marketo whenever a new mapping is saved. 

Front End work: https://github.com/segmentio/app/pull/19858

https://github.com/segmentio/action-destinations/assets/99763167/1c8912e3-8a10-4595-a4fe-5b746d35c471

![Screenshot 2024-04-03 at 3 20 53 PM](https://github.com/segmentio/action-destinations/assets/99763167/83a17205-c41f-41ea-b7ac-8b3543ebdb4b)

![Screenshot 2024-04-03 at 3 40 01 PM](https://github.com/segmentio/action-destinations/assets/99763167/66ca2a44-6ea0-409b-981d-9e0088ad5699)



## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
