### PR TITLE
Add external_id field to trackEvent Action

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -28,6 +28,7 @@ Object {
         "data": Object {
           "attributes": Object {
             "email": "rafebezuv@micfeoz.zm",
+            "external_id": "PE*zlOgIPA]mVozMLBaL",
             "other_properties": Object {
               "testType": "PE*zlOgIPA]mVozMLBaL",
             },

--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -68,6 +68,7 @@ Object {
         "data": Object {
           "attributes": Object {
             "email": "ujoeri@ifosi.kp",
+            "external_id": "mTdOx(Nl)",
             "other_properties": Object {
               "testType": "mTdOx(Nl)",
             },

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -16,6 +16,7 @@ Object {
         "data": Object {
           "attributes": Object {
             "email": "tobul@dij.uz",
+            "external_id": "923^%f]tQn]lN2o",
             "other_properties": Object {
               "testType": "923^%f]tQn]lN2o",
             },

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/index.test.ts
@@ -10,12 +10,13 @@ export const settings = {
   api_key: apiKey
 }
 
-const createProfile = (email: string, phoneNumber: string) => ({
+const createProfile = (email: string, phoneNumber: string, external_id: string) => ({
   data: {
     type: 'profile',
     attributes: {
       email,
-      phone_number: phoneNumber
+      phone_number: phoneNumber,
+      external_id
     }
   }
 })
@@ -33,7 +34,7 @@ const createRequestBody = (
   properties: Record<string, any>,
   value: number,
   metricName: string,
-  profile: { email: string; phone_number: string }
+  profile: { email: string; phone_number: string; external_id: string }
 ) => ({
   data: {
     type: 'event',
@@ -41,7 +42,7 @@ const createRequestBody = (
       properties,
       value,
       metric: createMetric(metricName),
-      profile: createProfile(profile.email, profile.phone_number)
+      profile: createProfile(profile.email, profile.phone_number, profile.external_id)
     }
   }
 })
@@ -57,7 +58,7 @@ describe('Order Completed', () => {
   })
 
   it('should successfully track event if proper parameters are provided', async () => {
-    const profile = { email: 'test@example.com', phone_number: '1234567890' }
+    const profile = { email: 'test@example.com', phone_number: '1234567890', external_id: 'klaviyo_123' }
     const properties = { key: 'value' }
     const metricName = 'Order Completed'
     const value = 10
@@ -77,7 +78,7 @@ describe('Order Completed', () => {
   })
 
   it('should throw an error if the API request fails', async () => {
-    const profile = { email: 'test@example.com', phone_number: '1234567890' }
+    const profile = { email: 'test@example.com', phone_number: '1234567890', external_id: 'klaviyo_123' }
     const properties = { key: 'value' }
     const metricName = 'Order Completed'
     const value = 10
@@ -106,7 +107,7 @@ describe('Order Completed', () => {
       }
     ]
 
-    const profile = { email: 'test@example.com', phone_number: '1234567890' }
+    const profile = { email: 'test@example.com', phone_number: '1234567890', external_id: 'klaviyo_123' }
     const properties = { key: 'value' }
     const metricName = 'Order Completed'
     const value = 10

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
@@ -7,6 +7,7 @@ export interface Payload {
   profile: {
     email?: string
     phone_number?: string
+    external_id?: string
     other_properties?: {
       [k: string]: unknown
     }

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
@@ -88,6 +88,10 @@ const action: ActionDefinition<Settings, Payload> = {
           label: 'Phone Number',
           type: 'string'
         },
+        external_id: {
+          label: 'External ID',
+          type: 'string'
+        },
         other_properties: {
           label: 'Other Properties',
           type: 'object'

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -16,6 +16,7 @@ Object {
         "data": Object {
           "attributes": Object {
             "email": "so@uzwumiz.wf",
+            "external_id": "]DD4LgSzT#hw(U]@J$a",
             "other_properties": Object {
               "testType": "]DD4LgSzT#hw(U]@J$a",
             },

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/__tests__/index.test.ts
@@ -45,7 +45,8 @@ describe('Track Event', () => {
               type: 'profile',
               attributes: {
                 email: 'test@example.com',
-                phone_number: '1234567890'
+                phone_number: '1234567890',
+                external_id: 'foo1234'
               }
             }
           }
@@ -61,7 +62,7 @@ describe('Track Event', () => {
     })
 
     const mapping = {
-      profile: { email: 'test@example.com', phone_number: '1234567890' },
+      profile: { email: 'test@example.com', phone_number: '1234567890', external_id: 'foo1234' },
       metric_name: 'event_name',
       properties: { key: 'value' },
       value: 10,

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/generated-types.ts
@@ -7,6 +7,7 @@ export interface Payload {
   profile: {
     email?: string
     phone_number?: string
+    external_id?: string
     other_properties?: {
       [k: string]: unknown
     }

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/index.ts
@@ -23,6 +23,10 @@ const action: ActionDefinition<Settings, Payload> = {
           label: 'Phone Number',
           type: 'string'
         },
+        external_id: {
+          label: 'External ID',
+          type: 'string'
+        },
         other_properties: {
           label: 'Other Properties',
           type: 'object'


### PR DESCRIPTION
This update adds the ability to map a Segment field to Klaviyo's external_id [in their create event api](https://developers.klaviyo.com/en/reference/create_event). 

![Screenshot 2024-04-26 at 1 57 28 PM](https://github.com/segmentio/action-destinations/assets/64277654/74386dbc-e370-4251-a282-fe3c84f09a74)

This comes at the request of the Klaviyo team: 

> The only other request I have Thomas is that in track/identify mappings for Klaviyo Actions, I’d love to have the ability to add “external_id” in as a profile property.  This would help on our side of attributing events in the case where if we wanted to map the segment user_id to an external_id on our end, we could track events without a hard email / phone in the payload (like track calls). 

## Testing

Tested locally: 
![Screenshot 2024-04-26 at 1 48 40 PM](https://github.com/segmentio/action-destinations/assets/64277654/2b58c1e8-b9dd-4bf6-9008-2c7fed9ce309)


