### PR TITLE
[Stratconn 3718] Add Remove Profile

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/index.ts
@@ -13,6 +13,7 @@ import removeProfileFromList from './removeProfileFromList'
 import trackEvent from './trackEvent'
 import orderCompleted from './orderCompleted'
 import { buildHeaders } from './functions'
+import removeProfile from './removeProfile'
 
 const destination: AudienceDestinationDefinition<Settings> = {
   name: 'Klaviyo (Actions)',
@@ -125,7 +126,8 @@ const destination: AudienceDestinationDefinition<Settings> = {
     addProfileToList,
     removeProfileFromList,
     trackEvent,
-    orderCompleted
+    orderCompleted,
+    removeProfile
   }
 }
 

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfile/__tests__/index.test.ts
@@ -1,0 +1,346 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Definition from '../../index'
+import { API_URL } from '../../config'
+import { AggregateAjvError } from '@segment/ajv-human-errors'
+import * as Functions from '../../functions'
+
+jest.mock('../../functions', () => ({
+  ...jest.requireActual('../../functions'),
+  getProfiles: jest.fn(),
+  removeProfileFromList: jest.fn(() => Promise.resolve({ success: true }))
+}))
+
+const testDestination = createTestIntegration(Definition)
+
+const apiKey = 'fake-api-key'
+
+export const settings = {
+  api_key: apiKey
+}
+const listId = 'XYZABC'
+
+const requestBody = {
+  data: [
+    {
+      type: 'profile',
+      id: 'XYZABC'
+    },
+    {
+      type: 'profile',
+      id: 'XYZABD'
+    }
+  ]
+}
+
+describe('Remove Profile', () => {
+  it('should throw error if no external_id/email is provided', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      properties: {}
+    })
+
+    await expect(testDestination.testAction('removeProfile', { event, settings })).rejects.toThrowError(
+      AggregateAjvError
+    )
+  })
+
+  it('should remove profile from list if successful with email address only', async () => {
+    const requestBody = {
+      data: [
+        {
+          type: 'profile',
+          id: 'XYZABC'
+        }
+      ]
+    }
+
+    const email = 'test@example.com'
+    nock(`${API_URL}/profiles`)
+      .get(`/?filter=equals(email,"${email}")`)
+      .reply(200, {
+        data: [{ id: 'XYZABC' }]
+      })
+
+    nock(`${API_URL}/lists/${listId}`)
+      .delete('/relationships/profiles/', requestBody)
+      .reply(200, {
+        data: [
+          {
+            id: 'XYZABC'
+          }
+        ]
+      })
+
+    const event = createTestEvent({
+      type: 'track',
+      userId: '123',
+      context: {
+        personas: {
+          external_audience_id: listId
+        },
+        traits: {
+          email: 'test@example.com'
+        }
+      }
+    })
+
+    await expect(
+      testDestination.testAction('removeProfile', { event, settings, useDefaultMappings: true })
+    ).resolves.not.toThrowError()
+  })
+
+  it('should remove profile from list if successful with External Id only', async () => {
+    const requestBody = {
+      data: [
+        {
+          type: 'profile',
+          id: 'XYZABC'
+        }
+      ]
+    }
+
+    const external_id = 'testing_123'
+    nock(`${API_URL}/profiles`)
+      .get(`/?filter=equals(external_id,"${external_id}")`)
+      .reply(200, {
+        data: [{ id: 'XYZABC' }]
+      })
+
+    nock(`${API_URL}/lists/${listId}`)
+      .delete('/relationships/profiles/', requestBody)
+      .reply(200, {
+        data: [
+          {
+            id: 'XYZABC'
+          }
+        ]
+      })
+
+    const event = createTestEvent({
+      type: 'track',
+      userId: '123',
+      context: {
+        personas: {
+          external_audience_id: listId
+        }
+      },
+      properties: {
+        external_id: 'testing_123'
+      }
+    })
+    const mapping = {
+      list_id: listId,
+      external_id: 'testing_123'
+    }
+
+    await expect(testDestination.testAction('removeProfile', { event, mapping, settings })).resolves.not.toThrowError()
+  })
+})
+
+describe('Remove Profile Batch', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+    jest.resetAllMocks()
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should remove multiple profiles with valid emails', async () => {
+    const events = [
+      createTestEvent({
+        properties: {
+          email: 'user1@example.com'
+        }
+      }),
+      createTestEvent({
+        properties: {
+          email: 'user2@example.com'
+        }
+      })
+    ]
+    const mapping = {
+      list_id: listId,
+      email: {
+        '@path': '$.properties.email'
+      }
+    }
+
+    nock(`${API_URL}`)
+      .get('/profiles/')
+      .query({
+        filter: 'any(email,["user1@example.com","user2@example.com"])'
+      })
+      .reply(200, {
+        data: [{ id: 'XYZABC' }, { id: 'XYZABD' }]
+      })
+
+    nock(`${API_URL}/lists/${listId}`).delete('/relationships/profiles/', requestBody).reply(200)
+
+    await expect(
+      testDestination.testBatchAction('removeProfile', {
+        settings,
+        events,
+        mapping
+      })
+    ).resolves.not.toThrowError()
+  })
+
+  it('should remove multiple profiles with valid external IDs', async () => {
+    const events = [
+      createTestEvent({
+        properties: {
+          external_id: 'externalId1'
+        }
+      }),
+      createTestEvent({
+        properties: {
+          external_id: 'externalId2'
+        }
+      })
+    ]
+
+    const mapping = {
+      list_id: listId,
+      external_id: {
+        '@path': '$.properties.external_id'
+      }
+    }
+
+    nock(`${API_URL}`)
+      .get('/profiles/')
+      .query({
+        filter: 'any(external_id,["externalId1","externalId2"])'
+      })
+      .reply(200, {
+        data: [{ id: 'XYZABC' }, { id: 'XYZABD' }]
+      })
+
+    nock(`${API_URL}/lists/${listId}`).delete('/relationships/profiles/', requestBody).reply(200)
+
+    await expect(
+      testDestination.testBatchAction('removeProfile', {
+        settings,
+        events,
+        mapping
+      })
+    ).resolves.not.toThrowError()
+  })
+
+  it('should remove profiles with valid emails and external IDs', async () => {
+    const events = [
+      createTestEvent({
+        properties: {
+          email: 'user1@example.com'
+        }
+      }),
+      createTestEvent({
+        properties: {
+          external_id: 'externalId2'
+        }
+      })
+    ]
+
+    const mapping = {
+      list_id: listId,
+      external_id: {
+        '@path': '$.properties.external_id'
+      },
+      email: {
+        '@path': '$.properties.email'
+      }
+    }
+
+    nock(`${API_URL}`)
+      .get('/profiles/')
+      .query({
+        filter: 'any(email,["user1@example.com"])'
+      })
+      .reply(200, {
+        data: [{ id: 'XYZABD' }]
+      })
+
+    nock(`${API_URL}`)
+      .get('/profiles/')
+      .query({
+        filter: 'any(external_id,["externalId2"])'
+      })
+      .reply(200, {
+        data: [{ id: 'XYZABC' }]
+      })
+
+    nock(`${API_URL}/lists/${listId}`).delete('/relationships/profiles/', requestBody).reply(200)
+
+    await expect(
+      testDestination.testBatchAction('removeProfile', {
+        settings,
+        events,
+        mapping
+      })
+    ).resolves.not.toThrowError()
+  })
+
+  it('should filter out profiles without email or external ID', async () => {
+    const events = [
+      createTestEvent({
+        properties: {
+          fake: 'property'
+        }
+      }),
+      createTestEvent({
+        properties: {
+          email: 'valid@example.com'
+        }
+      })
+    ]
+
+    const mapping = {
+      list_id: listId,
+      external_id: {
+        '@path': '$.properties.external_id'
+      },
+      email: {
+        '@path': '$.properties.email'
+      }
+    }
+
+    const requestBody = {
+      data: [
+        {
+          type: 'profile',
+          id: 'XYZABC'
+        }
+      ]
+    }
+
+    nock(`${API_URL}`)
+      .get('/profiles/')
+      .query({
+        filter: 'any(email,["valid@example.com"])'
+      })
+      .reply(200, {
+        data: [{ id: 'XYZABC' }]
+      })
+
+    nock(`${API_URL}/lists/${listId}`).delete('/relationships/profiles/', requestBody).reply(200)
+
+    await expect(
+      testDestination.testBatchAction('removeProfile', {
+        settings,
+        events,
+        mapping
+      })
+    ).resolves.not.toThrowError()
+  })
+
+  it('should handle an empty payload', async () => {
+    await testDestination.testBatchAction('removeProfile', {
+      settings,
+      events: []
+    })
+
+    expect(Functions.getProfiles).not.toHaveBeenCalled()
+    expect(Functions.removeProfileFromList).not.toHaveBeenCalled()
+  })
+})

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfile/__tests__/index.test.ts
@@ -46,6 +46,7 @@ describe('Remove Profile', () => {
   })
 
   it('should remove profile from list if successful with email address only', async () => {
+    const mapping = { list_id: listId, email: 'test@example.com' }
     const requestBody = {
       data: [
         {
@@ -86,7 +87,7 @@ describe('Remove Profile', () => {
     })
 
     await expect(
-      testDestination.testAction('removeProfile', { event, settings, useDefaultMappings: true })
+      testDestination.testAction('removeProfile', { event, settings, mapping, useDefaultMappings: true })
     ).resolves.not.toThrowError()
   })
 

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfile/generated-types.ts
@@ -1,0 +1,20 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The user's email to send to Klavio.
+   */
+  email?: string
+  /**
+   * A unique identifier used by customers to associate Klaviyo profiles with profiles in an external system. One of External ID and Email required.
+   */
+  external_id?: string
+  /**
+   * 'Insert the ID of the default list that you'd like to subscribe users to when you call .identify().'
+   */
+  list_id: string
+  /**
+   * When enabled, the action will use the klaviyo batch API.
+   */
+  enable_batching?: boolean
+}

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfile/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Payload {
   /**
-   * Individual's email address. One of External ID, Phone Number and Email required.
+   * Individual's email address. One of External ID, or Email required.
    */
   email?: string
   /**
@@ -12,7 +12,7 @@ export interface Payload {
   /**
    * The Klaviyo list to add the profile to.
    */
-  list_id?: string
+  list_id: string
   /**
    * When enabled, the action will use the klaviyo batch API.
    */

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfile/generated-types.ts
@@ -2,17 +2,17 @@
 
 export interface Payload {
   /**
-   * The user's email to send to Klavio.
+   * Individual's email address. One of External ID, Phone Number and Email required.
    */
   email?: string
   /**
-   * A unique identifier used by customers to associate Klaviyo profiles with profiles in an external system. One of External ID and Email required.
+   * A unique identifier used by customers to associate Klaviyo profiles with profiles in an external system. One of External ID, Phone Number and Email required.
    */
   external_id?: string
   /**
-   * 'Insert the ID of the default list that you'd like to subscribe users to when you call .identify().'
+   * The Klaviyo list to add the profile to.
    */
-  list_id: string
+  list_id?: string
   /**
    * When enabled, the action will use the klaviyo batch API.
    */

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
@@ -3,16 +3,31 @@ import type { Settings } from '../generated-types'
 import { Payload } from './generated-types'
 
 import { getProfiles, removeProfileFromList } from '../functions'
-import { email, list_id, external_id, enable_batching } from '../properties'
+import { enable_batching } from '../properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Remove Profile',
   description: 'Remove profile from list',
   defaultSubscription: 'event = "Identify"',
   fields: {
-    email: { ...email },
-    external_id: { ...external_id },
-    list_id: { ...list_id },
+    email: {
+      label: 'Email',
+      description: `Individual's email address. One of External ID, Phone Number and Email required.`,
+      type: 'string',
+      format: 'email',
+      default: { '@path': '$.traits.email' }
+    },
+    external_id: {
+      label: 'External ID',
+      description: `A unique identifier used by customers to associate Klaviyo profiles with profiles in an external system. One of External ID, Phone Number and Email required.`,
+      type: 'string'
+    },
+    list_id: {
+      label: 'List',
+      description: `The Klaviyo list to add the profile to.`,
+      type: 'string',
+      dynamic: true
+    },
     enable_batching: { ...enable_batching }
   },
   perform: async (request, { payload }) => {

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
@@ -37,7 +37,6 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, { payload }) => {
-    console.log('Remove perform')
     const { email, list_id, external_id } = payload
     if (!email && !external_id) {
       throw new PayloadValidationError('Missing Email or External Id')
@@ -46,7 +45,6 @@ const action: ActionDefinition<Settings, Payload> = {
     return await removeProfileFromList(request, profileIds, list_id)
   },
   performBatch: async (request, { payload }) => {
-    console.log('Remove perform Batch')
     // Filtering out profiles that do not contain either an email or external_id.
     const filteredPayload = payload.filter((profile) => profile.email || profile.external_id)
     const listId = filteredPayload[0]?.list_id

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
@@ -1,0 +1,42 @@
+import { ActionDefinition, PayloadValidationError } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import { Payload } from './generated-types'
+
+import { getProfiles, removeProfileFromList } from '../functions'
+import { email, list_id, external_id, enable_batching } from '../properties'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Remove Profile',
+  description: 'Remove profile from list',
+  defaultSubscription: 'event = "Identify"',
+  fields: {
+    email: { ...email },
+    external_id: { ...external_id },
+    list_id: { ...list_id },
+    enable_batching: { ...enable_batching }
+  },
+  perform: async (request, { payload }) => {
+    console.log('Remove perform')
+    const { email, list_id, external_id } = payload
+    if (!email && !external_id) {
+      throw new PayloadValidationError('Missing Email or External Id')
+    }
+    const profileIds = await getProfiles(request, email ? [email] : undefined, external_id ? [external_id] : undefined)
+    return await removeProfileFromList(request, profileIds, list_id)
+  },
+  performBatch: async (request, { payload }) => {
+    console.log('Remove perform Batch')
+    // Filtering out profiles that do not contain either an email or external_id.
+    const filteredPayload = payload.filter((profile) => profile.email || profile.external_id)
+    const listId = filteredPayload[0]?.list_id
+    const emails = filteredPayload.map((profile) => profile.email).filter((email) => email) as string[]
+    const externalIds = filteredPayload
+      .map((profile) => profile.external_id)
+      .filter((external_id) => external_id) as string[]
+
+    const profileIds = await getProfiles(request, emails, externalIds)
+    return await removeProfileFromList(request, profileIds, listId)
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
@@ -1,8 +1,8 @@
-import { ActionDefinition, PayloadValidationError } from '@segment/actions-core'
+import { ActionDefinition, DynamicFieldResponse, PayloadValidationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import { Payload } from './generated-types'
 
-import { getProfiles, removeProfileFromList } from '../functions'
+import { getListIdDynamicData, getProfiles, removeProfileFromList } from '../functions'
 import { enable_batching } from '../properties'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -12,7 +12,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     email: {
       label: 'Email',
-      description: `Individual's email address. One of External ID, Phone Number and Email required.`,
+      description: `Individual's email address. One of External ID, or Email required.`,
       type: 'string',
       format: 'email',
       default: { '@path': '$.traits.email' }
@@ -26,9 +26,15 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'List',
       description: `The Klaviyo list to add the profile to.`,
       type: 'string',
-      dynamic: true
+      dynamic: true,
+      required: true
     },
     enable_batching: { ...enable_batching }
+  },
+  dynamicFields: {
+    list_id: async (request): Promise<DynamicFieldResponse> => {
+      return getListIdDynamicData(request)
+    }
   },
   perform: async (request, { payload }) => {
     console.log('Remove perform')


### PR DESCRIPTION
Add Remove Profile action to klaviyo which works with rETL and mimics Remove Profile from List (Engage).

JIRA -> [STRATCONN-3718](https://segment.atlassian.net/browse/STRATCONN-3718)

## Testing

Test Completed Successfully in staging.
<img width="1544" alt="Screenshot 2024-04-16 at 11 26 56 AM" src="https://github.com/segmentio/action-destinations/assets/129737395/d973df1a-07b0-48eb-b591-35ad5e4f980d">


**RETL**
Mapping
<img width="1758" alt="Screenshot 2024-04-16 at 11 53 18 AM" src="https://github.com/segmentio/action-destinations/assets/129737395/b07ff99a-d09e-4183-8da2-161e2ad88f59">

<img width="1758" alt="Screenshot 2024-04-16 at 11 53 27 AM" src="https://github.com/segmentio/action-destinations/assets/129737395/8f42b698-4cf3-4cb1-beec-b927205bbbe4">

Result
<img width="1544" alt="Screenshot 2024-04-16 at 11 52 38 AM" src="https://github.com/segmentio/action-destinations/assets/129737395/a94cac21-81c6-4fba-9a02-f502859681d4">


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment


[STRATCONN-3718]: https://segment.atlassian.net/browse/STRATCONN-3718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