### PR TITLE
Patch for UI issue with Klaviyo Subscribe

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/functions.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/functions.ts
@@ -227,7 +227,7 @@ export function formatSubscribeRequestBody(
     }
   }
 
-  subData.data.attributes.custom_source = custom_source || -59
+  subData.data.attributes.custom_source = custom_source || '-59'
 
   if (list_id) {
     subData.data.relationships = {

--- a/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/__tests__/index.test.ts
@@ -100,7 +100,7 @@ describe('Subscribe Profile', () => {
       data: {
         type: 'profile-subscription-bulk-create-job',
         attributes: {
-          custom_source: -59,
+          custom_source: '-59',
           profiles: {
             data: [
               {
@@ -241,7 +241,7 @@ describe('Subscribe Profile', () => {
       data: {
         type: 'profile-subscription-bulk-create-job',
         attributes: {
-          custom_source: -59,
+          custom_source: '-59',
           profiles: {
             data: [
               {
@@ -467,7 +467,7 @@ describe('Subscribe Profile', () => {
       data: {
         type: 'profile-subscription-bulk-create-job',
         attributes: {
-          custom_source: -59,
+          custom_source: '-59',
           profiles: {
             data: [
               {

--- a/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/generated-types.ts
@@ -16,7 +16,7 @@ export interface Payload {
   /**
    * A custom method or source to detail source of consent preferences (e.g., "Marketing Event"). The default is set to -59, as this is [the $source value associated with Segment](https://help.klaviyo.com/hc/en-us/articles/1260804673530#h_01HDKHG9AM4BSSM009BM6XBF1H).
    */
-  custom_source?: number & string
+  custom_source?: string
   /**
    * The timestamp of when the profile's consent was gathered.
    */

--- a/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/index.ts
@@ -49,7 +49,7 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'A custom method or source to detail source of consent preferences (e.g., "Marketing Event"). The default is set to -59, as this is [the $source value associated with Segment](https://help.klaviyo.com/hc/en-us/articles/1260804673530#h_01HDKHG9AM4BSSM009BM6XBF1H).',
       type: 'string',
-      default: -59
+      default: '-59'
     },
     consented_at: {
       label: 'Consented At',


### PR DESCRIPTION
When attempting to add the subscribeProfile action in my workspace I get a graphql error. 

![Screenshot 2024-04-30 at 3 01 06 PM](https://github.com/segmentio/action-destinations/assets/64277654/463d3bf3-916d-480c-9105-c70f587be6ee)


This appears to be because the type for custom_source field is a string, and the current default value is set to a number `-59`. I previously thought klaviyo required that this be a number ([based off partner source codes](https://help.klaviyo.com/hc/en-us/articles/1260804673530#h_01HDKHG9AM4BSSM009BM6XBF1H)) but after testing you can set this to a string `"-59"` and the result in Klaviyo is the same. 

Note that there is no issue with adding the new unsibscribeProfile action, so I'm fairly certain this will fix the issue.  

## Testing

Sent events to Klaviyo's subscribe endopint using `custom_source: "-59"` and this successfully adds the right $source param on profile
![Screenshot 2024-04-30 at 3 34 11 PM](https://github.com/segmentio/action-destinations/assets/64277654/d3c2cd73-48d4-4d79-842f-291c66ef9e4a)


