### PR TITLE
Preventing double-hashing for TikTok Conversions.

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-conversions/__tests__/formatter.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/__tests__/formatter.test.ts
@@ -1,0 +1,43 @@
+import { formatEmails, formatPhones } from '../formatter'
+
+describe('Tiktok Conversions Formatter', () => {
+  describe('formatEmails', () => {
+    it('should hash and encode email addresses', () => {
+      const emails = ['bugsbunny@warnerbros.com', 'daffyduck@warnerbros.com']
+      const result = formatEmails(emails)
+      expect(result).toEqual([
+        '67e28cdcc3e845d3a4da05ca9fe5ddb7320a83b4cc2167f0555a3b04f63511e3',
+        '2d2fb2388f17f86affee71d632978425a3037fa8eed5b3f2baaa458c80d495ed'
+      ])
+    })
+
+    it('should not hash and encode already hashed email addresses', () => {
+      const emails = [
+        '67e28cdcc3e845d3a4da05ca9fe5ddb7320a83b4cc2167f0555a3b04f63511e3',
+        '2d2fb2388f17f86affee71d632978425a3037fa8eed5b3f2baaa458c80d495ed'
+      ]
+      const result = formatEmails(emails)
+      expect(result).toEqual(emails)
+    })
+  })
+
+  describe('formatPhones', () => {
+    it('should hash and encode phone numbers', () => {
+      const phones = ['12345678901234', '98765432109876']
+      const result = formatPhones(phones)
+      expect(result).toEqual([
+        '00a63bd0437d6ca0fa7b95c00ab2e7c020faa71440e5246750d6b517689e6777',
+        'ce7b12d132a021393e793d21d6e8e673ac06042922b73cc10f2d7db597657a4a'
+      ])
+    })
+
+    it('should not hash and encode already hashed phone numbers', () => {
+      const phones = [
+        'c17c025fb9ed44eae8a9d5c9df0312af5c6161bd79bd669692364fc5ecaf108a',
+        '5a1b78d720b151af8e69fde486784c1c279996813d20d23badbcce1e1037ee91'
+      ]
+      const result = formatPhones(phones)
+      expect(result).toEqual(phones)
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/tiktok-conversions/formatter.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/formatter.ts
@@ -1,5 +1,7 @@
 import { createHash } from 'crypto'
 
+const isHashedInformation = (information: string): boolean => new RegExp(/[0-9abcdef]{64}/gi).test(information)
+
 /**
  * Convert emails to lower case, and hash in SHA256.
  */
@@ -7,7 +9,14 @@ export const formatEmails = (email_addresses: string[] | undefined): string[] =>
   const result: string[] = []
   if (email_addresses) {
     email_addresses.forEach((email: string) => {
-      result.push(hashAndEncode(email.toLowerCase()))
+      let resolvedEmail
+      if (isHashedInformation(email)) {
+        resolvedEmail = email
+      } else {
+        resolvedEmail = hashAndEncode(email.toLowerCase())
+      }
+
+      result.push(resolvedEmail)
     })
   }
   return result
@@ -23,6 +32,11 @@ export const formatPhones = (phone_numbers: string[] | undefined): string[] => {
   if (!phone_numbers) return result
 
   phone_numbers.forEach((phone: string) => {
+    if (isHashedInformation(phone)) {
+      result.push(phone)
+      return
+    }
+
     const validatedPhone = phone.match(/[0-9]{0,14}/g)
     if (validatedPhone === null) {
       throw new Error(`${phone} is not a valid E.164 phone number.`)


### PR DESCRIPTION
It prevents double-hashing for email and phone when these traits are already hashed (SHA256).

## Testing

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
