### PR TITLE
Include optional fields in the condition

### DIFF
--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -86,7 +86,7 @@ export interface ActionDefinition<
    */
   dynamicFields?: {
     [K in keyof Payload]?: IsArray<Payload[K]> extends never
-      ? Payload[K] extends object
+      ? Payload[K] extends object | undefined
         ? {
             [ObjectProperty in keyof Payload[K] | '__keys__' | '__values__']?: RequestFn<
               Settings,


### PR DESCRIPTION
Ran into an issue where if an Object field is defined as optional, the `dynamicFields` block doesn't recongnize it as being an object, and treat it like a non-object field ( i.e., expects an immediate handler instead of a handler for `__values__` and `__keys__` ). This PR updates the types to account for that. 
 
## Testing
Tested locally to ensure that the type issue is solved. This PR has no functional impact tho. 