### PR TITLE
[STRATCONN-3874]: Allowing Pinterest Actions to add additional fields

### DIFF
--- a/packages/destination-actions/src/destinations/pinterest-conversions/pinterest-capi-custom-data.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/pinterest-capi-custom-data.ts
@@ -4,6 +4,7 @@ export const custom_data_field: InputField = {
   label: 'Custom Data',
   description: 'Object containing customer information data.',
   type: 'object',
+  additionalProperties: true,
   properties: {
     currency: {
       label: 'Currency',

--- a/packages/destination-actions/src/destinations/pinterest-conversions/pinterest-capi-custom-data.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/pinterest-capi-custom-data.ts
@@ -4,7 +4,6 @@ export const custom_data_field: InputField = {
   label: 'Custom Data',
   description: 'Object containing customer information data.',
   type: 'object',
-  additionalProperties: true,
   properties: {
     currency: {
       label: 'Currency',

--- a/packages/destination-actions/src/destinations/pinterest-conversions/pinterset-capi-user-data.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/pinterset-capi-user-data.ts
@@ -11,7 +11,6 @@ export const user_data_field: InputField = {
   description:
     'Object containing customer information data. Note, It is required at least one of 1) em, 2) hashed_maids or 3) pair client_ip_address + client_user_agent..',
   type: 'object',
-  additionalProperties: true,
   properties: {
     email: {
       label: 'Email',
@@ -96,6 +95,18 @@ export const user_data_field: InputField = {
       description: 'A two-letter country code in lowercase.',
       type: 'string',
       multiple: true
+    },
+    click_id: {
+      label: 'Click ID',
+      description: 'The unique identifier stored in _epik cookie on your domain or &epik= query parameter in the URL.',
+      type: 'string',
+      allowNull: true
+    },
+    partner_id: {
+      label: 'Partner ID',
+      description: "A unique identifier of visitors' information defined by third party partners.",
+      type: 'string',
+      allowNull: true
     }
   },
   default: {
@@ -232,6 +243,8 @@ export const hash_user_data = (payload: UserData): Object => {
     external_id: payload.user_data?.external_id,
     client_ip_address: payload.user_data?.client_ip_address,
     client_user_agent: payload.user_data?.client_user_agent,
-    hashed_maids: payload.user_data?.hashed_maids
+    hashed_maids: payload.user_data?.hashed_maids,
+    click_id: payload.user_data?.click_id,
+    partner_id: payload.user_data?.click_id
   }
 }

--- a/packages/destination-actions/src/destinations/pinterest-conversions/pinterset-capi-user-data.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/pinterset-capi-user-data.ts
@@ -245,6 +245,6 @@ export const hash_user_data = (payload: UserData): Object => {
     client_user_agent: payload.user_data?.client_user_agent,
     hashed_maids: payload.user_data?.hashed_maids,
     click_id: payload.user_data?.click_id,
-    partner_id: payload.user_data?.click_id
+    partner_id: payload.user_data?.partner_id
   }
 }

--- a/packages/destination-actions/src/destinations/pinterest-conversions/pinterset-capi-user-data.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/pinterset-capi-user-data.ts
@@ -11,6 +11,7 @@ export const user_data_field: InputField = {
   description:
     'Object containing customer information data. Note, It is required at least one of 1) em, 2) hashed_maids or 3) pair client_ip_address + client_user_agent..',
   type: 'object',
+  additionalProperties: true,
   properties: {
     email: {
       label: 'Email',

--- a/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/__tests__/__snapshots__/index.test.ts.snap
@@ -71,6 +71,9 @@ Object {
         ],
       },
       "wifi": undefined,
+      "wifi": undefined,
+      "click_id": "click-id1",
+      "partner_id": "partner-id1"
     },
   ],
 }
@@ -147,6 +150,8 @@ Object {
         ],
       },
       "wifi": undefined,
+      "click_id": "click-id1",
+      "partner_id": "partner-id1"
     },
   ],
 }

--- a/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/__tests__/__snapshots__/index.test.ts.snap
@@ -139,7 +139,7 @@ Object {
         "ln": Array [
           "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
         ],
-        "partner_id": "partner-id1"
+        "partner_id": "partner-id1",
         "ph": Array [
           "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
         ],

--- a/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/__tests__/__snapshots__/index.test.ts.snap
@@ -31,6 +31,7 @@ Object {
       "os_version": "8.1.3",
       "partner_name": "ss-segment",
       "user_data": Object {
+        "click_id": "click-id1",
         "client_ip_address": "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
         "client_user_agent": "5.5.5.5",
         "country": Array [
@@ -60,6 +61,7 @@ Object {
         "ln": Array [
           "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
         ],
+        "partner_id": "partner-id1",
         "ph": Array [
           "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
         ],
@@ -71,9 +73,6 @@ Object {
         ],
       },
       "wifi": undefined,
-      "wifi": undefined,
-      "click_id": "click-id1",
-      "partner_id": "partner-id1"
     },
   ],
 }
@@ -110,6 +109,7 @@ Object {
       "os_version": "8.1.3",
       "partner_name": "ss-segment",
       "user_data": Object {
+        "click_id": "click-id1",
         "client_ip_address": "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
         "client_user_agent": "5.5.5.5",
         "country": Array [
@@ -139,6 +139,7 @@ Object {
         "ln": Array [
           "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
         ],
+        "partner_id": "partner-id1"
         "ph": Array [
           "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
         ],
@@ -150,8 +151,6 @@ Object {
         ],
       },
       "wifi": undefined,
-      "click_id": "click-id1",
-      "partner_id": "partner-id1"
     },
   ],
 }

--- a/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/__tests__/index.test.ts
@@ -109,7 +109,7 @@ describe('PinterestConversionApi', () => {
             date_of_birth: ['1996-02-01'],
             email: ['test@gmail.com'],
             client_user_agent: '5.5.5.5',
-            click_id: 'clicki-id1',
+            click_id: 'click-id1',
             partner_id: 'partner-id1',
             client_ip_address:
               'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
@@ -166,7 +166,7 @@ describe('PinterestConversionApi', () => {
             date_of_birth: ['1996-02-01'],
             email: ['test@gmail.com'],
             client_user_agent: '5.5.5.5',
-            click_id: 'clicki-id1',
+            click_id: 'click-id1',
             partner_id: 'partner-id1',
             client_ip_address:
               'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'

--- a/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/__tests__/index.test.ts
@@ -109,6 +109,8 @@ describe('PinterestConversionApi', () => {
             date_of_birth: ['1996-02-01'],
             email: ['test@gmail.com'],
             client_user_agent: '5.5.5.5',
+            click_id: 'clicki-id1',
+            partner_id: 'partner-id1',
             client_ip_address:
               'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
           },
@@ -164,6 +166,8 @@ describe('PinterestConversionApi', () => {
             date_of_birth: ['1996-02-01'],
             email: ['test@gmail.com'],
             client_user_agent: '5.5.5.5',
+            click_id: 'clicki-id1',
+            partner_id: 'partner-id1',
             client_ip_address:
               'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
           }

--- a/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/generated-types.ts
@@ -85,6 +85,7 @@ export interface Payload {
      * A two-letter country code in lowercase.
      */
     country?: string[]
+    [k: string]: unknown
   }
   /**
    * Object containing customer information data.
@@ -135,6 +136,7 @@ export interface Payload {
      * opt_out_type is the field where we accept opt outs for your users’ privacy preference.  It can handle multiple values with commas separated.
      */
     opt_out_type?: string
+    [k: string]: unknown
   }
   /**
    * The app store app ID.

--- a/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/generated-types.ts
@@ -85,7 +85,14 @@ export interface Payload {
      * A two-letter country code in lowercase.
      */
     country?: string[]
-    [k: string]: unknown
+    /**
+     * The unique identifier stored in _epik cookie on your domain or &epik= query parameter in the URL.
+     */
+    click_id?: string | null
+    /**
+     * A unique identifier of visitors' information defined by third party partners.
+     */
+    partner_id?: string | null
   }
   /**
    * Object containing customer information data.
@@ -136,7 +143,6 @@ export interface Payload {
      * opt_out_type is the field where we accept opt outs for your users’ privacy preference.  It can handle multiple values with commas separated.
      */
     opt_out_type?: string
-    [k: string]: unknown
   }
   /**
    * The app store app ID.


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

## Summary

**Jira Ticket**: https://segment.atlassian.net/browse/STRATCONN-3874

[Pinterest Conversion API doesn’t support fields outside their schema ](https://developers.pinterest.com/docs/api/v5/#operation/events/create)but `click_id` and `partner_id` fields are optional fields that are already supported by the API. We can add the mapping from segment side. `Add Mapping Field` functionality will not be required.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment

### Stage Test
<img width="1728" alt="Screenshot 2024-06-26 at 7 10 54 PM" src="https://github.com/segmentio/action-destinations/assets/35370469/b5a89c3e-167d-4c40-8bd7-49e55bee79f8">
<img width="1727" alt="Screenshot 2024-06-26 at 7 11 57 PM" src="https://github.com/segmentio/action-destinations/assets/35370469/77af371f-f3d3-4f5c-bdd2-ecda8b644b19">

