### PR TITLE
Capture and rethrow json.parse and strigify errors from @json directive

### DIFF
--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -260,10 +260,18 @@ registerDirective('@json', (opts, payload) => {
 
   const value = resolve(opts.value, payload)
   if (opts.mode === 'encode') {
-    return JSON.stringify(value)
+    try {
+      return JSON.stringify(value)
+    } catch (err) {
+      throw new Error(`@json: failed to stringify value: ${err}`)
+    }
   } else if (opts.mode === 'decode') {
     if (typeof value === 'string') {
-      return JSON.parse(value)
+      try {
+        return JSON.parse(value)
+      } catch (err) {
+        throw new Error(`@json: failed to parse value: ${err}`)
+      }
     }
     return value
   }


### PR DESCRIPTION
Recently noticed a spike in internal errors for actions-amplitude. 

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/1b23aca6-d3c2-49db-984c-08556ea2a1b8">


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
