### PR TITLE
Fix generate:types lint-staged hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,8 +87,8 @@
     }
   },
   "lint-staged": {
-    "**/src/destinations/**/index.ts": [
-      "./bin/run generate:types",
+    "**/{browser-destinations,destinations}/**/*.ts": [
+      "./bin/run generate:types -p",
       "git add **/generated-types.ts"
     ],
     "!(**/templates/**)/*.ts": [


### PR DESCRIPTION
The lint-staged hook is super slow because we ran generate:types by scanning all files in the directory.

lint-staged by default passes files staged as argumenents. generate:types command accepts the file list with argument `-p`. ([code](https://github.com/segmentio/action-destinations/blob/0836b6a507662bb423b64b2440b16ec67d2f725f/packages/cli/src/commands/generate/types.ts#L34)). This significantly speeds the lint-stage hook command.

Also, the generate:types hook in the lint-stage command only runs if file was changed in cloud destination, that too an index.ts file. This PR also updates the path to ensure generate:types is run for all changed files so that devs don't end up seeing yarn validate in CI run failing often.

## Testing

Testing completed successfully.

**Before**

https://github.com/segmentio/action-destinations/assets/109586712/ac594c81-72b3-4c58-934c-ffe9d40d4957

**After**

https://github.com/segmentio/action-destinations/assets/109586712/638f5cce-b545-4651-aef6-cf613ca544e0




- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
