### PR TITLE
[MAIN] [STRATCONN] added consent for google campaign manager

### DIFF
--- a/packages/browser-destinations/destinations/google-campaign-manager/src/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/google-campaign-manager/src/__tests__/index.test.ts
@@ -30,6 +30,21 @@ describe('Google Tag for Campaign Manager', () => {
     await googleCampaignManagerPlugin.load(Context.system(), {} as Analytics)
   })
 
+  it('should not update consent if enable_consent mode is denied', async () => {
+    const settings = {
+      ...defaultSettings,
+      enableConsentMode: false
+    }
+
+    const [event] = await googleCampaignManager({ ...settings, subscriptions })
+    await event.load(Context.system(), {} as Analytics)
+    expect(destination.initialize).toHaveBeenCalled()
+
+    expect(window.dataLayer).toEqual(
+      expect.arrayContaining([expect.not.objectContaining(Object.assign({}, ['consent', 'default', {}]))])
+    )
+  })
+
   it('should update consent if analytics storage is granted', async () => {
     const settings = {
       ...defaultSettings,

--- a/packages/browser-destinations/destinations/google-campaign-manager/src/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/google-campaign-manager/src/__tests__/index.test.ts
@@ -1,0 +1,182 @@
+import { Subscription } from '@segment/browser-destination-runtime/types'
+import googleCampaignManager, { destination } from '../index'
+import { Analytics, Context } from '@segment/analytics-next'
+
+const subscriptions: Subscription[] = [
+  {
+    partnerAction: 'salesActivity',
+    name: 'Sales Activity',
+    enabled: true,
+    subscribe: 'type = "track"',
+    mapping: {}
+  }
+]
+
+describe('Google Tag for Campaign Manager', () => {
+  const defaultSettings = {
+    advertiserId: 'test123',
+    allowAdPersonalizationSignals: false,
+    conversionLinker: false
+  }
+  beforeEach(async () => {
+    jest.restoreAllMocks()
+
+    const [googleCampaignManagerPlugin] = await googleCampaignManager({
+      ...defaultSettings,
+      subscriptions
+    })
+    jest.spyOn(destination, 'initialize')
+
+    await googleCampaignManagerPlugin.load(Context.system(), {} as Analytics)
+  })
+
+  it('should update consent if analytics storage is granted', async () => {
+    const settings = {
+      ...defaultSettings,
+      enableConsentMode: true,
+      defaultAnalyticsStorageConsentState: 'granted'
+    }
+
+    const [event] = await googleCampaignManager({ ...settings, subscriptions })
+    await event.load(Context.system(), {} as Analytics)
+    expect(destination.initialize).toHaveBeenCalled()
+
+    expect(window.dataLayer).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining(Object.assign({}, ['consent', 'default', { analytics_storage: 'granted' }]))
+      ])
+    )
+  })
+
+  it('should update consent if analytics storage is denied', async () => {
+    const settings = {
+      ...defaultSettings,
+      enableConsentMode: true,
+      defaultAnalyticsStorageConsentState: 'denied'
+    }
+
+    const [event] = await googleCampaignManager({ ...settings, subscriptions })
+    await event.load(Context.system(), {} as Analytics)
+    expect(destination.initialize).toHaveBeenCalled()
+
+    expect(window.dataLayer).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining(Object.assign({}, ['consent', 'default', { analytics_storage: 'denied' }]))
+      ])
+    )
+  })
+  it('should update consent if Ad storage is granted', async () => {
+    const settings = {
+      ...defaultSettings,
+      enableConsentMode: true,
+      defaultAdsStorageConsentState: 'granted'
+    }
+
+    const [event] = await googleCampaignManager({ ...settings, subscriptions })
+    await event.load(Context.system(), {} as Analytics)
+    expect(destination.initialize).toHaveBeenCalled()
+
+    expect(window.dataLayer).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining(Object.assign({}, ['consent', 'default', { ad_storage: 'granted' }]))
+      ])
+    )
+  })
+  it('should update consent if Ad storage is denied', async () => {
+    const settings = {
+      ...defaultSettings,
+      enableConsentMode: true,
+      defaultAdsStorageConsentState: 'denied'
+    }
+
+    const [event] = await googleCampaignManager({ ...settings, subscriptions })
+    await event.load(Context.system(), {} as Analytics)
+    expect(destination.initialize).toHaveBeenCalled()
+
+    expect(window.dataLayer).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining(Object.assign({}, ['consent', 'default', { ad_storage: 'denied' }]))
+      ])
+    )
+  })
+  it('should update consent if Ad user data is granted', async () => {
+    const settings = {
+      ...defaultSettings,
+      enableConsentMode: true,
+      adUserDataConsentState: 'granted'
+    }
+
+    const [event] = await googleCampaignManager({ ...settings, subscriptions })
+    await event.load(Context.system(), {} as Analytics)
+    expect(destination.initialize).toHaveBeenCalled()
+
+    expect(window.dataLayer).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining(Object.assign({}, ['consent', 'default', { ad_user_data: 'granted' }]))
+      ])
+    )
+  })
+  it('should update consent if Ad user data is denied', async () => {
+    const settings = {
+      ...defaultSettings,
+      enableConsentMode: true,
+      adUserDataConsentState: 'denied'
+    }
+
+    const [event] = await googleCampaignManager({ ...settings, subscriptions })
+    await event.load(Context.system(), {} as Analytics)
+    expect(destination.initialize).toHaveBeenCalled()
+
+    expect(window.dataLayer).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining(Object.assign({}, ['consent', 'default', { ad_user_data: 'denied' }]))
+      ])
+    )
+  })
+  it('should update consent if Ad personalization is granted', async () => {
+    const settings = {
+      ...defaultSettings,
+      enableConsentMode: true,
+      adPersonalizationConsentState: 'granted'
+    }
+
+    const [event] = await googleCampaignManager({ ...settings, subscriptions })
+    await event.load(Context.system(), {} as Analytics)
+    expect(destination.initialize).toHaveBeenCalled()
+
+    expect(window.dataLayer).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining(
+          Object.assign({}, [
+            'consent',
+            'default',
+            { ad_personalization: 'granted', allow_ad_personalization_signals: false }
+          ])
+        )
+      ])
+    )
+  })
+  it('should update consent if Ad personalization is denied', async () => {
+    const settings = {
+      ...defaultSettings,
+      enableConsentMode: true,
+      adPersonalizationConsentState: 'denied'
+    }
+
+    const [event] = await googleCampaignManager({ ...settings, subscriptions })
+    await event.load(Context.system(), {} as Analytics)
+    expect(destination.initialize).toHaveBeenCalled()
+
+    expect(window.dataLayer).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining(
+          Object.assign({}, [
+            'consent',
+            'default',
+            { ad_personalization: 'denied', allow_ad_personalization_signals: false }
+          ])
+        )
+      ])
+    )
+  })
+})

