### PR TITLE
Dynamic Yield Destination - fix audience Id

### DIFF
--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/index.ts
@@ -141,11 +141,9 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         )
       }
 
-      const externalId = {
+      return {
         externalId: String(audience_id) // must be returned as a string
       }
-
-      return externalId
     },
     async getAudience(_, getAudienceInput) {
       return {

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
@@ -33,7 +33,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
       label: 'External Audience ID',
       description: 'Unique Audience Identifier returned by the createAudience() function call.',
       required: true,
-      unsafe_hidden: true,
+      unsafe_hidden: false,
       default: {
         '@path': '$.context.personas.external_audience_id'
       }
@@ -42,7 +42,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
       label: 'Audience Key',
       description: 'Segment Audience key / name',
       type: 'string',
-      unsafe_hidden: true,
+      unsafe_hidden: false,
       required: true,
       default: {
         '@path': '$.context.personas.computation_key'
@@ -52,7 +52,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
       label: 'Traits or Properties',
       description: 'Traits or Properties object',
       type: 'object',
-      unsafe_hidden: true,
+      unsafe_hidden: false,
       required: true,
       default: {
         '@if': {

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
@@ -107,12 +107,8 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     }
   },
 
-  perform: async (request, { audienceSettings, payload, settings, logger }) => {
+  perform: async (request, { audienceSettings, payload, settings }) => {
     const { external_audience_id } = payload
-
-    logger?.info(`actions-dynamic-yield-audiences:perform: payload ${JSON.stringify(payload, null, 2)}`)
-
-    logger?.info(`actions-dynamic-yield-audiences:perform: external_audience_id ${external_audience_id}`)
 
     if (!audienceSettings?.audience_name) {
       throw new IntegrationError('Audience Name is required', 'MISSING_REQUIRED_FIELD', 400)
@@ -130,10 +126,6 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     const identifierType = (audienceSettings?.identifier_type).toLowerCase().replace(/_/g, '')
     const audienceValue = payload.traits_or_props[payload.segment_audience_key]
 
-    logger?.info(
-      `actions-dynamic-yield-audiences:perform: audienceValue ${audienceValue}, identifierType ${identifierType}, audienceName ${audienceName}`
-    )
-
     let primaryIdentifier: string | undefined
 
     switch (identifierType) {
@@ -149,8 +141,6 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
       default:
         primaryIdentifier = (payload.traits_or_props[identifierType] as string) ?? undefined
     }
-
-    logger?.info(`actions-dynamic-yield-audiences:perform: primaryIdentifier ${primaryIdentifier}`)
 
     if (!primaryIdentifier) {
       throw new IntegrationError('Primary Identifier not found', 'MISSING_REQUIRED_FIELD', 400)
@@ -188,8 +178,6 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
         }
       ]
     }
-
-    logger?.info(`actions-dynamic-yield-audiences:perform: json ${JSON.stringify(json, null, 2)}, URL ${URL}`)
 
     return request(URL, {
       method: 'post',


### PR DESCRIPTION
Correcting the audience id being sent int he the perform function. Needs to be a number. 

## Testing

To be tested in Production. Unable to test locally as IP whitelisting is needed for data to be sent to DY, and this is only enabled in Production. 