### PR TITLE
Register extensible Destinations

### DIFF
--- a/packages/destination-actions/src/destinations/webook-extensible/__test__/webhook.test.ts
+++ b/packages/destination-actions/src/destinations/webook-extensible/__test__/webhook.test.ts
@@ -1,0 +1,184 @@
+import nock from 'nock'
+import {
+  PayloadValidationError,
+  createTestEvent,
+  createTestIntegration,
+  DestinationDefinition
+} from '@segment/actions-core'
+import Webhook from '../index'
+import { createHmac, timingSafeEqual } from 'crypto'
+import { SegmentEvent } from '@segment/actions-core'
+
+// Exported so we can re-use to test webhook-audiences
+export const baseWebhookTests = (def: DestinationDefinition<any>) => {
+  const testDestination = createTestIntegration(def)
+  describe(def.name, () => {
+    describe('send', () => {
+      it('should work with default mapping', async () => {
+        const url = 'https://example.com'
+        const event = createTestEvent()
+
+        nock(url)
+          .post('/', event as any)
+          .reply(200)
+
+        const responses = await testDestination.testAction('send', {
+          event,
+          mapping: {
+            url
+          },
+          useDefaultMappings: true
+        })
+
+        expect(responses.length).toBe(1)
+        expect(responses[0].status).toBe(200)
+      })
+
+      it('supports customizations', async () => {
+        const url = 'https://example.build'
+        const event = createTestEvent()
+        const headerField = 'Custom-Header'
+        const headerValue = 'Custom-Value'
+        const data = { cool: true }
+
+        nock(url).put('/', data).matchHeader(headerField, headerValue).reply(200)
+
+        const responses = await testDestination.testAction('send', {
+          event,
+          mapping: {
+            url,
+            method: 'PUT',
+            headers: { [headerField]: headerValue },
+            data
+          }
+        })
+
+        expect(responses.length).toBe(1)
+        expect(responses[0].status).toBe(200)
+      })
+
+      it('supports request signing', async () => {
+        const url = 'https://example.com'
+        const event = createTestEvent({
+          properties: { cool: true }
+        })
+        const payload = JSON.stringify(event.properties)
+        const sharedSecret = 'abc123'
+
+        nock(url)
+          .post('/', payload)
+          .reply(async function (_uri, body) {
+            // Normally you should use the raw body but nock automatically
+            // deserializes it (and doesn't allow us to access the raw request
+            // body) so we re-serialize the body here so that we can demonstrate
+            // signture validation.
+            const bodyString = JSON.stringify(body)
+
+            // Validate the signature
+            const expectSignature = this.req.headers['x-signature'][0]
+            const actualSignature = createHmac('sha1', sharedSecret).update(bodyString).digest('hex')
+
+            // Use constant-time comparison to avoid timing attacks
+            if (
+              expectSignature.length !== actualSignature.length ||
+              !timingSafeEqual(Buffer.from(actualSignature, 'hex'), Buffer.from(expectSignature, 'hex'))
+            ) {
+              return [400, 'Invalid signature']
+            }
+
+            return [200, 'OK']
+          })
+
+        const responses = await testDestination.testAction('send', {
+          event,
+          mapping: {
+            url,
+            data: { '@path': '$.properties' }
+          },
+          settings: { sharedSecret },
+          useDefaultMappings: true
+        })
+
+        expect(responses.length).toBe(1)
+        expect(responses[0].status).toBe(200)
+      })
+
+      it('supports request signing with batched events', async () => {
+        const url = 'https://example.com'
+
+        const events: SegmentEvent[] = [
+          createTestEvent({
+            properties: { cool: false }
+          }),
+          createTestEvent({
+            properties: { cool: true }
+          })
+        ]
+
+        const payload = JSON.stringify(events.map(({ properties }) => properties))
+        const sharedSecret = 'abc123'
+        nock(url)
+          .post('/', payload)
+          .reply(async function (_uri, body: any) {
+            // Normally you should use the raw body but nock automatically
+            // deserializes it (and doesn't allow us to access the raw request
+            // body) so we re-serialize the body here so that we can demonstrate
+            // signture validation
+
+            // Validate the signature
+            const expectSignature = this.req.headers['x-signature'][0]
+            const actualSignature = createHmac('sha1', sharedSecret).update(JSON.stringify(body[0])).digest('hex')
+
+            // Use constant-time comparison to avoid timing attacks
+            if (
+              expectSignature.length !== actualSignature.length ||
+              !timingSafeEqual(Buffer.from(actualSignature, 'hex'), Buffer.from(expectSignature, 'hex'))
+            ) {
+              return [400, 'Invalid signature123']
+            }
+
+            return [200, 'OK']
+          })
+
+        const responses = await testDestination.testBatchAction('send', {
+          events,
+          mapping: {
+            url,
+            data: { '@path': '$.properties' }
+          },
+          settings: { sharedSecret },
+          useDefaultMappings: true
+        })
+        expect(responses.length).toBe(1)
+        expect(responses[0].status).toBe(200)
+      })
+
+      it('should throw an error when header value is invalid', async () => {
+        const url = 'https://example.build'
+        const event = createTestEvent()
+        const headerField = 'Custom-Header'
+        const headerValue = 'هيثم'
+        const data = { cool: true }
+
+        nock(url)
+          .put('/', data)
+          .matchHeader(headerField, headerValue)
+          .replyWithError('TypeError: هيثم is not a legal HTTP header value')
+
+        await expect(
+          testDestination.testAction('send', {
+            event,
+            mapping: {
+              url,
+              method: 'PUT',
+              headers: { [headerField]: headerValue },
+              data
+            }
+          })
+        ).rejects.toThrow(PayloadValidationError)
+      })
+    })
+  })
+}
+
+baseWebhookTests(Webhook)

