### PR TITLE
fix: remove use of polyfill.io

### DIFF
--- a/packages/browser-destinations/destinations/commandbar/src/init-script.ts
+++ b/packages/browser-destinations/destinations/commandbar/src/init-script.ts
@@ -79,8 +79,5 @@ export function initScript(orgId) {
         t(''.concat(u, '/latest/').concat(o, '?').concat(d.join('&')), !0)
     }
   }
-  void 0 === Object.assign || 'undefined' == typeof Symbol || void 0 === Symbol.for
-    ? ((a.__CommandBarBootstrap__ = r),
-      t('https://polyfill.io/v3/polyfill.min.js?version=3.101.0&callback=__CommandBarBootstrap__&features=' + n))
-    : r()
+  r()
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

This change was tested as part of a general effort to remove [polyfill.io](http://polyfill.io/) from all installation methods
