### PR TITLE
Update MC contacts upsert to handle multiple identifiers

### DIFF
--- a/packages/destination-actions/src/destinations/sendgrid/__tests__/sendgrid-properties.test.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/__tests__/sendgrid-properties.test.ts
@@ -1,32 +1,48 @@
-import { tranformValueToAcceptedDataType } from '../sendgrid-properties'
+import { tranformValueToAcceptedDataType, validatePayload } from '../sendgrid-properties'
 
-describe('tranformValueToAcceptedDataType', () => {
-  it('should transform a boolean value into a string', () => {
-    expect(tranformValueToAcceptedDataType(true)).toBe('true')
+describe('sendgrid-properties', () => {
+  describe('tranformValueToAcceptedDataType', () => {
+    it('should transform a boolean value into a string', () => {
+      expect(tranformValueToAcceptedDataType(true)).toBe('true')
+    })
+
+    it('should transform an array value into a string', () => {
+      expect(tranformValueToAcceptedDataType([1, 2, 3])).toBe('[1,2,3]')
+    })
+
+    it('should transform an object value into a string', () => {
+      expect(tranformValueToAcceptedDataType({ a: 1 })).toBe('{"a":1}')
+    })
+
+    it('should transform nested arrays and objects into a string', () => {
+      const data = [[1, 2, 3], { a: 1, b: 2, c: { d: 3, e: ['f', 'g'] } }]
+      expect(tranformValueToAcceptedDataType(data)).toBe('[[1,2,3],{"a":1,"b":2,"c":{"d":3,"e":["f","g"]}}]')
+    })
+
+    it('should return the value for number types', () => {
+      expect(tranformValueToAcceptedDataType(123)).toBe(123)
+    })
+
+    it('should return the value for string types', () => {
+      expect(tranformValueToAcceptedDataType('Hello, test')).toBe('Hello, test')
+    })
+
+    it('should return the value for date types', () => {
+      expect(tranformValueToAcceptedDataType('2022-11-01T00:00:00Z')).toBe('2022-11-01T00:00:00Z')
+    })
   })
 
-  it('should transform an array value into a string', () => {
-    expect(tranformValueToAcceptedDataType([1, 2, 3])).toBe('[1,2,3]')
-  })
+  describe('validatePayload', () => {
+    it('should throw an error if no identifying field is included', () => {
+      const payload = {}
+      expect(() => validatePayload(payload)).toThrowError(
+        'Contact must have at least one identifying field included (email, phone_number_id, external_id, anonymous_id).'
+      )
+    })
 
-  it('should transform an object value into a string', () => {
-    expect(tranformValueToAcceptedDataType({ a: 1 })).toBe('{"a":1}')
-  })
-
-  it('should transform nested arrays and objects into a string', () => {
-    const data = [[1, 2, 3], { a: 1, b: 2, c: { d: 3, e: ['f', 'g'] } }]
-    expect(tranformValueToAcceptedDataType(data)).toBe('[[1,2,3],{"a":1,"b":2,"c":{"d":3,"e":["f","g"]}}]')
-  })
-
-  it('should return the value for number types', () => {
-    expect(tranformValueToAcceptedDataType(123)).toBe(123)
-  })
-
-  it('should return the value for string types', () => {
-    expect(tranformValueToAcceptedDataType('Hello, test')).toBe('Hello, test')
-  })
-
-  it('should return the value for date types', () => {
-    expect(tranformValueToAcceptedDataType('2022-11-01T00:00:00Z')).toBe('2022-11-01T00:00:00Z')
+    it('should not throw an error if at least one identifying field is included', () => {
+      const payload = { anonymous_id: 'hip-hop-anonymous' }
+      expect(() => validatePayload(payload)).not.toThrow()
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/sendgrid/sendgrid-properties.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/sendgrid-properties.ts
@@ -94,8 +94,23 @@ const transformValuesToAcceptedDataTypes = (data: any): any => {
   return tranformedData
 }
 
+// Validate the payload of each contact
+export const validatePayload = (payload: Payload) => {
+  // Validate that 1 of the 4 identifier fields is included in the payload
+  if (!payload.primary_email && !payload.phone_number_id && !payload.external_id && !payload.anonymous_id) {
+    throw new IntegrationError(
+      'Contact must have at least one identifying field included (email, phone_number_id, external_id, anonymous_id).',
+      'Invalid value',
+      400
+    )
+  }
+}
+
 export const convertPayload = (payload: Payload, accountCustomFields: CustomField[]) => {
   const { state, primary_email, enable_batching, customFields, ...rest } = payload
+
+  // Validate that each contact payload is correct (i.e. contains 1 of the 4 identifier fields)
+  validatePayload(payload)
 
   // If there are any custom fields, convert their key from sendgrid Name to sendgrid ID if needed
   const updatedCustomFields = customFields

--- a/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/generated-types.ts
@@ -64,7 +64,19 @@ export interface Payload {
   /**
    * The contact's email address.
    */
-  primary_email: string
+  primary_email?: string | null
+  /**
+   * The contact's Phone Number ID. This must be a valid phone number.
+   */
+  phone_number_id?: string | null
+  /**
+   * The contact's External ID.
+   */
+  external_id?: string | null
+  /**
+   * The contact's Anonymous ID.
+   */
+  anonymous_id?: string | null
   /**
    *
    *   Additional fields to send to SendGrid. On the left-hand side, input the SendGrid Custom Fields Id. On the right-hand side, map the Segment field that contains the value.

--- a/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/index.ts
@@ -201,13 +201,55 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Email Address',
       description: `The contact's email address.`,
       type: 'string',
-      allowNull: false,
-      required: true,
+      allowNull: true,
+      required: false,
       default: {
         '@if': {
           exists: { '@path': '$.traits.email' },
           then: { '@path': '$.traits.email' },
           else: { '@path': '$.properties.email' }
+        }
+      }
+    },
+    phone_number_id: {
+      label: 'Phone Number ID',
+      description: `The contact's Phone Number ID. This must be a valid phone number.`,
+      type: 'string',
+      allowNull: true,
+      required: false,
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.phone_number_id' },
+          then: { '@path': '$.traits.phone_number_id' },
+          else: { '@path': '$.properties.phone_number_id' }
+        }
+      }
+    },
+    external_id: {
+      label: 'External ID',
+      description: `The contact's External ID.`,
+      type: 'string',
+      allowNull: true,
+      required: false,
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.external_id' },
+          then: { '@path': '$.traits.external_id' },
+          else: { '@path': '$.properties.external_id' }
+        }
+      }
+    },
+    anonymous_id: {
+      label: 'Anonymous ID ',
+      description: `The contact's Anonymous ID.`,
+      type: 'string',
+      allowNull: true,
+      required: false,
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.anonymous_id' },
+          then: { '@path': '$.traits.anonymous_id' },
+          else: { '@path': '$.properties.anonymous_id' }
         }
       }
     },

--- a/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/index.ts
@@ -245,7 +245,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       allowNull: true,
       required: false,
-      default: { '@path': '$.anonymous_id' }
+      default: { '@path': '$.anonymousId' }
     },
     customFields: customFields
   },

--- a/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/index.ts
@@ -219,9 +219,9 @@ const action: ActionDefinition<Settings, Payload> = {
       required: false,
       default: {
         '@if': {
-          exists: { '@path': '$.traits.phone_number_id' },
-          then: { '@path': '$.traits.phone_number_id' },
-          else: { '@path': '$.properties.phone_number_id' }
+          exists: { '@path': '$.traits.phone' },
+          then: { '@path': '$.traits.phone' },
+          else: { '@path': '$.properties.phone' }
         }
       }
     },
@@ -247,8 +247,8 @@ const action: ActionDefinition<Settings, Payload> = {
       required: false,
       default: {
         '@if': {
-          exists: { '@path': '$.traits.anonymous_id' },
-          then: { '@path': '$.traits.anonymous_id' },
+          exists: { '@path': '$.anonymous_id' },
+          then: { '@path': '$.anonymous_id' },
           else: { '@path': '$.properties.anonymous_id' }
         }
       }

--- a/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/index.ts
@@ -245,13 +245,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       allowNull: true,
       required: false,
-      default: {
-        '@if': {
-          exists: { '@path': '$.anonymous_id' },
-          then: { '@path': '$.anonymous_id' },
-          else: { '@path': '$.properties.anonymous_id' }
-        }
-      }
+      default: { '@path': '$.anonymous_id' }
     },
     customFields: customFields
   },


### PR DESCRIPTION
Sendgrid Marketinc Campaigns (MC) recently updated our contacts system to allow for more identifier fields. Previously we required `primary_email` for each contact as the unique identifier. With the recent rollout of multiple identifiers, we added the identifier fields `phone_number_id`, `external_id`, and `anonymous_id`. Link to our [API docs](https://www.twilio.com/docs/sendgrid/api-reference/contacts/add-or-update-a-contact#request-body) showing this change.

Now, only one of these four identifier fields is required to send a contact to Sendgrid MC. With this change, we also allow for the `primary_email` field to be null if one of the other three identifiers is included.

To accommodate for multiple identifiers in the MC action destination, I have made the following changes:

- Added the new identifier fields `phone_number_id`, `external_id`, and `anonymous_id`
- Made the `primary_email` field optional now
- Added a check to validate the destination payload contains at least one of the four identifier fields

## Testing

I tested this locally by sending sample events to my test MC account. I also added a few more test cases to our unit tests for this destionation.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
