### PR TITLE
Implement batch support for Attio Actions

### DIFF
--- a/packages/destination-actions/src/destinations/attio/api/index.ts
+++ b/packages/destination-actions/src/destinations/attio/api/index.ts
@@ -3,6 +3,17 @@ import { ModifiedResponse } from '@segment/actions-core'
 import get from 'lodash/get'
 import sortBy from 'lodash/sortBy'
 
+export type SimpleValue = string | number | boolean
+
+type BatchAssertion = {
+  object: string
+  mode: 'create-or-update'
+  matching_attribute: string
+  multiselect_values: 'append'
+  values: Record<string, null | SimpleValue | Array<SimpleValue> | BatchAssertion | Array<BatchAssertion>>
+  received_at: string
+}
+
 export type AssertResponse = {
   data: {
     id: {
@@ -57,6 +68,26 @@ export class AttioClient {
         ...requestOptions
       }
     )
+  }
+
+  /**
+   * Send a series of (nested) assertions in a single HTTP call
+   *
+   * @param assertions One or more assertions to apply
+   * @param requestOptions Additional options for the request
+   */
+  async batchAssert({
+    assertions,
+    requestOptions
+  }: {
+    assertions: Array<BatchAssertion>
+    requestOptions?: Partial<RequestOptions>
+  }): Promise<ModifiedResponse<AssertResponse>> {
+    return await this.request(`${this.api_url}/v2/batch/records`, {
+      method: 'put',
+      json: { assertions },
+      ...requestOptions
+    })
   }
 
   /**

--- a/packages/destination-actions/src/destinations/attio/assertRecord/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/attio/assertRecord/__tests__/index.test.ts
@@ -141,4 +141,30 @@ describe('Attio.assertRecord', () => {
 
     expect(response.status).toBe(202)
   })
+
+  it('handles the case where receivedAt is not provided', async () => {
+    const lackingReceivedAtEvent = createTestEvent({
+      type: 'track' as const,
+      traits: {
+        name: 'Stair car',
+        number_of_wheels: 4
+      },
+      receivedAt: undefined
+    })
+
+    // Can't control the exact timestamp, so only check it starts on the same year-month-day and is ISO8601 formatted
+    const datePrefix = new Date().toISOString().split('T')[0]
+
+    nock('https://api.attio.com')
+      .put('/v2/batch/records', new RegExp(`"received_at":"${datePrefix}T`))
+      .reply(202, '')
+
+    const [response] = await testDestination.testBatchAction('assertRecord', {
+      events: [lackingReceivedAtEvent],
+      mapping,
+      settings: {}
+    })
+
+    expect(response.status).toBe(202)
+  })
 })

--- a/packages/destination-actions/src/destinations/attio/assertRecord/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/attio/assertRecord/__tests__/index.test.ts
@@ -13,7 +13,8 @@ const event = createTestEvent({
   traits: {
     name: 'Stair car',
     number_of_wheels: 4
-  }
+  },
+  receivedAt: '2024-05-24T10:00:00.000Z'
 })
 
 const mapping = {
@@ -26,6 +27,9 @@ const mapping = {
     number_of_wheels: {
       '@path': '$.traits.number_of_wheels'
     }
+  },
+  received_at: {
+    '@path': '$.receivedAt'
   }
 }
 
@@ -108,5 +112,33 @@ describe('Attio.assertRecord', () => {
         }
       })
     })
+  })
+
+  it('uses the batch assertion endpoint', async () => {
+    nock('https://api.attio.com')
+      .put('/v2/batch/records', {
+        assertions: [
+          {
+            object: 'vehicles',
+            mode: 'create-or-update',
+            matching_attribute: 'name',
+            multiselect_values: 'append',
+            values: {
+              name: 'Stair car',
+              number_of_wheels: 4
+            },
+            received_at: '2024-05-24T10:00:00.000Z'
+          }
+        ]
+      })
+      .reply(202, '')
+
+    const [response] = await testDestination.testBatchAction('assertRecord', {
+      events: [event],
+      mapping,
+      settings: {}
+    })
+
+    expect(response.status).toBe(202)
   })
 })

--- a/packages/destination-actions/src/destinations/attio/assertRecord/generated-types.ts
+++ b/packages/destination-actions/src/destinations/attio/assertRecord/generated-types.ts
@@ -15,4 +15,16 @@ export interface Payload {
   attributes?: {
     [k: string]: unknown
   }
+  /**
+   * Send data to Attio in batches for much better performance.
+   */
+  enable_batching?: boolean
+  /**
+   * Max batch size to send to Attio (limit is 10,000)
+   */
+  batch_size?: number
+  /**
+   * When the event was received.
+   */
+  received_at: string | number
 }

