### PR TITLE
[DC-789] adds subscription sync modes support in destination-kit

### DIFF
--- a/packages/core/src/__tests__/destination-kit.test.ts
+++ b/packages/core/src/__tests__/destination-kit.test.ts
@@ -306,6 +306,31 @@ describe('destination kit', () => {
         { output: 'Action Executed', data: ['this is a test', {}] }
       ])
     })
+
+    test('should inject the syncMode value in the perform handler', async () => {
+      const destinationTest = new Destination(destinationWithSyncMode)
+      const testEvent: SegmentEvent = { type: 'track' }
+      const testSettings = {
+        apiSecret: 'test_key',
+        subscription: {
+          subscribe: 'type = "track"',
+          partnerAction: 'customEvent',
+          mapping: {
+            __segment_internal_sync_mode: 'add'
+          }
+        }
+      }
+
+      const res = await destinationTest.onEvent(testEvent, testSettings)
+
+      expect(res).toEqual([
+        { output: 'Mappings resolved' },
+        {
+          output: 'Action Executed',
+          data: ['this is a test', 'add']
+        }
+      ])
+    })
   })
 
   describe('refresh token', () => {
@@ -400,31 +425,6 @@ describe('destination kit', () => {
           refreshToken: ''
         })
       ).resolves.not.toThrowError()
-    })
-
-    test.only('should inject the syncMode value in the perform handler', async () => {
-      const destinationTest = new Destination(destinationWithSyncMode)
-      const testEvent: SegmentEvent = { type: 'track' }
-      const testSettings = {
-        apiSecret: 'test_key',
-        subscription: {
-          subscribe: 'type = "track"',
-          partnerAction: 'customEvent',
-          mapping: {
-            __segment_internal_sync_mode: 'add'
-          }
-        }
-      }
-
-      const res = await destinationTest.onEvent(testEvent, testSettings)
-
-      expect(res).toEqual([
-        { output: 'Mappings resolved' },
-        {
-          output: 'Action Executed',
-          data: ['this is a test', 'add']
-        }
-      ])
     })
   })
 

--- a/packages/core/src/__tests__/destination-kit.test.ts
+++ b/packages/core/src/__tests__/destination-kit.test.ts
@@ -111,6 +111,37 @@ const destinationWithOptions: DestinationDefinition<JSONObject> = {
   }
 }
 
