### PR TITLE
[STRATCONN-4058] [Salesforce] - Handle concurrent token refresh error

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/index.test.ts
@@ -74,6 +74,24 @@ describe('Salesforce (Actions)', () => {
       ).rejects.toThrowError(new RetryableError('Concurrent token refresh error. This request will be retried'))
     })
 
+    it('should rethrow token request is already being processed as RetryableError', async () => {
+      nock(`https://login.salesforce.com/services/oauth2/token`)
+        .post('', new URLSearchParams(expectedRequest).toString())
+        .reply(400, {
+          error: 'invalid_grant',
+          error_description: 'token request is already being processed'
+        })
+
+      await expect(
+        testDestination.refreshAccessToken(settings, {
+          refreshToken: 'xyz321',
+          accessToken: 'abc123',
+          clientId: 'clientId',
+          clientSecret: 'clientSecret'
+        })
+      ).rejects.toThrowError(new RetryableError('Concurrent token refresh error. This request will be retried'))
+    })
+
     it('should rethrow other errors as APIError', async () => {
       nock(`https://login.salesforce.com/services/oauth2/token`)
         .post('', new URLSearchParams(expectedRequest).toString())

--- a/packages/destination-actions/src/destinations/salesforce/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/index.test.ts
@@ -1,0 +1,104 @@
+import nock from 'nock'
+import { createTestIntegration, HTTPError, InvalidAuthenticationError } from '@segment/actions-core'
+import Definition from '../index'
+
+const testDestination = createTestIntegration(Definition)
+const settings = {
+  instanceUrl: 'https://test.salesforce.com/',
+  isSandbox: false
+}
+
+const expectedRequest = {
+  refresh_token: 'xyz321',
+  client_id: 'clientId',
+  client_secret: 'clientSecret',
+  grant_type: 'refresh_token'
+}
+
+describe('Salesforce (Actions)', () => {
+  describe('refreshAccessToken', () => {
+    it('should return access token', async () => {
+      const mockResponse = {
+        access_token: 'abc123'
+      }
+      nock(`https://login.salesforce.com/services/oauth2/token`)
+        .post('', new URLSearchParams(expectedRequest).toString())
+        .reply(200, mockResponse)
+
+      const token = await testDestination.refreshAccessToken(settings, {
+        refreshToken: 'xyz321',
+        accessToken: 'abc123',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret'
+      })
+
+      expect(token).toEqual({ accessToken: mockResponse.access_token })
+    })
+
+    it('should use sandbox url when isSandbox settings is enabled', async () => {
+      const mockResponse = {
+        access_token: 'abc123'
+      }
+      nock(`https://test.salesforce.com/services/oauth2/token`)
+        .post('', new URLSearchParams(expectedRequest).toString())
+        .reply(200, mockResponse)
+
+      const token = await testDestination.refreshAccessToken(
+        { ...settings, isSandbox: true },
+        {
+          refreshToken: 'xyz321',
+          accessToken: 'abc123',
+          clientId: 'clientId',
+          clientSecret: 'clientSecret'
+        }
+      )
+
+      expect(token).toEqual({ accessToken: mockResponse.access_token })
+    })
+
+    it('should rethrow 401 error as InvalidAuthenticationError', async () => {
+      nock(`https://login.salesforce.com/services/oauth2/token`)
+        .post('', new URLSearchParams(expectedRequest).toString())
+        .reply(401)
+
+      await expect(
+        testDestination.refreshAccessToken(settings, {
+          refreshToken: 'xyz321',
+          accessToken: 'abc123',
+          clientId: 'clientId',
+          clientSecret: 'clientSecret'
+        })
+      ).rejects.toThrowError(InvalidAuthenticationError)
+    })
+
+    it('should rethrow 400 error as InvalidAuthenticationError', async () => {
+      nock(`https://login.salesforce.com/services/oauth2/token`)
+        .post('', new URLSearchParams(expectedRequest).toString())
+        .reply(401)
+
+      await expect(
+        testDestination.refreshAccessToken(settings, {
+          refreshToken: 'xyz321',
+          accessToken: 'abc123',
+          clientId: 'clientId',
+          clientSecret: 'clientSecret'
+        })
+      ).rejects.toThrowError(InvalidAuthenticationError)
+    })
+
+    it('should rethrow other errors as is', async () => {
+      nock(`https://login.salesforce.com/services/oauth2/token`)
+        .post('', new URLSearchParams(expectedRequest).toString())
+        .reply(500)
+
+      await expect(
+        testDestination.refreshAccessToken(settings, {
+          refreshToken: 'xyz321',
+          accessToken: 'abc123',
+          clientId: 'clientId',
+          clientSecret: 'clientSecret'
+        })
+      ).rejects.toThrowError(HTTPError)
+    })
+  })
+})


### PR DESCRIPTION
This PR handles concurrent token refresh error that Salesforce returns when trying to refresh access token with same refresh token. This was released recently by Salesforce. More on it  from Salesforce [here](https://help.salesforce.com/s/articleView?id=release-notes.rn_security_refresh_token_requests.htm&release=250&type=5).

[Slack Thread](https://twilio.slack.com/archives/C01RWN725QW/p1723746912329849)

I confirmed the error code and description by running a load test with a valid refresh token against salesforce's endpoint.

## Testing

Testing completed successfully in staging - [Test Doc](https://docs.google.com/document/d/1hNpM16ZTWIJEwAEdJyjstRuwtmEpnv9P6y9h4GiQyts/edit)

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