--- a/packages/destination-actions/src/destinations/attio/assertRecord/generated-types.ts
+++ b/packages/destination-actions/src/destinations/attio/assertRecord/generated-types.ts
@@ -26,5 +26,5 @@ export interface Payload {
   /**
    * When the event was received.
    */
-  received_at: string | number
+  received_at?: string | number
 }

--- a/packages/destination-actions/src/destinations/attio/assertRecord/index.ts
+++ b/packages/destination-actions/src/destinations/attio/assertRecord/index.ts
@@ -97,7 +97,7 @@ const action: ActionDefinition<Settings, Payload> = {
         matching_attribute: item.matching_attribute,
         multiselect_values: 'append',
         values: (item.attributes as Record<string, SimpleValue>) ?? {},
-        received_at: item.received_at.toString()
+        received_at: item.received_at?.toString() ?? new Date().toISOString()
       }))
     })
   }

--- a/packages/destination-actions/src/destinations/attio/assertRecord/index.ts
+++ b/packages/destination-actions/src/destinations/attio/assertRecord/index.ts
@@ -2,7 +2,8 @@ import type { ActionDefinition, DynamicFieldResponse, RequestClient } from '@seg
 import type { InputField } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { AttioClient } from '../api'
+import { AttioClient, SimpleValue } from '../api'
+import { commonFields } from '../common-fields'
 
 const object: InputField = {
   type: 'string',
@@ -68,7 +69,8 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     object,
     matching_attribute,
-    attributes
+    attributes,
+    ...commonFields
   },
 
   dynamicFields: {
@@ -82,6 +84,21 @@ const action: ActionDefinition<Settings, Payload> = {
       object: payload.object,
       matching_attribute: payload.matching_attribute,
       values: payload.attributes ?? {}
+    })
+  },
+
+  performBatch: async (request, { payload }) => {
+    const client = new AttioClient(request)
+
+    return await client.batchAssert({
+      assertions: payload.map((item) => ({
+        object: item.object,
+        mode: 'create-or-update',
+        matching_attribute: item.matching_attribute,
+        multiselect_values: 'append',
+        values: (item.attributes as Record<string, SimpleValue>) ?? {},
+        received_at: item.received_at.toString()
+      }))
     })
   }
 }

