### PR TITLE
Fix PR labeler bot

### DIFF
--- a/scripts/github-action/compute-labels.js
+++ b/scripts/github-action/compute-labels.js
@@ -8,7 +8,7 @@ module.exports = async ({ github, context, core }) => {
 }
 
 async function computeAuthorLabels(github, context, core) {
-  const teamSlugs = ['build-experience-team', 'libraries-web-team', 'strategic-connections-team']
+  const teamSlugs = ['libraries-web-team', 'strategic-connections-team']
   const username = context.payload.sender.login
   const organization = context.repo.owner
   const SEGMENT_CORE_LABEL = 'team:segment-core'


### PR DESCRIPTION
The PR labeler is failing because it's not able to find build-exp-team. Seems like the team was deleted.

![image](https://github.com/segmentio/action-destinations/assets/109586712/ac67a1ea-6de6-410a-8738-ead86506d322)

This PR removes build-exp-team from the list of internal teams to scan for.

## Testing

Testing not required because this is a simple change and has no impact on any of the destinations 

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
