### PR TITLE
Add batching to Braze Identify User and Create Alias actions

### DIFF
--- a/packages/destination-actions/src/destinations/braze/createAlias/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/braze/createAlias/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -12,6 +12,68 @@ Object {
 }
 `;
 
+exports[`Testing snapshot for Braze's createAlias destination action: it should work with a single batched events 1`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer my-api-key",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Testing snapshot for Braze's createAlias destination action: it should work with a single batched events 2`] = `
+Object {
+  "user_aliases": Array [
+    Object {
+      "alias_label": "foo",
+      "alias_name": "bar",
+      "external_id": "user123",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for Braze's createAlias destination action: it should work with batched events 1`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer my-api-key",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+    "x-braze-batch": Array [
+      "true",
+    ],
+  },
+}
+`;
+
+exports[`Testing snapshot for Braze's createAlias destination action: it should work with batched events 2`] = `
+Object {
+  "user_aliases": Array [
+    Object {
+      "alias_label": "foo",
+      "alias_name": "bar",
+    },
+    Object {
+      "alias_label": "boo",
+      "alias_name": "baz",
+      "external_id": "user2",
+    },
+    Object {
+      "alias_label": "foe",
+      "alias_name": "fum",
+      "external_id": "user3",
+    },
+  ],
+}
+`;
+
 exports[`Testing snapshot for Braze's createAlias destination action: required fields 1`] = `
 Object {
   "user_aliases": Array [
@@ -19,6 +81,17 @@ Object {
       "alias_label": "#HMCBuX*",
       "alias_name": "#HMCBuX*",
       "external_id": "#HMCBuX*",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for Braze's createAlias destination action: without external_id 1`] = `
+Object {
+  "user_aliases": Array [
+    Object {
+      "alias_label": "email",
+      "alias_name": "email@gmail.com",
     },
   ],
 }

--- a/packages/destination-actions/src/destinations/braze/createAlias/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/braze/createAlias/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -90,8 +90,8 @@ exports[`Testing snapshot for Braze's createAlias destination action: without ex
 Object {
   "user_aliases": Array [
     Object {
-      "alias_label": "email",
-      "alias_name": "email@gmail.com",
+      "alias_label": "#HMCBuX*",
+      "alias_name": "#HMCBuX*",
     },
   ],
 }

--- a/packages/destination-actions/src/destinations/braze/createAlias/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/braze/createAlias/__tests__/snapshot.test.ts
@@ -7,6 +7,10 @@ const testDestination = createTestIntegration(destination)
 const actionSlug = 'createAlias'
 const destinationSlug = 'Braze'
 const seedName = `${destinationSlug}#${actionSlug}`
+const settings = {
+  api_key: 'my-api-key',
+  endpoint: 'https://rest.iad-01.braze.com'
+}
 
 describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
   it('required fields', async () => {
@@ -71,5 +75,149 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     } catch (err) {
       expect(rawBody).toMatchSnapshot()
     }
+  })
+
+  it('without external_id', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      event: 'Create Alias',
+      userId: null,
+      properties: {
+        alias_name: 'email@gmail.com',
+        alias_label: 'email'
+      }
+    })
+
+    const mapping = {
+      external_id: {
+        '@path': '$.userId'
+      },
+      alias_name: {
+        '@path': '$.properties.alias_name'
+      },
+      alias_label: {
+        '@path': '$.properties.alias_label'
+      },
+      enable_batching: false
+    }
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping,
+      settings
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+
+  it('it should work with batched events', async () => {
+    nock(settings.endpoint).post('/users/alias/new').reply(200, {})
+
+    const events = [
+      createTestEvent({
+        type: 'track',
+        event: 'Create Alias',
+        userId: null,
+        properties: {
+          alias_label: 'foo',
+          alias_name: 'bar'
+        }
+      }),
+      createTestEvent({
+        type: 'track',
+        event: 'Create Alias',
+        userId: 'user2',
+        properties: {
+          alias_label: 'boo',
+          alias_name: 'baz'
+        }
+      }),
+      createTestEvent({
+        type: 'track',
+        event: 'Create Alias',
+        userId: 'user3',
+        properties: {
+          alias_label: 'foe',
+          alias_name: 'fum'
+        }
+      })
+    ]
+
+    const mapping = {
+      external_id: {
+        '@path': '$.userId'
+      },
+      alias_name: {
+        '@path': '$.properties.alias_name'
+      },
+      alias_label: {
+        '@path': '$.properties.alias_label'
+      },
+      enable_batching: true
+    }
+
+    const responses = await testDestination.testBatchAction(actionSlug, {
+      events,
+      mapping,
+      settings
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.headers).toMatchSnapshot()
+    expect(responses[0].options.json).toMatchSnapshot()
+  })
+
+  it('it should work with a single batched events', async () => {
+    nock(settings.endpoint).post('/users/alias/new').reply(200, {})
+
+    const events = [
+      createTestEvent({
+        type: 'track',
+        event: 'Create Alias',
+        userId: 'user123',
+        properties: {
+          alias_label: 'foo',
+          alias_name: 'bar'
+        }
+      })
+    ]
+
+    const mapping = {
+      external_id: {
+        '@path': '$.userId'
+      },
+      alias_name: {
+        '@path': '$.properties.alias_name'
+      },
+      alias_label: {
+        '@path': '$.properties.alias_label'
+      },
+      enable_batching: true
+    }
+
+    const responses = await testDestination.testBatchAction(actionSlug, {
+      events,
+      mapping,
+      settings
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.headers).toMatchSnapshot()
+    expect(responses[0].options.json).toMatchSnapshot()
   })
 })

--- a/packages/destination-actions/src/destinations/braze/createAlias/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/braze/createAlias/__tests__/snapshot.test.ts
@@ -78,37 +78,23 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
   })
 
   it('without external_id', async () => {
-    const event = createTestEvent({
-      type: 'track',
-      event: 'Create Alias',
-      userId: null,
-      properties: {
-        alias_name: 'email@gmail.com',
-        alias_label: 'email'
-      }
-    })
-
-    const mapping = {
-      external_id: {
-        '@path': '$.userId'
-      },
-      alias_name: {
-        '@path': '$.properties.alias_name'
-      },
-      alias_label: {
-        '@path': '$.properties.alias_label'
-      },
-      enable_batching: false
-    }
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+    delete eventData.external_id // remove external_id
 
     nock(/.*/).persist().get(/.*/).reply(200)
     nock(/.*/).persist().post(/.*/).reply(200)
     nock(/.*/).persist().put(/.*/).reply(200)
 
+    const event = createTestEvent({
+      properties: eventData
+    })
+
     const responses = await testDestination.testAction(actionSlug, {
       event: event,
-      mapping,
-      settings
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
     })
 
     const request = responses[0].request

--- a/packages/destination-actions/src/destinations/braze/createAlias/generated-types.ts
+++ b/packages/destination-actions/src/destinations/braze/createAlias/generated-types.ts
@@ -13,4 +13,12 @@ export interface Payload {
    * A label indicating the type of alias
    */
   alias_label: string
+  /**
+   * If true, Segment will batch events before sending to Braze’s create alias endpoint. Braze accepts batches of up to 50 events for this endpoint.
+   */
+  enable_batching?: boolean
+  /**
+   * Maximum number of events to include in each batch. Actual batch sizes may be lower.
+   */
+  batch_size?: number
 }

--- a/packages/destination-actions/src/destinations/braze/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/braze/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -11,25 +11,81 @@ Object {
       },
     },
   ],