--- a/packages/destination-actions/src/destinations/attio/common-fields.ts
+++ b/packages/destination-actions/src/destinations/attio/common-fields.ts
@@ -4,11 +4,11 @@ import { Settings } from './generated-types'
 export const commonFields: ActionDefinition<Settings>['fields'] = {
   enable_batching: {
     label: 'Send data to Attio in batches',
-    description: 'Send data to Attio in batches for much better performance.',
+    description:
+      'Send batches of events to Attio, for improved performance, however invalid events are silently dropped.',
     type: 'boolean',
     required: false,
-    unsafe_hidden: true,
-    default: true
+    default: false
   },
 
   batch_size: {

--- a/packages/destination-actions/src/destinations/attio/common-fields.ts
+++ b/packages/destination-actions/src/destinations/attio/common-fields.ts
@@ -24,7 +24,7 @@ export const commonFields: ActionDefinition<Settings>['fields'] = {
     label: 'Received at',
     description: 'When the event was received.',
     type: 'datetime',
-    required: true,
+    required: false,
     default: {
       '@path': '$.receivedAt'
     }

--- a/packages/destination-actions/src/destinations/attio/common-fields.ts
+++ b/packages/destination-actions/src/destinations/attio/common-fields.ts
@@ -1,0 +1,32 @@
+import { ActionDefinition } from '@segment/actions-core'
+import { Settings } from './generated-types'
+
+export const commonFields: ActionDefinition<Settings>['fields'] = {
+  enable_batching: {
+    label: 'Send data to Attio in batches',
+    description: 'Send data to Attio in batches for much better performance.',
+    type: 'boolean',
+    required: false,
+    unsafe_hidden: true,
+    default: true
+  },
+
+  batch_size: {
+    label: 'Batch Size',
+    description: 'Max batch size to send to Attio (limit is 10,000)',
+    type: 'number',
+    required: false,
+    unsafe_hidden: true,
+    default: 1_000
+  },
+
+  received_at: {
+    label: 'Received at',
+    description: 'When the event was received.',
+    type: 'datetime',
+    required: true,
+    default: {
+      '@path': '$.receivedAt'
+    }
+  }
+}

--- a/packages/destination-actions/src/destinations/attio/groupWorkspace/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/attio/groupWorkspace/__tests__/index.test.ts
@@ -224,4 +224,28 @@ describe('Attio.groupWorkspace', () => {
     expect(responses.length).toBe(2)
     expect(responses[1].status).toBe(202)
   })
+
+  it('handles the case where receivedAt is not provided', async () => {
+    const lackingReceivedAtEvent = createTestEvent({
+      type: 'group' as const,
+      traits: {
+        id: '42',
+        domain
+      },
+      receivedAt: undefined
+    })
+
+    // Can't control the exact timestamp, so only check it starts on the same year-month-day and is ISO8601 formatted
+    const datePrefix = new Date().toISOString().split('T')[0]
+
+    nock('https://api.attio.com')
+      .put('/v2/batch/records', new RegExp(`"received_at":"${datePrefix}T`))
+      .reply(202, '')
+
+    await testDestination.testBatchAction('groupWorkspace', {
+      events: [lackingReceivedAtEvent],
+      mapping,
+      settings: {}
+    })
+  })
 })

--- a/packages/destination-actions/src/destinations/attio/groupWorkspace/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/attio/groupWorkspace/__tests__/index.test.ts
@@ -12,13 +12,17 @@ const event = createTestEvent({
   traits: {
     id: '42',
     domain
-  }
+  },
+  receivedAt: '2024-05-24T10:00:00.000Z'
 })
 
 const mapping = {
   domain: { '@path': '$.traits.domain' },
   workspace_id: { '@path': '$.traits.id' },
-  user_id: { '@path': '$.userId' }
+  user_id: { '@path': '$.userId' },
+  received_at: {
+    '@path': '$.receivedAt'
+  }
 }
 
 describe('Attio.groupWorkspace', () => {
@@ -179,5 +183,45 @@ describe('Attio.groupWorkspace', () => {
         settings: {}
       })
     ).rejects.toThrowError()
+  })
+
+  it('uses the batch assertion endpoint', async () => {
+    nock('https://api.attio.com')
+      .put('/v2/batch/records', {
+        assertions: [
+          {
+            object: 'workspaces',
+            mode: 'create-or-update',
+            matching_attribute: 'workspace_id',
+            multiselect_values: 'append',
+            values: {
+              workspace_id: '42',
+              users: ['user1234'],
+
+              company: {
+                object: 'companies',
+                mode: 'create-or-update',
+                matching_attribute: 'domains',
+                multiselect_values: 'append',
+                values: {
+                  domains: domain
+                },
+                received_at: '2024-05-24T10:00:00.000Z'
+              }
+            },
+            received_at: '2024-05-24T10:00:00.000Z'
+          }
+        ]
+      })
+      .reply(202, '')
+
+    const responses = await testDestination.testBatchAction('groupWorkspace', {
+      events: [event],
+      mapping,
+      settings: {}
+    })
+
+    expect(responses.length).toBe(2)
+    expect(responses[1].status).toBe(202)
   })
 })

