### PR TITLE
[Klaviyo] Update profile identifiers for track and order completed events.

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -28,7 +28,9 @@ Object {
         "data": Object {
           "attributes": Object {
             "anonymous_id": "PE*zlOgIPA]mVozMLBaL",
+            "email": "rafebezuv@micfeoz.zm",
             "external_id": "PE*zlOgIPA]mVozMLBaL",
+            "phone_number": "PE*zlOgIPA]mVozMLBaL",
           },
           "type": "profile",
         },
@@ -109,7 +111,9 @@ Object {
         "data": Object {
           "attributes": Object {
             "anonymous_id": "mTdOx(Nl)",
+            "email": "ujoeri@ifosi.kp",
             "external_id": "mTdOx(Nl)",
+            "phone_number": "mTdOx(Nl)",
           },
           "type": "profile",
         },

--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -27,11 +27,8 @@ Object {
       "profile": Object {
         "data": Object {
           "attributes": Object {
-            "email": "rafebezuv@micfeoz.zm",
-            "other_properties": Object {
-              "testType": "PE*zlOgIPA]mVozMLBaL",
-            },
-            "phone_number": "PE*zlOgIPA]mVozMLBaL",
+            "anonymous_id": "PE*zlOgIPA]mVozMLBaL",
+            "external_id": "PE*zlOgIPA]mVozMLBaL",
           },
           "type": "profile",
         },
@@ -111,11 +108,8 @@ Object {
       "profile": Object {
         "data": Object {
           "attributes": Object {
-            "email": "ujoeri@ifosi.kp",
-            "other_properties": Object {
-              "testType": "mTdOx(Nl)",
-            },
-            "phone_number": "mTdOx(Nl)",
+            "anonymous_id": "mTdOx(Nl)",
+            "external_id": "mTdOx(Nl)",
           },
           "type": "profile",
         },

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -15,11 +15,8 @@ Object {
       "profile": Object {
         "data": Object {
           "attributes": Object {
-            "email": "tobul@dij.uz",
-            "other_properties": Object {
-              "testType": "923^%f]tQn]lN2o",
-            },
-            "phone_number": "923^%f]tQn]lN2o",
+            "anonymous_id": "923^%f]tQn]lN2o",
+            "external_id": "923^%f]tQn]lN2o",
           },
           "type": "profile",
         },

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -16,7 +16,9 @@ Object {
         "data": Object {
           "attributes": Object {
             "anonymous_id": "923^%f]tQn]lN2o",
+            "email": "tobul@dij.uz",
             "external_id": "923^%f]tQn]lN2o",
+            "phone_number": "923^%f]tQn]lN2o",
           },
           "type": "profile",
         },

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
@@ -5,6 +5,8 @@ export interface Payload {
    * Properties of the profile that triggered this event.
    */
   profile: {
+    email?: string
+    phone_number?: string
     /**
      * A unique identifier used by customers to associate Klaviyo profiles with profiles in an external system.
      */

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
@@ -5,11 +5,15 @@ export interface Payload {
    * Properties of the profile that triggered this event.
    */
   profile: {
-    email?: string
-    phone_number?: string
-    other_properties?: {
-      [k: string]: unknown
-    }
+    /**
+     * A unique identifier used by customers to associate Klaviyo profiles with profiles in an external system.
+     */
+    external_id?: string
+    /**
+     * Anonymous user identifier for the user.
+     */
+    anonymous_id?: string
+    [k: string]: unknown
   }
   /**
    * Properties of this event.

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
@@ -78,6 +78,14 @@ const action: ActionDefinition<Settings, Payload> = {
       description: `Properties of the profile that triggered this event.`,
       type: 'object',
       properties: {
+        email: {
+          label: 'Email',
+          type: 'string'
+        },
+        phone_number: {
+          label: 'Phone Number',
+          type: 'string'
+        },
         external_id: {
           label: 'External Id',
           description:

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
@@ -25,9 +25,7 @@ const createEventData = (payload: Payload) => ({
       profile: {
         data: {
           type: 'profile',
-          attributes: {
-            ...payload.profile
-          }
+          attributes: payload.profile
         }
       }
     }
@@ -80,19 +78,21 @@ const action: ActionDefinition<Settings, Payload> = {
       description: `Properties of the profile that triggered this event.`,
       type: 'object',
       properties: {
-        email: {
-          label: 'Email',
-          type: 'string'
+        external_id: {
+          label: 'External Id',
+          description:
+            'A unique identifier used by customers to associate Klaviyo profiles with profiles in an external system.',
+          type: 'string',
+          default: { '@path': '$.userId' }
         },
-        phone_number: {
-          label: 'Phone Number',
-          type: 'string'
-        },
-        other_properties: {
-          label: 'Other Properties',
-          type: 'object'
+        anonymous_id: {
+          label: 'Anonymous Id',
+          description: 'Anonymous user identifier for the user.',
+          type: 'string',
+          default: { '@path': '$.anonymousId' }
         }
       },
+      additionalProperties: true,
       required: true
     },
     properties: {
@@ -141,10 +141,10 @@ const action: ActionDefinition<Settings, Payload> = {
   },
 
   perform: async (request, { payload }) => {
-    const { email, phone_number } = payload.profile
+    const { email, phone_number, external_id, anonymous_id } = payload.profile
 
-    if (!email && !phone_number) {
-      throw new PayloadValidationError('One of Phone Number or Email is required.')
+    if (!email && !phone_number && !external_id && !anonymous_id) {
+      throw new PayloadValidationError('One of External ID, Anonymous ID, Phone Number or Email is required.')
     }
 
     const eventData = createEventData(payload)

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -15,11 +15,8 @@ Object {
       "profile": Object {
         "data": Object {
           "attributes": Object {
-            "email": "so@uzwumiz.wf",
-            "other_properties": Object {
-              "testType": "]DD4LgSzT#hw(U]@J$a",
-            },
-            "phone_number": "]DD4LgSzT#hw(U]@J$a",
+            "anonymous_id": "]DD4LgSzT#hw(U]@J$a",
+            "external_id": "]DD4LgSzT#hw(U]@J$a",
           },
           "type": "profile",
         },

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -16,7 +16,9 @@ Object {
         "data": Object {
           "attributes": Object {
             "anonymous_id": "]DD4LgSzT#hw(U]@J$a",
+            "email": "so@uzwumiz.wf",
             "external_id": "]DD4LgSzT#hw(U]@J$a",
+            "phone_number": "]DD4LgSzT#hw(U]@J$a",
           },
           "type": "profile",
         },

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/__tests__/index.test.ts
@@ -12,7 +12,7 @@ export const settings = {
 }
 
 describe('Track Event', () => {
-  it('should throw error if no email or phone_number is provided', async () => {
+  it('should throw error if no profile identifiers are provided', async () => {
     const event = createTestEvent({
       type: 'track'
     })
@@ -21,6 +21,104 @@ describe('Track Event', () => {
     await expect(testDestination.testAction('trackEvent', { event, mapping, settings })).rejects.toThrowError(
       IntegrationError
     )
+  })
+
+  it('should successfully track event with external Id', async () => {
+    const requestBody = {
+      data: {
+        type: 'event',
+        attributes: {
+          properties: { key: 'value' },
+          time: '2022-01-01T00:00:00.000Z',
+          value: 10,
+          unique_id: 'text-example-xyz',
+          metric: {
+            data: {
+              type: 'metric',
+              attributes: {
+                name: 'event_name'
+              }
+            }
+          },
+          profile: {
+            data: {
+              type: 'profile',
+              attributes: {
+                external_id: '3xt3rnal1d'
+              }
+            }
+          }
+        }
+      }
+    }
+
+    nock(`${API_URL}`).post('/events/', requestBody).reply(200, {})
+
+    const event = createTestEvent({
+      type: 'track',
+      timestamp: '2022-01-01T00:00:00.000Z'
+    })
+
+    const mapping = {
+      profile: { external_id: '3xt3rnal1d' },
+      metric_name: 'event_name',
+      properties: { key: 'value' },
+      value: 10,
+      unique_id: 'text-example-xyz'
+    }
+
+    await expect(
+      testDestination.testAction('trackEvent', { event, mapping, settings, useDefaultMappings: true })
+    ).resolves.not.toThrowError()
+  })
+
+  it('should successfully track event with anonymous Id', async () => {
+    const requestBody = {
+      data: {
+        type: 'event',
+        attributes: {
+          properties: { key: 'value' },
+          time: '2022-01-01T00:00:00.000Z',
+          value: 10,
+          unique_id: 'text-example-xyz',
+          metric: {
+            data: {
+              type: 'metric',
+              attributes: {
+                name: 'event_name'
+              }
+            }
+          },
+          profile: {
+            data: {
+              type: 'profile',
+              attributes: {
+                anonymous_id: 'an0nym0u51d'
+              }
+            }
+          }
+        }
+      }
+    }
+
+    nock(`${API_URL}`).post('/events/', requestBody).reply(200, {})
+
+    const event = createTestEvent({
+      type: 'track',
+      timestamp: '2022-01-01T00:00:00.000Z'
+    })
+
+    const mapping = {
+      profile: { anonymous_id: 'an0nym0u51d' },
+      metric_name: 'event_name',
+      properties: { key: 'value' },
+      value: 10,
+      unique_id: 'text-example-xyz'
+    }
+
+    await expect(
+      testDestination.testAction('trackEvent', { event, mapping, settings, useDefaultMappings: true })
+    ).resolves.not.toThrowError()
   })
 
   it('should successfully track event if proper parameters are provided', async () => {

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/generated-types.ts
@@ -5,11 +5,15 @@ export interface Payload {
    * Properties of the profile that triggered this event.
    */
   profile: {
-    email?: string
-    phone_number?: string
-    other_properties?: {
-      [k: string]: unknown
-    }
+    /**
+     * A unique identifier used by customers to associate Klaviyo profiles with profiles in an external system.
+     */
+    external_id?: string
+    /**
+     * Anonymous user identifier for the user.
+     */
+    anonymous_id?: string
+    [k: string]: unknown
   }
   /**
    * Name of the event. Must be less than 128 characters.

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/generated-types.ts
@@ -5,6 +5,8 @@ export interface Payload {
    * Properties of the profile that triggered this event.
    */
   profile: {
+    email?: string
+    phone_number?: string
     /**
      * A unique identifier used by customers to associate Klaviyo profiles with profiles in an external system.
      */

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/index.ts
@@ -15,6 +15,14 @@ const action: ActionDefinition<Settings, Payload> = {
       description: `Properties of the profile that triggered this event.`,
       type: 'object',
       properties: {
+        email: {
+          label: 'Email',
+          type: 'string'
+        },
+        phone_number: {
+          label: 'Phone Number',
+          type: 'string'
+        },
         external_id: {
           label: 'External Id',
           description:

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/index.ts
@@ -15,19 +15,21 @@ const action: ActionDefinition<Settings, Payload> = {
       description: `Properties of the profile that triggered this event.`,
       type: 'object',
       properties: {
-        email: {
-          label: 'Email',
-          type: 'string'
+        external_id: {
+          label: 'External Id',
+          description:
+            'A unique identifier used by customers to associate Klaviyo profiles with profiles in an external system.',
+          type: 'string',
+          default: { '@path': '$.userId' }
         },
-        phone_number: {
-          label: 'Phone Number',
-          type: 'string'
-        },
-        other_properties: {
-          label: 'Other Properties',
-          type: 'object'
+        anonymous_id: {
+          label: 'Anonymous Id',
+          description: 'Anonymous user identifier for the user.',
+          type: 'string',
+          default: { '@path': '$.anonymousId' }
         }
       },
+      additionalProperties: true,
       required: true
     },
     metric_name: {
@@ -78,10 +80,10 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: (request, { payload }) => {
-    const { email, phone_number } = payload.profile
+    const { email, phone_number, external_id, anonymous_id } = payload.profile
 
-    if (!email && !phone_number) {
-      throw new PayloadValidationError('One of Phone Number or Email is required.')
+    if (!email && !phone_number && !external_id && !anonymous_id) {
+      throw new PayloadValidationError('One of External ID, Anonymous ID, Phone Number or Email is required.')
     }
 
     const eventData = {
@@ -103,9 +105,7 @@ const action: ActionDefinition<Settings, Payload> = {
           profile: {
             data: {
               type: 'profile',
-              attributes: {
-                ...payload.profile
-              }
+              attributes: payload.profile
             }
           }
         }

--- a/packages/destination-actions/src/destinations/klaviyo/types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/types.ts
@@ -53,9 +53,8 @@ export interface EventData {
         data: {
           type: string
           attributes: {
-            email?: string
-            phone_number?: string
-            other_properties?: object
+            external_id?: string
+            anonymous_id?: string
           }
         }
       }

--- a/packages/destination-actions/src/destinations/klaviyo/types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/types.ts
@@ -53,6 +53,8 @@ export interface EventData {
         data: {
           type: string
           attributes: {
+            email?: string
+            phone_number?: string
             external_id?: string
             anonymous_id?: string
           }


### PR DESCRIPTION
This PR adds `external_id` and `anonymous_id` as profile identifiers, removes `other_properties` nested object from profile.

JIRA -> [STRATCONN-3857](https://segment.atlassian.net/browse/STRATCONN-3857)

## Testing
Mappings:
<img width="1444" alt="Screenshot 2024-06-10 at 5 44 34 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/90b8c791-4217-4a78-93b2-d84338af27db">

**Anonymous Id**: 

Track Event:
<img width="1437" alt="Screenshot 2024-06-10 at 5 40 58 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/5cf0f8fd-7450-479f-aded-b04caab0c77d">
<img width="1578" alt="Screenshot 2024-06-10 at 5 41 47 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/7f00f8fc-d28a-48b2-b138-fb643a2994f4">

Order Completed Event:
<img width="1444" alt="Screenshot 2024-06-10 at 6 22 31 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/138ddfa8-16a8-4fb1-9fb1-48c277605ee5">
<img width="1444" alt="Screenshot 2024-06-10 at 6 22 52 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/e4a50ba3-24f8-4a38-8cea-57a4a055262c">


**External Id**:
Track Event:
<img width="1578" alt="Screenshot 2024-06-10 at 5 43 00 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/4adae088-0e64-413a-8f76-f4625e8cd184">
<img width="1578" alt="Screenshot 2024-06-10 at 5 43 18 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/f8ed0aed-7ff0-4a2c-b213-3245e1db5d30">

Order Completed Event:
<img width="1444" alt="Screenshot 2024-06-10 at 6 38 01 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/94432699-3518-46b9-81ba-5f1a9d0b15fb">


Email:
Track Event:
<img width="1444" alt="Screenshot 2024-06-10 at 5 46 03 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/dea88e84-91a4-40f2-9a06-c6e2f1ed5fda">
<img width="1444" alt="Screenshot 2024-06-10 at 5 46 16 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/b48645a5-a6b6-4ef3-b8e0-e6c1e247c400">

Order Completed Event:
<img width="1444" alt="Screenshot 2024-06-10 at 7 14 43 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/ff17e9e1-18a7-4ff5-bbcb-0d9ebf4271e0">
<img width="1444" alt="Screenshot 2024-06-10 at 7 14 37 PM" src="https://github.com/segmentio/action-destinations/assets/129737395/78ac79ad-1370-4c38-baf0-0aa3391154bf">



_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment


[STRATCONN-3857]: https://segment.atlassian.net/browse/STRATCONN-3857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