### PR TITLE
Add override_list_id mapping in upsert Profile

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/functions.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/functions.ts
@@ -113,7 +113,7 @@ export const createImportJobPayload = (profiles: Payload[], listId?: string): { 
     type: 'profile-bulk-import-job',
     attributes: {
       profiles: {
-        data: profiles.map(({ list_id, enable_batching, batch_size, ...attributes }) => ({
+        data: profiles.map(({ list_id, enable_batching, batch_size, override_list_id, ...attributes }) => ({
           type: 'profile',
           attributes
         }))

--- a/packages/destination-actions/src/destinations/klaviyo/types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/types.ts
@@ -1,4 +1,5 @@
 import { HTTPError } from '@segment/actions-core'
+import { Payload } from './upsertProfile/generated-types'
 export class KlaviyoAPIError extends HTTPError {
   response: Response & {
     data: {
@@ -204,4 +205,8 @@ export interface UnsubscribeEventData {
       }
     }
   }
+}
+
+export interface GroupedProfiles {
+  [listId: string]: Payload[]
 }

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/__tests__/index.test.ts
@@ -3,12 +3,13 @@ import { IntegrationError, createTestEvent, createTestIntegration } from '@segme
 import Definition from '../../index'
 import { API_URL } from '../../config'
 import * as Functions from '../../functions'
+import { Settings } from '../../generated-types'
 
 const testDestination = createTestIntegration(Definition)
 
 const apiKey = 'fake-api-key'
 
-export const settings = {
+export const settings: Settings = {
   api_key: apiKey
 }
 
@@ -262,6 +263,53 @@ describe('Upsert Profile', () => {
 
     expect(Functions.addProfileToList).toHaveBeenCalledWith(expect.anything(), profileId, listId)
   })
+
+  it('should proritize using override_list_id if it is provided in event', async () => {
+    const profileId = '123'
+    const mapping = { list_id: 'abc123', override_list_id: '321bca' }
+
+    const requestBody = {
+      data: {
+        type: 'profile',
+        attributes: {
+          email: 'test@example.com',
+          first_name: 'John',
+          last_name: 'Doe',
+          location: {},
+          properties: {}
+        }
+      }
+    }
+
+    nock(`${API_URL}`)
+      .post('/profiles/', requestBody)
+      .reply(
+        200,
+        JSON.stringify({
+          data: {
+            id: profileId
+          }
+        })
+      )
+
+    nock(`${API_URL}`).post(`/lists/${mapping.override_list_id}/relationships/profiles/`).reply(200)
+
+    const event = createTestEvent({
+      type: 'track',
+      userId: '123',
+      traits: {
+        email: 'test@example.com',
+        firstName: 'John',
+        lastName: 'Doe'
+      }
+    })
+
+    await expect(
+      testDestination.testAction('upsertProfile', { event, mapping, settings, useDefaultMappings: true })
+    ).resolves.not.toThrowError()
+
+    expect(Functions.addProfileToList).toHaveBeenCalledWith(expect.anything(), profileId, mapping.override_list_id)
+  })
 })
 
 describe('Upsert Profile Batch', () => {
@@ -366,5 +414,21 @@ describe('Upsert Profile Batch', () => {
         useDefaultMappings: true
       })
     ).rejects.toThrow()
+  })
+
+  it('should group profiles by list_id correctly', () => {
+    const profiles = [
+      { email: 'profile1@example.com', list_id: 'listA', override_list_id: 'overridelistA' },
+      { email: 'profile2@example.com', list_id: 'listB' },
+      { email: 'profile3@example.com', list_id: 'listA' },
+      { email: 'profile4@example.com', override_list_id: 'overridelistA' }
+    ]
+
+    const grouped = Functions.groupByListId(profiles)
+
+    expect(Object.keys(grouped)).toEqual(['overridelistA', 'listB', 'listA'])
+    expect(grouped['listA']).toHaveLength(1)
+    expect(grouped['listB']).toHaveLength(1)
+    expect(grouped['overridelistA']).toHaveLength(2)
   })
 })

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/generated-types.ts
@@ -64,4 +64,8 @@ export interface Payload {
    * Maximum number of events to include in each batch. Actual batch sizes may be lower.
    */
   batch_size?: number
+  /**
+   * Klaviyo list ID to override the default list ID when provided in an event payload. Added to support backward compatibility with klaviyo(classic) and facilitate a seamless migration.
+   */
+  override_list_id?: string
 }

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
@@ -227,7 +227,7 @@ const action: ActionDefinition<Settings, Payload> = {
     payload = payload.filter((profile) => profile.email || profile.external_id || profile.phone_number)
 
     const profilesWithList = payload.filter((profile) => profile.list_id || profile.override_list_id)
-    const profilesWithoutList = payload.filter((profile) => !profile.list_id)
+    const profilesWithoutList = payload.filter((profile) => !profile.list_id && !profile.override_list_id)
 
     let importResponseWithList
     let importResponseWithoutList

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
@@ -226,8 +226,16 @@ const action: ActionDefinition<Settings, Payload> = {
   performBatch: async (request, { payload }) => {
     payload = payload.filter((profile) => profile.email || profile.external_id || profile.phone_number)
 
-    const profilesWithList = payload.filter((profile) => profile.list_id || profile.override_list_id)
-    const profilesWithoutList = payload.filter((profile) => !profile.list_id && !profile.override_list_id)
+    const profilesWithList: Payload[] = []
+    const profilesWithoutList: Payload[] = []
+
+    payload.forEach((profile) => {
+      if (profile.list_id || profile.override_list_id) {
+        profilesWithList.push(profile)
+      } else {
+        profilesWithoutList.push(profile)
+      }
+    })
 
     let importResponseWithList
     let importResponseWithoutList


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Add a hidden mapping in `upsertProfile` to support Klaviyo (classic) to Klaviyo actions migration.
Klaviyo (classic) has `list_id` in settings which can be overridden by manually using code in `integrations.Klaviyo.listId`.
More Info: https://segment.com/docs/connections/destinations/catalog/klaviyo/#adding-users-to-a-list

JIRA -> [STRATCONN-3819](https://segment.atlassian.net/browse/STRATCONN-3819)

## Testing

#### Stage Testing
**Mapping**
<img width="1465" alt="Screenshot 2024-05-21 at 6 10 43 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/d51050a9-ce87-4aa1-9b24-0dd8a8578512">

**Analytics JS call**
<img width="384" alt="Screenshot 2024-05-21 at 6 10 59 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/7b1197b9-9838-4fcc-bc51-df52bc0a9243">


**Klaviyo List**
<img width="658" alt="Screenshot 2024-05-21 at 6 11 11 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/cf94e308-91e3-4d50-bd26-4501243b56ef">

#### Test with multiple list Ids
<img width="304" alt="Screenshot 2024-05-24 at 5 47 40 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/a6a1c976-c3df-496f-a6c0-bcb305b74a0a">

**Default List**
<img width="1624" alt="Screenshot 2024-05-24 at 5 48 10 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/382b0fa8-cbda-4c59-9ec4-5addb42b4acb">

**List ID: xby8qm**
<img width="1624" alt="Screenshot 2024-05-24 at 5 48 22 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/c13caba0-2580-4684-88b5-7e54dbf1e49f">

**List ID: rpy4jc**
<img width="1600" alt="Screenshot 2024-05-24 at 5 48 53 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/7c455b88-f094-4b16-8778-f0a654ba146c">



_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment


[STRATCONN-3819]: https://segment.atlassian.net/browse/STRATCONN-3819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