+const destinationWithSyncMode: DestinationDefinition<JSONObject> = {
+  name: 'Actions Google Analytics 4',
+  mode: 'cloud',
+  actions: {
+    customEvent: {
+      title: 'Send a Custom Event',
+      description: 'Send events to a custom event in API',
+      defaultSubscription: 'type = "track"',
+      fields: {},
+      syncModes: {
+        default: 'add',
+        description: 'Select the sync mode for the subscription',
+        label: 'Sync Mode',
+        choices: [
+          {
+            label: 'Insert',
+            value: 'add'
+          },
+          {
+            label: 'Delete',
+            value: 'delete'
+          }
+        ]
+      },
+      perform: (_request, { syncMode }) => {
+        return ['this is a test', syncMode]
+      }
+    }
+  }
+}
+
 describe('destination kit', () => {
   describe('event validations', () => {
     test('should return `invalid subscription` when sending an empty subscribe', async () => {
@@ -369,6 +400,31 @@ describe('destination kit', () => {
           refreshToken: ''
         })
       ).resolves.not.toThrowError()
+    })
+
+    test.only('should inject the syncMode value in the perform handler', async () => {
+      const destinationTest = new Destination(destinationWithSyncMode)
+      const testEvent: SegmentEvent = { type: 'track' }
+      const testSettings = {
+        apiSecret: 'test_key',
+        subscription: {
+          subscribe: 'type = "track"',
+          partnerAction: 'customEvent',
+          mapping: {
+            __segment_internal_sync_mode: 'add'
+          }
+        }
+      }
+
+      const res = await destinationTest.onEvent(testEvent, testSettings)
+
+      expect(res).toEqual([
+        { output: 'Mappings resolved' },
+        {
+          output: 'Action Executed',
+          data: ['this is a test', 'add']
+        }
+      ])
     })
   })
 

--- a/packages/core/src/__tests__/destination-kit.test.ts
+++ b/packages/core/src/__tests__/destination-kit.test.ts
@@ -120,7 +120,7 @@ const destinationWithSyncMode: DestinationDefinition<JSONObject> = {
       description: 'Send events to a custom event in API',
       defaultSubscription: 'type = "track"',
       fields: {},
-      syncModes: {
+      syncMode: {
         default: 'add',
         description: 'Select the sync mode for the subscription',
         label: 'Sync Mode',

--- a/packages/core/src/__tests__/destination-kit.test.ts
+++ b/packages/core/src/__tests__/destination-kit.test.ts
@@ -137,6 +137,9 @@ const destinationWithSyncMode: DestinationDefinition<JSONObject> = {
       },
       perform: (_request, { syncMode }) => {
         return ['this is a test', syncMode]
+      },
+      performBatch: (_request, { syncMode }) => {
+        return ['this is a test', syncMode]
       }
     }
   }
@@ -325,6 +328,30 @@ describe('destination kit', () => {
 
       expect(res).toEqual([
         { output: 'Mappings resolved' },
+        {
+          output: 'Action Executed',
+          data: ['this is a test', 'add']
+        }
+      ])
+    })
+
+    test('should inject the syncMode value in the performBatch handler', async () => {
+      const destinationTest = new Destination(destinationWithSyncMode)
+      const testEvent: SegmentEvent = { type: 'track' }
+      const testSettings = {
+        apiSecret: 'test_key',
+        subscription: {
+          subscribe: 'type = "track"',
+          partnerAction: 'customEvent',
+          mapping: {
+            __segment_internal_sync_mode: 'add'
+          }
+        }
+      }
+
+      const res = await destinationTest.onBatch([testEvent], testSettings)
+
+      expect(res).toEqual([
         {
           output: 'Action Executed',
           data: ['this is a test', 'add']

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -12,7 +12,7 @@ import type {
   ExecuteInput,
   Result,
   SyncMode,
-  SyncModes
+  SyncModeDefinition
 } from './types'
 import { syncModeTypes } from './types'
 import { NormalizedOptions } from '../request-client'
@@ -103,8 +103,8 @@ export interface ActionDefinition<
     >
   }
 
-  /** The sync modes setting definition. This enables subscription sync mode selection when subscribing to this action. */
-  syncModes?: SyncModes
+  /** The sync mode setting definition. This enables subscription sync mode selection when subscribing to this action. */
+  syncMode?: SyncModeDefinition
 }
 
 export const hookTypeStrings = ['onMappingSave', 'retlOnMappingSave'] as const
@@ -280,7 +280,7 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
       }
     }
 
-    const syncMode = this.definition.syncModes ? bundle.mapping?.['__segment_internal_sync_mode'] : undefined
+    const syncMode = this.definition.syncMode ? bundle.mapping?.['__segment_internal_sync_mode'] : undefined
 
     // Construct the data bundle to send to an action
     const dataBundle = {

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -37,6 +37,8 @@ export interface ExecuteInput<
   hookOutputs?: Partial<Record<ActionHookType, ActionHookOutputs>>
   /** The page used in dynamic field requests */
   page?: string
+  /** The subscription sync mode */
+  syncMode?: SyncMode
   /** The data needed in OAuth requests */
   readonly auth?: AuthTokens
   /**
@@ -191,17 +193,34 @@ export interface InputField extends InputFieldJSONSchema {
   depends_on?: DependsOnConditions
 }
 
+/** Base interface for conditions  */
+interface BaseCondition {
+  operator: 'is' | 'is_not'
+}
+
 /**
- * A single condition defining whether a field should be shown.
+ * A single condition defining whether a field should be shown based on the value of the field specified by `fieldKey`.
  * fieldKey: The field key in the fields object to look at
  * operator: The operator to use when comparing the field value
  * value: The value we expect that field to have, if undefined, we will match based on whether the field contains a value or not
  */
-export interface Condition {
+export interface FieldCondition extends BaseCondition {
   fieldKey: string
-  operator: 'is' | 'is_not'
+  type?: 'field' // optional for backwards compatibility
   value: Omit<FieldValue, 'Directive'> | Array<Omit<FieldValue, 'Directive'>> | undefined
 }
+
+/**
+ * A single condition defining whether a field should be shown based on the current sync mode.
+ * operator: The operator to use when comparing the sync mode
+ * value: The value to compare against, if undefined, we will match based on whether a sync mode is set or not
+ */
+export interface SyncModeCondition extends BaseCondition {
+  type: 'syncMode'
+  value: SyncMode
+}
+
+export type Condition = FieldCondition | SyncModeCondition
 
 /**
  * If match is not set, it will default to 'all'
@@ -263,3 +282,26 @@ export type Deletion<Settings, Return = any> = (
   request: RequestClient,
   data: ExecuteInput<Settings, DeletionPayload>
 ) => MaybePromise<Return>
+
+/** The supported sync mode values  */
+export const syncModeTypes = ['add', 'update', 'upsert', 'delete'] as const
+export type SyncMode = typeof syncModeTypes[number]
+
+export interface SyncModeOption {
+  /** The human-readable label for this option */
+  label: string
+  /** The value of this option */
+  value: SyncMode
+}
+
+/** An action sync mode definition */
+export interface SyncModes {
+  /** The default sync mode that will be selected */
+  default: SyncMode
+  /** The human-readable label for this setting  */
+  label: string
+  /** The human-friendly description of the setting */
+  description: string
+  /** The available sync mode choices */
+  choices: SyncModeOption[]
+}

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -295,7 +295,7 @@ export interface SyncModeOption {
 }
 
 /** An action sync mode definition */
-export interface SyncModes {
+export interface SyncModeDefinition {
   /** The default sync mode that will be selected */
   default: SyncMode
   /** The human-readable label for this setting  */


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR adds Sync Modes support to destination-kit as part of the Mappings 2.0 project (See relevant section in the [blueprint](https://docs.google.com/document/d/1h-T40iySIxC9Zm6HVEiM-c0otTVmBUWn7dSamyFebrQ/edit#heading=h.ez9jlsj1msqz)) .

- [x] Adds ability to define sync modes setting for any action
- [x] Injects selected `syncMode` in perform block.
- [x] Adds ability to define `SyncModeCondition` (will allow conditionally displaying fields in app)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
