### PR TITLE
fixing auth for taboola

### DIFF
--- a/packages/destination-actions/src/destinations/taboola-actions/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/__tests__/index.test.ts
@@ -7,18 +7,16 @@ const accountId = 'TestAccount'
 const audienceId = '1111'
 const createAudienceUrl = `https://backstage.taboola.com/backstage/api/1.0/${accountId}`
 
-const createAudienceInput = {
-  settings: {},
-  audienceName: '',
-  audienceSettings: {
-    ttl_in_hours: 1024,
-    exclude_from_campaigns: false
-  }
-}
 const getAudienceInput = {
   externalId: audienceId,
-  settings: {}
+  settings: {
+    client_id: 'test_client_id',
+    client_secret: 'test_client'
+  },
+  audienceSettings: {}
 }
+
+
 
 describe('Taboola (actions)', () => {
   describe('testAuthentication', () => {
@@ -35,25 +33,62 @@ describe('Taboola (actions)', () => {
 
   describe('createAudience', () => {
     it('should fail if no audience name is set', async () => {
-      await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(
+
+      const createAudienceInput1 = {
+        settings: {
+          client_id: 'test_client_id',
+          client_secret: 'test_client'
+        },
+        audienceName: '',
+        audienceSettings: {
+          ttl_in_hours: 1024,
+          exclude_from_campaigns: false,
+          account_id:accountId
+        }
+      }
+
+      await expect(testDestination.createAudience(createAudienceInput1)).rejects.toThrowError(
         new IntegrationError("Missing 'Audience Name' value", 'MISSING_REQUIRED_FIELD', 400)
       )
     })
 
     it('should fail if no account ID is set', async () => {
-      createAudienceInput.audienceName = 'Test Audience'
-      await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(
+
+      const createAudienceInput2 = {
+        settings: {
+          client_id: 'test_client_id',
+          client_secret: 'test_client'
+        },
+        audienceName: 'Test Audience',
+        audienceSettings: {
+          ttl_in_hours: 1024,
+          exclude_from_campaigns: false,
+          account_id:''
+        }
+      }
+
+      await expect(testDestination.createAudience(createAudienceInput2)).rejects.toThrowError(
         new IntegrationError("Missing 'Account ID' value", 'MISSING_REQUIRED_FIELD', 400)
       )
     })
 
     it('should create a new Taboola Audience', async () => {
+      nock('https://backstage.taboola.com').post('/backstage/oauth/token').reply(200, { accessToken: 'some_token' })
       nock(createAudienceUrl).post('/audience_onboarding/create').reply(200, { audience_id: '1234' })
 
-      createAudienceInput.audienceName = 'Test Audience'
-      createAudienceInput.audienceSettings.account_id = accountId
-
-      const r = await testDestination.createAudience(createAudienceInput)
+      const createAudienceInput3 = {
+        settings: {
+          client_id: 'test_client_id',
+          client_secret: 'test_client'
+        },
+        audienceName: 'Test Audience',
+        audienceSettings: {
+          ttl_in_hours: 1024,
+          exclude_from_campaigns: false,
+          account_id:accountId
+        }
+      }
+      const r = await testDestination.createAudience(createAudienceInput3)
       expect(r).toEqual({ externalId: '1234' })
     })
   })

--- a/packages/destination-actions/src/destinations/taboola-actions/index.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/index.ts
@@ -1,12 +1,9 @@
 import type { AudienceDestinationDefinition } from '@segment/actions-core'
 import type { Settings, AudienceSettings } from './generated-types'
 import { IntegrationError } from '@segment/actions-core'
+import { TaboolaClient } from './syncAudience/client'
 
 import syncAudience from './syncAudience'
-
-interface RefreshTokenResponse {
-  access_token: string
-}
 
 const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   name: 'Taboola (actions)',
@@ -14,7 +11,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   mode: 'cloud',
 
   authentication: {
-    scheme: 'oauth-managed',
+    scheme: 'oauth2',
     fields: {
       client_id: {
         label: 'Client ID',
@@ -30,16 +27,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       }
     },
     refreshAccessToken: async (request, { settings }) => {
-      const res = await request<RefreshTokenResponse>('https://backstage.taboola.com/backstage/oauth/token', {
-        method: 'POST',
-        body: new URLSearchParams({
-          client_id: settings.client_id,
-          client_secret: settings.client_secret,
-          grant_type: 'client_credentials'
-        })
-      })
-
-      return { accessToken: res.data.access_token }
+      return await TaboolaClient.refreshAccessToken(request, { settings })
     }
   },
   extendRequest({ auth }) {
@@ -92,6 +80,10 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       }
 
       try {
+        const accessToken = (
+          await TaboolaClient.refreshAccessToken(request, { settings: createAudienceInput.settings })
+        ).accessToken
+
         const response = await request(
           `https://backstage.taboola.com/backstage/api/1.0/${accountId}/audience_onboarding/create`,
           {
@@ -100,9 +92,14 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
               audience_name: audienceName,
               ttl_in_hours: ttlInHours,
               exclude_from_campaigns: excludeFromCampaigns
+            },
+            headers: {
+              authorization: `Bearer ${accessToken}`,
+              'Content-Type': 'application/json'
             }
           }
         )
+
         const json = await response.json()
 
         return {

--- a/packages/destination-actions/src/destinations/taboola-actions/syncAudience/client.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/syncAudience/client.ts
@@ -2,7 +2,7 @@ import { createHash } from 'crypto'
 import type { ModifiedResponse } from '@segment/actions-core'
 import { RequestClient, IntegrationError } from '@segment/actions-core'
 import { Payload } from './generated-types'
-import { AudienceSettings } from '../generated-types'
+import { AudienceSettings, Settings } from '../generated-types'
 
 interface ClusterItem {
   user_id: string
@@ -18,19 +18,45 @@ interface TaboolaPayload {
   identities: Cluster[]
 }
 
+interface RefreshTokenResponse {
+  access_token: string
+}
+
 export class TaboolaClient {
   request: RequestClient
   payloads: Payload[]
-  audienceSettings: AudienceSettings
+  audienceSettings?: AudienceSettings
 
-  constructor(request: RequestClient, payloads: Payload[], audienceSettings: AudienceSettings) {
+  constructor(request: RequestClient, payloads: Payload[], audienceSettings?: AudienceSettings) {
     this.request = request
     this.payloads = payloads
     this.audienceSettings = audienceSettings
+
+    if (!this.audienceSettings) {
+      throw new IntegrationError('Bad Request: no audienceSettings found.', 'INVALID_REQUEST_DATA', 400)
+    }
+
+    if (!this.audienceSettings.account_id) {
+      throw new IntegrationError('Bad Request: no audienceSettings.account_id found.', 'INVALID_REQUEST_DATA', 400)
+    }
+  }
+
+  static async refreshAccessToken(request: RequestClient, { settings }: { settings: Settings }) {
+    const res = await request<RefreshTokenResponse>('https://backstage.taboola.com/backstage/oauth/token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: new URLSearchParams({
+        client_id: settings.client_id,
+        client_secret: settings.client_secret,
+        grant_type: 'client_credentials'
+      })
+    })
+    return { accessToken: res.data.access_token }
   }
 
   async sendToTaboola() {
-
     this.payloads.forEach((payload) => {
       payload.action = payload.traits_or_props[payload.segment_computation_key] ? 'ADD' : 'REMOVE'
     })
@@ -59,7 +85,9 @@ export class TaboolaClient {
         if (identities.length > 0) {
           taboolaRequests.push(
             this.request(
-              `https://backstage.taboola.com/backstage/api/1.0/${this.audienceSettings.account_id}/audience_onboarding`,
+              `https://backstage.taboola.com/backstage/api/1.0/${
+                this.audienceSettings?.account_id as string
+              }/audience_onboarding`,
               {
                 method: 'POST',
                 json: {

--- a/packages/destination-actions/src/destinations/taboola-actions/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/syncAudience/index.ts
@@ -107,7 +107,6 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     }
   },
   perform: (request, { payload, audienceSettings }) => {
-
     if (!payload.external_audience_id) {
       throw new IntegrationError('Bad Request: payload.external_audience_id missing.', 'INVALID_REQUEST_DATA', 400)
     }
@@ -120,27 +119,10 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
       )
     }
 
-    if (!audienceSettings) {
-      throw new IntegrationError('Bad Request: no audienceSettings found.', 'INVALID_REQUEST_DATA', 400)
-    }
-
-    if (!audienceSettings.account_id) {
-      throw new IntegrationError('Bad Request: no audienceSettings.account_id found.', 'INVALID_REQUEST_DATA', 400)
-    }
-
     const taboolaClient = new TaboolaClient(request, [payload], audienceSettings)
     return taboolaClient.sendToTaboola()
   },
-  performBatch: async (request, { payload: payloads, audienceSettings }) => {
-
-    if (!audienceSettings) {
-      throw new IntegrationError('Bad Request: no audienceSettings found.', 'INVALID_REQUEST_DATA', 400)
-    }
-
-    if (!audienceSettings.account_id) {
-      throw new IntegrationError('Bad Request: no audienceSettings.account_id found.', 'INVALID_REQUEST_DATA', 400)
-    }
-
+  performBatch: (request, { payload: payloads, audienceSettings }) => {
     const taboolaClient = new TaboolaClient(request, payloads, audienceSettings)
     return taboolaClient.sendToTaboola()
   }


### PR DESCRIPTION
auth isn't working for new Taboola Destination. 
Changed mechanism to oauth2 and added code to get new access token for the createAudience function. 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

Tested locally. 
