### PR TITLE
[marketo-static-lists] Improved error handling for the List Creation Hook

### DIFF
--- a/packages/destination-actions/src/destinations/marketo-static-lists/addToList/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/addToList/__tests__/index.test.ts
@@ -172,8 +172,8 @@ describe('MarketoStaticLists.addToList', () => {
         errors: [{ code: 1013, message: 'Static list not found' }]
       })
 
-    const r = await testDestination.actions.addToList.executeHook('retlOnMappingSave', hookInputExisting)
-
-    expect(r).toMatchObject({ error: { code: 'LIST_ID_VERIFICATION_FAILURE', message: 'Static list not found' } })
+    await expect(testDestination.actions.addToList.executeHook('retlOnMappingSave', hookInputExisting)).rejects.toThrow(
+      'Static list not found'
+    )
   })
 })

--- a/packages/destination-actions/src/destinations/marketo-static-lists/functions.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/functions.ts
@@ -197,12 +197,11 @@ export async function getList(request: RequestClient, settings: Settings, id: st
   })
 
   if (!getListResponse.data.success && getListResponse.data.errors) {
-    return {
-      error: {
-        message: getListResponse.data.errors[0].message,
-        code: 'LIST_ID_VERIFICATION_FAILURE'
-      }
-    }
+    throw new IntegrationError(`${getListResponse.data.errors[0].message}`, 'INVALID_RESPONSE', 400)
+  }
+
+  if (!getListResponse.data.result) {
+    throw new IntegrationError(`List with ID ${id} not found`, 'INVALID_REQUEST_DATA', 400)
   }
 
   return {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->
This PR updates the `performHook` method for Marketo Static Lists by passing along the error details when an error occurs. Previously only a hardcoded string 'Failed to create list' would be passed, hindering debugging.

## Testing

Tested successfully in staging, the error messages are passed along to users.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
