### PR TITLE
add 500 batch_size to google sheets

### DIFF
--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
@@ -1,7 +1,6 @@
 import { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-
 import { processData } from './operations'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -57,14 +56,14 @@ const action: ActionDefinition<Settings, Payload> = {
     fields: {
       label: 'Fields',
       description: `
-  The fields to write to the spreadsheet. 
+  The fields to write to the spreadsheet.
 
-  On the left-hand side, input the name of the field as it will appear in the Google Sheet. 
-  
+  On the left-hand side, input the name of the field as it will appear in the Google Sheet.
+
   On the right-hand side, select the field from your data model that maps to the given field in your sheet.
-     
+
   ---
-      
+
   `,
       type: 'object',
       required: true,
@@ -75,6 +74,13 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch Data to Google Sheets',
       description: 'Set as true to ensure Segment sends data to Google Sheets in batches. Please do not set to false.',
       default: true
+    },
+    batch_size: {
+      label: 'Batch Size',
+      description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
+      type: 'number',
+      required: false,
+      default: 500
     }
   },
   perform: (request, { payload }) => {

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet2/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet2/index.ts
@@ -1,7 +1,6 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-
 import { processData } from './operations2'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -87,6 +86,13 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch Data to Google Sheets',
       description: 'Set as true to ensure Segment sends data to Google Sheets in batches. Please do not set to false.',
       default: true
+    },
+    batch_size: {
+      label: 'Batch Size',
+      description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
+      type: 'number',
+      required: false,
+      default: 500
     }
   },
   perform: (request, { payload, syncMode }) => {


### PR DESCRIPTION
Batches of 1000 are timing out occasionally, reducing the value to 500 will help.

The `batch_size` will be configurable by the customer as there is no hard limit and this will allow the customer to adjust based their needs.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
