### PR TITLE
Facebook Conversions API double hashing prevention

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/user-data.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/user-data.test.ts
@@ -119,6 +119,38 @@ describe('FacebookConversionsApi', () => {
         expect(hashed_data.ge).toEqual('62c66a7a5dd70c3146618063c344e531e6d4b59e379808443ce962b3abd63c5a')
         expect(hashed_data.db).toEqual(undefined)
       })
+
+      it('if values are already hashed, should not hash again', async () => {
+        const test_payload = {
+          user_data: {
+            email: '2d2fb2388f17f86affee71d632978425a3037fa8eed5b3f2baaa458c80d495ed',
+            phone: '92b5be0b4bcd88dbe1c5f7de1cc3f479fa8a702bd02b9905a5bc14bf66243c05',
+            dateOfBirth: '4f8a154810062809cdb724b8254c2b9886e6ad3bc8b3fdfad4eb97f5b1916efd',
+            gender: '62c66a7a5dd70c3146618063c344e531e6d4b59e379808443ce962b3abd63c5a',
+            lastName: '3b67f1c91f4f245f6e219b364782ac53e912420f2284bf6a700e9cf71fbeafac',
+            firstName: 'a628aa64f14c8196c8c82c7ffb6482b2db7431e4cb5b28cd313004ce7ba4eb66',
+            city: 'b37d49779ef2040ccbb357b127d615c75a77ff74645071dbd6ec27ae54cbd912',
+            state: '4b650e5c4785025dee7bd65e3c5c527356717d7a1c0bfef5b4ada8ca1e9cbe17',
+            zip: '860d1f692a318f7ba200f47ab16bcae57e651d51bea0f56d7cef36569c198006',
+            country: '9b202ecbc6d45c6d8901d989a918878397a3eb9d00e8f48022fc051b19d21a1d',
+            externalId: ['2221aa193aea3b3fdee120c146c302fdb6ea606dbf4dfc5e1d587ec4b1aedf74']
+          }
+        }
+
+        const hashed_data = hash_user_data(test_payload) as Record<string, string>
+
+        expect(hashed_data.em).toEqual('2d2fb2388f17f86affee71d632978425a3037fa8eed5b3f2baaa458c80d495ed')
+        expect(hashed_data.ph).toEqual('92b5be0b4bcd88dbe1c5f7de1cc3f479fa8a702bd02b9905a5bc14bf66243c05')
+        expect(hashed_data.ge).toEqual('62c66a7a5dd70c3146618063c344e531e6d4b59e379808443ce962b3abd63c5a')
+        expect(hashed_data.db).toEqual('4f8a154810062809cdb724b8254c2b9886e6ad3bc8b3fdfad4eb97f5b1916efd')
+        expect(hashed_data.ln).toEqual('3b67f1c91f4f245f6e219b364782ac53e912420f2284bf6a700e9cf71fbeafac')
+        expect(hashed_data.fn).toEqual('a628aa64f14c8196c8c82c7ffb6482b2db7431e4cb5b28cd313004ce7ba4eb66')
+        expect(hashed_data.ct).toEqual('b37d49779ef2040ccbb357b127d615c75a77ff74645071dbd6ec27ae54cbd912')
+        expect(hashed_data.st).toEqual('4b650e5c4785025dee7bd65e3c5c527356717d7a1c0bfef5b4ada8ca1e9cbe17')
+        expect(hashed_data.zp).toEqual('860d1f692a318f7ba200f47ab16bcae57e651d51bea0f56d7cef36569c198006')
+        expect(hashed_data.country).toEqual('9b202ecbc6d45c6d8901d989a918878397a3eb9d00e8f48022fc051b19d21a1d')
+        expect(hashed_data.external_id).toEqual(['2221aa193aea3b3fdee120c146c302fdb6ea606dbf4dfc5e1d587ec4b1aedf74'])
+      })
     })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-user-data.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-user-data.ts
@@ -196,7 +196,7 @@ export const normalize_user_data = (payload: UserData) => {
     payload.user_data.email = payload.user_data.email.replace(/\s/g, '').toLowerCase()
   }
 
-  if (payload.user_data.phone) {
+  if (payload.user_data.phone && !isHashedInformation(payload.user_data.phone)) {
     // Regex removes all non-numeric characters from the string.
     payload.user_data.phone = payload.user_data.phone.replace(/\D/g, '')
   }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-user-data.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-user-data.ts
@@ -167,14 +167,17 @@ export const user_data_field: InputField = {
 
 type UserData = Pick<Payload, 'user_data'>
 
+const isHashedInformation = (information: string): boolean => new RegExp(/[0-9abcdef]{64}/gi).test(information)
+
 const hash = (value: string | string[] | undefined): string | string[] | undefined => {
   if (value === undefined || !value.length) return
 
   if (typeof value == 'string') {
+    if (isHashedInformation(value)) return value
     return hashValue(value)
-  } else {
-    return value.map((el: string) => hashValue(el))
   }
+
+  return value.map((el: string) => (isHashedInformation(el) ? el : hashValue(el)))
 }
 const hashValue = (val: string): string => {
   const hash = createHash('sha256')
@@ -182,8 +185,11 @@ const hashValue = (val: string): string => {
   return hash.digest('hex')
 }
 
-// Normalization of user data properties according to Facebooks specifications.
-// https://developers.facebook.com/docs/marketing-api/audiences/guides/custom-audiences#hash
+/**
+ * Normalization of user data properties according to Facebooks specifications.
+ * @param payload
+ * @see https://developers.facebook.com/docs/marketing-api/audiences/guides/custom-audiences#hash
+ */
 export const normalize_user_data = (payload: UserData) => {
   if (payload.user_data.email) {
     // Regex removes all whitespace in the string.


### PR DESCRIPTION
Adding mechanisms to avoid double-hashing for Facebook Conversions API.

## Testing

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
