### PR TITLE
Pass along context to all Ripe methods

### DIFF
--- a/packages/browser-destinations/destinations/ripe/src/group/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/ripe/src/group/__tests__/index.test.ts
@@ -31,6 +31,9 @@ const subscriptions: Subscription[] = [
       },
       traits: {
         '@path': '$.traits'
+      },
+      context: {
+        '@path': '$.context'
       }
     }
   }
@@ -61,6 +64,9 @@ describe('Ripe.group', () => {
         groupId: 'groupId1',
         traits: {
           is_new_group: true
+        },
+        context: {
+          ip: '1.2.3.4'
         }
       })
     )
@@ -75,6 +81,9 @@ describe('Ripe.group', () => {
           groupId: 'groupId1',
           traits: {
             is_new_group: true
+          },
+          context: {
+            ip: '1.2.3.4'
           }
         }
       })
@@ -85,7 +94,10 @@ describe('Ripe.group', () => {
       anonymousId: 'anonId1',
       userId: undefined,
       groupId: 'groupId1',
-      traits: expect.objectContaining({ is_new_group: true })
+      traits: expect.objectContaining({ is_new_group: true }),
+      context: {
+        ip: '1.2.3.4'
+      }
     })
   })
 })

--- a/packages/browser-destinations/destinations/ripe/src/group/generated-types.ts
+++ b/packages/browser-destinations/destinations/ripe/src/group/generated-types.ts
@@ -23,4 +23,10 @@ export interface Payload {
    * The Segment messageId
    */
   messageId?: string
+  /**
+   * Device context
+   */
+  context?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/browser-destinations/destinations/ripe/src/group/index.ts
+++ b/packages/browser-destinations/destinations/ripe/src/group/index.ts
@@ -45,6 +45,13 @@ const action: BrowserActionDefinition<Settings, RipeSDK, Payload> = {
       description: 'The Segment messageId',
       label: 'MessageId',
       default: { '@path': '$.messageId' }
+    },
+    context: {
+      type: 'object',
+      label: 'Context',
+      description: 'Device context',
+      required: false,
+      default: { '@path': '$.context' }
     }
   },
   perform: async (ripe, { payload }) => {
@@ -53,7 +60,8 @@ const action: BrowserActionDefinition<Settings, RipeSDK, Payload> = {
       anonymousId: payload.anonymousId,
       userId: payload.userId,
       groupId: payload.groupId,
-      traits: payload.traits
+      traits: payload.traits,
+      context: payload.context
     })
   }
 }

--- a/packages/browser-destinations/destinations/ripe/src/identify/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/ripe/src/identify/__tests__/index.test.ts
@@ -31,6 +31,9 @@ const subscriptions: Subscription[] = [
       },
       traits: {
         '@path': '$.traits'
+      },
+      context: {
+        '@path': '$.context'
       }
     }
   }
@@ -61,6 +64,9 @@ describe('Ripe.identify', () => {
         userId: 'userId',
         traits: {
           name: 'Simon'
+        },
+        context: {
+          ip: '1.2.3.4'
         }
       })
     )
@@ -75,6 +81,9 @@ describe('Ripe.identify', () => {
           groupId: undefined,
           traits: {
             name: 'Simon'
+          },
+          context: {
+            ip: '1.2.3.4'
           }
         }
       })
@@ -85,7 +94,10 @@ describe('Ripe.identify', () => {
       userId: expect.stringMatching('userId'),
       anonymousId: 'anonymousId',
       groupId: undefined,
-      traits: expect.objectContaining({ name: 'Simon' })
+      traits: expect.objectContaining({ name: 'Simon' }),
+      context: {
+        ip: '1.2.3.4'
+      }
     })
   })
 })

--- a/packages/browser-destinations/destinations/ripe/src/identify/generated-types.ts
+++ b/packages/browser-destinations/destinations/ripe/src/identify/generated-types.ts
@@ -23,4 +23,10 @@ export interface Payload {
    * The Segment messageId
    */
   messageId?: string
+  /**
+   * Device context
+   */
+  context?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/browser-destinations/destinations/ripe/src/identify/index.ts
+++ b/packages/browser-destinations/destinations/ripe/src/identify/index.ts
@@ -45,6 +45,13 @@ const action: BrowserActionDefinition<Settings, RipeSDK, Payload> = {
       description: 'The Segment messageId',
       label: 'MessageId',
       default: { '@path': '$.messageId' }
+    },
+    context: {
+      type: 'object',
+      label: 'Context',
+      description: 'Device context',
+      required: false,
+      default: { '@path': '$.context' }
     }
   },
   perform: async (ripe, { payload }) => {
@@ -53,7 +60,8 @@ const action: BrowserActionDefinition<Settings, RipeSDK, Payload> = {
       anonymousId: payload.anonymousId,
       userId: payload.userId,
       groupId: payload.groupId,
-      traits: payload.traits
+      traits: payload.traits,
+      context: payload.context
     })
   }
 }

--- a/packages/browser-destinations/destinations/ripe/src/page/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/ripe/src/page/__tests__/index.test.ts
@@ -37,6 +37,9 @@ const subscriptions: Subscription[] = [
       },
       properties: {
         '@path': '$.properties'
+      },
+      context: {
+        '@path': '$.context'
       }
     }
   }
@@ -68,6 +71,9 @@ describe('Ripe.page', () => {
         name: 'page2',
         properties: {
           previous: 'page1'
+        },
+        context: {
+          ip: '1.2.3.4'
         }
       })
     )
