### PR TITLE
Add Magellan AI (Action) Destination

### DIFF
--- a/packages/destination-actions/src/destinations/magellan-ai/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,243 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-magellan-ai destination: addToCart action - all fields 1`] = `
+Object {
+  "currency": "NIO",
+  "productId": "1ycI^2r",
+  "productName": "1ycI^2r",
+  "productType": "1ycI^2r",
+  "productVendor": "1ycI^2r",
+  "quantity": -64992310240215.04,
+  "token": "1ycI^2r",
+  "value": -64992310240215.04,
+  "variantId": "1ycI^2r",
+  "variantName": "1ycI^2r",
+}
+`;
+
+exports[`Testing snapshot for actions-magellan-ai destination: addToCart action - required fields 1`] = `
+Object {
+  "currency": "NIO",
+  "quantity": -64992310240215.04,
+  "token": "1ycI^2r",
+  "value": -64992310240215.04,
+}
+`;
+
+exports[`Testing snapshot for actions-magellan-ai destination: checkout action - all fields 1`] = `
+Object {
+  "currency": "MDL",
+  "discountCode": "TIKRkwh0SbShPf)0A#[",
+  "id": "TIKRkwh0SbShPf)0A#[",
+  "lineItems": Array [
+    Object {
+      "productId": "TIKRkwh0SbShPf)0A#[",
+      "productName": "TIKRkwh0SbShPf)0A#[",
+      "productType": "TIKRkwh0SbShPf)0A#[",
+      "productVendor": "TIKRkwh0SbShPf)0A#[",
+      "quantity": 78081917945118.72,
+      "value": 78081917945118.72,
+      "variantId": "TIKRkwh0SbShPf)0A#[",
+      "variantName": "TIKRkwh0SbShPf)0A#[",
+    },
+  ],
+  "quantity": 78081917945118.72,
+  "token": "TIKRkwh0SbShPf)0A#[",
+  "value": 78081917945118.72,
+}
+`;
+
+exports[`Testing snapshot for actions-magellan-ai destination: checkout action - required fields 1`] = `
+Object {
+  "currency": "MDL",
+  "id": "TIKRkwh0SbShPf)0A#[",
+  "token": "TIKRkwh0SbShPf)0A#[",
+  "value": 78081917945118.72,
+}
+`;
+
+exports[`Testing snapshot for actions-magellan-ai destination: code action - all fields 1`] = `
+Object {
+  "code": "*[IgdmoTG@k",
+  "token": "*[IgdmoTG@k",
+  "type": "*[IgdmoTG@k",
+}
+`;
+
+exports[`Testing snapshot for actions-magellan-ai destination: code action - required fields 1`] = `
+Object {
+  "code": "*[IgdmoTG@k",
+  "token": "*[IgdmoTG@k",
+  "type": "*[IgdmoTG@k",
+}
+`;
+
+exports[`Testing snapshot for actions-magellan-ai destination: identify action - all fields 1`] = `
+Object {
+  "token": "lkK!Vfi",
+  "userId": "lkK!Vfi",
+}
+`;
+
+exports[`Testing snapshot for actions-magellan-ai destination: identify action - required fields 1`] = `
+Object {
+  "token": "lkK!Vfi",
+  "userId": "lkK!Vfi",
+}
+`;
+
+exports[`Testing snapshot for actions-magellan-ai destination: install action - all fields 1`] = `
+Object {
+  "aifa": "Dv!9gsCj43Mi1j",
+  "andi": "Dv!9gsCj43Mi1j",
+  "app": "Dv!9gsCj43Mi1j",
+  "host": "Dv!9gsCj43Mi1j",
+  "idfa": "Dv!9gsCj43Mi1j",
+  "idfv": "Dv!9gsCj43Mi1j",
+  "ip": "153.102.75.215",
+  "plat": "Dv!9gsCj43Mi1j",
+  "token": "Dv!9gsCj43Mi1j",
+  "ts": "Dv!9gsCj43Mi1j",
+  "ua": "Dv!9gsCj43Mi1j",
+}
+`;
+
+exports[`Testing snapshot for actions-magellan-ai destination: install action - required fields 1`] = `
+Object {
+  "app": "Dv!9gsCj43Mi1j",
+  "host": "Dv!9gsCj43Mi1j",
+  "idfa": "Dv!9gsCj43Mi1j",
+  "idfv": "Dv!9gsCj43Mi1j",
+  "ip": "153.102.75.215",
+  "plat": "Dv!9gsCj43Mi1j",
+  "token": "Dv!9gsCj43Mi1j",
+  "ts": "Dv!9gsCj43Mi1j",
+  "ua": "Dv!9gsCj43Mi1j",
+}
+`;
+
+exports[`Testing snapshot for actions-magellan-ai destination: lead action - all fields 1`] = `
+Object {
+  "category": "2bsDJl3C^^TnRNgF",
+  "currency": "BYR",
+  "id": "2bsDJl3C^^TnRNgF",
+  "productId": "2bsDJl3C^^TnRNgF",
+  "quantity": 40312441573212.16,
+  "token": "2bsDJl3C^^TnRNgF",
+  "type": "2bsDJl3C^^TnRNgF",
+  "value": 40312441573212.16,
+}
+`;
+
+exports[`Testing snapshot for actions-magellan-ai destination: lead action - required fields 1`] = `
+Object {
+  "currency": "BYR",
+  "id": "2bsDJl3C^^TnRNgF",
+  "token": "2bsDJl3C^^TnRNgF",
+  "value": 40312441573212.16,
+}
+`;
+
+exports[`Testing snapshot for actions-magellan-ai destination: product action - all fields 1`] = `
+Object {
+  "currency": "JPY",
+  "productId": "t7uT6JwnvlnnOV2jL",
+  "productName": "t7uT6JwnvlnnOV2jL",
+  "productType": "t7uT6JwnvlnnOV2jL",
+  "productVendor": "t7uT6JwnvlnnOV2jL",
+  "token": "t7uT6JwnvlnnOV2jL",
+  "value": 50320375514398.72,
+  "variantId": "t7uT6JwnvlnnOV2jL",
+  "variantName": "t7uT6JwnvlnnOV2jL",
+}
+`;
+
+exports[`Testing snapshot for actions-magellan-ai destination: product action - required fields 1`] = `
+Object {
+  "currency": "JPY",
+  "token": "t7uT6JwnvlnnOV2jL",
+  "value": 50320375514398.72,
+}
+`;
+
+exports[`Testing snapshot for actions-magellan-ai destination: purchase action - all fields 1`] = `
+Object {
+  "currency": "UGX",
+  "discountCode": "!OdP7X6NC",
+  "id": "!OdP7X6NC",
+  "isNewCustomer": true,
+  "lineItems": Array [
+    Object {
+      "productId": "!OdP7X6NC",
+      "productName": "!OdP7X6NC",
+      "productType": "!OdP7X6NC",
+      "productVendor": "!OdP7X6NC",
+      "quantity": -43325033891758.08,
+      "value": -43325033891758.08,
+      "variantId": "!OdP7X6NC",
+      "variantName": "!OdP7X6NC",
+    },
+  ],
+  "quantity": -43325033891758.08,
+  "token": "!OdP7X6NC",
+  "value": -43325033891758.08,
+}
+`;
+
+exports[`Testing snapshot for actions-magellan-ai destination: purchase action - required fields 1`] = `
+Object {
+  "currency": "UGX",
+  "id": "!OdP7X6NC",
+  "token": "!OdP7X6NC",
+  "value": -43325033891758.08,
+}
+`;
+
+exports[`Testing snapshot for actions-magellan-ai destination: thirdPartyEvent action - all fields 1`] = `
+Object {
+  "aifa": "gpemivU7z(*Qt",
+  "andi": "gpemivU7z(*Qt",
+  "app": "gpemivU7z(*Qt",
+  "evtattrs": Object {
+    "testType": "gpemivU7z(*Qt",
+  },
+  "evtname": "gpemivU7z(*Qt",
+  "host": "gpemivU7z(*Qt",
+  "idfa": "gpemivU7z(*Qt",
+  "idfv": "gpemivU7z(*Qt",
+  "ip": "129.22.53.15",
+  "plat": "gpemivU7z(*Qt",
+  "token": "gpemivU7z(*Qt",
+  "ts": "gpemivU7z(*Qt",
+  "ua": "gpemivU7z(*Qt",
+}
+`;
+
+exports[`Testing snapshot for actions-magellan-ai destination: thirdPartyEvent action - required fields 1`] = `
+Object {
+  "app": "gpemivU7z(*Qt",
+  "evtname": "gpemivU7z(*Qt",
+  "host": "gpemivU7z(*Qt",
+  "idfa": "gpemivU7z(*Qt",
+  "idfv": "gpemivU7z(*Qt",
+  "ip": "129.22.53.15",
+  "plat": "gpemivU7z(*Qt",
+  "token": "gpemivU7z(*Qt",
+  "ts": "gpemivU7z(*Qt",
+  "ua": "gpemivU7z(*Qt",
+}
+`;
+
+exports[`Testing snapshot for actions-magellan-ai destination: view action - all fields 1`] = `
+Object {
+  "token": "9&#iCHP1",
+  "url": "http://ova.gt/wihsa",
+}
+`;
+
+exports[`Testing snapshot for actions-magellan-ai destination: view action - required fields 1`] = `
+Object {
+  "token": "9&#iCHP1",
+  "url": "http://ova.gt/wihsa",
+}
+`;

--- a/packages/destination-actions/src/destinations/magellan-ai/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/__tests__/index.test.ts
@@ -1,0 +1,42 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration, DecoratedResponse } from '@segment/actions-core'
+import Definition from '../index'
+
+const testDestination = createTestIntegration(Definition)
+
+const pixelToken = '123abc'
+
+describe('Magellan AI', () => {
+  describe('onDelete', () => {
+    it('does nothing if no apiToken is provided', async () => {
+      if (testDestination.onDelete) {
+        const event = createTestEvent()
+        const settings = { pixelToken }
+        await expect(testDestination.onDelete(event, settings)).resolves.not.toThrowError()
+      } else {
+        fail('onDelete not implemented')
+      }
+    })
+
+    it('sends an authorized deletion request to the Magellan API if an apiToken is provided', async () => {
+      if (testDestination.onDelete) {
+        const event = createTestEvent()
+        const { userId, anonymousId } = event
+        const settings = {
+          pixelToken,
+          apiToken: 'foo-bar-123-abc'
+        }
+        nock('https://app.magellan.ai')
+          .post('/api/v2/gdpr/delete', { userId, anonymousId, pixelToken })
+          .matchHeader('authorization', `Bearer ${settings.apiToken}`)
+          .reply(200, {})
+
+        const result = await testDestination.onDelete(event, settings)
+        const response = result as DecoratedResponse
+        expect(response.status).toBe(200)
+      } else {
+        fail('onDelete not implemented')
+      }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/__tests__/index.test.ts
@@ -26,8 +26,8 @@ describe('Magellan AI', () => {
           pixelToken,
           apiToken: 'foo-bar-123-abc'
         }
-        nock('https://app.magellan.ai')
-          .post('/api/v2/gdpr/delete', { userId, anonymousId, pixelToken })
+        nock('https://api.magellan.ai')
+          .post('/v2/gdpr/delete', { userId, anonymousId, pixelToken })
           .matchHeader('authorization', `Bearer ${settings.apiToken}`)
           .reply(200, {})
 

--- a/packages/destination-actions/src/destinations/magellan-ai/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-magellan-ai'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/addToCart/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/addToCart/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for MagellanAI's addToCart destination action: all fields 1`] = `
+Object {
+  "currency": "NOK",
+  "productId": "R2syV$j)mpbUuxE",
+  "productName": "R2syV$j)mpbUuxE",
+  "productType": "R2syV$j)mpbUuxE",
+  "productVendor": "R2syV$j)mpbUuxE",
+  "quantity": 33176727416995.84,
+  "token": "R2syV$j)mpbUuxE",
+  "value": 33176727416995.84,
+  "variantId": "R2syV$j)mpbUuxE",
+  "variantName": "R2syV$j)mpbUuxE",
+}
+`;
+
+exports[`Testing snapshot for MagellanAI's addToCart destination action: required fields 1`] = `
+Object {
+  "currency": "NOK",
+  "quantity": 33176727416995.84,
+  "token": "R2syV$j)mpbUuxE",
+  "value": 33176727416995.84,
+}
+`;

