### PR TITLE
Update enable_batching description

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -28,7 +28,7 @@ export const operation: InputField = {
 export const enable_batching: InputField = {
   label: 'Use Salesforce Bulk API',
   description:
-    'If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.',
+    'If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce.',
   type: 'boolean',
   default: false,
   depends_on: hideIfDeleteOperation


### PR DESCRIPTION
Bulk insert functionality was added to this destination in PR #1940. However, the `enable_batching` tooltip in the UI still states:

> Enabling Bulk API is not compatible with the `create` operation

Updated the `enable_batching` field so that this line is removed from the description.