### PR TITLE
Reduce the browser bundle limit to 151 kb from 160 kb

### DIFF
--- a/packages/browser-destinations/package.json
+++ b/packages/browser-destinations/package.json
@@ -84,7 +84,7 @@
   "size-limit": [
     {
       "path": "dist/web/*/*.js",
-      "limit": "160 KB"
+      "limit": "151 KB"
     }
   ]
 }


### PR DESCRIPTION
During a previous build issue, I increased the bundle limit by 10kb (from 150kb to 160kb) which might not help us catch any additional, unnecessary dependencies added to a destination. This PR reduces the limit to 151kb.

Previous PR - https://github.com/segmentio/action-destinations/pull/1991

## Testing

Testing not required because this is just a CI change.