--- a/packages/browser-destinations/destinations/google-campaign-manager/src/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/google-campaign-manager/src/__tests__/index.test.ts
@@ -146,13 +146,7 @@ describe('Google Tag for Campaign Manager', () => {
 
     expect(window.dataLayer).toEqual(
       expect.arrayContaining([
-        expect.objectContaining(
-          Object.assign({}, [
-            'consent',
-            'default',
-            { ad_personalization: 'granted', allow_ad_personalization_signals: false }
-          ])
-        )
+        expect.objectContaining(Object.assign({}, ['consent', 'default', { ad_personalization: 'granted' }]))
       ])
     )
   })
@@ -169,13 +163,7 @@ describe('Google Tag for Campaign Manager', () => {
 
     expect(window.dataLayer).toEqual(
       expect.arrayContaining([
-        expect.objectContaining(
-          Object.assign({}, [
-            'consent',
-            'default',
-            { ad_personalization: 'denied', allow_ad_personalization_signals: false }
-          ])
-        )
+        expect.objectContaining(Object.assign({}, ['consent', 'default', { ad_personalization: 'denied' }]))
       ])
     )
   })

--- a/packages/browser-destinations/destinations/google-campaign-manager/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-campaign-manager/src/generated-types.ts
@@ -13,4 +13,24 @@ export interface Settings {
    * This feature can be disabled if you do not want the global site tag to set first party cookies on your site domain.
    */
   conversionLinker: boolean
+  /**
+   * Set to true to enable Google’s [Consent Mode](https://support.google.com/analytics/answer/9976101?hl=en). Set to false by default.
+   */
+  enableConsentMode?: boolean
+  /**
+   * Consent state indicated by the user for ad cookies. Value must be "granted" or "denied." This is only used if the Enable Consent Mode setting is on.
+   */
+  adUserDataConsentState?: string
+  /**
+   * Consent state indicated by the user for ad cookies. Value must be "granted" or "denied." This is only used if the Enable Consent Mode setting is on.
+   */
+  adPersonalizationConsentState?: string
+  /**
+   * The default value for ad cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.
+   */
+  defaultAdsStorageConsentState?: string
+  /**
+   * The default value for analytics cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.
+   */
+  defaultAnalyticsStorageConsentState?: string
 }

