### PR TITLE
Heap - update property flattening on browserArrayLimit in track call

### DIFF
--- a/packages/browser-destinations/destinations/heap/src/trackEvent/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/heap/src/trackEvent/__tests__/index.test.ts
@@ -45,26 +45,22 @@ describe('#trackEvent', () => {
           products: [
             {
               name: 'Test Product 1',
-              properties: {
-                color: 'red',
-                qty: 2,
-                custom_vars: {
-                  position: 0,
-                  something_else: 'test',
-                  another_one: ['one', 'two', 'three']
-                }
+              color: 'red',
+              qty: 2,
+              custom_vars: {
+                position: 0,
+                something_else: 'test',
+                another_one: ['one', 'two', 'three']
               }
             },
             {
               name: 'Test Product 2',
-              properties: {
-                color: 'blue',
-                qty: 1,
-                custom_vars: {
-                  position: 1,
-                  something_else: 'blah',
-                  another_one: ['four', 'five', 'six']
-                }
+              color: 'blue',
+              qty: 1,
+              custom_vars: {
+                position: 1,
+                something_else: 'blah',
+                another_one: ['four', 'five', 'six']
               }
             }
           ]
@@ -92,7 +88,7 @@ describe('#trackEvent', () => {
     })
     expect(heapTrackSpy).toHaveBeenNthCalledWith(3, 'hello!', {
       products:
-        '[{"name":"Test Product 1","properties":{"color":"red","qty":2,"custom_vars":{"position":0,"something_else":"test","another_one":["one","two","three"]}}},{"name":"Test Product 2","properties":{"color":"blue","qty":1,"custom_vars":{"position":1,"something_else":"blah","another_one":["four","five","six"]}}}]',
+        '[{"name":"Test Product 1","color":"red","qty":2,"custom_vars":{"position":0,"something_else":"test","another_one":["one","two","three"]}},{"name":"Test Product 2","color":"blue","qty":1,"custom_vars":{"position":1,"something_else":"blah","another_one":["four","five","six"]}}]',
       segment_library: HEAP_SEGMENT_BROWSER_LIBRARY_NAME
     })
     expect(addUserPropertiesSpy).toHaveBeenCalledTimes(0)
@@ -114,13 +110,13 @@ describe('#trackEvent', () => {
 
     for (let i = 1; i <= 3; i++) {
       expect(heapTrackSpy).toHaveBeenNthCalledWith(i, 'hello! testArray1 item', {
-        val: i,
+        val: i.toString(),
         segment_library: HEAP_SEGMENT_BROWSER_LIBRARY_NAME
       })
     }
     for (let i = 4; i <= 5; i++) {
       expect(heapTrackSpy).toHaveBeenNthCalledWith(i, 'hello! testArray2 item', {
-        val: i,
+        val: i.toString(),
         segment_library: HEAP_SEGMENT_BROWSER_LIBRARY_NAME
       })
     }
@@ -191,13 +187,37 @@ describe('#trackEvent', () => {
     )
     expect(heapTrackSpy).toHaveBeenCalledWith('hello!', {
       segment_library: HEAP_SEGMENT_BROWSER_LIBRARY_NAME,
-      isAutomated: true,
-      isClickable: true,
-      bodyText: 'Testing text',
-      ctaText: 'Click me',
-      position: '0',
-      'testNestedValues.count': '5',
-      'testNestedValues.color': 'green'
+      isAutomated: 'true',
+      isClickable: 'true',
+      'custom_vars.bodyText': 'Testing text',
+      'custom_vars.ctaText': 'Click me',
+      'custom_vars.position': '0',
+      'custom_vars.testNestedValues.count': '5',
+      'custom_vars.testNestedValues.color': 'green'
+    })
+  })
+
+  it('should flatten properties on parent when browserArrayLimit is set', async () => {
+    await eventWithUnrolling.track?.(
+      new Context({
+        type: 'track',
+        name: 'hello!',
+        properties: {
+          boolean_test: false,
+          string_test: 'react',
+          number_test: 0,
+          custom_vars: {
+            property: 1
+          }
+        }
+      })
+    )
+    expect(heapTrackSpy).toHaveBeenCalledWith('hello!', {
+      segment_library: HEAP_SEGMENT_BROWSER_LIBRARY_NAME,
+      boolean_test: 'false',
+      string_test: 'react',
+      number_test: '0',
+      'custom_vars.property': '1'
     })
   })
 
@@ -316,27 +336,27 @@ describe('#trackEvent', () => {
         sku: 'PT2252152-0001-00',
         url: '/products/THE-ONE-JOGGER-PT2252152-0001-2',
         variant: 'Black',
-        vip_price: 59.95,
-        membership_brand_id: 1,
-        quantity: 1,
+        vip_price: '59.95',
+        membership_brand_id: '1',
+        quantity: '1',
         segment_library: HEAP_SEGMENT_BROWSER_LIBRARY_NAME
       })
       expect(heapTrackSpy).toHaveBeenNthCalledWith(2, 'Product List Viewed products item', {
         sku: 'PT2252152-4846-00',
         url: '/products/THE-ONE-JOGGER-PT2252152-4846',
         variant: 'Deep Navy',
-        vip_price: 59.95,
-        membership_brand_id: 1,
-        quantity: 1,
+        vip_price: '59.95',
+        membership_brand_id: '1',
+        quantity: '1',
         segment_library: HEAP_SEGMENT_BROWSER_LIBRARY_NAME
       })
       expect(heapTrackSpy).toHaveBeenNthCalledWith(3, 'Product List Viewed products item', {
         sku: 'PT2458220-0001-00',
         url: '/products/THE-YEAR-ROUND-TERRY-JOGGER-PT2458220-0001',
         variant: 'Black',
-        vip_price: 59.95,
-        membership_brand_id: 1,
-        quantity: 1,
+        vip_price: '59.95',
+        membership_brand_id: '1',
+        quantity: '1',
         segment_library: HEAP_SEGMENT_BROWSER_LIBRARY_NAME
       })
       expect(heapTrackSpy).toHaveBeenNthCalledWith(4, 'Product List Viewed', {

--- a/packages/browser-destinations/destinations/heap/src/trackEvent/index.ts
+++ b/packages/browser-destinations/destinations/heap/src/trackEvent/index.ts
@@ -101,12 +101,12 @@ const heapTrackArrays = (
       return eventProperties
     }
 
+    delete eventProperties[key]
+    eventProperties = { ...eventProperties, ...flat({ [key]: value }) }
+
     if (!Array.isArray(value)) {
       continue
     }
-
-    delete eventProperties[key]
-    eventProperties = { ...eventProperties, ...flat({ [key]: value }) }
 
     const arrayLength = value.length
     let arrayPropertyValues

--- a/packages/browser-destinations/destinations/heap/src/utils.ts
+++ b/packages/browser-destinations/destinations/heap/src/utils.ts
@@ -10,7 +10,7 @@ export type Properties = {
 }
 
 type FlattenProperties = object & {
-  [k: string]: string
+  [k: string]: string | null
 }
 
 export function flat(data?: Properties, prefix = ''): FlattenProperties | undefined {
@@ -24,9 +24,7 @@ export function flat(data?: Properties, prefix = ''): FlattenProperties | undefi
       result = { ...result, ...flatten }
     } else {
       const stringifiedValue = stringify(data[key])
-      // replaces the first . or .word.
-      const identifier = (prefix + '.' + key).replace(/^\.(\w+\.)?/, '')
-      result[identifier] = stringifiedValue
+      result[(prefix + '.' + key).replace(/^\./, '')] = stringifiedValue
     }
   }
   return result
@@ -39,14 +37,15 @@ export const flattenProperties = (arrayPropertyValue: any) => {
     if (typeof value == 'object' && value !== null) {
       arrayProperties = { ...arrayProperties, ...flat({ [key]: value as Properties }) }
     } else {
-      arrayProperties = Object.assign(arrayProperties, { [key]: value })
+      const stringifiedValue = stringify(value)
+      arrayProperties = Object.assign(arrayProperties, { [key]: stringifiedValue })
     }
   }
   return arrayProperties
 }
 
-function stringify(value: unknown): string {
-  if (typeof value === 'string') {
+function stringify(value: unknown): string | null {
+  if (typeof value === 'string' || value === null) {
     return value
   }
   if (typeof value === 'number' || typeof value === 'boolean') {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Updated flattening logic
- when `browserArrayLimit` is set, it should still flatten objects outside of arrays
- added test `should flatten properties on parent when browserArrayLimit is set` shows an example of this case (objects are dropped in heap so we flatten here to retain the information)
- updated stringify logic - this was inconsistent
- removed the logic to remove the top level name from the key (should be custom_vars.xxx instead of xxx)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
