### PR TITLE
Fix customer.io timestamp issue

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/__tests__/trackEvent.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/trackEvent.test.ts
@@ -172,7 +172,7 @@ describe('CustomerIO', () => {
             ...attributes,
             anonymous_id: event.anonymousId
           },
-          timestamp,
+          timestamp: dayjs.utc(timestamp).unix(),
           type: 'person'
         })
       })
@@ -208,7 +208,7 @@ describe('CustomerIO', () => {
         })
       })
 
-      it.only('should succeed with mapping of preset and Journeys Step Transition event(presets)', async () => {
+      it('should succeed with mapping of preset and Journeys Step Transition event(presets)', async () => {
         const userId = 'abc123'
         const name = 'testEvent'
         const data = {
@@ -268,7 +268,7 @@ describe('CustomerIO', () => {
             ...data,
             anonymous_id: event.anonymousId
           },
-          timestamp,
+          timestamp: dayjs.utc(timestamp).unix(),
           type: 'person'
         })
       })

--- a/packages/destination-actions/src/destinations/customerio/__tests__/trackPageView.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/trackPageView.test.ts
@@ -202,7 +202,7 @@ describe('CustomerIO', () => {
           identifiers: {
             id: userId
           },
-          timestamp
+          timestamp: dayjs.utc(timestamp).unix()
         })
       })
     })

--- a/packages/destination-actions/src/destinations/customerio/__tests__/trackScreenView.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/trackScreenView.test.ts
@@ -223,7 +223,7 @@ describe('CustomerIO', () => {
           identifiers: {
             id: userId
           },
-          timestamp
+          timestamp: dayjs.utc(timestamp).unix()
         })
       })
     })

--- a/packages/destination-actions/src/destinations/customerio/utils.ts
+++ b/packages/destination-actions/src/destinations/customerio/utils.ts
@@ -115,14 +115,20 @@ type BasePayload = {
   person_id?: string
   primary?: Identifiers
   secondary?: Identifiers
+  timestamp?: string | number
 }
 
 export const buildPayload = <Payload extends BasePayload>({ action, type, payload }: RequestPayload<Payload>) => {
-  const { convert_timestamp, person_id, anonymous_id, email, object_id, object_type_id, ...data } = payload
+  const { convert_timestamp, person_id, anonymous_id, email, object_id, object_type_id, timestamp, ...data } = payload
   let rest = data
 
   if ('convert_timestamp' in payload && convert_timestamp !== false) {
     rest = convertAttributeTimestamps(rest)
+  }
+
+  // Customer.io only accepts timestamps in unix format so it must always be converted regardless of the `convert_timestamp` setting.
+  if ('timestamp' in payload && timestamp) {
+    rest = { ...rest, timestamp: convertValidTimestamp(timestamp) }
   }
 
   const body: {


### PR DESCRIPTION
PR #1800 introduced a small regression. If users set `convert_timestamp` to false, then the `timestamp` field would not be converted which is actually not support by the Customer.io API. The API only accepts unix timestamps on the root `timestamp` field.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
