### PR TITLE
STRATCONN-3173: Add dropdown to region setting

### DIFF
--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/index.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/index.ts
@@ -77,7 +77,12 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       label: 'Region',
       description:
         'The geographical region of the CRM data segment based on the origin of PII. Can be US (United States and Canada), EU (European Union and the UK), or APAC (Asia-Pacific)',
-      required: true
+      required: true,
+      choices: [
+        { label: 'US', value: 'US' },
+        { label: 'EU', value: 'EU' },
+        { label: 'APAC', value: 'APAC' }
+      ]
     }
   },
   audienceConfig: {


### PR DESCRIPTION
Making region setting in The Trade Desk Destination a dropdown so it is easier for customers to configure.

## Testing
![Screenshot 2024-05-20 at 11 27 45 AM](https://github.com/segmentio/action-destinations/assets/99763167/c28a45da-d512-4518-ab2c-552e48c55eeb)

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