--- a/packages/destination-actions/src/destinations/magellan-ai/addToCart/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/addToCart/__tests__/index.test.ts
@@ -1,0 +1,65 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+const pixelToken = '123abc'
+const requiredFields = {
+  value: 1234.56,
+  currency: 'AUD',
+  quantity: 10
+}
+const optionalFields = {
+  productId: 'product_id_0123',
+  productName: 'Foo Bar Widget',
+  productType: 'widget',
+  productVendor: 'ACME',
+  variantId: 'variant_id_789abc',
+  variantName: 'Jumbo Widget'
+}
+
+describe('MagellanAI.addToCart', () => {
+  it('invokes the correct endpoint', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields }
+    nock('https://mgln.ai').post('/add_to_cart', expectedPayload).reply(200)
+
+    await testDestination.testAction('addToCart', {
+      mapping: requiredFields,
+      settings: { pixelToken: pixelToken }
+    })
+  })
+
+  for (const requiredField in requiredFields) {
+    it(`fails if the ${requiredField} field is missing`, async () => {
+      try {
+        await testDestination.testAction('addToCart', {
+          mapping: { ...requiredFields, [requiredField]: undefined },
+          settings: { pixelToken: pixelToken }
+        })
+      } catch (err) {
+        expect(err.message).toContain(`The root value is missing the required field '${requiredField}'.`)
+      }
+    })
+  }
+
+  it('accepts all optional fields', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields, ...optionalFields }
+    nock('https://mgln.ai').post('/add_to_cart', expectedPayload).reply(200)
+
+    await testDestination.testAction('addToCart', {
+      mapping: { ...requiredFields, ...optionalFields },
+      settings: { pixelToken: pixelToken }
+    })
+  })
+
+  it('rejects any extraneous fields', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields, ...optionalFields }
+    nock('https://mgln.ai').post('/add_to_cart', expectedPayload).reply(200)
+
+    await testDestination.testAction('addToCart', {
+      mapping: { ...requiredFields, ...optionalFields, foo: 'bar', baz: 123 },
+      settings: { pixelToken: pixelToken }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/addToCart/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/addToCart/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'addToCart'
+const destinationSlug = 'MagellanAI'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/addToCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/addToCart/generated-types.ts
@@ -1,0 +1,40 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The number of items added to the cart
+   */
+  quantity: number
+  /**
+   * The monetary value of this event, in the specified currency
+   */
+  value: number
+  /**
+   * ISO 4217 three-digit currency code (e.g., "USD", "CAD", "AUD")
+   */
+  currency: string
+  /**
+   * Your unique ID for this product
+   */
+  productId?: string
+  /**
+   * The name of this product
+   */
+  productName?: string
+  /**
+   * The type or category of this product
+   */
+  productType?: string
+  /**
+   * The vendor or brand for this product
+   */
+  productVendor?: string
+  /**
+   * The unique ID for this variant of the product
+   */
+  variantId?: string
+  /**
+   * The name of this variant of the product
+   */
+  variantName?: string
+}

--- a/packages/destination-actions/src/destinations/magellan-ai/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/addToCart/index.ts
@@ -1,0 +1,25 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+import { buildPerformer } from '../utils'
+import { productFields } from '../schema'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Add to Cart',
+  description: 'This event tracks any time an object is added to the cart.',
+  defaultSubscription: 'type = "track" and event = "Product Added"',
+  fields: {
+    quantity: {
+      label: 'Quantity',
+      description: 'The number of items added to the cart',
+      type: 'number',
+      default: { '@path': '$.properties.quantity' },
+      required: true
+    },
+    ...productFields
+  },
+  perform: buildPerformer('add_to_cart')
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/magellan-ai/checkout/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/checkout/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for MagellanAI's checkout destination action: all fields 1`] = `
+Object {
+  "currency": "ISK",
+  "discountCode": "tsbfmW@",
+  "id": "tsbfmW@",
+  "lineItems": Array [
+    Object {
+      "productId": "tsbfmW@",
+      "productName": "tsbfmW@",
+      "productType": "tsbfmW@",
+      "productVendor": "tsbfmW@",
+      "quantity": -60083978287185.92,
+      "value": -60083978287185.92,
+      "variantId": "tsbfmW@",
+      "variantName": "tsbfmW@",
+    },
+  ],
+  "quantity": -60083978287185.92,
+  "token": "tsbfmW@",
+  "value": -60083978287185.92,
+}
+`;
+
+exports[`Testing snapshot for MagellanAI's checkout destination action: required fields 1`] = `
+Object {
+  "currency": "ISK",
+  "id": "tsbfmW@",
+  "token": "tsbfmW@",
+  "value": -60083978287185.92,
+}
+`;

--- a/packages/destination-actions/src/destinations/magellan-ai/checkout/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/checkout/__tests__/index.test.ts
@@ -1,0 +1,81 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+const pixelToken = '123abc'
+const requiredFields = {
+  value: 999.99,
+  currency: 'USD'
+}
+const optionalFields = {
+  id: 'order_123-abc',
+  quantity: 20,
+  discountCode: 'FOOBAR29',
+  lineItems: [
+    {
+      productId: 'product_id_456def',
+      productName: 'Baz Widget',
+      productType: 'widget',
+      productVendor: 'ACME',
+      variantId: 'variant_id_012xyz',
+      variantName: 'Small Widget',
+      quantity: 5
+    },
+    {
+      productId: 'product_id_789ghi',
+      productName: 'Qux Widget',
+      productType: 'widget',
+      productVendor: 'ACME',
+      variantId: 'variant_id_345rst',
+      variantName: 'Medium Widget',
+      quantity: 3
+    }
+  ]
+}
+
+describe('MagellanAI.checkout', () => {
+  it('invokes the correct endpoint', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields }
+    nock('https://mgln.ai').post('/checkout', expectedPayload).reply(200)
+
+    await testDestination.testAction('checkout', {
+      mapping: requiredFields,
+      settings: { pixelToken: pixelToken }
+    })
+  })
+
+  for (const requiredField in requiredFields) {
+    it(`fails if the ${requiredField} field is missing`, async () => {
+      try {
+        await testDestination.testAction('checkout', {
+          mapping: { ...requiredFields, [requiredField]: undefined },
+          settings: { pixelToken: pixelToken }
+        })
+      } catch (err) {
+        expect(err.message).toContain(`The root value is missing the required field '${requiredField}'.`)
+      }
+    })
+  }
+
+  it('accepts all optional fields', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields, ...optionalFields }
+    nock('https://mgln.ai').post('/checkout', expectedPayload).reply(200)
+
+    await testDestination.testAction('checkout', {
+      mapping: { ...requiredFields, ...optionalFields },
+      settings: { pixelToken: pixelToken }
+    })
+  })
+
+  it('rejects any extraneous fields', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields, ...optionalFields }
+    nock('https://mgln.ai').post('/checkout', expectedPayload).reply(200)
+
+    await testDestination.testAction('checkout', {
+      mapping: { ...requiredFields, ...optionalFields, foo: 'bar', baz: 123 },
+      settings: { pixelToken: pixelToken }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/checkout/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/checkout/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'checkout'
+const destinationSlug = 'MagellanAI'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/checkout/generated-types.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/checkout/generated-types.ts
@@ -1,0 +1,61 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The monetary value of this event, in the specified currency
+   */
+  value: number
+  /**
+   * ISO 4217 three-digit currency code (e.g., "USD", "CAD", "AUD")
+   */
+  currency: string
+  /**
+   * The coupon or discount code applied to the cart
+   */
+  discountCode?: string
+  /**
+   * The unique ID for the order initiated by this checkout event
+   */
+  id?: string
+  /**
+   * The total number of items in the cart
+   */
+  quantity?: number
+  /**
+   * The list (array) of all products in the cart
+   */
+  lineItems?: {
+    /**
+     * The number of this product in the cart
+     */
+    quantity?: number
+    /**
+     * The price per unit of this product
+     */
+    value?: number
+    /**
+     * Your unique ID for this product
+     */
+    productId?: string
+    /**
+     * The name of this product
+     */
+    productName?: string
+    /**
+     * The type or category of this product
+     */
+    productType?: string
+    /**
+     * The vendor or brand for this product
+     */
+    productVendor?: string
+    /**
+     * The unique ID for this variant of the product
+     */
+    variantId?: string
+    /**
+     * The name of this variant of the product
+     */
+    variantName?: string
+  }[]
+}

--- a/packages/destination-actions/src/destinations/magellan-ai/checkout/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/checkout/index.ts
@@ -1,0 +1,19 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+import { buildPerformer } from '../utils'
+import { orderInfoFields, priceFields } from '../schema'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Checkout',
+  description: 'This event tracks when a user goes to check out, regardless of whether they complete the purchase.',
+  defaultSubscription: 'type = "track" and event = "Checkout Started"',
+  fields: {
+    ...priceFields(),
+    ...orderInfoFields
+  },
+  perform: buildPerformer('checkout')
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/magellan-ai/code/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/code/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for MagellanAI's code destination action: all fields 1`] = `
+Object {
+  "code": "W6d#2RidC^5]!BUD@%",
+  "token": "W6d#2RidC^5]!BUD@%",
+  "type": "W6d#2RidC^5]!BUD@%",
+}
+`;
+
+exports[`Testing snapshot for MagellanAI's code destination action: required fields 1`] = `
+Object {
+  "code": "W6d#2RidC^5]!BUD@%",
+  "token": "W6d#2RidC^5]!BUD@%",
+  "type": "W6d#2RidC^5]!BUD@%",
+}
+`;

