### PR TITLE
Improve flexibility of dynamic objects

### DIFF
--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -410,20 +410,20 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
     dynamicHandlerPath: string
     dynamicFieldContext?: DynamicFieldContext
   } {
-    const bracketRegex = /(.*)\.\[(\d+)\]\.(.*)/
-    const dotRegex = /(.*)\.(.*)/
+    const arrayRegex = /(.*)\.\[(\d+)\]\.(.*)/
+    const objectRegex = /(.*)\.(.*)/
     let dynamicHandlerPath = field
     let dynamicFieldContext: DynamicFieldContext | undefined
 
-    const match = bracketRegex.exec(field) || dotRegex.exec(field)
+    const match = arrayRegex.exec(field) || objectRegex.exec(field)
     if (match) {
       const [, parent, indexOrChild, child] = match
       if (child) {
-        // Bracket notation was used
+        // It is an array, so we need to extract the index from parent.[index].child and call paret.child handler
         dynamicFieldContext = { selectedArrayIndex: parseInt(indexOrChild, 10) }
         dynamicHandlerPath = `${parent}.${child}`
       } else {
-        // Dot notation
+        // It is an object, if there is a dedicated fetcher for child we use it otherwise we use parent.__values__
         const parentFetcher = this.definition.dynamicFields?.[parent]
         if (parentFetcher && !(indexOrChild in parentFetcher)) {
           dynamicHandlerPath = `${parent}.__values__`

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -12,7 +12,8 @@ import type {
   ExecuteInput,
   Result,
   SyncMode,
-  SyncModeDefinition
+  SyncModeDefinition,
+  DynamicFieldContext
 } from './types'
 import { syncModeTypes } from './types'
 import { NormalizedOptions } from '../request-client'
@@ -81,9 +82,8 @@ export interface ActionDefinition<
    * This is likely going to change as we productionalize the data model and definition object
    */
   dynamicFields?: {
-    [K in keyof Payload]?:
-      | RequestFn<Settings, Payload, DynamicFieldResponse, AudienceSettings>
-      | {
+    [K in keyof Payload]?: Payload[K] extends object
+      ? {
           [ObjectProperty in keyof Payload[K] | '__keys__' | '__values__']?: RequestFn<
             Settings,
             Payload[K],
@@ -91,6 +91,7 @@ export interface ActionDefinition<
             AudienceSettings
           >
         }
+      : RequestFn<Settings, Payload, DynamicFieldResponse, AudienceSettings>
   }
 
   /** The operation to perform when this action is triggered */
@@ -175,6 +176,7 @@ export interface ExecuteDynamicFieldInput<Settings, Payload, AudienceSettings = 
   features?: Features | undefined
   statsContext?: StatsContext | undefined
   hookInputs?: GenericActionHookValues
+  dynamicFieldContext?: DynamicFieldContext
 }
 
 interface ExecuteBundle<T = unknown, Data = unknown, AudienceSettings = any, ActionHookValues = any> {
@@ -398,6 +400,41 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
     return results
   }
 
+  /*
+   * Extract the dynamic field context and handler path from a field string. Examples:
+   * - "structured.first_name" => { dynamicHandlerPath: "structured.first_name" }
+   * - "unstructuredObject.testProperty" => { dynamicHandlerPath: "unstructuredObject.__values__", dynamicFieldContext: { selectedKey: "testProperty" } }
+   * - "structuredArray.[0].first_name" => { dynamicHandlerPath: "structuredArray.first_name", dynamicFieldContext: { selectedArrayIndex: 0 } }
+   */
+  private extractFieldContextAndHandler(field: string): {
+    dynamicHandlerPath: string
+    dynamicFieldContext?: DynamicFieldContext
+  } {
+    const bracketRegex = /(.*)\.\[(\d+)\]\.(.*)/
+    const dotRegex = /(.*)\.(.*)/
+    let dynamicHandlerPath = field
+    let dynamicFieldContext: DynamicFieldContext | undefined
+
+    const match = bracketRegex.exec(field) || dotRegex.exec(field)
+    if (match) {
+      const [, parent, indexOrChild, child] = match
+      if (child) {
+        // Bracket notation was used
+        dynamicFieldContext = { selectedArrayIndex: parseInt(indexOrChild, 10) }
+        dynamicHandlerPath = `${parent}.${child}`
+      } else {
+        // Dot notation
+        const parentFetcher = this.definition.dynamicFields?.[parent]
+        if (parentFetcher && !(indexOrChild in parentFetcher)) {
+          dynamicHandlerPath = `${parent}.__values__`
+          dynamicFieldContext = { selectedKey: indexOrChild }
+        }
+      }
+    }
+
+    return { dynamicHandlerPath, dynamicFieldContext }
+  }
+
   async executeDynamicField(
     field: string,
     data: ExecuteDynamicFieldInput<Settings, Payload, AudienceSettings>,
@@ -406,15 +443,16 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
      */
     dynamicFn?: RequestFn<Settings, Payload, DynamicFieldResponse, AudienceSettings>
   ): Promise<DynamicFieldResponse> {
-    let fn
     if (dynamicFn && typeof dynamicFn === 'function') {
-      fn = dynamicFn
-    } else {
-      fn = get<RequestFn<Settings, Payload, DynamicFieldResponse, AudienceSettings>>(
-        this.definition.dynamicFields,
-        field
-      )
+      return (await this.performRequest(dynamicFn, { ...data })) as DynamicFieldResponse
     }
+
+    const { dynamicHandlerPath, dynamicFieldContext } = this.extractFieldContextAndHandler(field)
+
+    const fn = get<RequestFn<Settings, Payload, DynamicFieldResponse, AudienceSettings>>(
+      this.definition.dynamicFields,
+      dynamicHandlerPath
+    )
 
     if (typeof fn !== 'function') {
       return Promise.resolve({
@@ -428,7 +466,7 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
     }
 
     // fn will always be a dynamic field function, so we can safely cast it to DynamicFieldResponse
-    return (await this.performRequest(fn, data)) as DynamicFieldResponse
+    return (await this.performRequest(fn, { ...data, dynamicFieldContext })) as DynamicFieldResponse
   }
 
   async executeHook(

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -16,6 +16,13 @@ export interface Result {
   data?: JSONObject | null
 }
 
+export interface DynamicFieldContext {
+  /** The index of the item in an array of objects that we are requesting data for */
+  selectedArrayIndex?: number
+  /** The key within a dynamic object for which we are requesting values */
+  selectedKey?: string
+}
+
 export interface ExecuteInput<
   Settings,
   Payload,
@@ -35,6 +42,8 @@ export interface ExecuteInput<
   hookInputs?: ActionHookInputs
   /** Stored outputs from an invokation of an actions hook */
   hookOutputs?: Partial<Record<ActionHookType, ActionHookOutputs>>
+  /** Context about dynamic fields */
+  dynamicFieldContext?: DynamicFieldContext
   /** The page used in dynamic field requests */
   page?: string
   /** The subscription sync mode */


### PR DESCRIPTION
This PR enhances the flexibility of value handlers for dynamic unstructured objects and dynamic arrays of objects by introducing an additional context object. This change ensures that the value fetcher is aware of the specific key it is being invoked for and the index in the array it is being invoked for.

- Dynamic Objects
For unstructured objects, when fetching values for dynamic fields, we need to know the specific key. For example, if a user selects the “cars” key and requests possible values, the value fetcher should be aware of this key. We pass parentObject.[dynamicKey] to the autocomplete API, extract dynamicKey, and send it to the dynamic field handler for values ( i.e., `__values__`.

- Dynamic Array of Objects 
For dynamic arrays of structured objects (a new field type), we need to know the array index when fetching values for a given key. We pass `parentObject.[arrayIndex].subFieldKey` to the autocomplete API, extract the index, and send it to the dynamic field handler for `parentObject.subFieldKey`.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
