### PR TITLE
[MOLOCO] Add a new field `Platform Name` in settings

### DIFF
--- a/packages/destination-actions/src/destinations/moloco-rmp/__tests__/convert.test.ts
+++ b/packages/destination-actions/src/destinations/moloco-rmp/__tests__/convert.test.ts
@@ -31,26 +31,26 @@ describe('Moloco MCM', () => {
             currency: 'USD',
             price: 12.34,
             quantity: 1,
-            seller_id: 'cs032b-11ee-9a73-0n5e570313ef',
+            seller_id: 'cs032b-11ee-9a73-0n5e570313ef'
           },
           {
             id: '456',
             currency: 'USD',
             price: 56.78,
             quantity: 2,
-            seller_id: 'cs032b-11ee-9a73-w5e570313ef',
+            seller_id: 'cs032b-11ee-9a73-w5e570313ef'
           }
         ],
         revenue: {
           currency: 'USD',
-          price: 69.12,
+          price: 69.12
         },
         search_query: 'iphone',
         page_id: '/home',
         referrer_page_id: 'google.com',
         shipping_charge: {
           currency: 'USD',
-          price: 5.00
+          price: 5.0
         }
       }
 
@@ -79,7 +79,7 @@ describe('Moloco MCM', () => {
               amount: 12.34
             },
             quantity: 1,
-            seller_id: 'cs032b-11ee-9a73-0n5e570313ef',
+            seller_id: 'cs032b-11ee-9a73-0n5e570313ef'
           },
           {
             id: '456',
@@ -88,23 +88,32 @@ describe('Moloco MCM', () => {
               amount: 56.78
             },
             quantity: 2,
-            seller_id: 'cs032b-11ee-9a73-w5e570313ef',
+            seller_id: 'cs032b-11ee-9a73-w5e570313ef'
           }
         ],
         revenue: {
           currency: 'USD',
-          amount: 69.12,
+          amount: 69.12
         },
         search_query: 'iphone',
         page_id: '/home',
         referrer_page_id: 'google.com',
         shipping_charge: {
           currency: 'USD',
-          amount: 5.00
+          amount: 5.0
         }
       }
-        
-      const output: MolocoEventPayload = convertEvent({ eventType: TEST_EVENT_TYPE, payload: input, settings: { channel_type: 'APP', platformId: 'any_plat_id', apiKey: 'any_api_key'}})
+
+      const output: MolocoEventPayload = convertEvent({
+        eventType: TEST_EVENT_TYPE,
+        payload: input,
+        settings: {
+          channel_type: 'APP',
+          platformId: 'any_plat_id',
+          platformName: 'any_plat_name',
+          apiKey: 'any_api_key'
+        }
+      })
       expect(output).toEqual(expectedOutput)
     })
 
@@ -130,26 +139,26 @@ describe('Moloco MCM', () => {
             currency: 'USD',
             price: 12.34,
             quantity: 1,
-            seller_id: 'cs032b-11ee-9a73-0n5e570313ef',
+            seller_id: 'cs032b-11ee-9a73-0n5e570313ef'
           },
           {
             id: '456',
             currency: 'USD',
             price: 56.78,
             quantity: 2,
-            seller_id: 'cs032b-11ee-9a73-w5e570313ef',
+            seller_id: 'cs032b-11ee-9a73-w5e570313ef'
           }
         ],
         revenue: {
           currency: 'USD',
-          price: 69.12,
+          price: 69.12
         },
         search_query: 'iphone',
         page_id: '/home',
         referrer_page_id: 'google.com',
         shipping_charge: {
           currency: 'USD',
-          price: 5.00
+          price: 5.0
         }
       }
 
@@ -178,7 +187,7 @@ describe('Moloco MCM', () => {
               amount: 12.34
             },
             quantity: 1,
-            seller_id: 'cs032b-11ee-9a73-0n5e570313ef',
+            seller_id: 'cs032b-11ee-9a73-0n5e570313ef'
           },
           {
             id: '456',
@@ -187,23 +196,32 @@ describe('Moloco MCM', () => {
               amount: 56.78
             },
             quantity: 2,
-            seller_id: 'cs032b-11ee-9a73-w5e570313ef',
+            seller_id: 'cs032b-11ee-9a73-w5e570313ef'
           }
         ],
         revenue: {
           currency: 'USD',
-          amount: 69.12,
+          amount: 69.12
         },
         search_query: 'iphone',
         page_id: '/home',
         referrer_page_id: 'google.com',
         shipping_charge: {
           currency: 'USD',
-          amount: 5.00
+          amount: 5.0
         }
       }
-        
-      const output: MolocoEventPayload = convertEvent({ eventType: TEST_EVENT_TYPE, payload: input, settings: { channel_type: 'APP', platformId: 'any_plat_id', apiKey: 'any_api_key'}})
+
+      const output: MolocoEventPayload = convertEvent({
+        eventType: TEST_EVENT_TYPE,
+        payload: input,
+        settings: {
+          channel_type: 'APP',
+          platformId: 'any_plat_id',
+          platformName: 'any_plat_name',
+          apiKey: 'any_api_key'
+        }
+      })
       expect(output).toEqual(expectedOutput)
     })
 
@@ -229,26 +247,26 @@ describe('Moloco MCM', () => {
             currency: 'USD',
             price: 12.34,
             quantity: 1,
-            seller_id: 'cs032b-11ee-9a73-0n5e570313ef',
+            seller_id: 'cs032b-11ee-9a73-0n5e570313ef'
           },
           {
             id: '456',
             currency: 'USD',
             price: 56.78,
             quantity: 2,
-            seller_id: 'cs032b-11ee-9a73-w5e570313ef',
+            seller_id: 'cs032b-11ee-9a73-w5e570313ef'
           }
         ],
         revenue: {
           currency: 'USD',
-          price: 69.12,
+          price: 69.12
         },
         search_query: 'iphone',
         page_id: '/home',
         referrer_page_id: 'google.com',
         shipping_charge: {
           currency: 'USD',
-          price: 5.00
+          price: 5.0
         }
       }
 
@@ -277,7 +295,7 @@ describe('Moloco MCM', () => {
               amount: 12.34
             },
             quantity: 1,
-            seller_id: 'cs032b-11ee-9a73-0n5e570313ef',
+            seller_id: 'cs032b-11ee-9a73-0n5e570313ef'
           },
           {
             id: '456',
@@ -286,26 +304,34 @@ describe('Moloco MCM', () => {
               amount: 56.78
             },
             quantity: 2,
-            seller_id: 'cs032b-11ee-9a73-w5e570313ef',
+            seller_id: 'cs032b-11ee-9a73-w5e570313ef'
           }
         ],
         revenue: {
           currency: 'USD',
-          amount: 69.12,
+          amount: 69.12
         },
         search_query: 'iphone',
         page_id: '/home',
         referrer_page_id: 'google.com',
         shipping_charge: {
           currency: 'USD',
-          amount: 5.00
+          amount: 5.0
         }
       }
-        
-      const output: MolocoEventPayload = convertEvent({ eventType: TEST_EVENT_TYPE, payload: input, settings: { channel_type: 'APP', platformId: 'any_plat_id', apiKey: 'any_api_key'}})
+
+      const output: MolocoEventPayload = convertEvent({
+        eventType: TEST_EVENT_TYPE,
+        payload: input,
+        settings: {
+          channel_type: 'APP',
+          platformId: 'any_plat_id',
+          platformName: 'any_plat_name',
+          apiKey: 'any_api_key'
+        }
+      })
       expect(output).toEqual(expectedOutput)
     })
