### PR TITLE
`excludeWhenNull` is applied to nested values in object

### DIFF
--- a/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
+++ b/packages/core/src/mapping-kit/__tests__/index.iso.test.ts
@@ -1073,12 +1073,20 @@ describe('@excludeWhenNull', () => {
     expect(output).toStrictEqual({ anotherField: 1 })
   })
 
-  test('dont exclude individual null fields in object when applied at object level', () => {
+  test('exclude individual null fields in object when applied at object level', () => {
     const output = transform(
       { neat: { '@excludeWhenNull': { '@path': '$.foo' } } },
       { foo: { bar: null, aces: { a: 1, b: 2 } } }
     )
-    expect(output).toStrictEqual({ neat: { bar: null, aces: { a: 1, b: 2 } } })
+    expect(output).toStrictEqual({ neat: { aces: { a: 1, b: 2 } } })
+  })
+
+  test('exclude individual deeply nested null fields in object when applied at object level', () => {
+    const output = transform(
+      { neat: { '@excludeWhenNull': { '@path': '$.foo' } } },
+      { foo: { bar: null, aces: { a: 1, b: 2, c: null, d: { a: null, b: null } } } }
+    )
+    expect(output).toStrictEqual({ neat: { aces: { a: 1, b: 2, d: {} } } })
   })
 
   test('exclude when resolved value is null using transform', () => {
@@ -1137,16 +1145,16 @@ describe('@excludeWhenNull', () => {
               }
             }
           },
-          // These are essentially no-ops bcos they always return non-null objects but good to exercise explicitly
-          jsonNullEncode: { '@excludeWhenNull': { '@json': { mode: 'encode', value: { '@path': '$.foo.bar' } } } },
           transformValue: {
             '@excludeWhenNull': {
               '@transform': {
-                apply: { properties: { '@path': '$.foo.bar' } },
+                apply: { properties: { '@path': '$.foo' } },
                 mapping: { properties: { '@path': '$.properties' } }
               }
             }
-          }
+          },
+          // These are essentially no-ops bcos they always return non-null objects but good to exercise explicitly
+          jsonNullEncode: { '@excludeWhenNull': { '@json': { mode: 'encode', value: { '@path': '$.foo.bar' } } } }
         }
       },
       { foo: { bar: null, aces: { a: 1, b: 2 } } }
@@ -1159,7 +1167,7 @@ describe('@excludeWhenNull', () => {
         transformNull: {},
         transformNull2: {},
         transformValue: {
-          properties: null
+          properties: { aces: { a: 1, b: 2 } }
         }
       }
     })

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -320,8 +320,33 @@ registerDirective('@excludeWhenNull', (value, payload) => {
     // assign undefined to the key which will get deleted at the end of all mappings
     return undefined
   }
+
+  // Go through all fields and remove any that are null
+  if (isObject(resolved)) {
+    return cleanNulls(resolved)
+  }
+
   return resolved
 })
+
+// Recursively remove all null values from an object
+function cleanNulls(value: JSONLike): JSONLike {
+  if (isObject(value)) {
+    const cleaned: JSONLike = Object.assign({}, value)
+    for (const key of Object.keys(value)) {
+      // value is already resolved, so we can check for null directly
+      const val = value[key]
+      if (val === null) {
+        cleaned[key] = undefined
+      } else if (isObject(val)) {
+        cleaned[key] = cleanNulls(val)
+      }
+    }
+    return cleaned
+  }
+
+  return value
+}
 
 function getMappingToProcess(mapping: JSONLikeObject): JSONLikeObject {
   let mappingToProcess = { ...mapping }

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -322,11 +322,7 @@ registerDirective('@excludeWhenNull', (value, payload) => {
   }
 
   // Go through all fields and remove any that are null
-  if (isObject(resolved)) {
-    return cleanNulls(resolved)
-  }
-
-  return resolved
+  return cleanNulls(resolved)
 })
 
 // Recursively remove all null values from an object


### PR DESCRIPTION
Following up from #2040, this PR adds changes to `excludeWhenNull` to apply to nested values in an object. This change ensures that individual deeply nested null fields in an object are excluded when `excludeWhenNull` is applied at the object level.

## Testing
- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
