### PR TITLE
[Facebook Custom Audience] final touches

### DIFF
--- a/packages/core/src/__tests__/hashing-utils.test.ts
+++ b/packages/core/src/__tests__/hashing-utils.test.ts
@@ -1,0 +1,45 @@
+import { sha256SmartHash, SmartHashing } from '../hashing-utils'
+
+describe('hashing utilities', () => {
+  it('should hash a non-hashed value', async () => {
+    const value = 'test_value'
+
+    expect(sha256SmartHash(value)).toEqual('4f7f6a4ae46676d9751fdccdf15ae1e6a200ed0de5653e06390148928c642006')
+  })
+
+  it('should not hash a hashed value', async () => {
+    const value = '4f7f6a4ae46676d9751fdccdf15ae1e6a200ed0de5653e06390148928c642006'
+
+    expect(sha256SmartHash(value)).toEqual(value)
+  })
+})
+
+describe('SmarrtHashing', () => {
+  it('should correctly check if a value is hashed or not', async () => {
+    const hashed = '4f7f6a4ae46676d9751fdccdf15ae1e6a200ed0de5653e06390148928c642006'
+    const notHashed = 'test_value'
+
+    const smartHashing = new SmartHashing('sha256')
+
+    expect(smartHashing.isAlreadyHashed(hashed)).toEqual(true)
+    expect(smartHashing.isAlreadyHashed(notHashed)).toEqual(false)
+  })
+
+  it('should hash a non-hashed value', async () => {
+    const notHashed = 'test_value'
+
+    const smartHashing = new SmartHashing('sha256')
+    smartHashing.isAlreadyHashed(notHashed)
+
+    expect(smartHashing.hash(notHashed)).toEqual('4f7f6a4ae46676d9751fdccdf15ae1e6a200ed0de5653e06390148928c642006')
+  })
+
+  it('should not hash a hashed value', async () => {
+    const hashed = '4f7f6a4ae46676d9751fdccdf15ae1e6a200ed0de5653e06390148928c642006'
+
+    const smartHashing = new SmartHashing('sha256')
+    smartHashing.isAlreadyHashed(hashed)
+
+    expect(smartHashing.hash(hashed)).toEqual(hashed)
+  })
+})

--- a/packages/core/src/hashing-utils.ts
+++ b/packages/core/src/hashing-utils.ts
@@ -11,3 +11,26 @@ export function sha256SmartHash(value: string): string {
   }
   return crypto.createHash('sha256').update(value).digest('hex')
 }
