### PR TITLE
[STRATCONN-3888]: Reduce batch size of salesforce marketing cloud to 10

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-properties.ts
@@ -92,5 +92,5 @@ export const batch_size: InputField = {
    * See: https://developer.salesforce.com/docs/marketing/marketing-cloud/guide/postDataExtensionRowsetByKey.html
    * And: inc-sev3-6609-sfmc-timeouts-in-bulk-batching-2023-10-23
    *  */
-  default: 50
+  default: 10
 }


### PR DESCRIPTION
Reduce batch size of actions salesforce marketing cloud to 10

https://segment.atlassian.net/browse/STRATCONN-3888

## Testing
Tested Successfully on stage via App. 
<img width="1728" alt="Screenshot 2024-08-07 at 11 56 34 AM" src="https://github.com/user-attachments/assets/07d8dca2-e467-4140-ba11-0030c4727b13">
<img width="1728" alt="Screenshot 2024-08-07 at 6 27 33 PM" src="https://github.com/user-attachments/assets/7bbde22d-a16d-4856-b613-09d61819bc5b">

