### PR TITLE
Adding a few more fields to the AppFit destination

### DIFF
--- a/packages/destination-actions/src/destinations/app-fit/track/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/app-fit/track/__tests__/index.test.ts
@@ -33,7 +33,7 @@ describe('AppFit.track', () => {
     expect(responses[0].status).toBe(200)
     expect(responses[0].data).toMatchObject({})
     expect(responses[0].options.body).toBe(
-      `{"eventSource":"segment","occurredAt":"${timestamp}","payload":{"eventId":"12345","userId":"userId1","anonymousId":"anonId1234","name":"Test Event","properties":{"foo":"bar"},"deviceId":"device1234","deviceType":"ios","deviceManufacturer":"Apple","deviceModel":"iPhone7,2","osName":"iPhone OS","osVersion":"10.1","appVersion":"1.0.0","ipAddress":"8.8.8.8"}}`
+      `{"eventSource":"segment","occurredAt":"${timestamp}","ipAddress":"8.8.8.8","payload":{"eventId":"12345","userId":"userId1","anonymousId":"anonId1234","name":"Test Event","properties":{"foo":"bar"},"deviceId":"device1234","deviceType":"ios","deviceManufacturer":"Apple","deviceModel":"iPhone7,2","osName":"iPhone OS","osVersion":"10.1","appVersion":"1.0.0"}}`
     )
   })
 })

--- a/packages/destination-actions/src/destinations/app-fit/track/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/app-fit/track/__tests__/index.test.ts
@@ -13,7 +13,12 @@ describe('AppFit.track', () => {
       messageId: '12345',
       userId: 'userId1',
       timestamp,
-      context: { device: { id: 'device1234', type: 'ios' }, os: { name: 'iPhone OS' } },
+      context: {
+        ip: '8.8.8.8',
+        app: { version: '1.0.0' },
+        device: { id: 'device1234', type: 'ios', model: 'iPhone7,2', manufacturer: 'Apple' },
+        os: { name: 'iPhone OS', version: '10.1' }
+      },
       properties: { foo: 'bar' }
     })
 
@@ -28,7 +33,7 @@ describe('AppFit.track', () => {
     expect(responses[0].status).toBe(200)
     expect(responses[0].data).toMatchObject({})
     expect(responses[0].options.body).toBe(
-      `{"eventSource":"segment","occurredAt":"${timestamp}","payload":{"eventId":"12345","userId":"userId1","anonymousId":"anonId1234","name":"Test Event","properties":{"foo":"bar"},"deviceId":"device1234","deviceType":"ios","osName":"iPhone OS"}}`
+      `{"eventSource":"segment","occurredAt":"${timestamp}","payload":{"eventId":"12345","userId":"userId1","anonymousId":"anonId1234","name":"Test Event","properties":{"foo":"bar"},"deviceId":"device1234","deviceType":"ios","deviceManufacturer":"Apple","deviceModel":"iPhone7,2","osName":"iPhone OS","osVersion":"10.1","appVersion":"1.0.0","ipAddress":"8.8.8.8"}}`
     )
   })
 })

--- a/packages/destination-actions/src/destinations/app-fit/track/generated-types.ts
+++ b/packages/destination-actions/src/destinations/app-fit/track/generated-types.ts
@@ -24,6 +24,10 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
+   * The app version
+   */
+  appVersion?: string
+  /**
    * The device ID of the user
    */
   deviceId?: string
@@ -32,9 +36,25 @@ export interface Payload {
    */
   deviceType?: string
   /**
+   * The device manufacturer
+   */
+  deviceManufacturer?: string
+  /**
+   * The device model
+   */
+  deviceModel?: string
+  /**
+   * The IP address of the client
+   */
+  ipAddress?: string
+  /**
    * The name of the operating system
    */
   osName?: string
+  /**
+   * The version of the operating system
+   */
+  osVersion?: string
   /**
    * The event ID
    */

--- a/packages/destination-actions/src/destinations/app-fit/track/index.ts
+++ b/packages/destination-actions/src/destinations/app-fit/track/index.ts
@@ -49,6 +49,14 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.properties'
       }
     },
+    appVersion: {
+      label: 'App Version',
+      description: 'The app version',
+      type: 'string',
+      default: {
+        '@path': '$.context.app.version'
+      }
+    },
     deviceId: {
       label: 'Device ID',
       description: 'The device ID of the user',
@@ -65,12 +73,44 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.context.device.type'
       }
     },
+    deviceManufacturer: {
+      label: 'Device Manufacturer',
+      description: 'The device manufacturer',
+      type: 'string',
+      default: {
+        '@path': '$.context.device.manufacturer'
+      }
+    },
+    deviceModel: {
+      label: 'Device Model',
+      description: 'The device model',
+      type: 'string',
+      default: {
+        '@path': '$.context.device.model'
+      }
+    },
+    ipAddress: {
+      label: 'IP Address',
+      description: 'The IP address of the client',
+      type: 'string',
+      default: {
+        '@path': '$.context.ip'
+      }
+    },
     osName: {
       label: 'OS Name',
       description: 'The name of the operating system',
       type: 'string',
       default: {
         '@path': '$.context.os.name'
+      }
+    },
+    osVersion: {
+      label: 'OS Version',
+      description: 'The version of the operating system',
+      type: 'string',
+      default: {
+        '@path': '$.context.os.version'
       }
     },
     eventId: {
@@ -99,7 +139,12 @@ const action: ActionDefinition<Settings, Payload> = {
           properties: payload.properties,
           deviceId: payload.deviceId,
           deviceType: payload.deviceType,
-          osName: payload.osName
+          deviceManufacturer: payload.deviceManufacturer,
+          deviceModel: payload.deviceModel,
+          osName: payload.osName,
+          osVersion: payload.osVersion,
+          appVersion: payload.appVersion,
+          ipAddress: payload.ipAddress
         }
       }
     })

--- a/packages/destination-actions/src/destinations/app-fit/track/index.ts
+++ b/packages/destination-actions/src/destinations/app-fit/track/index.ts
@@ -131,6 +131,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         eventSource: 'segment',
         occurredAt: payload.occurredAt,
+        ipAddress: payload.ipAddress,
         payload: {
           eventId: payload.eventId,
           userId: payload.userId,
@@ -143,8 +144,7 @@ const action: ActionDefinition<Settings, Payload> = {
           deviceModel: payload.deviceModel,
           osName: payload.osName,
           osVersion: payload.osVersion,
-          appVersion: payload.appVersion,
-          ipAddress: payload.ipAddress
+          appVersion: payload.appVersion
         }
       }
     })


### PR DESCRIPTION
We needed to send a few other fields from the context to make our app more robust.

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