+
+export class SmartHashing {
+  encryptionMethod: 'sha256'
+  preHashed: boolean
+
+  constructor(encryptionMethod: 'sha256') {
+    this.encryptionMethod = encryptionMethod
+    this.preHashed = false
+  }
+
+  isAlreadyHashed(value: string): boolean {
+    this.preHashed = sha256HashedRegex.test(value)
+    return this.preHashed
+  }
+
+  hash(value: string): string {
+    if (this.preHashed) {
+      return value
+    }
+
+    return crypto.createHash('sha256').update(value).digest('hex')
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,7 +44,7 @@ export {
 export { get } from './get'
 export { omit } from './omit'
 export { removeUndefined } from './remove-undefined'
-export { sha256SmartHash } from './hashing-utils'
+export { sha256SmartHash, SmartHashing } from './hashing-utils'
 export { time, duration } from './time'
 
 export { realTypeOf, isObject, isArray, isString } from './real-type-of'

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/__tests__/fb-operations.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/__tests__/fb-operations.test.ts
@@ -3,7 +3,7 @@ import FacebookClient, { BASE_URL, generateData } from '../fbca-operations'
 import { Settings } from '../generated-types'
 import nock from 'nock'
 import { Payload } from '../sync/generated-types'
-import { createHash } from 'crypto'
+import { sha256SmartHash } from '@segment/actions-core'
 import { normalizationFunctions } from '../fbca-properties'
 
 const requestClient = createRequestClient()
@@ -11,11 +11,6 @@ const settings: Settings = {
   retlAdAccountId: 'act_123456'
 }
 const EMPTY = ''
-
-// clone of the hash function in fbca-operations.ts since it's a private method
-const hash = (value: string): string => {
-  return createHash('sha256').update(value).digest('hex')
-}
 
 describe('Facebook Custom Audiences', () => {
   const facebookClient = new FacebookClient(requestClient, settings.retlAdAccountId)
@@ -57,14 +52,14 @@ describe('Facebook Custom Audiences', () => {
       expect(generateData(payloads)).toEqual([
         [
           '5', // external_id is not hashed or normalized
-          hash(normalizationFunctions.get('email')!(payloads[0].email || '')), // email
-          hash(normalizationFunctions.get('phone')!(payloads[0].phone || '')), // phone
+          sha256SmartHash(normalizationFunctions.get('email')!(payloads[0].email || '')), // email
+          sha256SmartHash(normalizationFunctions.get('phone')!(payloads[0].phone || '')), // phone
           EMPTY, // gender
           EMPTY, // year
           EMPTY, // month
           EMPTY, // day
-          hash(normalizationFunctions.get('last')!(payloads[0].name?.last || '')), // last_name
-          hash(normalizationFunctions.get('first')!(payloads[0].name?.first || '')), // first_name
+          sha256SmartHash(normalizationFunctions.get('last')!(payloads[0].name?.last || '')), // last_name
+          sha256SmartHash(normalizationFunctions.get('first')!(payloads[0].name?.first || '')), // first_name
           EMPTY, // first_initial
           EMPTY, // city
           EMPTY, // state
@@ -115,14 +110,14 @@ describe('Facebook Custom Audiences', () => {
       expect(generateData(payloads)).toEqual([
         [
           '5', // external_id
-          hash(normalizationFunctions.get('email')!(payloads[0].email || '')),
-          hash(normalizationFunctions.get('phone')!(payloads[0].phone || '')),
+          sha256SmartHash(normalizationFunctions.get('email')!(payloads[0].email || '')),
+          sha256SmartHash(normalizationFunctions.get('phone')!(payloads[0].phone || '')),
           EMPTY, // gender
           EMPTY, // year
           EMPTY, // month
           EMPTY, // day
-          hash(normalizationFunctions.get('last')!(payloads[0].name?.last || '')),
-          hash(normalizationFunctions.get('first')!(payloads[0].name?.first || '')),
+          sha256SmartHash(normalizationFunctions.get('last')!(payloads[0].name?.last || '')),
+          sha256SmartHash(normalizationFunctions.get('first')!(payloads[0].name?.first || '')),
           EMPTY, // first_initial
           EMPTY, // city
           EMPTY, // state
@@ -132,20 +127,20 @@ describe('Facebook Custom Audiences', () => {
         ],
         [
           '6', // external_id
-          hash(normalizationFunctions.get('email')!(payloads[1].email || '')),
+          sha256SmartHash(normalizationFunctions.get('email')!(payloads[1].email || '')),
           EMPTY, // phone
-          hash(normalizationFunctions.get('gender')!(payloads[1].gender || '')),
-          hash(normalizationFunctions.get('year')!(payloads[1].birth?.year || '')),
-          hash(normalizationFunctions.get('month')!(payloads[1].birth?.month || '')),
-          hash(normalizationFunctions.get('day')!(payloads[1].birth?.day || '')),
-          hash(normalizationFunctions.get('last')!(payloads[1].name?.last || '')),
-          hash(normalizationFunctions.get('first')!(payloads[1].name?.first || '')),
-          hash(normalizationFunctions.get('firstInitial')!(payloads[1].name?.firstInitial || '')),
-          hash(normalizationFunctions.get('city')!(payloads[1].city || '')),
-          hash(normalizationFunctions.get('state')!(payloads[1].state || '')),
-          hash(normalizationFunctions.get('zip')!(payloads[1].zip || '')),
+          sha256SmartHash(normalizationFunctions.get('gender')!(payloads[1].gender || '')),
+          sha256SmartHash(normalizationFunctions.get('year')!(payloads[1].birth?.year || '')),
+          sha256SmartHash(normalizationFunctions.get('month')!(payloads[1].birth?.month || '')),
+          sha256SmartHash(normalizationFunctions.get('day')!(payloads[1].birth?.day || '')),
+          sha256SmartHash(normalizationFunctions.get('last')!(payloads[1].name?.last || '')),
+          sha256SmartHash(normalizationFunctions.get('first')!(payloads[1].name?.first || '')),
+          sha256SmartHash(normalizationFunctions.get('firstInitial')!(payloads[1].name?.firstInitial || '')),
+          sha256SmartHash(normalizationFunctions.get('city')!(payloads[1].city || '')),
+          sha256SmartHash(normalizationFunctions.get('state')!(payloads[1].state || '')),
+          sha256SmartHash(normalizationFunctions.get('zip')!(payloads[1].zip || '')),
           EMPTY, // mobile_advertiser_id,
-          hash(normalizationFunctions.get('country')!(payloads[1].country || ''))
+          sha256SmartHash(normalizationFunctions.get('country')!(payloads[1].country || ''))
         ]
       ])
     })

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/__tests__/fb-operations.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/__tests__/fb-operations.test.ts
@@ -75,7 +75,7 @@ describe('Facebook Custom Audiences', () => {
 
       payloads[0] = {
         email: 'haaron@braves.com',
-        phone: '555-555-5555',
+        phone: '89a0af94167fe6b92b614c681cc5599cd23ff45f7e9cc7929ed5fabe26842468', // pre-hashed phone: 555-555-5555
         name: {
           first: 'Henry',
           last: 'Aaron'
@@ -111,7 +111,7 @@ describe('Facebook Custom Audiences', () => {
         [
           '5', // external_id
           sha256SmartHash(normalizationFunctions.get('email')!(payloads[0].email || '')),
-          sha256SmartHash(normalizationFunctions.get('phone')!(payloads[0].phone || '')),
+          '89a0af94167fe6b92b614c681cc5599cd23ff45f7e9cc7929ed5fabe26842468',
           EMPTY, // gender
           EMPTY, // year
           EMPTY, // month

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/fbca-operations.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/fbca-operations.ts
@@ -62,19 +62,14 @@ const appendToDataRow = (key: string, value: string | number, row: (string | num
     return
   }
 
-  if (typeof value === 'number' || ['externalId', 'mobileAdId'].includes(key)) {
+  const smartHash = new SmartHashing('sha256')
+
+  if (typeof value === 'number' || ['externalId', 'mobileAdId'].includes(key) || smartHash.isAlreadyHashed(value)) {
     row[index] = value
     return
   }
 
   const normalizationFunction = normalizationFunctions.get(key)
-  const smartHash = new SmartHashing('sha256')
-
-  if (smartHash.isAlreadyHashed(value)) {
-    row[index] = value
-    return
-  }
-
   if (!normalizationFunction) {
     throw new IntegrationError(`Normalization function not found for key: ${key}`, `cannot normalize ${key}`, 500)
   }

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/fbca-operations.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/fbca-operations.ts
@@ -1,7 +1,7 @@
 import { DynamicFieldItem, DynamicFieldError, RequestClient, IntegrationError } from '@segment/actions-core'
 import { Payload } from './sync/generated-types'
-import { createHash } from 'crypto'
 import { segmentSchemaKeyToArrayIndex, SCHEMA_PROPERTIES, normalizationFunctions } from './fbca-properties'
+import { sha256SmartHash } from '@segment/actions-core'
 
 const FACEBOOK_API_VERSION = 'v20.0'
 // exported for unit testing
@@ -74,11 +74,7 @@ const appendToDataRow = (key: string, value: string | number, row: (string | num
   }
 
   const normalizedValue = normalizationFunction(value)
-  row[index] = hash(normalizedValue)
-}
-
-const hash = (value: string): string => {
-  return createHash('sha256').update(value).digest('hex')
+  row[index] = sha256SmartHash(normalizedValue)
 }
 
 export default class FacebookClient {

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/index.ts
@@ -17,9 +17,6 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     scheme: 'oauth2',
     fields: {
       retlAdAccountId: adAccountId
-    },
-    refreshAccessToken: async () => {
-      return { accessToken: 'TODO: Implement this' }
     }
   },
   extendRequest({ auth }) {

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/index.test.ts
@@ -1,14 +1,9 @@
-import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration, sha256SmartHash } from '@segment/actions-core'
 import Destination from '../../index'
 import { BASE_URL } from '../../fbca-operations'
 import nock from 'nock'
 import { SCHEMA_PROPERTIES } from '../../fbca-properties'
-import { createHash } from 'crypto'
 import { normalizationFunctions } from '../../fbca-properties'
-// clone of the hash function in fbca-operations.ts since it's a private method
-const hash = (value: string): string => {
-  return createHash('sha256').update(value).digest('hex')
-}
 
 const testDestination = createTestIntegration(Destination)
 const auth = {
@@ -39,7 +34,8 @@ describe('FacebookCustomAudiences.sync', () => {
         annual_revenue: 1000000,
         account_id: '1234',
         zip_code: '92000',
-        address: '123 Main St'
+        address: '123 Main St',
+        email: '816341caf0c06dbc4c156d3465323f52b3cb62533241d5f9247c008f657e8343' // pre-hashed email: nick@email.com
       }
     })
 
@@ -51,8 +47,8 @@ describe('FacebookCustomAudiences.sync', () => {
             data: [
               [
                 event.properties?.id, // external_id
-                EMPTY, // email
-                hash(normalizationFunctions.get('phone')!((event.properties?.phone as string) || '')),
+                '816341caf0c06dbc4c156d3465323f52b3cb62533241d5f9247c008f657e8343', // email
+                sha256SmartHash(normalizationFunctions.get('phone')!((event.properties?.phone as string) || '')),
                 EMPTY, // gender
                 EMPTY, // year
                 EMPTY, // month
@@ -60,11 +56,11 @@ describe('FacebookCustomAudiences.sync', () => {
                 EMPTY, // last_name
                 EMPTY, // first_name
                 EMPTY, // first_initial
-                hash(normalizationFunctions.get('city')!((event.properties?.city as string) || '')),
-                hash(normalizationFunctions.get('state')!((event.properties?.state as string) || '')),
-                hash(normalizationFunctions.get('zip')!((event.properties?.zip_code as string) || '')),
+                sha256SmartHash(normalizationFunctions.get('city')!((event.properties?.city as string) || '')),
+                sha256SmartHash(normalizationFunctions.get('state')!((event.properties?.state as string) || '')),
+                sha256SmartHash(normalizationFunctions.get('zip')!((event.properties?.zip_code as string) || '')),
                 EMPTY, // mobile_advertiser_id,
-                hash(normalizationFunctions.get('country')!('US'))
+                sha256SmartHash(normalizationFunctions.get('country')!('US'))
               ]
             ]
           }
@@ -77,6 +73,7 @@ describe('FacebookCustomAudiences.sync', () => {
         auth,
         mapping: {
           __segment_internal_sync_mode: 'upsert',
+          email: { '@path': '$.properties.email' },
           phone: { '@path': '$.properties.phone' },
           city: { '@path': '$.properties.city' },
           state: { '@path': '$.properties.state' },
@@ -112,7 +109,7 @@ describe('FacebookCustomAudiences.sync', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"payload\\":{\\"schema\\":[\\"EXTERN_ID\\",\\"EMAIL\\",\\"PHONE\\",\\"GEN\\",\\"DOBY\\",\\"DOBM\\",\\"DOBD\\",\\"LN\\",\\"FN\\",\\"FI\\",\\"CT\\",\\"ST\\",\\"ZIP\\",\\"MADID\\",\\"COUNTRY\\"],\\"data\\":[[\\"1234\\",\\"\\",\\"a5ad7e6d5225ad00c5f05ddb6bb3b1597a843cc92f6cf188490ffcb88a1ef4ef\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"1a6bd4d9d79dc0a79b53795c70d3349fa9e38968a3fbefbfe8783efb1d2b6aac\\",\\"6959097001d10501ac7d54c0bdb8db61420f658f2922cc26e46d536119a31126\\",\\"ad16c1a6866c5887c5b59c1803cb1fc09769f1b403b6f1d9d0f10ad6ab4d5d50\\",\\"\\",\\"79adb2a2fce5c6ba215fe5f27f532d4e7edbac4b6a5e09e1ef3a08084a904621\\"]]}}"`
+        `"{\\"payload\\":{\\"schema\\":[\\"EXTERN_ID\\",\\"EMAIL\\",\\"PHONE\\",\\"GEN\\",\\"DOBY\\",\\"DOBM\\",\\"DOBD\\",\\"LN\\",\\"FN\\",\\"FI\\",\\"CT\\",\\"ST\\",\\"ZIP\\",\\"MADID\\",\\"COUNTRY\\"],\\"data\\":[[\\"1234\\",\\"816341caf0c06dbc4c156d3465323f52b3cb62533241d5f9247c008f657e8343\\",\\"a5ad7e6d5225ad00c5f05ddb6bb3b1597a843cc92f6cf188490ffcb88a1ef4ef\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"1a6bd4d9d79dc0a79b53795c70d3349fa9e38968a3fbefbfe8783efb1d2b6aac\\",\\"6959097001d10501ac7d54c0bdb8db61420f658f2922cc26e46d536119a31126\\",\\"ad16c1a6866c5887c5b59c1803cb1fc09769f1b403b6f1d9d0f10ad6ab4d5d50\\",\\"\\",\\"79adb2a2fce5c6ba215fe5f27f532d4e7edbac4b6a5e09e1ef3a08084a904621\\"]]}}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/index.test.ts
@@ -35,7 +35,9 @@ describe('FacebookCustomAudiences.sync', () => {
         account_id: '1234',
         zip_code: '92000',
         address: '123 Main St',
-        email: '816341caf0c06dbc4c156d3465323f52b3cb62533241d5f9247c008f657e8343' // pre-hashed email: nick@email.com
+        email: '816341caf0c06dbc4c156d3465323f52b3cb62533241d5f9247c008f657e8343', // pre-hashed email: nick@email.com
+        app_ids: [],
+        appleIDFA: '2024'
       }
     })
 
@@ -59,7 +61,7 @@ describe('FacebookCustomAudiences.sync', () => {
                 sha256SmartHash(normalizationFunctions.get('city')!((event.properties?.city as string) || '')),
                 sha256SmartHash(normalizationFunctions.get('state')!((event.properties?.state as string) || '')),
                 sha256SmartHash(normalizationFunctions.get('zip')!((event.properties?.zip_code as string) || '')),
-                EMPTY, // mobile_advertiser_id,
+                '2024', // mobile_advertiser_id,
                 sha256SmartHash(normalizationFunctions.get('country')!('US'))
               ]
             ]
@@ -80,6 +82,8 @@ describe('FacebookCustomAudiences.sync', () => {
           zip: { '@path': '$.properties.zip_code' },
           country: 'US',
           externalId: { '@path': '$.properties.id' },
+          appIds: { '@path': '$.properties.app_ids' },
+          mobileAdId: { '@path': '$.properties.appleIDFA' },
           retlOnMappingSave: {
             inputs: {},
             outputs: hookOutputs
@@ -109,7 +113,7 @@ describe('FacebookCustomAudiences.sync', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"payload\\":{\\"schema\\":[\\"EXTERN_ID\\",\\"EMAIL\\",\\"PHONE\\",\\"GEN\\",\\"DOBY\\",\\"DOBM\\",\\"DOBD\\",\\"LN\\",\\"FN\\",\\"FI\\",\\"CT\\",\\"ST\\",\\"ZIP\\",\\"MADID\\",\\"COUNTRY\\"],\\"data\\":[[\\"1234\\",\\"816341caf0c06dbc4c156d3465323f52b3cb62533241d5f9247c008f657e8343\\",\\"a5ad7e6d5225ad00c5f05ddb6bb3b1597a843cc92f6cf188490ffcb88a1ef4ef\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"1a6bd4d9d79dc0a79b53795c70d3349fa9e38968a3fbefbfe8783efb1d2b6aac\\",\\"6959097001d10501ac7d54c0bdb8db61420f658f2922cc26e46d536119a31126\\",\\"ad16c1a6866c5887c5b59c1803cb1fc09769f1b403b6f1d9d0f10ad6ab4d5d50\\",\\"\\",\\"79adb2a2fce5c6ba215fe5f27f532d4e7edbac4b6a5e09e1ef3a08084a904621\\"]]}}"`
+        `"{\\"payload\\":{\\"schema\\":[\\"EXTERN_ID\\",\\"EMAIL\\",\\"PHONE\\",\\"GEN\\",\\"DOBY\\",\\"DOBM\\",\\"DOBD\\",\\"LN\\",\\"FN\\",\\"FI\\",\\"CT\\",\\"ST\\",\\"ZIP\\",\\"MADID\\",\\"COUNTRY\\"],\\"data\\":[[\\"1234\\",\\"816341caf0c06dbc4c156d3465323f52b3cb62533241d5f9247c008f657e8343\\",\\"a5ad7e6d5225ad00c5f05ddb6bb3b1597a843cc92f6cf188490ffcb88a1ef4ef\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"1a6bd4d9d79dc0a79b53795c70d3349fa9e38968a3fbefbfe8783efb1d2b6aac\\",\\"6959097001d10501ac7d54c0bdb8db61420f658f2922cc26e46d536119a31126\\",\\"ad16c1a6866c5887c5b59c1803cb1fc09769f1b403b6f1d9d0f10ad6ab4d5d50\\",\\"2024\\",\\"79adb2a2fce5c6ba215fe5f27f532d4e7edbac4b6a5e09e1ef3a08084a904621\\"]]}}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/index.test.ts
@@ -36,7 +36,6 @@ describe('FacebookCustomAudiences.sync', () => {
         zip_code: '92000',
         address: '123 Main St',
         email: '816341caf0c06dbc4c156d3465323f52b3cb62533241d5f9247c008f657e8343', // pre-hashed email: nick@email.com
-        app_ids: [],
         appleIDFA: '2024'
       }
     })
@@ -64,7 +63,8 @@ describe('FacebookCustomAudiences.sync', () => {
                 '2024', // mobile_advertiser_id,
                 sha256SmartHash(normalizationFunctions.get('country')!('US'))
               ]
-            ]
+            ],
+            app_ids: ['2024']
           }
         })
         .reply(200, { test: 'test' })
@@ -82,7 +82,7 @@ describe('FacebookCustomAudiences.sync', () => {
           zip: { '@path': '$.properties.zip_code' },
           country: 'US',
           externalId: { '@path': '$.properties.id' },
-          appIds: { '@path': '$.properties.app_ids' },
+          appId: { '@path': '$.properties.appleIDFA' },
           mobileAdId: { '@path': '$.properties.appleIDFA' },
           retlOnMappingSave: {
             inputs: {},
@@ -113,7 +113,7 @@ describe('FacebookCustomAudiences.sync', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"payload\\":{\\"schema\\":[\\"EXTERN_ID\\",\\"EMAIL\\",\\"PHONE\\",\\"GEN\\",\\"DOBY\\",\\"DOBM\\",\\"DOBD\\",\\"LN\\",\\"FN\\",\\"FI\\",\\"CT\\",\\"ST\\",\\"ZIP\\",\\"MADID\\",\\"COUNTRY\\"],\\"data\\":[[\\"1234\\",\\"816341caf0c06dbc4c156d3465323f52b3cb62533241d5f9247c008f657e8343\\",\\"a5ad7e6d5225ad00c5f05ddb6bb3b1597a843cc92f6cf188490ffcb88a1ef4ef\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"1a6bd4d9d79dc0a79b53795c70d3349fa9e38968a3fbefbfe8783efb1d2b6aac\\",\\"6959097001d10501ac7d54c0bdb8db61420f658f2922cc26e46d536119a31126\\",\\"ad16c1a6866c5887c5b59c1803cb1fc09769f1b403b6f1d9d0f10ad6ab4d5d50\\",\\"2024\\",\\"79adb2a2fce5c6ba215fe5f27f532d4e7edbac4b6a5e09e1ef3a08084a904621\\"]]}}"`
+        `"{\\"payload\\":{\\"schema\\":[\\"EXTERN_ID\\",\\"EMAIL\\",\\"PHONE\\",\\"GEN\\",\\"DOBY\\",\\"DOBM\\",\\"DOBD\\",\\"LN\\",\\"FN\\",\\"FI\\",\\"CT\\",\\"ST\\",\\"ZIP\\",\\"MADID\\",\\"COUNTRY\\"],\\"data\\":[[\\"1234\\",\\"816341caf0c06dbc4c156d3465323f52b3cb62533241d5f9247c008f657e8343\\",\\"a5ad7e6d5225ad00c5f05ddb6bb3b1597a843cc92f6cf188490ffcb88a1ef4ef\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"1a6bd4d9d79dc0a79b53795c70d3349fa9e38968a3fbefbfe8783efb1d2b6aac\\",\\"6959097001d10501ac7d54c0bdb8db61420f658f2922cc26e46d536119a31126\\",\\"ad16c1a6866c5887c5b59c1803cb1fc09769f1b403b6f1d9d0f10ad6ab4d5d50\\",\\"2024\\",\\"79adb2a2fce5c6ba215fe5f27f532d4e7edbac4b6a5e09e1ef3a08084a904621\\"]],\\"app_ids\\":[\\"2024\\"]}}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/generated-types.ts
@@ -2,19 +2,23 @@
 
 export interface Payload {
   /**
-   * The email address of the user.
+   * Your company’s custom identifier for this user. This can be any unique ID, such as loyalty membership IDs, user IDs, and external cookie IDs.
+   */
+  externalId: string
+  /**
+   * User’s email (ex: foo@bar.com)
    */
   email?: string
   /**
-   * The phone number of the user.
+   * User’s phone number, including country code. Punctuation and spaces are ok (ex: 1-234-567-8910 or +44 844 412 4653)
    */
   phone?: string
   /**
-   * The gender of the user.
+   * User’s country. Use 2-letter country codes in ISO 3166-1 alpha-2 format.
    */
-  gender?: string
+  country?: string
   /**
-   * The date of birth of the user.
+   * User’s date of birth. Include as many fields as possible for better match rates (ex: year = YYYY, month = MM, day = DD)
    */
   birth?: {
     year?: string
@@ -22,7 +26,7 @@ export interface Payload {
     day?: string
   }
   /**
-   * The name of the user.
+   * User’s name. Include as many fields as possible for better match rates. Use a-z only. No punctuation. Special characters in UTF-8 format
    */
   name?: {
     first?: string
@@ -30,29 +34,25 @@ export interface Payload {
     firstInitial?: string
   }
   /**
-   * The city of the user
+   * User’s city. Use a-z only. No punctuation. No special characters.
    */
   city?: string
   /**
-   * The state of the user.
+   * User’s state. Use the 2-character ANSI abbreviation code, Normalize states outside the US with no punctuation and no special characters.
    */
   state?: string
   /**
-   * The postal code of the user.
+   * User’s postal code. For the US, use only the first 5 digits. For the UK, use the Area/District/Sector format.
    */
   zip?: string
   /**
-   * The country of the user.
+   * User’s gender (m for male, f for female)
    */
-  country?: string
+  gender?: string
   /**
-   * The mobile advertising ID of the user.
+   * User’s Apple IDFA, Android Ad ID, or Facebook app scoped ID. Keep hyphens (ex: AB1234CD-E123-12FG-J123)
    */
   mobileAdId?: string
-  /**
-   * The external ID of the user.
-   */
-  externalId?: string
   /**
    * The app IDs of the user.
    */

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/generated-types.ts
@@ -54,13 +54,13 @@ export interface Payload {
    */
   mobileAdId?: string
   /**
-   * The app IDs of the user.
+   * The app ID of the user.
    */
-  appIds?: string[]
+  appId?: string
   /**
-   * The page IDs of the user.
+   * The page ID of the user.
    */
-  pageIds?: string[]
+  pageId?: string
   /**
    * Enable batching of requests.
    */

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/index.ts
@@ -157,27 +157,30 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: true,
       label: 'External ID',
-      description: 'The external ID of the user.'
+      description:
+        'Your company’s custom identifier for this user. This can be any unique ID, such as loyalty membership IDs, user IDs, and external cookie IDs.'
     },
     email: {
       type: 'string',
       label: 'Email',
-      description: 'The email address of the user.'
+      description: 'User’s email (ex: foo@bar.com)'
     },
     phone: {
       type: 'string',
       label: 'Phone',
-      description: 'The phone number of the user.'
+      description:
+        'User’s phone number, including country code. Punctuation and spaces are ok (ex: 1-234-567-8910 or +44 844 412 4653)'
     },
     country: {
       type: 'string',
       label: 'Country',
-      description: 'The country of the user.'
+      description: 'User’s country. Use 2-letter country codes in ISO 3166-1 alpha-2 format.'
     },
     birth: {
       type: 'object',
       label: 'Date of Birth',
-      description: 'The date of birth of the user.',
+      description:
+        'User’s date of birth. Include as many fields as possible for better match rates (ex: year = YYYY, month = MM, day = DD)',
       properties: {
         year: {
           type: 'string',
@@ -196,7 +199,8 @@ const action: ActionDefinition<Settings, Payload> = {
     name: {
       type: 'object',
       label: 'Name',
-      description: 'The name of the user.',
+      description:
+        'User’s name. Include as many fields as possible for better match rates. Use a-z only. No punctuation. Special characters in UTF-8 format',
       properties: {
         first: {
           type: 'string',
@@ -215,27 +219,30 @@ const action: ActionDefinition<Settings, Payload> = {
     city: {
       type: 'string',
       label: 'City',
-      description: 'The city of the user'
+      description: 'User’s city. Use a-z only. No punctuation. No special characters.'
     },
     state: {
       type: 'string',
       label: 'State',
-      description: 'The state of the user.'
+      description:
+        'User’s state. Use the 2-character ANSI abbreviation code, Normalize states outside the US with no punctuation and no special characters.'
     },
     zip: {
       type: 'string',
       label: 'Postal Code',
-      description: 'The postal code of the user.'
+      description:
+        'User’s postal code. For the US, use only the first 5 digits. For the UK, use the Area/District/Sector format.'
     },
     gender: {
       type: 'string',
       label: 'Gender',
-      description: 'The gender of the user.'
+      description: 'User’s gender (m for male, f for female)'
     },
     mobileAdId: {
       type: 'string',
       label: 'Mobile Advertising ID',
-      description: 'The mobile advertising ID of the user.'
+      description:
+        'User’s Apple IDFA, Android Ad ID, or Facebook app scoped ID. Keep hyphens (ex: AB1234CD-E123-12FG-J123)'
     },
     appIds: {
       type: 'string',

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/index.ts
@@ -153,6 +153,12 @@ const action: ActionDefinition<Settings, Payload> = {
     ]
   },
   fields: {
+    externalId: {
+      type: 'string',
+      required: true,
+      label: 'External ID',
+      description: 'The external ID of the user.'
+    },
     email: {
       type: 'string',
       label: 'Email',
@@ -230,11 +236,6 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       label: 'Mobile Advertising ID',
       description: 'The mobile advertising ID of the user.'
-    },
-    externalId: {
-      type: 'string',
-      label: 'External ID',
-      description: 'The external ID of the user.'
     },
     appIds: {
       type: 'string',

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/index.ts
@@ -169,10 +169,10 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Phone',
       description: 'The phone number of the user.'
     },
-    gender: {
+    country: {
       type: 'string',
-      label: 'Gender',
-      description: 'The gender of the user.'
+      label: 'Country',
+      description: 'The country of the user.'
     },
     birth: {
       type: 'object',
@@ -227,10 +227,10 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Postal Code',
       description: 'The postal code of the user.'
     },
-    country: {
+    gender: {
       type: 'string',
-      label: 'Country',
-      description: 'The country of the user.'
+      label: 'Gender',
+      description: 'The gender of the user.'
     },
     mobileAdId: {
       type: 'string',

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/index.ts
@@ -244,17 +244,15 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'User’s Apple IDFA, Android Ad ID, or Facebook app scoped ID. Keep hyphens (ex: AB1234CD-E123-12FG-J123)'
     },
-    appIds: {
+    appId: {
       type: 'string',
-      multiple: true,
-      label: 'App IDs',
-      description: 'The app IDs of the user.'
+      label: 'App ID',
+      description: 'The app ID of the user.'
     },
-    pageIds: {
+    pageId: {
       type: 'string',
-      multiple: true,
-      label: 'Page IDs',
-      description: 'The page IDs of the user.'
+      label: 'Page ID',
+      description: 'The page ID of the user.'
     },
     enable_batching,
     batch_size


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR makes some final pre-release updates to the FB Custom Audiences destination:

- Marks 'external ID' as required
- Updates handling of app IDs and page IDs arrays to match FB expectations
- Updates descriptions for all fields
- Moves country field up the page and gender field down the page
- Implement smart hashing using the utility function in actions-core and adds a smart hashing class that supports checking whether a value is hashed first, which enables normalization flows.

## Testing

Tested successfully in stage

The external ID field is required & the field descriptions are updated & `country` appears near the top:
<img width="1236" alt="Screenshot 2024-08-07 at 9 30 02 AM" src="https://github.com/user-attachments/assets/da4b746d-7500-486e-a840-c9a3c9c8f065">

Event delivery with the configured mapping continues to succeed:
<img width="1698" alt="Screenshot 2024-08-07 at 9 34 09 AM" src="https://github.com/user-attachments/assets/dc4d9e1a-369a-43da-9843-0eac468f4a10">

<img width="690" alt="Screenshot 2024-08-07 at 9 34 17 AM" src="https://github.com/user-attachments/assets/2ad2a74c-3819-4b22-9a0e-b6df6685e4d2">


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
