### PR TITLE
[STRATCONN-4071] Add batching support to Google Enhanced Conversions

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadCallConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadCallConversion.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration, SegmentEvent } from '@segment/actions-core'
 import GoogleEnhancedConversions from '../index'
 import { API_VERSION, CANARY_API_VERSION, FLAGON_NAME } from '../functions'
 
@@ -8,8 +8,8 @@ const timestamp = new Date('Thu Jun 10 2021 11:08:04 GMT-0700 (Pacific Daylight 
 const customerId = '1234'
 
 describe('GoogleEnhancedConversions', () => {
-  describe('uploadCallConversion', () => {
-    it('sends an event with default mappings', async () => {
+  describe('uploadCallConversion Single Event', () => {
+    it('sends an event with default mappings - basic', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -96,7 +96,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[1].status).toBe(201)
     })
 
-    it('fails if customerId not set', async () => {
+    it('fails if customerId not set - basic', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -121,10 +121,13 @@ describe('GoogleEnhancedConversions', () => {
         })
         fail('the test should have thrown an error')
       } catch (e) {
-        expect(e.message).toBe('Customer ID is required for this action. Please set it in destination settings.')
+        expect((e as Error).message).toBe(
+          'Customer ID is required for this action. Please set it in destination settings.'
+        )
       }
     })
-    it('sends an event with default mappings', async () => {
+
+    it('sends an event with default mappings - with enhanced v12 flag', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -157,7 +160,8 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
     })
-    it('fails if customerId not set', async () => {
+
+    it('fails if customerId not set - with enhanced v12 flag', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -183,7 +187,9 @@ describe('GoogleEnhancedConversions', () => {
         })
         fail('the test should have thrown an error')
       } catch (e) {
-        expect(e.message).toBe('Customer ID is required for this action. Please set it in destination settings.')
+        expect((e as Error).message).toBe(
+          'Customer ID is required for this action. Please set it in destination settings.'
+        )
       }
     })
 
@@ -264,6 +270,347 @@ describe('GoogleEnhancedConversions', () => {
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
         `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+  })
+
+  describe('uploadCallConversion Batch Event', () => {
+    it('sends an event with default mappings - basic', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadCallConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadCallConversion', {
+        events,
+        mapping: { conversion_action: '12345', caller_id: '+1234567890', call_timestamp: timestamp },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\"},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\"}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('maps custom variables correctly', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}/googleAds:searchStream`)
+        .post('')
+        .reply(200, [
+          {
+            results: [
+              {
+                conversionCustomVariable: {
+                  resourceName: 'customers/1234/conversionCustomVariables/123445',
+                  id: '123445',
+                  name: 'username'
+                }
+              }
+            ]
+          }
+        ])
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadCallConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadCallConversion', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          caller_id: '+1234567890',
+          call_timestamp: timestamp,
+          custom_variables: { username: 'spongebob' }
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[1].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(2)
+      expect(responses[1].status).toBe(201)
+    })
+
+    it('fails if customerId not  - basic', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        properties: {
+          email: 'test@gmail.com',
+          orderId: '1234',
+          total: '200',
+          currency: 'USD'
+        }
+      })
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadCallConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      try {
+        await testDestination.testAction('uploadCallConversion', {
+          event,
+          mapping: { conversion_action: '12345', caller_id: '+1234567890', call_timestamp: timestamp },
+          useDefaultMappings: true,
+          settings: {}
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect((e as Error).message).toBe(
+          'Customer ID is required for this action. Please set it in destination settings.'
+        )
+      }
+    })
+
+    it('sends an event with default mappings - with enhanced v12 flag', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadCallConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadCallConversion', {
+        events,
+        features: { 'google-enhanced-v12': true },
+        mapping: { conversion_action: '12345', caller_id: '+1234567890', call_timestamp: timestamp },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\"},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\"}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('fails if customerId not set - with enhanced v12 flag', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadCallConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      try {
+        await testDestination.testBatchAction('uploadCallConversion', {
+          events,
+          features: { 'google-enhanced-v12': true },
+          mapping: { conversion_action: '12345', caller_id: '+1234567890', call_timestamp: timestamp },
+          useDefaultMappings: true,
+          settings: {}
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect((e as Error).message).toBe(
+          'Customer ID is required for this action. Please set it in destination settings.'
+        )
+      }
+    })
+
+    it('uses canary API version if flagon gate is set', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${CANARY_API_VERSION}/customers/${customerId}:uploadCallConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadCallConversion', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          caller_id: '+1234567890',
+          call_timestamp: timestamp,
+          ad_user_data_consent_state: 'GRANTED'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        },
+        features: {
+          [FLAGON_NAME]: true
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"consent\\":{\\"adUserData\\":\\"GRANTED\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"consent\\":{\\"adUserData\\":\\"GRANTED\\"}}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('Deny User Data and Personalised Consent State', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${CANARY_API_VERSION}/customers/${customerId}:uploadCallConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadCallConversion', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          caller_id: '+1234567890',
+          call_timestamp: timestamp,
+          ad_user_data_consent_state: 'DENIED',
+          ad_personalization_consent_state: 'DENIED'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        },
+        features: {
+          [FLAGON_NAME]: true
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadCallConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadCallConversion.test.ts
@@ -389,7 +389,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[1].status).toBe(201)
     })
 
-    it('fails if customerId not  - basic', async () => {
+    it('fails if customerId not - basic', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadCallConversion2.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadCallConversion2.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration, SegmentEvent } from '@segment/actions-core'
 import GoogleEnhancedConversions from '../index'
 import { API_VERSION, CANARY_API_VERSION, FLAGON_NAME } from '../functions'
 
@@ -8,7 +8,7 @@ const timestamp = new Date('Thu Jun 10 2021 11:08:04 GMT-0700 (Pacific Daylight 
 const customerId = '1234'
 
 describe('GoogleEnhancedConversions', () => {
-  describe('uploadCallConversion2', () => {
+  describe('uploadCallConversion2 Single Event', () => {
     it('sends an event with default mappings', async () => {
       const event = createTestEvent({
         timestamp,
@@ -102,7 +102,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[1].status).toBe(201)
     })
 
-    it('fails if customerId not set', async () => {
+    it('fails if customerId not set - basic', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -132,7 +132,9 @@ describe('GoogleEnhancedConversions', () => {
         })
         fail('the test should have thrown an error')
       } catch (e) {
-        expect(e.message).toBe('Customer ID is required for this action. Please set it in destination settings.')
+        expect((e as Error).message).toBe(
+          'Customer ID is required for this action. Please set it in destination settings.'
+        )
       }
     })
     it('sends an event with default mappings', async () => {
@@ -174,7 +176,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[0].status).toBe(201)
     })
 
-    it('fails if customerId not set', async () => {
+    it('fails if customerId not set - with enhanced v12 flag', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -205,7 +207,9 @@ describe('GoogleEnhancedConversions', () => {
         })
         fail('the test should have thrown an error')
       } catch (e) {
-        expect(e.message).toBe('Customer ID is required for this action. Please set it in destination settings.')
+        expect((e as Error).message).toBe(
+          'Customer ID is required for this action. Please set it in destination settings.'
+        )
       }
     })
 
@@ -325,7 +329,431 @@ describe('GoogleEnhancedConversions', () => {
         })
         fail('the test should have thrown an error')
       } catch (e) {
-        expect(e.message).toBe('Unsupported Sync Mode "upsert"')
+        expect((e as Error).message).toBe('Unsupported Sync Mode "upsert"')
+      }
+    })
+  })
+
+  describe('uploadCallConversion2 Batch Event', () => {
+    it('sends an event with default mappings - basic', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test1@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test2@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadCallConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadCallConversion2', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          caller_id: '+1234567890',
+          call_timestamp: timestamp,
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\"},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\"}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('maps custom variables correctly', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test1@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test2@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}/googleAds:searchStream`)
+        .post('')
+        .reply(200, [
+          {
+            results: [
+              {
+                conversionCustomVariable: {
+                  resourceName: 'customers/1234/conversionCustomVariables/123445',
+                  id: '123445',
+                  name: 'username'
+                }
+              }
+            ]
+          }
+        ])
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadCallConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadCallConversion2', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          caller_id: '+1234567890',
+          call_timestamp: timestamp,
+          custom_variables: { username: 'spongebob' },
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[1].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(2)
+      expect(responses[1].status).toBe(201)
+    })
+
+    it('fails if customerId not set - basic', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test1@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test2@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadCallConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      try {
+        await testDestination.testBatchAction('uploadCallConversion2', {
+          events,
+          mapping: {
+            conversion_action: '12345',
+            caller_id: '+1234567890',
+            call_timestamp: timestamp,
+            __segment_internal_sync_mode: 'add'
+          },
+          useDefaultMappings: true,
+          settings: {}
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect((e as Error).message).toBe(
+          'Customer ID is required for this action. Please set it in destination settings.'
+        )
+      }
+    })
+
+    it('sends an event with default mappings - with enhanced v12 flag', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test1@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test2@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadCallConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadCallConversion2', {
+        events,
+        features: { 'google-enhanced-v12': true },
+        mapping: {
+          conversion_action: '12345',
+          caller_id: '+1234567890',
+          call_timestamp: timestamp,
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\"},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\"}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('fails if customerId not set - with enhanced v12 flag', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test1@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test2@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadCallConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      try {
+        await testDestination.testBatchAction('uploadCallConversion2', {
+          events,
+          features: { 'google-enhanced-v12': true },
+          mapping: {
+            conversion_action: '12345',
+            caller_id: '+1234567890',
+            call_timestamp: timestamp,
+            __segment_internal_sync_mode: 'add'
+          },
+          useDefaultMappings: true,
+          settings: {}
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect((e as Error).message).toBe(
+          'Customer ID is required for this action. Please set it in destination settings.'
+        )
+      }
+    })
+
+    it('uses canary API version if flagon gate is set', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test1@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test2@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${CANARY_API_VERSION}/customers/${customerId}:uploadCallConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadCallConversion2', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          caller_id: '+1234567890',
+          call_timestamp: timestamp,
+          ad_user_data_consent_state: 'GRANTED',
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        },
+        features: {
+          [FLAGON_NAME]: true
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"consent\\":{\\"adUserData\\":\\"GRANTED\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"consent\\":{\\"adUserData\\":\\"GRANTED\\"}}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('Deny User Data and Personalised Consent State', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test1@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test2@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${CANARY_API_VERSION}/customers/${customerId}:uploadCallConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadCallConversion2', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          caller_id: '+1234567890',
+          call_timestamp: timestamp,
+          ad_user_data_consent_state: 'DENIED',
+          ad_personalization_consent_state: 'DENIED',
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        },
+        features: {
+          [FLAGON_NAME]: true
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"callerId\\":\\"+1234567890\\",\\"callStartDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('fails if sync mode is not supported', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test1@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        }),
+
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test2@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadCallConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      try {
+        await testDestination.testBatchAction('uploadCallConversion2', {
+          events,
+          features: { 'google-enhanced-v12': true },
+          mapping: {
+            conversion_action: '12345',
+            caller_id: '+1234567890',
+            call_timestamp: timestamp,
+            __segment_internal_sync_mode: 'upsert'
+          },
+          useDefaultMappings: true,
+          settings: {}
+        })
+        fail('the test should have thrown an error')
+      } catch (e) {
+        expect((e as Error).message).toBe('Unsupported Sync Mode "upsert"')
       }
     })
   })

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration, SegmentEvent } from '@segment/actions-core'
 import GoogleEnhancedConversions from '../index'
 import { API_VERSION, CANARY_API_VERSION, FLAGON_NAME } from '../functions'
 
@@ -8,8 +8,8 @@ const timestamp = new Date('Thu Jun 10 2021 11:08:04 GMT-0700 (Pacific Daylight 
 const customerId = '1234'
 
 describe('GoogleEnhancedConversions', () => {
-  describe('uploadClickConversion', () => {
-    it('sends an event with default mappings', async () => {
+  describe('uploadClickConversion Single Event', () => {
+    it('sends an event with default mappings - basic', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -50,7 +50,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[0].status).toBe(201)
     })
 
-    it('sends email and phone user_identifiers', async () => {
+    it('sends email and phone user_identifiers - basic', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -92,7 +92,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[0].status).toBe(201)
     })
 
-    it('sends email and phone user_identifiers with "+"', async () => {
+    it('sends email and phone user_identifiers - with "+"', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -190,7 +190,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[1].status).toBe(201)
     })
 
-    it('fails if customerId not set', async () => {
+    it('fails if customerId not set - basic', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -227,7 +227,7 @@ describe('GoogleEnhancedConversions', () => {
       }
     })
 
-    it('sends an event with default mappings', async () => {
+    it('sends an event with default mappings - with enhanced v12 flag', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -269,7 +269,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[0].status).toBe(201)
     })
 
-    it('sends email and phone user_identifiers', async () => {
+    it('sends email and phone user_identifiers - with enhanced v12 flag', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -312,7 +312,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[0].status).toBe(201)
     })
 
-    it('fails if customerId not set', async () => {
+    it('fails if customerId not set - with enhanced v12 flag', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -518,6 +518,765 @@ describe('GoogleEnhancedConversions', () => {
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
         `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}],\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}}],\\"partialFailure\\":true}"`
+      )
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+  })
+
+  describe('uploadClickConversion Batch Event', () => {
+    it('sends an event with default mappings - basic', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion', {
+        events,
+        mapping: { conversion_action: '12345' },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('sends email and phone user_identifiers - basic', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            phone: '6161729102',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            phone: '6161729102',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion', {
+        events,
+        mapping: { conversion_action: '12345' },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"e63a1ca2fcb2a9d4c7db0dfae9e63d86c7cdbb7cfdba742848f50f38d460a5ec\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"e63a1ca2fcb2a9d4c7db0dfae9e63d86c7cdbb7cfdba742848f50f38d460a5ec\\"}]}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('sends email and phone user_identifiers - with "+"', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            phone: '+6161729102',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            phone: '+6161729102',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion', {
+        events,
+        mapping: { conversion_action: '12345' },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"e63a1ca2fcb2a9d4c7db0dfae9e63d86c7cdbb7cfdba742848f50f38d460a5ec\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"e63a1ca2fcb2a9d4c7db0dfae9e63d86c7cdbb7cfdba742848f50f38d460a5ec\\"}]}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('correctly maps custom variables', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}/googleAds:searchStream`)
+        .post('')
+        .reply(200, [
+          {
+            results: [
+              {
+                conversionCustomVariable: {
+                  resourceName: 'customers/1234/conversionCustomVariables/123445',
+                  id: '123445',
+                  name: 'username'
+                }
+              }
+            ]
+          }
+        ])
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion', {
+        events,
+        mapping: { conversion_action: '12345', custom_variables: { username: 'spongebob' } },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[1].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[],\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[],\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(2)
+      expect(responses[1].status).toBe(201)
+    })
+
+    it('fails if customerId not set - basic', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, {})
+
+      try {
+        await testDestination.testBatchAction('uploadClickConversion', {
+          events,
+          mapping: { conversion_action: '12345' },
+          useDefaultMappings: true,
+          settings: {}
+        })
+        fail('the test should have thrown an error')
+      } catch (e: any) {
+        expect(e.message).toBe('Customer ID is required for this action. Please set it in destination settings.')
+      }
+    })
+
+    it('sends an event with default mappings - with enhanced v12 flag', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion', {
+        events,
+        features: { 'google-enhanced-v12': true },
+        mapping: { conversion_action: '12345' },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('sends email and phone user_identifiers - with enhanced v12 flag', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            phone: '6161729102',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            phone: '6161729102',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion', {
+        events,
+        features: { 'google-enhanced-v12': true },
+        mapping: { conversion_action: '12345' },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"e63a1ca2fcb2a9d4c7db0dfae9e63d86c7cdbb7cfdba742848f50f38d460a5ec\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"e63a1ca2fcb2a9d4c7db0dfae9e63d86c7cdbb7cfdba742848f50f38d460a5ec\\"}]}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('fails if customerId not set - with enhanced v12 flag', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, {})
+
+      try {
+        await testDestination.testBatchAction('uploadClickConversion', {
+          events,
+          features: { 'google-enhanced-v12': true },
+          mapping: { conversion_action: '12345' },
+          useDefaultMappings: true,
+          settings: {}
+        })
+        fail('the test should have thrown an error')
+      } catch (e: any) {
+        expect(e.message).toBe('Customer ID is required for this action. Please set it in destination settings.')
+      }
+    })
+
+    it('uses canary API version if flagon gate is set', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${CANARY_API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion', {
+        events,
+        mapping: { conversion_action: '12345' },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        },
+        features: {
+          [FLAGON_NAME]: true
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('hashed email and phone', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event',
+          properties: {
+            gclid: '54321',
+            email: 'a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9', //'test1@gmail.com'
+            phone: '64eab4e4d9e8e4f801e34d4f9043494ac3ccf778fb428dcbb555e632bb29d84b', // '6161729101'
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event',
+          properties: {
+            gclid: '54321',
+            email: 'cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47', //'test2@gmail.com'
+            phone: '1dba01a96da19f6df771cff07e0a8d822126709b82ae7adc6a3839b3aaa68a16', // '6161729102'
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          ad_personalization_consent_state: 'GRANTED'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"64eab4e4d9e8e4f801e34d4f9043494ac3ccf778fb428dcbb555e632bb29d84b\\"}],\\"consent\\":{\\"adPersonalization\\":\\"GRANTED\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"1dba01a96da19f6df771cff07e0a8d822126709b82ae7adc6a3839b3aaa68a16\\"}],\\"consent\\":{\\"adPersonalization\\":\\"GRANTED\\"}}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('fails if email is invalid', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'anything',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'anything',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, {})
+
+      try {
+        await testDestination.testBatchAction('uploadClickConversion', {
+          events,
+          features: { 'google-enhanced-v12': true },
+          mapping: { conversion_action: '12345' },
+          useDefaultMappings: true,
+          settings: {
+            customerId
+          }
+        })
+        fail('the test should have thrown an error')
+      } catch (e: any) {
+        expect(e.message).toBe("Email provided doesn't seem to be in a valid format.")
+      }
+    })
+
+    it('Deny User Data and Personalised Consent State', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9', //'test1@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47', //'test1@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          ad_user_data_consent_state: 'DENIED',
+          ad_personalization_consent_state: 'DENIED'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"}],\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"}],\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}}],\\"partialFailure\\":true}"`
       )
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
@@ -2,14 +2,15 @@ import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import GoogleEnhancedConversions from '../index'
 import { API_VERSION, CANARY_API_VERSION, FLAGON_NAME } from '../functions'
+import { SegmentEvent } from '@segment/actions-core/*'
 
 const testDestination = createTestIntegration(GoogleEnhancedConversions)
 const timestamp = new Date('Thu Jun 10 2021 11:08:04 GMT-0700 (Pacific Daylight Time)').toISOString()
 const customerId = '1234'
 
 describe('GoogleEnhancedConversions', () => {
-  describe('uploadClickConversion2', () => {
-    it('sends an event with default mappings', async () => {
+  describe('uploadClickConversion2 Single Event', () => {
+    it('sends an event with default mappings - basic', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -53,7 +54,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[0].status).toBe(201)
     })
 
-    it('sends email and phone user_identifiers', async () => {
+    it('sends email and phone user_identifiers - basic', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -98,7 +99,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[0].status).toBe(201)
     })
 
-    it('sends email and phone user_identifiers with "+"', async () => {
+    it('sends email and phone user_identifiers - with "+"', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -243,7 +244,7 @@ describe('GoogleEnhancedConversions', () => {
       }
     })
 
-    it('sends an event with default mappings', async () => {
+    it('sends an event with default mappings - with enhanced v12 flag', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -288,7 +289,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[0].status).toBe(201)
     })
 
-    it('sends email and phone user_identifiers', async () => {
+    it('sends email and phone user_identifiers - with enhanced v12 flag', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -583,6 +584,859 @@ describe('GoogleEnhancedConversions', () => {
       try {
         await testDestination.testAction('uploadClickConversion2', {
           event,
+          mapping: {
+            conversion_action: '12345',
+            __segment_internal_sync_mode: 'upsert'
+          },
+          useDefaultMappings: true,
+          settings: {}
+        })
+        fail('the test should have thrown an error')
+      } catch (e: any) {
+        expect(e.message).toBe('Unsupported Sync Mode "upsert"')
+      }
+    })
+  })
+
+  describe('uploadClickConversion2 Batch Event', () => {
+    it('sends an event with default mappings - basic', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test1@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test2@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion2', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"}]}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('sends email and phone user_identifiers - basic', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test1@gmail.com',
+            phone: '6161729102',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test2@gmail.com',
+            phone: '6161729102',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion2', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"e63a1ca2fcb2a9d4c7db0dfae9e63d86c7cdbb7cfdba742848f50f38d460a5ec\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"e63a1ca2fcb2a9d4c7db0dfae9e63d86c7cdbb7cfdba742848f50f38d460a5ec\\"}]}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('sends email and phone user_identifiers - with "+"', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test1@gmail.com',
+            phone: '+6161729101',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test2@gmail.com',
+            phone: '+6161729102',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion2', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"ef873ef70d75ae19678b2bacbddd956cccda7b619b4ffc7af2b60e570d27b095\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"e63a1ca2fcb2a9d4c7db0dfae9e63d86c7cdbb7cfdba742848f50f38d460a5ec\\"}]}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('correctly maps custom variables', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}/googleAds:searchStream`)
+        .post('')
+        .reply(200, [
+          {
+            results: [
+              {
+                conversionCustomVariable: {
+                  resourceName: 'customers/1234/conversionCustomVariables/123445',
+                  id: '123445',
+                  name: 'username'
+                }
+              }
+            ]
+          }
+        ])
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion2', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          custom_variables: { username: 'spongebob' },
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[1].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[],\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[],\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(2)
+      expect(responses[1].status).toBe(201)
+    })
+
+    it('fails if customerId not set - basic', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, {})
+
+      try {
+        await testDestination.testBatchAction('uploadClickConversion2', {
+          events,
+          mapping: {
+            conversion_action: '12345',
+            __segment_internal_sync_mode: 'add'
+          },
+          useDefaultMappings: true,
+          settings: {}
+        })
+        fail('the test should have thrown an error')
+      } catch (e: any) {
+        expect(e.message).toBe('Customer ID is required for this action. Please set it in destination settings.')
+      }
+    })
+
+    it('sends an event with default mappings - with enhanced v12 flag', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test1@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test2@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion2', {
+        events,
+        features: { 'google-enhanced-v12': true },
+        mapping: {
+          conversion_action: '12345',
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"}]}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('sends email and phone user_identifiers - with enhanced v12 flag', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test1@gmail.com',
+            phone: '6161729101',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test2@gmail.com',
+            phone: '6161729102',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion2', {
+        events,
+        features: { 'google-enhanced-v12': true },
+        mapping: {
+          conversion_action: '12345',
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"ef873ef70d75ae19678b2bacbddd956cccda7b619b4ffc7af2b60e570d27b095\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"e63a1ca2fcb2a9d4c7db0dfae9e63d86c7cdbb7cfdba742848f50f38d460a5ec\\"}]}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('fails if customerId not set - with enhanced v12 flag', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, {})
+
+      try {
+        await testDestination.testBatchAction('uploadClickConversion2', {
+          events,
+          features: { 'google-enhanced-v12': true },
+          mapping: {
+            conversion_action: '12345',
+            __segment_internal_sync_mode: 'add'
+          },
+          useDefaultMappings: true,
+          settings: {}
+        })
+        fail('the test should have thrown an error')
+      } catch (e: any) {
+        expect(e.message).toBe('Customer ID is required for this action. Please set it in destination settings.')
+      }
+    })
+
+    it('uses canary API version if flagon gate is set', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${CANARY_API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion2', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        },
+        features: {
+          [FLAGON_NAME]: true
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('hashed email and phone', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9', //'test1@gmail.com'
+            phone: '64eab4e4d9e8e4f801e34d4f9043494ac3ccf778fb428dcbb555e632bb29d84b', // '6161729101'
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47', //'test2@gmail.com'
+            phone: '1dba01a96da19f6df771cff07e0a8d822126709b82ae7adc6a3839b3aaa68a16', // '6161729102'
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion2', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          ad_personalization_consent_state: 'GRANTED',
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"64eab4e4d9e8e4f801e34d4f9043494ac3ccf778fb428dcbb555e632bb29d84b\\"}],\\"consent\\":{\\"adPersonalization\\":\\"GRANTED\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"1dba01a96da19f6df771cff07e0a8d822126709b82ae7adc6a3839b3aaa68a16\\"}],\\"consent\\":{\\"adPersonalization\\":\\"GRANTED\\"}}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('fails if email is invalid', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'anything',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'anything',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, {})
+
+      try {
+        await testDestination.testBatchAction('uploadClickConversion2', {
+          events,
+          features: { 'google-enhanced-v12': true },
+          mapping: {
+            conversion_action: '12345',
+            __segment_internal_sync_mode: 'add'
+          },
+          useDefaultMappings: true,
+          settings: {
+            customerId
+          }
+        })
+        fail('the test should have thrown an error')
+      } catch (e: any) {
+        expect(e.message).toBe("Email provided doesn't seem to be in a valid format.")
+      }
+    })
+
+    it('Deny User Data and Personalised Consent State', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event',
+          properties: {
+            gclid: '54321',
+            email: '87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674', //'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event',
+          properties: {
+            gclid: '54321',
+            email: '87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674', //'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion2', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          ad_user_data_consent_state: 'DENIED',
+          ad_personalization_consent_state: 'DENIED',
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}],\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}],\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}}],\\"partialFailure\\":true}"`
+      )
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('fails if sync mode is not supported', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, {})
+
+      try {
+        await testDestination.testBatchAction('uploadClickConversion2', {
+          events,
           mapping: {
             conversion_action: '12345',
             __segment_internal_sync_mode: 'upsert'

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadConversionAdjustment.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadConversionAdjustment.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration, SegmentEvent } from '@segment/actions-core'
 import GoogleEnhancedConversions from '../index'
 import { API_VERSION, CANARY_API_VERSION, FLAGON_NAME } from '../functions'
 
@@ -8,8 +8,8 @@ const timestamp = new Date('Thu Jun 10 2021 11:08:04 GMT-0700 (Pacific Daylight 
 const customerId = '1234'
 
 describe('GoogleEnhancedConversions', () => {
-  describe('uploadConversionAdjustment', () => {
-    it('sends an event with default mappings', async () => {
+  describe('uploadConversionAdjustment Single Event', () => {
+    it('sends an event with default mappings - basic', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -67,7 +67,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[0].status).toBe(201)
     })
 
-    it('sends an event with default mappings, hashed data should not be hashed again', async () => {
+    it('sends an event with default mappings - hashed data should not be hashed again', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -125,7 +125,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[0].status).toBe(201)
     })
 
-    it('fails if customerId not set', async () => {
+    it('fails if customerId not set - basic', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -153,7 +153,7 @@ describe('GoogleEnhancedConversions', () => {
       }
     })
 
-    it('sends restatement_value for restatements', async () => {
+    it('sends restatement_value for restatements - basic', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -199,7 +199,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[0].status).toBe(201)
     })
 
-    it('does not send restatement_value for retractions', async () => {
+    it('does not send restatement_value for retractions - basic', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -235,7 +235,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[0].status).toBe(201)
     })
 
-    it('fails if customerId not set', async () => {
+    it('fails if customerId not set - with enhanced v12 flag', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -264,7 +264,7 @@ describe('GoogleEnhancedConversions', () => {
       }
     })
 
-    it('sends restatement_value for restatements', async () => {
+    it('sends restatement_value for restatements - with enhanced v12 flag', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -311,7 +311,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[0].status).toBe(201)
     })
 
-    it('does not send restatement_value for retractions', async () => {
+    it('does not send restatement_value for retractions - with enhanced v12 flag', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -485,6 +485,662 @@ describe('GoogleEnhancedConversions', () => {
       try {
         await testDestination.testAction('uploadConversionAdjustment', {
           event,
+          features: { 'google-enhanced-v12': true },
+          mapping: { gclid: '123a', conversion_action: '12345', adjustment_type: 'ENHANCEMENT' },
+          useDefaultMappings: true,
+          settings: {
+            customerId
+          }
+        })
+        fail('the test should have thrown an error')
+      } catch (e: any) {
+        expect(e.message).toBe("Email provided doesn't seem to be in a valid format.")
+      }
+    })
+  })
+
+  describe('uploadConversionAdjustment Batch Event', () => {
+    it('sends an event with default mappings - basic', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadConversionAdjustment', {
+        events,
+        mapping: {
+          gclid: {
+            '@path': '$.properties.gclid'
+          },
+          conversion_action: '12345',
+          adjustment_type: 'ENHANCEMENT',
+          conversion_timestamp: {
+            '@path': '$.timestamp'
+          },
+          restatement_value: {
+            '@path': '$.properties.value'
+          },
+          restatement_currency_code: {
+            '@path': '$.properties.currency'
+          }
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversionAdjustments\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"ENHANCEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"54321\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"},{\\"addressInfo\\":{\\"hashedFirstName\\":\\"4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332\\",\\"hashedLastName\\":\\"fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7\\"}}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"ENHANCEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"54321\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"},{\\"addressInfo\\":{\\"hashedFirstName\\":\\"4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332\\",\\"hashedLastName\\":\\"fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7\\"}}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('sends an event with default mappings - hashed data should not be hashed again', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: '87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674',
+            orderId: '1234',
+            phone: 'c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646',
+            firstName: '4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332',
+            lastName: 'fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: '87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674',
+            orderId: '1234',
+            phone: 'c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646',
+            firstName: '4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332',
+            lastName: 'fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadConversionAdjustment', {
+        events,
+        mapping: {
+          gclid: {
+            '@path': '$.properties.gclid'
+          },
+          conversion_action: '12345',
+          adjustment_type: 'ENHANCEMENT',
+          conversion_timestamp: {
+            '@path': '$.timestamp'
+          },
+          restatement_value: {
+            '@path': '$.properties.value'
+          },
+          restatement_currency_code: {
+            '@path': '$.properties.currency'
+          }
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversionAdjustments\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"ENHANCEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"54321\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"},{\\"addressInfo\\":{\\"hashedFirstName\\":\\"4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332\\",\\"hashedLastName\\":\\"fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7\\"}}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"ENHANCEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"54321\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"},{\\"addressInfo\\":{\\"hashedFirstName\\":\\"4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332\\",\\"hashedLastName\\":\\"fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7\\"}}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('fails if customerId not set - basic', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      try {
+        await testDestination.testBatchAction('uploadConversionAdjustment', {
+          events,
+          mapping: { gclid: '123a', conversion_action: '12345', adjustment_type: 'ENHANCEMENT' },
+          useDefaultMappings: true,
+          settings: {}
+        })
+        fail('the test should have thrown an error')
+      } catch (e: any) {
+        expect(e.message).toBe('Customer ID is required for this action. Please set it in destination settings.')
+      }
+    })
+
+    it('sends restatement_value for restatements - basic', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test@gmail.com',
+            phone: '1234567890',
+            value: '123',
+            currency: 'USD'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test@gmail.com',
+            phone: '1234567890',
+            value: '123',
+            currency: 'USD'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadConversionAdjustment', {
+        events,
+        mapping: {
+          gclid: '123a',
+          conversion_action: '12345',
+          adjustment_type: 'RESTATEMENT',
+          conversion_timestamp: {
+            '@path': '$.timestamp'
+          },
+          restatement_value: {
+            '@path': '$.properties.value'
+          },
+          restatement_currency_code: {
+            '@path': '$.properties.currency'
+          }
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversionAdjustments\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"RESTATEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"123a\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"RESTATEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"123a\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('does not send restatement_value for retractions - basic', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test@gmail.com',
+            phone: '1234567890'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test@gmail.com',
+            phone: '1234567890'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadConversionAdjustment', {
+        events,
+        mapping: {
+          gclid: '123a',
+          conversion_action: '12345',
+          adjustment_type: 'RETRACTION',
+          conversion_timestamp: timestamp
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversionAdjustments\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"RETRACTION\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"123a\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"RETRACTION\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"123a\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('fails if customerId not set - with enhanced v12 flag', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      try {
+        await testDestination.testBatchAction('uploadConversionAdjustment', {
+          events,
+          features: { 'google-enhanced-v12': true },
+          mapping: { gclid: '123a', conversion_action: '12345', adjustment_type: 'ENHANCEMENT' },
+          useDefaultMappings: true,
+          settings: {}
+        })
+        fail('the test should have thrown an error')
+      } catch (e: any) {
+        expect(e.message).toBe('Customer ID is required for this action. Please set it in destination settings.')
+      }
+    })
+
+    it('sends restatement_value for restatements - with enhanced v12 flag', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test@gmail.com',
+            phone: '1234567890',
+            value: '123',
+            currency: 'USD'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test@gmail.com',
+            phone: '1234567890',
+            value: '123',
+            currency: 'USD'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadConversionAdjustment', {
+        events,
+        features: { 'google-enhanced-v12': true },
+        mapping: {
+          gclid: '123a',
+          conversion_action: '12345',
+          adjustment_type: 'RESTATEMENT',
+          conversion_timestamp: {
+            '@path': '$.timestamp'
+          },
+          restatement_value: {
+            '@path': '$.properties.value'
+          },
+          restatement_currency_code: {
+            '@path': '$.properties.currency'
+          }
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversionAdjustments\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"RESTATEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"123a\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"RESTATEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"123a\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('does not send restatement_value for retractions - with enhanced v12 flag', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test@gmail.com',
+            phone: '1234567890'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test@gmail.com',
+            phone: '1234567890'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadConversionAdjustment', {
+        events,
+        features: { 'google-enhanced-v12': true },
+        mapping: {
+          gclid: '123a',
+          conversion_action: '12345',
+          adjustment_type: 'RETRACTION',
+          conversion_timestamp: timestamp
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversionAdjustments\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"RETRACTION\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"123a\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"RETRACTION\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"123a\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('uses canary API version if flagon gate is set', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${CANARY_API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadConversionAdjustment', {
+        events,
+        mapping: {
+          gclid: {
+            '@path': '$.properties.gclid'
+          },
+          conversion_action: '12345',
+          adjustment_type: 'ENHANCEMENT',
+          conversion_timestamp: {
+            '@path': '$.timestamp'
+          },
+          restatement_value: {
+            '@path': '$.properties.value'
+          },
+          restatement_currency_code: {
+            '@path': '$.properties.currency'
+          }
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        },
+        features: {
+          [FLAGON_NAME]: true
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversionAdjustments\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"ENHANCEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"54321\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"},{\\"addressInfo\\":{\\"hashedFirstName\\":\\"4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332\\",\\"hashedLastName\\":\\"fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7\\"}}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"ENHANCEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"54321\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"},{\\"addressInfo\\":{\\"hashedFirstName\\":\\"4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332\\",\\"hashedLastName\\":\\"fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7\\"}}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('hashed email', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: '87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674',
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: '87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674',
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadConversionAdjustment', {
+        events,
+        mapping: {
+          gclid: {
+            '@path': '$.properties.gclid'
+          },
+          conversion_action: '12345',
+          adjustment_type: 'ENHANCEMENT',
+          conversion_timestamp: {
+            '@path': '$.timestamp'
+          },
+          restatement_value: {
+            '@path': '$.properties.value'
+          },
+          restatement_currency_code: {
+            '@path': '$.properties.currency'
+          }
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversionAdjustments\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"ENHANCEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"54321\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"},{\\"addressInfo\\":{\\"hashedFirstName\\":\\"4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332\\",\\"hashedLastName\\":\\"fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7\\"}}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"ENHANCEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"54321\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"},{\\"addressInfo\\":{\\"hashedFirstName\\":\\"4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332\\",\\"hashedLastName\\":\\"fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7\\"}}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('fails if email is invalid', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'anything',
+            orderId: '1234'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'anything',
+            orderId: '1234'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      try {
+        await testDestination.testBatchAction('uploadConversionAdjustment', {
+          events,
           features: { 'google-enhanced-v12': true },
           mapping: { gclid: '123a', conversion_action: '12345', adjustment_type: 'ENHANCEMENT' },
           useDefaultMappings: true,

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadConversionAdjustment2.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadConversionAdjustment2.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration, SegmentEvent } from '@segment/actions-core'
 import GoogleEnhancedConversions from '../index'
 import { API_VERSION, CANARY_API_VERSION, FLAGON_NAME } from '../functions'
 
@@ -8,8 +8,8 @@ const timestamp = new Date('Thu Jun 10 2021 11:08:04 GMT-0700 (Pacific Daylight 
 const customerId = '1234'
 
 describe('GoogleEnhancedConversions', () => {
-  describe('uploadConversionAdjustment2', () => {
-    it('sends an event with default mappings', async () => {
+  describe('uploadConversionAdjustment2 Single Event', () => {
+    it('sends an event with default mappings - basic', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -68,7 +68,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[0].status).toBe(201)
     })
 
-    it('sends an event with default mappings, hashed data should not be hashed again', async () => {
+    it('sends an event with default mappings - hashed data should not be hashed again', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -127,7 +127,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[0].status).toBe(201)
     })
 
-    it('fails if customerId not set', async () => {
+    it('fails if customerId not set - basic', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -193,7 +193,7 @@ describe('GoogleEnhancedConversions', () => {
       }
     })
 
-    it('sends restatement_value for restatements', async () => {
+    it('sends restatement_value for restatements - basic', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -240,7 +240,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[0].status).toBe(201)
     })
 
-    it('does not send restatement_value for retractions', async () => {
+    it('does not send restatement_value for retractions - basic', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -311,7 +311,7 @@ describe('GoogleEnhancedConversions', () => {
       }
     })
 
-    it('sends restatement_value for restatements', async () => {
+    it('sends restatement_value for restatements - with enhanced v12 flag', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -359,7 +359,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[0].status).toBe(201)
     })
 
-    it('does not send restatement_value for retractions', async () => {
+    it('does not send restatement_value for retractions - with enhanced v12 flag', async () => {
       const event = createTestEvent({
         timestamp,
         event: 'Test Event',
@@ -536,6 +536,729 @@ describe('GoogleEnhancedConversions', () => {
       try {
         await testDestination.testAction('uploadConversionAdjustment2', {
           event,
+          features: { 'google-enhanced-v12': true },
+          mapping: {
+            gclid: '123a',
+            conversion_action: '12345',
+            adjustment_type: 'ENHANCEMENT',
+            __segment_internal_sync_mode: 'add'
+          },
+          useDefaultMappings: true,
+          settings: {
+            customerId
+          }
+        })
+        fail('the test should have thrown an error')
+      } catch (e: any) {
+        expect(e.message).toBe("Email provided doesn't seem to be in a valid format.")
+      }
+    })
+  })
+
+  describe('uploadConversionAdjustment2 Batch Event', () => {
+    it('sends an event with default mappings - basic', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test1@gmail.com',
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test2@gmail.com',
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadConversionAdjustment2', {
+        events,
+        mapping: {
+          gclid: {
+            '@path': '$.properties.gclid'
+          },
+          conversion_action: '12345',
+          adjustment_type: 'ENHANCEMENT',
+          conversion_timestamp: {
+            '@path': '$.timestamp'
+          },
+          restatement_value: {
+            '@path': '$.properties.value'
+          },
+          restatement_currency_code: {
+            '@path': '$.properties.currency'
+          },
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversionAdjustments\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"ENHANCEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"54321\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"},{\\"addressInfo\\":{\\"hashedFirstName\\":\\"4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332\\",\\"hashedLastName\\":\\"fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7\\"}}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"ENHANCEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"54321\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"},{\\"addressInfo\\":{\\"hashedFirstName\\":\\"4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332\\",\\"hashedLastName\\":\\"fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7\\"}}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('sends an event with default mappings - hashed data should not be hashed again', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9', //'test1@gmail.com'
+            phone: '64eab4e4d9e8e4f801e34d4f9043494ac3ccf778fb428dcbb555e632bb29d84b', // '6161729101'
+            orderId: '1234',
+            firstName: '4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332',
+            lastName: 'fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47', //'test2@gmail.com'
+            phone: '1dba01a96da19f6df771cff07e0a8d822126709b82ae7adc6a3839b3aaa68a16', // '6161729102'
+            orderId: '1234',
+            firstName: '4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332',
+            lastName: 'fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadConversionAdjustment2', {
+        events,
+        mapping: {
+          gclid: {
+            '@path': '$.properties.gclid'
+          },
+          conversion_action: '12345',
+          adjustment_type: 'ENHANCEMENT',
+          conversion_timestamp: {
+            '@path': '$.timestamp'
+          },
+          restatement_value: {
+            '@path': '$.properties.value'
+          },
+          restatement_currency_code: {
+            '@path': '$.properties.currency'
+          },
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversionAdjustments\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"ENHANCEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"54321\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"64eab4e4d9e8e4f801e34d4f9043494ac3ccf778fb428dcbb555e632bb29d84b\\"},{\\"addressInfo\\":{\\"hashedFirstName\\":\\"4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332\\",\\"hashedLastName\\":\\"fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7\\"}}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"ENHANCEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"54321\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"1dba01a96da19f6df771cff07e0a8d822126709b82ae7adc6a3839b3aaa68a16\\"},{\\"addressInfo\\":{\\"hashedFirstName\\":\\"4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332\\",\\"hashedLastName\\":\\"fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7\\"}}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('fails if customerId not set - basic', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      try {
+        await testDestination.testBatchAction('uploadConversionAdjustment2', {
+          events,
+          mapping: {
+            gclid: '123a',
+            conversion_action: '12345',
+            adjustment_type: 'ENHANCEMENT',
+            __segment_internal_sync_mode: 'add'
+          },
+          useDefaultMappings: true,
+          settings: {}
+        })
+        fail('the test should have thrown an error')
+      } catch (e: any) {
+        expect(e.message).toBe('Customer ID is required for this action. Please set it in destination settings.')
+      }
+    })
+
+    it('fails if sync mode is not supported', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test1@gmail.com',
+            orderId: '1234'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test2@gmail.com',
+            orderId: '1234'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      try {
+        await testDestination.testBatchAction('uploadConversionAdjustment2', {
+          events,
+          mapping: {
+            gclid: '123a',
+            conversion_action: '12345',
+            adjustment_type: 'ENHANCEMENT',
+            __segment_internal_sync_mode: 'upsert'
+          },
+          useDefaultMappings: true,
+          settings: {}
+        })
+        fail('the test should have thrown an error')
+      } catch (e: any) {
+        expect(e.message).toBe('Unsupported Sync Mode "upsert"')
+      }
+    })
+
+    it('sends restatement_value for restatements - basic', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test1@gmail.com',
+            phone: '1234567890',
+            value: '123',
+            currency: 'USD'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test2@gmail.com',
+            phone: '1234567890',
+            value: '123',
+            currency: 'USD'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadConversionAdjustment2', {
+        events,
+        mapping: {
+          gclid: '123a',
+          conversion_action: '12345',
+          adjustment_type: 'RESTATEMENT',
+          conversion_timestamp: {
+            '@path': '$.timestamp'
+          },
+          restatement_value: {
+            '@path': '$.properties.value'
+          },
+          restatement_currency_code: {
+            '@path': '$.properties.currency'
+          },
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversionAdjustments\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"RESTATEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"123a\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"RESTATEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"123a\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('does not send restatement_value for retractions - basic', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test1@gmail.com',
+            phone: '1234567890'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test2@gmail.com',
+            phone: '1234567890'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadConversionAdjustment2', {
+        events,
+        mapping: {
+          gclid: '123a',
+          conversion_action: '12345',
+          adjustment_type: 'RETRACTION',
+          conversion_timestamp: timestamp,
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversionAdjustments\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"RETRACTION\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"123a\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"RETRACTION\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"123a\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('fails if customerId not set', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      try {
+        await testDestination.testBatchAction('uploadConversionAdjustment2', {
+          events,
+          features: { 'google-enhanced-v12': true },
+          mapping: {
+            gclid: '123a',
+            conversion_action: '12345',
+            adjustment_type: 'ENHANCEMENT',
+            __segment_internal_sync_mode: 'add'
+          },
+          useDefaultMappings: true,
+          settings: {}
+        })
+        fail('the test should have thrown an error')
+      } catch (e: any) {
+        expect(e.message).toBe('Customer ID is required for this action. Please set it in destination settings.')
+      }
+    })
+
+    it('sends restatement_value for restatements - with enhanced v12 flag', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event',
+          properties: {
+            email: 'test1@gmail.com',
+            phone: '1234567890',
+            value: '123',
+            currency: 'USD'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event',
+          properties: {
+            email: 'test2@gmail.com',
+            phone: '1234567890',
+            value: '123',
+            currency: 'USD'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadConversionAdjustment2', {
+        events,
+        features: { 'google-enhanced-v12': true },
+        mapping: {
+          gclid: '123a',
+          conversion_action: '12345',
+          adjustment_type: 'RESTATEMENT',
+          conversion_timestamp: {
+            '@path': '$.timestamp'
+          },
+          restatement_value: {
+            '@path': '$.properties.value'
+          },
+          restatement_currency_code: {
+            '@path': '$.properties.currency'
+          },
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversionAdjustments\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"RESTATEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"123a\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"RESTATEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"123a\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('does not send restatement_value for retractions - with enhanced v12 flag', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            email: 'test1@gmail.com',
+            phone: '1234567890'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            email: 'test2@gmail.com',
+            phone: '1234567890'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadConversionAdjustment2', {
+        events,
+        features: { 'google-enhanced-v12': true },
+        mapping: {
+          gclid: '123a',
+          conversion_action: '12345',
+          adjustment_type: 'RETRACTION',
+          conversion_timestamp: timestamp,
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversionAdjustments\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"RETRACTION\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"123a\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"RETRACTION\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"123a\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('uses canary API version if flagon gate is set', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'test1@gmail.com',
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'test2@gmail.com',
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${CANARY_API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadConversionAdjustment2', {
+        events,
+        mapping: {
+          gclid: {
+            '@path': '$.properties.gclid'
+          },
+          conversion_action: '12345',
+          adjustment_type: 'ENHANCEMENT',
+          conversion_timestamp: {
+            '@path': '$.timestamp'
+          },
+          restatement_value: {
+            '@path': '$.properties.value'
+          },
+          restatement_currency_code: {
+            '@path': '$.properties.currency'
+          },
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        },
+        features: {
+          [FLAGON_NAME]: true
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversionAdjustments\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"ENHANCEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"54321\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"},{\\"addressInfo\\":{\\"hashedFirstName\\":\\"4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332\\",\\"hashedLastName\\":\\"fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7\\"}}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"ENHANCEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"54321\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"},{\\"addressInfo\\":{\\"hashedFirstName\\":\\"4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332\\",\\"hashedLastName\\":\\"fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7\\"}}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('hashed email', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9', //'test1@gmail.com'
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47', //'test2@gmail.com'
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadConversionAdjustment2', {
+        events,
+        mapping: {
+          gclid: {
+            '@path': '$.properties.gclid'
+          },
+          conversion_action: '12345',
+          adjustment_type: 'ENHANCEMENT',
+          conversion_timestamp: {
+            '@path': '$.timestamp'
+          },
+          restatement_value: {
+            '@path': '$.properties.value'
+          },
+          restatement_currency_code: {
+            '@path': '$.properties.currency'
+          },
+          __segment_internal_sync_mode: 'add'
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversionAdjustments\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"ENHANCEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"54321\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"},{\\"addressInfo\\":{\\"hashedFirstName\\":\\"4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332\\",\\"hashedLastName\\":\\"fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7\\"}}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"adjustmentType\\":\\"ENHANCEMENT\\",\\"adjustmentDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"gclidDateTimePair\\":{\\"gclid\\":\\"54321\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\"},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646\\"},{\\"addressInfo\\":{\\"hashedFirstName\\":\\"4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332\\",\\"hashedLastName\\":\\"fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7\\"}}],\\"userAgent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"restatementValue\\":{\\"adjustedValue\\":123,\\"currencyCode\\":\\"USD\\"}}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('fails if email is invalid', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            email: 'anything',
+            orderId: '1234'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            email: 'anything',
+            orderId: '1234'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      try {
+        await testDestination.testBatchAction('uploadConversionAdjustment2', {
+          events,
           features: { 'google-enhanced-v12': true },
           mapping: {
             gclid: '123a',

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/constants.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/constants.ts
@@ -1,3 +1,3 @@
 // GEC's max batch size is 2000
 // https://developers.google.com/google-ads/api/docs/best-practices/quotas#conversion_upload_service
-export const GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE = 2000
+export const GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE = 1500

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/constants.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/constants.ts
@@ -1,0 +1,3 @@
+// GEC's max batch size is 2000
+// https://developers.google.com/google-ads/api/docs/best-practices/quotas#conversion_upload_service
+export const GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE = 2000

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -97,6 +97,26 @@ export async function getCustomVariables(
   )
 }
 
+export function memoizedGetCustomVariables() {
+  const cache: Map<string, Promise<ModifiedResponse<QueryResponse[]>>> = new Map()
+
+  return async (
+    customerId: string,
+    auth: any,
+    request: RequestClient,
+    features: Features | undefined,
+    statsContext: StatsContext | undefined
+  ) => {
+    if (cache.has(customerId)) {
+      return cache.get(customerId)
+    } else {
+      const result = getCustomVariables(customerId, auth, request, features, statsContext)
+      cache.set(customerId, result)
+      return result
+    }
+  }
+}
+
 export async function getConversionActionId(
   customerId: string | undefined,
   auth: any,

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/generated-types.ts
@@ -39,4 +39,12 @@ export interface Payload {
    * This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v15/Consent).
    */
   ad_personalization_consent_state?: string
+  /**
+   * If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.
+   */
+  enable_batching?: boolean
+  /**
+   * Maximum number of events to include in each batch.
+   */
+  batch_size: number
 }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/generated-types.ts
@@ -46,5 +46,5 @@ export interface Payload {
   /**
    * Maximum number of events to include in each batch.
    */
-  batch_size: number
+  batch_size?: number
 }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/index.ts
@@ -1,15 +1,10 @@
-import {
-  ActionDefinition,
-  DynamicFieldResponse,
-  PayloadValidationError,
-  RequestClient,
-  RequestFn
-} from '@segment/actions-core'
+import { ActionDefinition, DynamicFieldResponse, PayloadValidationError, RequestClient } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import {
   convertTimestamp,
   formatCustomVariables,
+  getCustomVariables,
   memoizedGetCustomVariables,
   getApiVersion,
   handleGoogleErrors,
@@ -126,86 +121,139 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, { auth, settings, payload, features, statsContext }) => {
-    return await uploadCallConversionAction(request, { auth, settings, payload: [payload], features, statsContext })
-  },
-  performBatch: async (request, { auth, settings, payload, features, statsContext }) => {
-    return await uploadCallConversionAction(request, { auth, settings, payload, features, statsContext })
-  }
-}
+    /* Enforcing this here since Customer ID is required for the Google Ads API
+    but not for the Enhanced Conversions API. */
+    if (!settings.customerId) {
+      throw new PayloadValidationError(
+        'Customer ID is required for this action. Please set it in destination settings.'
+      )
+    }
 
-const uploadCallConversionAction: RequestFn<Settings, Payload[]> = async (
-  request,
-  { auth, settings, payload, features, statsContext }
-) => {
-  /* Enforcing this here since Customer ID is required for the Google Ads API
-  but not for the Enhanced Conversions API. */
-  if (!settings.customerId) {
-    throw new PayloadValidationError('Customer ID is required for this action. Please set it in destination settings.')
-  }
+    settings.customerId = settings.customerId.replace(/-/g, '')
 
-  const customerId = settings.customerId.replace(/-/g, '')
+    const request_object: CallConversionRequestObjectInterface = {
+      conversionAction: `customers/${settings.customerId}/conversionActions/${payload.conversion_action}`,
+      callerId: payload.caller_id,
+      callStartDateTime: convertTimestamp(payload.call_timestamp),
+      conversionDateTime: convertTimestamp(payload.conversion_timestamp),
+      conversionValue: payload.value,
+      currencyCode: payload.currency
+    }
 
-  // Retrieves all of the custom variables that the customer has created in their Google Ads account
-  const getCustomVariables = memoizedGetCustomVariables()
-
-  const request_objects: CallConversionRequestObjectInterface[] = await Promise.all(
-    payload.map(async (payloadItem) => {
-      const request_object: CallConversionRequestObjectInterface = {
-        conversionAction: `customers/${customerId}/conversionActions/${payloadItem.conversion_action}`,
-        callerId: payloadItem.caller_id,
-        callStartDateTime: convertTimestamp(payloadItem.call_timestamp),
-        conversionDateTime: convertTimestamp(payloadItem.conversion_timestamp),
-        conversionValue: payloadItem.value,
-        currencyCode: payloadItem.currency
-      }
-
-      // Add Consent Signals 'adUserData' if it is defined
-      if (payloadItem.ad_user_data_consent_state) {
-        request_object['consent'] = {
-          adUserData: payloadItem.ad_user_data_consent_state
-        }
-      }
-
-      // Add Consent Signals 'adPersonalization' if it is defined
-      if (payloadItem.ad_personalization_consent_state) {
-        request_object['consent'] = {
-          ...request_object['consent'],
-          adPersonalization: payloadItem.ad_personalization_consent_state
-        }
-      }
-
-      if (payloadItem.custom_variables) {
-        const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
-        if (customVariableIds?.data?.length) {
-          request_object.customVariables = formatCustomVariables(
-            payloadItem.custom_variables,
-            customVariableIds.data[0].results
-          )
-        }
-      }
-
-      return request_object
-    })
-  )
-
-  const response: ModifiedResponse<PartialErrorResponse> = await request(
-    `https://googleads.googleapis.com/${getApiVersion(features, statsContext)}/customers/${
-      settings.customerId
-    }:uploadCallConversions`,
-    {
-      method: 'post',
-      headers: {
-        'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
-      },
-      json: {
-        conversions: request_objects,
-        partialFailure: true
+    // Add Consent Signals 'adUserData' if it is defined
+    if (payload.ad_user_data_consent_state) {
+      request_object['consent'] = {
+        adUserData: payload.ad_user_data_consent_state
       }
     }
-  )
 
-  handleGoogleErrors(response)
-  return response
+    // Add Consent Signals 'adPersonalization' if it is defined
+    if (payload.ad_personalization_consent_state) {
+      request_object['consent'] = {
+        ...request_object['consent'],
+        adPersonalization: payload.ad_personalization_consent_state
+      }
+    }
+    // Retrieves all of the custom variables that the customer has created in their Google Ads account
+    if (payload.custom_variables) {
+      const customVariableIds = await getCustomVariables(settings.customerId, auth, request, features, statsContext)
+      request_object.customVariables = formatCustomVariables(
+        payload.custom_variables,
+        customVariableIds.data[0].results
+      )
+    }
+    const response: ModifiedResponse<PartialErrorResponse> = await request(
+      `https://googleads.googleapis.com/${getApiVersion(features, statsContext)}/customers/${
+        settings.customerId
+      }:uploadCallConversions`,
+      {
+        method: 'post',
+        headers: {
+          'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
+        },
+        json: {
+          conversions: [request_object],
+          partialFailure: true
+        }
+      }
+    )
+
+    handleGoogleErrors(response)
+    return response
+  },
+  performBatch: async (request, { auth, settings, payload, features, statsContext }) => {
+    /* Enforcing this here since Customer ID is required for the Google Ads API
+  but not for the Enhanced Conversions API. */
+    if (!settings.customerId) {
+      throw new PayloadValidationError(
+        'Customer ID is required for this action. Please set it in destination settings.'
+      )
+    }
+
+    const customerId = settings.customerId.replace(/-/g, '')
+
+    // Retrieves all of the custom variables that the customer has created in their Google Ads account
+    const getCustomVariables = memoizedGetCustomVariables()
+
+    const request_objects: CallConversionRequestObjectInterface[] = await Promise.all(
+      payload.map(async (payloadItem) => {
+        const request_object: CallConversionRequestObjectInterface = {
+          conversionAction: `customers/${customerId}/conversionActions/${payloadItem.conversion_action}`,
+          callerId: payloadItem.caller_id,
+          callStartDateTime: convertTimestamp(payloadItem.call_timestamp),
+          conversionDateTime: convertTimestamp(payloadItem.conversion_timestamp),
+          conversionValue: payloadItem.value,
+          currencyCode: payloadItem.currency
+        }
+
+        // Add Consent Signals 'adUserData' if it is defined
+        if (payloadItem.ad_user_data_consent_state) {
+          request_object['consent'] = {
+            adUserData: payloadItem.ad_user_data_consent_state
+          }
+        }
+
+        // Add Consent Signals 'adPersonalization' if it is defined
+        if (payloadItem.ad_personalization_consent_state) {
+          request_object['consent'] = {
+            ...request_object['consent'],
+            adPersonalization: payloadItem.ad_personalization_consent_state
+          }
+        }
+
+        if (payloadItem.custom_variables) {
+          const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
+          if (customVariableIds?.data?.length) {
+            request_object.customVariables = formatCustomVariables(
+              payloadItem.custom_variables,
+              customVariableIds.data[0].results
+            )
+          }
+        }
+
+        return request_object
+      })
+    )
+
+    const response: ModifiedResponse<PartialErrorResponse> = await request(
+      `https://googleads.googleapis.com/${getApiVersion(features, statsContext)}/customers/${
+        settings.customerId
+      }:uploadCallConversions`,
+      {
+        method: 'post',
+        headers: {
+          'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
+        },
+        json: {
+          conversions: request_objects,
+          partialFailure: true
+        }
+      }
+    )
+
+    handleGoogleErrors(response)
+    return response
+  }
 }
 
 export default action

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/index.ts
@@ -100,13 +100,12 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch Data to Google Enhanced Conversions',
       description:
         'If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.',
-      default: true
+      default: false
     },
     batch_size: {
       label: 'Batch Size',
       description: 'Maximum number of events to include in each batch.',
       type: 'number',
-      required: true,
       unsafe_hidden: true,
       default: GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE
     }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/index.ts
@@ -1,16 +1,23 @@
-import { ActionDefinition, DynamicFieldResponse, PayloadValidationError, RequestClient } from '@segment/actions-core'
+import {
+  ActionDefinition,
+  DynamicFieldResponse,
+  PayloadValidationError,
+  RequestClient,
+  RequestFn
+} from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import {
   convertTimestamp,
   formatCustomVariables,
-  getCustomVariables,
+  memoizedGetCustomVariables,
   getApiVersion,
   handleGoogleErrors,
   getConversionActionDynamicData
 } from '../functions'
 import { CallConversionRequestObjectInterface, PartialErrorResponse } from '../types'
 import { ModifiedResponse } from '@segment/actions-core'
+import { GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE } from '../constants'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Upload Call Conversion',
@@ -92,6 +99,21 @@ const action: ActionDefinition<Settings, Payload> = {
         { label: 'DENIED', value: 'DENIED' },
         { label: 'UNSPECIFIED', value: 'UNSPECIFIED' }
       ]
+    },
+    enable_batching: {
+      type: 'boolean',
+      label: 'Batch Data to Google Enhanced Conversions',
+      description:
+        'If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.',
+      default: true
+    },
+    batch_size: {
+      label: 'Batch Size',
+      description: 'Maximum number of events to include in each batch.',
+      type: 'number',
+      required: true,
+      unsafe_hidden: true,
+      default: GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE
     }
   },
 
@@ -104,66 +126,86 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, { auth, settings, payload, features, statsContext }) => {
-    /* Enforcing this here since Customer ID is required for the Google Ads API
-    but not for the Enhanced Conversions API. */
-    if (!settings.customerId) {
-      throw new PayloadValidationError(
-        'Customer ID is required for this action. Please set it in destination settings.'
-      )
-    }
+    return await uploadCallConversionAction(request, { auth, settings, payload: [payload], features, statsContext })
+  },
+  performBatch: async (request, { auth, settings, payload, features, statsContext }) => {
+    return await uploadCallConversionAction(request, { auth, settings, payload, features, statsContext })
+  }
+}
 
-    settings.customerId = settings.customerId.replace(/-/g, '')
+const uploadCallConversionAction: RequestFn<Settings, Payload[]> = async (
+  request,
+  { auth, settings, payload, features, statsContext }
+) => {
+  /* Enforcing this here since Customer ID is required for the Google Ads API
+  but not for the Enhanced Conversions API. */
+  if (!settings.customerId) {
+    throw new PayloadValidationError('Customer ID is required for this action. Please set it in destination settings.')
+  }
 
-    const request_object: CallConversionRequestObjectInterface = {
-      conversionAction: `customers/${settings.customerId}/conversionActions/${payload.conversion_action}`,
-      callerId: payload.caller_id,
-      callStartDateTime: convertTimestamp(payload.call_timestamp),
-      conversionDateTime: convertTimestamp(payload.conversion_timestamp),
-      conversionValue: payload.value,
-      currencyCode: payload.currency
-    }
+  const customerId = settings.customerId.replace(/-/g, '')
 
-    // Add Consent Signals 'adUserData' if it is defined
-    if (payload.ad_user_data_consent_state) {
-      request_object['consent'] = {
-        adUserData: payload.ad_user_data_consent_state
+  // Retrieves all of the custom variables that the customer has created in their Google Ads account
+  const getCustomVariables = memoizedGetCustomVariables()
+
+  const request_objects: CallConversionRequestObjectInterface[] = await Promise.all(
+    payload.map(async (payloadItem) => {
+      const request_object: CallConversionRequestObjectInterface = {
+        conversionAction: `customers/${customerId}/conversionActions/${payloadItem.conversion_action}`,
+        callerId: payloadItem.caller_id,
+        callStartDateTime: convertTimestamp(payloadItem.call_timestamp),
+        conversionDateTime: convertTimestamp(payloadItem.conversion_timestamp),
+        conversionValue: payloadItem.value,
+        currencyCode: payloadItem.currency
       }
-    }
 
-    // Add Consent Signals 'adPersonalization' if it is defined
-    if (payload.ad_personalization_consent_state) {
-      request_object['consent'] = {
-        ...request_object['consent'],
-        adPersonalization: payload.ad_personalization_consent_state
-      }
-    }
-    // Retrieves all of the custom variables that the customer has created in their Google Ads account
-    if (payload.custom_variables) {
-      const customVariableIds = await getCustomVariables(settings.customerId, auth, request, features, statsContext)
-      request_object.customVariables = formatCustomVariables(
-        payload.custom_variables,
-        customVariableIds.data[0].results
-      )
-    }
-    const response: ModifiedResponse<PartialErrorResponse> = await request(
-      `https://googleads.googleapis.com/${getApiVersion(features, statsContext)}/customers/${
-        settings.customerId
-      }:uploadCallConversions`,
-      {
-        method: 'post',
-        headers: {
-          'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
-        },
-        json: {
-          conversions: [request_object],
-          partialFailure: true
+      // Add Consent Signals 'adUserData' if it is defined
+      if (payloadItem.ad_user_data_consent_state) {
+        request_object['consent'] = {
+          adUserData: payloadItem.ad_user_data_consent_state
         }
       }
-    )
 
-    handleGoogleErrors(response)
-    return response
-  }
+      // Add Consent Signals 'adPersonalization' if it is defined
+      if (payloadItem.ad_personalization_consent_state) {
+        request_object['consent'] = {
+          ...request_object['consent'],
+          adPersonalization: payloadItem.ad_personalization_consent_state
+        }
+      }
+
+      if (payloadItem.custom_variables) {
+        const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
+        if (customVariableIds?.data?.length) {
+          request_object.customVariables = formatCustomVariables(
+            payloadItem.custom_variables,
+            customVariableIds.data[0].results
+          )
+        }
+      }
+
+      return request_object
+    })
+  )
+
+  const response: ModifiedResponse<PartialErrorResponse> = await request(
+    `https://googleads.googleapis.com/${getApiVersion(features, statsContext)}/customers/${
+      settings.customerId
+    }:uploadCallConversions`,
+    {
+      method: 'post',
+      headers: {
+        'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
+      },
+      json: {
+        conversions: request_objects,
+        partialFailure: true
+      }
+    }
+  )
+
+  handleGoogleErrors(response)
+  return response
 }
 
 export default action

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/index.ts
@@ -100,6 +100,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch Data to Google Enhanced Conversions',
       description:
         'If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.',
+      unsafe_hidden: true,
       default: false
     },
     batch_size: {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion2/generated-types.ts
@@ -39,4 +39,12 @@ export interface Payload {
    * This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v15/Consent).
    */
   ad_personalization_consent_state?: string
+  /**
+   * If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.
+   */
+  enable_batching?: boolean
+  /**
+   * Maximum number of events to include in each batch.
+   */
+  batch_size?: number
 }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion2/index.ts
@@ -13,10 +13,12 @@ import {
   getCustomVariables,
   getApiVersion,
   handleGoogleErrors,
-  getConversionActionDynamicData
+  getConversionActionDynamicData,
+  memoizedGetCustomVariables
 } from '../functions'
 import { CallConversionRequestObjectInterface, PartialErrorResponse } from '../types'
 import { ModifiedResponse } from '@segment/actions-core'
+import { GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE } from '../constants'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Call Conversion',
@@ -104,6 +106,20 @@ const action: ActionDefinition<Settings, Payload> = {
         { label: 'DENIED', value: 'DENIED' },
         { label: 'UNSPECIFIED', value: 'UNSPECIFIED' }
       ]
+    },
+    enable_batching: {
+      type: 'boolean',
+      label: 'Batch Data to Google Enhanced Conversions',
+      description:
+        'If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.',
+      default: false
+    },
+    batch_size: {
+      label: 'Batch Size',
+      description: 'Maximum number of events to include in each batch.',
+      type: 'number',
+      unsafe_hidden: true,
+      default: GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE
     }
   },
 
@@ -179,6 +195,84 @@ const action: ActionDefinition<Settings, Payload> = {
     } else {
       throw new IntegrationError(`Unsupported Sync Mode "${syncMode}"`, 'INTEGRATION_ERROR', 400)
     }
+  },
+  performBatch: async (request, { auth, settings, payload, features, statsContext, syncMode }) => {
+    if (syncMode !== 'add') {
+      throw new IntegrationError(`Unsupported Sync Mode "${syncMode}"`, 'INTEGRATION_ERROR', 400)
+    }
+
+    /* Enforcing this here since Customer ID is required for the Google Ads API
+      but not for the Enhanced Conversions API. */
+    if (!settings.customerId) {
+      throw new PayloadValidationError(
+        'Customer ID is required for this action. Please set it in destination settings.'
+      )
+    }
+
+    const customerId = settings.customerId.replace(/-/g, '')
+
+    // Retrieves all of the custom variables that the customer has created in their Google Ads account
+    const getCustomVariables = memoizedGetCustomVariables()
+
+    const request_objects: CallConversionRequestObjectInterface[] = await Promise.all(
+      payload.map(async (payloadItem) => {
+        const request_object: CallConversionRequestObjectInterface = {
+          conversionAction: `customers/${settings.customerId}/conversionActions/${payloadItem.conversion_action}`,
+          callerId: payloadItem.caller_id,
+          callStartDateTime: convertTimestamp(payloadItem.call_timestamp),
+          conversionDateTime: convertTimestamp(payloadItem.conversion_timestamp),
+          conversionValue: payloadItem.value,
+          currencyCode: payloadItem.currency
+        }
+
+        // Add Consent Signals 'adUserData' if it is defined
+        if (payloadItem.ad_user_data_consent_state) {
+          request_object['consent'] = {
+            adUserData: payloadItem.ad_user_data_consent_state
+          }
+        }
+
+        // Add Consent Signals 'adPersonalization' if it is defined
+        if (payloadItem.ad_personalization_consent_state) {
+          request_object['consent'] = {
+            ...request_object['consent'],
+            adPersonalization: payloadItem.ad_personalization_consent_state
+          }
+        }
+
+        // Retrieves all of the custom variables that the customer has created in their Google Ads account
+        if (payloadItem.custom_variables) {
+          const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
+          if (customVariableIds?.data?.length) {
+            request_object.customVariables = formatCustomVariables(
+              payloadItem.custom_variables,
+              customVariableIds.data[0].results
+            )
+          }
+        }
+
+        return request_object
+      })
+    )
+
+    const response: ModifiedResponse<PartialErrorResponse> = await request(
+      `https://googleads.googleapis.com/${getApiVersion(features, statsContext)}/customers/${
+        settings.customerId
+      }:uploadCallConversions`,
+      {
+        method: 'post',
+        headers: {
+          'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
+        },
+        json: {
+          conversions: request_objects,
+          partialFailure: true
+        }
+      }
+    )
+
+    handleGoogleErrors(response)
+    return response
   }
 }
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion2/index.ts
@@ -112,6 +112,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch Data to Google Enhanced Conversions',
       description:
         'If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.',
+      unsafe_hidden: true,
       default: false
     },
     batch_size: {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/generated-types.ts
@@ -99,5 +99,5 @@ export interface Payload {
   /**
    * Maximum number of events to include in each batch.
    */
-  batch_size: number
+  batch_size?: number
 }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/generated-types.ts
@@ -92,4 +92,12 @@ export interface Payload {
    * This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v15/Consent).
    */
   ad_personalization_consent_state?: string
+  /**
+   * If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.
+   */
+  enable_batching?: boolean
+  /**
+   * Maximum number of events to include in each batch.
+   */
+  batch_size: number
 }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -226,13 +226,12 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch Data to Google Enhanced Conversions',
       description:
         'If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.',
-      default: true
+      default: false
     },
     batch_size: {
       label: 'Batch Size',
       description: 'Maximum number of events to include in each batch.',
       type: 'number',
-      required: true,
       unsafe_hidden: true,
       default: GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE
     }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -3,7 +3,8 @@ import {
   PayloadValidationError,
   ModifiedResponse,
   RequestClient,
-  DynamicFieldResponse
+  DynamicFieldResponse,
+  RequestFn
 } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -16,7 +17,7 @@ import {
 import {
   formatCustomVariables,
   hash,
-  getCustomVariables,
+  memoizedGetCustomVariables,
   handleGoogleErrors,
   convertTimestamp,
   getApiVersion,
@@ -24,6 +25,7 @@ import {
   getConversionActionDynamicData,
   isHashedInformation
 } from '../functions'
+import { GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE } from '../constants'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Upload Click Conversion',
@@ -218,6 +220,21 @@ const action: ActionDefinition<Settings, Payload> = {
         { label: 'DENIED', value: 'DENIED' },
         { label: 'UNSPECIFIED', value: 'UNSPECIFIED' }
       ]
+    },
+    enable_batching: {
+      type: 'boolean',
+      label: 'Batch Data to Google Enhanced Conversions',
+      description:
+        'If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.',
+      default: true
+    },
+    batch_size: {
+      label: 'Batch Size',
+      description: 'Maximum number of events to include in each batch.',
+      type: 'number',
+      required: true,
+      unsafe_hidden: true,
+      default: GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE
     }
   },
 
@@ -230,107 +247,126 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, { auth, settings, payload, features, statsContext }) => {
-    /* Enforcing this here since Customer ID is required for the Google Ads API
+    return await uploadClickConversionAction(request, { auth, settings, payload: [payload], features, statsContext })
+  },
+  performBatch: async (request, { auth, settings, payload, features, statsContext }) => {
+    return await uploadClickConversionAction(request, { auth, settings, payload, features, statsContext })
+  }
+}
+
+const uploadClickConversionAction: RequestFn<Settings, Payload[]> = async (
+  request,
+  { auth, settings, payload, features, statsContext }
+) => {
+  /* Enforcing this here since Customer ID is required for the Google Ads API
     but not for the Enhanced Conversions API. */
-    if (!settings.customerId) {
-      throw new PayloadValidationError(
-        'Customer ID is required for this action. Please set it in destination settings.'
-      )
-    }
-    settings.customerId = settings.customerId.replace(/-/g, '')
+  if (!settings.customerId) {
+    throw new PayloadValidationError('Customer ID is required for this action. Please set it in destination settings.')
+  }
 
-    let cartItems: CartItemInterface[] = []
-    if (payload.items) {
-      cartItems = payload.items.map((product) => {
-        return {
-          productId: product.product_id,
-          quantity: product.quantity,
-          unitPrice: product.price
-        } as CartItemInterface
-      })
-    }
+  const customerId = settings.customerId.replace(/-/g, '')
 
-    const request_object: ClickConversionRequestObjectInterface = {
-      conversionAction: `customers/${settings.customerId}/conversionActions/${payload.conversion_action}`,
-      conversionDateTime: convertTimestamp(payload.conversion_timestamp),
-      gclid: payload.gclid,
-      gbraid: payload.gbraid,
-      wbraid: payload.wbraid,
-      orderId: payload.order_id,
-      conversionValue: payload.value,
-      currencyCode: payload.currency,
-      conversionEnvironment: payload.conversion_environment,
-      cartData: {
-        merchantId: payload.merchant_id,
-        feedCountryCode: payload.merchant_country_code,
-        feedLanguageCode: payload.merchant_language_code,
-        localTransactionCost: payload.local_cost,
-        items: cartItems
-      },
-      userIdentifiers: []
-    }
-    // Add Consent Signals 'adUserData' if it is defined
-    if (payload.ad_user_data_consent_state) {
-      request_object['consent'] = {
-        adUserData: payload.ad_user_data_consent_state
+  const getCustomVariables = memoizedGetCustomVariables()
+
+  const request_objects: ClickConversionRequestObjectInterface[] = await Promise.all(
+    payload.map(async (payload) => {
+      let cartItems: CartItemInterface[] = []
+      if (payload.items) {
+        cartItems = payload.items.map((product) => {
+          return {
+            productId: product.product_id,
+            quantity: product.quantity,
+            unitPrice: product.price
+          } as CartItemInterface
+        })
       }
-    }
 
-    // Add Consent Signals 'adPersonalization' if it is defined
-    if (payload.ad_personalization_consent_state) {
-      request_object['consent'] = {
-        ...request_object['consent'],
-        adPersonalization: payload.ad_personalization_consent_state
-      }
-    }
-
-    // Retrieves all of the custom variables that the customer has created in their Google Ads account
-    if (payload.custom_variables) {
-      const customVariableIds = await getCustomVariables(settings.customerId, auth, request, features, statsContext)
-      if (customVariableIds?.data?.length) {
-        request_object.customVariables = formatCustomVariables(
-          payload.custom_variables,
-          customVariableIds.data[0].results
-        )
-      }
-    }
-
-    if (payload.email_address) {
-      const validatedEmail: string = commonHashedEmailValidation(payload.email_address)
-
-      request_object.userIdentifiers.push({
-        hashedEmail: validatedEmail
-      } as UserIdentifierInterface)
-    }
-
-    if (payload.phone_number) {
-      // remove '+' from phone number if received in payload duplicacy and add '+'
-      const phoneNumber = '+' + payload.phone_number.split('+').join('')
-
-      request_object.userIdentifiers.push({
-        hashedPhoneNumber: isHashedInformation(payload.phone_number) ? payload.phone_number : hash(phoneNumber)
-      } as UserIdentifierInterface)
-    }
-
-    const response: ModifiedResponse<PartialErrorResponse> = await request(
-      `https://googleads.googleapis.com/${getApiVersion(features, statsContext)}/customers/${
-        settings.customerId
-      }:uploadClickConversions`,
-      {
-        method: 'post',
-        headers: {
-          'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
+      const request_object: ClickConversionRequestObjectInterface = {
+        conversionAction: `customers/${customerId}/conversionActions/${payload.conversion_action}`,
+        conversionDateTime: convertTimestamp(payload.conversion_timestamp),
+        gclid: payload.gclid,
+        gbraid: payload.gbraid,
+        wbraid: payload.wbraid,
+        orderId: payload.order_id,
+        conversionValue: payload.value,
+        currencyCode: payload.currency,
+        conversionEnvironment: payload.conversion_environment,
+        cartData: {
+          merchantId: payload.merchant_id,
+          feedCountryCode: payload.merchant_country_code,
+          feedLanguageCode: payload.merchant_language_code,
+          localTransactionCost: payload.local_cost,
+          items: cartItems
         },
-        json: {
-          conversions: [request_object],
-          partialFailure: true
+        userIdentifiers: []
+      }
+
+      // Add Consent Signals 'adUserData' if it is defined
+      if (payload.ad_user_data_consent_state) {
+        request_object['consent'] = {
+          adUserData: payload.ad_user_data_consent_state
         }
       }
-    )
 
-    handleGoogleErrors(response)
-    return response
-  }
+      // Add Consent Signals 'adPersonalization' if it is defined
+      if (payload.ad_personalization_consent_state) {
+        request_object['consent'] = {
+          ...request_object['consent'],
+          adPersonalization: payload.ad_personalization_consent_state
+        }
+      }
+
+      // Retrieves all of the custom variables that the customer has created in their Google Ads account
+      if (payload.custom_variables) {
+        const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
+        if (customVariableIds?.data?.length) {
+          request_object.customVariables = formatCustomVariables(
+            payload.custom_variables,
+            customVariableIds.data[0].results
+          )
+        }
+      }
+
+      if (payload.email_address) {
+        const validatedEmail: string = commonHashedEmailValidation(payload.email_address)
+
+        request_object.userIdentifiers.push({
+          hashedEmail: validatedEmail
+        } as UserIdentifierInterface)
+      }
+
+      if (payload.phone_number) {
+        // remove '+' from phone number if received in payload duplicacy and add '+'
+        const phoneNumber = '+' + payload.phone_number.split('+').join('')
+
+        request_object.userIdentifiers.push({
+          hashedPhoneNumber: isHashedInformation(payload.phone_number) ? payload.phone_number : hash(phoneNumber)
+        } as UserIdentifierInterface)
+      }
+
+      return request_object
+    })
+  )
+
+  const response: ModifiedResponse<PartialErrorResponse> = await request(
+    `https://googleads.googleapis.com/${getApiVersion(
+      features,
+      statsContext
+    )}/customers/${customerId}:uploadClickConversions`,
+    {
+      method: 'post',
+      headers: {
+        'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
+      },
+      json: {
+        conversions: request_objects,
+        partialFailure: true
+      }
+    }
+  )
+
+  handleGoogleErrors(response)
+  return response
 }
 
 export default action

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -226,6 +226,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch Data to Google Enhanced Conversions',
       description:
         'If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.',
+      unsafe_hidden: true,
       default: false
     },
     batch_size: {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -3,8 +3,7 @@ import {
   PayloadValidationError,
   ModifiedResponse,
   RequestClient,
-  DynamicFieldResponse,
-  RequestFn
+  DynamicFieldResponse
 } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -17,6 +16,7 @@ import {
 import {
   formatCustomVariables,
   hash,
+  getCustomVariables,
   memoizedGetCustomVariables,
   handleGoogleErrors,
   convertTimestamp,
@@ -247,126 +247,220 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, { auth, settings, payload, features, statsContext }) => {
-    return await uploadClickConversionAction(request, { auth, settings, payload: [payload], features, statsContext })
-  },
-  performBatch: async (request, { auth, settings, payload, features, statsContext }) => {
-    return await uploadClickConversionAction(request, { auth, settings, payload, features, statsContext })
-  }
-}
-
-const uploadClickConversionAction: RequestFn<Settings, Payload[]> = async (
-  request,
-  { auth, settings, payload, features, statsContext }
-) => {
-  /* Enforcing this here since Customer ID is required for the Google Ads API
+    /* Enforcing this here since Customer ID is required for the Google Ads API
     but not for the Enhanced Conversions API. */
-  if (!settings.customerId) {
-    throw new PayloadValidationError('Customer ID is required for this action. Please set it in destination settings.')
-  }
+    if (!settings.customerId) {
+      throw new PayloadValidationError(
+        'Customer ID is required for this action. Please set it in destination settings.'
+      )
+    }
+    settings.customerId = settings.customerId.replace(/-/g, '')
 
-  const customerId = settings.customerId.replace(/-/g, '')
+    let cartItems: CartItemInterface[] = []
+    if (payload.items) {
+      cartItems = payload.items.map((product) => {
+        return {
+          productId: product.product_id,
+          quantity: product.quantity,
+          unitPrice: product.price
+        } as CartItemInterface
+      })
+    }
 
-  const getCustomVariables = memoizedGetCustomVariables()
-
-  const request_objects: ClickConversionRequestObjectInterface[] = await Promise.all(
-    payload.map(async (payload) => {
-      let cartItems: CartItemInterface[] = []
-      if (payload.items) {
-        cartItems = payload.items.map((product) => {
-          return {
-            productId: product.product_id,
-            quantity: product.quantity,
-            unitPrice: product.price
-          } as CartItemInterface
-        })
-      }
-
-      const request_object: ClickConversionRequestObjectInterface = {
-        conversionAction: `customers/${customerId}/conversionActions/${payload.conversion_action}`,
-        conversionDateTime: convertTimestamp(payload.conversion_timestamp),
-        gclid: payload.gclid,
-        gbraid: payload.gbraid,
-        wbraid: payload.wbraid,
-        orderId: payload.order_id,
-        conversionValue: payload.value,
-        currencyCode: payload.currency,
-        conversionEnvironment: payload.conversion_environment,
-        cartData: {
-          merchantId: payload.merchant_id,
-          feedCountryCode: payload.merchant_country_code,
-          feedLanguageCode: payload.merchant_language_code,
-          localTransactionCost: payload.local_cost,
-          items: cartItems
-        },
-        userIdentifiers: []
-      }
-
-      // Add Consent Signals 'adUserData' if it is defined
-      if (payload.ad_user_data_consent_state) {
-        request_object['consent'] = {
-          adUserData: payload.ad_user_data_consent_state
-        }
-      }
-
-      // Add Consent Signals 'adPersonalization' if it is defined
-      if (payload.ad_personalization_consent_state) {
-        request_object['consent'] = {
-          ...request_object['consent'],
-          adPersonalization: payload.ad_personalization_consent_state
-        }
-      }
-
-      // Retrieves all of the custom variables that the customer has created in their Google Ads account
-      if (payload.custom_variables) {
-        const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
-        if (customVariableIds?.data?.length) {
-          request_object.customVariables = formatCustomVariables(
-            payload.custom_variables,
-            customVariableIds.data[0].results
-          )
-        }
-      }
-
-      if (payload.email_address) {
-        const validatedEmail: string = commonHashedEmailValidation(payload.email_address)
-
-        request_object.userIdentifiers.push({
-          hashedEmail: validatedEmail
-        } as UserIdentifierInterface)
-      }
-
-      if (payload.phone_number) {
-        // remove '+' from phone number if received in payload duplicacy and add '+'
-        const phoneNumber = '+' + payload.phone_number.split('+').join('')
-
-        request_object.userIdentifiers.push({
-          hashedPhoneNumber: isHashedInformation(payload.phone_number) ? payload.phone_number : hash(phoneNumber)
-        } as UserIdentifierInterface)
-      }
-
-      return request_object
-    })
-  )
-
-  const response: ModifiedResponse<PartialErrorResponse> = await request(
-    `https://googleads.googleapis.com/${getApiVersion(
-      features,
-      statsContext
-    )}/customers/${customerId}:uploadClickConversions`,
-    {
-      method: 'post',
-      headers: {
-        'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
+    const request_object: ClickConversionRequestObjectInterface = {
+      conversionAction: `customers/${settings.customerId}/conversionActions/${payload.conversion_action}`,
+      conversionDateTime: convertTimestamp(payload.conversion_timestamp),
+      gclid: payload.gclid,
+      gbraid: payload.gbraid,
+      wbraid: payload.wbraid,
+      orderId: payload.order_id,
+      conversionValue: payload.value,
+      currencyCode: payload.currency,
+      conversionEnvironment: payload.conversion_environment,
+      cartData: {
+        merchantId: payload.merchant_id,
+        feedCountryCode: payload.merchant_country_code,
+        feedLanguageCode: payload.merchant_language_code,
+        localTransactionCost: payload.local_cost,
+        items: cartItems
       },
-      json: {
-        conversions: request_objects,
-        partialFailure: true
+      userIdentifiers: []
+    }
+    // Add Consent Signals 'adUserData' if it is defined
+    if (payload.ad_user_data_consent_state) {
+      request_object['consent'] = {
+        adUserData: payload.ad_user_data_consent_state
       }
     }
-  )
 
-  handleGoogleErrors(response)
-  return response
+    // Add Consent Signals 'adPersonalization' if it is defined
+    if (payload.ad_personalization_consent_state) {
+      request_object['consent'] = {
+        ...request_object['consent'],
+        adPersonalization: payload.ad_personalization_consent_state
+      }
+    }
+
+    // Retrieves all of the custom variables that the customer has created in their Google Ads account
+    if (payload.custom_variables) {
+      const customVariableIds = await getCustomVariables(settings.customerId, auth, request, features, statsContext)
+      if (customVariableIds?.data?.length) {
+        request_object.customVariables = formatCustomVariables(
+          payload.custom_variables,
+          customVariableIds.data[0].results
+        )
+      }
+    }
+
+    if (payload.email_address) {
+      const validatedEmail: string = commonHashedEmailValidation(payload.email_address)
+
+      request_object.userIdentifiers.push({
+        hashedEmail: validatedEmail
+      } as UserIdentifierInterface)
+    }
+
+    if (payload.phone_number) {
+      // remove '+' from phone number if received in payload duplicacy and add '+'
+      const phoneNumber = '+' + payload.phone_number.split('+').join('')
+
+      request_object.userIdentifiers.push({
+        hashedPhoneNumber: isHashedInformation(payload.phone_number) ? payload.phone_number : hash(phoneNumber)
+      } as UserIdentifierInterface)
+    }
+
+    const response: ModifiedResponse<PartialErrorResponse> = await request(
+      `https://googleads.googleapis.com/${getApiVersion(features, statsContext)}/customers/${
+        settings.customerId
+      }:uploadClickConversions`,
+      {
+        method: 'post',
+        headers: {
+          'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
+        },
+        json: {
+          conversions: [request_object],
+          partialFailure: true
+        }
+      }
+    )
+
+    handleGoogleErrors(response)
+    return response
+  },
+  performBatch: async (request, { auth, settings, payload, features, statsContext }) => {
+    /* Enforcing this here since Customer ID is required for the Google Ads API
+    but not for the Enhanced Conversions API. */
+    if (!settings.customerId) {
+      throw new PayloadValidationError(
+        'Customer ID is required for this action. Please set it in destination settings.'
+      )
+    }
+
+    const customerId = settings.customerId.replace(/-/g, '')
+
+    const getCustomVariables = memoizedGetCustomVariables()
+
+    const request_objects: ClickConversionRequestObjectInterface[] = await Promise.all(
+      payload.map(async (payload) => {
+        let cartItems: CartItemInterface[] = []
+        if (payload.items) {
+          cartItems = payload.items.map((product) => {
+            return {
+              productId: product.product_id,
+              quantity: product.quantity,
+              unitPrice: product.price
+            } as CartItemInterface
+          })
+        }
+
+        const request_object: ClickConversionRequestObjectInterface = {
+          conversionAction: `customers/${customerId}/conversionActions/${payload.conversion_action}`,
+          conversionDateTime: convertTimestamp(payload.conversion_timestamp),
+          gclid: payload.gclid,
+          gbraid: payload.gbraid,
+          wbraid: payload.wbraid,
+          orderId: payload.order_id,
+          conversionValue: payload.value,
+          currencyCode: payload.currency,
+          conversionEnvironment: payload.conversion_environment,
+          cartData: {
+            merchantId: payload.merchant_id,
+            feedCountryCode: payload.merchant_country_code,
+            feedLanguageCode: payload.merchant_language_code,
+            localTransactionCost: payload.local_cost,
+            items: cartItems
+          },
+          userIdentifiers: []
+        }
+
+        // Add Consent Signals 'adUserData' if it is defined
+        if (payload.ad_user_data_consent_state) {
+          request_object['consent'] = {
+            adUserData: payload.ad_user_data_consent_state
+          }
+        }
+
+        // Add Consent Signals 'adPersonalization' if it is defined
+        if (payload.ad_personalization_consent_state) {
+          request_object['consent'] = {
+            ...request_object['consent'],
+            adPersonalization: payload.ad_personalization_consent_state
+          }
+        }
+
+        // Retrieves all of the custom variables that the customer has created in their Google Ads account
+        if (payload.custom_variables) {
+          const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
+          if (customVariableIds?.data?.length) {
+            request_object.customVariables = formatCustomVariables(
+              payload.custom_variables,
+              customVariableIds.data[0].results
+            )
+          }
+        }
+
+        if (payload.email_address) {
+          const validatedEmail: string = commonHashedEmailValidation(payload.email_address)
+
+          request_object.userIdentifiers.push({
+            hashedEmail: validatedEmail
+          } as UserIdentifierInterface)
+        }
+
+        if (payload.phone_number) {
+          // remove '+' from phone number if received in payload duplicacy and add '+'
+          const phoneNumber = '+' + payload.phone_number.split('+').join('')
+
+          request_object.userIdentifiers.push({
+            hashedPhoneNumber: isHashedInformation(payload.phone_number) ? payload.phone_number : hash(phoneNumber)
+          } as UserIdentifierInterface)
+        }
+
+        return request_object
+      })
+    )
+
+    const response: ModifiedResponse<PartialErrorResponse> = await request(
+      `https://googleads.googleapis.com/${getApiVersion(
+        features,
+        statsContext
+      )}/customers/${customerId}:uploadClickConversions`,
+      {
+        method: 'post',
+        headers: {
+          'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
+        },
+        json: {
+          conversions: request_objects,
+          partialFailure: true
+        }
+      }
+    )
+
+    handleGoogleErrors(response)
+    return response
+  }
 }
 
 export default action

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/generated-types.ts
@@ -92,4 +92,12 @@ export interface Payload {
    * This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v15/Consent).
    */
   ad_personalization_consent_state?: string
+  /**
+   * If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.
+   */
+  enable_batching?: boolean
+  /**
+   * Maximum number of events to include in each batch.
+   */
+  batch_size?: number
 }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -233,6 +233,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch Data to Google Enhanced Conversions',
       description:
         'If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.',
+      unsafe_hidden: true,
       default: false
     },
     batch_size: {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -23,8 +23,10 @@ import {
   getApiVersion,
   commonHashedEmailValidation,
   getConversionActionDynamicData,
-  isHashedInformation
+  isHashedInformation,
+  memoizedGetCustomVariables
 } from '../functions'
+import { GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE } from '../constants'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Click Conversion',
@@ -225,6 +227,20 @@ const action: ActionDefinition<Settings, Payload> = {
         { label: 'DENIED', value: 'DENIED' },
         { label: 'UNSPECIFIED', value: 'UNSPECIFIED' }
       ]
+    },
+    enable_batching: {
+      type: 'boolean',
+      label: 'Batch Data to Google Enhanced Conversions',
+      description:
+        'If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.',
+      default: false
+    },
+    batch_size: {
+      label: 'Batch Size',
+      description: 'Maximum number of events to include in each batch.',
+      type: 'number',
+      unsafe_hidden: true,
+      default: GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE
     }
   },
 
@@ -340,6 +356,122 @@ const action: ActionDefinition<Settings, Payload> = {
     } else {
       throw new IntegrationError(`Unsupported Sync Mode "${syncMode}"`, 'INTEGRATION_ERROR', 400)
     }
+  },
+  performBatch: async (request, { auth, settings, payload, features, statsContext, syncMode }) => {
+    if (syncMode !== 'add') {
+      throw new IntegrationError(`Unsupported Sync Mode "${syncMode}"`, 'INTEGRATION_ERROR', 400)
+    }
+
+    /* Enforcing this here since Customer ID is required for the Google Ads API
+      but not for the Enhanced Conversions API. */
+    if (!settings.customerId) {
+      throw new PayloadValidationError(
+        'Customer ID is required for this action. Please set it in destination settings.'
+      )
+    }
+
+    const customerId = settings.customerId.replace(/-/g, '')
+
+    const getCustomVariables = memoizedGetCustomVariables()
+
+    const request_objects: ClickConversionRequestObjectInterface[] = await Promise.all(
+      payload.map(async (payloadItem) => {
+        let cartItems: CartItemInterface[] = []
+        if (payloadItem.items && Array.isArray(payloadItem.items)) {
+          cartItems = payloadItem.items.map((product) => {
+            return {
+              productId: product.product_id,
+              quantity: product.quantity,
+              unitPrice: product.price
+            } as CartItemInterface
+          })
+        }
+
+        const request_object: ClickConversionRequestObjectInterface = {
+          conversionAction: `customers/${settings.customerId}/conversionActions/${payloadItem.conversion_action}`,
+          conversionDateTime: convertTimestamp(payloadItem.conversion_timestamp),
+          gclid: payloadItem.gclid,
+          gbraid: payloadItem.gbraid,
+          wbraid: payloadItem.wbraid,
+          orderId: payloadItem.order_id,
+          conversionValue: payloadItem.value,
+          currencyCode: payloadItem.currency,
+          conversionEnvironment: payloadItem.conversion_environment,
+          cartData: {
+            merchantId: payloadItem.merchant_id,
+            feedCountryCode: payloadItem.merchant_country_code,
+            feedLanguageCode: payloadItem.merchant_language_code,
+            localTransactionCost: payloadItem.local_cost,
+            items: cartItems
+          },
+          userIdentifiers: []
+        }
+        // Add Consent Signals 'adUserData' if it is defined
+        if (payloadItem.ad_user_data_consent_state) {
+          request_object['consent'] = {
+            adUserData: payloadItem.ad_user_data_consent_state
+          }
+        }
+
+        // Add Consent Signals 'adPersonalization' if it is defined
+        if (payloadItem.ad_personalization_consent_state) {
+          request_object['consent'] = {
+            ...request_object['consent'],
+            adPersonalization: payloadItem.ad_personalization_consent_state
+          }
+        }
+
+        // Retrieves all of the custom variables that the customer has created in their Google Ads account
+        if (payloadItem.custom_variables) {
+          const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
+          if (customVariableIds?.data?.length) {
+            request_object.customVariables = formatCustomVariables(
+              payloadItem.custom_variables,
+              customVariableIds.data[0].results
+            )
+          }
+        }
+
+        if (payloadItem.email_address) {
+          const validatedEmail: string = commonHashedEmailValidation(payloadItem.email_address)
+
+          request_object.userIdentifiers.push({
+            hashedEmail: validatedEmail
+          } as UserIdentifierInterface)
+        }
+
+        if (payloadItem.phone_number) {
+          // remove '+' from phone number if received in payload duplicacy and add '+'
+          const phoneNumber = '+' + payloadItem.phone_number.split('+').join('')
+
+          request_object.userIdentifiers.push({
+            hashedPhoneNumber: isHashedInformation(payloadItem.phone_number)
+              ? payloadItem.phone_number
+              : hash(phoneNumber)
+          } as UserIdentifierInterface)
+        }
+
+        return request_object
+      })
+    )
+
+    const response: ModifiedResponse<PartialErrorResponse> = await request(
+      `https://googleads.googleapis.com/${getApiVersion(features, statsContext)}/customers/${
+        settings.customerId
+      }:uploadClickConversions`,
+      {
+        method: 'post',
+        headers: {
+          'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
+        },
+        json: {
+          conversions: request_objects,
+          partialFailure: true
+        }
+      }
+    )
+    handleGoogleErrors(response)
+    return response
   }
 }
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/generated-types.ts
@@ -80,5 +80,5 @@ export interface Payload {
   /**
    * Maximum number of events to include in each batch.
    */
-  batch_size: number
+  batch_size?: number
 }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/generated-types.ts
@@ -73,4 +73,12 @@ export interface Payload {
    * The user agent to enhance the original conversion. User agent can only be specified in enhancements with user identifiers. This should match the user agent of the request that sent the original conversion so the conversion and its enhancement are either both attributed as same-device or both attributed as cross-device.
    */
   user_agent?: string
+  /**
+   * If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.
+   */
+  enable_batching?: boolean
+  /**
+   * Maximum number of events to include in each batch.
+   */
+  batch_size: number
 }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
@@ -230,13 +230,12 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch Data to Google Enhanced Conversions',
       description:
         'If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.',
-      default: true
+      default: false
     },
     batch_size: {
       label: 'Batch Size',
       description: 'Maximum number of events to include in each batch.',
       type: 'number',
-      required: true,
       unsafe_hidden: true,
       default: GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE
     }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
@@ -230,6 +230,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch Data to Google Enhanced Conversions',
       description:
         'If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.',
+      unsafe_hidden: true,
       default: false
     },
     batch_size: {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment2/generated-types.ts
@@ -73,4 +73,12 @@ export interface Payload {
    * The user agent to enhance the original conversion. User agent can only be specified in enhancements with user identifiers. This should match the user agent of the request that sent the original conversion so the conversion and its enhancement are either both attributed as same-device or both attributed as cross-device.
    */
   user_agent?: string
+  /**
+   * If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.
+   */
+  enable_batching?: boolean
+  /**
+   * Maximum number of events to include in each batch.
+   */
+  batch_size?: number
 }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment2/index.ts
@@ -18,6 +18,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { PartialErrorResponse, ConversionAdjustmentRequestObjectInterface, UserIdentifierInterface } from '../types'
 import { ModifiedResponse } from '@segment/actions-core'
+import { GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE } from '../constants'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Conversion Adjustment',
@@ -235,6 +236,20 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.context.userAgent'
       }
+    },
+    enable_batching: {
+      type: 'boolean',
+      label: 'Batch Data to Google Enhanced Conversions',
+      description:
+        'If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.',
+      default: false
+    },
+    batch_size: {
+      label: 'Batch Size',
+      description: 'Maximum number of events to include in each batch.',
+      type: 'number',
+      unsafe_hidden: true,
+      default: GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE
     }
   },
   dynamicFields: {
@@ -348,6 +363,115 @@ const action: ActionDefinition<Settings, Payload> = {
     } else {
       throw new IntegrationError(`Unsupported Sync Mode "${syncMode}"`, 'INTEGRATION_ERROR', 400)
     }
+  },
+  performBatch: async (request, { settings, payload, features, statsContext, syncMode }) => {
+    if (syncMode !== 'add') {
+      throw new IntegrationError(`Unsupported Sync Mode "${syncMode}"`, 'INTEGRATION_ERROR', 400)
+    }
+
+    /* Enforcing this here since Customer ID is required for the Google Ads API
+      but not for the Enhanced Conversions API. */
+    if (!settings.customerId) {
+      throw new PayloadValidationError(
+        'Customer ID is required for this action. Please set it in destination settings.'
+      )
+    }
+
+    const customerId = settings.customerId.replace(/-/g, '')
+
+    const request_objects: ConversionAdjustmentRequestObjectInterface[] = payload.map((payloadItem) => {
+      if (!payloadItem.adjustment_timestamp) {
+        payloadItem.adjustment_timestamp = new Date().toISOString()
+      }
+
+      const request_object: ConversionAdjustmentRequestObjectInterface = {
+        conversionAction: `customers/${settings.customerId}/conversionActions/${payloadItem.conversion_action}`,
+        adjustmentType: payloadItem.adjustment_type,
+        adjustmentDateTime: convertTimestamp(payloadItem.adjustment_timestamp),
+        orderId: payloadItem.order_id,
+        gclidDateTimePair: {
+          gclid: payloadItem.gclid,
+          conversionDateTime: convertTimestamp(payloadItem.conversion_timestamp)
+        },
+        userIdentifiers: [],
+        userAgent: payloadItem.user_agent
+      }
+
+      // Google will return an error if this value is sent with retractions.
+      if (payloadItem.adjustment_type !== 'RETRACTION') {
+        request_object.restatementValue = {
+          adjustedValue: payloadItem.restatement_value,
+          currencyCode: payloadItem.restatement_currency_code
+        }
+      }
+
+      if (payloadItem.email_address) {
+        const validatedEmail: string = commonHashedEmailValidation(payloadItem.email_address)
+
+        request_object.userIdentifiers.push({
+          hashedEmail: validatedEmail
+        } as UserIdentifierInterface)
+      }
+
+      if (payloadItem.phone_number) {
+        request_object.userIdentifiers.push({
+          hashedPhoneNumber: isHashedInformation(payloadItem.phone_number)
+            ? payloadItem.phone_number
+            : hash(payloadItem.phone_number)
+        } as UserIdentifierInterface)
+      }
+
+      const containsAddressInfo =
+        payloadItem.first_name ||
+        payloadItem.last_name ||
+        payloadItem.city ||
+        payloadItem.state ||
+        payloadItem.country ||
+        payloadItem.postal_code ||
+        payloadItem.street_address
+
+      if (containsAddressInfo) {
+        request_object.userIdentifiers.push({
+          addressInfo: {
+            hashedFirstName: isHashedInformation(String(payloadItem.first_name))
+              ? payloadItem.first_name
+              : hash(payloadItem.first_name),
+            hashedLastName: isHashedInformation(String(payloadItem.last_name))
+              ? payloadItem.last_name
+              : hash(payloadItem.last_name),
+            hashedStreetAddress: isHashedInformation(String(payloadItem.street_address))
+              ? payloadItem.street_address
+              : hash(payloadItem.street_address),
+            city: payloadItem.city,
+            state: payloadItem.state,
+            countryCode: payloadItem.country,
+            postalCode: payloadItem.postal_code
+          }
+        })
+      }
+
+      return request_object
+    })
+
+    const response: ModifiedResponse<PartialErrorResponse> = await request(
+      `https://googleads.googleapis.com/${getApiVersion(
+        features,
+        statsContext
+      )}/customers/${customerId}:uploadConversionAdjustments`,
+      {
+        method: 'post',
+        headers: {
+          'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
+        },
+        json: {
+          conversionAdjustments: request_objects,
+          partialFailure: true
+        }
+      }
+    )
+
+    handleGoogleErrors(response)
+    return response
   }
 }
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment2/index.ts
@@ -242,6 +242,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch Data to Google Enhanced Conversions',
       description:
         'If true, Segment will batch events before sending to Google’s APIs. Google accepts batches of up to 2000 events.',
+      unsafe_hidden: true,
       default: false
     },
     batch_size: {


### PR DESCRIPTION
This PR adds Batching Support to the following actions of Google Enhanced Conversions
- uploadCallConversion
- uploadClickConversion
- uploadConversionAdjustment
- uploadCallConversion2
- uploadClickConversion2
- uploadConversionAdjustment2

To reduce risk this PR sets `enable_batching` field is hidden and set to false by default.
This would be useful to enable `performBatch` for selected customers.

## Testing
Tested locally with unit tests and on staging.
Staging and Prod test is not possible as it requires a working Google Ads account.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
