### PR TITLE
Update name to proper casing

### DIFF
--- a/packages/destination-actions/src/destinations/taboola-actions/index.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/index.ts
@@ -6,7 +6,7 @@ import { TaboolaClient } from './syncAudience/client'
 import syncAudience from './syncAudience'
 
 const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
-  name: 'Taboola (actions)',
+  name: 'Taboola (Actions)',
   slug: 'actions-taboola-actions',
   mode: 'cloud',
 


### PR DESCRIPTION
Change the name for Taboola, as mentioned [here](https://github.com/segmentio/segment-docs/pull/6826#issuecomment-2243194562). 

For cloud destinations, 

- you will need to update the name in both the `action-destinations` code and run a push for the destination, and you can change the name on partner-portal
    -  will change in portal once this is merged
- To Change the name of any action-destination, you also need to update [here](https://github.com/segmentio/integrations/blob/e4b625bfacee55d4a3f85bad7a99c867c9eefe9b/integrations/index.js#L441) in integrations.

## Testing

No testing needed
