### PR TITLE
[STRAT-3865] | Re-authentication Flow for CreateAudience and GetAudience to handle 401

### DIFF
--- a/packages/core/src/__tests__/destination-kit.test.ts
+++ b/packages/core/src/__tests__/destination-kit.test.ts
@@ -1,3 +1,4 @@
+import { IntegrationError } from '../errors'
 import { ActionDefinition } from '../destination-kit/action'
 import {
   StateContext,
@@ -6,10 +7,13 @@ import {
   Logger,
   StatsClient,
   StatsContext,
-  TransactionContext
+  TransactionContext,
+  AudienceDestinationDefinition,
+  AuthenticationScheme
 } from '../destination-kit'
 import { JSONObject } from '../json-object'
 import { SegmentEvent } from '../segment-event'
+const WRONG_AUDIENCE_ID = '1234567890'
 
 const destinationCustomAuth: DestinationDefinition<JSONObject> = {
   name: 'Actions Google Analytic 4',
@@ -76,6 +80,73 @@ const destinationOAuth2: DestinationDefinition<JSONObject> = {
       }
     }
   }
+}
+
+const authentication: AuthenticationScheme<JSONObject> = {
+  scheme: 'oauth2',
+  fields: {},
+  refreshAccessToken: (_request) => {
+    return new Promise((resolve, _reject) => {
+      resolve({
+        accessToken: 'fresh-token'
+      })
+    })
+  }
+}
+
+const audienceDestination: AudienceDestinationDefinition<JSONObject> = {
+  name: 'Amazon AMC (Actions)',
+  mode: 'cloud',
+  authentication: authentication,
+  audienceFields: {},
+  audienceConfig: {
+    mode: {
+      type: 'synced', // Indicates that the audience is synced on some schedule; update as necessary
+      full_audience_sync: false // If true, we send the entire audience. If false, we just send the delta.
+    },
+
+    // Mocked createAudience Handler
+    async createAudience(_request, createAudienceInput) {
+      const settings: any = createAudienceInput.settings
+      const audienceSettings: any = createAudienceInput.audienceSettings
+
+      // it could be due to invalid input or Bad Request
+      if (!audienceSettings?.advertiserId)
+        throw new IntegrationError('Missing advertiserId Value', 'MISSING_REQUIRED_FIELD', 400)
+
+      // invalid access token
+      if (settings.oauth.access_token == 'invalid-access-token' || settings.oauth.clientId == 'invalid_client_id') {
+        return new Promise((_resolve, reject) => {
+          reject(new IntegrationError('Unauthorized', 'UNAUTHORIZED', 401))
+        })
+      }
+
+      return new Promise((resolve, _reject) => {
+        resolve({ externalId: '123456789' })
+      })
+    },
+
+    // Mocked getAudience Handler
+    async getAudience(_request, getAudienceInput) {
+      const settings: any = getAudienceInput.settings
+      const audience_id = getAudienceInput.externalId
+
+      if (audience_id == WRONG_AUDIENCE_ID) {
+        throw new IntegrationError('audienceId not found', 'AUDIENCEID_NOT_FOUND', 400)
+      }
+
+      if (settings.oauth.access_token == 'invalid-access-token' || settings.oauth.clientId == 'invalid_client_id') {
+        return new Promise((_resolve, reject) => {
+          reject(new IntegrationError('Unauthorized', 'UNAUTHORIZED', 401))
+        })
+      }
+
+      return new Promise((resolve, _reject) => {
+        resolve({ externalId: audience_id })
+      })
+    }
+  },
+  actions: {}
 }
 
 const destinationWithOptions: DestinationDefinition<JSONObject> = {
@@ -958,6 +1029,188 @@ describe('destination kit', () => {
         choices: [],
         error: { code: '404', message: 'No dynamic field named testStructuredObject.ghostSubfield found.' },
         nextPage: ''
+      })
+    })
+  })
+  describe('Reauthentication Flow', () => {
+    beforeEach(async () => {
+      jest.restoreAllMocks()
+      jest.resetAllMocks()
+    })
+    describe('createAudience', () => {
+      test('Refreshes the access-token in case of Unauthorized(401)', async () => {
+        const createAudienceInput = {
+          audienceName: 'Test Audience',
+          settings: {
+            oauth: {
+              clientId: 'valid-client-id',
+              clientSecret: 'valid-client-secret',
+              access_token: 'invalid-access-token',
+              refresh_token: 'refresh-token',
+              token_type: 'bearer'
+            }
+          },
+          audienceSettings: {
+            advertiserId: '12334745462532'
+          }
+        }
+        const destinationTest = new Destination(audienceDestination)
+        const spy = jest.spyOn(authentication, 'refreshAccessToken')
+        const res = await destinationTest.createAudience(createAudienceInput)
+        expect(res).toEqual({ externalId: '123456789' })
+        expect(spy).toHaveBeenCalledTimes(1)
+      })
+
+      test('Will not refresh access-token in case of any non 401 error', async () => {
+        const createAudienceInput = {
+          audienceName: 'Test Audience',
+          settings: {
+            oauth: {
+              clientId: 'valid-client-id',
+              clientSecret: 'valid-client-secret',
+              access_token: 'access-token',
+              refresh_token: 'refresh-token',
+              token_type: 'bearer'
+            }
+          },
+          audienceSettings: {}
+        }
+        const destinationTest = new Destination(audienceDestination)
+        const spy = jest.spyOn(authentication, 'refreshAccessToken')
+        await expect(destinationTest.createAudience(createAudienceInput)).rejects.toThrowError()
+        expect(spy).not.toHaveBeenCalled()
+      })
+
+      test('Will not refresh access-token if token is already valid', async () => {
+        const createAudienceInput = {
+          audienceName: 'Test Audience',
+          settings: {
+            oauth: {
+              clientId: 'valid-client-id',
+              clientSecret: 'valid-client-secret',
+              access_token: 'valid-access-token',
+              refresh_token: 'refresh-token',
+              token_type: 'bearer'
+            }
+          },
+          audienceSettings: {
+            advertiserId: '12334745462532'
+          }
+        }
+
+        const destinationTest = new Destination(audienceDestination)
+        const spy = jest.spyOn(authentication, 'refreshAccessToken')
+        const res = await destinationTest.createAudience(createAudienceInput)
+        expect(res).toEqual({ externalId: '123456789' })
+        expect(spy).not.toHaveBeenCalled()
+      })
+
+      test('Will not refresh the access-token for non-Oauth authentication scheme', async () => {
+        const createAudienceInput = {
+          audienceName: 'Test Audience',
+          settings: {
+            oauth: {
+              clientId: 'invalid_client_id',
+              clientSecret: 'valid-client-secret'
+            }
+          },
+          audienceSettings: {
+            advertiserId: '12334745462532'
+          }
+        }
+        // Non-Oauth authentication scheme
+        audienceDestination.authentication = {
+          scheme: 'custom',
+          fields: {}
+        }
+        const destinationTest = new Destination(audienceDestination)
+        const spy = jest.spyOn(authentication, 'refreshAccessToken')
+        await expect(destinationTest.createAudience(createAudienceInput)).rejects.toThrowError()
+        expect(spy).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('getAudience', () => {
+      test('Refreshes the access-token in case of Unauthorized(401)', async () => {
+        const getAudienceInput = {
+          externalId: '366170701270726115',
+          settings: {
+            oauth: {
+              clientId: 'valid-client-id',
+              clientSecret: 'valid-client-secret',
+              access_token: 'invalid-access-token',
+              refresh_token: 'refresh-token',
+              token_type: 'bearer'
+            }
+          }
+        }
+        audienceDestination.authentication = authentication
+        const destinationTest = new Destination(audienceDestination)
+        const spy = jest.spyOn(authentication, 'refreshAccessToken')
+        const res = await destinationTest.getAudience(getAudienceInput)
+        expect(res).toEqual({ externalId: '366170701270726115' })
+        expect(spy).toHaveBeenCalledTimes(1)
+      })
+
+      test('Will not refresh access-token in case of any non 401 error', async () => {
+        const getAudienceInput = {
+          externalId: WRONG_AUDIENCE_ID,
+          settings: {
+            oauth: {
+              clientId: 'valid-client-id',
+              clientSecret: 'valid-client-secret',
+              access_token: 'valid-access-token',
+              refresh_token: 'refresh-token',
+              token_type: 'bearer'
+            }
+          }
+        }
+        const destinationTest = new Destination(audienceDestination)
+        const spy = jest.spyOn(authentication, 'refreshAccessToken')
+        await expect(destinationTest.getAudience(getAudienceInput)).rejects.toThrowError()
+        expect(spy).not.toHaveBeenCalled()
+      })
+
+      test('Will not refresh access-token if token is already valid', async () => {
+        const getAudienceInput = {
+          externalId: '366170701270726115',
+          settings: {
+            oauth: {
+              clientId: 'valid-client-id',
+              clientSecret: 'valid-client-secret',
+              access_token: 'valid-access-token',
+              refresh_token: 'refresh-token',
+              token_type: 'bearer'
+            }
+          }
+        }
+        const destinationTest = new Destination(audienceDestination)
+        const spy = jest.spyOn(authentication, 'refreshAccessToken')
+        const res = await destinationTest.getAudience(getAudienceInput)
+        expect(res).toEqual({ externalId: '366170701270726115' })
+        expect(spy).not.toHaveBeenCalled()
+      })
+
+      test('Will not refresh the access-token for non-Oauth authentication scheme', async () => {
+        const getAudienceInput = {
+          externalId: '366170701270726115',
+          settings: {
+            oauth: {
+              clientId: 'invalid_client_id',
+              clientSecret: 'valid-client-secret'
+            }
+          }
+        }
+
+        // Non-Oauth authentication scheme
+        audienceDestination.authentication = {
+          scheme: 'custom',
+          fields: {}
+        }
+        const destinationTest = new Destination(audienceDestination)
+        const spy = jest.spyOn(authentication, 'refreshAccessToken')
+        await expect(destinationTest.getAudience(getAudienceInput)).rejects.toThrowError()
+        expect(spy).not.toHaveBeenCalled()
       })
     })
   })

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -883,26 +883,18 @@ export class Destination<Settings = JSONObject, AudienceSettings = JSONObject> {
    * @throws {ResponseError & HTTPError} - If reauthentication is not needed or token refresh fails.
    */
   async handleAuthError(error: ResponseError & HTTPError, settings: JSONObject, options?: OnEventOptions) {
-    if (this.needsReauthentication(error)) {
-      const newTokens = await this.refreshTokenAndGetNewToken(settings, options)
-      settings = await this.updateTokensInSettings(settings, newTokens, options)
-    } else {
-      throw error
-    }
-    return settings
-  }
-
-  /**
-   * Determines if reauthentication is needed based on the error status.
-   * @param {ResponseError & HTTPError} error - The error object containing response details.
-   * @returns {boolean} - True if reauthentication is needed, otherwise false.
-   */
-  needsReauthentication(error: ResponseError & HTTPError): boolean {
     const statusCode = error?.status ?? error?.response?.status ?? 500
-    return (
+    const needsReauthentication =
       statusCode === 401 &&
       (this.authentication?.scheme === 'oauth2' || this.authentication?.scheme === 'oauth-managed')
-    )
+    if (!needsReauthentication) {
+      throw error
+    }
+    const newTokens = await this.refreshTokenAndGetNewToken(settings, options)
+    // Update new access-token in cache and in settings.
+    await options?.onTokenRefresh?.(newTokens)
+    settings = updateOAuthSettings(settings, newTokens)
+    return settings
   }
 
   /**
@@ -926,21 +918,5 @@ export class Destination<Settings = JSONObject, AudienceSettings = JSONObject> {
     }
 
     return newTokens
-  }
-
-  /**
-   * Updates the settings object with new tokens.
-   * @param {JSONObject} settings - The current settings object.
-   * @param {RefreshAccessTokenResult} newTokens - The new tokens object.
-   * @param {OnEventOptions} [options] - Optional event options for handling token refresh.
-   * @returns {Promise<JSONObject>} - The updated settings object.
-   */
-  async updateTokensInSettings(
-    settings: JSONObject,
-    newTokens: RefreshAccessTokenResult,
-    options?: OnEventOptions
-  ): Promise<JSONObject> {
-    await options?.onTokenRefresh?.(newTokens)
-    return updateOAuthSettings(settings, newTokens)
   }
 }

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -141,8 +141,8 @@ const instanceOfAudienceDestinationSettingsWithCreateGet = (
 export interface AudienceDestinationDefinition<Settings = unknown, AudienceSettings = unknown>
   extends DestinationDefinition<Settings> {
   audienceConfig:
-    | AudienceDestinationConfiguration
     | AudienceDestinationConfigurationWithCreateGet<Settings, AudienceSettings>
+    | AudienceDestinationConfiguration
 
   audienceFields: Record<string, GlobalSetting>
 
@@ -422,41 +422,56 @@ export class Destination<Settings = JSONObject, AudienceSettings = JSONObject> {
   }
 
   async createAudience(createAudienceInput: CreateAudienceInput<Settings, AudienceSettings>) {
-    const audienceDefinition = this.definition as AudienceDestinationDefinition
-    if (!instanceOfAudienceDestinationSettingsWithCreateGet(audienceDefinition.audienceConfig)) {
+    let settings: JSONObject = createAudienceInput.settings as unknown as JSONObject
+    const { audienceConfig } = this.definition as AudienceDestinationDefinition
+    if (!instanceOfAudienceDestinationSettingsWithCreateGet(audienceConfig)) {
       throw new Error('Unexpected call to createAudience')
     }
-    const destinationSettings = this.getDestinationSettings(createAudienceInput.settings as unknown as JSONObject)
-    const auth = getAuthData(createAudienceInput.settings as unknown as JSONObject)
-    const context: ExecuteInput<Settings, any, AudienceSettings> = {
-      audienceSettings: createAudienceInput.audienceSettings,
-      settings: destinationSettings,
-      payload: undefined,
-      auth
+    const destinationSettings = this.getDestinationSettings(settings)
+    const run = async () => {
+      const auth = getAuthData(settings)
+      const context: ExecuteInput<Settings, any, AudienceSettings> = {
+        audienceSettings: createAudienceInput.audienceSettings,
+        settings: destinationSettings,
+        payload: undefined,
+        auth
+      }
+      const opts = this.extendRequest?.(context) ?? {}
+      const requestClient = createRequestClient({ ...opts, statsContext: context.statsContext })
+      return await audienceConfig?.createAudience(requestClient, createAudienceInput)
     }
-    const options = this.extendRequest?.(context) ?? {}
-    const requestClient = createRequestClient({ ...options, statsContext: context.statsContext })
 
-    return audienceDefinition.audienceConfig?.createAudience(requestClient, createAudienceInput)
+    const onFailedAttempt = async (error: ResponseError & HTTPError) => {
+      settings = await this.handleAuthError(error, settings)
+    }
+    return await retry(run, { retries: 2, onFailedAttempt })
   }
 
   async getAudience(getAudienceInput: GetAudienceInput<Settings, AudienceSettings>) {
-    const audienceDefinition = this.definition as AudienceDestinationDefinition
-    if (!instanceOfAudienceDestinationSettingsWithCreateGet(audienceDefinition.audienceConfig)) {
+    const { audienceConfig } = this.definition as AudienceDestinationDefinition
+    let settings: JSONObject = getAudienceInput.settings as unknown as JSONObject
+    if (!instanceOfAudienceDestinationSettingsWithCreateGet(audienceConfig)) {
       throw new Error('Unexpected call to getAudience')
     }
-    const destinationSettings = this.getDestinationSettings(getAudienceInput.settings as unknown as JSONObject)
-    const auth = getAuthData(getAudienceInput.settings as unknown as JSONObject)
-    const context: ExecuteInput<Settings, any, AudienceSettings> = {
-      audienceSettings: getAudienceInput.audienceSettings,
-      settings: destinationSettings,
-      payload: undefined,
-      auth
+    const destinationSettings = this.getDestinationSettings(settings)
+    const run = async () => {
+      const auth = getAuthData(settings)
+      const context: ExecuteInput<Settings, any, AudienceSettings> = {
+        audienceSettings: getAudienceInput.audienceSettings,
+        settings: destinationSettings,
+        payload: undefined,
+        auth
+      }
+      const opts = this.extendRequest?.(context) ?? {}
+      const requestClient = createRequestClient({ ...opts, statsContext: context.statsContext })
+      return await audienceConfig?.getAudience(requestClient, getAudienceInput)
     }
-    const options = this.extendRequest?.(context) ?? {}
-    const requestClient = createRequestClient({ ...options, statsContext: context.statsContext })
 
-    return audienceDefinition.audienceConfig?.getAudience(requestClient, getAudienceInput)
+    const onFailedAttempt = async (error: ResponseError & HTTPError) => {
+      settings = await this.handleAuthError(error, settings)
+    }
+
+    return await retry(run, { retries: 2, onFailedAttempt })
   }
 
   async testAuthentication(settings: Settings): Promise<void> {
@@ -858,5 +873,74 @@ export class Destination<Settings = JSONObject, AudienceSettings = JSONObject> {
   private getDestinationSettings(settings: JSONObject): Settings {
     const { subcription, subscriptions, oauth, ...otherSettings } = settings
     return otherSettings as unknown as Settings
+  }
+
+  /**
+   * Handles the failed attempt by checking if reauthentication is needed and updating the token if necessary.
+   * @param {ResponseError & HTTPError} error - The error object from the failed attempt.
+   * @param {JSONObject} settings - The current settings object.
+   * @returns {Promise<JSONObject>} - The updated settings object.
+   * @throws {ResponseError & HTTPError} - If reauthentication is not needed or token refresh fails.
+   */
+  async handleAuthError(error: ResponseError & HTTPError, settings: JSONObject, options?: OnEventOptions) {
+    if (this.needsReauthentication(error)) {
+      const newTokens = await this.refreshTokenAndGetNewToken(settings, options)
+      settings = await this.updateTokensInSettings(settings, newTokens, options)
+    } else {
+      throw error
+    }
+    return settings
+  }
+
+  /**
+   * Determines if reauthentication is needed based on the error status.
+   * @param {ResponseError & HTTPError} error - The error object containing response details.
+   * @returns {boolean} - True if reauthentication is needed, otherwise false.
+   */
+  needsReauthentication(error: ResponseError & HTTPError): boolean {
+    const statusCode = error?.status ?? error?.response?.status ?? 500
+    return (
+      statusCode === 401 &&
+      (this.authentication?.scheme === 'oauth2' || this.authentication?.scheme === 'oauth-managed')
+    )
+  }
+
+  /**
+   * Refreshes the token and retrieves new tokens.
+   * @param {JSONObject} settings - The current settings object.
+   * @param {OnEventOptions} [options] - Optional event options for synchronizing token refresh.
+   * @returns {Promise<RefreshAccessTokenResult>} - The new tokens object.
+   * @throws {InvalidAuthenticationError} - If token refresh fails.
+   */
+  async refreshTokenAndGetNewToken(settings: JSONObject, options?: OnEventOptions): Promise<RefreshAccessTokenResult> {
+    const destinationSettings = this.getDestinationSettings(settings)
+    const oauthSettings = getOAuth2Data(settings)
+    const newTokens = await this.refreshAccessToken(
+      destinationSettings,
+      oauthSettings,
+      options?.synchronizeRefreshAccessToken
+    )
+
+    if (!newTokens) {
+      throw new InvalidAuthenticationError('Failed to refresh access token', ErrorCodes.OAUTH_REFRESH_FAILED)
+    }
+
+    return newTokens
+  }
+
+  /**
+   * Updates the settings object with new tokens.
+   * @param {JSONObject} settings - The current settings object.
+   * @param {RefreshAccessTokenResult} newTokens - The new tokens object.
+   * @param {OnEventOptions} [options] - Optional event options for handling token refresh.
+   * @returns {Promise<JSONObject>} - The updated settings object.
+   */
+  async updateTokensInSettings(
+    settings: JSONObject,
+    newTokens: RefreshAccessTokenResult,
+    options?: OnEventOptions
+  ): Promise<JSONObject> {
+    await options?.onTokenRefresh?.(newTokens)
+    return updateOAuthSettings(settings, newTokens)
   }
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pull request is to make re-authentication flow for **createAudience and getAudience** whenever it throws 401 error.
[Jira ticket](https://segment.atlassian.net/jira/software/c/projects/STRATCONN/boards/310?assignee=63617339fc0cc7a600b03c6b&selectedIssue=STRATCONN-3865)
[Acceptance Criteria ](https://docs.google.com/document/d/11d9tuxgwdcx--hwxs8MspVkTQ5_O2yP1RPHuIFkczv8/edit#heading=h.x9dgiyfuowsl)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment

Tested completed Successfully in [Staging](https://docs.google.com/document/d/11d9tuxgwdcx--hwxs8MspVkTQ5_O2yP1RPHuIFkczv8/edit#heading=h.x9dgiyfuowsl)

