### PR TITLE
disabling iam until it is fixed

### DIFF
--- a/packages/destination-actions/src/destinations/kafka/index.ts
+++ b/packages/destination-actions/src/destinations/kafka/index.ts
@@ -35,7 +35,7 @@ const destination: DestinationDefinition<Settings> = {
           { label: 'Plain', value: 'plain' },
           { label: 'SCRAM-SHA-256', value: 'scram-sha-256' },
           { label: 'SCRAM-SHA-512', value: 'scram-sha-512' },
-          { label: 'AWS IAM', value: 'aws' },
+          //  { label: 'AWS IAM', value: 'aws' },
           { label: 'Client Certificate', value: 'client-cert-auth' }
         ],
         default: 'plain'


### PR DESCRIPTION
Kafka IAM auth isn't working with MSK. Because of this we're disabling it until a fix is implemented. 

## Testing

Tested locally. 
