### PR TITLE
Taboola - upating device id field

### DIFF
--- a/packages/destination-actions/src/destinations/taboola-actions/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/syncAudience/__tests__/index.test.ts
@@ -18,10 +18,13 @@ describe('Taboola.syncAudience', () => {
     const event = createTestEvent({
       event: 'Audience Entered',
       type: 'track',
-      properties: {},
+      properties: {
+        ios: {
+          id: DEVICE_ID
+        }
+      },
       context: {
         device: {
-          id: DEVICE_ID,
           advertisingId: '11111'
         },
         traits: {
@@ -127,10 +130,13 @@ describe('Taboola.syncAudience', () => {
     const event = createTestEvent({
       event: 'Audience Entered',
       type: 'track',
-      properties: {},
+      properties: {
+        ios: {
+          id: DEVICE_ID
+        }
+      },
       context: {
         device: {
-          id: DEVICE_ID,
           advertisingId: '11111'
         },
         traits: {
@@ -165,10 +171,13 @@ describe('Taboola.syncAudience', () => {
       createTestEvent({
         event: 'Audience Entered',
         type: 'track',
-        properties: {},
+        properties: {
+          ios: {
+            id: DEVICE_ID
+          }
+        },
         context: {
           device: {
-            id: DEVICE_ID,
             advertisingId: '11111'
           },
           traits: {
@@ -186,10 +195,13 @@ describe('Taboola.syncAudience', () => {
       createTestEvent({
         event: 'Audience Exited',
         type: 'track',
-        properties: {},
+        properties: {
+          ios: {
+            id: '456'
+          }
+        },
         context: {
           device: {
-            id: '456',
             advertisingId: '22222'
           },
           traits: {

--- a/packages/destination-actions/src/destinations/taboola-actions/syncAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/syncAudience/generated-types.ts
@@ -28,7 +28,7 @@ export interface Payload {
    */
   enable_batching: boolean
   /**
-   * Mobile Device ID.
+   * To send iOS and Android Device IDs, include the 'ios.id' and 'android.id' Identifiers from the 'Customized Setup' option when connecting your Audience.
    */
   device_id?: string
   /**

--- a/packages/destination-actions/src/destinations/taboola-actions/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/syncAudience/index.ts
@@ -78,12 +78,17 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     },
     device_id: {
       label: 'Mobile Device ID',
-      description: 'Mobile Device ID.',
+      description:
+        "To send iOS and Android Device IDs, include the 'ios.id' and 'android.id' Identifiers from the 'Customized Setup' option when connecting your Audience.",
       type: 'string',
       required: false,
-      unsafe_hidden: true,
+      unsafe_hidden: false,
       default: {
-        '@path': '$.context.device.id'
+        '@if': {
+          exists: { '@path': '$.properties.ios.id' },
+          then: { '@path': '$.properties.ios.id' },
+          else: { '@path': '$.properties.android.id' }
+        }
       }
     },
     batch_size: {


### PR DESCRIPTION
New comment and default mapping for Device ID field for Taboola Destination. 
Not in use by any customers yet. 

## Testing

Testing not needed. Not in use by customers yet. 