### PR TITLE
Update Sendgrid c action destination field labels and descriptions

### DIFF
--- a/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/generated-types.ts
@@ -38,7 +38,7 @@ export interface Payload {
    */
   address_line_2?: string | null
   /**
-   * The contact's phone number.
+   * The contact's phone number. Note: This is different from the Phone Number ID field, but the same value can be stored in both fields.
    */
   phone_number?: string | null
   /**
@@ -46,11 +46,11 @@ export interface Payload {
    */
   whatsapp?: string | null
   /**
-   * The contact's LINE ID.
+   * The contact's landline.
    */
   line?: string | null
   /**
-   * The contact's Facebook ID.
+   * The contact's Facebook identifier.
    */
   facebook?: string | null
   /**
@@ -58,15 +58,11 @@ export interface Payload {
    */
   unique_name?: string | null
   /**
-   * The contact's identity.
-   */
-  identity?: string | null
-  /**
    * The contact's email address.
    */
   primary_email?: string | null
   /**
-   * The contact's Phone Number ID. This must be a valid phone number.
+   * Primary Phone Number used to identify a Contact. This must be a valid phone number.
    */
   phone_number_id?: string | null
   /**

--- a/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/index.ts
@@ -121,7 +121,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     phone_number: {
       label: 'Phone Number',
-      description: `The contact's phone number.`,
+      description: `The contact's phone number. Note: This is different from the Phone Number ID field, but the same value can be stored in both fields.`,
       type: 'string',
       allowNull: true,
       default: {
@@ -146,8 +146,8 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     line: {
-      label: 'LINE ID',
-      description: `The contact's LINE ID.`,
+      label: 'Line',
+      description: `The contact's landline.`,
       type: 'string',
       allowNull: true,
       default: {
@@ -159,8 +159,8 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     facebook: {
-      label: 'Facebook ID',
-      description: `The contact's Facebook ID.`,
+      label: 'Facebook',
+      description: `The contact's Facebook identifier.`,
       type: 'string',
       allowNull: true,
       default: {
@@ -184,19 +184,6 @@ const action: ActionDefinition<Settings, Payload> = {
         }
       }
     },
-    identity: {
-      label: 'Identity',
-      description: `The contact's identity.`,
-      type: 'string',
-      allowNull: true,
-      default: {
-        '@if': {
-          exists: { '@path': '$.traits.identity' },
-          then: { '@path': '$.traits.identity' },
-          else: { '@path': '$.properties.identity' }
-        }
-      }
-    },
     primary_email: {
       label: 'Email Address',
       description: `The contact's email address.`,
@@ -213,7 +200,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     phone_number_id: {
       label: 'Phone Number ID',
-      description: `The contact's Phone Number ID. This must be a valid phone number.`,
+      description: `Primary Phone Number used to identify a Contact. This must be a valid phone number.`,
       type: 'string',
       allowNull: true,
       required: false,


### PR DESCRIPTION
The labels and descriptions of several fields for this destination have been updated to better align with the SendGrid documentation and field names within SendGrid. The following fields were updated: Line ID, Facebook ID, WhatsApp, Unique Name, and Phone Number ID.

Additionally, the field identity has been removed, as it is not a valid field for this API.

[Reason for updating](https://twilio.slack.com/archives/CD3LFFTFZ/p1720806653782289)

## Testing

Not necessary, just metadata updates
