### PR TITLE
Nikumar/client credentials

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -108,6 +108,30 @@ export default class Init extends Command {
     ])
 
     const { name, slug, template } = answers
+    let grantType
+    if (template === 'oauth2-auth' || template === 'Audiences with OAuth2') {
+      const grantTypeAnswer = await autoPrompt(flags, [
+        {
+          type: 'select',
+          name: 'grantType',
+          message: 'Grant Type (default Authorization code',
+          choices: [
+            {
+              title: 'Authorisation code grant',
+              value: 'authorization_code'
+            },
+            {
+              title: 'Client Credentials grant',
+              value: 'client_credentials'
+            }
+          ]
+        }
+      ])
+      grantType = grantTypeAnswer.grantType
+      if (!grantType) {
+        grantType = 'authorization_code'
+      }
+    }
     if (!name || !slug || !template) {
       this.exit()
     }
@@ -122,7 +146,14 @@ export default class Init extends Command {
     const slugWithoutActions = String(slug).replace('actions-', '')
     const relativePath = path.join(directory, args.path || slugWithoutActions)
     const targetDirectory = path.join(process.cwd(), relativePath)
-    const templatePath = path.join(__dirname, '../../templates/destinations', template)
+
+    let templatePath
+    if ((template === 'oauth2-auth' || template === 'Audiences with OAuth2') && grantType === 'client_credentials') {
+      templatePath = path.join(__dirname, '../../templates/destinations', 'oauth2-client-credentials')
+    } else {
+      templatePath = path.join(__dirname, '../../templates/destinations', template)
+    }
+
     const snapshotPath = path.join(__dirname, '../../templates/actions/snapshot')
     const entryPath = isBrowserTemplate ? `${relativePath}/src/index.ts` : `${relativePath}/index.ts`
 

--- a/packages/cli/templates/destinations/oauth2-client-credentials/index.ts
+++ b/packages/cli/templates/destinations/oauth2-client-credentials/index.ts
@@ -1,0 +1,38 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+const destination: DestinationDefinition<Settings> = {
+  name: '{{name}}',
+  slug: '{{slug}}',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'oauth2',
+    oauthGrantType: 'client_credentials',
+    fields: {},
+    refreshAccessToken: async (request, { auth }) => {
+      // Return a request that refreshes the access_token if the API supports it
+      const res = await request('https://www.example.com/oauth/refresh', {
+        method: 'POST',
+        body: new URLSearchParams({
+          client_id: auth.clientId,
+          client_secret: auth.clientSecret,
+          grant_type: 'client_credentials'
+        })
+      })
+
+      return { accessToken: res.data.access_token }
+    }
+  },
+  extendRequest({ auth }) {
+    return {
+      headers: {
+        authorization: `Bearer ${auth?.accessToken}`
+      }
+    }
+  },
+
+  actions: {}
+}
+
+export default destination

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -240,6 +240,7 @@ export interface BasicAuthentication<Settings> extends Authentication<Settings> 
  */
 export interface OAuth2Authentication<Settings> extends Authentication<Settings> {
   scheme: 'oauth2'
+  grantType?: 'authorization_code' | 'client_credentials'
   /** A function that is used to refresh the access token
    * @todo look into merging input and oauthConfig so we can keep all the request functions with the same method signature (2 arguments)
    */
@@ -254,6 +255,7 @@ export interface OAuth2Authentication<Settings> extends Authentication<Settings>
  */
 export interface OAuthManagedAuthentication<Settings> extends Authentication<Settings> {
   scheme: 'oauth-managed'
+  grantType?: 'authorization_code' | 'client_credentials'
   /** A function that is used to refresh the access token
    */
   refreshAccessToken?: (

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -240,7 +240,7 @@ export interface BasicAuthentication<Settings> extends Authentication<Settings> 
  */
 export interface OAuth2Authentication<Settings> extends Authentication<Settings> {
   scheme: 'oauth2'
-  grantType?: 'authorization_code' | 'client_credentials'
+  oauthGrantType?: 'authorization_code' | 'client_credentials' | null
   /** A function that is used to refresh the access token
    * @todo look into merging input and oauthConfig so we can keep all the request functions with the same method signature (2 arguments)
    */
@@ -255,7 +255,7 @@ export interface OAuth2Authentication<Settings> extends Authentication<Settings>
  */
 export interface OAuthManagedAuthentication<Settings> extends Authentication<Settings> {
   scheme: 'oauth-managed'
-  grantType?: 'authorization_code' | 'client_credentials'
+  oauthGrantType?: 'authorization_code' | 'client_credentials' | null
   /** A function that is used to refresh the access token
    */
   refreshAccessToken?: (

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/index.ts
@@ -15,7 +15,7 @@ const destination: DestinationDefinition<Settings> = {
   mode: 'cloud',
   authentication: {
     scheme: 'oauth2',
-    grantType: 'client_credentials',
+    oauthGrantType: 'client_credentials',
     fields: {
       subdomain: {
         label: 'Subdomain',

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/index.ts
@@ -13,9 +13,9 @@ const destination: DestinationDefinition<Settings> = {
   name: 'Salesforce Marketing Cloud (Actions)',
   slug: 'actions-salesforce-marketing-cloud',
   mode: 'cloud',
-
   authentication: {
     scheme: 'oauth2',
+    grantType: 'client_credentials',
     fields: {
       subdomain: {
         label: 'Subdomain',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR 
1. Adds an additional field to `oauthGrantType` in `OAuth2Authentication` and `OAuthManagedAuthentication` which specifies the Oauth grant type followed by that Destination.
2. It also updates the `init` CLI command to prompt for grant-type when authentication scheme chosen is Oauth.
3. Also creates a new template for Destinations that follow grant type `client_credentials`.


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
