### PR TITLE
Update mc action destination field labels and descriptions.ts

### DIFF
--- a/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/index.ts
@@ -133,7 +133,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     whatsapp: {
-      label: 'WhatsApp*',
+      label: 'WhatsApp',
       description: `The contact's WhatsApp.`,
       type: 'string',
       allowNull: true,
@@ -146,7 +146,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     line: {
-      label: 'Line*',
+      label: 'Line',
       description: `The contact's landline.`,
       type: 'string',
       allowNull: true,
@@ -159,7 +159,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     facebook: {
-      label: 'Facebook*',
+      label: 'Facebook',
       description: `The contact's Facebook identifier.`,
       type: 'string',
       allowNull: true,
@@ -172,7 +172,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     unique_name: {
-      label: 'Unique Name*',
+      label: 'Unique Name',
       description: `The contact's unique name.`,
       type: 'string',
       allowNull: true,

--- a/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/index.ts
@@ -121,7 +121,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     phone_number: {
       label: 'Phone Number',
-      description: `The contact's phone number.`,
+      description: `The contact's phone number. Note: This is different from the Phone Number ID field, but the same value can be stored in both fields.`,
       type: 'string',
       allowNull: true,
       default: {
@@ -133,7 +133,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     whatsapp: {
-      label: 'WhatsApp',
+      label: 'WhatsApp*',
       description: `The contact's WhatsApp.`,
       type: 'string',
       allowNull: true,
@@ -146,8 +146,8 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     line: {
-      label: 'LINE ID',
-      description: `The contact's LINE ID.`,
+      label: 'Line*',
+      description: `The contact's landline.`,
       type: 'string',
       allowNull: true,
       default: {
@@ -159,8 +159,8 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     facebook: {
-      label: 'Facebook ID',
-      description: `The contact's Facebook ID.`,
+      label: 'Facebook*',
+      description: `The contact's Facebook identifier.`,
       type: 'string',
       allowNull: true,
       default: {
@@ -172,7 +172,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     unique_name: {
-      label: 'Unique Name',
+      label: 'Unique Name*',
       description: `The contact's unique name.`,
       type: 'string',
       allowNull: true,
@@ -213,7 +213,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     phone_number_id: {
       label: 'Phone Number ID',
-      description: `The contact's Phone Number ID. This must be a valid phone number.`,
+      description: `Primary Phone Number used to identify a Contact. This must be a valid phone number.`,
       type: 'string',
       allowNull: true,
       required: false,


### PR DESCRIPTION
Updated the labels of some of the fields for this destination along with their descriptions to better align with the sendgrid docs and field names within sendgrid.

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Updated the labels of some of the fields for this destination along with their descriptions to better align with the sendgrid docs and field names within sendgrid. The following fields were updated: Line ID, Facebook ID, WhatsApp, Unique Name, and Phone Number ID.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
