### PR TITLE
add new excludeWhenNull directive and update tests

### DIFF
--- a/packages/core/src/__tests__/remove-empty-values.test.ts
+++ b/packages/core/src/__tests__/remove-empty-values.test.ts
@@ -185,4 +185,60 @@ describe(removeEmptyValues.name, () => {
       }
     })
   })
+
+  it('null values with different schema types', () => {
+    const input = {
+      product: {
+        product_id: null, // string that doesn't allow null
+        name: null, // string that allows null
+        address: null, // object that doesn't allow null
+        traits: null, // object that allow null
+        age: null, // number that doesn't allow null
+        accountsCount: null, // integer that allows null
+        isPremium: null, // boolean that doesn't allow null
+        hasSubscription: null, // boolean that allows null
+        location: null, // no explicit type specified
+        nested: {
+          foo: null,
+          bar: ''
+        }
+      }
+    }
+
+    const schema: JSONSchema4 = {
+      type: 'object',
+      properties: {
+        product: {
+          type: 'object',
+          properties: {
+            product_id: { type: 'string' },
+            name: { type: ['null', 'string'] },
+            address: { type: 'object' },
+            traits: { type: ['null', 'object'] },
+            age: { type: 'number' },
+            accountsCount: { type: ['null', 'integer'] },
+            isPremium: { type: 'boolean' },
+            hasSubscription: { type: ['null', 'boolean'] },
+            nested: {
+              type: 'object'
+            }
+          }
+        }
+      }
+    }
+
+    expect(removeEmptyValues(input, schema, true)).toEqual({
+      product: {
+        name: null,
+        traits: null,
+        location: null,
+        accountsCount: null,
+        hasSubscription: null,
+        nested: {
+          foo: null,
+          bar: ''
+        }
+      }
+    })
+  })
 })

