### PR TITLE
Add depends on condition in revenue field

### DIFF
--- a/packages/destination-actions/src/destinations/amplitude/logPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logPurchase/index.ts
@@ -85,7 +85,22 @@ const action: ActionDefinition<Settings, Payload> = {
           label: 'Revenue',
           type: 'number',
           description:
-            'Revenue = price * quantity. If you send all 3 fields of price, quantity, and revenue, then (price * quantity) will be used as the revenue value. You can use negative values to indicate refunds.'
+            'Revenue = price * quantity. If you send all 3 fields of price, quantity, and revenue, then (price * quantity) will be used as the revenue value. You can use negative values to indicate refunds.',
+          depends_on: {
+            match: 'any',
+            conditions: [
+              {
+                fieldKey: 'price',
+                operator: 'is',
+                value: ''
+              },
+              {
+                fieldKey: 'quantity',
+                operator: 'is',
+                value: ''
+              }
+            ]
+          }
         },
         productId: {
           label: 'Product ID',


### PR DESCRIPTION
This PR adds a depends_on condition on the revenue field.

## Testing

https://github.com/segmentio/action-destinations/assets/129737395/3e2db6b0-2646-410b-a8ec-8373dc8ce658


_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
