### PR TITLE
CHANNELS-1125 - Bypass SendGrid IP block

### DIFF
--- a/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
+++ b/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
@@ -248,7 +248,9 @@ export class SendEmailPerformer extends MessageSendPerformer<Settings, Payload> 
       method: 'post',
       headers: {
         authorization: `Bearer ${this.settings.sendGridApiKey}`,
-        'x-nef-fp': '8272A86F-AC65-47D2-B2F4-A46FB00C5B9F'
+        // SendGrid may block the IP we are calling the mail send API from as it's from a shared AWS pool.
+        // This header is recognized by SendGrid to be us and thus bypasses any IP block.
+        'x-nef-fp': process.env.SENDGRID_BYPASS_IP_BLOCK_HEADER_SECRET ?? ''
       },
       json: mailContent
     }

--- a/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
+++ b/packages/destination-actions/src/destinations/engage/sendgrid/sendEmail/SendEmailPerformer.ts
@@ -247,7 +247,8 @@ export class SendEmailPerformer extends MessageSendPerformer<Settings, Payload> 
     const req: RequestOptions = {
       method: 'post',
       headers: {
-        authorization: `Bearer ${this.settings.sendGridApiKey}`
+        authorization: `Bearer ${this.settings.sendGridApiKey}`,
+        'x-nef-fp': '8272A86F-AC65-47D2-B2F4-A46FB00C5B9F'
       },
       json: mailContent
     }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

https://segment.atlassian.net/browse/CHANNELS-1125

SendGrid is blocking requests we're making from destination-actions-service in prod by IP.  Due to the IP being shared and potentially changing from time to time we can not allow list the IP block.  Instead we're adding a secret header known by us and SendGrid to bypass the block. 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
