### PR TITLE
[Amazon AMC] - Revamp Refresh Token Flow for createAudience and getAudience

### DIFF
--- a/packages/destination-actions/src/destinations/amazon-amc/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/__tests__/index.test.ts
@@ -1,7 +1,8 @@
 import nock from 'nock'
-import { createTestIntegration } from '@segment/actions-core'
+import { createTestIntegration, InvalidAuthenticationError } from '@segment/actions-core'
 import Definition from '../index'
 import { HTTPError } from '@segment/actions-core/*'
+import { AUTHORIZATION_URL } from '../utils'
 
 const testDestination = createTestIntegration(Definition)
 
@@ -115,7 +116,19 @@ describe('Amazon-Ads (actions)', () => {
       )
     })
 
-    it('should throw an HTTPError when the response is not ok', async () => {
+    it('should fail if refresh token API gets failed', async () => {
+      const endpoint = AUTHORIZATION_URL[`${settings.region}`]
+      nock(`${endpoint}`).post('/auth/o2/token').reply(401)
+
+      await expect(testDestination.createAudience(createAudienceInputTemp)).rejects.toThrowError(
+        InvalidAuthenticationError
+      )
+    })
+
+    it('should throw an HTTPError when createAudience API response is not ok', async () => {
+      const endpoint = AUTHORIZATION_URL[`${settings.region}`]
+      nock(`${endpoint}`).post('/auth/o2/token').reply(200)
+
       nock(`${settings.region}`)
         .post('/amc/audiences/metadata')
         .matchHeader('content-type', 'application/vnd.amcaudiences.v1+json')
@@ -124,24 +137,10 @@ describe('Amazon-Ads (actions)', () => {
       await expect(testDestination.createAudience(createAudienceInputTemp)).rejects.toThrowError('Bad Request')
     })
 
-    it('Should throw an error when invalid cpmCent is provided', async () => {
-      const createAudienceInput = {
-        settings,
-        audienceName: 'Test Audience',
-        audienceSettings: {
-          ...audienceSettings,
-          ttl: 12345678,
-          currency: 'USD',
-          cpmCents: 'invalid cpm cents'
-        }
-      }
-
-      await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(
-        'CPM_CENTS:-String can not be converted to Number'
-      )
-    })
-
     it('creates an audience', async () => {
+      const endpoint = AUTHORIZATION_URL[`${settings.region}`]
+      nock(`${endpoint}`).post('/auth/o2/token').reply(200)
+
       nock(`${settings.region}`)
         .post('/amc/audiences/metadata')
         .matchHeader('content-type', 'application/vnd.amcaudiences.v1+json')
@@ -169,6 +168,9 @@ describe('Amazon-Ads (actions)', () => {
   describe('getAudience', () => {
     const externalId = getAudienceInput.externalId
     it('should succeed when with valid audienceId', async () => {
+      const endpoint = AUTHORIZATION_URL[`${settings.region}`]
+      nock(`${endpoint}`).post('/auth/o2/token').reply(200)
+
       nock(`${settings.region}/amc/audiences/metadata`)
         .get(`/${externalId}`)
         .reply(200, {
@@ -190,7 +192,10 @@ describe('Amazon-Ads (actions)', () => {
       })
     })
 
-    it('should throw an HTTPError when the response is not ok', async () => {
+    it('should throw an HTTPError when getAudience API response is not ok', async () => {
+      const endpoint = AUTHORIZATION_URL[`${settings.region}`]
+      nock(`${endpoint}`).post('/auth/o2/token').reply(200)
+
       nock(`${settings.region}/amc/audiences/metadata`)
         .get(`/${externalId}`)
         .reply(404, { message: 'audienceId not found' })
@@ -199,6 +204,13 @@ describe('Amazon-Ads (actions)', () => {
       await expect(audiencePromise).rejects.toThrow(HTTPError)
       await expect(audiencePromise).rejects.toHaveProperty('response.statusText', 'Not Found')
       await expect(audiencePromise).rejects.toHaveProperty('response.status', 404)
+    })
+    it('should fail if refresh token API gets failed ', async () => {
+      const endpoint = AUTHORIZATION_URL[`${settings.region}`]
+      nock(`${endpoint}`).post('/auth/o2/token').reply(401)
+
+      const audiencePromise = testDestination.getAudience(getAudienceInput)
+      await expect(audiencePromise).rejects.toThrow(InvalidAuthenticationError)
     })
 
     it('should throw an IntegrationError when the audienceId is not provided', async () => {

--- a/packages/destination-actions/src/destinations/amazon-amc/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/index.ts
@@ -65,7 +65,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     return {
       headers: {
         authorization: `Bearer ${auth?.accessToken}`,
-        'Amazon-Advertising-API-ClientID': process.env.ACTIONS_AMAZON_ADS_CLIENT_ID || ''
+        'Amazon-Advertising-API-ClientID': process.env.ACTIONS_AMAZON_AMC_CLIENT_ID || ''
       }
     }
   },

--- a/packages/destination-actions/src/destinations/amazon-amc/utils.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/utils.ts
@@ -97,7 +97,7 @@ export const getAuthSettings = (settings: SettingsWithOauth): OAuth2ClientCreden
   return {
     refreshToken: settings.oauth?.refresh_token,
     accessToken: settings.oauth?.access_token,
-    clientId: process.env.ACTIONS_AMAZON_ADS_CLIENT_ID,
-    clientSecret: process.env.ACTIONS_AMAZON_ADS_CLIENT_SECRET
+    clientId: process.env.ACTIONS_AMAZON_AMC_CLIENT_ID,
+    clientSecret: process.env.ACTIONS_AMAZON_AMC_CLIENT_SECRET
   } as OAuth2ClientCredentials
 }

--- a/packages/destination-actions/src/destinations/amazon-amc/utils.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/utils.ts
@@ -1,6 +1,10 @@
-import { ErrorCodes, HTTPError, OAuth2ClientCredentials } from '@segment/actions-core'
-import { RequestClient } from '@segment/actions-core'
-import { InvalidAuthenticationError } from '@segment/actions-core/*'
+import {
+  ErrorCodes,
+  HTTPError,
+  OAuth2ClientCredentials,
+  InvalidAuthenticationError,
+  RequestClient
+} from '@segment/actions-core'
 import { Settings } from './generated-types'
 import { AmazonRefreshTokenError, RefreshTokenResponse } from './types'
 

--- a/packages/destination-actions/src/destinations/amazon-amc/utils.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/utils.ts
@@ -1,4 +1,8 @@
-import { HTTPError } from '@segment/actions-core'
+import { ErrorCodes, HTTPError, OAuth2ClientCredentials } from '@segment/actions-core'
+import { RequestClient } from '@segment/actions-core'
+import { InvalidAuthenticationError } from '@segment/actions-core/*'
+import { Settings } from './generated-types'
+import { AmazonRefreshTokenError, RefreshTokenResponse } from './types'
 
 export class AmazonAdsError extends HTTPError {
   response: Response & {
@@ -42,8 +46,54 @@ export const CURRENCY = ['USD', 'CAD', 'JPY', 'GBP', 'EUR', 'SAR', 'AUD', 'AED',
 
 export const REGEX_AUDIENCEID = /"audienceId":(\d+)/
 export const REGEX_ADVERTISERID = /"advertiserId":"(\d+)"/
+type AmazonAMCCredentials = { refresh_token: string; access_token: string; client_id: string; client_secret: string }
 
 export function extractNumberAndSubstituteWithStringValue(responseString: string, regex: any, substituteWith: string) {
   const resString = responseString.replace(regex, substituteWith)
   return JSON.parse(resString)
+}
+type SettingsWithOauth = Settings & { oauth: AmazonAMCCredentials }
+// Use the refresh token to get a new access token.
+// Refresh tokens, Client_id and secret are long-lived and belong to the DMP.
+// Given the short expiration time of access tokens, we need to refresh them periodically.
+export const getAuthToken = async (request: RequestClient, settings: Settings, auth: OAuth2ClientCredentials) => {
+  const endpoint = AUTHORIZATION_URL[`${settings.region}`]
+  try {
+    const { data } = await request<RefreshTokenResponse>(`${endpoint}/auth/o2/token`, {
+      method: 'POST',
+      body: new URLSearchParams({
+        refresh_token: auth.refreshToken,
+        client_id: auth.clientId,
+        client_secret: auth.clientSecret,
+        grant_type: 'refresh_token'
+      }),
+      headers: {
+        // Amazon ads refresh token API throws error with authorization header so explicity overriding Authorization header here.
+        authorization: ''
+      }
+    })
+    return data.access_token
+  } catch (e: any) {
+    const error = e as AmazonRefreshTokenError
+    if (error.response?.data?.error === 'invalid_grant') {
+      throw new InvalidAuthenticationError(
+        `Invalid Authentication: Your refresh token is invalid or expired. Please re-authenticate to fetch a new refresh token.`,
+        ErrorCodes.REFRESH_TOKEN_EXPIRED
+      )
+    }
+
+    throw new InvalidAuthenticationError(
+      `Failed to fetch a new access token. Reason: ${error.response?.data?.error}`,
+      ErrorCodes.OAUTH_REFRESH_FAILED
+    )
+  }
+}
+
+export const getAuthSettings = (settings: SettingsWithOauth): OAuth2ClientCredentials => {
+  return {
+    refreshToken: settings.oauth?.refresh_token,
+    accessToken: settings.oauth?.access_token,
+    clientId: process.env.ACTIONS_AMAZON_ADS_CLIENT_ID,
+    clientSecret: process.env.ACTIONS_AMAZON_ADS_CLIENT_SECRET
+  } as OAuth2ClientCredentials
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->
**Issue :-**  When token gets expired ,sync was getting failed , no audience was getting created and no events were sent to destination as refresh token flow does not apply for createAudience and getAudience methods.

This Pull request is to revamp refresh access token flow for createAudience and getAudience in Amazon AMC (Actions). Now if token gets expired , it doesn't create any issue in further syncing.

Jira ticket:- https://segment.atlassian.net/browse/STRATCONN-3792
<img width="1345" alt="Screenshot 2024-06-11 at 10 39 41 PM" src="https://github.com/segmentio/action-destinations/assets/117165746/52048e5f-942c-4361-9dca-fdea73614528">

<img width="1336" alt="Screenshot 2024-06-11 at 10 39 09 PM" src="https://github.com/segmentio/action-destinations/assets/117165746/e7b22429-7116-46af-9167-921560e55930">

<img width="1344" alt="Screenshot 2024-06-11 at 10 38 57 PM" src="https://github.com/segmentio/action-destinations/assets/117165746/af051ff6-fc92-4388-88da-78bbe436407e">


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