--- a/packages/browser-destinations/destinations/google-campaign-manager/src/index.ts
+++ b/packages/browser-destinations/destinations/google-campaign-manager/src/index.ts
@@ -101,8 +101,6 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
       // eslint-disable-next-line prefer-rest-params
       window.dataLayer.push(arguments)
     }
-
-    window.gtag('set', 'allow_ad_personalization_signals', settings.allowAdPersonalizationSignals)
     window.gtag('js', new Date())
     window.gtag('config', settings.advertiserId, {
       conversion_linker: settings.conversionLinker
@@ -113,6 +111,7 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
         analytics_storage?: ConsentParamsArg
         ad_user_data?: ConsentParamsArg
         ad_personalization?: ConsentParamsArg
+        allow_ad_personalization_signals?: Boolean
       } = {}
 
       if (settings.defaultAnalyticsStorageConsentState) {
@@ -126,8 +125,9 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
       }
       if (settings.adPersonalizationConsentState) {
         consent.ad_personalization = settings.adPersonalizationConsentState as ConsentParamsArg
+        consent.allow_ad_personalization_signals = settings.allowAdPersonalizationSignals
       }
-      window.gtag('consent', 'default', consent)
+      window.gtag('consent', settings.advertiserId, consent)
     }
     const script = `https://www.googletagmanager.com/gtag/js?id=${settings.advertiserId}`
     await deps.loadScript(script)

--- a/packages/browser-destinations/destinations/google-campaign-manager/src/index.ts
+++ b/packages/browser-destinations/destinations/google-campaign-manager/src/index.ts
@@ -11,6 +11,8 @@ declare global {
   }
 }
 
+type ConsentParamsArg = 'granted' | 'denied' | undefined
+
 export const destination: BrowserDestinationDefinition<Settings, Function> = {
   name: 'Google Tag for Campaign Manager',
   slug: 'actions-google-campaign-manager',
@@ -40,6 +42,56 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
       type: 'boolean',
       required: true,
       default: true
+    },
+    enableConsentMode: {
+      description: `Set to true to enable Google’s [Consent Mode](https://support.google.com/analytics/answer/9976101?hl=en). Set to false by default.`,
+      label: 'Enable Consent Mode',
+      type: 'boolean',
+      default: false
+    },
+    adUserDataConsentState: {
+      description:
+        'Consent state indicated by the user for ad cookies. Value must be "granted" or "denied." This is only used if the Enable Consent Mode setting is on.',
+      label: 'Ad User Data Consent State',
+      type: 'string',
+      choices: [
+        { label: 'Granted', value: 'granted' },
+        { label: 'Denied', value: 'denied' }
+      ],
+      default: undefined
+    },
+    adPersonalizationConsentState: {
+      description:
+        'Consent state indicated by the user for ad cookies. Value must be "granted" or "denied." This is only used if the Enable Consent Mode setting is on.',
+      label: 'Ad Personalization Consent State',
+      type: 'string',
+      choices: [
+        { label: 'Granted', value: 'granted' },
+        { label: 'Denied', value: 'denied' }
+      ],
+      default: undefined
+    },
+    defaultAdsStorageConsentState: {
+      description:
+        'The default value for ad cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.',
+      label: 'Default Ads Storage Consent State',
+      type: 'string',
+      choices: [
+        { label: 'Granted', value: 'granted' },
+        { label: 'Denied', value: 'denied' }
+      ],
+      default: undefined
+    },
+    defaultAnalyticsStorageConsentState: {
+      description:
+        'The default value for analytics cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.',
+      label: 'Default Analytics Storage Consent State',
+      type: 'string',
+      choices: [
+        { label: 'Granted', value: 'granted' },
+        { label: 'Denied', value: 'denied' }
+      ],
+      default: undefined
     }
   },
 
@@ -55,6 +107,24 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
     window.gtag('config', settings.advertiserId, {
       conversion_linker: settings.conversionLinker
     })
+    if (settings.enableConsentMode) {
+      const consent: {
+        ad_storage: ConsentParamsArg
+        analytics_storage: ConsentParamsArg
+        ad_user_data?: ConsentParamsArg
+        ad_personalization?: ConsentParamsArg
+      } = {
+        ad_storage: settings.defaultAdsStorageConsentState as ConsentParamsArg,
+        analytics_storage: settings.defaultAnalyticsStorageConsentState as ConsentParamsArg
+      }
+      if (settings.adUserDataConsentState) {
+        consent.ad_user_data = settings.adUserDataConsentState as ConsentParamsArg
+      }
+      if (settings.adPersonalizationConsentState) {
+        consent.ad_personalization = settings.adPersonalizationConsentState as ConsentParamsArg
+      }
+      window.gtag('consent', 'default', consent)
+    }
     const script = `https://www.googletagmanager.com/gtag/js?id=${settings.advertiserId}`
     await deps.loadScript(script)
     return window.gtag

