### PR TITLE
Remove hyphens from customer id in create/get Audience calls

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -129,7 +129,7 @@ const destination: AudienceDestinationDefinition<Settings> = {
     async getAudience(request, getAudienceInput: GetAudienceInput) {
       // The connections that were created before the audience methods
       // were added will have the externalId field as segment.
-      if (getAudienceInput.externalId == 'segment') {
+      if (getAudienceInput.externalId === 'segment') {
         return {
           externalId: getAudienceInput.externalId
         }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -5,7 +5,7 @@ import uploadCallConversion from './uploadCallConversion'
 import uploadClickConversion from './uploadClickConversion'
 import uploadConversionAdjustment from './uploadConversionAdjustment'
 import { CreateAudienceInput, GetAudienceInput, UserListResponse } from './types'
-import { createGoogleAudience, getGoogleAudience } from './functions'
+import { createGoogleAudience, getGoogleAudience, verifyCustomerId } from './functions'
 import uploadCallConversion2 from './uploadCallConversion2'
 import userList from './userList'
 import uploadClickConversion2 from './uploadClickConversion2'
@@ -112,6 +112,7 @@ const destination: AudienceDestinationDefinition<Settings> = {
       full_audience_sync: false // If true, we send the entire audience. If false, we just send the delta.
     },
     async createAudience(request, createAudienceInput: CreateAudienceInput) {
+      createAudienceInput.settings.customerId = verifyCustomerId(createAudienceInput.settings.customerId)
       const auth = createAudienceInput.settings.oauth
       const userListId = await createGoogleAudience(
         request,
@@ -126,6 +127,7 @@ const destination: AudienceDestinationDefinition<Settings> = {
     },
 
     async getAudience(request, getAudienceInput: GetAudienceInput) {
+      getAudienceInput.settings.customerId = verifyCustomerId(getAudienceInput.settings.customerId)
       const response: UserListResponse = await getGoogleAudience(
         request,
         getAudienceInput.settings,

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -127,6 +127,13 @@ const destination: AudienceDestinationDefinition<Settings> = {
     },
 
     async getAudience(request, getAudienceInput: GetAudienceInput) {
+      // The connections that were created before the audience methods
+      // were added will have the externalId field as segment.
+      if (getAudienceInput.externalId == 'segment') {
+        return {
+          externalId: getAudienceInput.externalId
+        }
+      }
       getAudienceInput.settings.customerId = verifyCustomerId(getAudienceInput.settings.customerId)
       const response: UserListResponse = await getGoogleAudience(
         request,


### PR DESCRIPTION
When customers input the setting they usually have it as `XXX-XX-XXXX` if we make requests like this the request will fail because Google does not want you to send the hyphens with the call. In all of the other calls for this destinations the hyphens are stripped beforehand but the create/ get audience call misses this check. Adding to resolve the customers `Forbidden` issue. 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment

[Destination](https://app.segment.build/maryam-test-5/destinations/actions-google-enhanced-conversions/sources/personas_tik_tok_audiences7/instances/66a2a6fc109696eaeab54561/configuration)
<img width="1433" alt="Screenshot 2024-08-20 at 2 26 14 PM" src="https://github.com/user-attachments/assets/ff218b52-aa32-46f9-9201-aaaf31f8cc2c">

[Audience](https://app.segment.build/maryam-test-5/engage/spaces/tik-tok-audiences/audiences/aud_2kwK7SMy1ksc4YQP7wmlBQKHcFj/overview)

Saved in db
<img width="728" alt="Screenshot 2024-08-20 at 2 34 38 PM" src="https://github.com/user-attachments/assets/86f350e2-20f6-41df-986d-9f3b692cff43">


Created in Google
<img width="1086" alt="Screenshot 2024-08-20 at 2 34 12 PM" src="https://github.com/user-attachments/assets/547cd7f6-64f9-43e1-8185-4ee5ca785c05">


