### PR TITLE
v2 Fix for Iterable date format bug 

### DIFF
--- a/packages/destination-actions/src/destinations/actions-pardot/prospects/index.ts
+++ b/packages/destination-actions/src/destinations/actions-pardot/prospects/index.ts
@@ -200,7 +200,7 @@ const action: ActionDefinition<Settings, Payload> = {
           `Pardot responded witha error code ${data.code}: ${data.message}. This means Pardot has received the call, but consider the payload to be invalid.  To identify the exact error, please refer to ` +
             `https://developer.salesforce.com/docs/marketing/pardot/guide/error-codes.html?q=error#numerical-list-of-error-codes and search for the error code you received.`,
           'PARDOT_ERROR',
-          400
+          statusCode
         )
       }
       //XML error response handles the error in headers.

--- a/packages/destination-actions/src/destinations/iterable/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/iterable/trackEvent/__tests__/index.test.ts
@@ -63,6 +63,56 @@ describe('Iterable.trackEvent', () => {
     })
   })
 
+  it('does not modify a yyyy-mm-dd date', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      userId: 'user1234',
+      properties: {
+        myDate: '2023-05-17'
+      }
+    })
+
+    nock('https://api.iterable.com/api').post('/events/track').reply(200, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].options.json).toMatchObject({
+      userId: 'user1234',
+      dataFields: {
+        myDate: '2023-05-17'
+      }
+    })
+  })
+
+  it('does not alter a midnight UTC datetime', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      userId: 'user1234',
+      properties: {
+        myDate: '2023-05-17T00:00:00.000Z'
+      }
+    })
+
+    nock('https://api.iterable.com/api').post('/events/track').reply(200, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].options.json).toMatchObject({
+      userId: 'user1234',
+      dataFields: {
+        myDate: '2023-05-17 00:00:00 +00:00'
+      }
+    })
+  })
+
   it('does not convert a non date string into a standard Iterable date format', async () => {
     const event = createTestEvent({
       type: 'track',

--- a/packages/destination-actions/src/destinations/iterable/utils.ts
+++ b/packages/destination-actions/src/destinations/iterable/utils.ts
@@ -17,11 +17,14 @@ function dateToIterableDateStringFormat(isoDateStr: string) {
   if (!isoDateRegExp.test(isoDateStr)) {
     return null // not a valid ISO string
   }
+
+  // Process full datetime strings
   const date = new Date(isoDateStr)
   if (date instanceof Date && !isNaN(date.valueOf())) {
     const dateString = date.toISOString().replace('T', ' ').split('.')[0]
     return `${dateString} +00:00`
   }
+
   return null
 }
 
@@ -35,15 +38,15 @@ export function convertDatesInObject(obj: Record<string, unknown>) {
     return obj
   }
   for (const prop in obj) {
-    let value = obj[prop]
+    const value = obj[prop]
     if (typeof value === 'string' && isoDateRegExp.test(value)) {
-      const dateValue = new Date(value)
-      if (!isNaN(dateValue.valueOf())) {
-        value = dateValue
+      // Don't convert the value to a Date if it's a date-only string
+      const dateOnlyRegex = /^\d{4}-\d{2}-\d{2}$/
+      if (dateOnlyRegex.test(value)) {
+        obj[prop] = value // Keep the date-only string as is
+      } else {
+        obj[prop] = dateToIterableDateStringFormat(value)
       }
-    }
-    if (value instanceof Date) {
-      obj[prop] = dateToIterableDateStringFormat(value.toISOString())
     } else if (typeof value === 'object' && value !== null) {
       convertDatesInObject(value as Record<string, unknown>)
     } else {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Modifications to [PR #2305](https://github.com/segmentio/action-destinations/pull/2305)
* Ensures that yyyy-mm-dd dates remain unmodified.
* Correctly parses datetime strings, including UTC midnight timestamps, to conform to the Iterable format.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
