### PR TITLE
Handle concurrent token refresh error for salesforce pardot

### DIFF
--- a/packages/destination-actions/src/destinations/actions-pardot/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/actions-pardot/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { createTestIntegration, createTestEvent } from '@segment/actions-core'
+import { createTestIntegration, createTestEvent, RetryableError, APIError } from '@segment/actions-core'
 import Definition from '../index'
 import { PARDOT_API_VERSION } from '../pa-operations'
 
@@ -14,6 +14,13 @@ const settings = {
 const auth = {
   refreshToken: 'xyz321',
   accessToken: 'abc123'
+}
+
+const expectedRequest = {
+  refresh_token: 'xyz321',
+  client_id: 'clientId',
+  client_secret: 'clientSecret',
+  grant_type: 'refresh_token'
 }
 
 const baseUrl = 'https://pi.pardot.com'
@@ -298,6 +305,101 @@ describe('Pardot', () => {
           }
         })
       ).rejects.toThrowError("The root value is missing the required field 'email'.")
+    })
+  })
+
+  describe('refreshAccessToken', () => {
+    it('should return access token', async () => {
+      const mockResponse = {
+        access_token: 'abc123'
+      }
+      nock(`https://login.salesforce.com/services/oauth2/token`)
+        .post('', new URLSearchParams(expectedRequest).toString())
+        .reply(200, mockResponse)
+
+      const token = await testDestination.refreshAccessToken(settings, {
+        refreshToken: 'xyz321',
+        accessToken: 'abc123',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret'
+      })
+
+      expect(token).toEqual({ accessToken: mockResponse.access_token })
+    })
+
+    it('should use sandbox url when isSandbox settings is enabled', async () => {
+      const mockResponse = {
+        access_token: 'abc123'
+      }
+      nock(`https://test.salesforce.com/services/oauth2/token`)
+        .post('', new URLSearchParams(expectedRequest).toString())
+        .reply(200, mockResponse)
+
+      const token = await testDestination.refreshAccessToken(
+        { ...settings, isSandbox: true },
+        {
+          refreshToken: 'xyz321',
+          accessToken: 'abc123',
+          clientId: 'clientId',
+          clientSecret: 'clientSecret'
+        }
+      )
+
+      expect(token).toEqual({ accessToken: mockResponse.access_token })
+    })
+
+    it('should rethrow 400 authorization code expired as RetryableError', async () => {
+      nock(`https://login.salesforce.com/services/oauth2/token`)
+        .post('', new URLSearchParams(expectedRequest).toString())
+        .reply(400, {
+          error: 'invalid_grant',
+          error_description: 'expired authorization code'
+        })
+
+      await expect(
+        testDestination.refreshAccessToken(settings, {
+          refreshToken: 'xyz321',
+          accessToken: 'abc123',
+          clientId: 'clientId',
+          clientSecret: 'clientSecret'
+        })
+      ).rejects.toThrowError(new RetryableError('Concurrent token refresh error. This request will be retried'))
+    })
+
+    it('should rethrow token request is already being processed as RetryableError', async () => {
+      nock(`https://login.salesforce.com/services/oauth2/token`)
+        .post('', new URLSearchParams(expectedRequest).toString())
+        .reply(400, {
+          error: 'invalid_grant',
+          error_description: 'token request is already being processed'
+        })
+
+      await expect(
+        testDestination.refreshAccessToken(settings, {
+          refreshToken: 'xyz321',
+          accessToken: 'abc123',
+          clientId: 'clientId',
+          clientSecret: 'clientSecret'
+        })
+      ).rejects.toThrowError(new RetryableError('Concurrent token refresh error. This request will be retried'))
+    })
+
+    it('should rethrow other errors as APIError', async () => {
+      nock(`https://login.salesforce.com/services/oauth2/token`)
+        .post('', new URLSearchParams(expectedRequest).toString())
+        .reply(401, {
+          error: 'invalid_grant',
+          error_description: 'Failed to refresh access token'
+        })
+
+      await expect(
+        testDestination.refreshAccessToken(settings, {
+          refreshToken: 'xyz321',
+          accessToken: 'abc123',
+          clientId: 'clientId',
+          clientSecret: 'clientSecret'
+        })
+      ).rejects.toThrowError(new APIError('Failed to refresh access token', 401))
     })
   })
 })


### PR DESCRIPTION
Same as https://github.com/segmentio/action-destinations/pull/2300

Since both actions-pardot and actions-salesforce use the same oauth endpoint, we handle the same concurrent token error we observed with salesforce actions.

## Testing

We don't have test account to validate this in stage. But the oauth token flow has been well tested for salesforce.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
