### PR TITLE
add source options to koala identifies

### DIFF
--- a/packages/browser-destinations/destinations/koala/src/identifyVisitor/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/koala/src/identifyVisitor/__tests__/index.test.ts
@@ -64,6 +64,9 @@ describe('Koala.identifyVisitor', () => {
     expect(window.ko.identify).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'Matt'
+      }),
+      expect.objectContaining({
+        source: 'segment-browser'
       })
     )
   })

--- a/packages/browser-destinations/destinations/koala/src/identifyVisitor/index.ts
+++ b/packages/browser-destinations/destinations/koala/src/identifyVisitor/index.ts
@@ -20,7 +20,7 @@ const action: BrowserActionDefinition<Settings, Koala, Payload> = {
   },
   perform: (koala, { payload }) => {
     if (payload?.traits) {
-      return koala.identify(payload.traits)
+      return koala.identify(payload.traits, { source: 'segment-browser' })
     }
   }
 }

--- a/packages/destination-actions/src/destinations/koala/identify/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/koala/identify/__tests__/index.test.ts
@@ -40,7 +40,9 @@ describe('Koala.identify', () => {
           sent_at: '2023-03-03T00:00:00.000Z',
           message_id: 'message_id',
           traits: { vip: true, email: 'netto@getkoala.com' },
-          context: {}
+          context: {
+            source: 'segment-cloud'
+          }
         }
       ]
     })

--- a/packages/destination-actions/src/destinations/koala/identify/index.ts
+++ b/packages/destination-actions/src/destinations/koala/identify/index.ts
@@ -63,6 +63,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const traits = data.payload.traits ?? {}
     const email = data.payload.email ?? data.payload.traits?.email ?? traits.email
     const ip = data.payload.traits?.ip ?? data.payload.device_ip
+    const context = data.payload.context ?? {}
 
     if (!profileId && !email) {
       // Skip call if no identifier is found
@@ -79,7 +80,10 @@ const action: ActionDefinition<Settings, Payload> = {
         identifies: [
           {
             type: 'identify',
-            source: 'segment-cloud',
+            context: {
+              ...context,
+              source: 'segment-cloud'
+            },
             ...data.payload
           }
         ]

--- a/packages/destination-actions/src/destinations/koala/identify/index.ts
+++ b/packages/destination-actions/src/destinations/koala/identify/index.ts
@@ -79,6 +79,7 @@ const action: ActionDefinition<Settings, Payload> = {
         identifies: [
           {
             type: 'identify',
+            source: 'segment-cloud',
             ...data.payload
           }
         ]


### PR DESCRIPTION
This change introduces a `source` option passed to `ko.identify`. This will help Koala customers to have better observability into their integration.

## Testing

I added to our existing unit tests to cover this additional data being sent to Koala. This should otherwise be a no-op change for behavior. 

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [-] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