--- a/packages/destination-actions/src/destinations/attio/groupWorkspace/generated-types.ts
+++ b/packages/destination-actions/src/destinations/attio/groupWorkspace/generated-types.ts
@@ -25,4 +25,16 @@ export interface Payload {
   workspace_attributes?: {
     [k: string]: unknown
   }
+  /**
+   * Send data to Attio in batches for much better performance.
+   */
+  enable_batching?: boolean
+  /**
+   * Max batch size to send to Attio (limit is 10,000)
+   */
+  batch_size?: number
+  /**
+   * When the event was received.
+   */
+  received_at: string | number
 }

--- a/packages/destination-actions/src/destinations/attio/groupWorkspace/generated-types.ts
+++ b/packages/destination-actions/src/destinations/attio/groupWorkspace/generated-types.ts
@@ -36,5 +36,5 @@ export interface Payload {
   /**
    * When the event was received.
    */
-  received_at: string | number
+  received_at?: string | number
 }

--- a/packages/destination-actions/src/destinations/attio/groupWorkspace/index.ts
+++ b/packages/destination-actions/src/destinations/attio/groupWorkspace/index.ts
@@ -128,10 +128,10 @@ const action: ActionDefinition<Settings, Payload> = {
               domains: item.domain,
               ...(item.company_attributes ?? {})
             },
-            received_at: item.received_at.toString()
+            received_at: item.received_at?.toString() ?? new Date().toISOString()
           }
         },
-        received_at: item.received_at.toString()
+        received_at: item.received_at?.toString() ?? new Date().toISOString()
       }))
     })
   }

--- a/packages/destination-actions/src/destinations/attio/groupWorkspace/index.ts
+++ b/packages/destination-actions/src/destinations/attio/groupWorkspace/index.ts
@@ -3,6 +3,7 @@ import type { InputField } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { AttioClient } from '../api'
+import { commonFields } from '../common-fields'
 
 const domain: InputField = {
   type: 'string',
@@ -76,7 +77,8 @@ const action: ActionDefinition<Settings, Payload> = {
     workspace_id,
     user_id,
     company_attributes,
-    workspace_attributes
+    workspace_attributes,
+    ...commonFields
   },
 
   perform: async (request, { payload }) => {
@@ -100,6 +102,37 @@ const action: ActionDefinition<Settings, Payload> = {
         ...(payload.user_id ? { users: [payload.user_id] } : {}),
         ...(payload.workspace_attributes ?? {})
       }
+    })
+  },
+
+  performBatch: async (request, { payload }) => {
+    const client = new AttioClient(request)
+
+    return await client.batchAssert({
+      assertions: payload.map((item) => ({
+        object: 'workspaces',
+        mode: 'create-or-update',
+        matching_attribute: 'workspace_id',
+        multiselect_values: 'append',
+        values: {
+          workspace_id: item.workspace_id,
+          ...(item.user_id ? { users: [item.user_id] } : {}),
+          ...(item.workspace_attributes ?? {}),
+
+          company: {
+            object: 'companies',
+            mode: 'create-or-update',
+            matching_attribute: 'domains',
+            multiselect_values: 'append',
+            values: {
+              domains: item.domain,
+              ...(item.company_attributes ?? {})
+            },
+            received_at: item.received_at.toString()
+          }
+        },
+        received_at: item.received_at.toString()
+      }))
     })
   }
 }

--- a/packages/destination-actions/src/destinations/attio/identifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/attio/identifyUser/__tests__/index.test.ts
@@ -125,4 +125,29 @@ describe('Attio.identifyUser', () => {
     expect(responses.length).toBe(2)
     expect(responses[1].status).toBe(202)
   })
