### PR TITLE
[CHANNELS-1156] remove email unsub link when unsubcribe tag not present

### DIFF
--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/SendEmailPerformer.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/SendEmailPerformer.ts
@@ -435,6 +435,9 @@ export class SendEmailPerformer extends MessageSendPerformer<Settings, Payload> 
       return $.html()
     }
 
+    // Remove unsubscribe link from email profile if no substution tag is found this will keep subscription tracking on
+    // so Sendgrid can keep track of unsubscriptions from the email header. This allows customers that use their own unsubscribe
+    // links to be able to set up a webhook to track unsubscribe events and sync it with their own subscription management system.
     if ($(unsubscribeLinkRef).length === 0) {
       _this.logger.info(`Unsubscribe tag is missing`)
       emailProfile.unsubscribeLink = ''

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/SendEmailPerformer.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/sendEmail/SendEmailPerformer.ts
@@ -435,6 +435,16 @@ export class SendEmailPerformer extends MessageSendPerformer<Settings, Payload> 
       return $.html()
     }
 
+    if ($(unsubscribeLinkRef).length === 0) {
+      _this.logger.info(`Unsubscribe tag is missing`)
+      emailProfile.unsubscribeLink = ''
+    }
+
+    if ($(preferencesLinkRef).length === 0) {
+      _this.logger.info(`Preferences tag missing`)
+      emailProfile.preferencesLink = ''
+    }
+
     if (groupId) {
       const group = emailProfile.groups?.find((grp) => grp.id === groupId)
       const groupUnsubscribeLink = group?.groupUnsubscribeLink


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->
This PR adds logic that will remove the unsubscribe link provided from Personas Subscription Service. We remove the unsubscribe link when there is no replacement tag in the html. 
JIRA: https://segment.atlassian.net/browse/CHANNELS-1156
## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
