### PR TITLE
Iterable Lists, to be used with Audiences only

### DIFF
--- a/packages/destination-actions/src/destinations/iterable-lists/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/__tests__/index.test.ts
@@ -1,0 +1,18 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Iterable Lists', () => {
+  describe('testAuthentication', () => {
+    it('should validate authentication inputs', async () => {
+      nock('https://your.destination.endpoint').get('*').reply(200, {})
+
+      // This should match your authentication.fields
+      const authData = {}
+
+      await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/iterable-lists/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-iterable-lists'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/iterable-lists/constants.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/constants.ts
@@ -1,0 +1,6 @@
+export const CONSTANTS = {
+  API_BASE_URL: 'https://api.iterable.com/api',
+  API_CUSTOM_AUDIENCE_ENDPOINT: '/lists',
+  SUBSCRIBE: 'subscribe',
+  UNSUBSCRIBE: 'unsubscribe'
+}

--- a/packages/destination-actions/src/destinations/iterable-lists/generated-types.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/generated-types.ts
@@ -1,0 +1,16 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * To obtain the API Key, go to the Iterable app and naviate to Integrations > API Keys. Create a new API Key with the 'Server-Side' type.
+   */
+  apiKey: string
+}
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface AudienceSettings {
+  /**
+   * Placeholder field to create the AudienceSettings object. Please do not change this.
+   */
+  placeholder?: boolean
+}

--- a/packages/destination-actions/src/destinations/iterable-lists/generated-types.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/generated-types.ts
@@ -10,7 +10,7 @@ export interface Settings {
 
 export interface AudienceSettings {
   /**
-   * Placeholder field to create the AudienceSettings object. Please do not change this.
+   * The audience id required by the destination
    */
-  placeholder?: boolean
+  audience_id: number
 }

--- a/packages/destination-actions/src/destinations/iterable-lists/index.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/index.ts
@@ -1,0 +1,85 @@
+import { IntegrationError, AudienceDestinationDefinition } from '@segment/actions-core'
+import type { AudienceSettings, Settings } from './generated-types'
+
+const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
+  name: 'Iterable Lists',
+  slug: 'actions-iterable-lists',
+  mode: 'cloud',
+  description: 'Sync Segment Engage Audiences to Iterable Lists',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      apiKey: {
+        type: 'string',
+        label: 'API Key',
+        description:
+          "To obtain the API Key, go to the Iterable app and naviate to Integrations > API Keys. Create a new API Key with the 'Server-Side' type.",
+        required: true
+      }
+    },
+    testAuthentication: (request, { settings }) => {
+      return request('https://api.iterable.com/api/lists', {
+        method: 'GET',
+        headers: { 'Api-Key': settings.apiKey }
+      })
+    }
+  },
+
+  audienceFields: {
+    placeholder: {
+      type: 'boolean',
+      label: 'Placeholder Setting',
+      description: 'Placeholder field to create the AudienceSettings object. Please do not change this.',
+      default: true
+    }
+  },
+  audienceConfig: {
+    mode: {
+      type: 'synced', // Indicates that the audience is synced on some schedule
+      full_audience_sync: false // If true, we send the entire audience. If false, we just send the delta.
+    },
+    async createAudience(request, createAudienceInput) {
+      const audienceSettings = createAudienceInput.audienceSettings
+      const settings = createAudienceInput.settings
+      // @ts-ignore type is not defined, and we will define it later
+      const personasSettings = audienceSettings.personas
+      if (!personasSettings) {
+        throw new IntegrationError('Missing computation parameters: Id and Key', 'MISSING_REQUIRED_FIELD', 400)
+      }
+
+      const audienceKey = personasSettings.computation_key
+
+      await request('https://api.iterable.com/api/lists', {
+        method: 'POST',
+        headers: { 'Api-Key': settings.apiKey },
+        body: JSON.stringify({
+          name: audienceKey
+        })
+      })
+
+      return { externalId: audienceKey }
+    },
+    async getAudience(request, getAudienceInput) {
+      const audienceKey = getAudienceInput.externalId
+      if (!audienceKey) {
+        throw new IntegrationError('Missing audience id value', 'MISSING_REQUIRED_FIELD', 400)
+      }
+
+      const response = await request(`https://api.iterable.com/api/lists/${audienceKey}`, {
+        method: 'GET',
+        headers: { 'Api-Key': getAudienceInput.settings.apiKey }
+      })
+
+      if (response.status === 404) {
+        throw new IntegrationError('Audience not found', 'NOT_FOUND', 404)
+      }
+
+      return { externalId: audienceKey }
+    }
+  },
+
+  actions: {}
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/iterable-lists/types.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/types.ts
@@ -1,0 +1,21 @@
+export interface UpsertUserPayload {
+  listId?: number
+  action?: 'subscribe' | 'usubscribe'
+  email?: string
+  userId?: string
+  dataFields: {
+    [k: string]: unknown
+  }
+  preferUserId: boolean
+  mergeNestedObjects: boolean
+}
+
+export interface RawData {
+  traits: Record<string, unknown>
+  properties: Record<string, unknown>
+  context: Record<string, unknown>
+}
+
+export interface SingleUpdateRequestData {
+  rawData: RawData
+}

--- a/packages/destination-actions/src/destinations/iterable-lists/upsert/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/upsert/__tests__/index.test.ts
@@ -1,0 +1,34 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { CONSTANTS } from '../../constants'
+
+const testDestination = createTestIntegration(Destination)
+
+const goodIdentifyEvent = createTestEvent({
+  type: 'identify',
+  context: {
+    personas: {
+      computation_class: 'audience',
+      computation_key: 'ld_segment_test',
+      computation_id: 'ld_segment_audience_id'
+    }
+  },
+  traits: {
+    audience_key: 'ld_segment_test',
+    ld_segment_test: true
+  }
+})
+
+describe('IterableLists.upsert', () => {
+  it('should not throw an error if the audience creation succeed - identify', async () => {
+    nock(CONSTANTS.API_BASE_URL).post('/lists').reply(204)
+
+    await expect(
+      testDestination.testAction('upsert', {
+        event: goodIdentifyEvent,
+        useDefaultMappings: true
+      })
+    ).resolves.not.toThrowError()
+  })
+})

--- a/packages/destination-actions/src/destinations/iterable-lists/upsert/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/upsert/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'upsert'
+const destinationSlug = 'IterableLists'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/iterable-lists/upsert/generated-types.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/upsert/generated-types.ts
@@ -1,0 +1,18 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Email address of the user
+   */
+  email?: string
+  /**
+   * User ID
+   */
+  user_id?: string
+  /**
+   * Data fields to sync to Iterable Lists
+   */
+  data_fields?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/iterable-lists/upsert/index.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/upsert/index.ts
@@ -1,0 +1,147 @@
+import { PayloadValidationError, ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { RawData, SingleUpdateRequestData, UpsertUserPayload } from '../types'
+import { CONSTANTS } from '../constants'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Sync To Iterable Lists',
+  description: 'Sync Segment Audience to Iterable Lists',
+  fields: {
+    email: {
+      label: 'Email',
+      description: 'Email address of the user',
+      type: 'string',
+      unsafe_hidden: false,
+      required: false,
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.email' },
+          then: { '@path': '$.traits.email' },
+          else: { '@path': '$.context.traits.email' } // Phone is sent as identify's trait or track's context.trait
+        }
+      }
+    },
+    user_id: {
+      label: 'User ID',
+      description: 'User ID',
+      type: 'string',
+      unsafe_hidden: false,
+      required: false,
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    data_fields: {
+      label: 'Data Fields',
+      description: 'Data fields to sync to Iterable Lists',
+      type: 'object',
+      required: false,
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits' },
+          then: { '@path': '$.traits' },
+          else: { '@path': '$.properties' }
+        }
+      }
+    }
+  },
+  perform: (request, data) => {
+    const payload = data.payload as { email: string; user_id: string; data_fields: Record<string, unknown> }
+    const rawData = (data as unknown as SingleUpdateRequestData).rawData
+    const iterablePayload = processPayload(payload, rawData)
+
+    const listId = iterablePayload.listId
+    delete iterablePayload.listId
+
+    const action = iterablePayload.action === 'subscribe' ? 'subscribe' : 'unsubscribe'
+    delete iterablePayload.action
+
+    return request(`${CONSTANTS.API_BASE_URL}/lists/${action}`, {
+      method: 'post',
+      json: {
+        listId: listId,
+        subscribers: [iterablePayload],
+        updateExistingUsersOnly: false
+      }
+    })
+  },
+  performBatch: (request, { payload }) => {
+    const iterablePayloads: { [key: number]: UpsertUserPayload[] } = {}
+
+    for (const singlePayload of payload) {
+      const singleUpdateRequestData = singlePayload as unknown as SingleUpdateRequestData
+      const processedPayload = processPayload(
+        singlePayload as { email: string; user_id: string; data_fields: Record<string, unknown> },
+        singleUpdateRequestData.rawData
+      )
+      if (processedPayload.listId) {
+        if (!(processedPayload.listId in iterablePayloads)) {
+          iterablePayloads[processedPayload.listId] = []
+        }
+
+        iterablePayloads[processedPayload.listId].push(processedPayload)
+      }
+    }
+
+    const promises = []
+    for (const [listId, payloads] of Object.entries(iterablePayloads)) {
+      const action = payloads[0].action === 'subscribe' ? 'subscribe' : 'unsubscribe'
+      delete payloads[0].action
+
+      promises.push(
+        request(`${CONSTANTS.API_BASE_URL}/lists/${action}`, {
+          method: 'post',
+          json: {
+            listId: Number(listId),
+            subscribers: payloads,
+            updateExistingUsersOnly: false
+          }
+        })
+      )
+    }
+
+    return processBatch(promises)
+  }
+}
+
+const processBatch = async (promises: Promise<unknown>[]) => await Promise.all(promises)
+
+const processPayload = (
+  payload: { email: string; user_id: string; data_fields: Record<string, unknown> },
+  rawData: RawData
+) => {
+  if (!payload.email && !payload.user_id) {
+    throw new PayloadValidationError('Must include email or user_id.')
+  }
+
+  const context = rawData.context
+  const personas = context.personas as { computation_key: string; computation_id: string; external_audience_id: string }
+  if (!personas.computation_key || !personas.computation_id || !personas.external_audience_id) {
+    throw new PayloadValidationError(
+      'Missing audience parameters: compuration id, computation key, and/or audience id.'
+    )
+  }
+
+  const traitsOrProps = rawData.traits || rawData.properties
+  const action = traitsOrProps[personas.computation_key] ? 'subscribe' : 'usubscribe'
+  const iterablePayload: UpsertUserPayload = {
+    listId: Number(personas.external_audience_id),
+    action: action,
+    dataFields: payload.data_fields,
+    preferUserId: true,
+    mergeNestedObjects: true
+  }
+
+  if (payload.email) {
+    iterablePayload.email = payload.email
+  }
+
+  if (payload.user_id) {
+    iterablePayload.userId = payload.user_id
+  }
+
+  return iterablePayload
+}
+
+export default action


### PR DESCRIPTION
This is different from [Iterable Action Destination](https://github.com/segmentio/action-destinations/tree/main/packages/destination-actions/src/destinations/iterable) because it operates in the scope of audiences only. 

One of our customers asked us to have Segment Audiences synced as Lists in Iterable. The endpoints are:

- https://api.iterable.com/api/docs#lists_subscribe
- https://api.iterable.com/api/docs#lists_create
- https://api.iterable.com/api/docs#lists_unsubscribe

Many implementation aspects of this implementation are very similar to Iterable Action Destination. In this implementation, the audience key (computation key) is used to create the list by name, and also fetch the List ID by name. 

This destination works with only two identifiers: `user_id` and `email`. Other traits can be sent through a `dataFields` property. 

## Testing

I need help testing this, since it is an Audience Destination.

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
