### PR TITLE
[Linkedin Conversions API] Add batching implementation

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -474,39 +474,34 @@ export class LinkedInConversions {
   }
 
   async batchConversionAdd(payloads: Payload[]): Promise<ModifiedResponse> {
-    try {
-      return this.request(`${BASE_URL}/conversionEvents`, {
-        method: 'post',
-        headers: {
-          'X-RestLi-Method': 'BATCH_CREATE'
-        },
-        json: {
-          elements: [
-            ...payloads.map((payload) => {
-              const conversionTime = isNotEpochTimestampInMilliseconds(payload.conversionHappenedAt)
-                ? convertToEpochMillis(payload.conversionHappenedAt)
-                : Number(payload.conversionHappenedAt)
-              validate(payload, conversionTime)
+    return this.request(`${BASE_URL}/conversionEvents`, {
+      method: 'post',
+      headers: {
+        'X-RestLi-Method': 'BATCH_CREATE'
+      },
+      json: {
+        elements: [
+          ...payloads.map((payload) => {
+            const conversionTime = isNotEpochTimestampInMilliseconds(payload.conversionHappenedAt)
+              ? convertToEpochMillis(payload.conversionHappenedAt)
+              : Number(payload.conversionHappenedAt)
+            validate(payload, conversionTime)
 
-              const userIds = this.buildUserIdsArray(payload)
-              return {
-                conversion: `urn:lla:llaPartnerConversion:${this.conversionRuleId}`,
-                conversionHappenedAt: conversionTime,
-                conversionValue: payload.conversionValue,
-                eventId: payload.eventId,
-                user: {
-                  userIds,
-                  userInfo: payload.userInfo
-                }
+            const userIds = this.buildUserIdsArray(payload)
+            return {
+              conversion: `urn:lla:llaPartnerConversion:${this.conversionRuleId}`,
+              conversionHappenedAt: conversionTime,
+              conversionValue: payload.conversionValue,
+              eventId: payload.eventId,
+              user: {
+                userIds,
+                userInfo: payload.userInfo
               }
-            })
-          ]
-        }
-      })
-    } catch (e) {
-      console.log(e)
-      throw e
-    }
+            }
+          })
+        ]
+      }
+    })
   }
 
   async bulkAssociateCampaignToConversion(campaignIds?: string[]): Promise<ModifiedResponse | void> {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -1,4 +1,10 @@
-import { RequestClient, ModifiedResponse, DynamicFieldResponse, ActionHookResponse } from '@segment/actions-core'
+import {
+  RequestClient,
+  ModifiedResponse,
+  DynamicFieldResponse,
+  ActionHookResponse,
+  PayloadValidationError
+} from '@segment/actions-core'
 import { BASE_URL, DEFAULT_POST_CLICK_LOOKBACK_WINDOW, DEFAULT_VIEW_THROUGH_LOOKBACK_WINDOW } from '../constants'
 import type {
   ProfileAPIResponse,
@@ -26,6 +32,35 @@ interface ConversionRuleUpdateValues {
 interface UserID {
   idType: 'SHA256_EMAIL' | 'LINKEDIN_FIRST_PARTY_ADS_TRACKING_UUID' | 'AXCIOM_ID' | 'ORACLE_MOAT_ID'
   idValue: string
+}
+
+function validate(payload: Payload, conversionTime: number) {
+  // Check if the timestamp is within the past 90 days
+  const ninetyDaysAgo = Date.now() - 90 * 24 * 60 * 60 * 1000
+  if (conversionTime < ninetyDaysAgo) {
+    throw new PayloadValidationError('Timestamp should be within the past 90 days.')
+  }
+
+  if (!payload.email && !payload.linkedInUUID && !payload.acxiomID && !payload.oracleID) {
+    throw new PayloadValidationError('One of email or LinkedIn UUID or Axciom ID or Oracle ID is required.')
+  }
+}
+
+function isNotEpochTimestampInMilliseconds(timestamp: string) {
+  if (typeof timestamp === 'string' && !isNaN(Number(timestamp))) {
+    const convertedTimestamp = Number(timestamp)
+    const startDate = new Date('1970-01-01T00:00:00Z').getTime()
+    const endDate = new Date('2100-01-01T00:00:00Z').getTime()
+    if (Number.isSafeInteger(convertedTimestamp) && convertedTimestamp >= startDate && convertedTimestamp <= endDate) {
+      return false
+    }
+  }
+  return true
+}
+
+function convertToEpochMillis(timestamp: string) {
+  const date = new Date(timestamp)
+  return date.getTime()
 }
 
 export class LinkedInConversions {
@@ -436,6 +471,44 @@ export class LinkedInConversions {
         }
       }
     })
+  }
+
+  async batchConversionAdd(payloads: Payload[]): Promise<ModifiedResponse> {
+    console.log('sending batch conversion add request')
+
+    try {
+      return this.request(`${BASE_URL}/conversionEvents`, {
+        method: 'post',
+        headers: {
+          'X-RestLi-Method': 'BATCH_CREATE'
+        },
+        json: {
+          elements: [
+            ...payloads.map((payload) => {
+              const conversionTime = isNotEpochTimestampInMilliseconds(payload.conversionHappenedAt)
+                ? convertToEpochMillis(payload.conversionHappenedAt)
+                : Number(payload.conversionHappenedAt)
+              validate(payload, conversionTime)
+
+              const userIds = this.buildUserIdsArray(payload)
+              return {
+                conversion: `urn:lla:llaPartnerConversion:${this.conversionRuleId}`,
+                conversionHappenedAt: conversionTime,
+                conversionValue: payload.conversionValue,
+                eventId: payload.eventId,
+                user: {
+                  userIds,
+                  userInfo: payload.userInfo
+                }
+              }
+            })
+          ]
+        }
+      })
+    } catch (e) {
+      console.log(e)
+      throw e
+    }
   }
 
   async bulkAssociateCampaignToConversion(campaignIds?: string[]): Promise<ModifiedResponse | void> {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -474,8 +474,6 @@ export class LinkedInConversions {
   }
 
   async batchConversionAdd(payloads: Payload[]): Promise<ModifiedResponse> {
-    console.log('sending batch conversion add request')
-
     try {
       return this.request(`${BASE_URL}/conversionEvents`, {
         method: 'post',

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
@@ -97,7 +97,9 @@ describe('LinkedinConversions.streamConversion', () => {
             outputs: {
               id: payload.conversionId
             }
-          }
+          },
+          enable_batching: true,
+          batch_size: 5000
         }
       })
     ).resolves.not.toThrowError()
@@ -155,7 +157,9 @@ describe('LinkedinConversions.streamConversion', () => {
             outputs: {
               id: payload.conversionId
             }
-          }
+          },
+          enable_batching: true,
+          batch_size: 5000
         }
       })
     ).resolves.not.toThrowError()
