### PR TITLE
fix: updates the account mappings for dynamic yield destination

### DIFF
--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/index.ts
@@ -108,8 +108,8 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         timestamp_ms: new Date().getTime(),
         account: {
           account_settings: {
-            section_id: getSectionId(settings.sectionId),
-            api_key: settings.accessKey
+            sectionId: getSectionId(settings.sectionId),
+            connectionKey: settings.accessKey
           }
         },
         audience_id: audience_id, // must be sent as an integer

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
@@ -152,9 +152,8 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
 
     const idTypeToSend = sendNormalizeIdType ? normalizedIdentifierType : identifierType
 
-    const sectionId = getSectionId(settings.sectionId)
-
-    const dataCenter = getDataCenter(sectionId)
+    // Receives the sectionId plain with the dev prefix if provided
+    const dataCenter = getDataCenter(settings.sectionId)
 
     const URL = getUpsertURL(dataCenter)
 
@@ -164,9 +163,9 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
       timestamp_ms: new Date(payload.timestamp).getTime(),
       account: {
         account_settings: {
-          section_id: sectionId,
-          identifier_type: idTypeToSend,
-          accessKey: settings.accessKey
+          sectionId: getSectionId(settings.sectionId),
+          identifier: idTypeToSend,
+          connectionKey: settings.accessKey
         }
       },
       user_profiles: [


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Minor version with:
- Align the DY account settings (sectionId, Identifier, etc) 
- Fixes the DEV environment not being activate when users are submitting for an Audience

## Testing

- [X] Executed existing unit tests locally 
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
