### PR TITLE
Map full event context in Ripe Cloud Mode

### DIFF
--- a/packages/destination-actions/src/destinations/ripe/group/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/ripe/group/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -3,6 +3,9 @@
 exports[`Testing snapshot for Ripe's group destination action: all fields 1`] = `
 Object {
   "anonymousId": "DY&TUQqmpg2I",
+  "context": Object {
+    "testType": "DY&TUQqmpg2I",
+  },
   "groupId": "DY&TUQqmpg2I",
   "messageId": Any<String>,
   "timestamp": Any<String>,
@@ -16,6 +19,9 @@ Object {
 exports[`Testing snapshot for Ripe's group destination action: required fields 1`] = `
 Object {
   "anonymousId": "anonId1234",
+  "context": Object {
+    "ip": "1.2.3.4",
+  },
   "groupId": "DY&TUQqmpg2I",
   "messageId": Any<String>,
   "timestamp": Any<String>,

--- a/packages/destination-actions/src/destinations/ripe/group/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/ripe/group/__tests__/snapshot.test.ts
@@ -18,7 +18,10 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     nock(/.*/).persist().put(/.*/).reply(200)
 
     const event = createTestEvent({
-      properties: eventData
+      properties: eventData,
+      context: {
+        ip: '1.2.3.4'
+      }
     })
 
     const responses = await testDestination.testAction(actionSlug, {

--- a/packages/destination-actions/src/destinations/ripe/group/generated-types.ts
+++ b/packages/destination-actions/src/destinations/ripe/group/generated-types.ts
@@ -14,6 +14,12 @@ export interface Payload {
    */
   groupId: string
   /**
+   * Device context
+   */
+  context?: {
+    [k: string]: unknown
+  }
+  /**
    * Traits to associate with the group
    */
   traits?: {

--- a/packages/destination-actions/src/destinations/ripe/group/index.ts
+++ b/packages/destination-actions/src/destinations/ripe/group/index.ts
@@ -28,6 +28,13 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Group ID',
       default: { '@path': '$.groupId' }
     },
+    context: {
+      type: 'object',
+      label: 'Context',
+      description: 'Device context',
+      required: false,
+      default: { '@path': '$.context' }
+    },
     traits: {
       type: 'object',
       label: 'Traits',
@@ -60,7 +67,8 @@ const action: ActionDefinition<Settings, Payload> = {
         groupId: payload.groupId,
         traits: payload.traits,
         messageId: payload.messageId,
-        timestamp: payload.timestamp ?? new Date()
+        timestamp: payload.timestamp ?? new Date(),
+        context: payload.context
       }
     })
   }

--- a/packages/destination-actions/src/destinations/ripe/identify/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/ripe/identify/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Testing snapshot for Ripe's identify destination action: all fields 1`]
 Object {
   "anonymousId": "ojywl7GMKZU*opR%8",
   "context": Object {
-    "groupId": "ojywl7GMKZU*opR%8",
+    "testType": "ojywl7GMKZU*opR%8",
   },
   "messageId": Any<String>,
   "timestamp": Any<String>,
@@ -18,7 +18,9 @@ Object {
 exports[`Testing snapshot for Ripe's identify destination action: required fields 1`] = `
 Object {
   "anonymousId": "anonId1234",
-  "context": Object {},
+  "context": Object {
+    "ip": "1.2.3.4",
+  },
   "messageId": Any<String>,
   "timestamp": Any<String>,
   "traits": Object {},

--- a/packages/destination-actions/src/destinations/ripe/identify/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/ripe/identify/__tests__/snapshot.test.ts
@@ -18,7 +18,10 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     nock(/.*/).persist().put(/.*/).reply(200)
 
     const event = createTestEvent({
-      properties: eventData
+      properties: eventData,
+      context: {
+        ip: '1.2.3.4'
+      }
     })
 
     const responses = await testDestination.testAction(actionSlug, {

--- a/packages/destination-actions/src/destinations/ripe/identify/generated-types.ts
+++ b/packages/destination-actions/src/destinations/ripe/identify/generated-types.ts
@@ -10,9 +10,11 @@ export interface Payload {
    */
   userId?: string | null
   /**
-   * The group id
+   * Device context
    */
-  groupId?: string | null
+  context?: {
+    [k: string]: unknown
+  }
   /**
    * Traits to associate with the user
    */

--- a/packages/destination-actions/src/destinations/ripe/identify/index.ts
+++ b/packages/destination-actions/src/destinations/ripe/identify/index.ts
@@ -21,12 +21,12 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'User ID',
       default: { '@path': '$.userId' }
     },
-    groupId: {
-      type: 'string',
-      allowNull: true,
-      description: 'The group id',
-      label: 'Group ID',
-      default: { '@path': '$.context.groupId' }
+    context: {
+      type: 'object',
+      label: 'Context',
+      description: 'Device context',
+      required: false,
+      default: { '@path': '$.context' }
     },
     traits: {
       type: 'object',
@@ -57,9 +57,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         anonymousId: payload.anonymousId,
         userId: payload.userId,
-        context: {
-          groupId: payload.groupId
-        },
+        context: payload.context,
         traits: payload.traits,
         messageId: payload.messageId,
         timestamp: payload.timestamp ?? new Date()

--- a/packages/destination-actions/src/destinations/ripe/page/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/ripe/page/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,7 +4,6 @@ exports[`Testing snapshot for Ripe's page destination action: all fields 1`] = `
 Object {
   "anonymousId": "Gm^2vj@raF9m",
   "context": Object {
-    "groupId": "Gm^2vj@raF9m",
     "page": Object {
       "path": "Gm^2vj@raF9m",
       "referrer": "Gm^2vj@raF9m",
@@ -12,6 +11,7 @@ Object {
       "title": "Gm^2vj@raF9m",
       "url": "http://fujav.cx/ef",
     },
+    "testType": "Gm^2vj@raF9m",
   },
   "messageId": Any<String>,
   "name": "Gm^2vj@raF9m",

--- a/packages/destination-actions/src/destinations/ripe/page/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/ripe/page/__tests__/snapshot.test.ts
@@ -18,7 +18,14 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     nock(/.*/).persist().put(/.*/).reply(200)
 
     const event = createTestEvent({
-      properties: eventData
+      properties: eventData,
+      context: {
+        page: {
+          path: '/academy/',
+          title: 'Analytics Academy',
+          url: 'https://segment.com/academy/'
+        }
+      }
     })
 
     const responses = await testDestination.testAction(actionSlug, {

--- a/packages/destination-actions/src/destinations/ripe/page/generated-types.ts
+++ b/packages/destination-actions/src/destinations/ripe/page/generated-types.ts
@@ -10,9 +10,11 @@ export interface Payload {
    */
   userId?: string | null
   /**
-   * The group id
+   * Device context
    */
-  groupId?: string | null
+  context?: {
+    [k: string]: unknown
+  }
   /**
    * Page properties
    */

--- a/packages/destination-actions/src/destinations/ripe/page/index.ts
+++ b/packages/destination-actions/src/destinations/ripe/page/index.ts
@@ -21,12 +21,12 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'User ID',
       default: { '@path': '$.userId' }
     },
-    groupId: {
-      type: 'string',
-      allowNull: true,
-      description: 'The group id',
-      label: 'Group ID',
-      default: { '@path': '$.context.groupId' }
+    context: {
+      type: 'object',
+      label: 'Context',
+      description: 'Device context',
+      required: false,
+      default: { '@path': '$.context' }
     },
     properties: {
       type: 'object',
@@ -133,7 +133,7 @@ const action: ActionDefinition<Settings, Payload> = {
         anonymousId: payload.anonymousId,
         userId: payload.userId,
         context: {
-          groupId: payload.groupId,
+          ...payload.context,
           page: {
             url: payload.url,
             path: payload.path,

--- a/packages/destination-actions/src/destinations/ripe/track/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/ripe/track/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Testing snapshot for Ripe's track destination action: all fields 1`] = 
 Object {
   "anonymousId": "f6t8rQsKdU^N",
   "context": Object {
-    "groupId": "f6t8rQsKdU^N",
+    "testType": "f6t8rQsKdU^N",
   },
   "event": "f6t8rQsKdU^N",
   "messageId": Any<String>,
@@ -20,7 +20,9 @@ Object {
 exports[`Testing snapshot for Ripe's track destination action: required fields 1`] = `
 Object {
   "anonymousId": "anonId1234",
-  "context": Object {},
+  "context": Object {
+    "ip": "1.2.3.4",
+  },
   "event": "f6t8rQsKdU^N",
   "messageId": Any<String>,
   "name": "f6t8rQsKdU^N",

--- a/packages/destination-actions/src/destinations/ripe/track/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/ripe/track/__tests__/snapshot.test.ts
@@ -18,7 +18,10 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     nock(/.*/).persist().put(/.*/).reply(200)
 
     const event = createTestEvent({
-      properties: eventData
+      properties: eventData,
+      context: {
+        ip: '1.2.3.4'
+      }
     })
 
     const responses = await testDestination.testAction(actionSlug, {

--- a/packages/destination-actions/src/destinations/ripe/track/generated-types.ts
+++ b/packages/destination-actions/src/destinations/ripe/track/generated-types.ts
@@ -10,13 +10,15 @@ export interface Payload {
    */
   userId?: string
   /**
-   * The group id
-   */
-  groupId?: string
-  /**
    * The event name
    */
   event: string
+  /**
+   * Device context
+   */
+  context?: {
+    [k: string]: unknown
+  }
   /**
    * Properties to send with the event
    */

--- a/packages/destination-actions/src/destinations/ripe/track/index.ts
+++ b/packages/destination-actions/src/destinations/ripe/track/index.ts
@@ -21,19 +21,19 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'User ID',
       default: { '@path': '$.userId' }
     },
-    groupId: {
-      type: 'string',
-      required: false,
-      description: 'The group id',
-      label: 'Group ID',
-      default: { '@path': '$.context.groupId' }
-    },
     event: {
       type: 'string',
       required: true,
       description: 'The event name',
       label: 'Event Name',
       default: { '@path': '$.event' }
+    },
+    context: {
+      type: 'object',
+      label: 'Context',
+      description: 'Device context',
+      required: false,
+      default: { '@path': '$.context' }
     },
     properties: {
       type: 'object',
@@ -65,9 +65,7 @@ const action: ActionDefinition<Settings, Payload> = {
         name: payload.event,
         anonymousId: payload.anonymousId,
         userId: payload.userId,
-        context: {
-          groupId: payload.groupId
-        },
+        context: payload.context,
         properties: payload.properties,
         event: payload.event,
         messageId: payload.messageId,


### PR DESCRIPTION
Mapping of the full event context in the Ripe Cloud Mode destination.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