@@ -240,7 +244,9 @@ describe('LinkedinConversions.streamConversion', () => {
             outputs: {
               id: payload.conversionId
             }
-          }
+          },
+          enable_batching: true,
+          batch_size: 5000
         }
       })
     ).resolves.not.toThrowError()
@@ -278,7 +284,9 @@ describe('LinkedinConversions.streamConversion', () => {
             outputs: {
               id: payload.conversionId
             }
-          }
+          },
+          enable_batching: true,
+          batch_size: 5000
         }
       })
     ).resolves.not.toThrowError()
@@ -293,7 +301,9 @@ describe('LinkedinConversions.streamConversion', () => {
           user: {
             '@path': '$.context.traits.user'
           },
-          conversionHappenedAt: '50000000000'
+          conversionHappenedAt: '50000000000',
+          enable_batching: true,
+          batch_size: 5000
         }
       })
     ).rejects.toThrowError('Timestamp should be within the past 90 days.')
@@ -307,7 +317,9 @@ describe('LinkedinConversions.streamConversion', () => {
         mapping: {
           conversionHappenedAt: {
             '@path': '$.timestamp'
-          }
+          },
+          enable_batching: true,
+          batch_size: 5000
         }
       })
     ).rejects.toThrowError('One of email or LinkedIn UUID or Axciom ID or Oracle ID is required.')
@@ -343,7 +355,9 @@ describe('LinkedinConversions.streamConversion', () => {
             outputs: {
               id: payload.conversionId
             }
-          }
+          },
+          enable_batching: true,
+          batch_size: 5000
         }
       })
     ).resolves.not.toThrowError()
