### PR TITLE
Increase browser bundle size limit

### DIFF
--- a/packages/browser-destinations/package.json
+++ b/packages/browser-destinations/package.json
@@ -84,7 +84,7 @@
   "size-limit": [
     {
       "path": "dist/web/*/*.js",
-      "limit": "150 KB"
+      "limit": "160 KB"
     }
   ]
 }


### PR DESCRIPTION
The bundle size checks have been failing with size-limit errors.
This PR bumps the size by 10kb to 160kb for now

<img width="1085" alt="image" src="https://github.com/segmentio/action-destinations/assets/109586712/84ce0168-d297-4ccf-9ea8-33f0f37ead7a">


## Testing

Testing completed successfully via this PR.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
