### PR TITLE
Add option for groupId in identify

### DIFF
--- a/packages/browser-destinations/destinations/pendo-web-actions/src/identify/generated-types.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/identify/generated-types.ts
@@ -11,4 +11,8 @@ export interface Payload {
   visitorData?: {
     [k: string]: unknown
   }
+  /**
+   * Pendo Account ID. Maps to Segment groupId.  Note: If you plan to change this, enable the setting "Use custom Segment group trait for Pendo account id"
+   */
+  accountId?: string
 }

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/identify/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/identify/index.ts
@@ -27,6 +27,21 @@ const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
         '@path': '$.traits'
       },
       readOnly: false
+    },
+    accountId: {
+      label: 'Account ID',
+      description:
+        'Pendo Account ID. Maps to Segment groupId.  Note: If you plan to change this, enable the setting "Use custom Segment group trait for Pendo account id"',
+      type: 'string',
+      required: false,
+      default: {
+        '@if': {
+          exists: { '@path': '$.context.groupId' },
+          then: { '@path': '$.context.groupId' },
+          else: { '@path': '$.groupId' }
+        }
+      },
+      readOnly: false
     }
   },
   perform: (pendo, event) => {
@@ -35,6 +50,13 @@ const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
         ...event.payload.visitorData,
         id: event.payload.visitorId
       }
+    }
+
+    const analyticsGroupId = event.analytics.group().id()
+    if (event.payload.accountId) {
+      payload['account'] = { id: event.payload.accountId }
+    } else if (analyticsGroupId && !event.settings.disableGroupIdAndTraitsOnLoad) {
+      payload['account'] = { id: analyticsGroupId }
     }
 
     pendo.identify(payload)


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Allow a Segment groupId passed via the context property in a Segment identify call to be passed to Pendo.  Also, if Segment's cookie has groupId, include it in the forwarded call to Pendo from the Segment identify call.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
