### PR TITLE
Bug/stratconn 3772 - Staging

### DIFF
--- a/packages/destination-subscriptions/src/__tests__/generate-fql.test.ts
+++ b/packages/destination-subscriptions/src/__tests__/generate-fql.test.ts
@@ -135,7 +135,7 @@ test('should handle field paths with non-regular values and escape properly', ()
       {
         type: 'event-trait',
         name: 'property dos',
-        operator: '=',
+        operator: '==',
         value: 2
       }
     ]

--- a/packages/destination-subscriptions/src/__tests__/generate-fql.test.ts
+++ b/packages/destination-subscriptions/src/__tests__/generate-fql.test.ts
@@ -29,6 +29,46 @@ test('should handle valid ast', () => {
   expect(generateFql(ast)).toEqual('properties.value = "x"')
 })
 
+test('should numeric equal (==) ast', () => {
+  const ast: Subscription = {
+    type: 'group',
+    operator: 'and',
+    children: [
+      {
+        type: 'event-property',
+        name: 'value',
+        operator: '==',
+        value: '123'
+      }
+    ]
+  }
+
+  expect(generateFql(ast)).toEqual('properties.value = 123')
+})
+
+test('should string equal (=) ast', () => {
+  const ast: Subscription = {
+    type: 'group',
+    operator: 'and',
+    children: [
+      {
+        type: 'event-property',
+        name: 'value',
+        operator: '==',
+        value: '123'
+      },
+      {
+        type: 'event-property',
+        name: 'label',
+        operator: '=',
+        value: '456'
+      }
+    ]
+  }
+
+  expect(generateFql(ast)).toEqual('properties.value = 123 and properties.label = "456"')
+})
+
 test('should handle ast with multiple childs (or condition)', () => {
   const ast: Subscription = {
     type: 'group',

--- a/packages/destination-subscriptions/src/__tests__/validate.test.ts
+++ b/packages/destination-subscriptions/src/__tests__/validate.test.ts
@@ -131,7 +131,7 @@ test('operators - equals (numbers)', () => {
       ]
     }
 
-    expect(validate(ast, { properties: { value: 123 } })).toEqual(true)
+    expect(validate(ast, { properties: { value: 123 } })).toEqual(false)
     expect(validate(ast, { properties: { value: '123' } })).toEqual(true)
     expect(validate(ast, { properties: { value: 0 } })).toEqual(false)
   }

--- a/packages/destination-subscriptions/src/__tests__/validate.test.ts
+++ b/packages/destination-subscriptions/src/__tests__/validate.test.ts
@@ -131,8 +131,29 @@ test('operators - equals (numbers)', () => {
       ]
     }
 
+    expect(validate(ast, { properties: { value: 123 } })).toEqual(true)
+    expect(validate(ast, { properties: { value: '123' } })).toEqual(true)
+    expect(validate(ast, { properties: { value: 0 } })).toEqual(false)
+  }
+})
+
+test('operators -  is equals to (==) (numbers)', () => {
+  for (const value of ['123', 123]) {
+    const ast = {
+      type: 'group',
+      operator: 'and',
+      children: [
+        {
+          type: 'event-property',
+          name: 'value',
+          operator: '==',
+          value
+        }
+      ]
+    }
+
     // Since action tester UI only supports string type input, we assume the value in the ast is a string for now (i.e. 123 !== "123")
-    expect(validate(ast, { properties: { value: 123 } })).toEqual(false)
+    expect(validate(ast, { properties: { value: 123 } })).toEqual(true)
 
     expect(validate(ast, { properties: { value: '123' } })).toEqual(true)
     expect(validate(ast, { properties: { value: 0 } })).toEqual(false)

--- a/packages/destination-subscriptions/src/__tests__/validate.test.ts
+++ b/packages/destination-subscriptions/src/__tests__/validate.test.ts
@@ -152,10 +152,9 @@ test('operators -  is equals to (==) (numbers)', () => {
       ]
     }
 
-    // Since action tester UI only supports string type input, we assume the value in the ast is a string for now (i.e. 123 !== "123")
     expect(validate(ast, { properties: { value: 123 } })).toEqual(true)
 
-    expect(validate(ast, { properties: { value: '123' } })).toEqual(true)
+    expect(validate(ast, { properties: { value: '123' } })).toEqual(false)
     expect(validate(ast, { properties: { value: 0 } })).toEqual(false)
   }
 })

--- a/packages/destination-subscriptions/src/generate-fql.ts
+++ b/packages/destination-subscriptions/src/generate-fql.ts
@@ -50,7 +50,7 @@ const fqlExpression = (name: string, operator: Operator, value: string | boolean
     case '==':
       return `${name} = ${Number(value)}`
     default:
-      return `${name} ${operator} ${stringifyValue(value)}`
+      return `${name} ${operator} "${value}"`
   }
 }
 

--- a/packages/destination-subscriptions/src/generate-fql.ts
+++ b/packages/destination-subscriptions/src/generate-fql.ts
@@ -47,6 +47,8 @@ const fqlExpression = (name: string, operator: Operator, value: string | boolean
     case '<=':
     case '>=':
       return `${name} ${operator} ${Number(value)}`
+    case '==':
+      return `${name} = ${Number(value)}`
     default:
       return `${name} ${operator} ${stringifyValue(value)}`
   }

--- a/packages/destination-subscriptions/src/parse-fql.ts
+++ b/packages/destination-subscriptions/src/parse-fql.ts
@@ -277,10 +277,12 @@ const parse = (tokens: Token[]): Condition => {
               operator: 'is_false'
             })
           } else {
+            const operator =
+              valueToken.type === 'number' && operatorToken.value === '=' ? '==' : (operatorToken.value as Operator)
             nodes.push({
               type: 'event-property',
               name: token.value.replace(/^(properties)\./, ''),
-              operator: operatorToken.value as Operator,
+              operator,
               value: getTokenValue(valueToken)
             })
           }

--- a/packages/destination-subscriptions/src/parse-fql.ts
+++ b/packages/destination-subscriptions/src/parse-fql.ts
@@ -165,6 +165,9 @@ const parseFqlFunction = (
   }
 }
 
+const parseOperator = (valueToken: Token, operatorToken: Token) =>
+  valueToken.type === 'number' && operatorToken.value === '=' ? '==' : (operatorToken.value as Operator)
+
 const parse = (tokens: Token[]): Condition => {
   const nodes: Condition[] = []
   let operator = 'and'
@@ -277,8 +280,7 @@ const parse = (tokens: Token[]): Condition => {
               operator: 'is_false'
             })
           } else {
-            const operator =
-              valueToken.type === 'number' && operatorToken.value === '=' ? '==' : (operatorToken.value as Operator)
+            const operator = parseOperator(valueToken, operatorToken)
             nodes.push({
               type: 'event-property',
               name: token.value.replace(/^(properties)\./, ''),
@@ -312,10 +314,11 @@ const parse = (tokens: Token[]): Condition => {
               operator: 'is_false'
             })
           } else {
+            const operator = parseOperator(valueToken, operatorToken)
             nodes.push({
               type: 'event-trait',
               name: token.value.replace(/^(traits)\./, ''),
-              operator: operatorToken.value as Operator,
+              operator,
               value: getTokenValue(valueToken)
             })
           }
@@ -345,10 +348,11 @@ const parse = (tokens: Token[]): Condition => {
               operator: 'is_false'
             })
           } else {
+            const operator = parseOperator(valueToken, operatorToken)
             nodes.push({
               type: 'event-context',
               name: token.value.replace(/^(context)\./, ''),
-              operator: operatorToken.value as Operator,
+              operator,
               value: getTokenValue(valueToken)
             })
           }

--- a/packages/destination-subscriptions/src/types.ts
+++ b/packages/destination-subscriptions/src/types.ts
@@ -73,6 +73,7 @@ export type Operator =
   | '<='
   | '>'
   | '>='
+  | '=='
   | 'contains'
   | 'not_contains'
   | 'starts_with'

--- a/packages/destination-subscriptions/src/validate.ts
+++ b/packages/destination-subscriptions/src/validate.ts
@@ -72,7 +72,8 @@ const validateCondition = (condition: Condition, data: any): boolean => {
 const validateValue = (actual: unknown, operator: Operator, expected?: string | boolean | number): boolean => {
   switch (operator) {
     case '=':
-      return actual === String(expected)
+    case '==':
+      return typeof actual === 'number' ? Number(actual) === Number(expected) : actual === String(expected)
     case '!=':
       return actual !== String(expected)
     case '<':

--- a/packages/destination-subscriptions/src/validate.ts
+++ b/packages/destination-subscriptions/src/validate.ts
@@ -72,8 +72,9 @@ const validateCondition = (condition: Condition, data: any): boolean => {
 const validateValue = (actual: unknown, operator: Operator, expected?: string | boolean | number): boolean => {
   switch (operator) {
     case '=':
-    case '==':
       return typeof actual === 'number' ? Number(actual) === Number(expected) : actual === String(expected)
+    case '==':
+      return typeof actual === 'number' && Number(actual) === Number(expected)
     case '!=':
       return actual !== String(expected)
     case '<':

--- a/packages/destination-subscriptions/src/validate.ts
+++ b/packages/destination-subscriptions/src/validate.ts
@@ -72,7 +72,7 @@ const validateCondition = (condition: Condition, data: any): boolean => {
 const validateValue = (actual: unknown, operator: Operator, expected?: string | boolean | number): boolean => {
   switch (operator) {
     case '=':
-      return typeof actual === 'number' ? Number(actual) === Number(expected) : actual === String(expected)
+      return actual === String(expected)
     case '==':
       return typeof actual === 'number' && Number(actual) === Number(expected)
     case '!=':


### PR DESCRIPTION
## Summary

Jira Ticket: https://segment.atlassian.net/browse/STRATCONN-3772

Addition of a new operator ("==") in validate, parse-fql and generate-fql functions in @segment/destination-subscriptions.

This operator does a strict numeric equality check. This operator is only at the AST level and doesn't get stored in the actual fql. Before generating fql, This operator will be transformed into "=" without stringifying its corresponding value token.



## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
