### PR TITLE
Trim AdvertiserID values

### DIFF
--- a/packages/destination-actions/src/destinations/display-video-360/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/__tests__/index.test.ts
@@ -86,6 +86,26 @@ describe('Display Video 360', () => {
       })
     })
 
+    it('should work when advertiserId starts or ends with a space', async () => {
+      createAudienceInput.audienceName = audienceName
+      createAudienceInput.audienceSettings.advertiserId = '                424242'
+
+      nock(OAUTH_URL).post(/.*/).reply(200, { access_token: 'tok3n' })
+      nock(advertiserCreateAudienceUrl)
+        .post(/.*/)
+        .reply(200, {
+          results: [
+            {
+              resourceName: `products/DISPLAY_VIDEO_ADVERTISER/customers/${advertiserId}/userLists/8460733279`
+            }
+          ]
+        })
+      const r = await testDestination.createAudience(createAudienceInput)
+      expect(r).toEqual({
+        externalId: `products/DISPLAY_VIDEO_ADVERTISER/customers/424242/userLists/8460733279`
+      })
+    })
+
     it('errors out when audience with same name already exists', async () => {
       nock(advertiserCreateAudienceUrl)
         .post(/.*/)
@@ -151,6 +171,17 @@ describe('Display Video 360', () => {
       nock(OAUTH_URL).post(/.*/).reply(200, { access_token: 'tok3n' })
       nock(advertiserGetAudienceUrl).post(/.*/).reply(200, getAudienceResponse)
 
+      const r = await testDestination.getAudience(getAudienceInput)
+      expect(r).toEqual({
+        externalId: expectedExternalID
+      })
+    })
+
+    it('should work when advertiserId starts or ends with a space', async () => {
+      nock(OAUTH_URL).post(/.*/).reply(200, { access_token: 'tok3n' })
+      nock(advertiserGetAudienceUrl).post(/.*/).reply(200, getAudienceResponse)
+
+      getAudienceInput.audienceSettings.advertiserId = '                424242  '
       const r = await testDestination.getAudience(getAudienceInput)
       expect(r).toEqual({
         externalId: expectedExternalID

--- a/packages/destination-actions/src/destinations/display-video-360/index.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/index.ts
@@ -40,7 +40,8 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     },
     async createAudience(request, createAudienceInput) {
       const { audienceName, audienceSettings, statsContext } = createAudienceInput
-      const { advertiserId, accountType } = audienceSettings || {}
+      const { accountType } = audienceSettings || {}
+      const advertiserId = audienceSettings?.advertiserId.trim()
       const { statsClient, tags: statsTags } = statsContext || {}
       const statsName = 'createAudience'
       statsTags?.push(`slug:${destination.slug}`)
@@ -105,7 +106,8 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     async getAudience(request, getAudienceInput) {
       const { statsContext, audienceSettings } = getAudienceInput
       const { statsClient, tags: statsTags } = statsContext || {}
-      const { advertiserId, accountType } = audienceSettings || {}
+      const { accountType } = audienceSettings || {}
+      const advertiserId = audienceSettings?.advertiserId.trim()
       const statsName = 'getAudience'
       statsTags?.push(`slug:${destination.slug}`)
       statsClient?.incr(`${statsName}.call`, 1, statsTags)


### PR DESCRIPTION
This PR ensures AdvertiserID values come trimmed.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
