### PR TITLE
Update name to remove the space

### DIFF
--- a/packages/destination-actions/src/destinations/chartmogul/index.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/index.ts
@@ -7,7 +7,7 @@ import sendContact from './sendContact'
 import sendCustomer from './sendCustomer'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Chart Mogul',
+  name: 'ChartMogul',
   slug: 'actions-chartmogul',
   mode: 'cloud',
   description: 'Send Contacts and Customers to ChartMogul.',


### PR DESCRIPTION
Per the request of the ChartMogul, I am making this PR to update the name of the destination to remove the space: `Chart Mogul` → `ChartMogul`. 

This name was previously occupied by a customcode destination that was no longer in use, and I've removed the old destination in order that the `ChartMogul` can now be used. 

[A push will need to be run for this destination once merged](https://paper.dropbox.com/doc/Destination-Actions-Interface--CNdr2ZpiSjB2BCitcj97kIiXAg-BS1RKGj9VKTcjqLrCSuBV#:uid=389630577965241677416096&h2=Q:-Can-I-rename-an-action-dest). 

## Testing
No change in functionality so no testing necessary