--- a/packages/destination-actions/src/destinations/webook-extensible/generated-types.ts
+++ b/packages/destination-actions/src/destinations/webook-extensible/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * If set, Segment will sign requests with an HMAC in the "X-Signature" request header. The HMAC is a hex-encoded SHA1 hash generated using this shared secret and the request body.
+   */
+  sharedSecret?: string
+}

--- a/packages/destination-actions/src/destinations/webook-extensible/index.ts
+++ b/packages/destination-actions/src/destinations/webook-extensible/index.ts
@@ -1,4 +1,4 @@
-import type { DestinationDefinition } from '@segment/actions-core'
+weimport type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import { createHmac } from 'crypto'
 
@@ -6,7 +6,7 @@ import send from './send'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Webhook',
-  slug: 'actions-webhook',
+  slug: 'extensible-webhook',
   mode: 'cloud',
   authentication: {
     scheme: 'custom',

--- a/packages/destination-actions/src/destinations/webook-extensible/index.ts
+++ b/packages/destination-actions/src/destinations/webook-extensible/index.ts
@@ -6,7 +6,7 @@ import send from './send'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Webhook',
-  slug: 'extensible-webhook',
+  slug: 'webhook-extensible',
   mode: 'cloud',
   authentication: {
     scheme: 'custom',

--- a/packages/destination-actions/src/destinations/webook-extensible/index.ts
+++ b/packages/destination-actions/src/destinations/webook-extensible/index.ts
@@ -1,4 +1,4 @@
-weimport type { DestinationDefinition } from '@segment/actions-core'
+import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import { createHmac } from 'crypto'
 

--- a/packages/destination-actions/src/destinations/webook-extensible/index.ts
+++ b/packages/destination-actions/src/destinations/webook-extensible/index.ts
@@ -1,0 +1,35 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+import { createHmac } from 'crypto'
+
+import send from './send'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Webhook',
+  slug: 'actions-webhook',
+  mode: 'cloud',
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      sharedSecret: {
+        type: 'string',
+        label: 'Shared Secret',
+        description:
+          'If set, Segment will sign requests with an HMAC in the "X-Signature" request header. The HMAC is a hex-encoded SHA1 hash generated using this shared secret and the request body.'
+      }
+    }
+  },
+  extendRequest: ({ settings, payload }) => {
+    const payloadData = payload.length ? payload[0]['data'] : payload['data']
+    if (settings.sharedSecret && payloadData) {
+      const digest = createHmac('sha1', settings.sharedSecret).update(JSON.stringify(payloadData), 'utf8').digest('hex')
+      return { headers: { 'X-Signature': digest } }
+    }
+    return {}
+  },
+  actions: {
+    send
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/webook-extensible/send/generated-types.ts
+++ b/packages/destination-actions/src/destinations/webook-extensible/send/generated-types.ts
@@ -1,0 +1,28 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * URL to deliver data to.
+   */
+  url: string
+  /**
+   * HTTP method to use.
+   */
+  method: string
+  /**
+   * Maximum number of events to include in each batch. Actual batch sizes may be lower.
+   */
+  batch_size?: number
+  /**
+   * HTTP headers to send with each request. Only ASCII characters are supported.
+   */
+  headers?: {
+    [k: string]: unknown
+  }
+  /**
+   * Payload to deliver to webhook URL (JSON-encoded).
+   */
+  data?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/webook-extensible/send/index.ts
+++ b/packages/destination-actions/src/destinations/webook-extensible/send/index.ts
@@ -1,0 +1,78 @@
+import { ActionDefinition, PayloadValidationError } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+type RequestMethod = 'POST' | 'PUT' | 'PATCH'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Send',
+  description: 'Send an HTTP request.',
+  fields: {
+    url: {
+      label: 'URL',
+      description: 'URL to deliver data to.',
+      type: 'string',
+      required: true,
+      format: 'uri'
+    },
+    method: {
+      label: 'Method',
+      description: 'HTTP method to use.',
+      type: 'string',
+      choices: [
+        { label: 'POST', value: 'POST' },
+        { label: 'PUT', value: 'PUT' },
+        { label: 'PATCH', value: 'PATCH' }
+      ],
+      default: 'POST',
+      required: true
+    },
+    batch_size: {
+      label: 'Batch Size',
+      description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
+      type: 'number',
+      required: false,
+      default: 0
+    },
+    headers: {
+      label: 'Headers',
+      description: 'HTTP headers to send with each request. Only ASCII characters are supported.',
+      type: 'object',
+      defaultObjectUI: 'keyvalue:only'
+    },
+    data: {
+      label: 'Data',
+      description: 'Payload to deliver to webhook URL (JSON-encoded).',
+      type: 'object',
+      default: { '@path': '$.' }
+    }
+  },
+  perform: (request, { payload }) => {
+    try {
+      return request(payload.url, {
+        method: payload.method as RequestMethod,
+        headers: payload.headers as Record<string, string>,
+        json: payload.data
+      })
+    } catch (error) {
+      if (error instanceof TypeError) throw new PayloadValidationError(error.message)
+      throw error
+    }
+  },
+  performBatch: (request, { payload }) => {
+    // Expect these to be the same across the payloads
+    const { url, method, headers } = payload[0]
+    try {
+      return request(url, {
+        method: method as RequestMethod,
+        headers: headers as Record<string, string>,
+        json: payload.map(({ data }) => data)
+      })
+    } catch (error) {
+      if (error instanceof TypeError) throw new PayloadValidationError(error.message)
+      throw error
+    }
+  }
+}
+
+export default action


### PR DESCRIPTION
This PR registers a new destination. `webhook-extensible`

Extensible Destinations [https://docs.google.com/document/d/1Ky0FMOWG0Lts0R_aq-5FptN5NPX_4bX1e0siYpz22Ss/edit#heading=h.dw9r7et1dda0](PRD)

## Testing

Testing not required as registering a new destination.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