--- a/packages/core/src/mapping-kit/README.md
+++ b/packages/core/src/mapping-kit/README.md
@@ -67,6 +67,7 @@ Output:
   - [@replace](#replace)
   - [@merge](#merge)
   - [@transform](#transform)
+  - [@excludeWhenNull](#excludewhennull)
 
 <!-- tocstop -->
 
@@ -685,5 +686,37 @@ Mappings:
 =>
 {
   "newValue": 1
+}
+```
+
+### @excludeWhenNull
+
+The @excludeWhenNull directive will exclude the field from the output if the resolved value is `null`.
+
+```json
+Input:
+
+{
+  "a": null,
+  "b": "hello"
+}
+
+Mappings:
+
+{
+  "a": {
+    "@excludeWhenNull": {
+      "@path": "$.a"
+    }
+  },
+  "b": {
+    "@excludeWhenNull": {
+      "@path": "$.b"
+    }
+  }
+}
+=>
+{
+  "b": "hello"
 }
 ```

--- a/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
@@ -648,6 +648,22 @@ describe('@replace', () => {
     )
     expect(output).toStrictEqual('')
   })
+  test('replace on null string', () => {
+    const payload = {
+      a: null
+    }
+    const output = transform(
+      {
+        '@replace': {
+          pattern: '_',
+          replacement: 'rrrrr',
+          value: { '@path': '$.a' }
+        }
+      },
+      payload
+    )
+    expect(output).toStrictEqual(null)
+  })
   test('replace on case sensitive string', () => {
     const payload = {
       a: 'cWWl-story-ww'
@@ -1033,6 +1049,119 @@ describe('@transform', () => {
         nested_b: 2
       },
       topLevel: 'special'
+    })
+  })
+})
+
+describe('@excludeWhenNull', () => {
+  test('simple', () => {
+    const output = transform(
+      { someFieldToExclude: { '@excludeWhenNull': { '@path': '$.foo.bar' } } },
+      { foo: { bar: null, aces: { a: 1, b: 2 } } }
+    )
+    expect(output).toStrictEqual({})
+  })
+
+  test('simple with multiple mappings', () => {
+    const output = transform(
+      {
+        someFieldToExclude: { '@excludeWhenNull': { '@path': '$.foo.bar' } },
+        anotherField: { '@path': '$.foo.aces.a' }
+      },
+      { foo: { bar: null, aces: { a: 1, b: 2 } } }
+    )
+    expect(output).toStrictEqual({ anotherField: 1 })
+  })
+
+  test('dont exclude individual null fields in object when applied at object level', () => {
+    const output = transform(
+      { neat: { '@excludeWhenNull': { '@path': '$.foo' } } },
+      { foo: { bar: null, aces: { a: 1, b: 2 } } }
+    )
+    expect(output).toStrictEqual({ neat: { bar: null, aces: { a: 1, b: 2 } } })
+  })
+
+  test('exclude when resolved value is null using transform', () => {
+    const output = transform(
+      {
+        empty: {
+          '@transform': {
+            apply: {
+              properties: {
+                '@excludeWhenNull': { '@path': '$.properties' }
+              }
+            },
+            mapping: {
+              properties: { '@path': '$.properties' },
+              topLevel: { '@path': '$.properties.nested_a' }
+            }
+          }
+        }
+      },
+      { foo: { bar: null, aces: { a: 1, b: 2 } } }
+    )
+    expect(output).toStrictEqual({ empty: {} })
+  })
+
+  test('composed with other directives', () => {
+    // Note: doesnt make sense to test with
+    // - transform: always returns non-null json object
+    // - merge: always returns non-null json object
+    // - flatten: always returns non-null json object
+    // - arrayPath: always returns non-null json array
+    const output = transform(
+      {
+        massive: {
+          pathNull: { '@excludeWhenNull': { '@path': '$.foo.bar' } },
+          templateEmpty: { '@excludeWhenNull': { '@template': '{{foo.bar}}' } },
+          literalNull: { '@excludeWhenNull': { '@literal': null } },
+          ifNull: { '@excludeWhenNull': { '@if': { exists: { '@path': '$.foo.foobar' }, then: 1, else: null } } },
+          caseNull: { '@excludeWhenNull': { '@case': { operator: 'upper', value: { '@path': '$.foo.bar' } } } },
+          replaceNull: {
+            '@excludeWhenNull': { '@replace': { pattern: '-', replacement: 'nice', value: { '@path': '$.foo.bar' } } }
+          },
+          jsonNull: { '@excludeWhenNull': { '@json': { mode: 'decode', value: { '@path': '$.foo.bar' } } } },
+          transformNull: {
+            '@excludeWhenNull': {
+              '@transform': {
+                apply: { properties: { '@path': '$.foo.bar' } },
+                mapping: { properties: { '@excludeWhenNull': { '@path': '$.properties' } } }
+              }
+            }
+          },
+          transformNull2: {
+            '@excludeWhenNull': {
+              '@transform': {
+                apply: { properties: { '@excludeWhenNull': { '@path': '$.foo.bar' } } },
+                mapping: { properties: { '@path': '$.properties' } }
+              }
+            }
+          },
+          // These are essentially no-ops bcos they always return non-null objects but good to exercise explicitly
+          jsonNullEncode: { '@excludeWhenNull': { '@json': { mode: 'encode', value: { '@path': '$.foo.bar' } } } },
+          transformValue: {
+            '@excludeWhenNull': {
+              '@transform': {
+                apply: { properties: { '@path': '$.foo.bar' } },
+                mapping: { properties: { '@path': '$.properties' } }
+              }
+            }
+          }
+        }
+      },
+      { foo: { bar: null, aces: { a: 1, b: 2 } } }
+    )
+    expect(output).toStrictEqual({
+      massive: {
+        templateEmpty: '',
+        jsonNullEncode: 'null',
+        replaceNull: '', // TODO possible that this is a bug in the replace directive and should return null and get excluded instead
+        transformNull: {},
+        transformNull2: {},
+        transformValue: {
+          properties: null
+        }
+      }
     })
   })
 })

--- a/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
@@ -662,7 +662,7 @@ describe('@replace', () => {
       },
       payload
     )
-    expect(output).toStrictEqual(null)
+    expect(output).toStrictEqual('')
   })
   test('replace on case sensitive string', () => {
     const payload = {

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -314,6 +314,15 @@ registerDirective('@transform', (opts, payload) => {
   return resolve(opts.mapping, newPayload)
 })
 
+registerDirective('@excludeWhenNull', (value, payload) => {
+  const resolved = resolve(value, payload)
+  if (resolved === null) {
+    // assign undefined to the key which will get deleted at the end of all mappings
+    return undefined
+  }
+  return resolved
+})
+
 function getMappingToProcess(mapping: JSONLikeObject): JSONLikeObject {
   let mappingToProcess = { ...mapping }
   // If we have a root mapping, inject all other mappings into the `mapping` object on that root directive

--- a/packages/core/src/mapping-kit/validate.ts
+++ b/packages/core/src/mapping-kit/validate.ts
@@ -367,6 +367,10 @@ directive('@transform', (v, stack) => {
   )
 })
 
+directive('@excludeWhenNull', (v, stack) => {
+  validateDirectiveOrRaw(v, stack)
+})
+
 function indefiniteArticle(s: string): string {
   switch (s.charAt(0)) {
     case 'a':


### PR DESCRIPTION
This PR adds a new `excludeWhenNull` directive. This directive can be used to filter out null values for certain mappings once fully evaluated.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