@@ -361,7 +375,9 @@ describe('LinkedinConversions.streamConversion', () => {
           email: { '@path': '$.context.traits.email' },
           conversionHappenedAt: {
             '@path': '$.timestamp'
-          }
+          },
+          enable_batching: true,
+          batch_size: 5000
         }
       })
     ).rejects.toThrowError(
@@ -381,7 +397,9 @@ describe('LinkedinConversions.streamConversion', () => {
           email: { '@path': '$.context.traits.email' },
           conversionHappenedAt: {
             '@path': '$.timestamp'
-          }
+          },
+          enable_batching: true,
+          batch_size: 5000
         }
       })
     ).rejects.toThrowError("User Info is missing the required field 'firstName'.")
@@ -399,7 +417,9 @@ describe('LinkedinConversions.streamConversion', () => {
           email: { '@path': '$.context.traits.email' },
           conversionHappenedAt: {
             '@path': '$.timestamp'
-          }
+          },
+          enable_batching: true,
+          batch_size: 5000
         }
       })
     ).rejects.toThrowError("User Info is missing the required field 'lastName'.")
@@ -484,7 +504,9 @@ describe('LinkedinConversions.timestamp', () => {
             outputs: {
               id: payload.conversionId
             }
-          }
+          },
+          enable_batching: true,
+          batch_size: 5000
         }
       })
     ).resolves.not.toThrowError()
@@ -509,7 +531,9 @@ describe('LinkedinConversions.timestamp', () => {
             outputs: {
               id: payload.conversionId
             }
-          }
+          },
+          enable_batching: true,
+          batch_size: 5000
         }
       })
     ).resolves.not.toThrowError()

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
@@ -33,6 +33,32 @@ const event = createTestEvent({
   }
 })
 
+const secondEvent = createTestEvent({
+  messageId: 'another-event-12345',
+  event: 'Example Event',
+  type: 'track',
+  timestamp: currentTimestamp.toString(),
+  context: {
+    traits: {
+      email: 'nick@testing.com',
+      upperCaseEmail: 'some_email@EMAIL.com',
+      first_name: 'sponge',
+      last_name: 'bob',
+      title: 'software engineer',
+      companyName: 'Krusty Krab',
+      countryCode: 'US',
+      value: 1000
+    }
+  },
+  traits: {
+    email: 'nick@testing.com'
+  },
+  properties: {
+    currency: 'USD',
+    revenue: 300
+  }
+})
+
 const settings = {}
 const payload = {
   campaignId: ['56789'],
@@ -107,6 +133,91 @@ describe('LinkedinConversions.streamConversion', () => {
     await expect(
       testDestination.testAction('streamConversion', {
         event,
+        settings,
+        mapping: {
+          email: { '@path': '$.context.traits.email' },
+          conversionHappenedAt: {
+            '@path': '$.timestamp'
+          },
+          conversionValue: {
+            currencyCode: 'USD',
+            amount: { '@path': '$.context.traits.value' }
+          },
+          userInfo: {
+            firstName: { '@path': '$.context.traits.first_name' },
+            lastName: { '@path': '$.context.traits.last_name' },
+            title: { '@path': '$.context.traits.title' },
+            companyName: { '@path': '$.context.traits.companyName' },
+            countryCode: { '@path': '$.context.traits.countryCode' }
+          },
+          onMappingSave: {
+            inputs: {},
+            outputs: {
+              id: payload.conversionId
+            }
+          }
+        }
+      })
+    ).resolves.not.toThrowError()
+  })
+
+  it('should successfully send a batch request with all fields', async () => {
+    nock(`${BASE_URL}/conversionEvents`)
+      .post('', {
+        elements: [
+          {
+            conversion: 'urn:lla:llaPartnerConversion:789123',
+            conversionHappenedAt: currentTimestamp,
+            conversionValue: {
+              currencyCode: 'USD',
+              amount: '100'
+            },
+            user: {
+              userIds: [
+                {
+                  idType: 'SHA256_EMAIL',
+                  idValue: '584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777'
+                }
+              ],
+              userInfo: {
+                firstName: 'mike',
+                lastName: 'smith',
+                title: 'software engineer',
+                companyName: 'microsoft',
+                countryCode: 'US'
+              }
+            }
+          },
+          {
+            conversion: 'urn:lla:llaPartnerConversion:789123',
+            conversionHappenedAt: currentTimestamp,
+            conversionValue: {
+              currencyCode: 'USD',
+              amount: '1000'
+            },
+            user: {
+              userIds: [
+                {
+                  idType: 'SHA256_EMAIL',
+                  idValue: '9155510f76fbf498f1d9d69198150962106ee10169eae019115efbeb16969921'
+                }
+              ],
+              userInfo: {
+                firstName: 'sponge',
+                lastName: 'bob',
+                title: 'software engineer',
+                companyName: 'Krusty Krab',
+                countryCode: 'US'
+              }
+            }
+          }
+        ]
+      })
+      .reply(201)
+
+    await expect(
+      testDestination.testBatchAction('streamConversion', {
+        events: [event, secondEvent],
         settings,
         mapping: {
           email: { '@path': '$.context.traits.email' },

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/snapshot.test.ts
@@ -33,7 +33,9 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
           outputs: {
             id: '1234'
           }
-        }
+        },
+        enable_batching: true,
+        batch_size: 5000
       },
       settings: settingsData,
       auth: undefined
@@ -92,7 +94,9 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
           outputs: {
             id: '1234'
           }
-        }
+        },
+        enable_batching: true,
+        batch_size: 5000
       },
       settings: settingsData,
       auth: undefined

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
@@ -48,6 +48,14 @@ export interface Payload {
     title?: string
     countryCode?: string
   }
+  /**
+   * Enable batching of requests.
+   */
+  enable_batching: boolean
+  /**
+   * Maximum number of events to include in each batch. Actual batch sizes may be lower.
+   */
+  batch_size: number
 }
 // Generated bundle for hooks. DO NOT MODIFY IT BY HAND.
 

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -279,6 +279,22 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
           required: false
         }
       }
