### PR TITLE
[linkedin conversions] Normalize user emails by setting them to lowercase

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -376,6 +376,10 @@ export class LinkedInConversions {
     }
   }
 
+  private normalizeEmail = (email: string): string => {
+    return email.toLowerCase()
+  }
+
   private hashValue = (val: string): string => {
     const hash = createHash('sha256')
     hash.update(val)
@@ -386,7 +390,7 @@ export class LinkedInConversions {
     const userIds: UserID[] = []
 
     if (payload.email) {
-      const hashedEmail = this.hashValue(payload.email)
+      const hashedEmail = this.hashValue(this.normalizeEmail(payload.email))
       userIds.push({
         idType: 'SHA256_EMAIL',
         idValue: hashedEmail

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -33,8 +33,8 @@ Object {
   "user": Object {
     "userIds": Array [
       Object {
-        "type": "SHA256_EMAIL",
-        "value": "e290e11fef012fc831059c96e9186cda491dd0b259641815f23463cb4c54b7e1",
+        "idType": "SHA256_EMAIL",
+        "idValue": "e290e11fef012fc831059c96e9186cda491dd0b259641815f23463cb4c54b7e1",
       },
     ],
   },

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/snapshot.test.ts
@@ -53,7 +53,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     expect(request.headers).toMatchSnapshot()
   })
 
-  it.only('all fields', async () => {
+  it('all fields', async () => {
     nock(/.*/).persist().get(/.*/).reply(200)
     nock(/.*/).persist().post(/.*/).reply(200)
     nock(/.*/).persist().put(/.*/).reply(200)


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR updates the Linkedin Conversions destination to normalize emails by setting them to lowercase before hashing.

https://segment.atlassian.net/browse/STRATCONN-3869

## Testing

Successfully tested locally + added unit test.

This request is made with an uppercase email:
<img width="1247" alt="Screenshot 2024-06-25 at 3 04 37 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/f2e4d771-926e-4aec-9ca2-32833c9a91bf">

This console log shows the hash was performed on the same email but in lowercase:
<img width="427" alt="Screenshot 2024-06-25 at 3 04 26 PM" src="https://github.com/segmentio/action-destinations/assets/27820201/b087bfcd-1865-4664-b74d-b7fb0ab8377b">

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
