### PR TITLE
[STRATCONN-3793] Added depends_on field on enableConsentMode of GA4-web

### DIFF
--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/index.ts
@@ -120,7 +120,16 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
         { label: 'Granted', value: 'granted' },
         { label: 'Denied', value: 'denied' }
       ],
-      default: 'granted'
+      default: 'granted',
+      depends_on: {
+        conditions: [
+          {
+            fieldKey: 'enableConsentMode',
+            operator: 'is',
+            value: true
+          }
+        ]
+      }
     },
     defaultAnalyticsStorageConsentState: {
       description:
@@ -131,7 +140,16 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
         { label: 'Granted', value: 'granted' },
         { label: 'Denied', value: 'denied' }
       ],
-      default: 'granted'
+      default: 'granted',
+      depends_on: {
+        conditions: [
+          {
+            fieldKey: 'enableConsentMode',
+            operator: 'is',
+            value: true
+          }
+        ]
+      }
     },
     adUserDataConsentState: {
       description:
@@ -142,7 +160,16 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
         { label: 'Granted', value: 'granted' },
         { label: 'Denied', value: 'denied' }
       ],
-      default: undefined
+      default: undefined,
+      depends_on: {
+        conditions: [
+          {
+            fieldKey: 'enableConsentMode',
+            operator: 'is',
+            value: true
+          }
+        ]
+      }
     },
     adPersonalizationConsentState: {
       description:
@@ -153,7 +180,16 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
         { label: 'Granted', value: 'granted' },
         { label: 'Denied', value: 'denied' }
       ],
-      default: undefined
+      default: undefined,
+      depends_on: {
+        conditions: [
+          {
+            fieldKey: 'enableConsentMode',
+            operator: 'is',
+            value: true
+          }
+        ]
+      }
     },
     waitTimeToUpdateConsentStage: {
       description:


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

Added depends_on field on GA4-web destinations. 

JIRA TICKET: https://segment.atlassian.net/browse/STRATCONN-3793

https://github.com/segmentio/action-destinations/assets/139338151/6cd885d9-7e58-4909-b77b-e0eb36287eaa



<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [X] [Segmenters] Tested in the staging environment
