### PR TITLE
Update codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,10 @@
 github_checks:
   annotations: false
-comment:
-  require_changes: true
+# Turn PR comments "off". This feature adds the code coverage summary as a
+# comment on each PR. See https://docs.codecov.io/docs/pull-request-comments
+# However, this same info is available from the Codecov checks in the PR's
+# "Checks" tab in GitHub. So, the comment is unnecessary.
+comment: false
 
 codecov:
   require_ci_to_pass: true # Require CI to pass before uploading coverage
@@ -18,4 +21,6 @@ coverage:
         informational: false
     patch:
       default:
-        informational: false
+        # Enable informational mode, which just provides info to reviewers & always passes
+        # https://docs.codecov.io/docs/commit-status#section-informational
+        informational: true


### PR DESCRIPTION
Disable codecov patch checks (only informational) and codecov comments on the PR.

The code cov results are available in [checks](https://github.com/segmentio/action-destinations/pull/2313/checks) tab of the PR.

## Testing

Testing is not required as this is codecov change.