### PR TITLE
registering aws-s3 destination

### DIFF
--- a/packages/destination-actions/src/destinations/index.ts
+++ b/packages/destination-actions/src/destinations/index.ts
@@ -169,6 +169,7 @@ register('664ce847b3e6f19ea96b3611', './trubrics')
 register('66684ba89c0523461d8bb7f3', './taboola-actions')
 register('6683e1d5e37fd84efcf3bbef', './first-party-dv360')
 register('668d1cb2a1dcc5ad33228d92', './angler-ai')
+register('6698df634212816c561d3e6a', './aws-s3')
 
 function register(id: MetadataId, destinationPath: string) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
## Description

Registered aws-s3 Destination

## Testing

None needed. 

⚠️  joe.ayoub@workbench-platform-production-usw2-0c1fdc73edf6808ef:~/action-destinations$ actions-cli register
✔ Which integration? › aws-s3
✔ Introspecting definition
✔ Checking availability for actions-s3-csv
✔ Preparing destination definition
Please review the definition before continuing:

{
  "name": "AWS S3 CSV",
  "slug": "actions-s3-csv",
  "type": "action_destination",
  "description": "Sync Segment event and Audience data to AWS S3.",
  "status": "PRIVATE_BUILDING",
  "methods": {
    "pageview": true,
    "identify": true,
    "alias": true,
    "track": true,
    "group": true
  },
  "platforms": {
    "browser": false,
    "server": true,
    "mobile": false
  },
  "options": {},
  "basicOptions": [],
  "supportsAudiences": true
}
✔ Do you want to register "AWS S3 CSV"? … yes
✔ Registering AWS S3 CSV
Successfully registered destination with id:

6698df634212816c561d3e6a