### PR TITLE
Adds a performBatch method to the Iterable updateUser destination.

### DIFF
--- a/packages/destination-actions/src/destinations/iterable/updateUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/iterable/updateUser/__tests__/index.test.ts
@@ -5,115 +5,175 @@ import Destination from '../../index'
 const testDestination = createTestIntegration(Destination)
 
 describe('Iterable.updateUser', () => {
-  it('works with default mappings', async () => {
-    const event = createTestEvent({ type: 'identify' })
+  describe('perform', () => {
+    it('works with default mappings', async () => {
+      const event = createTestEvent({ type: 'identify' })
 
-    nock('https://api.iterable.com/api').post('/users/update').reply(200, {})
+      nock('https://api.iterable.com/api').post('/users/update').reply(200, {})
 
-    const responses = await testDestination.testAction('updateUser', {
-      event,
-      useDefaultMappings: true
-    })
-
-    expect(responses.length).toBe(1)
-    expect(responses[0].status).toBe(200)
-  })
-
-  it('throws an error if `email` or `userId` are not defined', async () => {
-    const event = createTestEvent({
-      type: 'identify',
-      traits: {
-        firstName: 'Johnny',
-        lastName: 'Depp'
-      }
-    })
-
-    await expect(
-      testDestination.testAction('updateUser', {
-        event
+      const responses = await testDestination.testAction('updateUser', {
+        event,
+        useDefaultMappings: true
       })
-    ).rejects.toThrowError(PayloadValidationError)
-  })
 
-  it('maps phoneNumber in dataFields', async () => {
-    const event = createTestEvent({
-      type: 'identify',
-      userId: 'user1234',
-      traits: {
-        phone: '+14158675309'
-      }
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
     })
 
-    nock('https://api.iterable.com/api').post('/users/update').reply(200, {})
-
-    const responses = await testDestination.testAction('updateUser', {
-      event,
-      useDefaultMappings: true
-    })
-
-    expect(responses.length).toBe(1)
-    expect(responses[0].options.json).toMatchObject({
-      userId: 'user1234',
-      dataFields: {
-        phoneNumber: '+14158675309'
-      }
-    })
-  })
-
-  it('should success with mapping of preset and `identify` call', async () => {
-    const event = createTestEvent({
-      type: 'identify',
-      traits: {
-        phone: '+14158675309'
-      }
-    })
-
-    nock('https://api.iterable.com/api').post('/users/update').reply(200, {})
-
-    const responses = await testDestination.testAction('updateUser', {
-      event,
-      // Using the mapping of presets with event type 'track'
-      mapping: {
-        dataFields: {
-          '@path': '$.traits'
+    it('throws an error if `email` or `userId` are not defined', async () => {
+      const event = createTestEvent({
+        type: 'identify',
+        traits: {
+          firstName: 'Johnny',
+          lastName: 'Depp'
         }
-      },
-      useDefaultMappings: true
+      })
+
+      await expect(
+        testDestination.testAction('updateUser', {
+          event
+        })
+      ).rejects.toThrowError(PayloadValidationError)
     })
 
-    expect(responses.length).toBe(1)
-    expect(responses[0].status).toBe(200)
-  })
-
-  it('should allow passing null values for phoneNumber', async () => {
-    const event = createTestEvent({
-      type: 'identify',
-      userId: 'user1234',
-      traits: {
-        phone: null,
-        trait1: null
-      }
-    })
-
-    nock('https://api.iterable.com/api').post('/users/update').reply(200, {})
-
-    const responses = await testDestination.testAction('updateUser', {
-      event,
-      mapping: {
-        dataFields: {
-          '@path': '$.traits'
+    it('maps phoneNumber in dataFields', async () => {
+      const event = createTestEvent({
+        type: 'identify',
+        userId: 'user1234',
+        traits: {
+          phone: '+14158675309'
         }
-      },
-      useDefaultMappings: true
+      })
+
+      nock('https://api.iterable.com/api').post('/users/update').reply(200, {})
+
+      const responses = await testDestination.testAction('updateUser', {
+        event,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].options.json).toMatchObject({
+        userId: 'user1234',
+        dataFields: {
+          phoneNumber: '+14158675309'
+        }
+      })
     })
 
-    expect(responses.length).toBe(1)
-    expect(responses[0].options.json).toMatchObject({
-      userId: 'user1234',
-      dataFields: {
-        phoneNumber: null,
-        trait1: null
-      }
+    it('should success with mapping of preset and `identify` call', async () => {
+      const event = createTestEvent({
+        type: 'identify',
+        traits: {
+          phone: '+14158675309'
+        }
+      })
+
+      nock('https://api.iterable.com/api').post('/users/update').reply(200, {})
+
+      const responses = await testDestination.testAction('updateUser', {
+        event,
+        // Using the mapping of presets with event type 'track'
+        mapping: {
+          dataFields: {
+            '@path': '$.traits'
+          }
+        },
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+    })
+
+    it('should allow passing null values for phoneNumber', async () => {
+      const event = createTestEvent({
+        type: 'identify',
+        userId: 'user1234',
+        traits: {
+          phone: null,
+          trait1: null
+        }
+      })
+
+      nock('https://api.iterable.com/api').post('/users/update').reply(200, {})
+
+      const responses = await testDestination.testAction('updateUser', {
+        event,
+        mapping: {
+          dataFields: {
+            '@path': '$.traits'
+          }
+        },
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].options.json).toMatchObject({
+        userId: 'user1234',
+        dataFields: {
+          phoneNumber: null,
+          trait1: null
+        }
+      })
+    })
+  })
+  describe('performBatch', () => {
+    it('works with default mappings', async () => {
+      const events = [createTestEvent({ type: 'identify' }), createTestEvent({ type: 'identify' })]
+
+      nock('https://api.iterable.com/api').post('/users/bulkUpdate').reply(200, {})
+
+      const responses = await testDestination.testBatchAction('updateUser', {
+        events,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+    })
+    it('maps phoneNumber in dataFields', async () => {
+      const events = [
+        createTestEvent({
+          type: 'identify',
+          userId: 'user1234',
+          traits: {
+            phone: '+14158675309'
+          }
+        }),
+        createTestEvent({
+          type: 'identify',
+          userId: 'user5678',
+          traits: {
+            phone: '+24158675309'
+          }
+        })
+      ]
+
+      nock('https://api.iterable.com/api').post('/users/bulkUpdate').reply(200, {})
+
+      const responses = await testDestination.testBatchAction('updateUser', {
+        events,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].options.json).toMatchObject({
+        users: [
+          {
+            userId: 'user1234',
+            dataFields: {
+              phoneNumber: '+14158675309'
+            }
+          },
+          {
+            userId: 'user5678',
+            dataFields: {
+              phoneNumber: '+24158675309'
+            }
+          }
+        ]
+      })
     })
   })
 })

--- a/packages/destination-actions/src/destinations/iterable/utils.ts
+++ b/packages/destination-actions/src/destinations/iterable/utils.ts
@@ -89,6 +89,7 @@ const regionBaseUrls = {
 
 export const apiEndpoints = {
   updateUser: '/api/users/update',
+  bulkUpdateUser: '/api/users/bulkUpdate',
   trackEvent: '/api/events/track',
   updateCart: '/api/commerce/updateCart',
   trackPurchase: '/api/commerce/trackPurchase',


### PR DESCRIPTION
Refactors some of the payload transformation code from the perform method, to be reused in the performBatch.

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
