### PR TITLE
[STRAT-3865] | Removed getAuthToken from Amazon-amc createAudience and getAudience 

### DIFF
--- a/packages/destination-actions/src/destinations/amazon-amc/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { createTestIntegration, InvalidAuthenticationError } from '@segment/actions-core'
+import { createTestIntegration } from '@segment/actions-core'
 import Definition from '../index'
 import { HTTPError } from '@segment/actions-core/*'
 import { AUTHORIZATION_URL } from '../utils'
@@ -116,15 +116,6 @@ describe('Amazon-Ads (actions)', () => {
       )
     })
 
-    it('should fail if refresh token API gets failed', async () => {
-      const endpoint = AUTHORIZATION_URL[`${settings.region}`]
-      nock(`${endpoint}`).post('/auth/o2/token').reply(401)
-
-      await expect(testDestination.createAudience(createAudienceInputTemp)).rejects.toThrowError(
-        InvalidAuthenticationError
-      )
-    })
-
     it('should throw an HTTPError when createAudience API response is not ok', async () => {
       const endpoint = AUTHORIZATION_URL[`${settings.region}`]
       nock(`${endpoint}`).post('/auth/o2/token').reply(200)
@@ -138,9 +129,6 @@ describe('Amazon-Ads (actions)', () => {
     })
 
     it('creates an audience', async () => {
-      const endpoint = AUTHORIZATION_URL[`${settings.region}`]
-      nock(`${endpoint}`).post('/auth/o2/token').reply(200)
-
       nock(`${settings.region}`)
         .post('/amc/audiences/metadata')
         .matchHeader('content-type', 'application/vnd.amcaudiences.v1+json')
@@ -204,13 +192,6 @@ describe('Amazon-Ads (actions)', () => {
       await expect(audiencePromise).rejects.toThrow(HTTPError)
       await expect(audiencePromise).rejects.toHaveProperty('response.statusText', 'Not Found')
       await expect(audiencePromise).rejects.toHaveProperty('response.status', 404)
-    })
-    it('should fail if refresh token API gets failed ', async () => {
-      const endpoint = AUTHORIZATION_URL[`${settings.region}`]
-      nock(`${endpoint}`).post('/auth/o2/token').reply(401)
-
-      const audiencePromise = testDestination.getAudience(getAudienceInput)
-      await expect(audiencePromise).rejects.toThrow(InvalidAuthenticationError)
     })
 
     it('should throw an IntegrationError when the audienceId is not provided', async () => {

--- a/packages/destination-actions/src/destinations/amazon-amc/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/index.ts
@@ -4,7 +4,6 @@ import type { Settings, AudienceSettings } from './generated-types'
 import {
   AudiencePayload,
   extractNumberAndSubstituteWithStringValue,
-  getAuthSettings,
   getAuthToken,
   REGEX_ADVERTISERID,
   REGEX_AUDIENCEID
@@ -198,10 +197,6 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         })
       }
 
-      // @ts-ignore - TS doesn't know about the oauth property
-      const authSettings = getAuthSettings(settings)
-      const authToken = await getAuthToken(request, createAudienceInput.settings, authSettings)
-
       let payloadString = JSON.stringify(payload)
       // Regular expression to find a advertiserId numeric string and replace the quoted advertiserId string with an unquoted number
       // AdvertiserId is very big number string and can not be assigned or converted to number directly as it changes the value due to integer overflow.
@@ -211,8 +206,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         method: 'POST',
         body: payloadString,
         headers: {
-          'Content-Type': 'application/vnd.amcaudiences.v1+json',
-          authorization: `Bearer ${authToken}`
+          'Content-Type': 'application/vnd.amcaudiences.v1+json'
         }
       })
 
@@ -229,18 +223,11 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       const audience_id = getAudienceInput.externalId
       const { settings } = getAudienceInput
       const endpoint = settings.region
-
       if (!audience_id) {
         throw new IntegrationError('Missing audienceId value', 'MISSING_REQUIRED_FIELD', 400)
       }
-      // @ts-ignore - TS doesn't know about the oauth property
-      const authSettings = getAuthSettings(settings)
-      const authToken = await getAuthToken(request, settings, authSettings)
       const response = await request(`${endpoint}/amc/audiences/metadata/${audience_id}`, {
-        method: 'GET',
-        headers: {
-          authorization: `Bearer ${authToken}`
-        }
+        method: 'GET'
       })
       const res = await response.text()
       // Regular expression to find a audienceId number and replace the audienceId with quoted string


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pull request is to remove the getAuthToken from createAudience and getAudience Handler for Amazon-amc as it is not needed here. 
We have implemented re-authentication flow for [createAudience and getAudience](https://github.com/segmentio/action-destinations/pull/2287) Handler that will re-authenticate whenever it throws 401 Error.
[Dependent PR ](https://github.com/segmentio/action-destinations/pull/2287)
[Jira ticket](https://segment.atlassian.net/jira/software/c/projects/STRATCONN/boards/310?assignee=63617339fc0cc7a600b03c6b&selectedIssue=STRATCONN-3865)
[Acceptance Criteria ](https://docs.google.com/document/d/11d9tuxgwdcx--hwxs8MspVkTQ5_O2yP1RPHuIFkczv8/edit#heading=h.x9dgiyfuowsl)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment

Tested completed Successfully in [Staging](https://docs.google.com/document/d/11d9tuxgwdcx--hwxs8MspVkTQ5_O2yP1RPHuIFkczv8/edit#heading=h.x9dgiyfuowsl)

