### PR TITLE
move version field to top level

### DIFF
--- a/packages/destination-actions/src/destinations/app-fit/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/app-fit/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -26,8 +26,8 @@ Object {
       },
     },
     "userId": "m]^ldlwPRQruDQ&OXR1",
-    "version": "2",
   },
+  "version": "2",
 }
 `;
 
@@ -42,7 +42,7 @@ Object {
       "device": Object {},
       "os": Object {},
     },
-    "version": "2",
   },
+  "version": "2",
 }
 `;

--- a/packages/destination-actions/src/destinations/app-fit/track/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/app-fit/track/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -26,8 +26,8 @@ Object {
       },
     },
     "userId": "M$xwt#p",
-    "version": "2",
   },
+  "version": "2",
 }
 `;
 
@@ -42,7 +42,7 @@ Object {
       "device": Object {},
       "os": Object {},
     },
-    "version": "2",
   },
+  "version": "2",
 }
 `;

--- a/packages/destination-actions/src/destinations/app-fit/track/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/app-fit/track/__tests__/index.test.ts
@@ -33,7 +33,7 @@ describe('AppFit.track', () => {
     expect(responses[0].status).toBe(200)
     expect(responses[0].data).toMatchObject({})
     expect(responses[0].options.body).toBe(
-      `{"eventSource":"segment","occurredAt":"${timestamp}","payload":{"version":"2","sourceEventId":"12345","eventName":"Segment Test Event Name","userId":"userId1","anonymousId":"anonId1234","properties":{"foo":"bar"},"systemProperties":{"appVersion":"1.0.0","ipAddress":"8.8.8.8","os":{"name":"iPhone OS","version":"10.1"},"device":{"id":"device1234","advertisingId":"adId1234","manufacturer":"Apple","model":"iPhone7,2"}}}}`
+      `{"eventSource":"segment","occurredAt":"${timestamp}","version":"2","payload":{"sourceEventId":"12345","eventName":"Segment Test Event Name","userId":"userId1","anonymousId":"anonId1234","properties":{"foo":"bar"},"systemProperties":{"appVersion":"1.0.0","ipAddress":"8.8.8.8","os":{"name":"iPhone OS","version":"10.1"},"device":{"id":"device1234","advertisingId":"adId1234","manufacturer":"Apple","model":"iPhone7,2"}}}}`
     )
   })
 })

--- a/packages/destination-actions/src/destinations/app-fit/track/index.ts
+++ b/packages/destination-actions/src/destinations/app-fit/track/index.ts
@@ -139,8 +139,8 @@ const action: ActionDefinition<Settings, Payload> = {
       json: {
         eventSource: 'segment',
         occurredAt: payload.occurredAt,
+        version: '2',
         payload: {
-          version: '2',
           sourceEventId: payload.eventId,
           eventName: payload.name,
           userId: payload.userId,


### PR DESCRIPTION
Moved the version field to the top level so we can use it to determine how to parse the payload, it was erroneously put into the payload itself. 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
