### PR TITLE
increase actions-iterable request timeout to 30s

### DIFF
--- a/packages/destination-actions/src/destinations/iterable/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/trackEvent/index.ts
@@ -1,4 +1,4 @@
-import { ActionDefinition, PayloadValidationError } from '@segment/actions-core'
+import { ActionDefinition, PayloadValidationError, DEFAULT_REQUEST_TIMEOUT } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import dayjs from '../../../lib/dayjs'
@@ -80,7 +80,8 @@ const action: ActionDefinition<Settings, Payload> = {
 
     return request(endpoint, {
       method: 'post',
-      json: trackEventRequest
+      json: trackEventRequest,
+      timeout: Math.max(30_000, DEFAULT_REQUEST_TIMEOUT)
     })
   }
 }

--- a/packages/destination-actions/src/destinations/iterable/trackPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/trackPurchase/index.ts
@@ -1,4 +1,4 @@
-import { ActionDefinition, PayloadValidationError } from '@segment/actions-core'
+import { ActionDefinition, PayloadValidationError, DEFAULT_REQUEST_TIMEOUT } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import dayjs from '../../../lib/dayjs'
@@ -150,7 +150,8 @@ const action: ActionDefinition<Settings, Payload> = {
     const endpoint = getRegionalEndpoint('trackPurchase', settings.dataCenterLocation as DataCenterLocation)
     return request(endpoint, {
       method: 'post',
-      json: trackPurchaseRequest
+      json: trackPurchaseRequest,
+      timeout: Math.max(30_000, DEFAULT_REQUEST_TIMEOUT)
     })
   }
 }

--- a/packages/destination-actions/src/destinations/iterable/updateCart/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/updateCart/index.ts
@@ -1,4 +1,4 @@
-import { ActionDefinition, PayloadValidationError } from '@segment/actions-core'
+import { ActionDefinition, PayloadValidationError, DEFAULT_REQUEST_TIMEOUT } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import {
@@ -98,7 +98,8 @@ const action: ActionDefinition<Settings, Payload> = {
     const endpoint = getRegionalEndpoint('updateCart', settings.dataCenterLocation as DataCenterLocation)
     return request(endpoint, {
       method: 'post',
-      json: updateCartRequest
+      json: updateCartRequest,
+      timeout: Math.max(30_000, DEFAULT_REQUEST_TIMEOUT)
     })
   }
 }

--- a/packages/destination-actions/src/destinations/iterable/updateUser/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/updateUser/index.ts
@@ -1,4 +1,4 @@
-import { ActionDefinition, PayloadValidationError } from '@segment/actions-core'
+import { ActionDefinition, PayloadValidationError, DEFAULT_REQUEST_TIMEOUT } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import {
@@ -65,7 +65,8 @@ const action: ActionDefinition<Settings, Payload> = {
     const endpoint = getRegionalEndpoint('updateUser', settings.dataCenterLocation as DataCenterLocation)
     return request(endpoint, {
       method: 'post',
-      json: userUpdateRequest
+      json: userUpdateRequest,
+      timeout: Math.max(30_000, DEFAULT_REQUEST_TIMEOUT)
     })
   }
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Increase iterable timeout to 30s to reduce chance of duplicates.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
