### PR TITLE
Bucket destination: trackingKey -> publishableKey

### DIFF
--- a/packages/browser-destinations/destinations/bucket/src/index.ts
+++ b/packages/browser-destinations/destinations/bucket/src/index.ts
@@ -45,9 +45,10 @@ export const destination: BrowserDestinationDefinition<Settings, Bucket> = {
   ],
 
   settings: {
+    // kept as the legacy `trackingKey` here to avoid needing to migrate installed plugins
     trackingKey: {
-      description: 'Your Bucket App tracking key, found on the tracking page.',
-      label: 'Tracking Key',
+      description: 'The publishable key for your Bucket environment, found on the tracking page on app.bucket.co.',
+      label: 'Publishable Key',
       type: 'string',
       required: true
     }


### PR DESCRIPTION
At Bucket we're changing the terminology around keys from `tracking key` to `publishable key`. I've avoided updating the internals to reflect the terminology change to avoid needing to migrate the existing install base. That means changes in this PR are purely cosmetical.