### PR TITLE
CONSENT-309: Ensure consent data is copied for Segment Connections + Profiles

### DIFF
--- a/packages/destination-actions/src/destinations/segment-profiles/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -198,6 +198,11 @@ Object {
     "batch": Array [
       Object {
         "anonymousId": "[2uovRzxThJj",
+        "context": Object {
+          "consent": Object {
+            "testType": "[2uovRzxThJj",
+          },
+        },
         "event": "[2uovRzxThJj",
         "integrations": Object {
           "All": false,
@@ -222,6 +227,9 @@ Object {
     "batch": Array [
       Object {
         "anonymousId": "[2uovRzxThJj",
+        "context": Object {
+          "consent": Object {},
+        },
         "event": "[2uovRzxThJj",
         "integrations": Object {
           "All": false,

--- a/packages/destination-actions/src/destinations/segment-profiles/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -8,7 +8,10 @@ Object {
         "anonymousId": "cZE8HyAL0!BF#)WQb^",
         "context": Object {
           "consent": Object {
-            "testType": "cZE8HyAL0!BF#)WQb^",
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
           },
         },
         "groupId": "cZE8HyAL0!BF#)WQb^",
@@ -36,7 +39,12 @@ Object {
       Object {
         "anonymousId": "cZE8HyAL0!BF#)WQb^",
         "context": Object {
-          "consent": Object {},
+          "consent": Object {
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
+          },
         },
         "groupId": "cZE8HyAL0!BF#)WQb^",
         "integrations": Object {
@@ -61,7 +69,10 @@ Object {
       Object {
         "anonymousId": "hIC1OAmWa[Q!&d%o",
         "consent": Object {
-          "testType": "hIC1OAmWa[Q!&d%o",
+          "categoryPreferences": Object {
+            "analytics": true,
+            "marketing": false,
+          },
         },
         "groupId": "hIC1OAmWa[Q!&d%o",
         "integrations": Object {
@@ -87,7 +98,12 @@ Object {
     "batch": Array [
       Object {
         "anonymousId": "hIC1OAmWa[Q!&d%o",
-        "consent": Object {},
+        "consent": Object {
+          "categoryPreferences": Object {
+            "analytics": true,
+            "marketing": false,
+          },
+        },
         "groupId": "hIC1OAmWa[Q!&d%o",
         "integrations": Object {
           "All": false,
@@ -214,7 +230,10 @@ Object {
         "anonymousId": "[2uovRzxThJj",
         "context": Object {
           "consent": Object {
-            "testType": "[2uovRzxThJj",
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
           },
         },
         "event": "[2uovRzxThJj",
@@ -242,7 +261,12 @@ Object {
       Object {
         "anonymousId": "[2uovRzxThJj",
         "context": Object {
-          "consent": Object {},
+          "consent": Object {
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
+          },
         },
         "event": "[2uovRzxThJj",
         "integrations": Object {

--- a/packages/destination-actions/src/destinations/segment-profiles/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -6,6 +6,11 @@ Object {
     "batch": Array [
       Object {
         "anonymousId": "cZE8HyAL0!BF#)WQb^",
+        "context": Object {
+          "consent": Object {
+            "testType": "cZE8HyAL0!BF#)WQb^",
+          },
+        },
         "groupId": "cZE8HyAL0!BF#)WQb^",
         "integrations": Object {
           "All": false,
@@ -30,6 +35,9 @@ Object {
     "batch": Array [
       Object {
         "anonymousId": "cZE8HyAL0!BF#)WQb^",
+        "context": Object {
+          "consent": Object {},
+        },
         "groupId": "cZE8HyAL0!BF#)WQb^",
         "integrations": Object {
           "All": false,
@@ -52,6 +60,9 @@ Object {
     "batch": Array [
       Object {
         "anonymousId": "hIC1OAmWa[Q!&d%o",
+        "consent": Object {
+          "testType": "hIC1OAmWa[Q!&d%o",
+        },
         "groupId": "hIC1OAmWa[Q!&d%o",
         "integrations": Object {
           "All": false,
@@ -76,6 +87,7 @@ Object {
     "batch": Array [
       Object {
         "anonymousId": "hIC1OAmWa[Q!&d%o",
+        "consent": Object {},
         "groupId": "hIC1OAmWa[Q!&d%o",
         "integrations": Object {
           "All": false,
@@ -99,6 +111,7 @@ Object {
       Object {
         "anonymousId": undefined,
         "context": Object {
+          "consent": Object {},
           "externalIds": Array [
             Object {
               "collection": "users",
@@ -149,6 +162,7 @@ Object {
       Object {
         "anonymousId": undefined,
         "context": Object {
+          "consent": Object {},
           "externalIds": Array [
             Object {
               "collection": "users",

--- a/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
@@ -67,3 +67,11 @@ export const properties: InputField = {
   defaultObjectUI: 'keyvalue',
   additionalProperties: true
 }
+
+export const context: InputField = {
+  label: 'Context',
+  description: 'Free-form dictionary of context of the event.',
+  type: 'object',
+  defaultObjectUI: 'keyvalue',
+  additionalProperties: true
+}

--- a/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
@@ -1,4 +1,5 @@
 import { InputField } from '@segment/actions-core/destination-kit/types'
+import { InvalidConsentObject } from '../segment/errors'
 
 export const user_id: InputField = {
   label: 'User ID',
@@ -75,4 +76,25 @@ export const consent: InputField = {
   default: { '@path': '$.context.consent' },
   additionalProperties: true,
   unsafe_hidden: true
+}
+
+function isCategoryPreferences(obj: unknown): boolean {
+  if (typeof obj !== 'object' || obj === null) {
+    return false
+  }
+
+  return Object.values(obj).every((value) => typeof value === 'boolean')
+}
+export const validateConsentObject = (obj: { [k: string]: unknown } | undefined): void => {
+  if (obj == undefined) {
+    return
+  }
+
+  if (typeof obj !== 'object' || obj === null) {
+    throw InvalidConsentObject
+  }
+
+  if (!('categoryPreferences' in obj && isCategoryPreferences(obj['categoryPreferences']))) {
+    throw InvalidConsentObject
+  }
 }

--- a/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
@@ -73,7 +73,6 @@ export const consent: InputField = {
   description: 'Segment event consent category preferences.',
   type: 'object',
   default: { '@path': '$.context.consent' },
-  additionalProperties: true,
   unsafe_hidden: true
 }
 

--- a/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
@@ -67,11 +67,3 @@ export const properties: InputField = {
   defaultObjectUI: 'keyvalue',
   additionalProperties: true
 }
-
-export const context: InputField = {
-  label: 'Context',
-  description: 'Free-form dictionary of context of the event.',
-  type: 'object',
-  defaultObjectUI: 'keyvalue',
-  additionalProperties: true
-}

--- a/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
@@ -67,3 +67,12 @@ export const properties: InputField = {
   defaultObjectUI: 'keyvalue',
   additionalProperties: true
 }
+
+export const consent: InputField = {
+  label: 'Consent',
+  description: 'Segment event consent category preferences.',
+  type: 'object',
+  default: { '@path': '$.context.consent' },
+  additionalProperties: true,
+  unsafe_hidden: true
+}

--- a/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/segment-properties.ts
@@ -1,5 +1,4 @@
 import { InputField } from '@segment/actions-core/destination-kit/types'
-import { InvalidConsentObject } from '../segment/errors'
 
 export const user_id: InputField = {
   label: 'User ID',
@@ -85,16 +84,14 @@ function isCategoryPreferences(obj: unknown): boolean {
 
   return Object.values(obj).every((value) => typeof value === 'boolean')
 }
-export const validateConsentObject = (obj: { [k: string]: unknown } | undefined): void => {
+export const validateConsentObject = (obj: { [k: string]: unknown } | undefined): boolean => {
   if (obj == undefined) {
-    return
+    return true
   }
 
   if (typeof obj !== 'object' || obj === null) {
-    throw InvalidConsentObject
+    throw false
   }
 
-  if (!('categoryPreferences' in obj && isCategoryPreferences(obj['categoryPreferences']))) {
-    throw InvalidConsentObject
-  }
+  return 'categoryPreferences' in obj && isCategoryPreferences(obj['categoryPreferences'])
 }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/__snapshots__/index.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "batch": Array [
     Object {
       "anonymousId": "arky4h2sh7k",
+      "context": Object {
+        "consent": Object {},
+      },
       "groupId": "test-group-ks2i7e",
       "integrations": Object {
         "All": false,

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -6,6 +6,11 @@ Object {
     "batch": Array [
       Object {
         "anonymousId": "tKaa(2A",
+        "context": Object {
+          "consent": Object {
+            "testType": "tKaa(2A",
+          },
+        },
         "groupId": "tKaa(2A",
         "integrations": Object {
           "All": false,
@@ -30,6 +35,9 @@ Object {
     "batch": Array [
       Object {
         "anonymousId": "tKaa(2A",
+        "context": Object {
+          "consent": Object {},
+        },
         "groupId": "tKaa(2A",
         "integrations": Object {
           "All": false,

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -8,7 +8,10 @@ Object {
         "anonymousId": "tKaa(2A",
         "context": Object {
           "consent": Object {
-            "testType": "tKaa(2A",
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
           },
         },
         "groupId": "tKaa(2A",
@@ -36,7 +39,12 @@ Object {
       Object {
         "anonymousId": "tKaa(2A",
         "context": Object {
-          "consent": Object {},
+          "consent": Object {
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
+          },
         },
         "groupId": "tKaa(2A",
         "integrations": Object {

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/generated-types.ts
@@ -31,4 +31,10 @@ export interface Payload {
    * The Segment messageId.
    */
   message_id?: string
+  /**
+   * Segment event consent category preferences.
+   */
+  consent?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/index.ts
@@ -9,7 +9,8 @@ import {
   engage_space,
   timestamp,
   message_id,
-  consent
+  consent,
+  validateConsentObject
 } from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
@@ -31,6 +32,8 @@ const action: ActionDefinition<Settings, Payload> = {
     if (!payload.anonymous_id && !payload.user_id) {
       throw MissingUserOrAnonymousIdThrowableError
     }
+    validateConsentObject(payload?.consent)
+
     const groupPayload: Object = {
       userId: payload?.user_id,
       anonymousId: payload?.anonymous_id,

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/index.ts
@@ -1,7 +1,16 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { user_id, anonymous_id, group_id, traits, engage_space, timestamp, message_id } from '../segment-properties'
+import {
+  user_id,
+  anonymous_id,
+  group_id,
+  traits,
+  engage_space,
+  timestamp,
+  message_id,
+  consent
+} from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -15,7 +24,8 @@ const action: ActionDefinition<Settings, Payload> = {
     group_id: { ...group_id, required: true },
     traits,
     timestamp,
-    message_id
+    message_id,
+    consent
   },
   perform: (_request, { payload, statsContext }) => {
     if (!payload.anonymous_id && !payload.user_id) {
@@ -35,7 +45,12 @@ const action: ActionDefinition<Settings, Payload> = {
         // to any destinations which is connected to the Segment Profiles space.
         All: false
       },
-      type: 'group'
+      type: 'group',
+      context: {
+        consent: {
+          ...payload?.consent
+        }
+      }
     }
 
     statsContext?.statsClient?.incr('tapi_internal', 1, [...statsContext.tags, `action:sendGroup`])

--- a/packages/destination-actions/src/destinations/segment-profiles/sendGroup/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendGroup/index.ts
@@ -32,7 +32,7 @@ const action: ActionDefinition<Settings, Payload> = {
     if (!payload.anonymous_id && !payload.user_id) {
       throw MissingUserOrAnonymousIdThrowableError
     }
-    validateConsentObject(payload?.consent)
+    const isValidConsentObject = validateConsentObject(payload?.consent)
 
     const groupPayload: Object = {
       userId: payload?.user_id,
@@ -50,9 +50,7 @@ const action: ActionDefinition<Settings, Payload> = {
       },
       type: 'group',
       context: {
-        consent: {
-          ...payload?.consent
-        }
+        consent: isValidConsentObject ? { ...payload?.consent } : {}
       }
     }
 

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/index.test.ts.snap
@@ -5,6 +5,7 @@ Object {
   "batch": Array [
     Object {
       "anonymousId": "arky4h2sh7k",
+      "consent": Object {},
       "groupId": undefined,
       "integrations": Object {
         "All": false,

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -7,7 +7,10 @@ Object {
       Object {
         "anonymousId": "mV[ZQcEVgZO$MX",
         "consent": Object {
-          "testType": "mV[ZQcEVgZO$MX",
+          "categoryPreferences": Object {
+            "analytics": true,
+            "marketing": false,
+          },
         },
         "groupId": "mV[ZQcEVgZO$MX",
         "integrations": Object {
@@ -33,7 +36,12 @@ Object {
     "batch": Array [
       Object {
         "anonymousId": "mV[ZQcEVgZO$MX",
-        "consent": Object {},
+        "consent": Object {
+          "categoryPreferences": Object {
+            "analytics": true,
+            "marketing": false,
+          },
+        },
         "groupId": "mV[ZQcEVgZO$MX",
         "integrations": Object {
           "All": false,

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -6,6 +6,9 @@ Object {
     "batch": Array [
       Object {
         "anonymousId": "mV[ZQcEVgZO$MX",
+        "consent": Object {
+          "testType": "mV[ZQcEVgZO$MX",
+        },
         "groupId": "mV[ZQcEVgZO$MX",
         "integrations": Object {
           "All": false,
@@ -30,6 +33,7 @@ Object {
     "batch": Array [
       Object {
         "anonymousId": "mV[ZQcEVgZO$MX",
+        "consent": Object {},
         "groupId": "mV[ZQcEVgZO$MX",
         "integrations": Object {
           "All": false,

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/generated-types.ts
@@ -31,4 +31,10 @@ export interface Payload {
    * The Segment messageId.
    */
   message_id?: string
+  /**
+   * Segment event consent category preferences.
+   */
+  consent?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
@@ -9,7 +9,8 @@ import {
   engage_space,
   timestamp,
   message_id,
-  consent
+  consent,
+  validateConsentObject
 } from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
@@ -32,6 +33,9 @@ const action: ActionDefinition<Settings, Payload> = {
     if (!payload.anonymous_id && !payload.user_id) {
       throw MissingUserOrAnonymousIdThrowableError
     }
+
+    validateConsentObject(payload?.consent)
+
     const identityPayload: Object = {
       userId: payload?.user_id,
       anonymousId: payload?.anonymous_id,

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
@@ -34,7 +34,7 @@ const action: ActionDefinition<Settings, Payload> = {
       throw MissingUserOrAnonymousIdThrowableError
     }
 
-    validateConsentObject(payload?.consent)
+    const isValidConsentObject = validateConsentObject(payload?.consent)
 
     const identityPayload: Object = {
       userId: payload?.user_id,
@@ -51,9 +51,7 @@ const action: ActionDefinition<Settings, Payload> = {
         All: false
       },
       type: 'identify',
-      consent: {
-        ...payload?.consent
-      }
+      consent: isValidConsentObject ? { ...payload?.consent } : {}
     }
 
     statsContext?.statsClient?.incr('tapi_internal', 1, [...statsContext.tags, `action:sendIdentify`])

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
@@ -1,7 +1,16 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { user_id, anonymous_id, group_id, traits, engage_space, timestamp, message_id } from '../segment-properties'
+import {
+  user_id,
+  anonymous_id,
+  group_id,
+  traits,
+  engage_space,
+  timestamp,
+  message_id,
+  consent
+} from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -16,7 +25,8 @@ const action: ActionDefinition<Settings, Payload> = {
     group_id,
     traits,
     timestamp,
-    message_id
+    message_id,
+    consent
   },
   perform: (_request, { payload, statsContext }) => {
     if (!payload.anonymous_id && !payload.user_id) {
@@ -36,7 +46,10 @@ const action: ActionDefinition<Settings, Payload> = {
         // to any destinations which is connected to the Segment Profiles space.
         All: false
       },
-      type: 'identify'
+      type: 'identify',
+      consent: {
+        ...payload?.consent
+      }
     }
 
     statsContext?.statsClient?.incr('tapi_internal', 1, [...statsContext.tags, `action:sendIdentify`])

--- a/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/__tests__/__snapshots__/index.test.ts.snap
@@ -6,6 +6,7 @@ Object {
     Object {
       "anonymousId": "anonId1234",
       "context": Object {
+        "consent": Object {},
         "externalIds": Array [
           Object {
             "collection": "users",
@@ -83,6 +84,7 @@ Object {
     Object {
       "anonymousId": "anonId1234",
       "context": Object {
+        "consent": Object {},
         "externalIds": Array [
           Object {
             "collection": "users",

--- a/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -7,6 +7,7 @@ Object {
       Object {
         "anonymousId": undefined,
         "context": Object {
+          "consent": Object {},
           "externalIds": Array [
             Object {
               "collection": "users",
@@ -98,6 +99,7 @@ Object {
       Object {
         "anonymousId": undefined,
         "context": Object {
+          "consent": Object {},
           "externalIds": Array [
             Object {
               "collection": "users",

--- a/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/generated-types.ts
@@ -69,4 +69,10 @@ export interface Payload {
    * The Segment messageId.
    */
   message_id?: string
+  /**
+   * Segment event consent category preferences.
+   */
+  consent?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/index.ts
@@ -16,7 +16,8 @@ import {
   android_push_subscription_status,
   ios_push_subscription_status,
   ios_push_token,
-  message_id
+  message_id,
+  consent
 } from './subscription-properties'
 import {
   InvalidSubscriptionStatusError,
@@ -280,7 +281,8 @@ const action: ActionDefinition<Settings, Payload> = {
     ios_push_subscription_status,
     traits,
     timestamp,
-    message_id
+    message_id,
+    consent
   },
   perform: (_request, { payload, statsContext }) => {
     const statsClient = statsContext?.statsClient
@@ -302,7 +304,10 @@ const action: ActionDefinition<Settings, Payload> = {
       context: {
         messaging_subscriptions: messagingSubscriptions,
         externalIds,
-        messaging_subscriptions_retl: true
+        messaging_subscriptions_retl: true,
+        consent: {
+          ...payload?.consent
+        }
       },
       timestamp: payload?.timestamp,
       integrations: {

--- a/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/index.ts
@@ -29,7 +29,7 @@ import {
   MissingIosPushTokenIfIosPushSubscriptionIsPresentError,
   MissingPhoneIfSmsOrWhatsappSubscriptionIsPresentError
 } from '../errors'
-import { timestamp } from '../segment-properties'
+import { timestamp, validateConsentObject } from '../segment-properties'
 import { StatsClient } from '@segment/actions-core/destination-kit'
 
 interface SubscriptionStatusConfig {
@@ -291,6 +291,8 @@ const action: ActionDefinition<Settings, Payload> = {
 
     // Before sending subscription data to Segment, a series of validations are done.
     validateSubscriptions(payload, statsClient, tags)
+    validateConsentObject(payload?.consent)
+
     // Enriches ExternalId's
     const externalIds: ExtenalId[] = enrichExternalIds(payload, [])
     // Enrich Messaging Subscriptions

--- a/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/index.ts
@@ -291,7 +291,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
     // Before sending subscription data to Segment, a series of validations are done.
     validateSubscriptions(payload, statsClient, tags)
-    validateConsentObject(payload?.consent)
+    const isValidConsentObject = validateConsentObject(payload?.consent)
 
     // Enriches ExternalId's
     const externalIds: ExtenalId[] = enrichExternalIds(payload, [])
@@ -307,9 +307,7 @@ const action: ActionDefinition<Settings, Payload> = {
         messaging_subscriptions: messagingSubscriptions,
         externalIds,
         messaging_subscriptions_retl: true,
-        consent: {
-          ...payload?.consent
-        }
+        consent: isValidConsentObject ? { ...payload?.consent } : {}
       },
       timestamp: payload?.timestamp,
       integrations: {

--- a/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/subscription-properties.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/subscription-properties.ts
@@ -110,3 +110,12 @@ export const message_id: InputField = {
   default: { '@path': '$.messageId' },
   unsafe_hidden: true
 }
+
+export const consent: InputField = {
+  label: 'Consent',
+  description: 'Segment event consent category preferences.',
+  type: 'object',
+  default: { '@path': '$.context.consent' },
+  additionalProperties: true,
+  unsafe_hidden: true
+}

--- a/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/subscription-properties.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendSubscription/subscription-properties.ts
@@ -116,6 +116,5 @@ export const consent: InputField = {
   description: 'Segment event consent category preferences.',
   type: 'object',
   default: { '@path': '$.context.consent' },
-  additionalProperties: true,
   unsafe_hidden: true
 }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/__tests__/__snapshots__/index.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "batch": Array [
     Object {
       "anonymousId": "arky4h2sh7k",
+      "context": Object {
+        "consent": Object {},
+      },
       "event": "Test Event",
       "integrations": Object {
         "All": false,

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/generated-types.ts
@@ -35,4 +35,10 @@ export interface Payload {
    * The Segment messageId.
    */
   message_id?: string
+  /**
+   * Segment event consent category preferences.
+   */
+  consent?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/generated-types.ts
@@ -35,4 +35,10 @@ export interface Payload {
    * The Segment messageId.
    */
   message_id?: string
+  /**
+   * Free-form dictionary of context of the event.
+   */
+  context?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/generated-types.ts
@@ -35,10 +35,4 @@ export interface Payload {
    * The Segment messageId.
    */
   message_id?: string
-  /**
-   * Free-form dictionary of context of the event.
-   */
-  context?: {
-    [k: string]: unknown
-  }
 }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
@@ -9,7 +9,8 @@ import {
   group_id,
   properties,
   engage_space,
-  message_id
+  message_id,
+  context
 } from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
@@ -24,7 +25,8 @@ const action: ActionDefinition<Settings, Payload> = {
     event_name,
     group_id,
     properties,
-    message_id
+    message_id,
+    context
   },
   perform: (_, { payload, statsContext }) => {
     if (!payload.anonymous_id && !payload.user_id) {
@@ -47,6 +49,9 @@ const action: ActionDefinition<Settings, Payload> = {
           },
           properties: {
             ...payload?.properties
+          },
+          context: {
+            ...payload?.context
           },
           type: 'track'
         }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
@@ -34,7 +34,7 @@ const action: ActionDefinition<Settings, Payload> = {
       throw MissingUserOrAnonymousIdThrowableError
     }
 
-    validateConsentObject(payload?.consent)
+    const isValidConsentObject = validateConsentObject(payload?.consent)
 
     statsContext?.statsClient?.incr('tapi_internal', 1, [...statsContext.tags, `action:sendTrack`])
 
@@ -55,9 +55,7 @@ const action: ActionDefinition<Settings, Payload> = {
             ...payload?.properties
           },
           context: {
-            consent: {
-              ...payload?.consent
-            }
+            consent: isValidConsentObject ? { ...payload?.consent } : {}
           },
           type: 'track'
         }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
@@ -9,8 +9,7 @@ import {
   group_id,
   properties,
   engage_space,
-  message_id,
-  context
+  message_id
 } from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
@@ -25,8 +24,7 @@ const action: ActionDefinition<Settings, Payload> = {
     event_name,
     group_id,
     properties,
-    message_id,
-    context
+    message_id
   },
   perform: (_, { payload, statsContext }) => {
     if (!payload.anonymous_id && !payload.user_id) {
@@ -49,9 +47,6 @@ const action: ActionDefinition<Settings, Payload> = {
           },
           properties: {
             ...payload?.properties
-          },
-          context: {
-            ...payload?.context
           },
           type: 'track'
         }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
@@ -9,7 +9,8 @@ import {
   group_id,
   properties,
   engage_space,
-  message_id
+  message_id,
+  consent
 } from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
@@ -24,7 +25,8 @@ const action: ActionDefinition<Settings, Payload> = {
     event_name,
     group_id,
     properties,
-    message_id
+    message_id,
+    consent
   },
   perform: (_, { payload, statsContext }) => {
     if (!payload.anonymous_id && !payload.user_id) {
@@ -47,6 +49,11 @@ const action: ActionDefinition<Settings, Payload> = {
           },
           properties: {
             ...payload?.properties
+          },
+          context: {
+            consent: {
+              ...payload?.consent
+            }
           },
           type: 'track'
         }

--- a/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendTrack/index.ts
@@ -10,7 +10,8 @@ import {
   properties,
   engage_space,
   message_id,
-  consent
+  consent,
+  validateConsentObject
 } from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
@@ -32,6 +33,9 @@ const action: ActionDefinition<Settings, Payload> = {
     if (!payload.anonymous_id && !payload.user_id) {
       throw MissingUserOrAnonymousIdThrowableError
     }
+
+    validateConsentObject(payload?.consent)
+
     statsContext?.statsClient?.incr('tapi_internal', 1, [...statsContext.tags, `action:sendTrack`])
 
     return {

--- a/packages/destination-actions/src/destinations/segment/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -563,7 +563,7 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
-          "consent": undefined,
+          "consent": Object {},
           "device": undefined,
           "groupId": "CYyxkIddLM",
           "ip": undefined,

--- a/packages/destination-actions/src/destinations/segment/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -20,6 +20,9 @@ Object {
             "source": "(m6Ifxh1N4",
             "term": "(m6Ifxh1N4",
           },
+          "consent": Object {
+            "testType": "(m6Ifxh1N4",
+          },
           "device": Object {
             "adTracking_Enabled": true,
             "advertising_id": "(m6Ifxh1N4",
@@ -88,6 +91,7 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
+          "consent": Object {},
           "device": undefined,
           "ip": undefined,
           "locale": undefined,
@@ -131,6 +135,9 @@ Object {
             "name": ")#1JCeQHYVLgzRan",
             "source": ")#1JCeQHYVLgzRan",
             "term": ")#1JCeQHYVLgzRan",
+          },
+          "consent": Object {
+            "testType": ")#1JCeQHYVLgzRan",
           },
           "device": Object {
             "adTracking_Enabled": false,
@@ -200,6 +207,7 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
+          "consent": Object {},
           "device": undefined,
           "groupId": ")#1JCeQHYVLgzRan",
           "ip": undefined,
@@ -243,6 +251,9 @@ Object {
             "name": "qB3uqzs44u!@O",
             "source": "qB3uqzs44u!@O",
             "term": "qB3uqzs44u!@O",
+          },
+          "consent": Object {
+            "testType": "qB3uqzs44u!@O",
           },
           "device": Object {
             "adTracking_Enabled": false,
@@ -320,6 +331,7 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
+          "consent": Object {},
           "device": undefined,
           "groupId": "qB3uqzs44u!@O",
           "ip": undefined,
@@ -372,6 +384,9 @@ Object {
             "name": "s62Sv8d1C1w",
             "source": "s62Sv8d1C1w",
             "term": "s62Sv8d1C1w",
+          },
+          "consent": Object {
+            "testType": "s62Sv8d1C1w",
           },
           "device": Object {
             "adTracking_Enabled": true,
@@ -442,6 +457,7 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
+          "consent": Object {},
           "device": undefined,
           "groupId": "s62Sv8d1C1w",
           "ip": undefined,

--- a/packages/destination-actions/src/destinations/segment/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -21,7 +21,10 @@ Object {
             "term": "(m6Ifxh1N4",
           },
           "consent": Object {
-            "testType": "(m6Ifxh1N4",
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
           },
           "device": Object {
             "adTracking_Enabled": true,
@@ -91,7 +94,12 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
-          "consent": Object {},
+          "consent": Object {
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
+          },
           "device": undefined,
           "ip": undefined,
           "locale": undefined,
@@ -137,7 +145,10 @@ Object {
             "term": ")#1JCeQHYVLgzRan",
           },
           "consent": Object {
-            "testType": ")#1JCeQHYVLgzRan",
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
           },
           "device": Object {
             "adTracking_Enabled": false,
@@ -207,7 +218,12 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
-          "consent": Object {},
+          "consent": Object {
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
+          },
           "device": undefined,
           "groupId": ")#1JCeQHYVLgzRan",
           "ip": undefined,
@@ -253,7 +269,10 @@ Object {
             "term": "qB3uqzs44u!@O",
           },
           "consent": Object {
-            "testType": "qB3uqzs44u!@O",
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
           },
           "device": Object {
             "adTracking_Enabled": false,
@@ -331,7 +350,12 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
-          "consent": Object {},
+          "consent": Object {
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
+          },
           "device": undefined,
           "groupId": "qB3uqzs44u!@O",
           "ip": undefined,
@@ -386,7 +410,10 @@ Object {
             "term": "s62Sv8d1C1w",
           },
           "consent": Object {
-            "testType": "s62Sv8d1C1w",
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
           },
           "device": Object {
             "adTracking_Enabled": true,
@@ -457,7 +484,12 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
-          "consent": Object {},
+          "consent": Object {
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
+          },
           "device": undefined,
           "groupId": "s62Sv8d1C1w",
           "ip": undefined,
@@ -505,7 +537,10 @@ Object {
             "term": "CYyxkIddLM",
           },
           "consent": Object {
-            "testType": "CYyxkIddLM",
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
           },
           "device": Object {
             "adTracking_Enabled": true,
@@ -579,7 +614,12 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
-          "consent": Object {},
+          "consent": Object {
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
+          },
           "device": undefined,
           "groupId": "CYyxkIddLM",
           "ip": undefined,

--- a/packages/destination-actions/src/destinations/segment/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -488,6 +488,9 @@ Object {
             "source": "CYyxkIddLM",
             "term": "CYyxkIddLM",
           },
+          "consent": Object {
+            "testType": "CYyxkIddLM",
+          },
           "device": Object {
             "adTracking_Enabled": true,
             "advertising_id": "CYyxkIddLM",
@@ -560,6 +563,7 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
+          "consent": undefined,
           "device": undefined,
           "groupId": "CYyxkIddLM",
           "ip": undefined,

--- a/packages/destination-actions/src/destinations/segment/errors.ts
+++ b/packages/destination-actions/src/destinations/segment/errors.ts
@@ -7,3 +7,7 @@ export const MissingUserOrAnonymousIdThrowableError = new PayloadValidationError
 export const InvalidEndpointSelectedThrowableError = new PayloadValidationError(
   'A valid endpoint must be selected. Please check your Segment settings.'
 )
+
+export const InvalidConsentObject = new PayloadValidationError(
+  'Consent object must be an object with `categoryPreferences`, a map of strings to booleans.'
+)

--- a/packages/destination-actions/src/destinations/segment/errors.ts
+++ b/packages/destination-actions/src/destinations/segment/errors.ts
@@ -7,7 +7,3 @@ export const MissingUserOrAnonymousIdThrowableError = new PayloadValidationError
 export const InvalidEndpointSelectedThrowableError = new PayloadValidationError(
   'A valid endpoint must be selected. Please check your Segment settings.'
 )
-
-export const InvalidConsentObject = new PayloadValidationError(
-  'Consent object must be an object with `categoryPreferences`, a map of strings to booleans.'
-)

--- a/packages/destination-actions/src/destinations/segment/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment/segment-properties.ts
@@ -109,7 +109,7 @@ export const campaign_parameters: InputField = {
   }
 }
 
-export const context: InputField = {
+export const consent: InputField = {
   label: 'consent',
   description: 'Free-form dictionary of consent category preferences.',
   type: 'object',

--- a/packages/destination-actions/src/destinations/segment/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment/segment-properties.ts
@@ -365,7 +365,6 @@ export const consent: InputField = {
   description: 'Segment event consent category preferences.',
   type: 'object',
   default: { '@path': '$.context.consent' },
-  additionalProperties: true,
   unsafe_hidden: true
 }
 function isCategoryPreferences(obj: unknown): boolean {

--- a/packages/destination-actions/src/destinations/segment/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment/segment-properties.ts
@@ -109,6 +109,14 @@ export const campaign_parameters: InputField = {
   }
 }
 
+export const context: InputField = {
+  label: 'consent',
+  description: 'Free-form dictionary of consent category preferences.',
+  type: 'object',
+  defaultObjectUI: 'keyvalue',
+  additionalProperties: true
+}
+
 export const device: InputField = {
   label: 'Device',
   description: 'Dictionary of information about the device the API call originated from.',

--- a/packages/destination-actions/src/destinations/segment/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment/segment-properties.ts
@@ -108,15 +108,6 @@ export const campaign_parameters: InputField = {
     }
   }
 }
-
-export const consent: InputField = {
-  label: 'consent',
-  description: 'Free-form dictionary of consent category preferences.',
-  type: 'object',
-  defaultObjectUI: 'keyvalue',
-  additionalProperties: true
-}
-
 export const device: InputField = {
   label: 'Device',
   description: 'Dictionary of information about the device the API call originated from.',
@@ -366,5 +357,14 @@ export const message_id: InputField = {
   label: 'MessageId',
   description: 'The Segment messageId.',
   default: { '@path': '$.messageId' },
+  unsafe_hidden: true
+}
+
+export const consent: InputField = {
+  label: 'Consent',
+  description: 'Segment event consent category preferences.',
+  type: 'object',
+  default: { '@path': '$.context.consent' },
+  additionalProperties: true,
   unsafe_hidden: true
 }

--- a/packages/destination-actions/src/destinations/segment/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment/segment-properties.ts
@@ -1,5 +1,4 @@
 import { InputField } from '@segment/actions-core/destination-kit/types'
-import { InvalidConsentObject } from './errors'
 
 export const user_id: InputField = {
   label: 'User ID',
@@ -376,16 +375,14 @@ function isCategoryPreferences(obj: unknown): boolean {
 
   return Object.values(obj).every((value) => typeof value === 'boolean')
 }
-export const validateConsentObject = (obj: { [k: string]: unknown } | undefined): void => {
+export const validateConsentObject = (obj: { [k: string]: unknown } | undefined): boolean => {
   if (obj == undefined) {
-    return
+    return true
   }
 
   if (typeof obj !== 'object' || obj === null) {
-    throw InvalidConsentObject
+    throw false
   }
 
-  if (!('categoryPreferences' in obj && isCategoryPreferences(obj['categoryPreferences']))) {
-    throw InvalidConsentObject
-  }
+  return 'categoryPreferences' in obj && isCategoryPreferences(obj['categoryPreferences'])
 }

--- a/packages/destination-actions/src/destinations/segment/segment-properties.ts
+++ b/packages/destination-actions/src/destinations/segment/segment-properties.ts
@@ -1,4 +1,5 @@
 import { InputField } from '@segment/actions-core/destination-kit/types'
+import { InvalidConsentObject } from './errors'
 
 export const user_id: InputField = {
   label: 'User ID',
@@ -367,4 +368,24 @@ export const consent: InputField = {
   default: { '@path': '$.context.consent' },
   additionalProperties: true,
   unsafe_hidden: true
+}
+function isCategoryPreferences(obj: unknown): boolean {
+  if (typeof obj !== 'object' || obj === null) {
+    return false
+  }
+
+  return Object.values(obj).every((value) => typeof value === 'boolean')
+}
+export const validateConsentObject = (obj: { [k: string]: unknown } | undefined): void => {
+  if (obj == undefined) {
+    return
+  }
+
+  if (typeof obj !== 'object' || obj === null) {
+    throw InvalidConsentObject
+  }
+
+  if (!('categoryPreferences' in obj && isCategoryPreferences(obj['categoryPreferences']))) {
+    throw InvalidConsentObject
+  }
 }

--- a/packages/destination-actions/src/destinations/segment/sendGroup/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment/sendGroup/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -27,6 +27,9 @@ Array [
               "source": "92N!&JfP",
               "term": "92N!&JfP",
             },
+            "consent": Object {
+              "testType": "92N!&JfP",
+            },
             "device": Object {
               "adTracking_Enabled": true,
               "advertising_id": "92N!&JfP",
@@ -96,6 +99,7 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
+          "consent": Object {},
           "device": undefined,
           "ip": undefined,
           "locale": undefined,

--- a/packages/destination-actions/src/destinations/segment/sendGroup/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment/sendGroup/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -28,7 +28,10 @@ Array [
               "term": "92N!&JfP",
             },
             "consent": Object {
-              "testType": "92N!&JfP",
+              "categoryPreferences": Object {
+                "analytics": true,
+                "marketing": false,
+              },
             },
             "device": Object {
               "adTracking_Enabled": true,
@@ -99,7 +102,12 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
-          "consent": Object {},
+          "consent": Object {
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
+          },
           "device": undefined,
           "ip": undefined,
           "locale": undefined,

--- a/packages/destination-actions/src/destinations/segment/sendGroup/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment/sendGroup/generated-types.ts
@@ -231,4 +231,10 @@ export interface Payload {
    * This is always disabled pending a full removal. When enabled, the action will send batch data. Segment accepts batches of up to 225 events.
    */
   enable_batching?: boolean
+  /**
+   * Segment event consent category preferences.
+   */
+  consent?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/segment/sendGroup/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendGroup/index.ts
@@ -20,7 +20,8 @@ import {
   timezone,
   traits,
   message_id,
-  enable_batching
+  enable_batching,
+  consent
 } from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
@@ -47,7 +48,8 @@ const action: ActionDefinition<Settings, Payload> = {
     timezone,
     traits,
     message_id,
-    enable_batching
+    enable_batching,
+    consent
   },
   perform: (_request, { payload, statsContext }) => {
     if (!payload.anonymous_id && !payload.user_id) {
@@ -84,6 +86,9 @@ function convertPayload(data: Payload) {
     context: {
       app: data?.application,
       campaign: data?.campaign_parameters,
+      consent: {
+        ...data?.consent
+      },
       device: data?.device,
       ip: data?.ip_address,
       locale: data?.locale,

--- a/packages/destination-actions/src/destinations/segment/sendGroup/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendGroup/index.ts
@@ -21,7 +21,8 @@ import {
   traits,
   message_id,
   enable_batching,
-  consent
+  consent,
+  validateConsentObject
 } from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
@@ -56,6 +57,7 @@ const action: ActionDefinition<Settings, Payload> = {
       throw MissingUserOrAnonymousIdThrowableError
     }
 
+    validateConsentObject(payload?.consent)
     const groupPayload: Object = convertPayload(payload)
 
     // Returns transformed payload without snding it to TAPI endpoint.
@@ -68,6 +70,7 @@ const action: ActionDefinition<Settings, Payload> = {
       if (!data.anonymous_id && !data.user_id) {
         throw MissingUserOrAnonymousIdThrowableError
       }
+      validateConsentObject(data?.consent)
       return convertPayload(data)
     })
 

--- a/packages/destination-actions/src/destinations/segment/sendGroup/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendGroup/index.ts
@@ -57,7 +57,6 @@ const action: ActionDefinition<Settings, Payload> = {
       throw MissingUserOrAnonymousIdThrowableError
     }
 
-    validateConsentObject(payload?.consent)
     const groupPayload: Object = convertPayload(payload)
 
     // Returns transformed payload without snding it to TAPI endpoint.
@@ -70,7 +69,6 @@ const action: ActionDefinition<Settings, Payload> = {
       if (!data.anonymous_id && !data.user_id) {
         throw MissingUserOrAnonymousIdThrowableError
       }
-      validateConsentObject(data?.consent)
       return convertPayload(data)
     })
 
@@ -80,6 +78,7 @@ const action: ActionDefinition<Settings, Payload> = {
 }
 
 function convertPayload(data: Payload) {
+  const isValidateConsentObject = validateConsentObject(data.consent)
   return {
     userId: data?.user_id,
     anonymousId: data?.anonymous_id,
@@ -89,9 +88,7 @@ function convertPayload(data: Payload) {
     context: {
       app: data?.application,
       campaign: data?.campaign_parameters,
-      consent: {
-        ...data?.consent
-      },
+      consent: isValidateConsentObject ? { ...data?.consent } : {},
       device: data?.device,
       ip: data?.ip_address,
       locale: data?.locale,

--- a/packages/destination-actions/src/destinations/segment/sendIdentify/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment/sendIdentify/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -20,6 +20,9 @@ Object {
             "source": "l1ibvt$6IJOK*&*ZgReE",
             "term": "l1ibvt$6IJOK*&*ZgReE",
           },
+          "consent": Object {
+            "testType": "l1ibvt$6IJOK*&*ZgReE",
+          },
           "device": Object {
             "adTracking_Enabled": false,
             "advertising_id": "l1ibvt$6IJOK*&*ZgReE",
@@ -88,6 +91,7 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
+          "consent": Object {},
           "device": undefined,
           "groupId": "l1ibvt$6IJOK*&*ZgReE",
           "ip": undefined,

--- a/packages/destination-actions/src/destinations/segment/sendIdentify/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment/sendIdentify/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -21,7 +21,10 @@ Object {
             "term": "l1ibvt$6IJOK*&*ZgReE",
           },
           "consent": Object {
-            "testType": "l1ibvt$6IJOK*&*ZgReE",
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
           },
           "device": Object {
             "adTracking_Enabled": false,
@@ -91,7 +94,12 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
-          "consent": Object {},
+          "consent": Object {
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
+          },
           "device": undefined,
           "groupId": "l1ibvt$6IJOK*&*ZgReE",
           "ip": undefined,

--- a/packages/destination-actions/src/destinations/segment/sendIdentify/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment/sendIdentify/generated-types.ts
@@ -231,4 +231,10 @@ export interface Payload {
    * This is always disabled pending a full removal. When enabled, the action will send batch data. Segment accepts batches of up to 225 events.
    */
   enable_batching?: boolean
+  /**
+   * Segment event consent category preferences.
+   */
+  consent?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/segment/sendIdentify/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendIdentify/index.ts
@@ -58,7 +58,6 @@ const action: ActionDefinition<Settings, Payload> = {
       throw MissingUserOrAnonymousIdThrowableError
     }
 
-    validateConsentObject(payload?.consent)
     const identifyPayload = convertPayload(payload)
     statsContext?.statsClient?.incr('tapi_internal', 1, [...statsContext.tags, 'action:sendIdentify'])
     return { batch: [identifyPayload] }
@@ -68,7 +67,6 @@ const action: ActionDefinition<Settings, Payload> = {
       if (!data.anonymous_id && !data.user_id) {
         throw MissingUserOrAnonymousIdThrowableError
       }
-      validateConsentObject(data?.consent)
       return convertPayload(data)
     })
 
@@ -78,6 +76,7 @@ const action: ActionDefinition<Settings, Payload> = {
 }
 
 function convertPayload(data: Payload) {
+  const isValidConsentObject = validateConsentObject(data?.consent)
   return {
     userId: data?.user_id,
     anonymousId: data?.anonymous_id,
@@ -86,9 +85,7 @@ function convertPayload(data: Payload) {
     context: {
       app: data?.application,
       campaign: data?.campaign_parameters,
-      consent: {
-        ...data?.consent
-      },
+      consent: isValidConsentObject ? { ...data?.consent } : {},
       device: data?.device,
       ip: data?.ip_address,
       locale: data?.locale,

--- a/packages/destination-actions/src/destinations/segment/sendIdentify/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendIdentify/index.ts
@@ -21,7 +21,8 @@ import {
   traits,
   message_id,
   enable_batching,
-  consent
+  consent,
+  validateConsentObject
 } from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
@@ -57,6 +58,7 @@ const action: ActionDefinition<Settings, Payload> = {
       throw MissingUserOrAnonymousIdThrowableError
     }
 
+    validateConsentObject(payload?.consent)
     const identifyPayload = convertPayload(payload)
     statsContext?.statsClient?.incr('tapi_internal', 1, [...statsContext.tags, 'action:sendIdentify'])
     return { batch: [identifyPayload] }
@@ -66,6 +68,7 @@ const action: ActionDefinition<Settings, Payload> = {
       if (!data.anonymous_id && !data.user_id) {
         throw MissingUserOrAnonymousIdThrowableError
       }
+      validateConsentObject(data?.consent)
       return convertPayload(data)
     })
 

--- a/packages/destination-actions/src/destinations/segment/sendIdentify/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendIdentify/index.ts
@@ -20,7 +20,8 @@ import {
   location,
   traits,
   message_id,
-  enable_batching
+  enable_batching,
+  consent
 } from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
@@ -48,7 +49,8 @@ const action: ActionDefinition<Settings, Payload> = {
     group_id,
     traits,
     message_id,
-    enable_batching
+    enable_batching,
+    consent
   },
   perform: (_request, { payload, statsContext }) => {
     if (!payload.anonymous_id && !payload.user_id) {
@@ -81,6 +83,9 @@ function convertPayload(data: Payload) {
     context: {
       app: data?.application,
       campaign: data?.campaign_parameters,
+      consent: {
+        ...data?.consent
+      },
       device: data?.device,
       ip: data?.ip_address,
       locale: data?.locale,

--- a/packages/destination-actions/src/destinations/segment/sendPage/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment/sendPage/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -21,7 +21,10 @@ Object {
             "term": "!jvXo22kjE9u2QlY4S",
           },
           "consent": Object {
-            "testType": "!jvXo22kjE9u2QlY4S",
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
           },
           "device": Object {
             "adTracking_Enabled": false,
@@ -99,7 +102,12 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
-          "consent": Object {},
+          "consent": Object {
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
+          },
           "device": undefined,
           "groupId": "!jvXo22kjE9u2QlY4S",
           "ip": undefined,

--- a/packages/destination-actions/src/destinations/segment/sendPage/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment/sendPage/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -20,6 +20,9 @@ Object {
             "source": "!jvXo22kjE9u2QlY4S",
             "term": "!jvXo22kjE9u2QlY4S",
           },
+          "consent": Object {
+            "testType": "!jvXo22kjE9u2QlY4S",
+          },
           "device": Object {
             "adTracking_Enabled": false,
             "advertising_id": "!jvXo22kjE9u2QlY4S",
@@ -96,6 +99,7 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
+          "consent": Object {},
           "device": undefined,
           "groupId": "!jvXo22kjE9u2QlY4S",
           "ip": undefined,

--- a/packages/destination-actions/src/destinations/segment/sendPage/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment/sendPage/generated-types.ts
@@ -239,4 +239,10 @@ export interface Payload {
    * This is always disabled pending a full removal. When enabled, the action will send batch data. Segment accepts batches of up to 225 events.
    */
   enable_batching?: boolean
+  /**
+   * Segment event consent category preferences.
+   */
+  consent?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/segment/sendPage/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendPage/index.ts
@@ -22,7 +22,8 @@ import {
   group_id,
   properties,
   message_id,
-  enable_batching
+  enable_batching,
+  consent
 } from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
@@ -51,7 +52,8 @@ const action: ActionDefinition<Settings, Payload> = {
     group_id,
     properties,
     message_id,
-    enable_batching
+    enable_batching,
+    consent
   },
   perform: (_request, { payload, statsContext }) => {
     if (!payload.anonymous_id && !payload.user_id) {
@@ -86,6 +88,9 @@ function convertPayload(data: Payload) {
     context: {
       app: data?.application,
       campaign: data?.campaign_parameters,
+      consent: {
+        ...data?.consent
+      },
       device: data?.device,
       ip: data?.ip_address,
       locale: data?.locale,

--- a/packages/destination-actions/src/destinations/segment/sendPage/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendPage/index.ts
@@ -61,7 +61,6 @@ const action: ActionDefinition<Settings, Payload> = {
       throw MissingUserOrAnonymousIdThrowableError
     }
 
-    validateConsentObject(payload?.consent)
     const pagePayload: Object = convertPayload(payload)
 
     statsContext?.statsClient?.incr('tapi_internal', 1, [...statsContext.tags, 'action:sendPage'])
@@ -70,7 +69,6 @@ const action: ActionDefinition<Settings, Payload> = {
   performBatch: (_request, { payload, statsContext }) => {
     const pagePayload = payload.map((data) => {
       if (!data.anonymous_id && !data.user_id) {
-        validateConsentObject(data?.consent)
         throw MissingUserOrAnonymousIdThrowableError
       }
       return convertPayload(data)
@@ -82,6 +80,8 @@ const action: ActionDefinition<Settings, Payload> = {
 }
 
 function convertPayload(data: Payload) {
+  const isValidConsentObject = validateConsentObject(data?.consent)
+
   return {
     userId: data?.user_id,
     anonymousId: data?.anonymous_id,
@@ -91,9 +91,7 @@ function convertPayload(data: Payload) {
     context: {
       app: data?.application,
       campaign: data?.campaign_parameters,
-      consent: {
-        ...data?.consent
-      },
+      consent: isValidConsentObject ? { ...data?.consent } : {},
       device: data?.device,
       ip: data?.ip_address,
       locale: data?.locale,

--- a/packages/destination-actions/src/destinations/segment/sendPage/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendPage/index.ts
@@ -23,7 +23,8 @@ import {
   properties,
   message_id,
   enable_batching,
-  consent
+  consent,
+  validateConsentObject
 } from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
@@ -60,6 +61,7 @@ const action: ActionDefinition<Settings, Payload> = {
       throw MissingUserOrAnonymousIdThrowableError
     }
 
+    validateConsentObject(payload?.consent)
     const pagePayload: Object = convertPayload(payload)
 
     statsContext?.statsClient?.incr('tapi_internal', 1, [...statsContext.tags, 'action:sendPage'])
@@ -68,6 +70,7 @@ const action: ActionDefinition<Settings, Payload> = {
   performBatch: (_request, { payload, statsContext }) => {
     const pagePayload = payload.map((data) => {
       if (!data.anonymous_id && !data.user_id) {
+        validateConsentObject(data?.consent)
         throw MissingUserOrAnonymousIdThrowableError
       }
       return convertPayload(data)

--- a/packages/destination-actions/src/destinations/segment/sendScreen/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment/sendScreen/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -21,7 +21,10 @@ Object {
             "term": "O3*7wUzuzQ",
           },
           "consent": Object {
-            "testType": "O3*7wUzuzQ",
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
           },
           "device": Object {
             "adTracking_Enabled": true,
@@ -92,7 +95,12 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
-          "consent": Object {},
+          "consent": Object {
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
+          },
           "device": undefined,
           "groupId": "O3*7wUzuzQ",
           "ip": undefined,

--- a/packages/destination-actions/src/destinations/segment/sendScreen/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment/sendScreen/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -20,6 +20,9 @@ Object {
             "source": "O3*7wUzuzQ",
             "term": "O3*7wUzuzQ",
           },
+          "consent": Object {
+            "testType": "O3*7wUzuzQ",
+          },
           "device": Object {
             "adTracking_Enabled": true,
             "advertising_id": "O3*7wUzuzQ",
@@ -89,6 +92,7 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
+          "consent": Object {},
           "device": undefined,
           "groupId": "O3*7wUzuzQ",
           "ip": undefined,

--- a/packages/destination-actions/src/destinations/segment/sendScreen/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment/sendScreen/generated-types.ts
@@ -235,4 +235,10 @@ export interface Payload {
    * This is always disabled pending a full removal. When enabled, the action will send batch data. Segment accepts batches of up to 225 events.
    */
   enable_batching?: boolean
+  /**
+   * Segment event consent category preferences.
+   */
+  consent?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/segment/sendScreen/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendScreen/index.ts
@@ -59,7 +59,6 @@ const action: ActionDefinition<Settings, Payload> = {
       throw MissingUserOrAnonymousIdThrowableError
     }
 
-    validateConsentObject(payload?.consent)
     const screenPayload: Object = convertPayload(payload)
 
     statsContext?.statsClient?.incr('tapi_internal', 1, [...statsContext.tags, 'action:sendScreen'])
@@ -70,7 +69,6 @@ const action: ActionDefinition<Settings, Payload> = {
       if (!data.anonymous_id && !data.user_id) {
         throw MissingUserOrAnonymousIdThrowableError
       }
-      validateConsentObject(data?.consent)
       return convertPayload(data)
     })
 
@@ -80,6 +78,8 @@ const action: ActionDefinition<Settings, Payload> = {
 }
 
 function convertPayload(data: Payload) {
+  const isValidConsentObject = validateConsentObject(data?.consent)
+
   return {
     userId: data?.user_id,
     anonymousId: data?.anonymous_id,
@@ -89,9 +89,7 @@ function convertPayload(data: Payload) {
     context: {
       app: data?.application,
       campaign: data?.campaign_parameters,
-      consent: {
-        ...data?.consent
-      },
+      consent: isValidConsentObject ? { ...data?.consent } : {},
       device: data?.device,
       ip: data?.ip_address,
       locale: data?.locale,

--- a/packages/destination-actions/src/destinations/segment/sendScreen/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendScreen/index.ts
@@ -21,7 +21,8 @@ import {
   locale,
   location,
   message_id,
-  enable_batching
+  enable_batching,
+  consent
 } from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
@@ -49,7 +50,8 @@ const action: ActionDefinition<Settings, Payload> = {
     group_id,
     properties,
     message_id,
-    enable_batching
+    enable_batching,
+    consent
   },
   perform: (_request, { payload, statsContext }) => {
     if (!payload.anonymous_id && !payload.user_id) {
@@ -84,6 +86,9 @@ function convertPayload(data: Payload) {
     context: {
       app: data?.application,
       campaign: data?.campaign_parameters,
+      consent: {
+        ...data?.consent
+      },
       device: data?.device,
       ip: data?.ip_address,
       locale: data?.locale,

--- a/packages/destination-actions/src/destinations/segment/sendScreen/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendScreen/index.ts
@@ -22,7 +22,8 @@ import {
   location,
   message_id,
   enable_batching,
-  consent
+  consent,
+  validateConsentObject
 } from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
@@ -58,6 +59,7 @@ const action: ActionDefinition<Settings, Payload> = {
       throw MissingUserOrAnonymousIdThrowableError
     }
 
+    validateConsentObject(payload?.consent)
     const screenPayload: Object = convertPayload(payload)
 
     statsContext?.statsClient?.incr('tapi_internal', 1, [...statsContext.tags, 'action:sendScreen'])
@@ -68,6 +70,7 @@ const action: ActionDefinition<Settings, Payload> = {
       if (!data.anonymous_id && !data.user_id) {
         throw MissingUserOrAnonymousIdThrowableError
       }
+      validateConsentObject(data?.consent)
       return convertPayload(data)
     })
 

--- a/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -20,6 +20,9 @@ Object {
             "source": "ET^Xg5cIGF]2ok",
             "term": "ET^Xg5cIGF]2ok",
           },
+          "consent": Object {
+            "testType": "ET^Xg5cIGF]2ok",
+          },
           "device": Object {
             "adTracking_Enabled": false,
             "advertising_id": "ET^Xg5cIGF]2ok",
@@ -92,6 +95,7 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
+          "consent": undefined,
           "device": undefined,
           "groupId": "ET^Xg5cIGF]2ok",
           "ip": undefined,

--- a/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -21,7 +21,10 @@ Object {
             "term": "ET^Xg5cIGF]2ok",
           },
           "consent": Object {
-            "testType": "ET^Xg5cIGF]2ok",
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
           },
           "device": Object {
             "adTracking_Enabled": false,
@@ -95,7 +98,12 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
-          "consent": Object {},
+          "consent": Object {
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
+          },
           "device": undefined,
           "groupId": "ET^Xg5cIGF]2ok",
           "ip": undefined,

--- a/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -95,7 +95,7 @@ Object {
         "context": Object {
           "app": undefined,
           "campaign": undefined,
-          "consent": undefined,
+          "consent": Object {},
           "device": undefined,
           "groupId": "ET^Xg5cIGF]2ok",
           "ip": undefined,

--- a/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/index.test.ts
@@ -82,6 +82,53 @@ describe('Segment.sendTrack', () => {
     })
   })
 
+  test('Should return transformed event with consent', async () => {
+    const event = createTestEvent({
+      context: {
+        consent: {
+          categoryPreferences: {
+            analytics: true,
+            marketing: false
+          }
+        },
+        userId: 'test-user-ufi5bgkko5',
+        anonymousId: 'arky4h2sh7k',
+        event: 'Test Event'
+      }
+    })
+
+    const responses = await testDestination.testAction('sendTrack', {
+      event,
+      mapping: defaultTrackMapping,
+      settings: {
+        source_write_key: 'test-source-write-key'
+      }
+    })
+
+    const results = testDestination.results
+    expect(responses.length).toBe(0)
+    expect(results.length).toBe(3)
+    expect(results[2].data).toMatchObject({
+      batch: [
+        {
+          userId: event.userId,
+          anonymousId: event.anonymousId,
+          properties: {
+            ...event.properties
+          },
+          context: {
+            consent: {
+              categoryPreferences: {
+                analytics: true,
+                marketing: false
+              }
+            }
+          }
+        }
+      ]
+    })
+  })
+
   it('should work with batch events', async () => {
     const events: SegmentEvent[] = [
       createTestEvent({

--- a/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/__tests__/index.test.ts
@@ -82,53 +82,6 @@ describe('Segment.sendTrack', () => {
     })
   })
 
-  test('Should return transformed event with consent', async () => {
-    const event = createTestEvent({
-      context: {
-        consent: {
-          categoryPreferences: {
-            analytics: true,
-            marketing: false
-          }
-        },
-        userId: 'test-user-ufi5bgkko5',
-        anonymousId: 'arky4h2sh7k',
-        event: 'Test Event'
-      }
-    })
-
-    const responses = await testDestination.testAction('sendTrack', {
-      event,
-      mapping: defaultTrackMapping,
-      settings: {
-        source_write_key: 'test-source-write-key'
-      }
-    })
-
-    const results = testDestination.results
-    expect(responses.length).toBe(0)
-    expect(results.length).toBe(3)
-    expect(results[2].data).toMatchObject({
-      batch: [
-        {
-          userId: event.userId,
-          anonymousId: event.anonymousId,
-          properties: {
-            ...event.properties
-          },
-          context: {
-            consent: {
-              categoryPreferences: {
-                analytics: true,
-                marketing: false
-              }
-            }
-          }
-        }
-      ]
-    })
-  })
-
   it('should work with batch events', async () => {
     const events: SegmentEvent[] = [
       createTestEvent({

--- a/packages/destination-actions/src/destinations/segment/sendTrack/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/generated-types.ts
@@ -242,7 +242,7 @@ export interface Payload {
    */
   enable_batching?: boolean
   /**
-   * Free-form dictionary of consent category preferences.
+   * Segment event consent category preferences.
    */
   consent?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/segment/sendTrack/generated-types.ts
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/generated-types.ts
@@ -241,4 +241,10 @@ export interface Payload {
    * This is always disabled pending a full removal. When enabled, the action will send batch data. Segment accepts batches of up to 225 events.
    */
   enable_batching?: boolean
+  /**
+   * Free-form dictionary of consent category preferences.
+   */
+  consent?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/segment/sendTrack/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/index.ts
@@ -91,7 +91,9 @@ function convertPayload(data: Payload) {
       },
       app: data?.application,
       campaign: data?.campaign_parameters,
-      consent: data?.consent,
+      consent: {
+        ...data?.consent
+      },
       device: data?.device,
       ip: data?.ip_address,
       locale: data?.locale,

--- a/packages/destination-actions/src/destinations/segment/sendTrack/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/index.ts
@@ -61,8 +61,6 @@ const action: ActionDefinition<Settings, Payload> = {
       throw MissingUserOrAnonymousIdThrowableError
     }
 
-    validateConsentObject(payload?.consent)
-
     const trackPayload: Object = convertPayload(payload)
 
     statsContext?.statsClient?.incr('tapi_internal', 1, [...statsContext.tags, 'action:sendTrack'])
@@ -73,7 +71,6 @@ const action: ActionDefinition<Settings, Payload> = {
       if (!data.anonymous_id && !data.user_id) {
         throw MissingUserOrAnonymousIdThrowableError
       }
-      validateConsentObject(data?.consent)
       return convertPayload(data)
     })
 
@@ -83,6 +80,8 @@ const action: ActionDefinition<Settings, Payload> = {
 }
 
 function convertPayload(data: Payload) {
+  const isValidConsentObject = validateConsentObject(data?.consent)
+
   return {
     userId: data?.user_id,
     anonymousId: data?.anonymous_id,
@@ -95,9 +94,7 @@ function convertPayload(data: Payload) {
       },
       app: data?.application,
       campaign: data?.campaign_parameters,
-      consent: {
-        ...data?.consent
-      },
+      consent: isValidConsentObject ? { ...data?.consent } : {},
       device: data?.device,
       ip: data?.ip_address,
       locale: data?.locale,

--- a/packages/destination-actions/src/destinations/segment/sendTrack/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/index.ts
@@ -22,7 +22,8 @@ import {
   properties,
   traits,
   message_id,
-  enable_batching
+  enable_batching,
+  consent
 } from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
@@ -51,7 +52,8 @@ const action: ActionDefinition<Settings, Payload> = {
     properties,
     traits,
     message_id,
-    enable_batching
+    enable_batching,
+    consent
   },
   perform: (_request, { payload, statsContext }) => {
     if (!payload.anonymous_id && !payload.user_id) {

--- a/packages/destination-actions/src/destinations/segment/sendTrack/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/index.ts
@@ -89,6 +89,7 @@ function convertPayload(data: Payload) {
       },
       app: data?.application,
       campaign: data?.campaign_parameters,
+      consent: data?.consent,
       device: data?.device,
       ip: data?.ip_address,
       locale: data?.locale,

--- a/packages/destination-actions/src/destinations/segment/sendTrack/index.ts
+++ b/packages/destination-actions/src/destinations/segment/sendTrack/index.ts
@@ -23,7 +23,8 @@ import {
   traits,
   message_id,
   enable_batching,
-  consent
+  consent,
+  validateConsentObject
 } from '../segment-properties'
 import { MissingUserOrAnonymousIdThrowableError } from '../errors'
 
@@ -60,6 +61,8 @@ const action: ActionDefinition<Settings, Payload> = {
       throw MissingUserOrAnonymousIdThrowableError
     }
 
+    validateConsentObject(payload?.consent)
+
     const trackPayload: Object = convertPayload(payload)
 
     statsContext?.statsClient?.incr('tapi_internal', 1, [...statsContext.tags, 'action:sendTrack'])
@@ -70,6 +73,7 @@ const action: ActionDefinition<Settings, Payload> = {
       if (!data.anonymous_id && !data.user_id) {
         throw MissingUserOrAnonymousIdThrowableError
       }
+      validateConsentObject(data?.consent)
       return convertPayload(data)
     })
 

--- a/packages/destination-actions/src/lib/test-data.ts
+++ b/packages/destination-actions/src/lib/test-data.ts
@@ -110,7 +110,7 @@ export function generateTestData(
   }
 
   for (const [name, field] of Object.entries(action.fields)) {
-    if (isRequiredOnly && !(field.required || name.includes('id'))) {
+    if (isRequiredOnly && !(field.required || name.includes('id') || name.includes('consent'))) {
       continue
     }
 
@@ -133,6 +133,16 @@ export function generateTestData(
       continue
     }
 
+    if (name == 'consent') {
+      const consent = {
+        categoryPreferences: {
+          analytics: true,
+          marketing: false
+        }
+      }
+      eventData = setData(eventData, seedName, name, field, consent)
+      continue
+    }
     eventData = setData(eventData, seedName, name, field)
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14962,7 +14962,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15020,7 +15029,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15047,6 +15056,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -16532,7 +16548,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -16554,6 +16570,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2435,6 +2435,30 @@
   resolved "https://registry.yarnpkg.com/@segment/a1-notation/-/a1-notation-2.1.4.tgz#35a48a0688019c3ffff23b1ba890e864c891a11f"
   integrity sha512-SId7GOdDFmm/B9ajIQpXELHW4OTbVvmJbOsoJkQOcUEtoZIiX2UWfk1v4BpKql8wJW9oAhzhIIru2Pv2Yxcg+w==
 
+"@segment/action-destinations@^3.190.0":
+  version "3.269.0"
+  resolved "https://registry.yarnpkg.com/@segment/action-destinations/-/action-destinations-3.269.0.tgz#302358a14e3d51994d681c525430c221b2d08595"
+  integrity sha512-UFHe74T9QybuZOty5EMLNZonb9XSBs07m8zkfeaGdFABOvDN94zn9dzbdNvpGL6v8CVU5SL01Zi8UDBF/Jvk0A==
+  dependencies:
+    "@amplitude/ua-parser-js" "^0.7.25"
+    "@bufbuild/buf" "^1.28.0"
+    "@bufbuild/protobuf" "^1.4.2"
+    "@bufbuild/protoc-gen-es" "^1.4.2"
+    "@segment/a1-notation" "^2.1.4"
+    "@segment/actions-core" "^3.111.0"
+    "@segment/actions-shared" "^1.93.0"
+    "@types/node" "^18.11.15"
+    ajv-formats "^2.1.1"
+    aws4 "^1.12.0"
+    cheerio "^1.0.0-rc.10"
+    dayjs "^1.10.7"
+    escape-goat "^3"
+    google-libphonenumber "^3.2.31"
+    kafkajs "^2.2.4"
+    liquidjs "^10.8.4"
+    lodash "^4.17.21"
+    ssh2-sftp-client "^9.1.0"
+
 "@segment/action-emitters@^1.3.6":
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/@segment/action-emitters/-/action-emitters-1.3.6.tgz#0160442ae99821c43a9465c05226afddec73cbe5"
@@ -14962,16 +14986,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15029,7 +15044,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15056,13 +15071,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -16548,7 +16556,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -16570,15 +16578,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2435,30 +2435,6 @@
   resolved "https://registry.yarnpkg.com/@segment/a1-notation/-/a1-notation-2.1.4.tgz#35a48a0688019c3ffff23b1ba890e864c891a11f"
   integrity sha512-SId7GOdDFmm/B9ajIQpXELHW4OTbVvmJbOsoJkQOcUEtoZIiX2UWfk1v4BpKql8wJW9oAhzhIIru2Pv2Yxcg+w==
 
-"@segment/action-destinations@^3.190.0":
-  version "3.269.0"
-  resolved "https://registry.yarnpkg.com/@segment/action-destinations/-/action-destinations-3.269.0.tgz#302358a14e3d51994d681c525430c221b2d08595"
-  integrity sha512-UFHe74T9QybuZOty5EMLNZonb9XSBs07m8zkfeaGdFABOvDN94zn9dzbdNvpGL6v8CVU5SL01Zi8UDBF/Jvk0A==
-  dependencies:
-    "@amplitude/ua-parser-js" "^0.7.25"
-    "@bufbuild/buf" "^1.28.0"
-    "@bufbuild/protobuf" "^1.4.2"
-    "@bufbuild/protoc-gen-es" "^1.4.2"
-    "@segment/a1-notation" "^2.1.4"
-    "@segment/actions-core" "^3.111.0"
-    "@segment/actions-shared" "^1.93.0"
-    "@types/node" "^18.11.15"
-    ajv-formats "^2.1.1"
-    aws4 "^1.12.0"
-    cheerio "^1.0.0-rc.10"
-    dayjs "^1.10.7"
-    escape-goat "^3"
-    google-libphonenumber "^3.2.31"
-    kafkajs "^2.2.4"
-    liquidjs "^10.8.4"
-    lodash "^4.17.21"
-    ssh2-sftp-client "^9.1.0"
-
 "@segment/action-emitters@^1.3.6":
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/@segment/action-emitters/-/action-emitters-1.3.6.tgz#0160442ae99821c43a9465c05226afddec73cbe5"


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

While working on consent in RETL, we realized that the event's `context.consent.categoryPreferences` data isn't copied over. This PR adds the data to the track events for Segment Connections + Profiles.
 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment

Tested the change in stage and verified the events in Segment Connections + Profiles have the consent data.

Segment Connections:
![Screenshot 2024-06-10 at 5 03 12 PM](https://github.com/segmentio/action-destinations/assets/44650496/93394e27-5dea-4d85-b50a-5634201dbe7b)
Segment Profiles:
![Screenshot 2024-06-10 at 5 03 49 PM](https://github.com/segmentio/action-destinations/assets/44650496/d3fd5b65-b7aa-426a-b77e-49c62e345f94)
