### PR TITLE
[LinkedIn Conversions] Hidden batching fields are not required

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
@@ -51,11 +51,11 @@ export interface Payload {
   /**
    * Enable batching of requests.
    */
-  enable_batching: boolean
+  enable_batching?: boolean
   /**
    * Maximum number of events to include in each batch. Actual batch sizes may be lower.
    */
-  batch_size: number
+  batch_size?: number
 }
 // Generated bundle for hooks. DO NOT MODIFY IT BY HAND.
 

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -285,16 +285,14 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
       description: 'Enable batching of requests.',
       type: 'boolean',
       default: true,
-      unsafe_hidden: true,
-      required: true
+      unsafe_hidden: true
     },
     batch_size: {
       label: 'Batch Size',
       description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
       type: 'number',
       default: 5000,
-      unsafe_hidden: true,
-      required: true
+      unsafe_hidden: true
     }
   },
   perform: async (request, { payload, hookOutputs }) => {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR updates the LinkedIn batching configuration to ensure that these hidden fields are NOT required. This commit was tested in staging and should have been included in: https://github.com/segmentio/action-destinations/pull/2273

## Testing
Tested successfully in staging. Evidence can be found on the prior PR: https://github.com/segmentio/action-destinations/pull/2273

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
