### PR TITLE
Add E.164 phone number validation to all Klaviyo actions

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -38,7 +38,7 @@ Object {
       "metric": Object {
         "data": Object {
           "attributes": Object {
-            "name": "PE*zlOgIPA]mVozMLBaL",
+            "name": "Order Completed",
           },
           "type": "metric",
         },

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -7,7 +7,7 @@ Object {
       "metric": Object {
         "data": Object {
           "attributes": Object {
-            "name": "923^%f]tQn]lN2o",
+            "name": "Order Completed",
           },
           "type": "metric",
         },

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/index.test.ts
@@ -51,6 +51,24 @@ describe('Order Completed', () => {
     )
   })
 
+  it('should throw an error for invalid phone number format', async () => {
+    const profile = { email: 'test@example.com', phone_number: 'invalid-phone-number' }
+    const properties = { key: 'value' }
+    const metricName = 'Order Completed'
+    const value = 10
+
+    const event = createTestEvent({
+      type: 'track',
+      timestamp: '2022-01-01T00:00:00.000Z'
+    })
+
+    const mapping = { profile, metric_name: metricName, properties, value }
+
+    await expect(testDestination.testAction('orderCompleted', { event, mapping, settings })).rejects.toThrowError(
+      'invalid-phone-number is not a valid E.164 phone number.'
+    )
+  })
+
   it('should successfully track event with external Id', async () => {
     const profile = { external_id: '3xt3rnal1d' }
     const properties = { key: 'value' }
@@ -94,7 +112,7 @@ describe('Order Completed', () => {
   })
 
   it('should successfully track event if proper parameters are provided', async () => {
-    const profile = { email: 'test@example.com', phone_number: '1234567890' }
+    const profile = { email: 'test@example.com', phone_number: '+14155552671' }
     const properties = { key: 'value' }
     const metricName = 'Order Completed'
     const value = 10
@@ -115,7 +133,7 @@ describe('Order Completed', () => {
   })
 
   it('should throw an error if the API request fails', async () => {
-    const profile = { email: 'test@example.com', phone_number: '1234567890' }
+    const profile = { email: 'test@example.com', phone_number: '+14155552671' }
     const properties = { key: 'value' }
     const metricName = 'Order Completed'
     const value = 10
@@ -145,7 +163,7 @@ describe('Order Completed', () => {
       }
     ]
 
-    const profile = { email: 'test@example.com', phone_number: '1234567890' }
+    const profile = { email: 'test@example.com', phone_number: '+14155552671' }
     const properties = { key: 'value' }
     const metricName = 'Order Completed'
     const value = 10
@@ -183,7 +201,7 @@ describe('Order Completed', () => {
           body.data.attributes.metric.data &&
           body.data.attributes.metric.data.type === `metric` &&
           body.data.attributes.metric.data.attributes &&
-          body.data.attributes.metric.data.attributes.name &&
+          body.data.attributes.metric.data.attributes.name === `Ordered Product` &&
           body.data.attributes.profile
         )
       })

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
@@ -5,6 +5,7 @@ import { PayloadValidationError, RequestClient } from '@segment/actions-core'
 import { API_URL } from '../config'
 import { EventData } from '../types'
 import { v4 as uuidv4 } from '@lukeed/uuid'
+import { validatePhoneNumber } from '../functions'
 
 const createEventData = (payload: Payload) => ({
   data: {
@@ -18,7 +19,7 @@ const createEventData = (payload: Payload) => ({
         data: {
           type: 'metric',
           attributes: {
-            name: payload.event_name
+            name: 'Order Completed'
           }
         }
       },
@@ -49,7 +50,7 @@ const sendProductRequests = async (payload: Payload, orderEventData: EventData, 
             data: {
               type: 'metric',
               attributes: {
-                name: payload.event_name
+                name: 'Ordered Product'
               }
             }
           },
@@ -161,8 +162,8 @@ const action: ActionDefinition<Settings, Payload> = {
       throw new PayloadValidationError('One of External ID, Anonymous ID, Phone Number or Email is required.')
     }
 
-    if (!payload.event_name) {
-      payload.event_name = 'Order Completed'
+    if (phone_number && !validatePhoneNumber(phone_number)) {
+      throw new PayloadValidationError(`${phone_number} is not a valid E.164 phone number.`)
     }
 
     const eventData = createEventData(payload)

--- a/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/__tests__/index.test.ts
@@ -18,6 +18,26 @@ describe('Subscribe Profile', () => {
       testDestination.testAction('subscribeProfile', { event, settings, useDefaultMappings: true })
     ).rejects.toThrowError(PayloadValidationError)
   })
+  it('should throw an error for invalid phone number format', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      context: {
+        traits: {
+          phone: 'invalid-phone-number'
+        }
+      },
+      properties: {}
+    })
+    const mapping = {
+      phone_number: {
+        '@path': '$.context.traits.phone'
+      }
+    }
+
+    await expect(testDestination.testAction('subscribeProfile', { event, mapping })).rejects.toThrowError(
+      'invalid-phone-number is not a valid E.164 phone number.'
+    )
+  })
   it('formats the correct request body when list id is empty and custom_source is defined', async () => {
     const payload = {
       email: 'segment@email.com',
@@ -419,6 +439,66 @@ describe('Subscribe Profile', () => {
     await expect(
       testDestination.testBatchAction('subscribeProfile', { events, settings, mapping })
     ).rejects.toThrowError(PayloadValidationError)
+  })
+  it('should filter out profiles with invalid phone numbers', async () => {
+    const events = [
+      createTestEvent({
+        context: { traits: { email: 'user1@example.com' } }
+      }),
+      createTestEvent({
+        context: { traits: { phone: 'invalid-phone-number' } }
+      })
+    ]
+
+    const mapping = {
+      email: {
+        '@path': '$.context.traits.email'
+      },
+      phone_number: {
+        '@path': '$.context.traits.phone'
+      }
+    }
+
+    const validRequestBody = {
+      data: {
+        type: 'profile-subscription-bulk-create-job',
+        attributes: {
+          profiles: {
+            data: [
+              {
+                type: 'profile',
+                attributes: {
+                  subscriptions: {
+                    email: {
+                      marketing: {
+                        consent: 'SUBSCRIBED'
+                      }
+                    }
+                  },
+                  email: 'user1@example.com'
+                }
+              }
+            ]
+          },
+          custom_source: '-59'
+        }
+      }
+    }
+
+    nock('https://a.klaviyo.com/api')
+      .post('/profile-subscription-bulk-create-jobs/', validRequestBody)
+      .reply(200, { success: true })
+
+    await expect(
+      testDestination.testBatchAction('subscribeProfile', {
+        settings,
+        events,
+        mapping
+      })
+    ).resolves.not.toThrowError()
+
+    // Verify that the invalid phone number was filtered out and correct request was made
+    expect(nock.isDone()).toBe(true)
   })
   it('formats the correct request body for batch requests', async () => {
     const mapping = {

--- a/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition, DynamicFieldResponse, ModifiedResponse } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { getListIdDynamicData } from '../functions'
+import { getListIdDynamicData, validatePhoneNumber } from '../functions'
 
 import { PayloadValidationError } from '@segment/actions-core'
 import { formatSubscribeProfile, formatSubscribeRequestBody } from '../functions'
@@ -75,6 +75,9 @@ const action: ActionDefinition<Settings, Payload> = {
     if (!email && !phone_number) {
       throw new PayloadValidationError('Phone Number or Email is required.')
     }
+    if (phone_number && !validatePhoneNumber(phone_number)) {
+      throw new PayloadValidationError(`${phone_number} is not a valid E.164 phone number.`)
+    }
 
     const profileToSubscribe = formatSubscribeProfile(email, phone_number, consented_at)
     const subData = formatSubscribeRequestBody(profileToSubscribe, list_id, custom_source)
@@ -90,7 +93,12 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   performBatch: async (request, { payload }) => {
     // remove payloads that have niether email or phone_number
-    const filteredPayload = payload.filter((profile) => profile.email || profile.phone_number)
+    const filteredPayload = payload.filter((profile) => {
+      if (profile.phone_number && !validatePhoneNumber(profile.phone_number)) {
+        return false
+      }
+      return profile.email || profile.phone_number
+    })
 
     // if there are no payloads with phone or email throw error
     if (filteredPayload.length === 0) {

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/__tests__/index.test.ts
@@ -23,6 +23,24 @@ describe('Track Event', () => {
     )
   })
 
+  it('should throw an error for invalid phone number format', async () => {
+    const profile = { email: 'test@example.com', phone_number: 'invalid-phone-number' }
+    const properties = { key: 'value' }
+    const metricName = 'Order Completed'
+    const value = 10
+
+    const event = createTestEvent({
+      type: 'track',
+      timestamp: '2022-01-01T00:00:00.000Z'
+    })
+
+    const mapping = { profile, metric_name: metricName, properties, value }
+
+    await expect(testDestination.testAction('orderCompleted', { event, mapping, settings })).rejects.toThrowError(
+      'invalid-phone-number is not a valid E.164 phone number.'
+    )
+  })
+
   it('should successfully track event with external Id', async () => {
     const requestBody = {
       data: {
@@ -143,7 +161,7 @@ describe('Track Event', () => {
               type: 'profile',
               attributes: {
                 email: 'test@example.com',
-                phone_number: '1234567890'
+                phone_number: '+14155552671'
               }
             }
           }
@@ -159,7 +177,7 @@ describe('Track Event', () => {
     })
 
     const mapping = {
-      profile: { email: 'test@example.com', phone_number: '1234567890' },
+      profile: { email: 'test@example.com', phone_number: '+14155552671' },
       metric_name: 'event_name',
       properties: { key: 'value' },
       value: 10,
@@ -193,7 +211,7 @@ describe('Track Event', () => {
               type: 'profile',
               attributes: {
                 email: 'test@example.com',
-                phone_number: '1234567890'
+                phone_number: '+14155552671'
               }
             }
           }
@@ -209,7 +227,7 @@ describe('Track Event', () => {
     })
 
     const mapping = {
-      profile: { email: 'test@example.com', phone_number: '1234567890' },
+      profile: { email: 'test@example.com', phone_number: '+14155552671' },
       metric_name: 'event_name',
       properties: { key: 'value' },
       value: 10,

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/index.ts
@@ -4,6 +4,7 @@ import type { Payload } from './generated-types'
 
 import { PayloadValidationError } from '@segment/actions-core'
 import { API_URL } from '../config'
+import { validatePhoneNumber } from '../functions'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track Event',
@@ -92,6 +93,10 @@ const action: ActionDefinition<Settings, Payload> = {
 
     if (!email && !phone_number && !external_id && !anonymous_id) {
       throw new PayloadValidationError('One of External ID, Anonymous ID, Phone Number or Email is required.')
+    }
+
+    if (phone_number && !validatePhoneNumber(phone_number)) {
+      throw new PayloadValidationError(`${phone_number} is not a valid E.164 phone number.`)
     }
 
     const eventData = {

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
@@ -13,7 +13,8 @@ import {
   getList,
   createList,
   groupByListId,
-  processProfilesByGroup
+  processProfilesByGroup,
+  validatePhoneNumber
 } from '../functions'
 import { batch_size } from '../properties'
 
@@ -242,6 +243,10 @@ const action: ActionDefinition<Settings, Payload> = {
       throw new PayloadValidationError('One of External ID, Phone Number and Email is required.')
     }
 
+    if (phone_number && !validatePhoneNumber(phone_number)) {
+      throw new PayloadValidationError(`${phone_number} is not a valid E.164 phone number.`)
+    }
+
     const profileData: ProfileData = {
       data: {
         type: 'profile',
@@ -292,7 +297,12 @@ const action: ActionDefinition<Settings, Payload> = {
   },
 
   performBatch: async (request, { payload, hookOutputs }) => {
-    payload = payload.filter((profile) => profile.email || profile.external_id || profile.phone_number)
+    payload = payload.filter((profile) => {
+      if (profile.phone_number && !validatePhoneNumber(profile.phone_number)) {
+        return false
+      }
+      return profile.email || profile.phone_number || profile.external_id
+    })
 
     const profilesWithList: Payload[] = []
     const profilesWithoutList: Payload[] = []


### PR DESCRIPTION
Add E.164 validation for all klaviyo actions.

JIRA -> [STRATCONN-3866](https://segment.atlassian.net/browse/STRATCONN-3866)

## Testing
Tested successfully in local and staging env.
Testing doc -> https://docs.google.com/document/d/1tlUdTiNfkiXF86yvW2faTpV8UGjI4sVzOqQ_2mzak0g/edit?usp=sharing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment


[STRATCONN-3866]: https://segment.atlassian.net/browse/STRATCONN-3866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