-  "merge_behavior": "merge",
 }
 `;
 
-exports[`Testing snapshot for Braze's identifyUser destination action: required fields 1`] = `
+exports[`Testing snapshot for Braze's identifyUser destination action: it should work with a single batched events 1`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer my-api-key",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Testing snapshot for Braze's identifyUser destination action: it should work with a single batched events 2`] = `
 Object {
   "aliases_to_identify": Array [
     Object {
-      "external_id": "L6iTV8uKjdSaPxy2fjx9",
+      "external_id": "user1",
       "user_alias": Object {
-        "alias_label": "L6iTV8uKjdSaPxy2fjx9",
-        "alias_name": "L6iTV8uKjdSaPxy2fjx9",
+        "alias_label": "foo",
+        "alias_name": "bar",
       },
     },
   ],
 }
 `;
 
-exports[`all fields - backwards compatibility testing 1`] = `
+exports[`Testing snapshot for Braze's identifyUser destination action: it should work with batched events 1`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer my-api-key",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+    "x-braze-batch": Array [
+      "true",
+    ],
+  },
+}
+`;
+
+exports[`Testing snapshot for Braze's identifyUser destination action: it should work with batched events 2`] = `
+Object {
+  "aliases_to_identify": Array [
+    Object {
+      "external_id": "user1",
+      "user_alias": Object {
+        "alias_label": "foo",
+        "alias_name": "bar",
+      },
+    },
+    Object {
+      "external_id": "user2",
+      "user_alias": Object {
+        "alias_label": "boo",
+        "alias_name": "baz",
+      },
+    },
+    Object {
+      "external_id": "user3",
+      "user_alias": Object {
+        "alias_label": "foe",
+        "alias_name": "fum",
+      },
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for Braze's identifyUser destination action: required fields 1`] = `
 Object {
   "aliases_to_identify": Array [
     Object {

--- a/packages/destination-actions/src/destinations/braze/identifyUser/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/braze/identifyUser/__tests__/snapshot.test.ts
@@ -7,6 +7,10 @@ const testDestination = createTestIntegration(destination)
 const actionSlug = 'identifyUser'
 const destinationSlug = 'Braze'
 const seedName = `${destinationSlug}#${actionSlug}`
+const settings = {
+  api_key: 'my-api-key',
+  endpoint: 'https://rest.iad-01.braze.com'
+}
 
 describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
   it('required fields', async () => {
@@ -72,38 +76,98 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       expect(rawBody).toMatchSnapshot()
     }
   })
-})
 
-it('all fields - backwards compatibility testing', async () => {
-  const action = destination.actions[actionSlug]
-  const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+  it('it should work with batched events', async () => {
+    nock(settings.endpoint).post('/users/identify').reply(200, {})
 
-  nock(/.*/).persist().get(/.*/).reply(200)
-  nock(/.*/).persist().post(/.*/).reply(200)
-  nock(/.*/).persist().put(/.*/).reply(200)
+    const events = [
+      createTestEvent({
+        userId: 'user1',
+        properties: {
+          alias_label: 'foo',
+          alias_name: 'bar'
+        }
+      }),
+      createTestEvent({
+        userId: 'user2',
+        properties: {
+          alias_label: 'boo',
+          alias_name: 'baz'
+        }
+      }),
+      createTestEvent({
+        userId: 'user3',
+        properties: {
+          alias_label: 'foe',
+          alias_name: 'fum'
+        }
+      })
+    ]
 
-  const event = createTestEvent({
-    properties: eventData
+    const mapping = {
+      external_id: {
+        '@path': '$.userId'
+      },
+      user_alias: {
+        alias_label: {
+          '@path': '$.properties.alias_label'
+        },
+        alias_name: {
+          '@path': '$.properties.alias_name'
+        }
+      },
+      enable_batching: true
+    }
+
+    const responses = await testDestination.testBatchAction(actionSlug, {
+      events,
+      mapping,
+      settings
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.headers).toMatchSnapshot()
+    expect(responses[0].options.json).toMatchSnapshot()
   })
 
-  // make sure existing destinations payload did not change if they don't have merge_behavior defined
-  delete eventData.merge_behavior
+  it('it should work with a single batched events', async () => {
+    nock(settings.endpoint).post('/users/identify').reply(200, {})
 
-  const responses = await testDestination.testAction(actionSlug, {
-    event: event,
-    mapping: event.properties,
-    settings: settingsData,
-    auth: undefined
+    const events = [
+      createTestEvent({
+        userId: 'user1',
+        properties: {
+          alias_label: 'foo',
+          alias_name: 'bar'
+        }
+      })
+    ]
+
+    const mapping = {
+      external_id: {
+        '@path': '$.userId'
+      },
+      user_alias: {
+        alias_label: {
+          '@path': '$.properties.alias_label'
+        },
+        alias_name: {
+          '@path': '$.properties.alias_name'
+        }
+      },
+      enable_batching: true
+    }
+
+    const responses = await testDestination.testBatchAction(actionSlug, {
+      events,
+      mapping,
+      settings
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.headers).toMatchSnapshot()
+    expect(responses[0].options.json).toMatchSnapshot()
   })
-
-  const request = responses[0].request
-  const rawBody = await request.text()
-
-  try {
-    const json = JSON.parse(rawBody)
-    expect(json).toMatchSnapshot()
-    return
-  } catch (err) {
-    expect(rawBody).toMatchSnapshot()
-  }
 })

--- a/packages/destination-actions/src/destinations/braze/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/braze/identifyUser/generated-types.ts
@@ -16,4 +16,12 @@ export interface Payload {
    * Sets the endpoint to merge some fields found exclusively on the anonymous user to the identified user. See [the docs](https://www.braze.com/docs/api/endpoints/user_data/post_user_identify/#request-parameters).
    */
   merge_behavior?: string
+  /**
+   * If true, Segment will batch events before sending to Braze’s identify user endpoint. Braze accepts batches of up to 50 events for this endpoint.
+   */
+  enable_batching?: boolean
+  /**
+   * Maximum number of events to include in each batch. Actual batch sizes may be lower.
+   */
+  batch_size?: number
 }

--- a/packages/destination-actions/src/destinations/braze/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/braze/identifyUser/generated-types.ts
@@ -13,10 +13,6 @@ export interface Payload {
     alias_label: string
   }
   /**
-   * Sets the endpoint to merge some fields found exclusively on the anonymous user to the identified user. See [the docs](https://www.braze.com/docs/api/endpoints/user_data/post_user_identify/#request-parameters).
-   */
-  merge_behavior?: string
-  /**
    * If true, Segment will batch events before sending to Braze’s identify user endpoint. Braze accepts batches of up to 50 events for this endpoint.
    */
   enable_batching?: boolean


### PR DESCRIPTION
This PR introduces batching for the two remaining Braze actions that previously lacked it.

This update is in response to a recent issue where Braze contacted us about RETL overloading their API at these endpoints: [STRATCONN-4091](https://segment.atlassian.net/browse/STRATCONN-4091).

- By implementing batching, we could have significantly reduced the impact on Braze's servers and potentially prevented the issue altogether.


**Remaining points to clarify:** 
- Can we remove Merge field without a change in functionality (waiting for response from Braze contact on this)
![image](https://github.com/user-attachments/assets/539c51df-8d94-43f3-80b2-ab562f74349a)

- Will the 50 batch_size be supported?

## Testing

- ✅ Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- ✅ Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)

https://github.com/user-attachments/assets/85dba6fd-08a8-40f6-b387-5d46bed18563

- TODO: [Segmenters] Tested in the staging environment