-
 
     it('tests an event payload with a missing field (session_id)', async () => {
       const input: SegmentEventPayload = {
@@ -328,26 +354,26 @@ describe('Moloco MCM', () => {
             currency: 'USD',
             price: 12.34,
             quantity: 1,
-            seller_id: 'cs032b-11ee-9a73-0n5e570313ef',
+            seller_id: 'cs032b-11ee-9a73-0n5e570313ef'
           },
           {
             id: '456',
             currency: 'USD',
             price: 56.78,
             quantity: 2,
-            seller_id: 'cs032b-11ee-9a73-w5e570313ef',
+            seller_id: 'cs032b-11ee-9a73-w5e570313ef'
           }
         ],
         revenue: {
           currency: 'USD',
-          price: 69.12,
+          price: 69.12
         },
         search_query: 'iphone',
         page_id: '/home',
         referrer_page_id: 'google.com',
         shipping_charge: {
           currency: 'USD',
-          price: 5.00
+          price: 5.0
         }
       }
 
@@ -375,7 +401,7 @@ describe('Moloco MCM', () => {
               amount: 12.34
             },
             quantity: 1,
-            seller_id: 'cs032b-11ee-9a73-0n5e570313ef',
+            seller_id: 'cs032b-11ee-9a73-0n5e570313ef'
           },
           {
             id: '456',
@@ -384,23 +410,32 @@ describe('Moloco MCM', () => {
               amount: 56.78
             },
             quantity: 2,
-            seller_id: 'cs032b-11ee-9a73-w5e570313ef',
+            seller_id: 'cs032b-11ee-9a73-w5e570313ef'
           }
         ],
         revenue: {
           currency: 'USD',
-          amount: 69.12,
+          amount: 69.12
         },
         search_query: 'iphone',
         page_id: '/home',
         referrer_page_id: 'google.com',
         shipping_charge: {
           currency: 'USD',
-          amount: 5.00
+          amount: 5.0
         }
       }
-        
-      const output: MolocoEventPayload = convertEvent({ eventType: TEST_EVENT_TYPE, payload: input, settings: { channel_type: 'APP', platformId: 'any_plat_id', apiKey: 'any_api_key'}})
+
+      const output: MolocoEventPayload = convertEvent({
+        eventType: TEST_EVENT_TYPE,
+        payload: input,
+        settings: {
+          channel_type: 'APP',
+          platformId: 'any_plat_id',
+          platformName: 'any_plat_name',
+          apiKey: 'any_api_key'
+        }
+      })
       expect(output).toEqual(expectedOutput)
     })
 
@@ -425,19 +460,30 @@ describe('Moloco MCM', () => {
             id: '123',
             price: 12.34,
             quantity: 1,
-            seller_id: 'cs032b-11ee-9a73-0n5e570313ef',
+            seller_id: 'cs032b-11ee-9a73-0n5e570313ef'
           },
           {
             id: '456',
             currency: 'USD',
             price: 56.78,
             quantity: 2,
-            seller_id: 'cs032b-11ee-9a73-w5e570313ef',
+            seller_id: 'cs032b-11ee-9a73-w5e570313ef'
           }
         ]
       }
 
-      expect(() => convertEvent({ eventType: TEST_EVENT_TYPE, payload: input,  settings: { channel_type: 'APP', platformId: 'any_plat_id', apiKey: 'any_api_key'} })).toThrowError(PayloadValidationError)
+      expect(() =>
+        convertEvent({
+          eventType: TEST_EVENT_TYPE,
+          payload: input,
+          settings: {
+            channel_type: 'APP',
+            platformId: 'any_plat_id',
+            platformName: 'any_plat_name',
+            apiKey: 'any_api_key'
+          }
+        })
+      ).toThrowError(PayloadValidationError)
     })
   })
 })

--- a/packages/destination-actions/src/destinations/moloco-rmp/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/moloco-rmp/__tests__/index.test.ts
@@ -14,10 +14,10 @@ const TEST_EVENT_TYPE = EventType.Home
 
 const AUTH = {
   platformId: 'foo',
+  platformName: 'foo',
   apiKey: 'bar',
   channel_type: 'SITE'
 }
