### PR TITLE
Adding support for FieldDisplayModes & disabling certain input methods

### DIFF
--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -113,7 +113,13 @@ export interface GlobalSetting {
 export type FieldTypeName = 'string' | 'text' | 'number' | 'integer' | 'datetime' | 'boolean' | 'password' | 'object'
 
 /** The supported field categories */
-type FieldCategory = 'identifier' | 'data' | 'internal' | 'config'
+type FieldCategory = 'identifier' | 'data' | 'internal' | 'config' | 'sync'
+
+/** supported input methods when picking values */
+type FieldInputMethods = 'literal' | 'variable' | 'function' | 'enrichment' | 'freeform'
+
+/** display modes for a field */
+type FieldDisplayMode = 'expanded' | 'normal' | 'collapsed'
 
 /** Properties of an InputField which are involved in creating the generated-types.ts file */
 export interface InputFieldJSONSchema {
@@ -213,6 +219,19 @@ export interface InputField extends InputFieldJSONSchema {
    * Determines how the field should be categorized in the UI. This is useful for grouping fields together in the UI.
    */
   category?: FieldCategory
+
+  /**
+   * Determines how the field should be displayed in the UI:
+   * - expanded: Fully visible title and description for detailed information.
+   * - normal: One line field, and title, with description hidden behind a tooltip.
+   * - collapsed: Fields grouped behind a dropdown
+   */
+  displayMode?: FieldDisplayMode
+
+  /**
+   * Determines which input methods are disabled for this field. This is useful when you want to restrict variable selection, freeform entry, etc.
+   */
+  disabledInputMethods?: FieldInputMethods[]
 }
 
 /** Base interface for conditions  */

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -223,7 +223,7 @@ export interface InputField extends InputFieldJSONSchema {
   /**
    * Determines how the field should be displayed in the UI:
    * - expanded: Fully visible title and description for detailed information.
-   * - normal: One line field, and title, with description hidden behind a tooltip.
+   * - normal (default): One line field, and title, with description hidden behind a tooltip.
    * - collapsed: Fields grouped behind a dropdown
    */
   displayMode?: FieldDisplayMode


### PR DESCRIPTION
This ticket update types to support these features: 
- **FieldDisplayMode** --> this flag determines how the field will be displayed between three modes:

Normal, the same as current view of the fields 
<img width="1224" alt="Screenshot 2024-07-17 at 3 24 55 PM" src="https://github.com/user-attachments/assets/5b27578d-e9fe-44c3-a7ff-d186096b16d2">

Expanded, where the label and description will be expanded on top 
<img width="1185" alt="Screenshot 2024-07-17 at 3 25 29 PM" src="https://github.com/user-attachments/assets/d2168a67-6c35-4083-b205-e4c670027810">


Collapsed, where multiple fields will be collapsed behind a dropdown
<img width="1195" alt="Screenshot 2024-07-17 at 3 25 56 PM" src="https://github.com/user-attachments/assets/fc33b56c-79c7-4714-a9ad-9c0d2c8090b4">


- **disabledInputMethods**: This is an array that include the list of entry methods that should be disabled for the field. This is to prevent certain fields from being mappable to payload variables ( only allowing static values ) or disabling certain tabs in the picker. 


- Adding a new `sync` category to allow certain fields being displayed in the sync section instead of the main mapping area

**Note**: After merging types, there will be [subsequent PR](https://github.com/segmentio/action-cli/pull/174) into actions-cli to push these flags to `displayMetadata` for the field. 

## Testing

Testing not required as this is just adding new optional types. 