### PR TITLE
adding snakeCase to listId

### DIFF
--- a/packages/destination-actions/src/destinations/courier/audienceToList/index.ts
+++ b/packages/destination-actions/src/destinations/courier/audienceToList/index.ts
@@ -2,6 +2,7 @@ import { ActionDefinition, ModifiedResponse, RequestOptions } from '@segment/act
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { getDomain } from '..'
+import snakeCase from 'lodash/snakeCase'
 
 export const CONSTANTS = {
   ADD: 'ADD',
@@ -100,7 +101,7 @@ const processPayload = (
 
   const domain = getDomain(settings.region)
 
-  const list_id = `${payload.segment_audience_key}-${payload.segment_audience_id}`
+  const list_id = snakeCase(`${payload.segment_audience_key}-${payload.segment_audience_id}`)
   const user_id = payload.segment_user_id ?? payload.segment_anonymous_id
 
   if (payload.audience_action === CONSTANTS.ADD) {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_courier listId needs to be url friendly, making it audience_key + audience_id to be snakecased_

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
