### PR TITLE
[Segment Profiles] fix consent object in sendIdentify action

### DIFF
--- a/packages/destination-actions/src/destinations/segment-profiles/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -68,10 +68,12 @@ Object {
     "batch": Array [
       Object {
         "anonymousId": "hIC1OAmWa[Q!&d%o",
-        "consent": Object {
-          "categoryPreferences": Object {
-            "analytics": true,
-            "marketing": false,
+        "context": Object {
+          "consent": Object {
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
           },
         },
         "groupId": "hIC1OAmWa[Q!&d%o",
@@ -98,10 +100,12 @@ Object {
     "batch": Array [
       Object {
         "anonymousId": "hIC1OAmWa[Q!&d%o",
-        "consent": Object {
-          "categoryPreferences": Object {
-            "analytics": true,
-            "marketing": false,
+        "context": Object {
+          "consent": Object {
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
           },
         },
         "groupId": "hIC1OAmWa[Q!&d%o",

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/index.test.ts.snap
@@ -5,7 +5,9 @@ Object {
   "batch": Array [
     Object {
       "anonymousId": "arky4h2sh7k",
-      "consent": Object {},
+      "context": Object {
+        "consent": Object {},
+      },
       "groupId": undefined,
       "integrations": Object {
         "All": false,

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -6,10 +6,12 @@ Object {
     "batch": Array [
       Object {
         "anonymousId": "mV[ZQcEVgZO$MX",
-        "consent": Object {
-          "categoryPreferences": Object {
-            "analytics": true,
-            "marketing": false,
+        "context": Object {
+          "consent": Object {
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
           },
         },
         "groupId": "mV[ZQcEVgZO$MX",
@@ -36,10 +38,12 @@ Object {
     "batch": Array [
       Object {
         "anonymousId": "mV[ZQcEVgZO$MX",
-        "consent": Object {
-          "categoryPreferences": Object {
-            "analytics": true,
-            "marketing": false,
+        "context": Object {
+          "consent": Object {
+            "categoryPreferences": Object {
+              "analytics": true,
+              "marketing": false,
+            },
           },
         },
         "groupId": "mV[ZQcEVgZO$MX",

--- a/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
+++ b/packages/destination-actions/src/destinations/segment-profiles/sendIdentify/index.ts
@@ -51,7 +51,9 @@ const action: ActionDefinition<Settings, Payload> = {
         All: false
       },
       type: 'identify',
-      consent: isValidConsentObject ? { ...payload?.consent } : {}
+      context: {
+        consent: isValidConsentObject ? { ...payload?.consent } : {}
+      }
     }
 
     statsContext?.statsClient?.incr('tapi_internal', 1, [...statsContext.tags, `action:sendIdentify`])


### PR DESCRIPTION
This PR fixes a bug with `sendIdentify` action of Segment Profiles introduced by https://github.com/segmentio/action-destinations/pull/2070. `consent`object should be placed within `context`

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
