### PR TITLE
[SALESFORCE] Add Sync Mode Support to "Lead" action

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/__tests__/lead2.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/lead2.test.ts
@@ -1,0 +1,532 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../index'
+import { API_VERSION } from '../sf-operations'
+
+const testDestination = createTestIntegration(Destination)
+
+const settings = {
+  instanceUrl: 'https://test.salesforce.com/'
+}
+const auth = {
+  refreshToken: 'xyz321',
+  accessToken: 'abc123'
+}
+
+describe('Salesforce', () => {
+  describe('Lead2', () => {
+    it('should create a lead record', async () => {
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).post('/Lead').reply(201, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Create Lead',
+        properties: {
+          email: 'sponge@seamail.com',
+          company: 'Krusty Krab',
+          last_name: 'Squarepants'
+        }
+      })
+
+      const responses = await testDestination.testAction('lead2', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          __segment_internal_sync_mode: 'add',
+          email: {
+            '@path': '$.properties.email'
+          },
+          company: {
+            '@path': '$.properties.company'
+          },
+          last_name: {
+            '@path': '$.properties.last_name'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].request.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "authorization": Array [
+              "Bearer abc123",
+            ],
+            "content-type": Array [
+              "application/json",
+            ],
+            "user-agent": Array [
+              "Segment (Actions)",
+            ],
+          },
+        }
+      `)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"LastName\\":\\"Squarepants\\",\\"Company\\":\\"Krusty Krab\\",\\"Email\\":\\"sponge@seamail.com\\"}"`
+      )
+    })
+
+    it('should delete a lead record given an Id', async () => {
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).delete('/Lead/123').reply(204, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Delete',
+        userId: '123'
+      })
+
+      const responses = await testDestination.testAction('lead2', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          __segment_internal_sync_mode: 'delete',
+          traits: {
+            Id: { '@path': '$.userId' }
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(204)
+    })
+
+    it('should delete a lead record given some lookup traits', async () => {
+      const query = encodeURIComponent(`SELECT Id FROM Lead WHERE Email = 'bob@bobsburgers.net'`)
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/query`)
+        .get(`/?q=${query}`)
+        .reply(201, {
+          totalSize: 1,
+          records: [{ Id: 'abc123' }]
+        })
+
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).delete('/Lead/abc123').reply(201, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Delete',
+        properties: {
+          email: 'bob@bobsburgers.net'
+        }
+      })
+
+      const responses = await testDestination.testAction('lead2', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          __segment_internal_sync_mode: 'delete',
+          traits: {
+            Email: { '@path': '$.properties.email' }
+          }
+        }
+      })
+
+      expect(responses.length).toBe(2)
+      expect(responses[0].status).toBe(201)
+      expect(responses[1].status).toBe(201)
+    })
+
+    it('should create a lead record with default mappings', async () => {
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).post('/Lead').reply(201, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Create Lead',
+        properties: {
+          email: 'sponge@seamail.com',
+          company: 'Krusty Krab',
+          address: {
+            city: 'Bikini Bottom',
+            postal_code: '12345',
+            country: 'The Ocean',
+            street: 'Pineapple Ln',
+            state: 'Water'
+          },
+          last_name: 'Bob',
+          first_name: 'Sponge'
+        }
+      })
+
+      const responses = await testDestination.testAction('lead2', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].request.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "authorization": Array [
+              "Bearer abc123",
+            ],
+            "content-type": Array [
+              "application/json",
+            ],
+            "user-agent": Array [
+              "Segment (Actions)",
+            ],
+          },
+        }
+      `)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"LastName\\":\\"Bob\\",\\"Company\\":\\"Krusty Krab\\",\\"FirstName\\":\\"Sponge\\",\\"State\\":\\"Water\\",\\"Street\\":\\"Pineapple Ln\\",\\"Country\\":\\"The Ocean\\",\\"PostalCode\\":\\"12345\\",\\"City\\":\\"Bikini Bottom\\",\\"Email\\":\\"sponge@seamail.com\\"}"`
+      )
+    })
+
+    it('should create a lead record with custom fields', async () => {
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).post('/Lead').reply(201, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Create Lead',
+        properties: {
+          email: 'sponge@seamail.com',
+          company: 'Krusty Krab',
+          last_name: 'Squarepants'
+        }
+      })
+
+      const responses = await testDestination.testAction('lead2', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          __segment_internal_sync_mode: 'add',
+          email: {
+            '@path': '$.properties.email'
+          },
+          company: {
+            '@path': '$.properties.company'
+          },
+          last_name: {
+            '@path': '$.properties.last_name'
+          },
+          customFields: {
+            A: '1',
+            B: '2',
+            C: '3'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].request.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "authorization": Array [
+              "Bearer abc123",
+            ],
+            "content-type": Array [
+              "application/json",
+            ],
+            "user-agent": Array [
+              "Segment (Actions)",
+            ],
+          },
+        }
+      `)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"LastName\\":\\"Squarepants\\",\\"Company\\":\\"Krusty Krab\\",\\"Email\\":\\"sponge@seamail.com\\",\\"A\\":\\"1\\",\\"B\\":\\"2\\",\\"C\\":\\"3\\"}"`
+      )
+    })
+
+    it('should update a lead record', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Update Lead',
+        properties: {
+          email: 'sponge@seamail.com',
+          company: 'Krusty Krab LLC',
+          last_name: 'Squarepants',
+          address: {
+            city: 'Bikini Bottom',
+            postal_code: '12345',
+            street: 'Pineapple St'
+          }
+        }
+      })
+
+      const query = encodeURIComponent(`SELECT Id FROM Lead WHERE company = 'Krusty Krab'`)
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/query`)
+        .get(`/?q=${query}`)
+        .reply(201, {
+          Id: 'abc123',
+          totalSize: 1,
+          records: [{ Id: '123456' }]
+        })
+
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).patch('/Lead/123456').reply(201, {})
+
+      const responses = await testDestination.testAction('lead2', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          __segment_internal_sync_mode: 'update',
+          traits: {
+            company: 'Krusty Krab'
+          },
+          email: {
+            '@path': '$.properties.email'
+          },
+          company: {
+            '@path': '$.properties.company'
+          },
+          last_name: {
+            '@path': '$.properties.last_name'
+          },
+          city: {
+            '@path': '$.properties.address.city'
+          },
+          postal_code: {
+            '@path': '$.properties.address.postal_code'
+          },
+          street: {
+            '@path': '$.properties.address.street'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(2)
+      expect(responses[0].status).toBe(201)
+      expect(responses[1].status).toBe(201)
+
+      expect(responses[0].request.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "authorization": Array [
+              "Bearer abc123",
+            ],
+            "user-agent": Array [
+              "Segment (Actions)",
+            ],
+          },
+        }
+      `)
+
+      expect(responses[1].options.body).toMatchInlineSnapshot(
+        `"{\\"LastName\\":\\"Squarepants\\",\\"Company\\":\\"Krusty Krab LLC\\",\\"Street\\":\\"Pineapple St\\",\\"PostalCode\\":\\"12345\\",\\"City\\":\\"Bikini Bottom\\",\\"Email\\":\\"sponge@seamail.com\\"}"`
+      )
+    })
+
+    it('should upsert an existing record', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Upsert Lead',
+        properties: {
+          email: 'sponge@seamail.com',
+          company: 'Krusty Krab LLC',
+          last_name: 'Squarepants',
+          address: {
+            city: 'Bikini Bottom',
+            postal_code: '12345',
+            street: 'Pineapple St'
+          }
+        }
+      })
+
+      const query = encodeURIComponent(`SELECT Id FROM Lead WHERE company = 'Krusty Krab'`)
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/query`)
+        .get(`/?q=${query}`)
+        .reply(201, {
+          Id: 'abc123',
+          totalSize: 1,
+          records: [{ Id: '123456' }]
+        })
+
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).patch('/Lead/123456').reply(201, {})
+
+      const responses = await testDestination.testAction('lead2', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          __segment_internal_sync_mode: 'upsert',
+          traits: {
+            company: 'Krusty Krab'
+          },
+          email: {
+            '@path': '$.properties.email'
+          },
+          company: {
+            '@path': '$.properties.company'
+          },
+          last_name: {
+            '@path': '$.properties.last_name'
+          },
+          city: {
+            '@path': '$.properties.address.city'
+          },
+          postal_code: {
+            '@path': '$.properties.address.postal_code'
+          },
+          street: {
+            '@path': '$.properties.address.street'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(2)
+      expect(responses[0].status).toBe(201)
+      expect(responses[1].status).toBe(201)
+
+      expect(responses[0].request.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "authorization": Array [
+              "Bearer abc123",
+            ],
+            "user-agent": Array [
+              "Segment (Actions)",
+            ],
+          },
+        }
+      `)
+
+      expect(responses[1].options.body).toMatchInlineSnapshot(
+        `"{\\"LastName\\":\\"Squarepants\\",\\"Company\\":\\"Krusty Krab LLC\\",\\"Street\\":\\"Pineapple St\\",\\"PostalCode\\":\\"12345\\",\\"City\\":\\"Bikini Bottom\\",\\"Email\\":\\"sponge@seamail.com\\"}"`
+      )
+    })
+
+    it('should upsert a nonexistent record', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Upsert Lead',
+        properties: {
+          email: 'sponge@seamail.com',
+          company: 'Krusty Krab LLC',
+          last_name: 'Squarepants',
+          address: {
+            city: 'Bikini Bottom',
+            postal_code: '12345',
+            street: 'Pineapple St'
+          }
+        }
+      })
+
+      const query = encodeURIComponent(`SELECT Id FROM Lead WHERE company = 'Krusty Krab'`)
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/query`).get(`/?q=${query}`).reply(201, {
+        Id: 'abc123',
+        totalSize: 0
+      })
+
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).post('/Lead').reply(201, {})
+
+      const responses = await testDestination.testAction('lead2', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          __segment_internal_sync_mode: 'upsert',
+          traits: {
+            company: 'Krusty Krab'
+          },
+          email: {
+            '@path': '$.properties.email'
+          },
+          company: {
+            '@path': '$.properties.company'
+          },
+          last_name: {
+            '@path': '$.properties.last_name'
+          },
+          city: {
+            '@path': '$.properties.address.city'
+          },
+          postal_code: {
+            '@path': '$.properties.address.postal_code'
+          },
+          street: {
+            '@path': '$.properties.address.street'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(2)
+      expect(responses[0].status).toBe(201)
+      expect(responses[1].status).toBe(201)
+
+      expect(responses[0].request.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "authorization": Array [
+              "Bearer abc123",
+            ],
+            "user-agent": Array [
+              "Segment (Actions)",
+            ],
+          },
+        }
+      `)
+
+      expect(responses[1].options.body).toMatchInlineSnapshot(
+        `"{\\"LastName\\":\\"Squarepants\\",\\"Company\\":\\"Krusty Krab LLC\\",\\"Street\\":\\"Pineapple St\\",\\"PostalCode\\":\\"12345\\",\\"City\\":\\"Bikini Bottom\\",\\"Email\\":\\"sponge@seamail.com\\"}"`
+      )
+    })
+
+    describe('batching', () => {
+      it('should fail if delete is set as syncMode', async () => {
+        const event = createTestEvent({
+          type: 'track',
+          event: 'Delete',
+          userId: '123'
+        })
+
+        await expect(async () => {
+          await testDestination.testBatchAction('lead2', {
+            events: [event],
+            settings,
+            auth,
+            mapping: {
+              __segment_internal_sync_mode: 'delete',
+              enable_batching: true,
+              traits: {
+                Id: { '@path': '$.userId' }
+              }
+            }
+          })
+        }).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"Unsupported operation: Bulk API does not support the delete operation"`
+        )
+      })
+    })
+
+    it('should fail if syncMode is undefined', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Delete',
+        userId: '123'
+      })
+
+      await expect(async () => {
+        await testDestination.testBatchAction('lead2', {
+          events: [event],
+          settings,
+          auth,
+          mapping: {
+            enable_batching: true,
+            traits: {
+              Id: { '@path': '$.userId' }
+            }
+          }
+        })
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"syncMode is required"`)
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/lead2.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/lead2.test.ts
@@ -505,6 +505,28 @@ describe('Salesforce', () => {
           `"Unsupported operation: Bulk API does not support the delete operation"`
         )
       })
+
+      it('should fail if syncMode is undefined', async () => {
+        const event = createTestEvent({
+          type: 'track',
+          event: 'Delete',
+          userId: '123'
+        })
+
+        await expect(async () => {
+          await testDestination.testBatchAction('lead2', {
+            events: [event],
+            settings,
+            auth,
+            mapping: {
+              enable_batching: true,
+              traits: {
+                Id: { '@path': '$.userId' }
+              }
+            }
+          })
+        }).rejects.toThrowErrorMatchingInlineSnapshot(`"syncMode is required"`)
+      })
     })
 
     it('should fail if syncMode is undefined', async () => {

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
@@ -555,8 +555,7 @@ describe('Salesforce', () => {
       nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest`)
         .post('', {
           object: 'Account',
-          operation: 'insert', // I think it was a mistake because the operation is 'create' in the payload. Please advise @nick.
-          // This impacts line 185 of sf-utils.ts
+          operation: 'insert',
           contentType: 'CSV'
         })
         .reply(201, {

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
@@ -774,6 +774,325 @@ describe('Salesforce', () => {
     })
   })
 
+  describe('Bulk Operations With Sync Mode', () => {
+    const sf: Salesforce = new Salesforce(settings.instanceUrl, requestClient)
+
+    const bulkInsertPayloads: GenericPayload[] = [
+      {
+        operation: 'create',
+        enable_batching: true,
+        name: 'SpongeBob Squarepants',
+        phone: '1234567890',
+        description: 'Krusty Krab'
+      },
+      {
+        operation: 'create',
+        enable_batching: true,
+        name: 'Squidward Tentacles',
+        phone: '1234567891',
+        description: 'Krusty Krab'
+      }
+    ]
+
+    const bulkUpsertPayloads: GenericPayload[] = [
+      {
+        operation: 'upsert',
+        enable_batching: true,
+        bulkUpsertExternalId: {
+          externalIdName: 'test__c',
+          externalIdValue: 'ab'
+        },
+        name: 'SpongeBob Squarepants',
+        phone: '1234567890',
+        description: 'Krusty Krab'
+      },
+      {
+        operation: 'upsert',
+        enable_batching: true,
+        bulkUpsertExternalId: {
+          externalIdName: 'test__c',
+          externalIdValue: 'cd'
+        },
+        name: 'Squidward Tentacles',
+        phone: '1234567891',
+        description: 'Krusty Krab'
+      }
+    ]
+
+    const customPayloads: GenericPayload[] = [
+      {
+        operation: 'upsert',
+        enable_batching: true,
+        bulkUpsertExternalId: {
+          externalIdName: 'test__c',
+          externalIdValue: 'ab'
+        },
+        name: 'SpongeBob Squarepants',
+        phone: '1234567890',
+        description: 'Krusty Krab',
+        customFields: {
+          TickerSymbol: 'KRAB'
+        }
+      },
+      {
+        operation: 'upsert',
+        enable_batching: true,
+        bulkUpsertExternalId: {
+          externalIdName: 'test__c',
+          externalIdValue: 'cd'
+        },
+        name: 'Squidward Tentacles',
+        phone: '1234567891',
+        description: 'Krusty Krab',
+        customFields: {
+          TickerSymbol: 'KRAB'
+        }
+      }
+    ]
+
+    const bulkUpdatePayloads: GenericPayload[] = [
+      {
+        operation: 'update',
+        enable_batching: true,
+        bulkUpdateRecordId: 'ab',
+        name: 'SpongeBob Squarepants',
+        phone: '1234567890',
+        description: 'Krusty Krab'
+      },
+      {
+        operation: 'update',
+        enable_batching: true,
+        bulkUpdateRecordId: 'cd',
+        name: 'Squidward Tentacles',
+        phone: '1234567891',
+        description: 'Krusty Krab'
+      }
+    ]
+
+    it('should correctly insert a batch of records', async () => {
+      //create bulk job
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest`)
+        .post('', {
+          object: 'Account',
+          operation: 'insert', // I think it was a mistake because the operation is 'create' in the payload. Please advise @nick.
+          // This impacts line 185 of sf-utils.ts
+          contentType: 'CSV'
+        })
+        .reply(201, {
+          id: 'abc123'
+        })
+
+      const CSV = `Name,Phone,Description\n"SpongeBob Squarepants","1234567890","Krusty Krab"\n"Squidward Tentacles","1234567891","Krusty Krab"\n`
+
+      //upload csv
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest/abc123/batches`, {
+        reqheaders: {
+          'Content-Type': 'text/csv',
+          Accept: 'application/json'
+        }
+      })
+        .put('', CSV)
+        .reply(201, {})
+
+      //close bulk job
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest/abc123`)
+        .patch('', {
+          state: 'UploadComplete'
+        })
+        .reply(201, {})
+
+      await sf.bulkHandlerWithSyncMode(bulkInsertPayloads, 'Account', 'add') // add is the syncMode setting not "create" nor "insert"
+    })
+
+    it('should correctly upsert a batch of records', async () => {
+      //create bulk job
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest`)
+        .post('', {
+          object: 'Account',
+          externalIdFieldName: 'test__c',
+          operation: 'upsert',
+          contentType: 'CSV'
+        })
+        .reply(201, {
+          id: 'abc123'
+        })
+
+      const CSV = `Name,Phone,Description,test__c\n"SpongeBob Squarepants","1234567890","Krusty Krab","ab"\n"Squidward Tentacles","1234567891","Krusty Krab","cd"\n`
+
+      //upload csv
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest/abc123/batches`, {
+        reqheaders: {
+          'Content-Type': 'text/csv',
+          Accept: 'application/json'
+        }
+      })
+        .put('', CSV)
+        .reply(201, {})
+
+      //close bulk job
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest/abc123`)
+        .patch('', {
+          state: 'UploadComplete'
+        })
+        .reply(201, {})
+
+      await sf.bulkHandlerWithSyncMode(bulkUpsertPayloads, 'Account', 'upsert')
+    })
+
+    it('should correctly parse the customFields object', async () => {
+      //create bulk job
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest`)
+        .post('', {
+          object: 'Account',
+          externalIdFieldName: 'test__c',
+          operation: 'upsert',
+          contentType: 'CSV'
+        })
+        .reply(201, {
+          id: 'xyz987'
+        })
+
+      const CSV = `Name,Phone,Description,TickerSymbol,test__c\n"SpongeBob Squarepants","1234567890","Krusty Krab","KRAB","ab"\n"Squidward Tentacles","1234567891","Krusty Krab","KRAB","cd"\n`
+
+      //upload csv
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest/xyz987/batches`, {
+        reqheaders: {
+          'Content-Type': 'text/csv',
+          Accept: 'application/json'
+        }
+      })
+        .put('', CSV)
+        .reply(201, {})
+
+      //close bulk job
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest/xyz987`)
+        .patch('', {
+          state: 'UploadComplete'
+        })
+        .reply(201, {})
+
+      await sf.bulkHandlerWithSyncMode(customPayloads, 'Account', 'upsert')
+    })
+
+    it('should correctly update a batch of records', async () => {
+      //create bulk job
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest`)
+        .post('', {
+          object: 'Account',
+          externalIdFieldName: 'Id',
+          operation: 'update',
+          contentType: 'CSV'
+        })
+        .reply(201, {
+          id: 'abc123'
+        })
+
+      const CSV = `Name,Phone,Description,Id\n"SpongeBob Squarepants","1234567890","Krusty Krab","ab"\n"Squidward Tentacles","1234567891","Krusty Krab","cd"\n`
+
+      //upload csv
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest/abc123/batches`, {
+        reqheaders: {
+          'Content-Type': 'text/csv',
+          Accept: 'application/json'
+        }
+      })
+        .put('', CSV)
+        .reply(201, {})
+
+      //close bulk job
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest/abc123`)
+        .patch('', {
+          state: 'UploadComplete'
+        })
+        .reply(201, {})
+
+      await sf.bulkHandlerWithSyncMode(bulkUpdatePayloads, 'Account', 'update')
+    })
+
+    it('should pass NO_VALUE when a bulk record ID is missing', async () => {
+      const missingRecordPayload = {
+        operation: 'update',
+        enable_batching: true,
+        bulkUpdateRecordId: undefined,
+        name: 'Plankton',
+        phone: '123-evil',
+        description: 'Proprietor of the 1 star restaurant, The Chum Bucket'
+      }
+
+      //create bulk job
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest`)
+        .post('', {
+          object: 'Account',
+          externalIdFieldName: 'Id',
+          operation: 'update',
+          contentType: 'CSV'
+        })
+        .reply(201, {
+          id: 'abc123'
+        })
+
+      const CSV = `Name,Phone,Description,Id\n"SpongeBob Squarepants","1234567890","Krusty Krab","ab"\n"Squidward Tentacles","1234567891","Krusty Krab","cd"\n"Plankton","123-evil","Proprietor of the 1 star restaurant, The Chum Bucket","#N/A"\n`
+
+      //upload csv
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest/abc123/batches`, {
+        reqheaders: {
+          'Content-Type': 'text/csv',
+          Accept: 'application/json'
+        }
+      })
+        .put('', CSV)
+        .reply(201, {})
+
+      //close bulk job
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest/abc123`)
+        .patch('', {
+          state: 'UploadComplete'
+        })
+        .reply(201, {})
+
+      await sf.bulkHandlerWithSyncMode([...bulkUpdatePayloads, missingRecordPayload], 'Account', 'update')
+    })
+
+    it('should fail if a user selects a bulk delete operation', async () => {
+      const payloads: GenericPayload[] = [
+        {
+          operation: 'delete',
+          enable_batching: true,
+          name: 'SpongeBob Squarepants',
+          phone: '1234567890',
+          description: 'Krusty Krab'
+        }
+      ]
+
+      await expect(sf.bulkHandlerWithSyncMode(payloads, 'Account', 'delete')).rejects.toThrow(
+        'Unsupported operation: Bulk API does not support the delete operation'
+      )
+    })
+
+    it('should fail if the bulkHandler is triggered but enable_batching is not true', async () => {
+      const payloads: GenericPayload[] = [
+        {
+          operation: 'upsert',
+          enable_batching: false,
+          name: 'SpongeBob Squarepants',
+          phone: '1234567890',
+          description: 'Krusty Krab'
+        },
+        {
+          operation: 'upsert',
+          enable_batching: false,
+          name: 'Squidward Tentacles',
+          phone: '1234567891',
+          description: 'Krusty Krab'
+        }
+      ]
+
+      await expect(sf.bulkHandlerWithSyncMode(payloads, 'Account', 'upsert')).rejects.toThrow(
+        'Bulk operation triggered where enable_batching is false.'
+      )
+    })
+  })
+
   describe('Username & Password flow', () => {
     const usernamePasswordOnly: Settings = {
       username: 'spongebob@seamail.com',

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-operations.test.ts
@@ -555,7 +555,8 @@ describe('Salesforce', () => {
       nock(`${settings.instanceUrl}services/data/${API_VERSION}/jobs/ingest`)
         .post('', {
           object: 'Account',
-          operation: 'insert',
+          operation: 'insert', // I think it was a mistake because the operation is 'create' in the payload. Please advise @nick.
+          // This impacts line 185 of sf-utils.ts
           contentType: 'CSV'
         })
         .reply(201, {

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
@@ -137,7 +137,7 @@ describe('Salesforce Utils', () => {
         }
       ]
 
-      const csv = buildCSVData(createPayloads, '', 'create')
+      const csv = buildCSVData(createPayloads, '', 'insert')
       const expected = `Name,Phone,Description\n"SpongeBob Squarepants","1234567890","Krusty Krab"\n"Squidward Tentacles","1234567891","Krusty Krab"\n`
 
       expect(csv).toEqual(expected)
@@ -159,7 +159,7 @@ describe('Salesforce Utils', () => {
         }
       ]
 
-      const csv = buildCSVData(incompleteCreatePayloads, '', 'create')
+      const csv = buildCSVData(incompleteCreatePayloads, '', 'insert')
       const expected = `Name,Description,Phone\n"SpongeBob Squarepants",#N/A,"1234567890"\n"Squidward Tentacles","Krusty Krab",#N/A\n`
 
       expect(csv).toEqual(expected)

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
@@ -33,11 +33,12 @@ describe('Salesforce Utils', () => {
         }
       ]
 
-      const csv = buildCSVData(completePayloads, 'test__c')
+      const csv = buildCSVData(completePayloads, 'test__c', 'upsert')
       const expected = `Name,Email,Phone,test__c\n"SpongeBob SquarePants","sponge@seamail.com","555-555-5555","00"\n"Patrick Star","star@seamail.com","555-555-5555","01"\n`
 
       expect(csv).toEqual(expected)
     })
+
     it('should correctly build a CSV from payloads with incomplete data', async () => {
       const incompletePayloads: GenericPayload[] = [
         {
@@ -75,7 +76,7 @@ describe('Salesforce Utils', () => {
         }
       ]
 
-      const csv = buildCSVData(incompletePayloads, 'test__c')
+      const csv = buildCSVData(incompletePayloads, 'test__c', 'upsert')
       const expected = `Name,MailingState,Phone,Email,FavoriteFood,test__c\n"SpongeBob Squarepants",#N/A,#N/A,"sponge@seamail.com","Krabby Patty","00"\n"Patrick Star",#N/A,"123-456-7890",#N/A,#N/A,"01"\n"Sandy Cheeks","Texas",#N/A,#N/A,#N/A,"11"\n`
 
       expect(csv).toEqual(expected)
@@ -114,7 +115,7 @@ describe('Salesforce Utils', () => {
       ]
 
       expect(() => {
-        buildCSVData(invalidCustomFieldPayloads, 'test__c')
+        buildCSVData(invalidCustomFieldPayloads, 'test__c', 'upsert')
       }).toThrowError(`Invalid character in field name: a,weird,field`)
     })
 
@@ -136,7 +137,7 @@ describe('Salesforce Utils', () => {
         }
       ]
 
-      const csv = buildCSVData(createPayloads, '')
+      const csv = buildCSVData(createPayloads, '', 'create')
       const expected = `Name,Phone,Description\n"SpongeBob Squarepants","1234567890","Krusty Krab"\n"Squidward Tentacles","1234567891","Krusty Krab"\n`
 
       expect(csv).toEqual(expected)
@@ -158,7 +159,7 @@ describe('Salesforce Utils', () => {
         }
       ]
 
-      const csv = buildCSVData(incompleteCreatePayloads, '')
+      const csv = buildCSVData(incompleteCreatePayloads, '', 'create')
       const expected = `Name,Description,Phone\n"SpongeBob Squarepants",#N/A,"1234567890"\n"Squidward Tentacles","Krusty Krab",#N/A\n`
 
       expect(csv).toEqual(expected)
@@ -184,7 +185,7 @@ describe('Salesforce Utils', () => {
         }
       ]
 
-      const csv = buildCSVData(updatePayloads, 'Id')
+      const csv = buildCSVData(updatePayloads, 'Id', 'update')
       const expected = `Name,Phone,Description,Id\n"SpongeBob Squarepants","1234567890","Krusty Krab","00"\n"Squidward Tentacles","1234567891","Krusty Krab","01"\n`
 
       expect(csv).toEqual(expected)
@@ -208,7 +209,7 @@ describe('Salesforce Utils', () => {
         }
       ]
 
-      const csv = buildCSVData(incompleteUpdatePayloads, 'Id')
+      const csv = buildCSVData(incompleteUpdatePayloads, 'Id', 'Update')
       const expected = `Name,Description,Phone,Id\n"SpongeBob Squarepants",#N/A,"1234567890","00"\n"Squidward Tentacles","Krusty Krab",#N/A,"01"\n`
 
       expect(csv).toEqual(expected)
@@ -238,7 +239,7 @@ describe('Salesforce Utils', () => {
         }
       ]
 
-      const csv = buildCSVData(nullPayloads, 'test__c')
+      const csv = buildCSVData(nullPayloads, 'test__c', 'upsert')
       const expected = `Name,Description,test__c\n"SpongeBob Squarepants",#N/A,"00"\n"Squidward Tentacles",#N/A,"01"\n`
 
       expect(csv).toEqual(expected)
@@ -262,7 +263,7 @@ describe('Salesforce Utils', () => {
         }
       ]
 
-      const csv = buildCSVData(updatePayloads, 'Id')
+      const csv = buildCSVData(updatePayloads, 'Id', 'update')
       const expected = `Name,Description,Id\n"Sponge """"Bob"""" ""Square"" ""pants""",#N/A,"00"\n"Tentacles, ""Squidward""","Squidward Tentacles is a fictional character in the American animated television series ""SpongeBob SquarePants"".\n He is voiced by actor Rodger Bumpass and first appeared on television in the series' pilot episode on May 1, 1999.","01"\n`
       expect(csv).toEqual(expected)
     })
@@ -291,7 +292,7 @@ describe('Salesforce Utils', () => {
         }
       ]
 
-      const csv = buildCSVData(updatePayloads, 'Id')
+      const csv = buildCSVData(updatePayloads, 'Id', 'update')
       const expected = `Name,NumberOfEmployees,sellsKrabbyPatties__c,Id\n"Krusty Krab","2","true","00"\n"Chum Bucket","1","false","01"\n`
       expect(csv).toEqual(expected)
     })

--- a/packages/destination-actions/src/destinations/salesforce/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/index.ts
@@ -9,6 +9,8 @@ import contact from './contact'
 import account from './account'
 import { authenticateWithPassword } from './sf-operations'
 
+import lead2 from './lead2'
+
 interface RefreshTokenResponse {
   access_token?: string
   error?: string
@@ -118,7 +120,8 @@ const destination: DestinationDefinition<Settings> = {
     cases,
     contact,
     opportunity,
-    account
+    account,
+    lead2
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/lead2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead2/generated-types.ts
@@ -1,0 +1,96 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * This field affects how Segment uses the record matchers to query Salesforce records. By default, Segment uses the "OR" operator to query Salesforce for a record. If you would like to query Salesforce records using a combination of multiple record matchers, change this to "AND".
+   */
+  recordMatcherOperator?: string
+  /**
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce.
+   */
+  enable_batching?: boolean
+  /**
+   * Maximum number of events to include in each batch. Actual batch sizes may be lower.
+   */
+  batch_size?: number
+  /**
+   * The fields used to find Salesforce records for updates. **This is required if the operation is Delete, Update or Upsert.**
+   *
+   *   Any field can function as a matcher, including Record ID, External IDs, standard fields and custom fields. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.
+   *
+   *   If multiple records are found, no changes will be made. **Please use fields that result in unique records.**
+   *
+   *   ---
+   *
+   *
+   */
+  traits?: {
+    [k: string]: unknown
+  }
+  /**
+   * The external id field name and mapping to use for bulk upsert.
+   */
+  bulkUpsertExternalId?: {
+    /**
+     * The external id field name as defined in Salesforce.
+     */
+    externalIdName?: string
+    /**
+     * The external id field value to use for bulk upsert.
+     */
+    externalIdValue?: string
+  }
+  /**
+   * The record id value to use for bulk update.
+   */
+  bulkUpdateRecordId?: string
+  /**
+   * The lead's company. **This is required to create a lead.**
+   */
+  company?: string
+  /**
+   * The lead's last name. **This is required to create a lead.**
+   */
+  last_name?: string
+  /**
+   * The lead's first name.
+   */
+  first_name?: string
+  /**
+   * The lead's email address.
+   */
+  email?: string
+  /**
+   * City for the lead's address.
+   */
+  city?: string
+  /**
+   * Postal code for the lead's address.
+   */
+  postal_code?: string
+  /**
+   * Country for the lead's address.
+   */
+  country?: string
+  /**
+   * Street number and name for the lead's address.
+   */
+  street?: string
+  /**
+   * State for the lead's address.
+   */
+  state?: string
+  /**
+   *
+   *   Additional fields to send to Salesforce. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.
+   *
+   *   This can include standard or custom fields. Custom fields must be predefined in your Salesforce account and the API field name should have __c appended.
+   *
+   *   ---
+   *
+   *
+   */
+  customFields?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/salesforce/lead2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead2/generated-types.ts
@@ -45,6 +45,19 @@ export interface Payload {
    */
   bulkUpdateRecordId?: string
   /**
+   *
+   *   Additional fields to send to Salesforce. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.
+   *
+   *   This can include standard or custom fields. Custom fields must be predefined in your Salesforce account and the API field name should have __c appended.
+   *
+   *   ---
+   *
+   *
+   */
+  customFields?: {
+    [k: string]: unknown
+  }
+  /**
    * The lead's company. **This is required to create a lead.**
    */
   company?: string
@@ -80,17 +93,4 @@ export interface Payload {
    * State for the lead's address.
    */
   state?: string
-  /**
-   *
-   *   Additional fields to send to Salesforce. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.
-   *
-   *   This can include standard or custom fields. Custom fields must be predefined in your Salesforce account and the API field name should have __c appended.
-   *
-   *   ---
-   *
-   *
-   */
-  customFields?: {
-    [k: string]: unknown
-  }
 }

--- a/packages/destination-actions/src/destinations/salesforce/lead2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead2/index.ts
@@ -1,0 +1,200 @@
+import { ActionDefinition, IntegrationError } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import {
+  bulkUpdateRecordId2,
+  bulkUpsertExternalId2,
+  customFields2,
+  traits2,
+  validateLookup2,
+  enable_batching2,
+  recordMatcherOperator2,
+  batch_size2,
+  hideIfDeleteSyncMode
+} from '../sf-properties'
+import Salesforce, { generateSalesforceRequest } from '../sf-operations'
+
+const OBJECT_NAME = 'Lead'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Lead V2',
+  description: 'Create, update, or upsert leads in Salesforce.',
+  defaultSubscription: 'type = "identify"',
+  syncMode: {
+    description: 'Define how the records from your destination will be synced.',
+    label: 'How to sync records',
+    default: 'add',
+    choices: [
+      { label: 'Insert Records', value: 'add' },
+      { label: 'Update Records', value: 'update' },
+      { label: 'Upsert Records', value: 'upsert' },
+      { label: 'Delete Records. Not available when using batching. Requests will result in errors.', value: 'delete' }
+    ]
+  },
+  fields: {
+    recordMatcherOperator: recordMatcherOperator2,
+    enable_batching: enable_batching2,
+    batch_size: batch_size2,
+    traits: traits2,
+    bulkUpsertExternalId: bulkUpsertExternalId2,
+    bulkUpdateRecordId: bulkUpdateRecordId2,
+    customFields: customFields2,
+    company: {
+      label: 'Company',
+      description: "The lead's company. **This is required to create a lead.**",
+      type: 'string',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.company' },
+          then: { '@path': '$.traits.company' },
+          else: { '@path': '$.properties.company' }
+        }
+      },
+      depends_on: hideIfDeleteSyncMode
+    },
+    last_name: {
+      label: 'Last Name',
+      description: "The lead's last name. **This is required to create a lead.**",
+      type: 'string',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.last_name' },
+          then: { '@path': '$.traits.last_name' },
+          else: { '@path': '$.properties.last_name' }
+        }
+      },
+      depends_on: hideIfDeleteSyncMode
+    },
+    first_name: {
+      label: 'First Name',
+      description: "The lead's first name.",
+      type: 'string',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.first_name' },
+          then: { '@path': '$.traits.first_name' },
+          else: { '@path': '$.properties.first_name' }
+        }
+      },
+      depends_on: hideIfDeleteSyncMode
+    },
+    email: {
+      label: 'Email',
+      description: "The lead's email address.",
+      type: 'string',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.email' },
+          then: { '@path': '$.traits.email' },
+          else: { '@path': '$.properties.email' }
+        }
+      },
+      depends_on: hideIfDeleteSyncMode
+    },
+    city: {
+      label: 'City',
+      description: "City for the lead's address.",
+      type: 'string',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.address.city' },
+          then: { '@path': '$.traits.address.city' },
+          else: { '@path': '$.properties.address.city' }
+        }
+      },
+      depends_on: hideIfDeleteSyncMode
+    },
+    postal_code: {
+      label: 'Postal Code',
+      description: "Postal code for the lead's address.",
+      type: 'string',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.address.postal_code' },
+          then: { '@path': '$.traits.address.postal_code' },
+          else: { '@path': '$.properties.address.postal_code' }
+        }
+      },
+      depends_on: hideIfDeleteSyncMode
+    },
+    country: {
+      label: 'Country',
+      description: "Country for the lead's address.",
+      type: 'string',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.address.country' },
+          then: { '@path': '$.traits.address.country' },
+          else: { '@path': '$.properties.address.country' }
+        }
+      },
+      depends_on: hideIfDeleteSyncMode
+    },
+    street: {
+      label: 'Street',
+      description: "Street number and name for the lead's address.",
+      type: 'string',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.address.street' },
+          then: { '@path': '$.traits.address.street' },
+          else: { '@path': '$.properties.address.street' }
+        }
+      },
+      depends_on: hideIfDeleteSyncMode
+    },
+    state: {
+      label: 'State',
+      description: "State for the lead's address.",
+      type: 'string',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.address.state' },
+          then: { '@path': '$.traits.address.state' },
+          else: { '@path': '$.properties.address.state' }
+        }
+      },
+      depends_on: hideIfDeleteSyncMode
+    }
+  },
+  perform: async (request, { settings, payload, syncMode }) => {
+    const sf: Salesforce = new Salesforce(settings.instanceUrl, await generateSalesforceRequest(settings, request))
+
+    if (syncMode === 'add') {
+      if (!payload.last_name) {
+        throw new IntegrationError('Missing last_name value', 'Misconfigured required field', 400)
+      }
+      return await sf.createRecord(payload, OBJECT_NAME)
+    }
+
+    validateLookup2(syncMode, payload)
+
+    if (syncMode === 'update') {
+      return await sf.updateRecord(payload, OBJECT_NAME)
+    }
+
+    if (syncMode === 'upsert') {
+      if (!payload.last_name) {
+        throw new IntegrationError('Missing last_name value', 'Misconfigured required field', 400)
+      }
+      return await sf.upsertRecord(payload, OBJECT_NAME)
+    }
+
+    if (syncMode === 'delete') {
+      return await sf.deleteRecord(payload, OBJECT_NAME)
+    }
+  },
+  performBatch: async (request, { settings, payload, syncMode }) => {
+    const sf: Salesforce = new Salesforce(settings.instanceUrl, await generateSalesforceRequest(settings, request))
+
+    if (syncMode === 'upsert') {
+      if (!payload[0].last_name) {
+        throw new IntegrationError('Missing last_name value', 'Misconfigured required field', 400)
+      }
+    }
+
+    return sf.bulkHandlerWithSyncMode(payload, OBJECT_NAME, syncMode)
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -127,10 +127,10 @@ export const traits: InputField = {
   label: 'Record Matchers',
   description: `The fields used to find Salesforce records for updates. **This is required if the operation is Delete, Update or Upsert.**
 
-  Any field can function as a matcher, including Record ID, External IDs, standard fields and custom fields. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.  
-  
+  Any field can function as a matcher, including Record ID, External IDs, standard fields and custom fields. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.
+
   If multiple records are found, no changes will be made. **Please use fields that result in unique records.**
-  
+
   ---
 
   `,
@@ -153,9 +153,9 @@ export const customFields: InputField = {
   Additional fields to send to Salesforce. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.
 
   This can include standard or custom fields. Custom fields must be predefined in your Salesforce account and the API field name should have __c appended.
-  
+
   ---
-  
+
   `,
   type: 'object',
   defaultObjectUI: 'keyvalue',
@@ -169,6 +169,188 @@ interface Payload {
 
 export const validateLookup = (payload: Payload) => {
   if (payload.operation === 'update' || payload.operation === 'upsert' || payload.operation === 'delete') {
+    if (!payload.traits) {
+      throw new IntegrationError(
+        'Undefined lookup traits for update or upsert operation',
+        'Misconfigured Required Field',
+        400
+      )
+    }
+  }
+}
+
+// Mappings 2.0 fields.
+
+export const traits2: InputField = {
+  label: 'Record Matchers',
+  description: `The fields used to find Salesforce records for updates. **This is required if the operation is Delete, Update or Upsert.**
+
+  Any field can function as a matcher, including Record ID, External IDs, standard fields and custom fields. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.
+
+  If multiple records are found, no changes will be made. **Please use fields that result in unique records.**
+
+  ---
+
+  `,
+  type: 'object',
+  defaultObjectUI: 'keyvalue:only',
+  depends_on: {
+    match: 'any',
+    conditions: [
+      {
+        type: 'syncMode',
+        operator: 'is',
+        value: 'update'
+      },
+      {
+        type: 'syncMode',
+        operator: 'is',
+        value: 'upsert'
+      },
+      {
+        type: 'syncMode',
+        operator: 'is',
+        value: 'delete'
+      }
+    ]
+  }
+}
+
+export const recordMatcherOperator2: InputField = {
+  label: 'Record Matchers Operator',
+  description:
+    'This field affects how Segment uses the record matchers to query Salesforce records. By default, Segment uses the "OR" operator to query Salesforce for a record. If you would like to query Salesforce records using a combination of multiple record matchers, change this to "AND".',
+  type: 'string',
+  choices: [
+    { label: 'OR', value: 'OR' },
+    { label: 'AND', value: 'AND' }
+  ],
+  default: 'OR',
+  depends_on: {
+    match: 'any',
+    conditions: [
+      {
+        type: 'syncMode',
+        operator: 'is',
+        value: 'update'
+      },
+      {
+        type: 'syncMode',
+        operator: 'is',
+        value: 'upsert'
+      },
+      {
+        type: 'syncMode',
+        operator: 'is',
+        value: 'delete'
+      }
+    ]
+  }
+}
+
+export const hideIfDeleteSyncMode: DependsOnConditions = {
+  match: 'any',
+  conditions: [
+    {
+      type: 'syncMode',
+      operator: 'is_not',
+      value: 'delete'
+    }
+  ]
+}
+
+export const enable_batching2: InputField = {
+  label: 'Use Salesforce Bulk API',
+  description:
+    'If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce.',
+  type: 'boolean',
+  default: false,
+  depends_on: hideIfDeleteSyncMode
+}
+
+export const batch_size2: InputField = {
+  label: 'Batch Size',
+  description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
+  type: 'number',
+  required: false,
+  unsafe_hidden: true,
+  default: 5000,
+  depends_on: hideIfDeleteSyncMode
+}
+
+export const bulkUpsertExternalId2: InputField = {
+  label: 'Bulk Upsert External Id',
+  description: 'The external id field name and mapping to use for bulk upsert.',
+  type: 'object',
+  defaultObjectUI: 'keyvalue:only',
+  additionalProperties: false,
+  properties: {
+    externalIdName: {
+      label: 'External Id Name',
+      description: 'The external id field name as defined in Salesforce.',
+      type: 'string'
+    },
+    externalIdValue: {
+      label: 'External Id Value',
+      description: 'The external id field value to use for bulk upsert.',
+      type: 'string'
+    }
+  },
+  depends_on: {
+    match: 'all',
+    conditions: [
+      {
+        type: 'syncMode',
+        operator: 'is',
+        value: 'upsert'
+      },
+      {
+        fieldKey: 'enable_batching',
+        operator: 'is',
+        value: true
+      }
+    ]
+  }
+}
+
+export const bulkUpdateRecordId2: InputField = {
+  label: 'Bulk Update Record Id',
+  description: 'The record id value to use for bulk update.',
+  type: 'string',
+  depends_on: {
+    match: 'all',
+    conditions: [
+      {
+        type: 'syncMode',
+        operator: 'is',
+        value: 'update'
+      },
+      {
+        fieldKey: 'enable_batching',
+        operator: 'is',
+        value: true
+      }
+    ]
+  }
+}
+
+export const customFields2: InputField = {
+  label: 'Other Fields',
+  description: `
+  Additional fields to send to Salesforce. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.
+
+  This can include standard or custom fields. Custom fields must be predefined in your Salesforce account and the API field name should have __c appended.
+
+  ---
+
+  `,
+  type: 'object',
+  defaultObjectUI: 'keyvalue',
+  depends_on: hideIfDeleteSyncMode
+}
+
+export const validateLookup2 = (syncMode: string | undefined, payload: Payload) => {
+  if (syncMode === 'update' || syncMode === 'upsert' || syncMode === 'delete') {
     if (!payload.traits) {
       throw new IntegrationError(
         'Undefined lookup traits for update or upsert operation',

--- a/packages/destination-actions/src/destinations/salesforce/sf-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-types.ts
@@ -1,4 +1,5 @@
 import type { Payload as LeadPayload } from './lead/generated-types'
+import type { Payload as Lead2Payload } from './lead2/generated-types'
 import type { Payload as CustomPayload } from './customObject/generated-types'
 import type { Payload as CasePayload } from './cases/generated-types'
 import type { Payload as ContactPayload } from './contact/generated-types'
@@ -6,7 +7,7 @@ import type { Payload as OpportunityPayload } from './opportunity/generated-type
 import type { Payload as AccountPayload } from './account/generated-types'
 
 export type GenericPayload = Partial<
-  LeadPayload & CustomPayload & CasePayload & AccountPayload & OpportunityPayload & ContactPayload
+  LeadPayload & CustomPayload & CasePayload & AccountPayload & OpportunityPayload & ContactPayload & Lead2Payload
 >
 
 export type LeadBaseShapeType = {

--- a/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
@@ -101,12 +101,14 @@ const buildHeaders = (headerMap: Map<string, [[CSVData, number]]>): string => {
  * @param payloads Each payload in the batch.
  * @param headerMap Represents each column in the CSV file.
  * @param n The size of the batch.
+ * @param operation Represents the way the data will flow into the destination.
  * @returns The data rows of the CSV file.
  */
 const buildCSVFromHeaderMap = (
   payloads: GenericPayload[],
   headerMap: Map<string, [[CSVData, number]]>,
-  n: number
+  n: number,
+  operation: string | undefined
 ): string => {
   let rows = ''
 
@@ -127,29 +129,38 @@ const buildCSVFromHeaderMap = (
       }
     }
 
-    if (payloads[i].operation === 'create') {
+    // We are choosing to continue to check payloads[i].operation here to minimize
+    // the blast radious of the V2 update. payloads[i].operation is a mapping setting while operation
+    // comes directly from the syncMode setting chosen by the user.
+    // It's extremely unlikely (or impossible) that from a given payload of N size, M elements will have different operation.
+    // In any case, the statement below keeps the original code intact while starting to support the new syncMode setting.
+    // operation "create" comes from the mapping setting and "insert" is the converted value of the "add" mapping.
+    operation = payloads[i].operation || operation
+
+    if (operation === 'create' || operation === 'insert') {
       // Remove the trailing comma from the row, there is no unique ID to append
       row = row.substring(0, row.length - 1)
       rows += `${row}\n`
     } else {
-      const uniqueIdValue = getUniqueIdValue(payloads[i])
+      const uniqueIdValue = getUniqueIdValue(payloads[i], operation)
       rows += `${row}"${uniqueIdValue}"\n`
     }
   }
   return rows
 }
 
-const getUniqueIdValue = (payload: GenericPayload): string => {
+const getUniqueIdValue = (payload: GenericPayload, operation: string | undefined): string => {
+  operation = payload.operation || operation
   if (
     payload.enable_batching &&
-    payload.operation === 'upsert' &&
+    operation === 'upsert' &&
     payload.bulkUpsertExternalId &&
     payload.bulkUpsertExternalId.externalIdValue
   ) {
     return payload.bulkUpsertExternalId.externalIdValue
   }
 
-  if (payload.enable_batching && payload.operation === 'update' && payload.bulkUpdateRecordId) {
+  if (payload.enable_batching && operation === 'update' && payload.bulkUpdateRecordId) {
     return payload.bulkUpdateRecordId
   }
 
@@ -160,18 +171,23 @@ const getUniqueIdValue = (payload: GenericPayload): string => {
  *
  * @param payloads Each payload in the batch.
  * @param uniqueIdName The name of the field that contains the external ID, or 'Id' when being used for bulk update.
+ * @param operation Represents the way the data will flow into the destination.
  * @returns The complete CSV to send to Salesforce.
  */
-export const buildCSVData = (payloads: GenericPayload[], uniqueIdName: string): string => {
+export const buildCSVData = (
+  payloads: GenericPayload[],
+  uniqueIdName: string,
+  operation: string | undefined
+): string => {
   const headerMap = buildHeaderMap(payloads)
   let csv = buildHeaders(headerMap)
 
-  if (payloads[0].operation === 'create') {
+  if (operation === 'create') {
     // Remove the trailing comma, since there is no unique ID to append
     csv = csv.substring(0, csv.length - 1)
   }
 
-  csv += `${uniqueIdName}\n` + buildCSVFromHeaderMap(payloads, headerMap, payloads.length)
+  csv += `${uniqueIdName}\n` + buildCSVFromHeaderMap(payloads, headerMap, payloads.length, operation)
 
   return csv
 }

--- a/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
@@ -182,7 +182,7 @@ export const buildCSVData = (
   const headerMap = buildHeaderMap(payloads)
   let csv = buildHeaders(headerMap)
 
-  if (operation === 'create') {
+  if (operation === 'create' || operation === 'insert') {
     // Remove the trailing comma, since there is no unique ID to append
     csv = csv.substring(0, csv.length - 1)
   }

--- a/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
@@ -182,7 +182,7 @@ export const buildCSVData = (
   const headerMap = buildHeaderMap(payloads)
   let csv = buildHeaders(headerMap)
 
-  if (operation === 'create' || operation === 'insert') {
+  if (operation === 'insert') {
     // Remove the trailing comma, since there is no unique ID to append
     csv = csv.substring(0, csv.length - 1)
   }


### PR DESCRIPTION
The destination already implements its own version of Sync Mode via mapping settings.
We will translate the “legacy” sync mode into our new and native Sync Mode. After all, backwards compatibility is not of concern given that we are creating a new action.

The sync modes supported by `perform` are different from the ones supported by `performBatch` and the UI is not aware of that. We will offer all of the sync modes for both perform and performBatch. The UI team will make use of conditional field so the options not supported by performBatch are hidden. For now, we will return a non-retryable error code for those scenarios and update the docs to illustrate this difference.

## Testing

In Progress

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
