### PR TITLE
feat(screeb): identify on init

### DIFF
--- a/packages/browser-destinations/destinations/screeb/src/index.ts
+++ b/packages/browser-destinations/destinations/screeb/src/index.ts
@@ -72,7 +72,7 @@ export const destination: BrowserDestinationDefinition<Settings, Screeb> = {
     await deps.loadScript('https://t.screeb.app/tag.js')
     await deps.resolveWhen(() => window.$screeb !== preloadFunction, 500)
 
-    let visitorId: ID = null
+    let visitorId: string | null | undefined = null
     if (analytics.user().id()) {
       visitorId = analytics.user().id()
     }


### PR DESCRIPTION
At Screeb, we need to identify users when the tag is initialized. If we do it later, then the tag will create an identify for a short period (between `init()` and `identify()`). Customers are disappointed by this behavior, so we inject the segment userId.

AnonymousId is ignored since Screeb does not have such a concept.
