### PR TITLE
Add array editor option for defaultObjectUI 

### DIFF
--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -188,6 +188,7 @@ export interface InputField extends InputFieldJSONSchema {
     | 'object' // Users will see the object editor by default and can change to the key value editor.
     | 'keyvalue:only' // Users will only use the key value editor.
     | 'object:only' // Users will only use the object editor.
+    | 'arrayeditor' // Users will see the array editor by default.
 
   /**
    * Determines whether this field should be hidden in the UI. Only use this in very limited cases where the field represents

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -188,7 +188,7 @@ export interface InputField extends InputFieldJSONSchema {
     | 'object' // Users will see the object editor by default and can change to the key value editor.
     | 'keyvalue:only' // Users will only use the key value editor.
     | 'object:only' // Users will only use the object editor.
-    | 'arrayeditor' // Users will see the array editor by default.
+    | 'arrayeditor' // if used in conjunction with multi:true will allow user to edit array of object elements.
 
   /**
    * Determines whether this field should be hidden in the UI. Only use this in very limited cases where the field represents


### PR DESCRIPTION
Adding support for editable array of objects to support the following UI: 
<img width="751" alt="Screenshot 2024-07-02 at 1 14 00 PM" src="https://github.com/segmentio/action-destinations/assets/2992515/8de7371e-b0fe-4bf9-b24d-4392c7e40023">

## Testing
Testing not required as this is just a type update