### PR TITLE
[salesforce] Removes outdated warning from 'enable_batching' field description

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   operation: string
   /**
-   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce.
    */
   enable_batching?: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   recordMatcherOperator?: string
   /**
-   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce.
    */
   enable_batching?: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   recordMatcherOperator?: string
   /**
-   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce.
    */
   enable_batching?: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   recordMatcherOperator?: string
   /**
-   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce.
    */
   enable_batching?: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   recordMatcherOperator?: string
   /**
-   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce.
    */
   enable_batching?: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   recordMatcherOperator?: string
   /**
-   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.
+   * If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce.
    */
   enable_batching?: boolean
   /**

--- a/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-properties.ts
@@ -28,7 +28,7 @@ export const operation: InputField = {
 export const enable_batching: InputField = {
   label: 'Use Salesforce Bulk API',
   description:
-    'If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce. *Enabling Bulk API is not compatible with the `create` operation*.',
+    'If true, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) rather than their streaming REST API. Once enabled, Segment will collect events into batches of 5000 before sending to Salesforce.',
   type: 'boolean',
   default: false,
   depends_on: hideIfDeleteOperation


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR updates a field description so that it's no longer misleading.

## Testing

Testing not required since this is a non-functional change.
