### PR TITLE
schematic - remove locked property name for userId

### DIFF
--- a/packages/destination-actions/src/destinations/schematic/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/schematic/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -14,7 +14,7 @@ Object {
       },
     },
     "keys": Object {
-      "userId": "G10lVP",
+      "testType": "G10lVP",
     },
     "name": "G10lVP",
     "traits": Object {
@@ -35,7 +35,9 @@ Object {
         "testType": "G10lVP",
       },
     },
-    "keys": Object {},
+    "keys": Object {
+      "testType": "G10lVP",
+    },
   },
   "sent_at": "2023-01-01T00:00:00.000Z",
   "type": "identify",
@@ -54,7 +56,7 @@ Object {
       "raw_event_name": "uvfeUI#M",
     },
     "user": Object {
-      "userId": "uvfeUI#M",
+      "testType": "uvfeUI#M",
     },
   },
   "sent_at": "2023-01-01T00:00:00.000Z",

--- a/packages/destination-actions/src/destinations/schematic/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/schematic/identifyUser/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -14,7 +14,7 @@ Object {
       },
     },
     "keys": Object {
-      "userId": "A7WJL)2NKFy&pmtr0",
+      "testType": "A7WJL)2NKFy&pmtr0",
     },
     "name": "A7WJL)2NKFy&pmtr0",
     "traits": Object {
@@ -35,7 +35,9 @@ Object {
         "testType": "A7WJL)2NKFy&pmtr0",
       },
     },
-    "keys": Object {},
+    "keys": Object {
+      "testType": "A7WJL)2NKFy&pmtr0",
+    },
   },
   "sent_at": "2021-02-01T00:00:00.000Z",
   "type": "identify",

--- a/packages/destination-actions/src/destinations/schematic/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/schematic/identifyUser/generated-types.ts
@@ -25,10 +25,6 @@ export interface Payload {
    * Key-value pairs associated with a user (e.g. email: example@example.com)
    */
   user_keys: {
-    /**
-     * Your unique ID for your user
-     */
-    userId?: string
     [k: string]: unknown
   }
   /**

--- a/packages/destination-actions/src/destinations/schematic/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/schematic/identifyUser/index.ts
@@ -46,14 +46,6 @@ const action: ActionDefinition<Settings, Payload> = {
       defaultObjectUI: 'keyvalue',
       required: true,
       additionalProperties: true,
-      properties: {
-        userId: {
-          label: 'User ID',
-          description: 'Your unique ID for your user',
-          type: 'string',
-          required: false
-        }
-      },
       default: {
         userId: { '@path': '$.userId' }
       }

--- a/packages/destination-actions/src/destinations/schematic/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/schematic/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -12,7 +12,7 @@ Object {
       "raw_event_name": "H%fspr!Jez(TWP",
     },
     "user": Object {
-      "userId": "H%fspr!Jez(TWP",
+      "testType": "H%fspr!Jez(TWP",
     },
   },
   "sent_at": "2021-02-01T00:00:00.000Z",

--- a/packages/destination-actions/src/destinations/schematic/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/schematic/trackEvent/generated-types.ts
@@ -19,10 +19,6 @@ export interface Payload {
    * Key-value pairs associated with a user (e.g. email: example@example.com)
    */
   user_keys?: {
-    /**
-     * Your unique ID for your user
-     */
-    userId?: string
     [k: string]: unknown
   }
   /**

--- a/packages/destination-actions/src/destinations/schematic/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/schematic/trackEvent/index.ts
@@ -74,14 +74,6 @@ const action: ActionDefinition<Settings, Payload> = {
       required: false,
       defaultObjectUI: 'keyvalue',
       additionalProperties: true,
-      properties: {
-        userId: {
-          label: 'User ID',
-          description: 'Your unique ID for your user',
-          type: 'string',
-          required: false
-        }
-      },
       default: {
         userId: { '@path': '$.userId' }
       }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

removed properties from user_keys for both actions. the desired behavior is that the user can choose the property name, not that we assume/lock one.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