--- a/packages/browser-destinations/destinations/google-campaign-manager/src/index.ts
+++ b/packages/browser-destinations/destinations/google-campaign-manager/src/index.ts
@@ -109,13 +109,17 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
     })
     if (settings.enableConsentMode) {
       const consent: {
-        ad_storage: ConsentParamsArg
-        analytics_storage: ConsentParamsArg
+        ad_storage?: ConsentParamsArg
+        analytics_storage?: ConsentParamsArg
         ad_user_data?: ConsentParamsArg
         ad_personalization?: ConsentParamsArg
-      } = {
-        ad_storage: settings.defaultAdsStorageConsentState as ConsentParamsArg,
-        analytics_storage: settings.defaultAnalyticsStorageConsentState as ConsentParamsArg
+      } = {}
+
+      if (settings.defaultAnalyticsStorageConsentState) {
+        consent.analytics_storage = settings.defaultAnalyticsStorageConsentState as ConsentParamsArg
+      }
+      if (settings.defaultAdsStorageConsentState) {
+        consent.ad_storage = settings.defaultAdsStorageConsentState as ConsentParamsArg
       }
       if (settings.adUserDataConsentState) {
         consent.ad_user_data = settings.adUserDataConsentState as ConsentParamsArg

--- a/packages/browser-destinations/destinations/google-campaign-manager/src/index.ts
+++ b/packages/browser-destinations/destinations/google-campaign-manager/src/index.ts
@@ -101,6 +101,7 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
       // eslint-disable-next-line prefer-rest-params
       window.dataLayer.push(arguments)
     }
+    window.gtag('set', 'allow_ad_personalization_signals', settings.allowAdPersonalizationSignals)
     window.gtag('js', new Date())
     window.gtag('config', settings.advertiserId, {
       conversion_linker: settings.conversionLinker
@@ -125,7 +126,6 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
       }
       if (settings.adPersonalizationConsentState) {
         consent.ad_personalization = settings.adPersonalizationConsentState as ConsentParamsArg
-        consent.allow_ad_personalization_signals = settings.allowAdPersonalizationSignals
       }
 
       window.gtag('consent', 'default', consent)

--- a/packages/browser-destinations/destinations/google-campaign-manager/src/index.ts
+++ b/packages/browser-destinations/destinations/google-campaign-manager/src/index.ts
@@ -127,7 +127,8 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
         consent.ad_personalization = settings.adPersonalizationConsentState as ConsentParamsArg
         consent.allow_ad_personalization_signals = settings.allowAdPersonalizationSignals
       }
-      window.gtag('consent', settings.advertiserId, consent)
+
+      window.gtag('consent', 'default', consent)
     }
     const script = `https://www.googletagmanager.com/gtag/js?id=${settings.advertiserId}`
     await deps.loadScript(script)

--- a/packages/browser-destinations/package.json
+++ b/packages/browser-destinations/package.json
@@ -84,7 +84,7 @@
   "size-limit": [
     {
       "path": "dist/web/*/*.js",
-      "limit": "151 KB"
+      "limit": "152 KB"
     }
   ]
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

Added consent mode settings for google campaign manager

JIRA TICKET: https://segment.atlassian.net/browse/STRATCONN-3789

Action Tester:

<img width="1488" alt="Screenshot 2024-05-02 at 3 27 47 PM" src="https://github.com/segmentio/action-destinations/assets/139338151/bc7b3333-9385-4ab6-a8ed-78db387d1b4b">

Segment App:

<img width="1510" alt="Screenshot 2024-05-10 at 2 06 02 PM" src="https://github.com/segmentio/action-destinations/assets/139338151/35cb6c45-b12a-447a-8ec2-4683c5a9461d">

GTAG manager:

<img width="1191" alt="Screenshot 2024-05-10 at 2 03 05 PM" src="https://github.com/segmentio/action-destinations/assets/139338151/d62cd43d-614c-4268-99b1-5af7c1d32100">

Chrome console:

<img width="802" alt="Screenshot 2024-05-10 at 2 04 56 PM" src="https://github.com/segmentio/action-destinations/assets/139338151/d5f288b0-34ff-4359-b12a-10d4293f040a">



<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [X] [Segmenters] Tested in the staging environment