-
 
 describe('Moloco MCM', () => {
   // TEST 1: Test the default mappings. The input event data are automatically collected fields
@@ -56,9 +56,9 @@ describe('Moloco MCM', () => {
             url: 'https://segment.com/academy/'
           },
           userAgent:
-            'Mozilla/5.0 (Chrome; intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36',
+            'Mozilla/5.0 (Chrome; intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36'
         }
-      } as const;
+      } as const
 
       const expectedPayload: EventPayload = {
         event_type: TEST_EVENT_TYPE,
@@ -68,19 +68,19 @@ describe('Moloco MCM', () => {
         user_id: webEvent.userId,
         device: {
           ua: webEvent.context.userAgent,
-          ip: webEvent.context.ip,
+          ip: webEvent.context.ip
         },
         session_id: webEvent.anonymousId,
-        page_id: webEvent.context.page.path,
+        page_id: webEvent.context.page.path
       }
-        
+
       const responses = await testDestination.testAction(TEST_ACTION_SLUG, {
         event: webEvent,
         settings: AUTH,
         useDefaultMappings: true,
         mapping: {
-          channel_type: 'SITE',
-        },
+          channel_type: 'SITE'
+        }
       })
 
       expect(responses.length).toBe(1)
@@ -109,7 +109,7 @@ describe('Moloco MCM', () => {
           app: {
             name: 'AppName',
             version: '1.0.0',
-            build: '1',
+            build: '1'
           },
           device: {
             type: 'ios',
@@ -118,7 +118,7 @@ describe('Moloco MCM', () => {
             adTrackingEnabled: true,
             manufacturer: 'Apple',
             model: 'iPhone',
-            name: 'iPhone',
+            name: 'iPhone'
           },
           library: {
             name: 'analytics.iOS',
@@ -140,9 +140,9 @@ describe('Moloco MCM', () => {
             width: 750
           },
           traits: {},
-          timezone: 'America/Los_Angeles',
+          timezone: 'America/Los_Angeles'
         }
-      } as const;
+      } as const
 
       const expectedPayload: EventPayload = {
         event_type: TEST_EVENT_TYPE,
@@ -156,18 +156,18 @@ describe('Moloco MCM', () => {
           model: iosEvent.context.device.model,
           os: iosEvent.context.os.name.toUpperCase(),
           os_version: iosEvent.context.os.version,
-          unique_device_id: iosEvent.context.device.id,
+          unique_device_id: iosEvent.context.device.id
         },
-        session_id: iosEvent.anonymousId,
+        session_id: iosEvent.anonymousId
       }
-        
+
       const responses = await testDestination.testAction(TEST_ACTION_SLUG, {
         event: iosEvent,
-        settings: { ...AUTH, channel_type: 'APP'},
+        settings: { ...AUTH, channel_type: 'APP' },
         useDefaultMappings: true,
         mapping: {
-          channel_type: 'APP',
-        },
+          channel_type: 'APP'
+        }
       })
 
       expect(responses.length).toBe(1)
@@ -196,7 +196,7 @@ describe('Moloco MCM', () => {
           app: {
             name: 'AppName',
             version: '1.0.0',
-            build: '1',
+            build: '1'
           },
           device: {
             type: 'android',
@@ -205,7 +205,7 @@ describe('Moloco MCM', () => {
             adTrackingEnabled: true,
             manufacturer: 'Samsung',
             model: 'Galaxy S10',
-            name: 'galaxy',
+            name: 'galaxy'
           },
           library: {
             name: 'analytics.ANDROID',
@@ -217,7 +217,7 @@ describe('Moloco MCM', () => {
             carrier: 'T-Mobile US',
             cellular: true,
             wifi: false,
-            bluetooth: false,
+            bluetooth: false
           },
           os: {
             name: 'Google Android',
@@ -229,10 +229,11 @@ describe('Moloco MCM', () => {
             density: 2.0
           },
           traits: {},
-          userAgent: 'Mozilla/5.0 (Linux; Android 10; SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Mobile Safari/537.36',
-          timezone: 'America/Los_Angeles',
+          userAgent:
+            'Mozilla/5.0 (Linux; Android 10; SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Mobile Safari/537.36',
+          timezone: 'America/Los_Angeles'
         }
-      } as const;
+      } as const
 
       const expectedPayload: EventPayload = {
         event_type: TEST_EVENT_TYPE,
@@ -247,18 +248,18 @@ describe('Moloco MCM', () => {
           os: androidEvent.context.os.name.toUpperCase(),
           os_version: androidEvent.context.os.version,
           ua: androidEvent.context.userAgent,
-          unique_device_id: androidEvent.context.device.id,
+          unique_device_id: androidEvent.context.device.id
         },
-        session_id: androidEvent.anonymousId,
+        session_id: androidEvent.anonymousId
       }
-        
+
       const responses = await testDestination.testAction(TEST_ACTION_SLUG, {
         event: androidEvent,
-        settings: { ...AUTH, channel_type: 'APP'},
+        settings: { ...AUTH, channel_type: 'APP' },
         useDefaultMappings: true,
         mapping: {
-          channel_type: 'APP',
-        },
+          channel_type: 'APP'
+        }
       })
 
       expect(responses.length).toBe(1)
@@ -295,9 +296,9 @@ describe('Moloco MCM', () => {
             url: 'https://segment.com/academy/'
           },
           userAgent:
-            'Mozilla/5.0 (Chrome; intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36',
+            'Mozilla/5.0 (Chrome; intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36'
         }
-      } as const;
+      } as const
 
       const expectedPayload: EventPayload = {
         event_type: TEST_EVENT_TYPE,
@@ -306,29 +307,27 @@ describe('Moloco MCM', () => {
         channel_type: 'SITE',
         user_id: event.userId,
         device: {
-          ua: event.context.userAgent,
+          ua: event.context.userAgent
           // ip: event.context.ip, -- absent even though there is a default mapping for it
         },
         session_id: event.anonymousId,
-        page_id: event.context.page.path,
+        page_id: event.context.page.path
       }
-        
+
       const responses = await testDestination.testAction(TEST_ACTION_SLUG, {
         event: event,
         settings: AUTH,
         useDefaultMappings: true,
         mapping: {
-          channel_type: 'SITE',
-        },
+          channel_type: 'SITE'
+        }
       })
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       expect(responses[0].options.json).toEqual(expectedPayload)
     })
-
   })
-
 
   // TEST 2: Test the custom mappings. The input event data are automatically collected fields
   // Custom mapping options are provided so the default mappings are not used
@@ -366,9 +365,9 @@ describe('Moloco MCM', () => {
             url: 'https://segment.com/academy/'
           },
           userAgent:
-            'Mozilla/5.0 (Chrome; intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36',
+            'Mozilla/5.0 (Chrome; intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36'
         }
-      } as const;
+      } as const
 
       const expectedPayload: EventPayload = {
         event_type: TEST_EVENT_TYPE,
@@ -378,12 +377,12 @@ describe('Moloco MCM', () => {
         user_id: event.userId,
         device: {
           ua: event.context.userAgent,
-          ip: event.context.ip,
+          ip: event.context.ip
         },
         session_id: event.anonymousId,
-        page_id: event.context.page.path,
+        page_id: event.context.page.path
       }
-        
+
       const responses = await testDestination.testAction(TEST_ACTION_SLUG, {
         event: event,
         settings: AUTH,
@@ -391,7 +390,7 @@ describe('Moloco MCM', () => {
         mapping: {
           channel_type: 'SITE',
           event_id: { '@path': '$.eventId' }
-        },
+        }
       })
 
       expect(responses.length).toBe(1)
@@ -429,9 +428,9 @@ describe('Moloco MCM', () => {
             url: 'https://segment.com/academy/'
           },
           userAgent:
-            'Mozilla/5.0 (Chrome; intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36',
+            'Mozilla/5.0 (Chrome; intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36'
         }
-      } as const;
+      } as const
 
       const expectedPayload: EventPayload = {
         event_type: TEST_EVENT_TYPE,
@@ -441,12 +440,12 @@ describe('Moloco MCM', () => {
         user_id: event.userId,
         device: {
           ua: event.context.userAgent,
-          ip: event.context.ip,
+          ip: event.context.ip
         },
         session_id: event.anonymousId,
-        page_id: event.context.page.path,
+        page_id: event.context.page.path
       }
-        
+
       const responses = await testDestination.testAction(TEST_ACTION_SLUG, {
         event: event,
         settings: AUTH,
@@ -455,7 +454,7 @@ describe('Moloco MCM', () => {
           timestamp: { '@path': '$.timestamp' },
           channel_type: 'SITE',
           event_id: { '@path': '$.eventId' }
-        },
+        }
       })
 
       expect(responses.length).toBe(1)
@@ -463,7 +462,7 @@ describe('Moloco MCM', () => {
       expect(responses[0].options.json).toEqual(expectedPayload)
     })
 
-    it('should validate custom mappings for an object array mapping(items). The input IS NOT an array.' , async () => {
+    it('should validate custom mappings for an object array mapping(items). The input IS NOT an array.', async () => {
       nock(/.*/).persist().post(/.*/).reply(200)
 
       // A test event case with automatically collected fields
@@ -486,12 +485,12 @@ describe('Moloco MCM', () => {
             name: 'Monopoly: 3rd Edition',
             price: 19.99,
             brand: 'Hasbro',
-            currency: 'USD',
+            currency: 'USD'
           },
           app: {
             name: 'AppName',
             version: '1.0.0',
-            build: '1',
+            build: '1'
           },
           device: {
             type: 'android',
@@ -500,7 +499,7 @@ describe('Moloco MCM', () => {
             adTrackingEnabled: true,
             manufacturer: 'Samsung',
             model: 'Galaxy S10',
-            name: 'galaxy',
+            name: 'galaxy'
           },
           library: {
             name: 'analytics.ANDROID',
@@ -512,7 +511,7 @@ describe('Moloco MCM', () => {
             carrier: 'T-Mobile US',
             cellular: true,
             wifi: false,
-            bluetooth: false,
+            bluetooth: false
           },
           os: {
             name: 'Google Android',
@@ -524,10 +523,11 @@ describe('Moloco MCM', () => {
             density: 2.0
           },
           traits: {},
-          userAgent: 'Mozilla/5.0 (Linux; Android 10; SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Mobile Safari/537.36',
-          timezone: 'America/Los_Angeles',
+          userAgent:
+            'Mozilla/5.0 (Linux; Android 10; SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Mobile Safari/537.36',
+          timezone: 'America/Los_Angeles'
         }
-      } as const;
+      } as const
 
       const expectedPayload: EventPayload = {
         event_type: TEST_EVENT_TYPE,
@@ -542,23 +542,23 @@ describe('Moloco MCM', () => {
           os: androidEvent.context.os.name.toUpperCase(),
           os_version: androidEvent.context.os.version,
           ua: androidEvent.context.userAgent,
-          unique_device_id: androidEvent.context.device.id,
+          unique_device_id: androidEvent.context.device.id
         },
         items: [
           {
             id: androidEvent.context.product.id,
             price: {
               amount: androidEvent.context.product.price,
-              currency: androidEvent.context.product.currency,
+              currency: androidEvent.context.product.currency
             }
           }
         ],
-        session_id: androidEvent.anonymousId,
+        session_id: androidEvent.anonymousId
       }
-        
+
       const responses = await testDestination.testAction(TEST_ACTION_SLUG, {
         event: androidEvent,
-        settings: { ...AUTH, channel_type: 'APP'},
+        settings: { ...AUTH, channel_type: 'APP' },
         useDefaultMappings: true,
         mapping: {
           channel_type: 'APP',
@@ -567,9 +567,9 @@ describe('Moloco MCM', () => {
               id: { '@path': '$.context.product.id' },
               price: { '@path': '$.context.product.price' },
               currency: { '@path': '$.context.product.currency' }
-            },
+            }
           ]
-        },
+        }
       })
 
       expect(responses.length).toBe(1)
@@ -577,7 +577,7 @@ describe('Moloco MCM', () => {
       expect(responses[0].options.json).toEqual(expectedPayload)
     })
 
-    it('should validate custom mappings for an object array mapping(items). The input IS an array.' , async () => {
+    it('should validate custom mappings for an object array mapping(items). The input IS an array.', async () => {
       nock(/.*/).persist().post(/.*/).reply(200)
 
       // A test event case with automatically collected fields
@@ -601,20 +601,20 @@ describe('Moloco MCM', () => {
               name: 'Monopoly: 3rd Edition',
               price: 19.99,
               brand: 'Hasbro',
-              currency: 'USD',
+              currency: 'USD'
             },
             {
               id: 'nae2d1',
               name: 'Hogwarts: 3rd Edition',
               price: 29.99,
               brand: 'Hasbro',
-              currency: 'USD',
+              currency: 'USD'
             }
           ],
           app: {
             name: 'AppName',
             version: '1.0.0',
-            build: '1',
+            build: '1'
           },
           device: {
             type: 'android',
@@ -623,7 +623,7 @@ describe('Moloco MCM', () => {
             adTrackingEnabled: true,
             manufacturer: 'Samsung',
             model: 'Galaxy S10',
-            name: 'galaxy',
+            name: 'galaxy'
           },
           library: {
             name: 'analytics.ANDROID',
@@ -635,7 +635,7 @@ describe('Moloco MCM', () => {
             carrier: 'T-Mobile US',
             cellular: true,
             wifi: false,
-            bluetooth: false,
+            bluetooth: false
           },
           os: {
             name: 'Google Android',
@@ -647,10 +647,11 @@ describe('Moloco MCM', () => {
             density: 2.0
           },
           traits: {},
-          userAgent: 'Mozilla/5.0 (Linux; Android 10; SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Mobile Safari/537.36',
-          timezone: 'America/Los_Angeles',
+          userAgent:
+            'Mozilla/5.0 (Linux; Android 10; SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Mobile Safari/537.36',
+          timezone: 'America/Los_Angeles'
         }
-      } as const;
+      } as const
 
       const expectedPayload: EventPayload = {
         event_type: TEST_EVENT_TYPE,
@@ -665,30 +666,30 @@ describe('Moloco MCM', () => {
           os: androidEvent.context.os.name.toUpperCase(),
           os_version: androidEvent.context.os.version,
           ua: androidEvent.context.userAgent,
-          unique_device_id: androidEvent.context.device.id,
+          unique_device_id: androidEvent.context.device.id
         },
         items: [
           {
             id: androidEvent.context.product[0].id,
             price: {
               amount: androidEvent.context.product[0].price,
-              currency: androidEvent.context.product[0].currency,
+              currency: androidEvent.context.product[0].currency
             }
           },
           {
             id: androidEvent.context.product[1].id,
             price: {
               amount: androidEvent.context.product[1].price,
-              currency: androidEvent.context.product[0].currency,
+              currency: androidEvent.context.product[0].currency
             }
           }
         ],
-        session_id: androidEvent.anonymousId,
+        session_id: androidEvent.anonymousId
       }
-        
+
       const responses = await testDestination.testAction(TEST_ACTION_SLUG, {
         event: androidEvent,
-        settings: { ...AUTH, channel_type: 'APP'},
+        settings: { ...AUTH, channel_type: 'APP' },
         useDefaultMappings: true,
         mapping: {
           channel_type: 'APP',
@@ -702,7 +703,7 @@ describe('Moloco MCM', () => {
               }
             ]
           }
-        },
+        }
       })
 
       expect(responses.length).toBe(1)
@@ -710,7 +711,7 @@ describe('Moloco MCM', () => {
       expect(responses[0].options.json).toEqual(expectedPayload)
     })
 
-    it('should validate items mapping with currency / when both default currency and currency for each item are given, it should use the latter.' , async () => {
+    it('should validate items mapping with currency / when both default currency and currency for each item are given, it should use the latter.', async () => {
       nock(/.*/).persist().post(/.*/).reply(200)
 
       // A test event case with automatically collected fields
@@ -735,20 +736,20 @@ describe('Moloco MCM', () => {
               name: 'Monopoly: 3rd Edition',
               price: 19.99,
               brand: 'Hasbro',
-              currency: 'USD',
+              currency: 'USD'
             },
             {
               id: 'nae2d1',
               name: 'Hogwarts: 3rd Edition',
               price: 29.99,
               brand: 'Hasbro',
-              currency: 'USD',
+              currency: 'USD'
             }
           ],
           app: {
             name: 'AppName',
             version: '1.0.0',
-            build: '1',
+            build: '1'
           },
           device: {
             type: 'android',
@@ -757,7 +758,7 @@ describe('Moloco MCM', () => {
             adTrackingEnabled: true,
             manufacturer: 'Samsung',
             model: 'Galaxy S10',
-            name: 'galaxy',
+            name: 'galaxy'
           },
           library: {
             name: 'analytics.ANDROID',
@@ -769,7 +770,7 @@ describe('Moloco MCM', () => {
             carrier: 'T-Mobile US',
             cellular: true,
             wifi: false,
-            bluetooth: false,
+            bluetooth: false
           },
           os: {
             name: 'Google Android',
@@ -781,8 +782,9 @@ describe('Moloco MCM', () => {
             density: 2.0
           },
           traits: {},
-          userAgent: 'Mozilla/5.0 (Linux; Android 10; SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Mobile Safari/537.36',
-          timezone: 'America/Los_Angeles',
+          userAgent:
+            'Mozilla/5.0 (Linux; Android 10; SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Mobile Safari/537.36',
+          timezone: 'America/Los_Angeles'
         }
       }
 
@@ -799,30 +801,30 @@ describe('Moloco MCM', () => {
           os: androidEvent.context.os.name.toUpperCase(),
           os_version: androidEvent.context.os.version,
           ua: androidEvent.context.userAgent,
-          unique_device_id: androidEvent.context.device.id,
+          unique_device_id: androidEvent.context.device.id
         },
         items: [
           {
             id: androidEvent.context.product[0].id,
             price: {
               amount: androidEvent.context.product[0].price,
-              currency: androidEvent.context.product[0].currency,
+              currency: androidEvent.context.product[0].currency
             }
           },
           {
             id: androidEvent.context.product[1].id,
             price: {
               amount: androidEvent.context.product[1].price,
-              currency: androidEvent.context.product[0].currency,
+              currency: androidEvent.context.product[0].currency
             }
           }
         ],
-        session_id: androidEvent.anonymousId,
+        session_id: androidEvent.anonymousId
       }
-        
+
       const responses = await testDestination.testAction(TEST_ACTION_SLUG, {
         event: androidEvent as SegmentEvent,
-        settings: { ...AUTH, channel_type: 'APP'},
+        settings: { ...AUTH, channel_type: 'APP' },
         useDefaultMappings: true,
         mapping: {
           timestamp: { '@path': '$.timestamp' },
@@ -838,7 +840,7 @@ describe('Moloco MCM', () => {
               }
             ]
           }
-        },
+        }
       })
 
       expect(responses.length).toBe(1)
@@ -846,7 +848,7 @@ describe('Moloco MCM', () => {
       expect(responses[0].options.json).toEqual(expectedPayload)
     })
 
-    it('should validate items mapping with currency / only default currency is given and it is used for each item.' , async () => {
+    it('should validate items mapping with currency / only default currency is given and it is used for each item.', async () => {
       nock(/.*/).persist().post(/.*/).reply(200)
 
       // A test event case with automatically collected fields
@@ -882,7 +884,7 @@ describe('Moloco MCM', () => {
           app: {
             name: 'AppName',
             version: '1.0.0',
-            build: '1',
+            build: '1'
           },
           device: {
             type: 'android',
@@ -891,7 +893,7 @@ describe('Moloco MCM', () => {
             adTrackingEnabled: true,
             manufacturer: 'Samsung',
             model: 'Galaxy S10',
-            name: 'galaxy',
+            name: 'galaxy'
           },
           library: {
             name: 'analytics.ANDROID',
@@ -903,7 +905,7 @@ describe('Moloco MCM', () => {
             carrier: 'T-Mobile US',
             cellular: true,
             wifi: false,
-            bluetooth: false,
+            bluetooth: false
           },
           os: {
             name: 'Google Android',
@@ -915,8 +917,9 @@ describe('Moloco MCM', () => {
             density: 2.0
           },
           traits: {},
-          userAgent: 'Mozilla/5.0 (Linux; Android 10; SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Mobile Safari/537.36',
-          timezone: 'America/Los_Angeles',
+          userAgent:
+            'Mozilla/5.0 (Linux; Android 10; SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Mobile Safari/537.36',
+          timezone: 'America/Los_Angeles'
         }
       }
 
@@ -933,30 +936,30 @@ describe('Moloco MCM', () => {
           os: androidEvent.context.os.name.toUpperCase(),
           os_version: androidEvent.context.os.version,
           ua: androidEvent.context.userAgent,
-          unique_device_id: androidEvent.context.device.id,
+          unique_device_id: androidEvent.context.device.id
         },
         items: [
           {
             id: androidEvent.context.product[0].id,
             price: {
               amount: androidEvent.context.product[0].price,
-              currency: androidEvent.context.defaultCurrency,
+              currency: androidEvent.context.defaultCurrency
             }
           },
           {
             id: androidEvent.context.product[1].id,
             price: {
               amount: androidEvent.context.product[1].price,
-              currency: androidEvent.context.defaultCurrency,
+              currency: androidEvent.context.defaultCurrency
             }
           }
         ],
-        session_id: androidEvent.anonymousId,
+        session_id: androidEvent.anonymousId
       }
-        
+
       const responses = await testDestination.testAction(TEST_ACTION_SLUG, {
         event: androidEvent as SegmentEvent,
-        settings: { ...AUTH, channel_type: 'APP'},
+        settings: { ...AUTH, channel_type: 'APP' },
         useDefaultMappings: true,
         mapping: {
           timestamp: { '@path': '$.timestamp' },
@@ -972,7 +975,7 @@ describe('Moloco MCM', () => {
               }
             ]
           }
-        },
+        }
       })
 
       expect(responses.length).toBe(1)
@@ -980,7 +983,7 @@ describe('Moloco MCM', () => {
       expect(responses[0].options.json).toEqual(expectedPayload)
     })
 
-    it('should validate the page_id conversion when both "page_id" and "page_identifier_tokens" are given ("page_id" should be used).' , async () => {
+    it('should validate the page_id conversion when both "page_id" and "page_identifier_tokens" are given ("page_id" should be used).', async () => {
       nock(/.*/).persist().post(/.*/).reply(200)
 
       // A test event case with automatically collected fields
@@ -1002,7 +1005,7 @@ describe('Moloco MCM', () => {
           app: {
             name: 'AppName',
             version: '1.0.0',
-            build: '1',
+            build: '1'
           },
           device: {
             type: 'android',
@@ -1011,7 +1014,7 @@ describe('Moloco MCM', () => {
             adTrackingEnabled: true,
             manufacturer: 'Samsung',
             model: 'Galaxy S10',
-            name: 'galaxy',
+            name: 'galaxy'
           },
           library: {
             name: 'analytics.ANDROID',
@@ -1023,7 +1026,7 @@ describe('Moloco MCM', () => {
             carrier: 'T-Mobile US',
             cellular: true,
             wifi: false,
-            bluetooth: false,
+            bluetooth: false
           },
           os: {
             name: 'Google Android',
@@ -1035,7 +1038,8 @@ describe('Moloco MCM', () => {
             density: 2.0
           },
           traits: {},
-          userAgent: 'Mozilla/5.0 (Linux; Android 10; SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Mobile Safari/537.36',
+          userAgent:
+            'Mozilla/5.0 (Linux; Android 10; SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Mobile Safari/537.36',
           timezone: 'America/Los_Angeles',
           event: 'Product List Viewed',
           vertical: 'fruit'
@@ -1055,15 +1059,15 @@ describe('Moloco MCM', () => {
           os: event.context.os.name.toUpperCase(),
           os_version: event.context.os.version,
           ua: event.context.userAgent,
-          unique_device_id: event.context.device.id,
+          unique_device_id: event.context.device.id
         },
         page_id: event.pageId, // -- still uses the pageId
-        session_id: event.anonymousId,
+        session_id: event.anonymousId
       }
-        
+
       const responses = await testDestination.testAction(TEST_ACTION_SLUG, {
         event: event,
-        settings: { ...AUTH, channel_type: 'APP'},
+        settings: { ...AUTH, channel_type: 'APP' },
         useDefaultMappings: true,
         mapping: {
           timestamp: { '@path': '$.timestamp' },
@@ -1073,7 +1077,7 @@ describe('Moloco MCM', () => {
             event: { '@path': '$.context.event' },
             vertical: { '@path': '$.context.vertical' }
           }
-        },
+        }
       })
 
       expect(responses.length).toBe(1)
@@ -1081,7 +1085,7 @@ describe('Moloco MCM', () => {
       expect(responses[0].options.json).toEqual(expectedPayload)
     })
 
-    it('should validate the page_id conversion when only "page_identifier_tokens" is given.' , async () => {
+    it('should validate the page_id conversion when only "page_identifier_tokens" is given.', async () => {
       nock(/.*/).persist().post(/.*/).reply(200)
 
       // A test event case with automatically collected fields
@@ -1103,7 +1107,7 @@ describe('Moloco MCM', () => {
           app: {
             name: 'AppName',
             version: '1.0.0',
-            build: '1',
+            build: '1'
           },
           device: {
             type: 'android',
@@ -1112,7 +1116,7 @@ describe('Moloco MCM', () => {
             adTrackingEnabled: true,
             manufacturer: 'Samsung',
             model: 'Galaxy S10',
-            name: 'galaxy',
+            name: 'galaxy'
           },
           library: {
             name: 'analytics.ANDROID',
@@ -1124,7 +1128,7 @@ describe('Moloco MCM', () => {
             carrier: 'T-Mobile US',
             cellular: true,
             wifi: false,
-            bluetooth: false,
+            bluetooth: false
           },
           os: {
             name: 'Google Android',
@@ -1136,7 +1140,8 @@ describe('Moloco MCM', () => {
             density: 2.0
           },
           traits: {},
-          userAgent: 'Mozilla/5.0 (Linux; Android 10; SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Mobile Safari/537.36',
+          userAgent:
+            'Mozilla/5.0 (Linux; Android 10; SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Mobile Safari/537.36',
           timezone: 'America/Los_Angeles',
           event: 'Product List Viewed',
           vertical: 'fruit'
@@ -1156,15 +1161,15 @@ describe('Moloco MCM', () => {
           os: event.context.os.name.toUpperCase(),
           os_version: event.context.os.version,
           ua: event.context.userAgent,
-          unique_device_id: event.context.device.id,
+          unique_device_id: event.context.device.id
         },
-        page_id: "event:Product List Viewed;vertical:fruit", // stringified from pageIdentifierTokens
-        session_id: event.anonymousId,
+        page_id: 'event:Product List Viewed;vertical:fruit', // stringified from pageIdentifierTokens
+        session_id: event.anonymousId
       }
-        
+
       const responses = await testDestination.testAction(TEST_ACTION_SLUG, {
         event: event,
-        settings: { ...AUTH, channel_type: 'APP'},
+        settings: { ...AUTH, channel_type: 'APP' },
         useDefaultMappings: true,
         mapping: {
           timestamp: { '@path': '$.timestamp' },
@@ -1174,7 +1179,7 @@ describe('Moloco MCM', () => {
             event: { '@path': '$.context.event' },
             vertical: { '@path': '$.context.vertical' }
           }
-        },
+        }
       })
 
       expect(responses.length).toBe(1)

--- a/packages/destination-actions/src/destinations/moloco-rmp/addToCart/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/moloco-rmp/addToCart/__tests__/index.test.ts
@@ -16,7 +16,7 @@ describe('MolocoMCM.addToCart', () => {
           price: 100,
           currency: 'USD',
           quantity: 1,
-          sellerId: 'seller123',
+          sellerId: 'seller123'
         }
       }
     })
@@ -25,7 +25,8 @@ describe('MolocoMCM.addToCart', () => {
       event,
       settings: {
         platformId: 'foo',
-        apiKey: 'bar', 
+        platformName: 'foo',
+        apiKey: 'bar',
         channel_type: 'SITE'
       },
       mapping: {
@@ -46,11 +47,11 @@ describe('MolocoMCM.addToCart', () => {
             },
             sellerId: {
               '@path': '$.properties.item.sellerId'
-            },
+            }
           }
         ]
       },
-      useDefaultMappings: true,
+      useDefaultMappings: true
     })
 
     expect(responses.length).toBe(1)
@@ -67,40 +68,43 @@ describe('MolocoMCM.addToCart', () => {
           price: 100,
           currency: 'USD',
           quantity: 1,
-          sellerId: 'seller123',
+          sellerId: 'seller123'
         }
       }
     })
 
-    await expect(testDestination.testAction('addToCart', {
-      event,
-      settings: {
-        platformId: 'foo',
-        apiKey: 'bar',
-        channel_type: 'SITE'
-      },
-      mapping: {
-        // items: [
-        //   {
-        //     id: {
-        //       '@path': '$.properties.item.id'
-        //     },
-        //     price: {
-        //       '@path': '$.properties.item.price'
-        //     },
-        //     currency: {
-        //       '@path': '$.properties.item.currency'
-        //     },
-        //     quantity: {
-        //       '@path': '$.properties.item.quantity'
-        //     },
-        //     sellerId: {
-        //       '@path': '$.properties.item.sellerId'
-        //     },
-        //   }
-        // ] -- missing required field
-      },
-      useDefaultMappings: true,
-    })).rejects.toThrowError(AggregateAjvError)
+    await expect(
+      testDestination.testAction('addToCart', {
+        event,
+        settings: {
+          platformId: 'foo',
+          platformName: 'foo',
+          apiKey: 'bar',
+          channel_type: 'SITE'
+        },
+        mapping: {
+          // items: [
+          //   {
+          //     id: {
+          //       '@path': '$.properties.item.id'
+          //     },
+          //     price: {
+          //       '@path': '$.properties.item.price'
+          //     },
+          //     currency: {
+          //       '@path': '$.properties.item.currency'
+          //     },
+          //     quantity: {
+          //       '@path': '$.properties.item.quantity'
+          //     },
+          //     sellerId: {
+          //       '@path': '$.properties.item.sellerId'
+          //     },
+          //   }
+          // ] -- missing required field
+        },
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError(AggregateAjvError)
   })
 })

--- a/packages/destination-actions/src/destinations/moloco-rmp/addToWishlist/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/moloco-rmp/addToWishlist/__tests__/index.test.ts
@@ -11,7 +11,6 @@ describe('MolocoMCM.addToWishlist', () => {
 
     const event = createTestEvent({
       properties: {
-        
         id: '123',
         price: 100,
         currency: 'USD',
@@ -25,7 +24,8 @@ describe('MolocoMCM.addToWishlist', () => {
       event,
       settings: {
         platformId: 'foo',
-        apiKey: 'bar', 
+        platformName: 'foo',
+        apiKey: 'bar',
         channel_type: 'SITE'
       },
       mapping: {
@@ -46,11 +46,11 @@ describe('MolocoMCM.addToWishlist', () => {
             },
             sellerId: {
               '@path': '$.properties.sellerId'
-            },
+            }
           }
         ]
       },
-      useDefaultMappings: true,
+      useDefaultMappings: true
     })
 
     expect(responses.length).toBe(1)
@@ -67,41 +67,43 @@ describe('MolocoMCM.addToWishlist', () => {
           price: 100,
           currency: 'USD',
           quantity: 1,
-          sellerId: 'seller123',
+          sellerId: 'seller123'
         }
       }
     })
 
-    await expect(testDestination.testAction('addToWishlist', {
-      event,
-      settings: {
-        platformId: 'foo',
-        apiKey: 'bar',
-        channel_type: 'SITE'
-      },
-      mapping: {
-
-        // items: [
-        //   {
-        //     id: {
-        //       '@path': '$.properties.item.id'
-        //     },
-        //     price: {
-        //       '@path': '$.properties.item.price'
-        //     },
-        //     currency: {
-        //       '@path': '$.properties.item.currency'
-        //     },
-        //     quantity: {
-        //       '@path': '$.properties.item.quantity'
-        //     },
-        //     sellerId: {
-        //       '@path': '$.properties.item.sellerId'
-        //     },
-        //   }
-        // ] -- missing required field
-      },
-      useDefaultMappings: true,
-    })).rejects.toThrowError(AggregateAjvError)
+    await expect(
+      testDestination.testAction('addToWishlist', {
+        event,
+        settings: {
+          platformId: 'foo',
+          platformName: 'foo',
+          apiKey: 'bar',
+          channel_type: 'SITE'
+        },
+        mapping: {
+          // items: [
+          //   {
+          //     id: {
+          //       '@path': '$.properties.item.id'
+          //     },
+          //     price: {
+          //       '@path': '$.properties.item.price'
+          //     },
+          //     currency: {
+          //       '@path': '$.properties.item.currency'
+          //     },
+          //     quantity: {
+          //       '@path': '$.properties.item.quantity'
+          //     },
+          //     sellerId: {
+          //       '@path': '$.properties.item.sellerId'
+          //     },
+          //   }
+          // ] -- missing required field
+        },
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError(AggregateAjvError)
   })
 })

--- a/packages/destination-actions/src/destinations/moloco-rmp/common/request-client.ts
+++ b/packages/destination-actions/src/destinations/moloco-rmp/common/request-client.ts
@@ -1,39 +1,38 @@
-import { 
-    RequestClient,
-    ModifiedResponse
-} from '@segment/actions-core'
+import { RequestClient, ModifiedResponse } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 
 export class MolocoAPIClient {
-    url: string
-    platform: string
-    apiKey: string
+  url: string
+  platformId: string
+  platformName: string
+  apiKey: string
 
-    request: RequestClient
+  request: RequestClient
 
-    constructor(request: RequestClient, settings: Settings) {
-        this.platform = settings.platformId
-        this.apiKey = settings.apiKey
-        this.request = request
+  constructor(request: RequestClient, settings: Settings) {
+    this.platformId = settings.platformId
+    this.platformName = settings.platformName
+    this.apiKey = settings.apiKey
+    this.request = request
 
-        this.url = this.getEndpoint()
+    this.url = this.getEndpoint()
+  }
+
+  private getEndpoint() {
+    return `https://${this.platformName.replace(/_/g, '-')}-evt.rmp-api.moloco.com/cdp/SEGMENT`
+  }
+
+  async sendEvent(body: Record<string, any>): Promise<ModifiedResponse> {
+    const headers = {
+      'x-api-key': this.apiKey,
+      'x-platform-id': this.platformId,
+      'Content-Type': 'application/json'
     }
 
-    private getEndpoint() {
-        return `https://${this.platform.replace(/_/g, '-')}-evt.rmp-api.moloco.com/cdp/SEGMENT`
-    }
-
-    async sendEvent(body: Record<string, any>): Promise<ModifiedResponse> {
-        const headers = {
-            'x-api-key': this.apiKey,
-            'x-platform-id': this.platform,
-            'Content-Type': 'application/json'
-        }
-
-        return await this.request(this.url, {
-            method: 'POST',
-            headers,
-            json: body
-        })
-    }
+    return await this.request(this.url, {
+      method: 'POST',
+      headers,
+      json: body
+    })
+  }
 }

--- a/packages/destination-actions/src/destinations/moloco-rmp/common/request-client.ts
+++ b/packages/destination-actions/src/destinations/moloco-rmp/common/request-client.ts
@@ -19,7 +19,8 @@ export class MolocoAPIClient {
   }
 
   private getEndpoint() {
-    return `https://${this.platformName.replace(/_/g, '-')}-evt.rmp-api.moloco.com/cdp/SEGMENT`
+    const nameOrId = this.platformName ? this.platformName : this.platformId
+    return `https://${nameOrId.replace(/_/g, '-')}-evt.rmp-api.moloco.com/cdp/SEGMENT`
   }
 
   async sendEvent(body: Record<string, any>): Promise<ModifiedResponse> {

--- a/packages/destination-actions/src/destinations/moloco-rmp/common/settings.ts
+++ b/packages/destination-actions/src/destinations/moloco-rmp/common/settings.ts
@@ -1,8 +1,9 @@
 // Generalized interface for auth.authentication.fields
 // All destination actions, will use the auth.authentication to define the fields for the authentication scheme,
 // and the corresponding interface will be automatically generated.
-// This interface is the generalized version of that auto-generated interface. 
+// This interface is the generalized version of that auto-generated interface.
 export interface Settings {
-    platformId: string
-    apiKey: string
+  platformId: string
+  platformName: string
+  apiKey: string
 }

--- a/packages/destination-actions/src/destinations/moloco-rmp/generated-types.ts
+++ b/packages/destination-actions/src/destinations/moloco-rmp/generated-types.ts
@@ -6,6 +6,10 @@ export interface Settings {
    */
   platformId: string
   /**
+   * Name of the platform
+   */
+  platformName: string
+  /**
    * The API key for the platform
    */
   apiKey: string

--- a/packages/destination-actions/src/destinations/moloco-rmp/generated-types.ts
+++ b/packages/destination-actions/src/destinations/moloco-rmp/generated-types.ts
@@ -6,9 +6,9 @@ export interface Settings {
    */
   platformId: string
   /**
-   * Name of the platform
+   * Name of the platform (default to the `Platform ID`)
    */
-  platformName: string
+  platformName?: string
   /**
    * The API key for the platform
    */

--- a/packages/destination-actions/src/destinations/moloco-rmp/home/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/moloco-rmp/home/__tests__/index.test.ts
@@ -4,7 +4,7 @@ import Destination from '../../index'
 
 const testDestination = createTestIntegration(Destination)
 
-describe('MolocoMCM.home', () => {  
+describe('MolocoMCM.home', () => {
   it('should successfully build an event and send', async () => {
     nock(/.*/).persist().post(/.*/).reply(200)
 
@@ -13,13 +13,14 @@ describe('MolocoMCM.home', () => {
       event,
       settings: {
         platformId: 'foo',
+        platformName: 'foo',
         apiKey: 'bar',
         channel_type: 'SITE'
       },
       mapping: {
         timestamp: { '@path': '$.timestamp' }
       },
-      useDefaultMappings: true,
+      useDefaultMappings: true
     })
 
     expect(responses.length).toBe(1)

--- a/packages/destination-actions/src/destinations/moloco-rmp/index.ts
+++ b/packages/destination-actions/src/destinations/moloco-rmp/index.ts
@@ -32,6 +32,12 @@ const destination: DestinationDefinition<Settings> = {
         type: 'string',
         required: true
       },
+      platformName: {
+        label: 'Platform Name',
+        description: 'Name of the platform',
+        type: 'string',
+        required: true
+      },
       apiKey: {
         label: 'API Key',
         description: 'The API key for the platform',

--- a/packages/destination-actions/src/destinations/moloco-rmp/index.ts
+++ b/packages/destination-actions/src/destinations/moloco-rmp/index.ts
@@ -34,9 +34,10 @@ const destination: DestinationDefinition<Settings> = {
       },
       platformName: {
         label: 'Platform Name',
-        description: 'Name of the platform',
+        description: 'Name of the platform (default to the `Platform ID`)',
         type: 'string',
-        required: true
+        required: false,
+        default: ''
       },
       apiKey: {
         label: 'API Key',

--- a/packages/destination-actions/src/destinations/moloco-rmp/itemPageView/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/moloco-rmp/itemPageView/__tests__/index.test.ts
@@ -16,7 +16,7 @@ describe('MolocoMCM.itemPageView', () => {
           price: 100,
           currency: 'USD',
           quantity: 1,
-          sellerId: 'seller123',
+          sellerId: 'seller123'
         }
       }
     })
@@ -25,8 +25,9 @@ describe('MolocoMCM.itemPageView', () => {
       event,
       settings: {
         platformId: 'foo',
+        platformName: 'foo',
         apiKey: 'bar',
-        channel_type: 'SITE',
+        channel_type: 'SITE'
       },
       mapping: {
         timestamp: { '@path': '$.timestamp' },
@@ -51,7 +52,7 @@ describe('MolocoMCM.itemPageView', () => {
           }
         ]
       },
-      useDefaultMappings: true,
+      useDefaultMappings: true
     })
 
     expect(responses.length).toBe(1)
@@ -73,36 +74,38 @@ describe('MolocoMCM.itemPageView', () => {
       }
     })
 
-    await expect(testDestination.testAction('itemPageView', {
-      event,
-      settings: {
-        platformId: 'foo',
-        apiKey: 'bar',
-        channel_type: 'SITE',
-      },
-      mapping: {
-        // items: [
-        //   {
-        //     id: {
-        //       '@path': '$.properties.item.id'
-        //     },
-        //     price: {
-        //       '@path': '$.properties.item.price'
-        //     },
-        //     currency: {
-        //       '@path': '$.properties.item.currency'
-        //     },
-        //     quantity: {
-        //       '@path': '$.properties.item.quantity'
-        //     },
-        //     sellerId: {
-        //       '@path': '$.properties.item.sellerId'
-        //     }
-        //   }
-        // ] -- missing required field
-      },
-      useDefaultMappings: true,
-    })).rejects.toThrowError(AggregateAjvError)
+    await expect(
+      testDestination.testAction('itemPageView', {
+        event,
+        settings: {
+          platformId: 'foo',
+          platformName: 'foo',
+          apiKey: 'bar',
+          channel_type: 'SITE'
+        },
+        mapping: {
+          // items: [
+          //   {
+          //     id: {
+          //       '@path': '$.properties.item.id'
+          //     },
+          //     price: {
+          //       '@path': '$.properties.item.price'
+          //     },
+          //     currency: {
+          //       '@path': '$.properties.item.currency'
+          //     },
+          //     quantity: {
+          //       '@path': '$.properties.item.quantity'
+          //     },
+          //     sellerId: {
+          //       '@path': '$.properties.item.sellerId'
+          //     }
+          //   }
+          // ] -- missing required field
+        },
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError(AggregateAjvError)
   })
-
 })

--- a/packages/destination-actions/src/destinations/moloco-rmp/land/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/moloco-rmp/land/__tests__/index.test.ts
@@ -41,15 +41,16 @@ describe('MolocoMCM.land', () => {
       event,
       settings: {
         platformId: 'foo',
+        platformName: 'foo',
         apiKey: 'bar',
         channel_type: 'SITE'
       },
       mapping: {
-        timestamp: { '@path': '$.timestamp' },
+        timestamp: { '@path': '$.timestamp' }
 
         // referrer_page_id is default to context.page.referrer
       },
-      useDefaultMappings: true,
+      useDefaultMappings: true
     })
 
     expect(responses.length).toBe(1)
@@ -87,17 +88,18 @@ describe('MolocoMCM.land', () => {
       }
     })
 
-    await expect(testDestination.testAction('land', {
-      event,
-      settings: {
-        platformId: 'foo',
-        apiKey: 'bar',
-        channel_type: 'SITE'
-      },
-      mapping: {
-
-      },
-      useDefaultMappings: true,
-    })).rejects.toThrowError(AggregateAjvError)
+    await expect(
+      testDestination.testAction('land', {
+        event,
+        settings: {
+          platformId: 'foo',
+          platformName: 'foo',
+          apiKey: 'bar',
+          channel_type: 'SITE'
+        },
+        mapping: {},
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError(AggregateAjvError)
   })
 })

--- a/packages/destination-actions/src/destinations/moloco-rmp/pageView/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/moloco-rmp/pageView/__tests__/index.test.ts
@@ -40,14 +40,14 @@ describe('MolocoMCM.pageView', () => {
       event,
       settings: {
         platformId: 'foo',
+        platformName: 'foo',
         apiKey: 'bar',
         channel_type: 'SITE'
       },
       mapping: {
-
         // page_id is default to context.page.path
       },
-      useDefaultMappings: true,
+      useDefaultMappings: true
     })
 
     expect(responses.length).toBe(1)

--- a/packages/destination-actions/src/destinations/moloco-rmp/purchase/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/moloco-rmp/purchase/__tests__/index.test.ts
@@ -26,8 +26,9 @@ describe('MolocoMCM.purchase', () => {
       event,
       settings: {
         platformId: 'foo',
+        platformName: 'foo',
         apiKey: 'bar',
-        channel_type: 'SITE',
+        channel_type: 'SITE'
       },
       mapping: {
         timestamp: { '@path': '$.timestamp' },
@@ -59,7 +60,7 @@ describe('MolocoMCM.purchase', () => {
           }
         }
       },
-      useDefaultMappings: true,
+      useDefaultMappings: true
     })
 
     expect(responses.length).toBe(1)
@@ -82,26 +83,28 @@ describe('MolocoMCM.purchase', () => {
       }
     })
 
-    await expect(testDestination.testAction('purchase', {
-      event,
-      settings: {
-        platformId: 'foo',
-        apiKey: 'bar',
-        channel_type: 'SITE'
-      },
-      mapping: {
-        // items: -- missing mapping for a required field
-        revenue: {
-          price: {
-            '@path': '$.properties.revenue'
-          },
-          currency: {
-            '@path': '$.properties.currency'
+    await expect(
+      testDestination.testAction('purchase', {
+        event,
+        settings: {
+          platformId: 'foo',
+          platformName: 'foo',
+          apiKey: 'bar',
+          channel_type: 'SITE'
+        },
+        mapping: {
+          // items: -- missing mapping for a required field
+          revenue: {
+            price: {
+              '@path': '$.properties.revenue'
+            },
+            currency: {
+              '@path': '$.properties.currency'
+            }
           }
-        }
-      },
-      useDefaultMappings: true,
-    })).rejects.toThrowError(AggregateAjvError)
+        },
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError(AggregateAjvError)
   })
-
 })

--- a/packages/destination-actions/src/destinations/moloco-rmp/search/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/moloco-rmp/search/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import nock from 'nock'
 import { AggregateAjvError } from '@segment/ajv-human-errors'
-import { createTestEvent, createTestIntegration,  } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 
 const testDestination = createTestIntegration(Destination)
@@ -13,24 +13,25 @@ describe('MolocoMCM.search', () => {
       properties: {
         context: {
           page: {
-            query: "Test Query"
+            query: 'Test Query'
           }
         }
       }
     })
-  
+
     const responses = await testDestination.testAction('search', {
       event,
       settings: {
         platformId: 'foo',
+        platformName: 'foo',
         apiKey: 'bar',
         channel_type: 'SITE'
       },
       mapping: {
         timestamp: { '@path': '$.timestamp' },
-        search_query: { '@path': '$.properties.context.page.query'}
+        search_query: { '@path': '$.properties.context.page.query' }
       },
-      useDefaultMappings: true,
+      useDefaultMappings: true
     })
 
     expect(responses.length).toBe(1)
@@ -44,25 +45,28 @@ describe('MolocoMCM.search', () => {
       properties: {
         context: {
           page: {
-            query: "Test Query"
+            query: 'Test Query'
           }
         }
       }
     })
 
-    await expect(testDestination.testAction('search', {
-      event,
-      settings: {
-        platformId: 'foo',
-        apiKey: 'bar',
-        channel_type: 'SITE'
-      },
-      mapping: {
-        // searchQuery: {
-        //   '@path': '$.properties.context.page.query'
-        // } -- missing required field
-      },
-      useDefaultMappings: true,
-    })).rejects.toThrowError(AggregateAjvError)
+    await expect(
+      testDestination.testAction('search', {
+        event,
+        settings: {
+          platformId: 'foo',
+          platformName: 'foo',
+          apiKey: 'bar',
+          channel_type: 'SITE'
+        },
+        mapping: {
+          // searchQuery: {
+          //   '@path': '$.properties.context.page.query'
+          // } -- missing required field
+        },
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError(AggregateAjvError)
   })
 })


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->
## Testing

- [✅ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [✅ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment


## Summary
This PR adds a new field to settings: `platformName`

Previously, `platform` was used for both URL creation and in the request header, but now `platformName` will be used for URL creation, and `platformId` will be used for the header separately.


_Note: there are lots of changes automatically created due to pre-commit linter_
