### PR TITLE
Allow builders to conditionally show settings + implementation for Kafka

### DIFF
--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -91,6 +91,7 @@ export interface GlobalSetting {
   default?: string | number | boolean
   properties?: InputField['properties']
   format?: InputField['format']
+  depends_on?: InputField['depends_on']
 }
 
 /** The supported field type names */

--- a/packages/destination-actions/src/destinations/kafka/index.ts
+++ b/packages/destination-actions/src/destinations/kafka/index.ts
@@ -1,6 +1,6 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
-import { validate, getTopics } from './utils'
+import { validate, getTopics, DEPENDS_ON_CLIENT_CERT, DEPEONDS_ON_AWS, DEPENDS_ON_PLAIN_OR_SCRAM } from './utils'
 import send from './send'
 
 const destination: DestinationDefinition<Settings> = {
@@ -45,35 +45,40 @@ const destination: DestinationDefinition<Settings> = {
         description:
           'The username for your Kafka instance. Should be populated only if using PLAIN or SCRAM Authentication Mechanisms.',
         type: 'string',
-        required: false
+        required: false,
+        depends_on: DEPENDS_ON_PLAIN_OR_SCRAM
       },
       password: {
         label: 'Password',
         description:
           'The password for your Kafka instance. Should only be populated if using PLAIN or SCRAM Authentication Mechanisms.',
         type: 'password',
-        required: false
+        required: false,
+        depends_on: DEPENDS_ON_PLAIN_OR_SCRAM
       },
       accessKeyId: {
         label: 'AWS Access Key ID',
         description:
           'The Access Key ID for your AWS IAM instance. Must be populated if using AWS IAM Authentication Mechanism.',
         type: 'string',
-        required: false
+        required: false,
+        depends_on: DEPEONDS_ON_AWS
       },
       secretAccessKey: {
         label: 'AWS Secret Key',
         description:
           'The Secret Key for your AWS IAM instance. Must be populated if using AWS IAM Authentication Mechanism.',
         type: 'password',
-        required: false
+        required: false,
+        depends_on: DEPEONDS_ON_AWS
       },
       authorizationIdentity: {
         label: 'AWS Authorization Identity',
         description:
           'AWS IAM role ARN used for authorization. This field is optional, and should only be populated if using the AWS IAM Authentication Mechanism.',
         type: 'string',
-        required: false
+        required: false,
+        depends_on: DEPEONDS_ON_AWS
       },
       ssl_enabled: {
         label: 'SSL Enabled',
@@ -94,14 +99,16 @@ const destination: DestinationDefinition<Settings> = {
         description:
           'The Client Key for your Kafka instance. Exclude the first and last lines from the file. i.e `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`.',
         type: 'string',
-        required: false
+        required: false,
+        depends_on: DEPENDS_ON_CLIENT_CERT
       },
       ssl_cert: {
         label: 'SSL Client Certificate',
         description:
           'The Certificate Authority for your Kafka instance. Exclude the first and last lines from the file. i.e `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`.',
         type: 'string',
-        required: false
+        required: false,
+        depends_on: DEPENDS_ON_CLIENT_CERT
       },
       ssl_reject_unauthorized_ca: {
         label: 'SSL - Reject Unauthorized Certificate Authority',

--- a/packages/destination-actions/src/destinations/kafka/utils.ts
+++ b/packages/destination-actions/src/destinations/kafka/utils.ts
@@ -2,8 +2,48 @@ import { Kafka, ProducerRecord, Partitioners, SASLOptions, KafkaConfig, KafkaJSE
 import { DynamicFieldResponse, IntegrationError } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import type { Payload } from './send/generated-types'
+import { DependsOnConditions } from '@segment/actions-core/destination-kittypes'
 
 export const DEFAULT_PARTITIONER = 'DefaultPartitioner'
+
+export const DEPENDS_ON_PLAIN_OR_SCRAM: DependsOnConditions = {
+  match: 'any',
+  conditions: [
+    {
+      fieldKey: 'mechanism',
+      operator: 'is',
+      value: 'plain'
+    },
+    {
+      fieldKey: 'mechanism',
+      operator: 'is',
+      value: 'scram-sha-256'
+    },
+    {
+      fieldKey: 'mechanism',
+      operator: 'is',
+      value: 'scram-sha-512'
+    }
+  ]
+}
+export const DEPEONDS_ON_AWS: DependsOnConditions = {
+  conditions: [
+    {
+      fieldKey: 'mechanism',
+      operator: 'is',
+      value: 'aws'
+    }
+  ]
+}
+export const DEPENDS_ON_CLIENT_CERT: DependsOnConditions = {
+  conditions: [
+    {
+      fieldKey: 'mechanism',
+      operator: 'is',
+      value: 'client-cert-auth'
+    }
+  ]
+}
 
 interface Message {
   value: string


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR allows builders to define a `depends_on` object for top-level settings. This is a continuation of the work done for `InputField` in this PR: https://github.com/segmentio/app/pull/19589

The PR also implements top level conditionally shown settings for the Kafka destination.
Users are required to select an 'Authentication Mechanism', which determines which settings further down the page are relevant. For example, if a user selects 'AWS IAM', then only settings relevant to AWS will be displayed on the page.

This PR is part of this series of PRs:
https://github.com/segmentio/app/pull/20031
https://github.com/segmentio/control-plane/pull/4585
https://github.com/segmentio/action-cli/pull/163

## Testing
Testing successfully in staging.

https://github.com/segmentio/app/assets/27820201/58af1860-541e-4079-98a0-f38aa5f75731

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
