### PR TITLE
[DC-792] injects matchingKey in the perform block

### DIFF
--- a/packages/browser-destinations/package.json
+++ b/packages/browser-destinations/package.json
@@ -84,7 +84,7 @@
   "size-limit": [
     {
       "path": "dist/web/*/*.js",
-      "limit": "159 KB"
+      "limit": "169 KB"
     }
   ]
 }

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -302,9 +302,7 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
 
     const syncMode = this.definition.syncMode ? bundle.mapping?.['__segment_internal_sync_mode'] : undefined
 
-    const matchingKey = Object.values(this.definition.fields).find((field) => field.category === 'identifier')
-      ? bundle.mapping?.['__segment_internal_matching_key']
-      : undefined
+    const matchingKey = bundle.mapping?.['__segment_internal_matching_key']
 
     // Construct the data bundle to send to an action
     const dataBundle = {
@@ -377,9 +375,8 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
 
     if (this.definition.performBatch) {
       const syncMode = this.definition.syncMode ? bundle.mapping?.['__segment_internal_sync_mode'] : undefined
-      const matchingKey = Object.values(this.definition.fields).find((field) => field.category === 'identifier')
-        ? bundle.mapping?.['__segment_internal_matching_key']
-        : undefined
+      const matchingKey = bundle.mapping?.['__segment_internal_matching_key']
+
       const data = {
         rawData: bundle.data,
         rawMapping: bundle.mapping,

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -39,6 +39,8 @@ export interface ExecuteInput<
   page?: string
   /** The subscription sync mode */
   syncMode?: SyncMode
+  /** The key for the action's field used to match data between Segment and the Destination */
+  matchingKey?: string
   /** The data needed in OAuth requests */
   readonly auth?: AuthTokens
   /**


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR adds the ability to access user-selected record matching field in the perform block. The `matchingKey` is the field key for one of the action fields of category `identifier`. The record matching field is meant to be selected via a dropdown in the mapping UI for RETL (upcoming work). [See the relevant section of the blueprint for more context.](https://docs.google.com/document/d/1h-T40iySIxC9Zm6HVEiM-c0otTVmBUWn7dSamyFebrQ/edit#heading=h.2vwlxsapfz26)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
