### PR TITLE
Updating comp key to avoid gitleaks clash

### DIFF
--- a/packages/destination-actions/src/destinations/iterable-lists/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/syncAudience/__tests__/index.test.ts
@@ -49,7 +49,7 @@ describe('IterableLists.syncAudience', () => {
         context: {
           personas: {
             audience_settings: {
-              computation_key: 'the_super_mario_bros_super_audience_2',
+              computation_key: 'test',
               external_audience_id: '4269566'
             }
           }
@@ -64,7 +64,7 @@ describe('IterableLists.syncAudience', () => {
         context: {
           personas: {
             audience_settings: {
-              computation_key: 'the_super_mario_bros_super_audience_2',
+              computation_key: 'test',
               external_audience_id: '4269566'
             }
           }


### PR DESCRIPTION
changing computation key in test for Iterable Lists so that it doesn't cause any Gitleaks issues. 

## Testing

None needed. 