### PR TITLE
Rename gameball integration

### DIFF
--- a/packages/destination-actions/src/destinations/gameball/index.ts
+++ b/packages/destination-actions/src/destinations/gameball/index.ts
@@ -10,7 +10,7 @@ import trackOrder from './trackOrder'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'gameball',
-  slug: 'actions-gameball',
+  slug: 'Gameball (Actions)',
   mode: 'cloud',
 
   authentication: {


### PR DESCRIPTION
Per the request of the Gameball, I am making this PR to update the name of the destination to remove the space: gameball → Gameball (Actions).

[A push will need to be run for this destination once merged](https://paper.dropbox.com/doc/Destination-Actions-Interface--CNdr2ZpiSjB2BCitcj97kIiXAg-BS1RKGj9VKTcjqLrCSuBV#:uid=389630577965241677416096&h2=Q:-Can-I-rename-an-action-dest).

Testing
No change in functionality so no testing necessary