### PR TITLE
Revert "Hide legacy postConversion action that is no longer supported"

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
@@ -26,7 +26,6 @@ interface GoogleError {
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Upload Enhanced Conversion (Legacy)',
   description: 'Upload a conversion enhancement to the legacy Google Enhanced Conversions API.',
-  hidden: true,
   fields: {
     // Required Fields - These fields are required by Google's EC API to successfully match conversions.
     conversion_label: {


### PR DESCRIPTION
- Reverts segmentio/action-destinations#2132
- These actions should remain visible until we confirm that Google has actually deprecated them. More context here: https://twilio.slack.com/archives/GSUCUMF6J/p1721152825028129