### PR TITLE
[Stratconn 3726 ]- Fixed re-authorisation issue in Google Ads Conversion.

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -11,16 +11,23 @@ import {
   RequestClient,
   IntegrationError,
   PayloadValidationError,
-  DynamicFieldResponse,
-  APIError
+  DynamicFieldResponse
 } from '@segment/actions-core'
 import { StatsContext } from '@segment/actions-core/destination-kit'
 import { Features } from '@segment/actions-core/mapping-kit'
 import { fullFormats } from 'ajv-formats/dist/formats'
+import { HTTPError } from '@segment/actions-core/*'
 
 export const API_VERSION = 'v15'
 export const CANARY_API_VERSION = 'v15'
 export const FLAGON_NAME = 'google-enhanced-canary-version'
+
+export class GoogleAdsError extends HTTPError {
+  response: Response & {
+    status: string
+    statusText: string
+  }
+}
 
 export function formatCustomVariables(
   customVariables: object,
@@ -131,8 +138,8 @@ export async function getConversionActionDynamicData(
       choices: [],
       nextPage: '',
       error: {
-        message: (err as APIError).message ?? 'Unknown error',
-        code: (err as APIError).status + '' ?? 'Unknown error'
+        message: (err as GoogleAdsError).response?.statusText ?? 'Unknown error',
+        code: (err as GoogleAdsError).response?.status + '' ?? '500'
       }
     }
   }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -16,8 +16,7 @@ import {
 import { StatsContext } from '@segment/actions-core/destination-kit'
 import { Features } from '@segment/actions-core/mapping-kit'
 import { fullFormats } from 'ajv-formats/dist/formats'
-import { HTTPError } from '@segment/actions-core/*'
-
+import { HTTPError } from '@segment/actions-core'
 export const API_VERSION = 'v15'
 export const CANARY_API_VERSION = 'v15'
 export const FLAGON_NAME = 'google-enhanced-canary-version'


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pull request is to fix reauthorisation issue for dynamic fields in Google Enhanced Conversion.If Status Code 401 is thrown then destination action service refreshes the token.

Related PR :- https://github.com/segmentio/integrations/pull/2839/files
Jira Ticket:- https://segment.atlassian.net/browse/STRATCONN-3726

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment

<img width="1403" alt="Screenshot 2024-04-09 at 12 19 08 PM" src="https://github.com/segmentio/action-destinations/assets/117165746/f921f170-2a6f-4fbc-b6c3-13b31f1eca1c">

<img width="1287" alt="Screenshot 2024-04-09 at 12 19 18 PM" src="https://github.com/segmentio/action-destinations/assets/117165746/c20e102b-e3c1-488c-a23f-dcd325bd887f">