--- a/packages/destination-actions/src/destinations/magellan-ai/code/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/code/__tests__/index.test.ts
@@ -1,0 +1,42 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+const pixelToken = '123abc'
+const requiredFields = { code: 'FOOBAR29', type: 'discount%' }
+const expectedPayload = { token: pixelToken, ...requiredFields }
+
+describe('MagellanAI.code', () => {
+  it('invokes the correct endpoint', async () => {
+    nock('https://mgln.ai').post('/code', expectedPayload).reply(200)
+
+    await testDestination.testAction('code', {
+      mapping: { code: 'FOOBAR29', type: 'discount%' },
+      settings: { pixelToken: pixelToken }
+    })
+  })
+
+  for (const requiredField in requiredFields) {
+    it(`fails if the ${requiredField} field is missing`, async () => {
+      try {
+        await testDestination.testAction('code', {
+          mapping: { ...requiredFields, [requiredField]: undefined },
+          settings: { pixelToken: pixelToken }
+        })
+      } catch (err) {
+        expect(err.message).toContain(`The root value is missing the required field '${requiredField}'.`)
+      }
+    })
+  }
+
+  it('rejects extraneous data', async () => {
+    nock('https://mgln.ai').post('/code', expectedPayload).reply(200)
+
+    await testDestination.testAction('code', {
+      mapping: { code: 'FOOBAR29', type: 'discount%', baz: 'bar' },
+      settings: { pixelToken: pixelToken }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/code/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/code/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'code'
+const destinationSlug = 'MagellanAI'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/code/generated-types.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/code/generated-types.ts
@@ -1,0 +1,12 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The coupon or discount code applied
+   */
+  code: string
+  /**
+   * The type of coupon or discount code used
+   */
+  type: string
+}

--- a/packages/destination-actions/src/destinations/magellan-ai/code/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/code/index.ts
@@ -1,0 +1,30 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+import { buildPerformer } from '../utils'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Code',
+  description: 'Track when a user enters a discount code at checkout.',
+  defaultSubscription: 'type = "track" and event = "Coupon Entered"',
+  fields: {
+    code: {
+      label: 'Code',
+      description: 'The coupon or discount code applied',
+      type: 'string',
+      default: { '@path': '$.properties.coupon_id' },
+      required: true
+    },
+    type: {
+      label: 'Type',
+      description: 'The type of coupon or discount code used',
+      type: 'string',
+      default: 'promo',
+      required: true
+    }
+  },
+  perform: buildPerformer('code')
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/magellan-ai/generated-types.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/generated-types.ts
@@ -1,0 +1,12 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Unique identifier for the web pixel on whose behalf the event is being sent; 32 hex digits
+   */
+  pixelToken: string
+  /**
+   * Required in order to pass GDPR deletion requests to Magellan AI
+   */
+  apiToken?: string
+}

--- a/packages/destination-actions/src/destinations/magellan-ai/identify/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/identify/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for MagellanAI's identify destination action: all fields 1`] = `
+Object {
+  "token": "UD9DA$2xqXR[KfJmt",
+  "userId": "UD9DA$2xqXR[KfJmt",
+}
+`;
+
+exports[`Testing snapshot for MagellanAI's identify destination action: required fields 1`] = `
+Object {
+  "token": "UD9DA$2xqXR[KfJmt",
+  "userId": "UD9DA$2xqXR[KfJmt",
+}
+`;

--- a/packages/destination-actions/src/destinations/magellan-ai/identify/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/identify/__tests__/index.test.ts
@@ -1,0 +1,39 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+const pixelToken = '123abc'
+const expectedPayload = { userId: 'user_foo', token: pixelToken }
+
+describe('MagellanAI.identify', () => {
+  it('invokes the correct endpoint', async () => {
+    nock('https://mgln.ai').post('/identify', expectedPayload).reply(200)
+
+    await testDestination.testAction('identify', {
+      mapping: { userId: 'user_foo' },
+      settings: { pixelToken: pixelToken }
+    })
+  })
+
+  it(`fails if the userId field is missing`, async () => {
+    try {
+      await testDestination.testAction('identify', {
+        mapping: {},
+        settings: { pixelToken: pixelToken }
+      })
+    } catch (err) {
+      expect(err.message).toContain("The root value is missing the required field 'userId'.")
+    }
+  })
+
+  it('rejects extraneous data', async () => {
+    nock('https://mgln.ai').post('/identify', expectedPayload).reply(200)
+
+    await testDestination.testAction('identify', {
+      mapping: { userId: 'user_foo', foo: 'bar' },
+      settings: { pixelToken: pixelToken }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/identify/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/identify/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'identify'
+const destinationSlug = 'MagellanAI'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/identify/generated-types.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/identify/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Your internal, unique identifier for the user
+   */
+  userId: string
+}

--- a/packages/destination-actions/src/destinations/magellan-ai/identify/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/identify/index.ts
@@ -14,7 +14,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'User ID',
       description: 'Your internal, unique identifier for the user',
       type: 'string',
-      default: { '@path': '$.traits.id' },
+      default: { '@path': '$.userId' },
       required: true
     }
   },

--- a/packages/destination-actions/src/destinations/magellan-ai/identify/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/identify/index.ts
@@ -1,0 +1,24 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+import { buildPerformer } from '../utils'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Identify',
+  description:
+    'If you have your own identifiers for customers, Magellan AI can accept that identifier and report it back to you with other measurement data.',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    userId: {
+      label: 'User ID',
+      description: 'Your internal, unique identifier for the user',
+      type: 'string',
+      default: { '@path': '$.traits.id' },
+      required: true
+    }
+  },
+  perform: buildPerformer('identify')
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/magellan-ai/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/index.ts
@@ -38,7 +38,7 @@ const destination: DestinationDefinition<Settings> = {
   onDelete: async (request: RequestClient, { payload, settings }) => {
     if (!settings.apiToken) return
 
-    return request('https://app.magellan.ai/api/v2/gdpr/delete', {
+    return request('https://api.magellan.ai/v2/gdpr/delete', {
       method: 'post',
       headers: { Authorization: `Bearer ${settings.apiToken}` },
       json: { ...payload, pixelToken: settings.pixelToken }

--- a/packages/destination-actions/src/destinations/magellan-ai/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/index.ts
@@ -1,0 +1,62 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import identify from './identify'
+import view from './view'
+import lead from './lead'
+import product from './product'
+import addToCart from './addToCart'
+import checkout from './checkout'
+import code from './code'
+import purchase from './purchase'
+import install from './install'
+import thirdPartyEvent from './thirdPartyEvent'
+import { RequestClient } from '@segment/actions-core'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Magellan AI',
+  slug: 'actions-magellan-ai',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      pixelToken: {
+        label: 'Pixel token',
+        description: 'Unique identifier for the web pixel on whose behalf the event is being sent; 32 hex digits',
+        type: 'string',
+        required: true
+      },
+      apiToken: {
+        label: 'API token',
+        description: 'Required in order to pass GDPR deletion requests to Magellan AI',
+        type: 'string',
+        required: false
+      }
+    }
+  },
+
+  onDelete: async (request: RequestClient, { payload, settings }) => {
+    if (!settings.apiToken) return
+
+    return request('https://app.magellan.ai/api/v2/gdpr/delete', {
+      method: 'post',
+      json: payload
+    })
+  },
+
+  actions: {
+    identify,
+    view,
+    lead,
+    product,
+    addToCart,
+    checkout,
+    code,
+    purchase,
+    install,
+    thirdPartyEvent
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/magellan-ai/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/index.ts
@@ -1,4 +1,4 @@
-import type { DestinationDefinition } from '@segment/actions-core'
+import type { DestinationDefinition, RequestClient } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
 import identify from './identify'
@@ -11,7 +11,6 @@ import code from './code'
 import purchase from './purchase'
 import install from './install'
 import thirdPartyEvent from './thirdPartyEvent'
-import { RequestClient } from '@segment/actions-core'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Magellan AI',
@@ -41,7 +40,8 @@ const destination: DestinationDefinition<Settings> = {
 
     return request('https://app.magellan.ai/api/v2/gdpr/delete', {
       method: 'post',
-      json: payload
+      headers: { Authorization: `Bearer ${settings.apiToken}` },
+      json: { ...payload, pixelToken: settings.pixelToken }
     })
   },
 

--- a/packages/destination-actions/src/destinations/magellan-ai/install/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/install/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for MagellanAI's install destination action: all fields 1`] = `
+Object {
+  "aifa": "@m[(r7Yt",
+  "andi": "@m[(r7Yt",
+  "app": "@m[(r7Yt",
+  "host": "@m[(r7Yt",
+  "idfa": "@m[(r7Yt",
+  "idfv": "@m[(r7Yt",
+  "ip": "53.218.42.250",
+  "plat": "@m[(r7Yt",
+  "token": "@m[(r7Yt",
+  "ts": "@m[(r7Yt",
+  "ua": "@m[(r7Yt",
+}
+`;
+
+exports[`Testing snapshot for MagellanAI's install destination action: required fields 1`] = `
+Object {
+  "app": "@m[(r7Yt",
+  "host": "@m[(r7Yt",
+  "idfa": "@m[(r7Yt",
+  "idfv": "@m[(r7Yt",
+  "ip": "53.218.42.250",
+  "plat": "@m[(r7Yt",
+  "token": "@m[(r7Yt",
+  "ts": "@m[(r7Yt",
+  "ua": "@m[(r7Yt",
+}
+`;

--- a/packages/destination-actions/src/destinations/magellan-ai/install/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/install/__tests__/index.test.ts
@@ -1,0 +1,66 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+const pixelToken = '123abc'
+const requiredFields = {
+  host: 'Appsflyer',
+  app: 'Magellan AI Mobile',
+  ip: '12.34.56.78',
+  ua: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+  ts: '2024-04-24 12:34:56.000',
+  plat: 'Android'
+}
+const optionalFields = {
+  aifa: '12345678-1234-1234-1234-1234567890ab',
+  andi: '12345678-1234-1234-1234-1234567890ab',
+  idfa: '12345678-1234-1234-1234-1234567890ab',
+  idfv: '12345678-1234-1234-1234-1234567890ab'
+}
+
+describe('MagellanAI.install', () => {
+  it('invokes the correct endpoint', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields }
+    nock('https://mgln.ai').post('/install', expectedPayload).reply(200)
+
+    await testDestination.testAction('install', {
+      mapping: requiredFields,
+      settings: { pixelToken: pixelToken }
+    })
+  })
+
+  for (const requiredField in requiredFields) {
+    it(`fails if the ${requiredField} field is missing`, async () => {
+      try {
+        await testDestination.testAction('install', {
+          mapping: { ...requiredFields, [requiredField]: undefined },
+          settings: { pixelToken: pixelToken }
+        })
+      } catch (err) {
+        expect(err.message).toContain(`The root value is missing the required field '${requiredField}'.`)
+      }
+    })
+  }
+
+  it('accepts all optional fields', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields, ...optionalFields }
+    nock('https://mgln.ai').post('/install', expectedPayload).reply(200)
+
+    await testDestination.testAction('install', {
+      mapping: { ...requiredFields, ...optionalFields },
+      settings: { pixelToken: pixelToken }
+    })
+  })
+
+  it('rejects any extraneous fields', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields, ...optionalFields }
+    nock('https://mgln.ai').post('/install', expectedPayload).reply(200)
+
+    await testDestination.testAction('install', {
+      mapping: { ...requiredFields, ...optionalFields, foo: 'bar', baz: 123 },
+      settings: { pixelToken: pixelToken }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/install/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/install/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'install'
+const destinationSlug = 'MagellanAI'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/install/generated-types.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/install/generated-types.ts
@@ -1,0 +1,44 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The name of the MMP platform transmitting this event to Segment (e.g., Appsflyer, Singular, etc.)
+   */
+  host: string
+  /**
+   * The name of the mobile application
+   */
+  app: string
+  /**
+   * The IPv4 address of the end user who installed the app (Note: Segment does not support collecting IPv6 addresses)
+   */
+  ip: string
+  /**
+   * The user agent of the end user who installed the app (Note: not sent by the iOS Segment agent)
+   */
+  ua: string
+  /**
+   * When the event occurred, in ISO 8601 format
+   */
+  ts: string
+  /**
+   * The mobile platform of the device (e.g., iOS, Android)
+   */
+  plat: string
+  /**
+   * The Google Advertising ID, on Android devices
+   */
+  aifa?: string
+  /**
+   * The Android ID, on Android devices
+   */
+  andi?: string
+  /**
+   * The ID for Advertising, on iOS devices
+   */
+  idfa?: string
+  /**
+   * The ID for Vendors, on iOS devices
+   */
+  idfv?: string
+}

--- a/packages/destination-actions/src/destinations/magellan-ai/install/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/install/index.ts
@@ -1,0 +1,16 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+import { buildPerformer } from '../utils'
+import { mobileFields } from '../schema'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Install',
+  description: 'Fire this event to track when a user installs your mobile application.',
+  defaultSubscription: 'type = "track" and event = "Application Installed"',
+  fields: mobileFields,
+  perform: buildPerformer('install')
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/magellan-ai/install/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/install/index.ts
@@ -7,7 +7,7 @@ import { mobileFields } from '../schema'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Install',
-  description: 'Fire this event to track when a user installs your mobile application.',
+  description: 'Fire this event to track when a user installs your mobile application. (Mobile applications only)',
   defaultSubscription: 'type = "track" and event = "Application Installed"',
   fields: mobileFields,
   perform: buildPerformer('install')

--- a/packages/destination-actions/src/destinations/magellan-ai/lead/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/lead/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for MagellanAI's lead destination action: all fields 1`] = `
+Object {
+  "category": "dtVRL!L9hrw]avE1wNG",
+  "currency": "HNL",
+  "id": "dtVRL!L9hrw]avE1wNG",
+  "productId": "dtVRL!L9hrw]avE1wNG",
+  "quantity": 75893497596477.44,
+  "token": "dtVRL!L9hrw]avE1wNG",
+  "type": "dtVRL!L9hrw]avE1wNG",
+  "value": 75893497596477.44,
+}
+`;
+
+exports[`Testing snapshot for MagellanAI's lead destination action: required fields 1`] = `
+Object {
+  "currency": "HNL",
+  "id": "dtVRL!L9hrw]avE1wNG",
+  "token": "dtVRL!L9hrw]avE1wNG",
+  "value": 75893497596477.44,
+}
+`;

--- a/packages/destination-actions/src/destinations/magellan-ai/lead/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/lead/__tests__/index.test.ts
@@ -1,0 +1,63 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+const pixelToken = '123abc'
+const requiredFields = {
+  value: 1099.99,
+  currency: 'USD'
+}
+const optionalFields = {
+  id: 'lead-ID-123',
+  productId: 'product_id_0123',
+  quantity: 100,
+  type: 'Bulk',
+  category: 'Sales'
+}
+
+describe('MagellanAI.lead', () => {
+  it('invokes the correct endpoint', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields }
+    nock('https://mgln.ai').post('/lead', expectedPayload).reply(200)
+
+    await testDestination.testAction('lead', {
+      mapping: requiredFields,
+      settings: { pixelToken: pixelToken }
+    })
+  })
+
+  for (const requiredField in requiredFields) {
+    it(`fails if the ${requiredField} field is missing`, async () => {
+      try {
+        await testDestination.testAction('lead', {
+          mapping: { ...requiredFields, [requiredField]: undefined },
+          settings: { pixelToken: pixelToken }
+        })
+      } catch (err) {
+        expect(err.message).toContain(`The root value is missing the required field '${requiredField}'.`)
+      }
+    })
+  }
+
+  it('accepts all optional fields', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields, ...optionalFields }
+    nock('https://mgln.ai').post('/lead', expectedPayload).reply(200)
+
+    await testDestination.testAction('lead', {
+      mapping: { ...requiredFields, ...optionalFields },
+      settings: { pixelToken: pixelToken }
+    })
+  })
+
+  it('rejects any extraneous fields', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields, ...optionalFields }
+    nock('https://mgln.ai').post('/lead', expectedPayload).reply(200)
+
+    await testDestination.testAction('lead', {
+      mapping: { ...requiredFields, ...optionalFields, foo: 'bar', baz: 123 },
+      settings: { pixelToken: pixelToken }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/lead/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/lead/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'lead'
+const destinationSlug = 'MagellanAI'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/lead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/lead/generated-types.ts
@@ -1,0 +1,32 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The monetary value of this event, in the specified currency
+   */
+  value: number
+  /**
+   * ISO 4217 three-digit currency code (e.g., "USD", "CAD", "AUD")
+   */
+  currency: string
+  /**
+   * The unique ID for this generated lead
+   */
+  id?: string
+  /**
+   * The product ID associated with this lead
+   */
+  productId?: string
+  /**
+   * The number of items represented by this lead
+   */
+  quantity?: number
+  /**
+   * The type of lead
+   */
+  type?: string
+  /**
+   * The category of lead
+   */
+  category?: string
+}

--- a/packages/destination-actions/src/destinations/magellan-ai/lead/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/lead/index.ts
@@ -1,0 +1,52 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+import { buildPerformer } from '../utils'
+import { priceFields } from '../schema'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Lead',
+  description: 'Track lead generation, like signups, subscriptions, and notification requests.',
+  defaultSubscription: 'type = "track" and event = "Signed Up"',
+  fields: {
+    ...priceFields(),
+    id: {
+      label: 'Lead ID',
+      description: 'The unique ID for this generated lead',
+      type: 'string',
+      required: false
+    },
+    productId: {
+      label: 'Product ID',
+      description: 'The product ID associated with this lead',
+      type: 'string',
+      default: { '@path': '$.properties.product_id' },
+      required: false
+    },
+    quantity: {
+      label: 'Quantity',
+      description: 'The number of items represented by this lead',
+      type: 'number',
+      default: { '@path': '$.properties.quantity' },
+      required: false
+    },
+    type: {
+      label: 'Lead type',
+      description: 'The type of lead',
+      type: 'string',
+      default: { '@path': '$.properties.type' },
+      required: false
+    },
+    category: {
+      label: 'Lead category',
+      description: 'The category of lead',
+      type: 'string',
+      default: { '@path': '$.properties.category' },
+      required: false
+    }
+  },
+  perform: buildPerformer('lead')
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/magellan-ai/product/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/product/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for MagellanAI's product destination action: all fields 1`] = `
+Object {
+  "currency": "GHS",
+  "productId": "&UIB5u0l0tYL8FZ*gE&f",
+  "productName": "&UIB5u0l0tYL8FZ*gE&f",
+  "productType": "&UIB5u0l0tYL8FZ*gE&f",
+  "productVendor": "&UIB5u0l0tYL8FZ*gE&f",
+  "token": "&UIB5u0l0tYL8FZ*gE&f",
+  "value": 85171452310978.56,
+  "variantId": "&UIB5u0l0tYL8FZ*gE&f",
+  "variantName": "&UIB5u0l0tYL8FZ*gE&f",
+}
+`;
+
+exports[`Testing snapshot for MagellanAI's product destination action: required fields 1`] = `
+Object {
+  "currency": "GHS",
+  "token": "&UIB5u0l0tYL8FZ*gE&f",
+  "value": 85171452310978.56,
+}
+`;

--- a/packages/destination-actions/src/destinations/magellan-ai/product/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/product/__tests__/index.test.ts
@@ -1,0 +1,64 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+const pixelToken = '123abc'
+const requiredFields = {
+  value: 1099.99,
+  currency: 'CAD'
+}
+const optionalFields = {
+  productId: 'product_id_0123',
+  productName: 'Foo Bar Widget',
+  productType: 'widget',
+  productVendor: 'ACME',
+  variantId: 'variant_id_789abc',
+  variantName: 'Jumbo Widget'
+}
+
+describe('MagellanAI.product', () => {
+  it('invokes the correct endpoint', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields }
+    nock('https://mgln.ai').post('/product', expectedPayload).reply(200)
+
+    await testDestination.testAction('product', {
+      mapping: requiredFields,
+      settings: { pixelToken: pixelToken }
+    })
+  })
+
+  for (const requiredField in requiredFields) {
+    it(`fails if the ${requiredField} field is missing`, async () => {
+      try {
+        await testDestination.testAction('product', {
+          mapping: { ...requiredFields, [requiredField]: undefined },
+          settings: { pixelToken: pixelToken }
+        })
+      } catch (err) {
+        expect(err.message).toContain(`The root value is missing the required field '${requiredField}'.`)
+      }
+    })
+  }
+
+  it('accepts all optional fields', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields, ...optionalFields }
+    nock('https://mgln.ai').post('/product', expectedPayload).reply(200)
+
+    await testDestination.testAction('product', {
+      mapping: { ...requiredFields, ...optionalFields },
+      settings: { pixelToken: pixelToken }
+    })
+  })
+
+  it('rejects any extraneous fields', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields, ...optionalFields }
+    nock('https://mgln.ai').post('/product', expectedPayload).reply(200)
+
+    await testDestination.testAction('product', {
+      mapping: { ...requiredFields, ...optionalFields, foo: 'bar', baz: 123 },
+      settings: { pixelToken: pixelToken }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/product/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/product/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'product'
+const destinationSlug = 'MagellanAI'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/product/generated-types.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/product/generated-types.ts
@@ -1,0 +1,36 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The monetary value of this event, in the specified currency
+   */
+  value: number
+  /**
+   * ISO 4217 three-digit currency code (e.g., "USD", "CAD", "AUD")
+   */
+  currency: string
+  /**
+   * Your unique ID for this product
+   */
+  productId?: string
+  /**
+   * The name of this product
+   */
+  productName?: string
+  /**
+   * The type or category of this product
+   */
+  productType?: string
+  /**
+   * The vendor or brand for this product
+   */
+  productVendor?: string
+  /**
+   * The unique ID for this variant of the product
+   */
+  variantId?: string
+  /**
+   * The name of this variant of the product
+   */
+  variantName?: string
+}

--- a/packages/destination-actions/src/destinations/magellan-ai/product/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/product/index.ts
@@ -1,0 +1,17 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+import { buildPerformer } from '../utils'
+import { productFields } from '../schema'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Product',
+  description:
+    'Indicates that a user has visited the page for a specific product or variant of a product. This event is similar to the view event, but allows you to provide more details about the product the user has seen.',
+  defaultSubscription: 'type = "track" and event = "Product Viewed"',
+  fields: productFields,
+  perform: buildPerformer('product')
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/magellan-ai/purchase/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/purchase/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for MagellanAI's purchase destination action: all fields 1`] = `
+Object {
+  "currency": "UZS",
+  "discountCode": "PDOIxm6D7Wge",
+  "id": "PDOIxm6D7Wge",
+  "isNewCustomer": true,
+  "lineItems": Array [
+    Object {
+      "productId": "PDOIxm6D7Wge",
+      "productName": "PDOIxm6D7Wge",
+      "productType": "PDOIxm6D7Wge",
+      "productVendor": "PDOIxm6D7Wge",
+      "quantity": -5726199338762.24,
+      "value": -5726199338762.24,
+      "variantId": "PDOIxm6D7Wge",
+      "variantName": "PDOIxm6D7Wge",
+    },
+  ],
+  "quantity": -5726199338762.24,
+  "token": "PDOIxm6D7Wge",
+  "value": -5726199338762.24,
+}
+`;
+
+exports[`Testing snapshot for MagellanAI's purchase destination action: required fields 1`] = `
+Object {
+  "currency": "UZS",
+  "id": "PDOIxm6D7Wge",
+  "token": "PDOIxm6D7Wge",
+  "value": -5726199338762.24,
+}
+`;

--- a/packages/destination-actions/src/destinations/magellan-ai/purchase/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/purchase/__tests__/index.test.ts
@@ -1,0 +1,82 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+const pixelToken = '123abc'
+const requiredFields = {
+  value: 999.99,
+  currency: 'USD'
+}
+const optionalFields = {
+  id: 'order_123-abc',
+  quantity: 20,
+  discountCode: 'FOOBAR29',
+  isNewCustomer: true,
+  lineItems: [
+    {
+      productId: 'product_id_456def',
+      productName: 'Baz Widget',
+      productType: 'widget',
+      productVendor: 'ACME',
+      variantId: 'variant_id_012xyz',
+      variantName: 'Small Widget',
+      quantity: 5
+    },
+    {
+      productId: 'product_id_789ghi',
+      productName: 'Qux Widget',
+      productType: 'widget',
+      productVendor: 'ACME',
+      variantId: 'variant_id_345rst',
+      variantName: 'Medium Widget',
+      quantity: 3
+    }
+  ]
+}
+
+describe('MagellanAI.purchase', () => {
+  it('invokes the correct endpoint', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields }
+    nock('https://mgln.ai').post('/purchase', expectedPayload).reply(200)
+
+    await testDestination.testAction('purchase', {
+      mapping: requiredFields,
+      settings: { pixelToken: pixelToken }
+    })
+  })
+
+  for (const requiredField in requiredFields) {
+    it(`fails if the ${requiredField} field is missing`, async () => {
+      try {
+        await testDestination.testAction('purchase', {
+          mapping: { ...requiredFields, [requiredField]: undefined },
+          settings: { pixelToken: pixelToken }
+        })
+      } catch (err) {
+        expect(err.message).toContain(`The root value is missing the required field '${requiredField}'.`)
+      }
+    })
+  }
+
+  it('accepts all optional fields', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields, ...optionalFields }
+    nock('https://mgln.ai').post('/purchase', expectedPayload).reply(200)
+
+    await testDestination.testAction('purchase', {
+      mapping: { ...requiredFields, ...optionalFields },
+      settings: { pixelToken: pixelToken }
+    })
+  })
+
+  it('rejects any extraneous fields', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields, ...optionalFields }
+    nock('https://mgln.ai').post('/purchase', expectedPayload).reply(200)
+
+    await testDestination.testAction('purchase', {
+      mapping: { ...requiredFields, ...optionalFields, foo: 'bar', baz: 123 },
+      settings: { pixelToken: pixelToken }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/purchase/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/purchase/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'purchase'
+const destinationSlug = 'MagellanAI'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/purchase/generated-types.ts
@@ -1,0 +1,65 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The monetary value of this event, in the specified currency
+   */
+  value: number
+  /**
+   * ISO 4217 three-digit currency code (e.g., "USD", "CAD", "AUD")
+   */
+  currency: string
+  /**
+   * The coupon or discount code applied to the cart
+   */
+  discountCode?: string
+  /**
+   * The unique ID for the order initiated by this checkout event
+   */
+  id?: string
+  /**
+   * The total number of items in the cart
+   */
+  quantity?: number
+  /**
+   * The list (array) of all products in the cart
+   */
+  lineItems?: {
+    /**
+     * The number of this product in the cart
+     */
+    quantity?: number
+    /**
+     * The price per unit of this product
+     */
+    value?: number
+    /**
+     * Your unique ID for this product
+     */
+    productId?: string
+    /**
+     * The name of this product
+     */
+    productName?: string
+    /**
+     * The type or category of this product
+     */
+    productType?: string
+    /**
+     * The vendor or brand for this product
+     */
+    productVendor?: string
+    /**
+     * The unique ID for this variant of the product
+     */
+    variantId?: string
+    /**
+     * The name of this variant of the product
+     */
+    variantName?: string
+  }[]
+  /**
+   * Whether or not this customer is a first-time buyer from your store
+   */
+  isNewCustomer?: boolean
+}

--- a/packages/destination-actions/src/destinations/magellan-ai/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/purchase/index.ts
@@ -1,0 +1,25 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+import { buildPerformer } from '../utils'
+import { orderInfoFields, priceFields } from '../schema'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Purchase',
+  description: 'Fire this event upon successful completion of a purchase.',
+  defaultSubscription: 'type = "track" and event = "Order Completed"',
+  fields: {
+    ...priceFields('total'),
+    ...orderInfoFields,
+    isNewCustomer: {
+      label: 'New customer?',
+      description: 'Whether or not this customer is a first-time buyer from your store',
+      type: 'boolean',
+      required: false
+    }
+  },
+  perform: buildPerformer('purchase')
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/magellan-ai/schema.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/schema.ts
@@ -103,7 +103,7 @@ export const orderInfoFields: Record<string, InputField> = {
         required: false
       },
       value: {
-        label: 'Quantity',
+        label: 'Price',
         description: 'The price per unit of this product',
         type: 'number',
         required: false

--- a/packages/destination-actions/src/destinations/magellan-ai/schema.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/schema.ts
@@ -1,0 +1,246 @@
+import { InputField } from '@segment/actions-core'
+
+export function priceFields(valueSource = 'value'): Record<string, InputField> {
+  return {
+    value: {
+      label: 'Value',
+      description: 'The monetary value of this event, in the specified currency',
+      type: 'number',
+      default: { '@path': `$.properties.${valueSource}` },
+      required: true
+    },
+    currency: {
+      label: 'Currency',
+      description: 'ISO 4217 three-digit currency code (e.g., "USD", "CAD", "AUD")',
+      type: 'string',
+      default: { '@path': '$.properties.currency' },
+      required: true
+    }
+  }
+}
+
+export const lineItemFields: Record<string, InputField> = {
+  productId: {
+    label: 'Product ID',
+    description: 'Your unique ID for this product',
+    type: 'string',
+    default: { '@path': '$.properties.product_id' },
+    required: false
+  },
+  productName: {
+    label: 'Product name',
+    description: 'The name of this product',
+    type: 'string',
+    default: { '@path': '$.properties.name' },
+    required: false
+  },
+  productType: {
+    label: 'Product type',
+    description: 'The type or category of this product',
+    type: 'string',
+    default: { '@path': '$.properties.category' },
+    required: false
+  },
+  productVendor: {
+    label: 'Vendor',
+    description: 'The vendor or brand for this product',
+    type: 'string',
+    default: { '@path': '$.properties.brand' },
+    required: false
+  },
+  variantId: {
+    label: 'Variant ID',
+    description: 'The unique ID for this variant of the product',
+    type: 'string',
+    default: { '@path': '$.properties.variant_id' },
+    required: false
+  },
+  variantName: {
+    label: 'Variant name',
+    description: 'The name of this variant of the product',
+    type: 'string',
+    default: { '@path': '$.properties.variant' },
+    required: false
+  }
+}
+
+export const productFields: Record<string, InputField> = {
+  ...priceFields('price'),
+  ...lineItemFields
+}
+
+export const orderInfoFields: Record<string, InputField> = {
+  discountCode: {
+    label: 'Discount code',
+    description: 'The coupon or discount code applied to the cart',
+    type: 'string',
+    default: { '@path': '$.properties.coupon' },
+    required: false
+  },
+  id: {
+    label: 'Order ID',
+    description: 'The unique ID for the order initiated by this checkout event',
+    type: 'string',
+    default: { '@path': '$.properties.order_id' },
+    required: false
+  },
+  quantity: {
+    label: 'Quantity',
+    description: 'The total number of items in the cart',
+    type: 'number',
+    required: false
+  },
+  lineItems: {
+    label: 'Line items',
+    description: 'The list (array) of all products in the cart',
+    type: 'object',
+    multiple: true,
+    properties: {
+      quantity: {
+        label: 'Quantity',
+        description: 'The number of this product in the cart',
+        type: 'number',
+        required: false
+      },
+      value: {
+        label: 'Quantity',
+        description: 'The price per unit of this product',
+        type: 'number',
+        required: false
+      },
+      productId: {
+        label: 'Product ID',
+        description: 'Your unique ID for this product',
+        type: 'string',
+        required: false
+      },
+      productName: {
+        label: 'Product name',
+        description: 'The name of this product',
+        type: 'string',
+        required: false
+      },
+      productType: {
+        label: 'Product type',
+        description: 'The type or category of this product',
+        type: 'string',
+        required: false
+      },
+      productVendor: {
+        label: 'Vendor',
+        description: 'The vendor or brand for this product',
+        type: 'string',
+        required: false
+      },
+      variantId: {
+        label: 'Variant ID',
+        description: 'The unique ID for this variant of the product',
+        type: 'string',
+        required: false
+      },
+      variantName: {
+        label: 'Variant name',
+        description: 'The name of this variant of the product',
+        type: 'string',
+        required: false
+      }
+    },
+    default: {
+      '@arrayPath': [
+        '$.properties.products',
+        {
+          quantity: { '@path': '$.quantity' },
+          value: { '@path': '$.price' },
+          productId: { '@path': '$.product_id' },
+          productName: { '@path': '$.name' },
+          productType: { '@path': '$.category' },
+          productVendor: { '@path': '$.brand' },
+          variantId: { '@path': '$.variant_id' },
+          variantName: { '@path': '$.variant' }
+        }
+      ]
+    },
+    required: false
+  }
+}
+
+export const mobileFields: Record<string, InputField> = {
+  host: {
+    label: 'MMP Host',
+    description: 'The name of the MMP platform transmitting this event to Segment (e.g., Appsflyer, Singular, etc.)',
+    type: 'string',
+    default: 'segment',
+    required: true
+  },
+  app: {
+    label: 'App name',
+    description: 'The name of the mobile application',
+    type: 'string',
+    default: { '@path': '$.context.app.name' },
+    required: true
+  },
+  ip: {
+    label: 'IP address',
+    description:
+      'The IPv4 address of the end user who installed the app (Note: Segment does not support collecting IPv6 addresses)',
+    type: 'string',
+    format: 'ipv4',
+    default: { '@path': '$.context.ip' },
+    required: true
+  },
+  ua: {
+    label: 'User agent',
+    description: 'The user agent of the end user who installed the app (Note: not sent by the iOS Segment agent)',
+    type: 'string',
+    default: {
+      '@if': {
+        exists: { '@path': '$.context.userAgent' },
+        then: { '@path': '$.context.userAgent' },
+        else: { '@path': '$.context.library.name' }
+      }
+    },
+    required: true
+  },
+  ts: {
+    label: 'Timestamp',
+    description: 'When the event occurred, in ISO 8601 format',
+    type: 'string',
+    default: { '@path': '$.receivedAt' },
+    required: true
+  },
+  plat: {
+    label: 'Mobile platform',
+    description: 'The mobile platform of the device (e.g., iOS, Android)',
+    type: 'string',
+    default: { '@path': '$.context.device.type' },
+    required: true
+  },
+  aifa: {
+    label: 'GAID/AIFA',
+    description: 'The Google Advertising ID, on Android devices',
+    type: 'string',
+    default: { '@path': '$.context.device.advertisingId' },
+    required: false
+  },
+  andi: {
+    label: 'AID/ANDI',
+    description: 'The Android ID, on Android devices',
+    type: 'string',
+    default: { '@path': '$.context.device.id' },
+    required: false
+  },
+  idfa: {
+    label: 'IDFA',
+    description: 'The ID for Advertising, on iOS devices',
+    type: 'string',
+    default: { '@path': '$.context.device.advertisingId' },
+    required: false
+  },
+  idfv: {
+    label: 'IDFV',
+    description: 'The ID for Vendors, on iOS devices',
+    type: 'string',
+    default: { '@path': '$.context.device.id' },
+    required: false
+  }
+}

--- a/packages/destination-actions/src/destinations/magellan-ai/schema.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/schema.ts
@@ -205,7 +205,7 @@ export const mobileFields: Record<string, InputField> = {
     label: 'Timestamp',
     description: 'When the event occurred, in ISO 8601 format',
     type: 'string',
-    default: { '@path': '$.receivedAt' },
+    default: { '@path': '$.timestamp' },
     required: true
   },
   plat: {

--- a/packages/destination-actions/src/destinations/magellan-ai/thirdPartyEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/thirdPartyEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for MagellanAI's thirdPartyEvent destination action: all fields 1`] = `
+Object {
+  "aifa": "eow1m",
+  "andi": "eow1m",
+  "app": "eow1m",
+  "evtattrs": Object {
+    "testType": "eow1m",
+  },
+  "evtname": "eow1m",
+  "host": "eow1m",
+  "idfa": "eow1m",
+  "idfv": "eow1m",
+  "ip": "14.15.48.77",
+  "plat": "eow1m",
+  "token": "eow1m",
+  "ts": "eow1m",
+  "ua": "eow1m",
+}
+`;
+
+exports[`Testing snapshot for MagellanAI's thirdPartyEvent destination action: required fields 1`] = `
+Object {
+  "app": "eow1m",
+  "evtname": "eow1m",
+  "host": "eow1m",
+  "idfa": "eow1m",
+  "idfv": "eow1m",
+  "ip": "14.15.48.77",
+  "plat": "eow1m",
+  "token": "eow1m",
+  "ts": "eow1m",
+  "ua": "eow1m",
+}
+`;

