### PR TITLE
schematic destination - fix company key bug

### DIFF
--- a/packages/destination-actions/src/destinations/schematic/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/schematic/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -14,7 +14,7 @@ Object {
       },
     },
     "keys": Object {
-      "user_id": "G10lVP",
+      "userId": "G10lVP",
     },
     "name": "G10lVP",
     "traits": Object {
@@ -54,7 +54,7 @@ Object {
       "raw_event_name": "uvfeUI#M",
     },
     "user": Object {
-      "user_id": "uvfeUI#M",
+      "userId": "uvfeUI#M",
     },
   },
   "sent_at": "2023-01-01T00:00:00.000Z",

--- a/packages/destination-actions/src/destinations/schematic/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/schematic/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -14,7 +14,7 @@ Object {
       },
     },
     "keys": Object {
-      "user_id": "A7WJL)2NKFy&pmtr0",
+      "userId": "A7WJL)2NKFy&pmtr0",
     },
     "name": "A7WJL)2NKFy&pmtr0",
     "traits": Object {

--- a/packages/destination-actions/src/destinations/schematic/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/schematic/identifyUser/generated-types.ts
@@ -28,7 +28,7 @@ export interface Payload {
     /**
      * Your unique ID for your user
      */
-    user_id?: string
+    userId?: string
     [k: string]: unknown
   }
   /**

--- a/packages/destination-actions/src/destinations/schematic/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/schematic/identifyUser/index.ts
@@ -13,7 +13,10 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'object',
       required: true,
       defaultObjectUI: 'keyvalue',
-      additionalProperties: true
+      additionalProperties: true,
+      default: {
+        groupId: { '@path': '$.context.groupId' }
+      }
     },
     company_name: {
       label: 'Company name',
@@ -44,7 +47,7 @@ const action: ActionDefinition<Settings, Payload> = {
       required: true,
       additionalProperties: true,
       properties: {
-        user_id: {
+        userId: {
           label: 'User ID',
           description: 'Your unique ID for your user',
           type: 'string',
@@ -52,7 +55,7 @@ const action: ActionDefinition<Settings, Payload> = {
         }
       },
       default: {
-        user_id: { '@path': '$.userId' }
+        userId: { '@path': '$.userId' }
       }
     },
     user_name: {

--- a/packages/destination-actions/src/destinations/schematic/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/schematic/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -12,7 +12,7 @@ Object {
       "raw_event_name": "H%fspr!Jez(TWP",
     },
     "user": Object {
-      "user_id": "H%fspr!Jez(TWP",
+      "userId": "H%fspr!Jez(TWP",
     },
   },
   "sent_at": "2021-02-01T00:00:00.000Z",

--- a/packages/destination-actions/src/destinations/schematic/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/schematic/trackEvent/generated-types.ts
@@ -22,7 +22,7 @@ export interface Payload {
     /**
      * Your unique ID for your user
      */
-    user_id?: string
+    userId?: string
     [k: string]: unknown
   }
   /**

--- a/packages/destination-actions/src/destinations/schematic/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/schematic/trackEvent/index.ts
@@ -75,7 +75,7 @@ const action: ActionDefinition<Settings, Payload> = {
       defaultObjectUI: 'keyvalue',
       additionalProperties: true,
       properties: {
-        user_id: {
+        userId: {
           label: 'User ID',
           description: 'Your unique ID for your user',
           type: 'string',
@@ -83,7 +83,7 @@ const action: ActionDefinition<Settings, Payload> = {
         }
       },
       default: {
-        user_id: { '@path': '$.userId' }
+        userId: { '@path': '$.userId' }
       }
     },
     traits: {


### PR DESCRIPTION
When creating the destination, the preset mappings are causing a validation issue. Specifically, in the Identify User preset, the company_keys field is marked as required, and because there is no default value for this field, we fail to create the destination mapping, and thus the destination.

![image](https://github.com/user-attachments/assets/bf9ba3c6-a66d-43f8-8593-cb66d514a8c1)


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
