### PR TITLE
GA4 - Cloud - Enabling button to add additional item params to product arrays

### DIFF
--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/generated-types.ts
@@ -117,6 +117,7 @@ export interface Payload {
      * Item quantity.
      */
     quantity?: number
+    [k: string]: unknown
   }[]
   /**
    * The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties.

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/generated-types.ts
@@ -105,6 +105,7 @@ export interface Payload {
      * Item quantity.
      */
     quantity?: number
+    [k: string]: unknown
   }[]
   /**
    * The monetary value of the event.

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/generated-types.ts
@@ -109,6 +109,7 @@ export interface Payload {
      * Item quantity.
      */
     quantity?: number
+    [k: string]: unknown
   }[]
   /**
    * The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties.

--- a/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/generated-types.ts
@@ -109,6 +109,7 @@ export interface Payload {
      * Item quantity.
      */
     quantity?: number
+    [k: string]: unknown
   }[]
   /**
    * The monetary value of the event.

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-properties.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-properties.ts
@@ -156,6 +156,7 @@ export const minimal_items: InputField = {
   description: 'The list of products purchased.',
   type: 'object',
   multiple: true,
+  additionalProperties: true,
   properties: {
     item_id: {
       label: 'Product ID',

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/generated-types.ts
@@ -113,6 +113,7 @@ export interface Payload {
      * Item quantity.
      */
     quantity?: number
+    [k: string]: unknown
   }[]
   /**
    * The unique identifier of a transaction.

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/generated-types.ts
@@ -129,6 +129,7 @@ export interface Payload {
      * Item quantity.
      */
     quantity?: number
+    [k: string]: unknown
   }[]
   /**
    * The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties.

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/generated-types.ts
@@ -109,6 +109,7 @@ export interface Payload {
      * Item quantity.
      */
     quantity?: number
+    [k: string]: unknown
   }[]
   /**
    * The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties.

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/generated-types.ts
@@ -109,6 +109,7 @@ export interface Payload {
      * Item quantity.
      */
     quantity?: number
+    [k: string]: unknown
   }[]
   /**
    * The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties.

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/generated-types.ts
@@ -137,6 +137,7 @@ export interface Payload {
      * The ID of the promotion associated with the event.
      */
     promotion_id?: string
+    [k: string]: unknown
   }[]
   /**
    * The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties.

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/generated-types.ts
@@ -109,6 +109,7 @@ export interface Payload {
      * Item quantity.
      */
     quantity?: number
+    [k: string]: unknown
   }[]
   /**
    * The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties.

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/generated-types.ts
@@ -109,6 +109,7 @@ export interface Payload {
      * Item quantity.
      */
     quantity?: number
+    [k: string]: unknown
   }[]
   /**
    * The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties.

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/generated-types.ts
@@ -109,6 +109,7 @@ export interface Payload {
      * Item quantity.
      */
     quantity?: number
+    [k: string]: unknown
   }[]
   /**
    * The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties.

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/generated-types.ts
@@ -137,6 +137,7 @@ export interface Payload {
      * The ID of the promotion associated with the event.
      */
     promotion_id?: string
+    [k: string]: unknown
   }[]
   /**
    * The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties.


### PR DESCRIPTION
@Kal-Segment is working with customers who pointed out that the GA4 Cloud Mode Destination doesn't allow customers to add custom item params to the products array. However the GA4 Web Mode Destination does. 

This is a simple change to enable this in the UI for GA4 Cloud Mode. 

[Here](https://developers.google.com/analytics/devguides/collection/ga4/item-scoped-ecommerce) and [here](https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=firebase#custom_parameters) are the GA4 API docs which state that custom item params can be added. 

[Here's](https://github.com/segmentio/action-destinations/blob/main/packages/browser-destinations/destinations/google-analytics-4-web/src/ga4-properties.ts#L193) where the GA4 Web Mode Destination enables this capability (via a single line). 

![image](https://github.com/segmentio/action-destinations/assets/45374896/5f4346fd-a04d-4b0e-a5c0-85497ec01848)


Kal would simply like to enable the same thing for Cloud Mode. Could someone who looks after this Destination please review + approve?


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