--- a/packages/destination-actions/src/destinations/magellan-ai/thirdPartyEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/thirdPartyEvent/__tests__/index.test.ts
@@ -1,0 +1,71 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+const pixelToken = '123abc'
+const requiredFields = {
+  evtname: 'Custom Event',
+  host: 'Appsflyer',
+  app: 'Magellan AI Mobile',
+  ip: '12.34.56.78',
+  ua: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+  ts: '2024-04-24 12:34:56.000',
+  plat: 'Android'
+}
+const optionalFields = {
+  aifa: '12345678-1234-1234-1234-1234567890ab',
+  andi: '12345678-1234-1234-1234-1234567890ab',
+  idfa: '12345678-1234-1234-1234-1234567890ab',
+  idfv: '12345678-1234-1234-1234-1234567890ab',
+  evtattrs: {
+    foo: 'bar',
+    baz: 123
+  }
+}
+
+describe('MagellanAI.thirdPartyEvent', () => {
+  it('invokes the correct endpoint', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields }
+    nock('https://mgln.ai').post('/event', expectedPayload).reply(200)
+
+    await testDestination.testAction('thirdPartyEvent', {
+      mapping: requiredFields,
+      settings: { pixelToken: pixelToken }
+    })
+  })
+
+  for (const requiredField in requiredFields) {
+    it(`fails if the ${requiredField} field is missing`, async () => {
+      try {
+        await testDestination.testAction('thirdPartyEvent', {
+          mapping: { ...requiredFields, [requiredField]: undefined },
+          settings: { pixelToken: pixelToken }
+        })
+      } catch (err) {
+        expect(err.message).toContain(`The root value is missing the required field '${requiredField}'.`)
+      }
+    })
+  }
+
+  it('accepts all optional fields', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields, ...optionalFields }
+    nock('https://mgln.ai').post('/event', expectedPayload).reply(200)
+
+    await testDestination.testAction('thirdPartyEvent', {
+      mapping: { ...requiredFields, ...optionalFields },
+      settings: { pixelToken: pixelToken }
+    })
+  })
+
+  it('rejects any extraneous fields', async () => {
+    const expectedPayload = { token: pixelToken, ...requiredFields, ...optionalFields }
+    nock('https://mgln.ai').post('/event', expectedPayload).reply(200)
+
+    await testDestination.testAction('thirdPartyEvent', {
+      mapping: { ...requiredFields, ...optionalFields, foo: 'bar', baz: 123 },
+      settings: { pixelToken: pixelToken }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/thirdPartyEvent/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/thirdPartyEvent/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'thirdPartyEvent'
+const destinationSlug = 'MagellanAI'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/thirdPartyEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/thirdPartyEvent/generated-types.ts
@@ -1,0 +1,54 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The name of the custom third-party event to pass to Magellan AI
+   */
+  evtname: string
+  /**
+   * An arbitrary JSON object containing any additional data about this event
+   */
+  evtattrs?: {
+    [k: string]: unknown
+  }
+  /**
+   * The name of the MMP platform transmitting this event to Segment (e.g., Appsflyer, Singular, etc.)
+   */
+  host: string
+  /**
+   * The name of the mobile application
+   */
+  app: string
+  /**
+   * The IPv4 address of the end user who installed the app (Note: Segment does not support collecting IPv6 addresses)
+   */
+  ip: string
+  /**
+   * The user agent of the end user who installed the app (Note: not sent by the iOS Segment agent)
+   */
+  ua: string
+  /**
+   * When the event occurred, in ISO 8601 format
+   */
+  ts: string
+  /**
+   * The mobile platform of the device (e.g., iOS, Android)
+   */
+  plat: string
+  /**
+   * The Google Advertising ID, on Android devices
+   */
+  aifa?: string
+  /**
+   * The Android ID, on Android devices
+   */
+  andi?: string
+  /**
+   * The ID for Advertising, on iOS devices
+   */
+  idfa?: string
+  /**
+   * The ID for Vendors, on iOS devices
+   */
+  idfv?: string
+}

--- a/packages/destination-actions/src/destinations/magellan-ai/thirdPartyEvent/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/thirdPartyEvent/index.ts
@@ -7,7 +7,7 @@ import { mobileFields } from '../schema'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Custom third-party event',
-  description: 'Fire arbitrary, custom third-party events from your mobile app.',
+  description: 'Fire arbitrary, custom third-party events from your mobile app. (Mobile applications only)',
   defaultSubscription: 'type = "track" and event in ["foo", "bar"]',
   fields: {
     evtname: {

--- a/packages/destination-actions/src/destinations/magellan-ai/thirdPartyEvent/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/thirdPartyEvent/index.ts
@@ -1,0 +1,32 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+import { buildPerformer } from '../utils'
+import { mobileFields } from '../schema'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Custom third-party event',
+  description: 'Fire arbitrary, custom third-party events from your mobile app.',
+  defaultSubscription: 'type = "track" and event in ["foo", "bar"]',
+  fields: {
+    evtname: {
+      label: 'Event name',
+      description: 'The name of the custom third-party event to pass to Magellan AI',
+      type: 'string',
+      default: { '@path': '$.event' },
+      required: true
+    },
+    evtattrs: {
+      label: 'Event attributes',
+      description: 'An arbitrary JSON object containing any additional data about this event',
+      type: 'object',
+      default: { '@path': '$.properties' },
+      required: false
+    },
+    ...mobileFields
+  },
+  perform: buildPerformer('event')
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/magellan-ai/thirdPartyEvent/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/thirdPartyEvent/index.ts
@@ -8,7 +8,6 @@ import { mobileFields } from '../schema'
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Custom third-party event',
   description: 'Fire arbitrary, custom third-party events from your mobile app. (Mobile applications only)',
-  defaultSubscription: 'type = "track" and event in ["foo", "bar"]',
   fields: {
     evtname: {
       label: 'Event name',

--- a/packages/destination-actions/src/destinations/magellan-ai/utils.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/utils.ts
@@ -1,0 +1,16 @@
+import { RequestClient } from '@segment/actions-core'
+
+const API_BASE_URL = 'https://mgln.ai'
+
+function buildApiEndpoint(maiEventType: string) {
+  return `${API_BASE_URL}/${maiEventType}`
+}
+
+export function buildPerformer(eventType: string) {
+  const url = buildApiEndpoint(eventType)
+  // @ts-ignore Segment: "Payloads may be any type so we use `any` explicitly here."
+  return async function emit(request: RequestClient, { payload, settings }) {
+    payload.token = settings.pixelToken
+    return request(url, { method: 'post', json: payload })
+  }
+}

--- a/packages/destination-actions/src/destinations/magellan-ai/view/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/view/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for MagellanAI's view destination action: all fields 1`] = `
+Object {
+  "token": "Sb]^DX%^W2b",
+  "url": "http://buwvu.tt/bardoc",
+}
+`;
+
+exports[`Testing snapshot for MagellanAI's view destination action: required fields 1`] = `
+Object {
+  "token": "Sb]^DX%^W2b",
+  "url": "http://buwvu.tt/bardoc",
+}
+`;

--- a/packages/destination-actions/src/destinations/magellan-ai/view/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/view/__tests__/index.test.ts
@@ -1,0 +1,29 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+const pixelToken = '123abc'
+
+describe('MagellanAI.view', () => {
+  it('invokes the correct endpoint', async () => {
+    nock('https://mgln.ai').post('/view', { url: 'https://foo.bar/testing.html', token: '123abc' }).reply(200)
+
+    await testDestination.testAction('view', {
+      mapping: { url: 'https://foo.bar/testing.html' },
+      settings: { pixelToken: pixelToken }
+    })
+  })
+
+  it(`fails if the url field is missing`, async () => {
+    try {
+      await testDestination.testAction('view', {
+        mapping: {},
+        settings: { pixelToken: pixelToken }
+      })
+    } catch (err) {
+      expect(err.message).toContain("The root value is missing the required field 'url'.")
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/view/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/view/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'view'
+const destinationSlug = 'MagellanAI'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/magellan-ai/view/generated-types.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/view/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The address of the page viewed
+   */
+  url: string
+}

--- a/packages/destination-actions/src/destinations/magellan-ai/view/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/view/index.ts
@@ -1,0 +1,24 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+import { buildPerformer } from '../utils'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'View',
+  description: 'Tracks a page view. We recommend including this on every page.',
+  defaultSubscription: 'type = "page"',
+  fields: {
+    url: {
+      label: 'URL',
+      description: 'The address of the page viewed',
+      type: 'string',
+      default: { '@path': '$.context.page.url' },
+      format: 'uri',
+      required: true
+    }
+  },
+  perform: buildPerformer('view')
+}
+
+export default action


### PR DESCRIPTION
Initial PR adding an action destination for [Magellan AI](https://www.magellan.ai)'s measurement and attribution platform ([more information](https://help.magellan.ai/)).

## Testing

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment

Tested locally, and we *think* we properly constructed all the complex e-commerce events. 🤞

## Notes

PR for documentation incoming.  Documentation points out that semantically, the `Signed Up` event maps most closely to our `Lead` action, but our concept of leads would fit better with your e-commerce events.

Thank you, and let us know what next steps you need from us!