+
+  it('handles the case where receivedAt is not provided', async () => {
+    const lackingReceivedAtEvent = createTestEvent({
+      type: 'identify' as const,
+      userId: '9',
+      traits: {
+        name: 'George Oscar Bluth',
+        email
+      },
+      receivedAt: undefined
+    })
+
+    // Can't control the exact timestamp, so only check it starts on the same year-month-day and is ISO8601 formatted
+    const datePrefix = new Date().toISOString().split('T')[0]
+
+    nock('https://api.attio.com')
+      .put('/v2/batch/records', new RegExp(`"received_at":"${datePrefix}T`))
+      .reply(202, '')
+
+    await testDestination.testBatchAction('identifyUser', {
+      events: [lackingReceivedAtEvent],
+      mapping,
+      settings: {}
+    })
+  })
 })

--- a/packages/destination-actions/src/destinations/attio/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/attio/identifyUser/generated-types.ts
@@ -21,4 +21,16 @@ export interface Payload {
   person_attributes?: {
     [k: string]: unknown
   }
+  /**
+   * Send data to Attio in batches for much better performance.
+   */
+  enable_batching?: boolean
+  /**
+   * Max batch size to send to Attio (limit is 10,000)
+   */
+  batch_size?: number
+  /**
+   * When the event was received.
+   */
+  received_at: string | number
 }

--- a/packages/destination-actions/src/destinations/attio/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/attio/identifyUser/generated-types.ts
@@ -32,5 +32,5 @@ export interface Payload {
   /**
    * When the event was received.
    */
-  received_at: string | number
+  received_at?: string | number
 }

--- a/packages/destination-actions/src/destinations/attio/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/attio/identifyUser/index.ts
@@ -3,6 +3,7 @@ import type { InputField } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { AttioClient } from '../api'
+import { commonFields } from '../common-fields'
 
 const email_address: InputField = {
   type: 'string',
@@ -60,7 +61,8 @@ const action: ActionDefinition<Settings, Payload> = {
     email_address,
     user_id,
     user_attributes,
-    person_attributes
+    person_attributes,
+    ...commonFields
   },
 
   perform: async (request, { payload }) => {
@@ -84,6 +86,37 @@ const action: ActionDefinition<Settings, Payload> = {
         user_id: payload.user_id,
         ...(payload.user_attributes ?? {})
       }
+    })
+  },
+
+  performBatch: async (request, { payload }) => {
+    const client = new AttioClient(request)
+
+    return await client.batchAssert({
+      assertions: payload.map((item) => ({
+        object: 'users',
+        mode: 'create-or-update',
+        matching_attribute: 'user_id',
+        multiselect_values: 'append',
+        values: {
+          primary_email_address: item.email_address,
+          user_id: item.user_id,
+          ...(item.user_attributes ?? {}),
+
+          person: {
+            object: 'people',
+            mode: 'create-or-update',
+            matching_attribute: 'email_addresses',
+            multiselect_values: 'append',
+            values: {
+              email_addresses: item.email_address,
+              ...(item.person_attributes ?? {})
+            },
+            received_at: item.received_at.toString()
+          }
+        },
+        received_at: item.received_at.toString()
+      }))
     })
   }
 }

--- a/packages/destination-actions/src/destinations/attio/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/attio/identifyUser/index.ts
@@ -112,10 +112,10 @@ const action: ActionDefinition<Settings, Payload> = {
               email_addresses: item.email_address,
               ...(item.person_attributes ?? {})
             },
-            received_at: item.received_at.toString()
+            received_at: item.received_at?.toString() ?? new Date().toISOString()
           }
         },
-        received_at: item.received_at.toString()
+        received_at: item.received_at?.toString() ?? new Date().toISOString()
       }))
     })
   }


### PR DESCRIPTION
This pull request adds batch support for the Attio Actions destination. We're looking to make this change because our customers are seeing high failure rates (rate limit exceeded, timeouts and 5xx errors) with the single-event mechanisms.

Our secret batching API supports up to 10,000 Segment events in a single batch that will allow us to process these asynchronously, in order, in our own infrastructure in a more controlled and reliable way.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
