### PR TITLE
Add batch_size fields for braze actions

### DIFF
--- a/packages/destination-actions/src/destinations/braze/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/braze/trackEvent/generated-types.ts
@@ -42,4 +42,8 @@ export interface Payload {
    * If true, Segment will batch events before sending to Braze’s user track endpoint. Braze accepts batches of up to 75 events.
    */
   enable_batching?: boolean
+  /**
+   * Maximum number of events to include in each batch. Actual batch sizes may be lower.
+   */
+  batch_size?: number
 }

--- a/packages/destination-actions/src/destinations/braze/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/braze/trackEvent/index.ts
@@ -88,6 +88,13 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'If true, Segment will batch events before sending to Braze’s user track endpoint. Braze accepts batches of up to 75 events.',
       default: true
+    },
+    batch_size: {
+      label: 'Batch Size',
+      description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
+      type: 'number',
+      default: 75,
+      unsafe_hidden: true
     }
   },
   perform: (request, { settings, payload }) => {

--- a/packages/destination-actions/src/destinations/braze/trackPurchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/braze/trackPurchase/generated-types.ts
@@ -48,4 +48,8 @@ export interface Payload {
    * If true, Segment will batch events before sending to Braze’s user track endpoint. Braze accepts batches of up to 75 events.
    */
   enable_batching?: boolean
+  /**
+   * Maximum number of events to include in each batch. Actual batch sizes may be lower.
+   */
+  batch_size?: number
 }

--- a/packages/destination-actions/src/destinations/braze/trackPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/braze/trackPurchase/index.ts
@@ -110,6 +110,13 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'If true, Segment will batch events before sending to Braze’s user track endpoint. Braze accepts batches of up to 75 events.',
       default: true
+    },
+    batch_size: {
+      label: 'Batch Size',
+      description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
+      type: 'number',
+      default: 75,
+      unsafe_hidden: true
     }
   },
   perform: (request, { settings, payload }) => {

--- a/packages/destination-actions/src/destinations/braze/updateUserProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/braze/updateUserProfile/generated-types.ts
@@ -144,4 +144,8 @@ export interface Payload {
    * If true, Segment will batch events before sending to Braze’s user track endpoint. Braze accepts batches of up to 75 events.
    */
   enable_batching?: boolean
+  /**
+   * Maximum number of events to include in each batch. Actual batch sizes may be lower.
+   */
+  batch_size?: number
 }

--- a/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
+++ b/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
@@ -287,6 +287,13 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'If true, Segment will batch events before sending to Braze’s user track endpoint. Braze accepts batches of up to 75 events.',
       default: true
+    },
+    batch_size: {
+      label: 'Batch Size',
+      description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
+      type: 'number',
+      default: 75,
+      unsafe_hidden: true
     }
   },
 


### PR DESCRIPTION
This PR is related to [PR #2280](https://github.com/segmentio/action-destinations/pull/2280).

Currently, we use a [batch override in integrations-go](https://github.com/segmentio/integrations-go/blob/v3/models/actions/catalog/overrides/braze/integration.go#L10) to set a batch size of 75 for Braze Actions.

PR #2280 introduces batching for the remaining Braze actions that previously lacked it. However, these endpoints have a different batch size limit of 50.

To accommodate this change, we need to remove the existing override so we have the ability to set a different batch size for actions that require a size other than 75. 

- ✅  [Confirming with wider team first](https://twilio.slack.com/archives/C01RWN725QW/p1723512428995229)
- [And confirmed here](https://twilio.slack.com/archives/C03NK2Y2GTC/p1723769127291769?thread_ts=1723057856.418679&cid=C03NK2Y2GTC)

Once this merged, I will work with the integrations-go team to get override removed. 

