### PR TITLE
restricting additional_identifiers_and_traits_columns field entry method

### DIFF
--- a/packages/destination-actions/src/destinations/aws-s3/syncAudienceToCSV/index.ts
+++ b/packages/destination-actions/src/destinations/aws-s3/syncAudienceToCSV/index.ts
@@ -188,6 +188,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
         'Additional user identifiers and traits to include as separate columns in the CSV file. Each item should contain a key and a value. The key is the trait or identifier name from the payload, and the value is the column name to be written to the CSV file.',
       type: 'object',
       required: false,
+      disabledInputMethods: ['function', 'variable', 'enrichment', 'freeform'],
       defaultObjectUI: 'keyvalue:only'
     },
     enable_batching: {

--- a/packages/destination-actions/src/destinations/aws-s3/syncAudienceToCSV/index.ts
+++ b/packages/destination-actions/src/destinations/aws-s3/syncAudienceToCSV/index.ts
@@ -188,7 +188,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
         'Additional user identifiers and traits to include as separate columns in the CSV file. Each item should contain a key and a value. The key is the trait or identifier name from the payload, and the value is the column name to be written to the CSV file.',
       type: 'object',
       required: false,
-      disabledInputMethods: ['function', 'variable', 'enrichment', 'freeform'],
+      disabledInputMethods: ['enrichment', 'function', 'variable'],
       defaultObjectUI: 'keyvalue:only'
     },
     enable_batching: {


### PR DESCRIPTION
Restricting entry mode for additional_identifiers_and_traits_columns field in aws-s3-csv destination. 

## Testing

None needed - private beta