### PR TITLE
[LinkedIn CAPI] Uses client ID and client secret from chamber for refreshing tokens

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/index.ts
@@ -39,13 +39,32 @@ const destination: DestinationDefinition<Settings> = {
     refreshAccessToken: async (request, { auth }) => {
       let res
 
+      if (!process.env.ACTIONS_LINKEDIN_CONVERSIONS_CLIENT_ID) {
+        throw new IntegrationError(`Missing client ID`, ErrorCodes.OAUTH_REFRESH_FAILED, 500)
+      }
+
+      if (!process.env.ACTIONS_LINKEDIN_CONVERSIONS_CLIENT_SECRET) {
+        throw new IntegrationError(`Missing client secret`, ErrorCodes.OAUTH_REFRESH_FAILED, 500)
+      }
+
+      if (!auth?.refreshToken) {
+        throw new IntegrationError(
+          `Missing refresh token. Please re-authenticate to fetch a new refresh token.`,
+          ErrorCodes.OAUTH_REFRESH_FAILED,
+          401
+        )
+      }
+
       try {
         res = await request<RefreshTokenResponse>('https://www.linkedin.com/oauth/v2/accessToken', {
           method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded'
+          },
           body: new URLSearchParams({
             refresh_token: auth.refreshToken,
-            client_id: auth.clientId,
-            client_secret: auth.clientSecret,
+            client_id: process.env.ACTIONS_LINKEDIN_CONVERSIONS_CLIENT_ID,
+            client_secret: process.env.ACTIONS_LINKEDIN_CONVERSIONS_CLIENT_SECRET,
             grant_type: 'refresh_token'
           })
         })


### PR DESCRIPTION

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->
https://segment.atlassian.net/browse/STRATCONN-4076

This PR updates the usage of the client ID and client secret when refreshing access tokens. Previously the destination was attempting to use values stored in a users auth destination settings, however those values only exist in chamber. This PR uses the correct chamber values and adds some error handling when values are not present.

## Testing
Tested successfully in local. **Note: ** I deployed this to staging as well, but the LinkedIn 'revoke' access token request I used to invalidate the token and trigger a refreshAccessToken call also invalidates the refreshToken, so there's no way to test this in stage other than waiting for 60 days for the token to expire. 

Local testing shows the new access token is successfully returned.
<img width="1513" alt="Screenshot 2024-08-29 at 11 28 11 AM" src="https://github.com/user-attachments/assets/6f431b71-cea2-4d05-9b86-11495fe10b92">

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment (See Note)
