### PR TITLE
fixing build - unclosed literal

### DIFF
--- a/packages/browser-destinations/destinations/braze/src/index.ts
+++ b/packages/browser-destinations/destinations/braze/src/index.ts
@@ -88,7 +88,7 @@ export const destination: BrowserDestinationDefinition<Settings, BrazeDestinatio
         },
         {
           value: '4.10',
-          label: '4.10
+          label: '4.10'
         }
       ],
       default: defaultVersion,


### PR DESCRIPTION
Build breaking due to bad braze PR which had an unclosed literal. 

## Testing