@@ -84,6 +90,9 @@ describe('Ripe.page', () => {
           name: 'page2',
           properties: {
             previous: 'page1'
+          },
+          context: {
+            ip: '1.2.3.4'
           }
         }
       })
@@ -96,7 +105,10 @@ describe('Ripe.page', () => {
       anonymousId: 'anonymousId',
       category: 'main',
       name: 'page2',
-      properties: expect.objectContaining({ previous: 'page1' })
+      properties: expect.objectContaining({ previous: 'page1' }),
+      context: {
+        ip: '1.2.3.4'
+      }
     })
   })
 })

--- a/packages/browser-destinations/destinations/ripe/src/page/generated-types.ts
+++ b/packages/browser-destinations/destinations/ripe/src/page/generated-types.ts
@@ -31,4 +31,10 @@ export interface Payload {
    * The Segment messageId
    */
   messageId?: string
+  /**
+   * Device context
+   */
+  context?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/browser-destinations/destinations/ripe/src/page/index.ts
+++ b/packages/browser-destinations/destinations/ripe/src/page/index.ts
@@ -71,6 +71,13 @@ const action: BrowserActionDefinition<Settings, RipeSDK, Payload> = {
       description: 'The Segment messageId',
       label: 'MessageId',
       default: { '@path': '$.messageId' }
+    },
+    context: {
+      type: 'object',
+      label: 'Context',
+      description: 'Device context',
+      required: false,
+      default: { '@path': '$.context' }
     }
   },
   perform: async (ripe, { payload }) => {
@@ -81,7 +88,8 @@ const action: BrowserActionDefinition<Settings, RipeSDK, Payload> = {
       groupId: payload.groupId,
       category: payload.category,
       name: payload.name,
-      properties: payload.properties
+      properties: payload.properties,
+      context: payload.context
     })
   }
 }

--- a/packages/browser-destinations/destinations/ripe/src/track/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/ripe/src/track/__tests__/index.test.ts
@@ -34,6 +34,9 @@ const subscriptions: Subscription[] = [
       },
       properties: {
         '@path': '$.properties'
+      },
+      context: {
+        '@path': '$.context'
       }
     }
   }
@@ -64,6 +67,9 @@ describe('Ripe.track', () => {
         event: 'Form Submitted',
         properties: {
           is_new_lead: true
+        },
+        context: {
+          ip: '1.2.3.4'
         }
       })
     )
@@ -79,6 +85,9 @@ describe('Ripe.track', () => {
           event: 'Form Submitted',
           properties: {
             is_new_lead: true
+          },
+          context: {
+            ip: '1.2.3.4'
           }
         }
       })
@@ -90,7 +99,10 @@ describe('Ripe.track', () => {
       userId: undefined,
       groupId: undefined,
       event: 'Form Submitted',
-      properties: expect.objectContaining({ is_new_lead: true })
+      properties: expect.objectContaining({ is_new_lead: true }),
+      context: {
+        ip: '1.2.3.4'
+      }
     })
   })
 })

--- a/packages/browser-destinations/destinations/ripe/src/track/generated-types.ts
+++ b/packages/browser-destinations/destinations/ripe/src/track/generated-types.ts
@@ -27,4 +27,10 @@ export interface Payload {
    * The Segment messageId
    */
   messageId?: string
+  /**
+   * Device context
+   */
+  context?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/browser-destinations/destinations/ripe/src/track/index.ts
+++ b/packages/browser-destinations/destinations/ripe/src/track/index.ts
@@ -52,6 +52,13 @@ const action: BrowserActionDefinition<Settings, RipeSDK, Payload> = {
       description: 'The Segment messageId',
       label: 'MessageId',
       default: { '@path': '$.messageId' }
+    },
+    context: {
+      type: 'object',
+      label: 'Context',
+      description: 'Device context',
+      required: false,
+      default: { '@path': '$.context' }
     }
   },
   perform: async (ripe, { payload }) => {
@@ -62,7 +69,8 @@ const action: BrowserActionDefinition<Settings, RipeSDK, Payload> = {
         userId: payload.userId,
         groupId: payload.groupId,
         event: payload.event,
-        properties: payload.properties
+        properties: payload.properties,
+        context: payload.context
       })
     }
   }

--- a/packages/browser-destinations/destinations/ripe/src/types.ts
+++ b/packages/browser-destinations/destinations/ripe/src/types.ts
@@ -11,6 +11,7 @@ export interface RipeSDK {
     userId?: string | null
     groupId: string | null
     traits?: Record<string, unknown>
+    context?: Record<string, unknown>
   }) => Promise<void>
   identify: ({
     messageId,
@@ -24,6 +25,7 @@ export interface RipeSDK {
     userId?: string | null
     groupId?: string | null
     traits?: Record<string, unknown>
+    context?: Record<string, unknown>
   }) => Promise<void>
   init: (apiKey: string) => Promise<void>
   page: ({
@@ -42,6 +44,7 @@ export interface RipeSDK {
     category?: string
     name?: string
     properties?: Record<string, unknown>
+    context?: Record<string, unknown>
   }) => Promise<void>
   track: ({
     messageId,
@@ -57,5 +60,6 @@ export interface RipeSDK {
     groupId?: string | null
     event: string
     properties?: Record<string, unknown>
+    context?: Record<string, unknown>
   }) => Promise<void>
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Passing through the context object to the Ripe device mode destination. We're looking to use some of the information in there for enrichment purposes on our end.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
