### PR TITLE
[STRATCONN-3905] [OrderComplete] Add features to bring parity with klaviyo classic

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -37,7 +37,7 @@ Object {
       "metric": Object {
         "data": Object {
           "attributes": Object {
-            "name": "Order Completed",
+            "name": "PE*zlOgIPA]mVozMLBaL",
           },
           "type": "metric",
         },

--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -54,7 +54,37 @@ Object {
         },
       },
       "properties": Object {
-        "testType": "PE*zlOgIPA]mVozMLBaL",
+        "Affiliation": "PE*zlOgIPA]mVozMLBaL",
+        "Categories": Array [
+          "PE*zlOgIPA]mVozMLBaL",
+        ],
+        "CheckoutId": "PE*zlOgIPA]mVozMLBaL",
+        "Coupon": "PE*zlOgIPA]mVozMLBaL",
+        "Currency": "SAR",
+        "Discount": 83414764297912.31,
+        "ItemNames": Array [
+          "PE*zlOgIPA]mVozMLBaL",
+        ],
+        "Items": Array [
+          Object {
+            "Categories": Array [
+              "PE*zlOgIPA]mVozMLBaL",
+            ],
+            "ImageURL": "PE*zlOgIPA]mVozMLBaL",
+            "ItemPrice": 83414764297912.31,
+            "ProductId": "PE*zlOgIPA]mVozMLBaL",
+            "ProductName": "PE*zlOgIPA]mVozMLBaL",
+            "ProductURL": "PE*zlOgIPA]mVozMLBaL",
+            "Quantity": 83414764297912.31,
+            "RowTotal": 83414764297912.31,
+            "SKU": "PE*zlOgIPA]mVozMLBaL",
+          },
+        ],
+        "OrderId": "PE*zlOgIPA]mVozMLBaL",
+        "Revenue": 83414764297912.31,
+        "Shipping": 83414764297912.31,
+        "Subtotal": 83414764297912.31,
+        "Tax": 83414764297912.31,
       },
       "time": "2021-02-01T00:00:00.000Z",
       "unique_id": "PE*zlOgIPA]mVozMLBaL",

--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -37,7 +37,7 @@ Object {
       "metric": Object {
         "data": Object {
           "attributes": Object {
-            "name": "PE*zlOgIPA]mVozMLBaL",
+            "name": "Order Completed",
           },
           "type": "metric",
         },

--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -54,14 +54,9 @@ Object {
         },
       },
       "properties": Object {
-        "Affiliation": "PE*zlOgIPA]mVozMLBaL",
         "Categories": Array [
           "PE*zlOgIPA]mVozMLBaL",
         ],
-        "CheckoutId": "PE*zlOgIPA]mVozMLBaL",
-        "Coupon": "PE*zlOgIPA]mVozMLBaL",
-        "Currency": "SAR",
-        "Discount": 83414764297912.31,
         "ItemNames": Array [
           "PE*zlOgIPA]mVozMLBaL",
         ],
@@ -81,10 +76,6 @@ Object {
           },
         ],
         "OrderId": "PE*zlOgIPA]mVozMLBaL",
-        "Revenue": 83414764297912.31,
-        "Shipping": 83414764297912.31,
-        "Subtotal": 83414764297912.31,
-        "Tax": 83414764297912.31,
       },
       "time": "2021-02-01T00:00:00.000Z",
       "unique_id": "PE*zlOgIPA]mVozMLBaL",

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -7,7 +7,7 @@ Object {
       "metric": Object {
         "data": Object {
           "attributes": Object {
-            "name": "Order Completed",
+            "name": "923^%f]tQn]lN2o",
           },
           "type": "metric",
         },

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -7,7 +7,7 @@ Object {
       "metric": Object {
         "data": Object {
           "attributes": Object {
-            "name": "923^%f]tQn]lN2o",
+            "name": "Order Completed",
           },
           "type": "metric",
         },

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -24,14 +24,9 @@ Object {
         },
       },
       "properties": Object {
-        "Affiliation": "923^%f]tQn]lN2o",
         "Categories": Array [
           "923^%f]tQn]lN2o",
         ],
-        "CheckoutId": "923^%f]tQn]lN2o",
-        "Coupon": "923^%f]tQn]lN2o",
-        "Currency": "KRW",
-        "Discount": 28946631197982.72,
         "ItemNames": Array [
           "923^%f]tQn]lN2o",
         ],
@@ -51,10 +46,6 @@ Object {
           },
         ],
         "OrderId": "923^%f]tQn]lN2o",
-        "Revenue": 28946631197982.72,
-        "Shipping": 28946631197982.72,
-        "Subtotal": 28946631197982.72,
-        "Tax": 28946631197982.72,
       },
       "time": "2021-02-01T00:00:00.000Z",
       "unique_id": "923^%f]tQn]lN2o",

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -24,7 +24,37 @@ Object {
         },
       },
       "properties": Object {
-        "testType": "923^%f]tQn]lN2o",
+        "Affiliation": "923^%f]tQn]lN2o",
+        "Categories": Array [
+          "923^%f]tQn]lN2o",
+        ],
+        "CheckoutId": "923^%f]tQn]lN2o",
+        "Coupon": "923^%f]tQn]lN2o",
+        "Currency": "KRW",
+        "Discount": 28946631197982.72,
+        "ItemNames": Array [
+          "923^%f]tQn]lN2o",
+        ],
+        "Items": Array [
+          Object {
+            "Categories": Array [
+              "923^%f]tQn]lN2o",
+            ],
+            "ImageURL": "923^%f]tQn]lN2o",
+            "ItemPrice": 28946631197982.72,
+            "ProductId": "923^%f]tQn]lN2o",
+            "ProductName": "923^%f]tQn]lN2o",
+            "ProductURL": "923^%f]tQn]lN2o",
+            "Quantity": 28946631197982.72,
+            "RowTotal": 28946631197982.72,
+            "SKU": "923^%f]tQn]lN2o",
+          },
+        ],
+        "OrderId": "923^%f]tQn]lN2o",
+        "Revenue": 28946631197982.72,
+        "Shipping": 28946631197982.72,
+        "Subtotal": 28946631197982.72,
+        "Tax": 28946631197982.72,
       },
       "time": "2021-02-01T00:00:00.000Z",
       "unique_id": "923^%f]tQn]lN2o",

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/formatter.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/formatter.test.ts
@@ -1,0 +1,198 @@
+import { formatOrderedProduct, formatProductItems, convertKeysToTitleCase } from '../formatters'
+import { Product } from '../types'
+
+describe('formatProductItems', () => {
+  it('should format product items', () => {
+    const product: Product = {
+      product_id: 'product_id',
+      sku: 'sku',
+      name: 'name',
+      quantity: 1,
+      price: 10,
+      category: 'category',
+      url: 'url',
+      image_url: 'image_url',
+      'property with space': 'space',
+      property_with_underscore: 'underscore',
+      array: ['value1', 'value2'],
+      shippingAddress: {
+        street: 'street',
+        city: 'city',
+        state: 'state',
+        postalCode: 'postal_code',
+        country: 'country',
+        nested: {
+          key: 'value'
+        }
+      }
+    }
+
+    expect(formatProductItems(product)).toEqual({
+      ProductId: 'product_id',
+      SKU: 'sku',
+      ProductName: 'name',
+      Quantity: 1,
+      ItemPrice: 10,
+      RowTotal: 10,
+      Categories: ['category'],
+      ProductURL: 'url',
+      ImageURL: 'image_url',
+      PropertyWithSpace: 'space',
+      PropertyWithUnderscore: 'underscore',
+      Array: ['value1', 'value2'],
+      ShippingAddress: {
+        Street: 'street',
+        City: 'city',
+        State: 'state',
+        PostalCode: 'postal_code',
+        Country: 'country',
+        Nested: {
+          key: 'value'
+        }
+      }
+    })
+  })
+  it('should use id attribute for ProductId if product_id is not present', () => {
+    const product: Product = {
+      id: 'random_id',
+      sku: 'sku',
+      name: 'name',
+      quantity: 1,
+      price: 10,
+      category: 'category',
+      url: 'url',
+      image_url: 'image_url',
+      'property with space': 'space',
+      property_with_underscore: 'underscore'
+    }
+
+    const result = formatOrderedProduct(product)
+    expect(result.productProperties.ProductId).toEqual('random_id')
+  })
+})
+
+describe('formatOrderedProduct', () => {
+  it('should format ordered product', () => {
+    const product: Product = {
+      product_id: 'product_id',
+      sku: 'sku',
+      name: 'name',
+      quantity: 1,
+      price: 10,
+      category: 'category',
+      url: 'url',
+      image_url: 'image_url',
+      'property with space': 'space',
+      property_with_underscore: 'underscore'
+    }
+
+    expect(formatOrderedProduct(product, 'order_id')).toEqual({
+      unique_id: 'order_id_product_id',
+      productProperties: {
+        OrderId: 'order_id',
+        ProductId: 'product_id',
+        SKU: 'sku',
+        ProductName: 'name',
+        Quantity: 1,
+        Categories: ['category'],
+        ProductURL: 'url',
+        ImageURL: 'image_url',
+        PropertyWithSpace: 'space',
+        PropertyWithUnderscore: 'underscore'
+      }
+    })
+  })
+
+  it('should use sku instead for unique_id if product_id is not present', () => {
+    const product: Product = {
+      sku: 'sku',
+      name: 'name',
+      quantity: 1,
+      price: 10,
+      category: 'category',
+      url: 'url',
+      image_url: 'image_url',
+      'property with space': 'space',
+      property_with_underscore: 'underscore'
+    }
+
+    const result = formatOrderedProduct(product, 'order_id')
+    expect(result.unique_id).toEqual('order_id_sku')
+  })
+
+  it('should use sku for  unique_id if product_id is not present', () => {
+    const product: Product = {
+      sku: 'sku',
+      name: 'name',
+      quantity: 1,
+      price: 10,
+      category: 'category',
+      url: 'url',
+      image_url: 'image_url',
+      'property with space': 'space',
+      property_with_underscore: 'underscore'
+    }
+
+    const result = formatOrderedProduct(product, 'order_id')
+    expect(result.unique_id).toEqual('order_id_sku')
+  })
+
+  it('should use id attribute for unique_id if product_id and sku are not present', () => {
+    const product: Product = {
+      id: 'random_id',
+      name: 'name',
+      quantity: 1,
+      price: 10,
+      category: 'category',
+      url: 'url',
+      image_url: 'image_url',
+      'property with space': 'space',
+      property_with_underscore: 'underscore'
+    }
+
+    const result = formatOrderedProduct(product, 'order_id')
+    expect(result.unique_id).toEqual('order_id_random_id')
+  })
+
+  it('should use random uuid for unique_id if product_id, sku and id are not present', () => {
+    const product: Product = {
+      name: 'name',
+      quantity: 1,
+      price: 10,
+      category: 'category',
+      url: 'url',
+      image_url: 'image_url',
+      'property with space': 'space',
+      property_with_underscore: 'underscore'
+    }
+
+    const result = formatOrderedProduct(product, 'order_id')
+    expect(result.unique_id).not.toContain('order_id')
+  })
+})
+
+describe('convertKeysToTitleCase', () => {
+  it('should convert keys to title case upt to 2 levels', () => {
+    const obj = {
+      key1: 'value1',
+      key2: {
+        key3: 'value3',
+        key4: {
+          key5: 'value5'
+        }
+      },
+      key6: ['value6', 'value7']
+    }
+
+    expect(convertKeysToTitleCase(obj)).toEqual({
+      Key1: 'value1',
+      Key2: {
+        Key3: 'value3',
+        Key4: {
+          key5: 'value5'
+        }
+      },
+      Key6: ['value6', 'value7']
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/formatter.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/formatter.test.ts
@@ -120,7 +120,7 @@ describe('formatOrderedProduct', () => {
     expect(result.unique_id).toEqual('order_id_sku')
   })
 
-  it('should use sku for  unique_id if product_id is not present', () => {
+  it('should use sku for unique_id if product_id is not present', () => {
     const product: Product = {
       sku: 'sku',
       name: 'name',
@@ -154,7 +154,7 @@ describe('formatOrderedProduct', () => {
     expect(result.unique_id).toEqual('order_id_random_id')
   })
 
-  it('should use random uuid for unique_id if product_id, sku and id are not present', () => {
+  it('should not set unique_id if product_id, sku and id are not present', () => {
     const product: Product = {
       name: 'name',
       quantity: 1,
@@ -167,7 +167,7 @@ describe('formatOrderedProduct', () => {
     }
 
     const result = formatOrderedProduct(product, 'order_id')
-    expect(result.unique_id).not.toContain('order_id')
+    expect(result.unique_id).not.toBeDefined()
   })
 })
 

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/formatters.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/formatters.ts
@@ -1,3 +1,6 @@
+import { v4 as uuidv4 } from '@lukeed/uuid'
+import { Product } from './types'
+
 function toTitleCase(str: string) {
   return (
     str
@@ -14,13 +17,15 @@ function toTitleCase(str: string) {
 }
 
 // Recursively capitalize all keys in an object up to two levels deep
-// Array values are not modified
-export function capitalizeKeys(obj: Record<string, unknown>, level = 0): Record<string, unknown> {
+// Array values are not modified.
+// We do this because Klaviyo examples and classic destinations use title case for keys.
+// https://developers.klaviyo.com/en/docs/guide_to_integrating_a_platform_without_a_pre_built_klaviyo_integration#placed-order
+export function convertKeysToTitleCase(obj: Record<string, unknown>, level = 0): Record<string, unknown> {
   if (level > 1) return obj
   return Object.fromEntries(
     Object.entries(obj).map(([key, value]) => {
       if (typeof value === 'object' && !Array.isArray(value)) {
-        return [toTitleCase(key), capitalizeKeys(value as Record<string, unknown>, level + 1)]
+        return [toTitleCase(key), convertKeysToTitleCase(value as Record<string, unknown>, level + 1)]
       }
       if (Array.isArray(value)) {
         return [toTitleCase(key), value]
@@ -28,4 +33,45 @@ export function capitalizeKeys(obj: Record<string, unknown>, level = 0): Record<
       return [toTitleCase(key), value]
     })
   )
+}
+
+export function formatOrderedProduct(product: Product, order_id?: String) {
+  // unique_id should ensure retries don't result in duplicate event. hence we use product_id or sku + order_id as unique_id
+  const unique_product_id = product.product_id || product.sku || product?.id
+  const unique_id = order_id && unique_product_id ? `${order_id}_${unique_product_id}` : uuidv4()
+
+  const { name, quantity, sku, price, url, image_url, category, product_id, id, ...otherProperties } = product
+  const productProperties = {
+    OrderId: order_id,
+    ProductId: product_id ?? id,
+    SKU: product.sku,
+    ProductName: product.name,
+    Quantity: product.quantity,
+    Categories: category ? [category] : [],
+    ProductURL: url,
+    ImageURL: image_url,
+    // copy other properties as is. If other properties have properties with same name
+    // as the above, they will be overwritten which is the expected behavior
+    ...convertKeysToTitleCase(otherProperties)
+  }
+  return { unique_id, productProperties }
+}
+
+export function formatProductItems(product: Product) {
+  const { sku, name, quantity, price, category, url, image_url, id, product_id, ...otherProperties } = product
+  const formattedProduct = {
+    ProductId: product_id ?? id,
+    SKU: sku,
+    ProductName: name,
+    Quantity: quantity,
+    ItemPrice: price,
+    RowTotal: price,
+    Categories: category ? [category] : [],
+    ProductURL: url,
+    ImageURL: image_url,
+    // copy other properties as is. If other properties have properties with same name
+    // as the above, they will be overwritten which is the expected behavior
+    ...otherProperties
+  }
+  return convertKeysToTitleCase(formattedProduct)
 }

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/formatters.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/formatters.ts
@@ -1,0 +1,31 @@
+function toTitleCase(str: string) {
+  return (
+    str
+      // remove special characters and replace with space
+      .replace(/[^a-zA-Z0-9]/g, ' ')
+      // replace multiple spaces with single space
+      .replace(/\s+/g, ' ')
+      // split by space and title case each word
+      .trim()
+      .split(' ')
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join('')
+  )
+}
+
+// Recursively capitalize all keys in an object up to two levels deep
+// Array values are not modified
+export function capitalizeKeys(obj: Record<string, unknown>, level = 0): Record<string, unknown> {
+  if (level > 1) return obj
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => {
+      if (typeof value === 'object' && !Array.isArray(value)) {
+        return [toTitleCase(key), capitalizeKeys(value as Record<string, unknown>, level + 1)]
+      }
+      if (Array.isArray(value)) {
+        return [toTitleCase(key), value]
+      }
+      return [toTitleCase(key), value]
+    })
+  )
+}

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/formatters.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/formatters.ts
@@ -60,7 +60,7 @@ export function formatOrderedProduct(product: Product, order_id?: string, unique
 
 export function formatProductItems(product: Product) {
   const { sku, name, quantity, price, category, url, image_url, id, product_id, ...otherProperties } = product
-  const formattedProduct = {
+  return {
     ProductId: product_id ?? id,
     SKU: sku,
     ProductName: name,
@@ -72,7 +72,6 @@ export function formatProductItems(product: Product) {
     ImageURL: image_url,
     // copy other properties as is. If other properties have properties with same name
     // as the above, they will be overwritten which is the expected behavior
-    ...otherProperties
+    ...convertKeysToTitleCase(otherProperties)
   }
-  return convertKeysToTitleCase(formattedProduct)
 }

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/formatters.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/formatters.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from '@lukeed/uuid'
 import { Product } from './types'
 
 function toTitleCase(str: string) {
@@ -35,18 +34,20 @@ export function convertKeysToTitleCase(obj: Record<string, unknown>, level = 0):
   )
 }
 
-export function formatOrderedProduct(product: Product, order_id?: String) {
+export function formatOrderedProduct(product: Product, order_id?: string, unique_event_id?: String) {
   // unique_id should ensure retries don't result in duplicate event. hence we use product_id or sku + order_id as unique_id
+  const event_id = unique_event_id ?? order_id
   const unique_product_id = product.product_id || product.sku || product?.id
-  const unique_id = order_id && unique_product_id ? `${order_id}_${unique_product_id}` : uuidv4()
+  // if unique_id is not provided, klaviyo will use timestamp for deduplication
+  const unique_id = event_id && unique_product_id ? `${event_id}_${unique_product_id}` : undefined
 
   const { name, quantity, sku, price, url, image_url, category, product_id, id, ...otherProperties } = product
   const productProperties = {
     OrderId: order_id,
     ProductId: product_id ?? id,
-    SKU: product.sku,
-    ProductName: product.name,
-    Quantity: product.quantity,
+    SKU: sku,
+    ProductName: name,
+    Quantity: quantity,
     Categories: category ? [category] : [],
     ProductURL: url,
     ImageURL: image_url,

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
@@ -18,7 +18,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * Properties of this event. Segment will title case the keys of this object before sending it to Klaviyo.
+   * Properties of this event. Segment adds products array as Items, ItemNames and Categories properties in the properties object. Segment will title case the keys of this object before sending it to Klaviyo.
    */
   properties: {
     /**
@@ -47,7 +47,7 @@ export interface Payload {
    */
   unique_id?: string
   /**
-   * List of products purchased in the order. Segment will title case the keys of this object before sending it to Klaviyo.
+   * List of products purchased in the order.
    */
   products?: {
     /**

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
@@ -50,13 +50,37 @@ export interface Payload {
    * List of products purchased in the order.
    */
   products?: {
+    /**
+     * Id of the product.
+     */
     product_id?: string
+    /**
+     * Category of the product
+     */
     category?: string
+    /**
+     * Name of the product
+     */
     name?: string
+    /**
+     * Stock Keeping Unit of the product
+     */
     sku?: string
+    /**
+     * Price of the product
+     */
     price?: number
+    /**
+     * URL of the image of the product
+     */
     image_url?: string
+    /**
+     * URL of the product page
+     */
     url?: string
+    /**
+     * Quantity of the product
+     */
     quantity?: number
     [k: string]: unknown
   }[]

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
@@ -22,45 +22,9 @@ export interface Payload {
    */
   properties: {
     /**
-     * Unique identifier for the checkout.
-     */
-    checkout_id?: string
-    /**
      * Unique identifier for the order.
      */
     order_id?: string
-    /**
-     * Affiliation of the order.
-     */
-    affiliation?: string
-    /**
-     * Subtotal of the order.
-     */
-    subtotal?: number
-    /**
-     * Tax of the order.
-     */
-    tax?: number
-    /**
-     * Revenue ($) associated with the transaction (including discounts, but excluding shipping and taxes)
-     */
-    revenue?: number
-    /**
-     * Shipping cost associated with the transaction.
-     */
-    shipping?: number
-    /**
-     * Discount of the order.
-     */
-    discount?: number
-    /**
-     * Coupon code used for the order.
-     */
-    coupon?: string
-    /**
-     * Currency of the order.
-     */
-    currency?: string
     [k: string]: unknown
   }
   /**

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
@@ -18,7 +18,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * Properties of this event.
+   * Properties of this event. Segment will title case the keys of this object before sending it to Klaviyo.
    */
   properties: {
     /**
@@ -47,7 +47,7 @@ export interface Payload {
    */
   unique_id?: string
   /**
-   * List of products purchased in the order.
+   * List of products purchased in the order. Segment will title case the keys of this object before sending it to Klaviyo.
    */
   products?: {
     /**

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
@@ -21,6 +21,46 @@ export interface Payload {
    * Properties of this event.
    */
   properties: {
+    /**
+     * Unique identifier for the checkout.
+     */
+    checkout_id?: string
+    /**
+     * Unique identifier for the order.
+     */
+    order_id?: string
+    /**
+     * Affiliation of the order.
+     */
+    affiliation?: string
+    /**
+     * Subtotal of the order.
+     */
+    subtotal?: number
+    /**
+     * Tax of the order.
+     */
+    tax?: number
+    /**
+     * Revenue ($) associated with the transaction (including discounts, but excluding shipping and taxes)
+     */
+    revenue?: number
+    /**
+     * Shipping cost associated with the transaction.
+     */
+    shipping?: number
+    /**
+     * Discount of the order.
+     */
+    discount?: number
+    /**
+     * Coupon code used for the order.
+     */
+    coupon?: string
+    /**
+     * Currency of the order.
+     */
+    currency?: string
     [k: string]: unknown
   }
   /**
@@ -46,13 +86,13 @@ export interface Payload {
    * List of products purchased in the order.
    */
   products?: {
-    order_id?: string
+    product_id?: string
     category?: string
     name?: string
     sku?: string
     price?: number
     image_url?: string
-    product_url?: string
+    url?: string
     quantity?: number
     [k: string]: unknown
   }[]

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
@@ -46,6 +46,14 @@ export interface Payload {
    * List of products purchased in the order.
    */
   products?: {
+    order_id?: string
+    category?: string
+    name?: string
+    sku?: string
+    price?: number
+    image_url?: string
+    product_url?: string
+    quantity?: number
     [k: string]: unknown
   }[]
 }

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
@@ -39,11 +39,11 @@ function createOrderCompleteEvent(payload: Payload) {
       SKU: sku,
       Name: name,
       Quantity: quantity,
-      ItemPrice: price,
-      RowTotal: price,
+      'Item Price': price,
+      'Row Total': price,
       Categories: [category],
-      ProductURL: product['product_url'] ?? product['productURL'],
-      ImageURL: product['image_url'] ?? product['imageUrl'],
+      'Product URL': product['product_url'] ?? product['productURL'],
+      'Image URL': product['image_url'] ?? product['imageUrl'],
       ...customProps
     }
   })
@@ -85,14 +85,52 @@ const sendProductRequests = async (payload: Payload, request: RequestClient) => 
     return
   }
 
+  const specialProps = [
+    'name',
+    'product categories',
+    'category',
+    'categories',
+    'id',
+    'productId',
+    'product_id',
+    'sku',
+    'quantity',
+    'price',
+    'product url',
+    'productUrl',
+    'image url',
+    'imageUrl'
+  ]
+
   delete payload.properties?.products
+
   const productPromises = payload.products.map((product) => {
+    const customProps = { ...product }
+    for (const prop of specialProps) {
+      delete customProps[prop]
+    }
+
+    const productPayload = {
+      SKU: product.sku,
+      Name: product.name,
+      Quantity: product.quantity,
+      Price: product.price,
+      'Product Categories': [product.category],
+      'Product URL': product['product_url'] ?? product['productUrl'],
+      'Image URL': product['image_url'] ?? product['imageUrl'],
+      ...customProps
+    }
+
     const productEventData = {
       data: {
         type: 'event',
         attributes: {
-          properties: { ...product, ...payload.properties },
+          properties: {
+            ...productPayload,
+            ...payload.properties
+          },
           unique_id: uuidv4(),
+          value: product.price,
           metric: {
             data: {
               type: 'metric',

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
@@ -42,7 +42,7 @@ const action: ActionDefinition<Settings, Payload> = {
       required: true
     },
     properties: {
-      description: `Properties of this event.`,
+      description: `Properties of this event. Segment will title case the keys of this object before sending it to Klaviyo.`,
       label: 'Properties',
       type: 'object',
       additionalProperties: true,
@@ -99,7 +99,8 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     products: {
       label: 'Products',
-      description: 'List of products purchased in the order.',
+      description:
+        'List of products purchased in the order. Segment will title case the keys of this object before sending it to Klaviyo.',
       multiple: true,
       type: 'object',
       additionalProperties: true,
@@ -238,7 +239,7 @@ function sendOrderedProduct(request: RequestClient, payload: Payload, product: P
     data: {
       type: 'event',
       attributes: {
-        properties: convertKeysToTitleCase(productProperties),
+        properties: productProperties,
         unique_id: unique_id,
         // for ordered product, we use price as value
         value: product.price,

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
@@ -100,35 +100,43 @@ const action: ActionDefinition<Settings, Payload> = {
       properties: {
         product_id: {
           label: 'Product ID',
+          description: 'Id of the product.',
           type: 'string'
         },
         category: {
           label: 'Category',
+          description: 'Category of the product',
           type: 'string'
         },
         name: {
           label: 'Name',
-          type: 'string'
+          type: 'string',
+          description: 'Name of the product'
         },
         sku: {
           label: 'SKU',
-          type: 'string'
+          type: 'string',
+          description: 'Stock Keeping Unit of the product'
         },
         price: {
           label: 'Price',
-          type: 'number'
+          type: 'number',
+          description: 'Price of the product'
         },
         image_url: {
           label: 'Image URL of the product',
-          type: 'string'
+          type: 'string',
+          description: 'URL of the image of the product'
         },
         url: {
-          label: 'URL of the product page',
-          type: 'string'
+          label: 'Product URL',
+          type: 'string',
+          description: 'URL of the product page'
         },
         quantity: {
           label: 'Quantity',
-          type: 'number'
+          type: 'number',
+          description: 'Quantity of the product'
         }
       },
       default: {

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
@@ -57,7 +57,13 @@ const action: ActionDefinition<Settings, Payload> = {
         '@arrayPath': [
           '$.properties',
           {
-            order_id: { '@path': '$.properties.order_id' }
+            order_id: {
+              '@if': {
+                exists: { '@path': '$.properties.order_id' },
+                then: { '@path': '$.properties.order_id' },
+                else: { '@path': '$.properties.orderId' }
+              }
+            }
           }
         ]
       },
@@ -143,7 +149,13 @@ const action: ActionDefinition<Settings, Payload> = {
         '@arrayPath': [
           '$.properties.products',
           {
-            product_id: { '@path': '$.properties.product_id' },
+            product_id: {
+              '@if': {
+                exists: { '@path': '$.properties.product_id' },
+                then: { '@path': '$.properties.product_id' },
+                else: { '@path': '$.properties.productId' }
+              }
+            },
             category: { '@path': '$.properties.category' },
             name: { '@path': '$.properties.name' },
             sku: { '@path': '$.properties.sku' },

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
@@ -9,7 +9,7 @@ import { Product } from './types'
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Order Completed',
   description: 'Order Completed Event action tracks users Order Completed events and associate it with their profile.',
-  defaultSubscription: 'type = "track"',
+  defaultSubscription: 'type = "track" and event = "Order Completed"',
   fields: {
     profile: {
       label: 'Profile',

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
@@ -42,7 +42,7 @@ const action: ActionDefinition<Settings, Payload> = {
       required: true
     },
     properties: {
-      description: `Properties of this event. Segment will title case the keys of this object before sending it to Klaviyo.`,
+      description: `Properties of this event. Segment adds products array as Items, ItemNames and Categories properties in the properties object. Segment will title case the keys of this object before sending it to Klaviyo.`,
       label: 'Properties',
       type: 'object',
       additionalProperties: true,
@@ -99,8 +99,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     products: {
       label: 'Products',
-      description:
-        'List of products purchased in the order. Segment will title case the keys of this object before sending it to Klaviyo.',
+      description: 'List of products purchased in the order.',
       multiple: true,
       type: 'object',
       additionalProperties: true,

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
@@ -47,55 +47,9 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'object',
       additionalProperties: true,
       properties: {
-        checkout_id: {
-          label: 'Checkout ID',
-          description: 'Unique identifier for the checkout.',
-          type: 'string'
-        },
         order_id: {
           label: 'Order ID',
           description: 'Unique identifier for the order.',
-          type: 'string'
-        },
-        affiliation: {
-          label: 'Affiliation',
-          description: 'Affiliation of the order.',
-          type: 'string'
-        },
-        subtotal: {
-          label: 'Subtotal',
-          description: 'Subtotal of the order.',
-          type: 'number'
-        },
-        tax: {
-          label: 'Tax',
-          description: 'Tax of the order.',
-          type: 'number'
-        },
-        revenue: {
-          label: 'Revenue',
-          description:
-            'Revenue ($) associated with the transaction (including discounts, but excluding shipping and taxes)',
-          type: 'number'
-        },
-        shipping: {
-          label: 'Shipping',
-          description: 'Shipping cost associated with the transaction.',
-          type: 'number'
-        },
-        discount: {
-          label: 'Discount',
-          description: 'Discount of the order.',
-          type: 'number'
-        },
-        coupon: {
-          label: 'Coupon',
-          description: 'Coupon code used for the order.',
-          type: 'string'
-        },
-        currency: {
-          label: 'Currency',
-          description: 'Currency of the order.',
           type: 'string'
         }
       },
@@ -103,16 +57,7 @@ const action: ActionDefinition<Settings, Payload> = {
         '@arrayPath': [
           '$.properties',
           {
-            checkout_id: { '@path': '$.properties.checkout_id' },
-            order_id: { '@path': '$.properties.order_id' },
-            affiliation: { '@path': '$.properties.affiliation' },
-            subtotal: { '@path': '$.properties.subtotal' },
-            tax: { '@path': '$.properties.tax' },
-            revenue: { '@path': '$.properties.revenue' },
-            shipping: { '@path': '$.properties.shipping' },
-            discount: { '@path': '$.properties.discount' },
-            coupon: { '@path': '$.properties.coupon' },
-            currency: { '@path': '$.properties.currency' }
+            order_id: { '@path': '$.properties.order_id' }
           }
         ]
       },
@@ -267,7 +212,7 @@ function createOrderCompleteEvent(payload: Payload) {
 }
 
 function sendOrderedProduct(request: RequestClient, payload: Payload, product: Product) {
-  const { unique_id, productProperties } = formatOrderedProduct(product, payload.properties.order_id)
+  const { unique_id, productProperties } = formatOrderedProduct(product, payload.properties.order_id, payload.unique_id)
 
   const productEventData = {
     data: {

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/types.ts
@@ -1,0 +1,3 @@
+import type { Payload } from './generated-types'
+
+export type Product = NonNullable<Payload['products']>[number]

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/index.ts
@@ -8,7 +8,7 @@ import { API_URL } from '../config'
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track Event',
   description: 'Track user events and associate it with their profile.',
-  defaultSubscription: 'type = "track" and event !="Order Completed"',
+  defaultSubscription: 'type = "track" and event != "Order Completed"',
   fields: {
     profile: {
       label: 'Profile',

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/index.ts
@@ -8,7 +8,7 @@ import { API_URL } from '../config'
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track Event',
   description: 'Track user events and associate it with their profile.',
-  defaultSubscription: 'type = "track"',
+  defaultSubscription: 'type = "track" and event !="Order Completed"',
   fields: {
     profile: {
       label: 'Profile',


### PR DESCRIPTION
[JIRA](https://segment.atlassian.net/browse/STRATCONN-3905)

Klaviyo classic destination makes some additional formatting before submitting Order Complete events to klaviyo API. This PR aims to port most of the formatting to Klaviyo Actions. Key changes are
- Adds sub-fields to `properties` and `products` object fields. None of the new fields are required and hence change should be backward compatible. In case customers had defined some other properties, they'll be retained as `additionalProperties:true` attribute has been added.
- Formats property names sent to destination to title case by default. [cloud classic destination](https://github.com/segmentio/integrations/blob/c1042ca507274d7a5ccdd4ca8b06bf68b8158642/integrations/klaviyo/lib/mapper.js#L138), [device classic destination](https://github.com/segmentio/analytics.js-integrations/blob/e09a39466bd1288fe496ead63acebb7ee5510d10/integrations/klaviyo/lib/index.js#L268) has inconsistent formatting for same fields. So, went with the latest [Klaviyo docs](https://developers.klaviyo.com/en/docs/guide_to_integrating_a_platform_without_a_pre_built_klaviyo_integration#placed-order)
- Sets `value` to product price instead of order value in `Products Ordered` event.  
- Fixes default subscription for trackEvent and orderCompleted actions
- Adds two new mappings to allow overriding Order Complete and Products Ordered event names.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment

Test results can be found [here](https://docs.google.com/document/d/1-7HsTAGabosgiLbxY-O8qZuWZ4pF4x2UPsscOUrtEXQ/edit)


Diff in order completed event before and after

![image](https://github.com/segmentio/action-destinations/assets/109586712/fde9f4bd-adb9-4c13-b44c-c96b2c0556c2)

Diff in ordered product event before and after.

We were repeating Order complete properties which is not necessary.

![image](https://github.com/segmentio/action-destinations/assets/109586712/7c050ebc-6790-4957-b507-d142ea8b3a54)

