### PR TITLE
[TikTok Audiences] Remove id_type from createAudience call

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-audiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/__tests__/index.test.ts
@@ -97,7 +97,6 @@ describe('TikTok Audiences', () => {
         .post(`/${TIKTOK_API_VERSION}/segment/audience/`, {
           custom_audience_name: 'The Super Mario Brothers Fans',
           advertiser_id: '42884288',
-          id_type: 'EMAIL_SHA256',
           action: 'create'
         })
         .reply(200, {

--- a/packages/destination-actions/src/destinations/tiktok-audiences/api/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/api/index.ts
@@ -110,7 +110,6 @@ export class TikTokAudiences {
       json: {
         custom_audience_name: payload.custom_audience_name,
         advertiser_id: this.selectedAdvertiserID,
-        id_type: payload.id_type,
         action: 'create'
       }
     })

--- a/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/__tests__/index.test.ts
@@ -23,7 +23,6 @@ const event = createTestEvent({
 const createAudienceRequestBody = {
   custom_audience_name: 'personas_test_audience',
   advertiser_id: '123',
-  id_type: 'EMAIL_SHA256',
   action: 'create'
 }
 
@@ -43,8 +42,7 @@ describe('TiktokAudiences.createAudience', () => {
         auth,
         mapping: {
           selected_advertiser_id: '123',
-          custom_audience_name: 'personas_test_audience',
-          id_type: 'EMAIL_SHA256'
+          custom_audience_name: 'personas_test_audience'
         }
       })
     ).resolves.not.toThrowError()

--- a/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/generated-types.ts
@@ -9,8 +9,4 @@ export interface Payload {
    * Custom audience name of audience to be created. Please note that names over 70 characters will be truncated to 67 characters with "..." appended.
    */
   custom_audience_name: string
-  /**
-   * Encryption type to be used for populating the audience. This field is set only when Segment creates a new audience.
-   */
-  id_type: string
 }

--- a/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/createAudience/index.ts
@@ -2,7 +2,7 @@ import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { createAudience } from '../functions'
-import { selected_advertiser_id, custom_audience_name, id_type } from '../properties'
+import { selected_advertiser_id, custom_audience_name } from '../properties'
 import { TikTokAudiences } from '../api'
 
 // === NOTE ===
@@ -11,12 +11,12 @@ import { TikTokAudiences } from '../api'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Create Audience (Legacy)',
-  description: 'Use this action to create a new audience in TikTok Audience Segment. This is required for legacy instances of the TikTok Audience destination to create a partner audience within TikTok for syncing Engage audiences to.',
+  description:
+    'Use this action to create a new audience in TikTok Audience Segment. This is required for legacy instances of the TikTok Audience destination to create a partner audience within TikTok for syncing Engage audiences to.',
   defaultSubscription: 'event = "Create Audience"',
   fields: {
     selected_advertiser_id: { ...selected_advertiser_id },
-    custom_audience_name: { ...custom_audience_name },
-    id_type: { ...id_type }
+    custom_audience_name: { ...custom_audience_name }
   },
   dynamicFields: {
     selected_advertiser_id: async (request, { settings }) => {

--- a/packages/destination-actions/src/destinations/tiktok-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/generated-types.ts
@@ -13,8 +13,4 @@ export interface AudienceSettings {
    * The advertiser ID to use when syncing audiences. Required if you wish to create or update an audience.
    */
   advertiserId?: string
-  /**
-   * Encryption type to be used for populating the audience. This field is required and only set when Segment creates a new audience.
-   */
-  idType?: string
 }

--- a/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
@@ -87,7 +87,6 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     },
     async createAudience(request, createAudienceInput) {
       const audienceName = createAudienceInput.audienceName
-      const idType = createAudienceInput.audienceSettings?.idType
       const advertiserId = createAudienceInput.audienceSettings?.advertiserId
       const statsClient = createAudienceInput?.statsContext?.statsClient
       const statsTags = createAudienceInput?.statsContext?.tags
@@ -100,16 +99,11 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         throw new IntegrationError('Missing advertiser ID value', 'MISSING_REQUIRED_FIELD', 400)
       }
 
-      if (!idType) {
-        throw new IntegrationError('Missing ID type value', 'MISSING_REQUIRED_FIELD', 400)
-      }
-
       const response = await request(CREATE_AUDIENCE_URL, {
         method: 'POST',
         json: {
           custom_audience_name: audienceName,
           advertiser_id: advertiserId,
-          id_type: idType,
           action: 'create'
         }
       })

--- a/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
@@ -66,18 +66,6 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       label: 'Advertiser ID',
       description:
         'The advertiser ID to use when syncing audiences. Required if you wish to create or update an audience.'
-    },
-    idType: {
-      type: 'string',
-      label: 'ID Type',
-      description:
-        'Encryption type to be used for populating the audience. This field is required and only set when Segment creates a new audience.',
-      choices: [
-        { label: 'Email', value: 'EMAIL_SHA256' },
-        { label: 'Google Advertising ID', value: 'GAID_SHA256' },
-        { label: 'Android Advertising ID', value: 'AAID_SHA256' },
-        { label: 'iOS Advertising ID', value: 'IDFA_SHA256' }
-      ]
     }
   },
   audienceConfig: {

--- a/packages/destination-actions/src/destinations/tiktok-audiences/properties.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/properties.ts
@@ -8,20 +8,6 @@ export const selected_advertiser_id: InputField = {
   required: true
 }
 
-export const id_type: InputField = {
-  label: 'ID Type',
-  description:
-    'Encryption type to be used for populating the audience. This field is set only when Segment creates a new audience.',
-  type: 'string',
-  choices: [
-    { label: 'Email', value: 'EMAIL_SHA256' },
-    { label: 'Google Advertising ID', value: 'GAID_SHA256' },
-    { label: 'Android Advertising ID', value: 'AAID_SHA256' },
-    { label: 'iOS Advertising ID', value: 'IDFA_SHA256' }
-  ],
-  required: true
-}
-
 export const audience_id: InputField = {
   label: 'Audience ID',
   description:


### PR DESCRIPTION
TikTok has removed this field from the [API](https://business-api.tiktok.com/portal/docs?id=1739940583739393) request. It is no longer necessary.

[STRATCONN-3973](https://segment.atlassian.net/browse/STRATCONN-3973)

[Testing Document](https://docs.google.com/document/d/1A0MoDsLeTOCYC9-pa3GGEIDeO5mMO5bTr8ktmtQktOk/edit?pli=1)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment


[STRATCONN-3973]: https://segment.atlassian.net/browse/STRATCONN-3973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