### PR TITLE
Change name of browser destination

### DIFF
--- a/packages/browser-destinations/destinations/stackadapt/src/index.ts
+++ b/packages/browser-destinations/destinations/stackadapt/src/index.ts
@@ -14,7 +14,7 @@ declare global {
 }
 
 export const destination: BrowserDestinationDefinition<Settings, StackAdaptSDK> = {
-  name: 'StackAdapt (Actions)',
+  name: 'StackAdapt Pixel (Actions)',
   slug: 'actions-stackadapt',
   mode: 'device',
   presets: [


### PR DESCRIPTION
Change the name of the StackAdapt browser destination to "StackAdapt Pixel (Actions)" so that the cloud mode destination can be renamed to "StackAdapt (Actions)" without the name conflicting with the browser destination.

## Testing

N/A

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
