### PR TITLE
Remove (Actions) from StackAdapt destination names

### DIFF
--- a/packages/browser-destinations/destinations/stackadapt/src/index.ts
+++ b/packages/browser-destinations/destinations/stackadapt/src/index.ts
@@ -14,7 +14,7 @@ declare global {
 }
 
 export const destination: BrowserDestinationDefinition<Settings, StackAdaptSDK> = {
-  name: 'StackAdapt Pixel (Actions)',
+  name: 'StackAdapt Pixel',
   slug: 'actions-stackadapt',
   mode: 'device',
   presets: [

--- a/packages/destination-actions/src/destinations/stackadapt/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt/index.ts
@@ -5,7 +5,7 @@ import { defaultValues } from '@segment/actions-core'
 import forwardEvent from './forwardEvent'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'StackAdapt (Actions)',
+  name: 'StackAdapt',
   slug: 'actions-stackadapt-cloud',
   mode: 'cloud',
   description:


### PR DESCRIPTION
Change destination names in the code to match changes made to the destination metadata by @joe-ayoub-segment 

## Testing

N/A

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
