### PR TITLE
[Facebook Conversions] Adds `anon_id` parameter to `user_data`

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
@@ -86,6 +86,10 @@ export interface Payload {
      */
     fbLoginID?: number
     /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom/generated-types.ts
@@ -90,6 +90,10 @@ export interface Payload {
      */
     fbLoginID?: number
     /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-user-data.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-user-data.ts
@@ -108,7 +108,7 @@ export const user_data_field: InputField = {
       type: 'integer'
     },
     anonId: {
-      label: 'anon_id: Your install ID',
+      label: 'Install ID (anon_id)',
       description:
         'This field represents unique application installation instances. Note: This parameter is for app events only.',
       type: 'string'

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-user-data.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-user-data.ts
@@ -107,6 +107,12 @@ export const user_data_field: InputField = {
       description: 'The ID issued by Facebook when a person first logs into an instance of an app.',
       type: 'integer'
     },
+    anonId: {
+      label: 'anon_id: Your install ID',
+      description:
+        'This field represents unique application installation instances. Note: This parameter is for app events only.',
+      type: 'string'
+    },
     partner_id: {
       label: 'Partner ID',
       description: 'The ID issued by Facebook identity partner.',
@@ -277,6 +283,7 @@ export const hash_user_data = (payload: UserData): Object => {
     fbp: payload.user_data?.fbp,
     subscription_id: payload.user_data?.subscriptionID,
     lead_id: payload.user_data?.leadID,
+    anon_id: payload.user_data?.anonId,
     fb_login_id: payload.user_data?.fbLoginID,
     partner_id: payload.user_data?.partner_id,
     partner_name: payload.user_data?.partner_name

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
@@ -86,6 +86,10 @@ export interface Payload {
      */
     fbLoginID?: number
     /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
@@ -86,6 +86,10 @@ export interface Payload {
      */
     fbLoginID?: number
     /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
@@ -90,6 +90,10 @@ export interface Payload {
      */
     fbLoginID?: number
     /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
@@ -86,6 +86,10 @@ export interface Payload {
      */
     fbLoginID?: number
     /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
@@ -86,6 +86,10 @@ export interface Payload {
      */
     fbLoginID?: number
     /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR adds the `anon_id` parameter to the `user_data` object so it can be sent to Facebook. 

## Testing
Tested successfully in staging, the parameter is sent to FB and accepted:
<img width="1297" alt="Screenshot 2024-08-30 at 11 06 53 AM" src="https://github.com/user-attachments/assets/165c252c-3d42-4abe-929d-fe58ef1cfff6">


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
