### PR TITLE
[AMAZON-AMC] | Fixed "415 Unsupported Media Type" issue while doing testAuthentication.

### DIFF
--- a/packages/destination-actions/src/destinations/amazon-amc/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/__tests__/index.test.ts
@@ -36,7 +36,7 @@ const getAudienceInput = {
 describe('Amazon-Ads (actions)', () => {
   describe('testAuthentication', () => {
     it('should not throw an error if all the appropriate credentials are available', async () => {
-      nock(`${settings.region}`).get('/v2/profiles').reply(200, {})
+      nock(`${settings.region}`).get('/v2/profiles').matchHeader('content-type', 'application/json').reply(200, {})
       await expect(testDestination.testAuthentication(validSettings)).resolves.not.toThrowError()
     })
 

--- a/packages/destination-actions/src/destinations/amazon-amc/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/index.ts
@@ -41,7 +41,10 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
 
       try {
         await request<RefreshTokenResponse>(`${settings.region}/v2/profiles`, {
-          method: 'GET'
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json'
+          }
         })
       } catch (e: any) {
         const error = e as AmazonTestAuthenticationError


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pull request is to fix **"415 Unsupported Media Type"** issue while doing testAuthentication.
[API which is being used](https://advertising.amazon.com/API/docs/en-us/reference/2/profiles#tag/Profiles) to authenticate in amazon accepts **content-Type application/json**

<img width="1331" alt="Screenshot 2024-06-03 at 12 50 48 PM" src="https://github.com/segmentio/action-destinations/assets/117165746/b35cd09d-8503-4566-b0fd-7b97aac72840">

<img width="930" alt="Screenshot 2024-06-03 at 6 50 01 PM" src="https://github.com/segmentio/action-destinations/assets/117165746/9839719b-a428-4fc5-aca6-09e137a58cc9">

<img width="918" alt="Screenshot 2024-06-03 at 6 49 44 PM" src="https://github.com/segmentio/action-destinations/assets/117165746/b7f51a84-e758-4fb4-b8ad-bab271e3c723">

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
