### PR TITLE
HubSpot Actions | Fixed Hubspot Action destination reauthorisation issue

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/__tests__/index.test.ts
@@ -469,4 +469,23 @@ describe('HubSpot.sendCustomBehavioralEvent', () => {
       ])
     )
   })
+
+  it('should return error message and code if dynamic fetch fails', async () => {
+    const errorResponse = {
+      status: '401',
+      message: 'Unable to fetch schemas',
+      correlationId: 'da20ed7c-1834-43c8-8d29-c8f65c411bc2',
+      category: 'EXPIRED_AUTHENTICATION'
+    }
+    nock(HUBSPOT_BASE_URL).get(`/events/v3/event-definitions`).reply(401, errorResponse)
+    const payload = {}
+    const responses = (await testDestination.executeDynamicField('sendCustomBehavioralEvent', 'eventName', {
+      payload: payload,
+      settings: {}
+    })) as DynamicFieldResponse
+
+    expect(responses.choices.length).toBe(0)
+    expect(responses.error?.message).toEqual(errorResponse.message)
+    expect(responses.error?.code).toEqual(errorResponse.status)
+  })
 })

--- a/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/sendCustomBehavioralEvent/index.ts
@@ -87,7 +87,7 @@ const action: ActionDefinition<Settings, Payload> = {
           choices: [],
           error: {
             message: (err as HubSpotError)?.response?.data?.message ?? 'Unknown error',
-            code: (err as HubSpotError)?.response?.data?.category ?? 'Unknown code'
+            code: (err as HubSpotError)?.response?.status + '' ?? '500'
           }
         }
       }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pull request is to fix reauthorisation issue in dynamic field dropdown of Hubspot Action Destination so that there is no need to reauthorise again whenever it gets expired.
Jira ticket:- https://segment.atlassian.net/browse/STRATCONN-3872
<img width="1507" alt="Screenshot 2024-06-19 at 11 49 29 AM" src="https://github.com/segmentio/action-destinations/assets/117165746/feec9a84-1edb-4434-a090-052f4b61fdb6">

<img width="1450" alt="Screenshot 2024-06-19 at 11 49 41 AM" src="https://github.com/segmentio/action-destinations/assets/117165746/f1304e6e-4356-4d11-a91a-692cc255d913">


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
