### PR TITLE
[SALESFORCE] Add Sync Mode Support for "Case" action

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/__tests__/cases2.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/cases2.test.ts
@@ -1,0 +1,387 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../index'
+import { API_VERSION } from '../sf-operations'
+
+const testDestination = createTestIntegration(Destination)
+
+const settings = {
+  instanceUrl: 'https://test.salesforce.com/'
+}
+const auth = {
+  refreshToken: 'xyz123',
+  accessToken: 'abc123'
+}
+
+describe('Salesforce', () => {
+  describe('Case2', () => {
+    it('should create a case record', async () => {
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).post('/Case').reply(201, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Create new case',
+        properties: {
+          description: 'This is test description'
+        }
+      })
+
+      const responses = await testDestination.testAction('cases2', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          __segment_internal_sync_mode: 'add',
+          description: {
+            '@path': '$.properties.description'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].request.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "authorization": Array [
+              "Bearer abc123",
+            ],
+            "content-type": Array [
+              "application/json",
+            ],
+            "user-agent": Array [
+              "Segment (Actions)",
+            ],
+          },
+        }
+      `)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"Description\\":\\"This is test description\\"}"`)
+    })
+
+    it('should create a case record with custom fields', async () => {
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).post('/Case').reply(201, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Create new case',
+        properties: {
+          description: 'This is test description'
+        }
+      })
+
+      const responses = await testDestination.testAction('cases2', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          __segment_internal_sync_mode: 'add',
+          description: {
+            '@path': '$.properties.description'
+          },
+          customFields: {
+            A: '1',
+            B: '2',
+            C: '3'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].request.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "authorization": Array [
+              "Bearer abc123",
+            ],
+            "content-type": Array [
+              "application/json",
+            ],
+            "user-agent": Array [
+              "Segment (Actions)",
+            ],
+          },
+        }
+      `)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"Description\\":\\"This is test description\\",\\"A\\":\\"1\\",\\"B\\":\\"2\\",\\"C\\":\\"3\\"}"`
+      )
+    })
+
+    it('should delete a case record given an Id', async () => {
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).delete('/Case/123').reply(204, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Delete',
+        userId: '123'
+      })
+
+      const responses = await testDestination.testAction('cases2', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          __segment_internal_sync_mode: 'delete',
+          traits: {
+            Id: { '@path': '$.userId' }
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(204)
+    })
+
+    it('should delete a case record given some lookup traits', async () => {
+      const query = encodeURIComponent(`SELECT Id FROM Case WHERE Email = 'bob@bobsburgers.net'`)
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/query`)
+        .get(`/?q=${query}`)
+        .reply(201, {
+          totalSize: 1,
+          records: [{ Id: 'abc123' }]
+        })
+
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).delete('/Case/abc123').reply(201, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Delete',
+        properties: {
+          email: 'bob@bobsburgers.net'
+        }
+      })
+
+      const responses = await testDestination.testAction('cases2', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          __segment_internal_sync_mode: 'delete',
+          traits: {
+            Email: { '@path': '$.properties.email' }
+          }
+        }
+      })
+
+      expect(responses.length).toBe(2)
+      expect(responses[0].status).toBe(201)
+      expect(responses[1].status).toBe(201)
+    })
+
+    it('should update a case record', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Update case',
+        properties: {
+          description: 'Test two'
+        }
+      })
+
+      const query = encodeURIComponent(`SELECT Id FROM Case WHERE description = 'Test one'`)
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/query`)
+        .get(`/?q=${query}`)
+        .reply(201, {
+          Id: 'abc123',
+          totalSize: 1,
+          records: [{ Id: '123456' }]
+        })
+
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).patch('/Case/123456').reply(201, {})
+
+      const responses = await testDestination.testAction('cases2', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          __segment_internal_sync_mode: 'update',
+          traits: {
+            description: 'Test one'
+          },
+          description: {
+            '@path': '$.properties.description'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(2)
+      expect(responses[0].status).toBe(201)
+      expect(responses[1].status).toBe(201)
+
+      expect(responses[0].request.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "authorization": Array [
+              "Bearer abc123",
+            ],
+            "user-agent": Array [
+              "Segment (Actions)",
+            ],
+          },
+        }
+      `)
+
+      expect(responses[1].options.body).toMatchInlineSnapshot(`"{\\"Description\\":\\"Test two\\"}"`)
+    })
+
+    it('should upsert an existing record', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Upsert existing case',
+        properties: {
+          description: 'Test two'
+        }
+      })
+
+      const query = encodeURIComponent(`SELECT Id FROM Case WHERE description = 'Test one'`)
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/query`)
+        .get(`/?q=${query}`)
+        .reply(201, {
+          Id: 'abc123',
+          totalSize: 1,
+          records: [{ Id: '123456' }]
+        })
+
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).patch('/Case/123456').reply(201, {})
+
+      const responses = await testDestination.testAction('cases2', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          __segment_internal_sync_mode: 'upsert',
+          traits: {
+            description: 'Test one'
+          },
+          description: {
+            '@path': '$.properties.description'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(2)
+      expect(responses[0].status).toBe(201)
+      expect(responses[1].status).toBe(201)
+
+      expect(responses[0].request.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "authorization": Array [
+              "Bearer abc123",
+            ],
+            "user-agent": Array [
+              "Segment (Actions)",
+            ],
+          },
+        }
+      `)
+
+      expect(responses[1].options.body).toMatchInlineSnapshot(`"{\\"Description\\":\\"Test two\\"}"`)
+    })
+
+    it('should upsert a non-existent record', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Upsert non-existent case',
+        properties: {
+          description: 'Test two'
+        }
+      })
+
+      const query = encodeURIComponent(`SELECT Id FROM Case WHERE description = 'Test one'`)
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/query`).get(`/?q=${query}`).reply(201, {
+        Id: 'abc123',
+        totalSize: 0
+      })
+
+      nock(`${settings.instanceUrl}services/data/${API_VERSION}/sobjects`).post('/Case').reply(201, {})
+
+      const responses = await testDestination.testAction('cases2', {
+        event,
+        settings,
+        auth,
+        mapping: {
+          __segment_internal_sync_mode: 'upsert',
+          traits: {
+            description: 'Test one'
+          },
+          description: {
+            '@path': '$.properties.description'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(2)
+      expect(responses[0].status).toBe(201)
+      expect(responses[1].status).toBe(201)
+
+      expect(responses[0].request.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "authorization": Array [
+              "Bearer abc123",
+            ],
+            "user-agent": Array [
+              "Segment (Actions)",
+            ],
+          },
+        }
+      `)
+
+      expect(responses[1].options.body).toMatchInlineSnapshot(`"{\\"Description\\":\\"Test two\\"}"`)
+    })
+
+    describe('batching', () => {
+      it('should fail if delete is set as syncMode', async () => {
+        const event = createTestEvent({
+          type: 'track',
+          event: 'Delete',
+          userId: '123'
+        })
+
+        await expect(async () => {
+          await testDestination.testBatchAction('cases2', {
+            events: [event],
+            settings,
+            auth,
+            mapping: {
+              __segment_internal_sync_mode: 'delete',
+              enable_batching: true,
+              traits: {
+                Id: { '@path': '$.userId' }
+              }
+            }
+          })
+        }).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"Unsupported operation: Bulk API does not support the delete operation"`
+        )
+      })
+
+      it('should fail if syncMode is undefined', async () => {
+        const event = createTestEvent({
+          type: 'track',
+          event: 'Delete',
+          userId: '123'
+        })
+
+        await expect(async () => {
+          await testDestination.testBatchAction('cases2', {
+            events: [event],
+            settings,
+            auth,
+            mapping: {
+              enable_batching: true,
+              traits: {
+                Id: { '@path': '$.userId' }
+              }
+            }
+          })
+        }).rejects.toThrowErrorMatchingInlineSnapshot(`"syncMode is required"`)
+      })
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/salesforce/cases2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases2/generated-types.ts
@@ -1,0 +1,64 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * This field affects how Segment uses the record matchers to query Salesforce records. By default, Segment uses the "OR" operator to query Salesforce for a record. If you would like to query Salesforce records using a combination of multiple record matchers, change this to "AND".
+   */
+  recordMatcherOperator?: string
+  /**
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce.
+   */
+  enable_batching?: boolean
+  /**
+   * Maximum number of events to include in each batch. Actual batch sizes may be lower.
+   */
+  batch_size?: number
+  /**
+   * The fields used to find Salesforce records for updates. **This is required if the operation is Delete, Update or Upsert.**
+   *
+   *   Any field can function as a matcher, including Record ID, External IDs, standard fields and custom fields. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.
+   *
+   *   If multiple records are found, no changes will be made. **Please use fields that result in unique records.**
+   *
+   *   ---
+   *
+   *
+   */
+  traits?: {
+    [k: string]: unknown
+  }
+  /**
+   * The external id field name and mapping to use for bulk upsert.
+   */
+  bulkUpsertExternalId?: {
+    /**
+     * The external id field name as defined in Salesforce.
+     */
+    externalIdName?: string
+    /**
+     * The external id field value to use for bulk upsert.
+     */
+    externalIdValue?: string
+  }
+  /**
+   * The record id value to use for bulk update.
+   */
+  bulkUpdateRecordId?: string
+  /**
+   * A text description of the case.
+   */
+  description?: string
+  /**
+   *
+   *   Additional fields to send to Salesforce. On the left-hand side, input the Salesforce field API name. On the right-hand side, map the Segment field that contains the value.
+   *
+   *   This can include standard or custom fields. Custom fields must be predefined in your Salesforce account and the API field name should have __c appended.
+   *
+   *   ---
+   *
+   *
+   */
+  customFields?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/salesforce/cases2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases2/index.ts
@@ -1,0 +1,76 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import {
+  bulkUpsertExternalId2,
+  bulkUpdateRecordId2,
+  customFields2,
+  traits2,
+  validateLookup2,
+  enable_batching2,
+  recordMatcherOperator2,
+  batch_size2,
+  hideIfDeleteSyncMode
+} from '../sf-properties'
+import Salesforce, { generateSalesforceRequest } from '../sf-operations'
+
+const OBJECT_NAME = 'Case'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Case',
+  description: 'Create, update, or upsert cases in Salesforce.',
+  syncMode: {
+    description: 'Define how the records from your destination will be synced.',
+    label: 'How to sync records',
+    default: 'add',
+    choices: [
+      { label: 'Insert Records', value: 'add' },
+      { label: 'Update Records', value: 'update' },
+      { label: 'Upsert Records', value: 'upsert' },
+      { label: 'Delete Records. Not available when using batching. Requests will result in errors.', value: 'delete' }
+    ]
+  },
+  fields: {
+    recordMatcherOperator: recordMatcherOperator2,
+    enable_batching: enable_batching2,
+    batch_size: batch_size2,
+    traits: traits2,
+    bulkUpsertExternalId: bulkUpsertExternalId2,
+    bulkUpdateRecordId: bulkUpdateRecordId2,
+    description: {
+      label: 'Description',
+      description: 'A text description of the case.',
+      type: 'string',
+      depends_on: hideIfDeleteSyncMode
+    },
+    customFields: customFields2
+  },
+  perform: async (request, { settings, payload, syncMode }) => {
+    const sf: Salesforce = new Salesforce(settings.instanceUrl, await generateSalesforceRequest(settings, request))
+
+    if (syncMode === 'add') {
+      return await sf.createRecord(payload, OBJECT_NAME)
+    }
+
+    validateLookup2(syncMode, payload)
+
+    if (syncMode === 'update') {
+      return await sf.updateRecord(payload, OBJECT_NAME)
+    }
+
+    if (syncMode === 'upsert') {
+      return await sf.upsertRecord(payload, OBJECT_NAME)
+    }
+
+    if (syncMode === 'delete') {
+      return await sf.deleteRecord(payload, OBJECT_NAME)
+    }
+  },
+  performBatch: async (request, { settings, payload, syncMode }) => {
+    const sf: Salesforce = new Salesforce(settings.instanceUrl, await generateSalesforceRequest(settings, request))
+
+    return sf.bulkHandlerWithSyncMode(payload, OBJECT_NAME, syncMode)
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/salesforce/cases2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases2/index.ts
@@ -17,7 +17,7 @@ import Salesforce, { generateSalesforceRequest } from '../sf-operations'
 const OBJECT_NAME = 'Case'
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Case',
+  title: 'Case V2',
   description: 'Create, update, or upsert cases in Salesforce.',
   syncMode: {
     description: 'Define how the records from your destination will be synced.',

--- a/packages/destination-actions/src/destinations/salesforce/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/index.ts
@@ -11,6 +11,8 @@ import { authenticateWithPassword } from './sf-operations'
 
 import lead2 from './lead2'
 
+import cases2 from './cases2'
+
 interface RefreshTokenResponse {
   access_token?: string
   error?: string
@@ -121,7 +123,8 @@ const destination: DestinationDefinition<Settings> = {
     contact,
     opportunity,
     account,
-    lead2
+    lead2,
+    cases2
   }
 }
 


### PR DESCRIPTION
**Note to the reviewer**: it's easier to review this if you go commit by commit instead of going through all the files at once as I separated the ported legacy action from the syncMode implementation.

The destination already implements its own version of Sync Mode via mapping settings.
We will translate the “legacy” sync mode into our new and native Sync Mode. After all, backwards compatibility is not of concern given that we are creating a new action.

The sync modes supported by perform are different from the ones supported by performBatch and the UI is not aware of that. We will offer all of the sync modes for both perform and performBatch. The UI team will make use of conditional field so the options not supported by performBatch are hidden. For now, we will return a non-retryable error code for those scenarios and update the docs to illustrate this difference.

## Testing

Work In Progress

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
