### PR TITLE
renaming extensible webhook

### DIFF
--- a/packages/destination-actions/src/destinations/webook-extensible/index.ts
+++ b/packages/destination-actions/src/destinations/webook-extensible/index.ts
@@ -6,7 +6,7 @@ import send from './send'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Webhook',
-  slug: 'webhook-extensible',
+  slug: 'actions-webhook-extensible',
   mode: 'cloud',
   authentication: {
     scheme: 'custom',


### PR DESCRIPTION
adding the word actions to the slug for extenble webhook destination

## Testing

None needed. Not in use yet. 
