### PR TITLE
update labels, no-op change

### DIFF
--- a/packages/destination-actions/src/destinations/koala/identify/index.ts
+++ b/packages/destination-actions/src/destinations/koala/identify/index.ts
@@ -47,7 +47,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: false,
       description: 'The device IP collected from the context',
-      label: 'Context properties',
+      label: 'Device IP',
       default: { '@path': '$.context.ip' }
     },
     message_id: {

--- a/packages/destination-actions/src/destinations/koala/track/index.ts
+++ b/packages/destination-actions/src/destinations/koala/track/index.ts
@@ -55,14 +55,14 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'object',
       required: false,
       description: 'Traits inherited from the context object',
-      label: 'Context properties',
+      label: 'Traits',
       default: { '@path': '$.context.traits' }
     },
     device_ip: {
       type: 'string',
       required: false,
       description: 'The device IP collected from the context',
-      label: 'Context properties',
+      label: 'Device IP',
       default: { '@path': '$.context.ip' }
     },
     message_id: {


### PR DESCRIPTION
This is a no-op change to improve the labels for mapped properties. 

## Testing

No changes to integration behavior or types, just metadata about the field labels!

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
