### PR TITLE
renaming webhook extensible

### DIFF
--- a/packages/destination-actions/src/destinations/webook-extensible/index.ts
+++ b/packages/destination-actions/src/destinations/webook-extensible/index.ts
@@ -5,7 +5,7 @@ import { createHmac } from 'crypto'
 import send from './send'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Webhook',
+  name: 'Extensible Webhook',
   slug: 'actions-webhook-extensible',
   mode: 'cloud',
   authentication: {


### PR DESCRIPTION
rename webhook extensions destination - to avoid clash. Not in use yet. 

## Testing

Not needed. 