### PR TITLE
adding default subscription to Taboola Action

### DIFF
--- a/packages/destination-actions/src/destinations/taboola-actions/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/syncAudience/index.ts
@@ -7,6 +7,7 @@ import { TaboolaClient } from './client'
 const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
   title: 'Sync Audience',
   description: 'Sync a Segment Engage Audience to Taboola.',
+  defaultSubscription: 'type = "track"',
   fields: {
     external_audience_id: {
       label: 'External Audience ID',


### PR DESCRIPTION
Adding default subscription to Taboola Actions Destination

## Testing
No testing needed. Not in use by any customers. 