### PR TITLE
[SEV] Remove logic to update status Pardot Actions

### DIFF
--- a/packages/destination-actions/src/destinations/actions-pardot/prospects/index.ts
+++ b/packages/destination-actions/src/destinations/actions-pardot/prospects/index.ts
@@ -200,7 +200,7 @@ const action: ActionDefinition<Settings, Payload> = {
           `Pardot responded witha error code ${data.code}: ${data.message}. This means Pardot has received the call, but consider the payload to be invalid.  To identify the exact error, please refer to ` +
             `https://developer.salesforce.com/docs/marketing/pardot/guide/error-codes.html?q=error#numerical-list-of-error-codes and search for the error code you received.`,
           'PARDOT_ERROR',
-          400
+          statusCode
         )
       }
       //XML error response handles the error in headers.


### PR DESCRIPTION


<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_This PR is in response to #inc-sev3-10166-pardot-actions-destination-failing-to-cache-oauth-access-tokens-._

We suspect that an update in Pardot’s content type response to include application/json has caused a status change from 401 to 400 in the relevant code block. This alteration appears to be impacting the refresh token flow. Here’s a detailed breakdown of the findings and next steps:

Issue Investigation:

@varadarajan-tw  and I have reviewed the no-refresh-token metrics and determined that the timing issues are correlated. However, the refresh flow itself is functioning as expected with valid client IDs and client secrets.

We identified that the refresh token flow is not being triggered for Pardot. Specifically, the transition from status 400 to 401 is blocking the invocation of the refresh token flow.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
