### PR TITLE
[pendo-web-actions] add setting to exclude certain segment users

### DIFF
--- a/packages/browser-destinations/destinations/pendo-web-actions/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/generated-types.ts
@@ -14,6 +14,10 @@ export interface Settings {
    */
   cnameContentHost?: string
   /**
+   * Specify a Segment user trait, which, if exists and is set to true, will prevent Pendo initialization and actions for the Segment user.
+   */
+  exclusionUserTrait?: string
+  /**
    * Override sending Segment's user traits on load. This will prevent Pendo from initializing with the user traits from Segment (analytics.user().traits()). Allowing you to adjust the mapping of visitor metadata in Segment's identify event.
    */
   disableUserTraitsOnLoad?: boolean

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/group/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/group/index.ts
@@ -55,6 +55,10 @@ const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
     }
   },
   perform: (pendo, { mapping, payload }) => {
+    if (!pendo) {
+      return
+    }
+
     // remove parentAccountData field data from the accountData if the paths overlap
 
     type pathMapping = {

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/identify/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/identify/index.ts
@@ -30,6 +30,10 @@ const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
     }
   },
   perform: (pendo, event) => {
+    if (!pendo) {
+      return
+    }
+
     const payload: PendoOptions = {
       visitor: {
         ...event.payload.visitorData,

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/index.ts
@@ -50,6 +50,13 @@ export const destination: BrowserDestinationDefinition<Settings, PendoSDK> = {
       type: 'string',
       required: false
     },
+    exclusionUserTrait: {
+      label: 'Optional Segment user trait to exclude Segment user(s) from Pendo',
+      description:
+        'Specify a Segment user trait, which, if exists and is set to true, will prevent Pendo initialization and actions for the Segment user.',
+      type: 'string',
+      required: false
+    },
     disableUserTraitsOnLoad: {
       label: "Disable passing Segment's user traits to Pendo on start up",
       description:
@@ -69,6 +76,15 @@ export const destination: BrowserDestinationDefinition<Settings, PendoSDK> = {
   },
 
   initialize: async ({ settings, analytics }, deps) => {
+    if (settings.exclusionUserTrait) {
+      const trait = analytics.user().traits()[settings.exclusionUserTrait]
+      const isExcluded = trait === true || String(trait).toLowerCase() === 'true'
+
+      if (isExcluded) {
+        return
+      }
+    }
+
     if (settings.cnameContentHost && !/^https?:/.exec(settings.cnameContentHost) && settings.cnameContentHost.length) {
       settings.cnameContentHost = 'https://' + settings.cnameContentHost
     }

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/track/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/track/index.ts
@@ -30,6 +30,10 @@ const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
     }
   },
   perform: (pendo, { payload }) => {
+    if (!pendo) {
+      return
+    }
+
     pendo.track(payload.event, payload.metadata)
   }
 }


### PR DESCRIPTION
Allows end-users to set a specific user trait in Segment to control whether Pendo should initialize and receive events for that particular user.

The end-user defines an exclusion user trait in the settings. This trait acts as a flag to determine if a user should be excluded from Pendo tracking.

This feature provides flexibility to end-users by allowing them to control Pendo tracking on a per-user basis. They can set the designated user trait in Segment to true or 'true' for specific users they want to exclude from Pendo tracking. This can be useful in scenarios where certain users, such as internal team members or test accounts, should not be tracked by Pendo.