### PR TITLE
fixing auth for contentstack cloud

### DIFF
--- a/packages/browser-destinations/destinations/contentstack-web/package.json
+++ b/packages/browser-destinations/destinations/contentstack-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics-browser-actions-contentstack-web",
-  "version": "1.5.0",
+  "version": "1.0.0",
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/destination-actions/src/destinations/contentstack/index.ts
+++ b/packages/destination-actions/src/destinations/contentstack/index.ts
@@ -9,7 +9,7 @@ const destination: DestinationDefinition<Settings> = {
   mode: 'cloud',
 
   authentication: {
-    scheme: 'oauth-managed',
+    scheme: 'custom',
     fields: {
       personalizeProjectId: {
         label: 'Personalize project ID',

--- a/packages/destinations-manifest/package.json
+++ b/packages/destinations-manifest/package.json
@@ -21,7 +21,7 @@
     "@segment/analytics-browser-actions-bucket": "^1.38.0",
     "@segment/analytics-browser-actions-cdpresolution": "^1.45.0",
     "@segment/analytics-browser-actions-commandbar": "^1.58.0",
-    "@segment/analytics-browser-actions-contentstack-web": "^1.5.0",
+    "@segment/analytics-browser-actions-contentstack-web": "^1.0.0",
     "@segment/analytics-browser-actions-devrev": "^1.45.0",
     "@segment/analytics-browser-actions-friendbuy": "^1.59.0",
     "@segment/analytics-browser-actions-fullstory": "^1.60.0",


### PR DESCRIPTION
Fix auth for contentstack. 
Also reset web version to 1.0.0 as it is now a standalone destination. 

## Testing

No customers using. 