### PR TITLE
Support for dynamic objects

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/actions-core",
   "description": "Core runtime for Destinations Actions.",
-  "version": "3.113.0",
+  "version": "3.114.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/fab-5-engine",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/actions-core",
   "description": "Core runtime for Destinations Actions.",
-  "version": "3.114.0",
+  "version": "3.113.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/fab-5-engine",

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -22,6 +22,7 @@ import { AuthTokens } from './parse-settings'
 import { IntegrationError } from '../errors'
 import { removeEmptyValues } from '../remove-empty-values'
 import { Logger, StatsContext, TransactionContext, StateContext, DataFeedCache } from './index'
+import { get } from '../get'
 
 type MaybePromise<T> = T | Promise<T>
 type RequestClient = ReturnType<typeof createRequestClient>
@@ -80,7 +81,16 @@ export interface ActionDefinition<
    * This is likely going to change as we productionalize the data model and definition object
    */
   dynamicFields?: {
-    [K in keyof Payload]?: RequestFn<Settings, Payload, DynamicFieldResponse, AudienceSettings>
+    [K in keyof Payload]?:
+      | RequestFn<Settings, Payload, DynamicFieldResponse, AudienceSettings>
+      | {
+          [ObjectProperty in keyof Payload[K] | '__keys__' | '__values__']?: RequestFn<
+            Settings,
+            Payload[K],
+            DynamicFieldResponse,
+            AudienceSettings
+          >
+        }
   }
 
   /** The operation to perform when this action is triggered */
@@ -400,7 +410,10 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
     if (dynamicFn && typeof dynamicFn === 'function') {
       fn = dynamicFn
     } else {
-      fn = this.definition.dynamicFields?.[field]
+      fn = get<RequestFn<Settings, Payload, DynamicFieldResponse, AudienceSettings>>(
+        this.definition.dynamicFields,
+        field
+      )
     }
 
     if (typeof fn !== 'function') {

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -67,6 +67,8 @@ export interface DynamicFieldError {
 export interface DynamicFieldItem {
   label: string
   value: string
+  description?: string
+  type?: FieldTypeName
 }
 
 /** The shape of authentication and top-level settings */


### PR DESCRIPTION
This PR adds support for two dynamic object use-cases: 
- Unstructured object: we can specify a field with data type `object` as dynamic, and define fetchers for keys and/or values. 
- Structured object: we can define a sub-property of a structured `object` as `dynamic` and define fetchers for the subfield values.

The syntax for defining fetchers look like this: 
```javascript
...
fields: {
  unstructuredObject: {
    ...
    type: 'object',
    dynamic: true
  },
  structuredObject: {
    ...,
    type: 'object',
    properties: {
     price: {
       ...
       dynamic: true
    },
  }
},
dynamicFields: {
    unstructuredObject: {
	__keys__: async (request, payload) =>: Promise<DynamicFieldResponse>
	__values__: async (request, payload): Promise<DynamicFieldResponse>  
    },
    structuredObject: {
      price: async (request, payload) =>: Promise<DynamicFieldResponse>
    }
}
```

We won't be changing the signature of the auto-complete endpoint in the destination action service. To invoke the dynamic field the caller can use the following notation: 
```
field = 'unstructuredObject.__keys__' // fetch keys for an object 
field = 'unstructuredObject.__values__' // fetch values for an object
field = 'structuredObject.price' // fetch values for a sub-property
```

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
