### PR TITLE
hide event context field for mixpanel

### DIFF
--- a/packages/destination-actions/src/destinations/mixpanel/mixpanel-properties.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/mixpanel-properties.ts
@@ -344,6 +344,7 @@ export const eventProperties: Record<string, InputField> = {
     label: 'Event context',
     description: 'An object of key-value pairs that provides useful context about the event.',
     type: 'object',
+    unsafe_hidden: true,
     default: {
       '@path': '$.context'
     }


### PR DESCRIPTION
This comes at the request of Mixpanel:

> Hi all!
> 
> This is Donna from Mixpanel's Support Team.
> 
> I wanted to reach out regarding Mixpanel Actions Destination Mappings: https://segment.com/docs/connections/destinations/catalog/actions-mixpanel/
> 
> We are seeing that customers are confused by the "Event Context" that is shown in Track Calls.
> 
> Customers see that mapping, and they are confused as to why Mixpanel does not attach all of "event context" data to their Mixpanel Events.
> 
> With the Destination, we are only taking certain data from the Event Context (as Context is not a concept in Mixpanel) so I wanted to ask if we could hide this mapping in the UI for Mixpanel Actions?
> image.png
> 
> We've also previously brought this up in the shared Slack channel we have (#segment_mixpanel_integration) if you'd like to continue the conversation via Slack.

I can't think of a use case for exposing this, other than if a user wants to NOT pass any context details. So open to discussion on this. 