### PR TITLE
Change StackAdapt destination name

### DIFF
--- a/packages/destination-actions/src/destinations/stackadapt/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/index.ts
@@ -5,7 +5,7 @@ import { defaultValues } from '@segment/actions-core'
 import forwardEvent from './forwardEvent'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'StackAdapt Cloud (Actions)',
+  name: 'StackAdapt (Actions)',
   slug: 'actions-stackadapt-cloud',
   mode: 'cloud',
   description:


### PR DESCRIPTION
Changing name of the StackAdapt destination based on feedback from the StackAdapt marketing team.

## Testing

N/A

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
