### PR TITLE
Update dynamic field types to support dynamic array of objects

### DIFF
--- a/packages/core/src/__tests__/destination-kit.test.ts
+++ b/packages/core/src/__tests__/destination-kit.test.ts
@@ -1,3 +1,4 @@
+import { ActionDefinition } from 'src/destination-kit/action'
 import {
   StateContext,
   Destination,
@@ -172,6 +173,15 @@ const destinationWithIdentifier: DestinationDefinition<JSONObject> = {
   }
 }
 
+interface Payload {
+  testDynamicField: string
+  testUnstructuredObject: Record<string, string>
+  testStructuredObject: {
+    testDynamicSubfield: string
+  }
+  testObjectArrays: Array<{ testDynamicSubfield: string }>
+}
+
 const destinationWithDynamicFields: DestinationDefinition<JSONObject> = {
   name: 'Actions Dynamic Fields',
   mode: 'cloud',
@@ -271,7 +281,7 @@ const destinationWithDynamicFields: DestinationDefinition<JSONObject> = {
       perform: (_request, { syncMode }) => {
         return ['this is a test', syncMode]
       }
-    }
+    } as ActionDefinition<JSONObject, Payload>
   }
 }
 

--- a/packages/core/src/__tests__/destination-kit.test.ts
+++ b/packages/core/src/__tests__/destination-kit.test.ts
@@ -1,4 +1,4 @@
-import { ActionDefinition } from 'src/destination-kit/action'
+import { ActionDefinition } from '../destination-kit/action'
 import {
   StateContext,
   Destination,

--- a/packages/destination-actions/src/destinations/webhook-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/webhook-audiences/index.ts
@@ -1,9 +1,10 @@
-import type { AudienceDestinationDefinition } from '@segment/actions-core'
+import type { ActionDefinition, AudienceDestinationDefinition } from '@segment/actions-core'
 import type { Settings, AudienceSettings } from './generated-types'
 
 import send from '../webhook/send'
 import { IntegrationError } from '@segment/actions-core'
 import { createHmac } from 'crypto'
+import { Payload } from './send.types'
 const externalIdKey = 'externalId'
 const audienceNameKey = 'audienceName'
 
@@ -157,7 +158,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
           settings
         })
       }
-    }
+    } as ActionDefinition<Settings, Payload>
   }
 }
 


### PR DESCRIPTION
Updating types to support array of objects: 
<img width="654" alt="Screenshot 2024-07-11 at 4 06 40 PM" src="https://github.com/user-attachments/assets/18d434ba-add4-4639-babe-52de3ba509e6">

Note: Since adjusting types to be stricter, had to update the code in a couple of places to make sure the types for the ActionDefinition is accurate 

## Testing
Testing not required as this is a non-functional change. 