+    },
+    enable_batching: {
+      label: 'Enable Batching',
+      description: 'Enable batching of requests.',
+      type: 'boolean',
+      default: true,
+      unsafe_hidden: true,
+      required: true
+    },
+    batch_size: {
+      label: 'Batch Size',
+      description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
+      type: 'number',
+      default: 5000,
+      unsafe_hidden: true,
+      required: true
     }
   },
   perform: async (request, { payload, hookOutputs }) => {

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -304,6 +304,22 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
     } catch (error) {
       throw handleRequestError(error)
     }
+  },
+  performBatch: async (request, { payload: payloads, hookOutputs }) => {
+    const linkedinApiClient: LinkedInConversions = new LinkedInConversions(request)
+    const conversionRuleId = hookOutputs?.onMappingSave?.outputs?.id
+
+    if (!conversionRuleId) {
+      throw new PayloadValidationError('Conversion Rule ID is required.')
+    }
+
+    linkedinApiClient.setConversionRuleId(conversionRuleId)
+
+    try {
+      return linkedinApiClient.batchConversionAdd(payloads)
+    } catch (error) {
+      throw handleRequestError(error)
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR updates the LinkedIn Conversions API destination with a `performBatch` method that implements the batching functionality described in these [LinkedIn Docs.](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/conversions-api?view=li-lms-2024-01&tabs=curl#adding-multiple-conversion-events-in-a-batch)

## Testing
Tested in staging by sending through batches of 1000, ,5000 (The max batch size) and 50,000 events.

1000 Events successfully delivered:
<img width="1511" alt="Screenshot 2024-08-12 at 10 54 39 AM" src="https://github.com/user-attachments/assets/d053a5e1-907e-45be-a693-8a37ec087fe5">

Those events make it to LinkedIn (Unfortunately there is no count of how many conversions arrive or any other info):
<img width="936" alt="Screenshot 2024-08-12 at 10 44 11 AM" src="https://github.com/user-attachments/assets/5d02084e-fb5a-4344-8c97-308110d19e12">

Batch sizes are averaging 500:
<img width="1503" alt="Screenshot 2024-08-12 at 10 43 14 AM" src="https://github.com/user-attachments/assets/93ddefe6-3113-48d5-b704-437a57e8081e">


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
