### PR TITLE
[Github Actions] Adds publish-canary workflow and minor update to version-packages

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,0 +1,53 @@
+name: Publish Canary
+
+on:
+  push:
+    branches:
+      - staging
+
+jobs:
+  build-and-publish:
+    env:
+      HUSKY: 0
+    if: startsWith(github.event.head_commit.message, 'Publish') == true
+    runs-on: ubuntu-20.04
+
+    timeout-minutes: 15
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+          cache: yarn
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile --ignore-optional
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Build
+        run: NODE_ENV=production yarn build
+
+      - name: Fetch Latest Tags
+        run: |
+          git fetch --tags
+
+      - name: Set NPM Token
+        run: |
+          npm set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_PUBLISH_TOKEN }}
+          npm whoami
+
+      - name: Publish
+        run: |
+          yarn lerna publish from-package --yes --allowBranch=staging --loglevel=verbose --dist-tag canary

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -1,5 +1,6 @@
 # This workflow is triggered manually via the GitHub Actions page or API
 name: Version Packages
+run-name: Version Packages ${{ github.event.inputs.run_id }}
 on:
   workflow_dispatch:
     inputs:
@@ -17,8 +18,7 @@ on:
           - release
       run_id:
         description: 'Unique identifier for the run'
-        required: true
-        default: ${{ github.run_id }}
+        required: false
 
 jobs:
   build-and-version-packages:

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -15,6 +15,10 @@ on:
         options:
           - main
           - release
+      run_id:
+        description: 'Unique identifier for the run'
+        required: true
+        default: ${{ github.run_id }}
 
 jobs:
   build-and-version-packages:

--- a/lerna.json
+++ b/lerna.json
@@ -8,7 +8,7 @@
       "npmClientArgs": ["--ignore-engines", "--ignore-optional"]
     },
     "version": {
-      "allowBranch": ["main", "hotfix-*"]
+      "allowBranch": ["main", "release"]
     }
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -8,7 +8,7 @@
       "npmClientArgs": ["--ignore-engines", "--ignore-optional"]
     },
     "version": {
-      "allowBranch": ["main", "release"]
+      "allowBranch": ["main", "hotfix-*"]
     }
   }
 }


### PR DESCRIPTION
- Adds a new publish canary workflow to be used by Segment Engineers for staging deploys
- Updates run id param for version packages workflow. This will be used to programatically identify workflow triggered via API. Github's dispatch workflow API doesn't provide an ID for workflows created via API 😞 . So, we have to resort to this sort of workaround.

## Testing

Sample Run 
- https://github.com/segmentio/action-destinations/actions/runs/10053573449
- https://github.com/segmentio/action-destinations/actions/runs/10046217687