### PR TITLE
Per Google, GCLID, GBRAID and WBRAID can't be used at the same time.

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -254,6 +254,14 @@ const action: ActionDefinition<Settings, Payload> = {
         'Customer ID is required for this action. Please set it in destination settings.'
       )
     }
+
+    // GCLID, GBRAID and WBRAID are mutually exclusive. Only one of them can be set.
+    // Per Google, for iOS, GCLID does not exist if user never gave consent to track their data.
+    // GBRAID and WBRAID are used for iOS 14 and later.
+    if (payload.gclid && (payload.gbraid || payload.wbraid)) {
+      throw new PayloadValidationError('GCLID, GBRAID and WBRAID are mutually exclusive. Only one of them can be set.')
+    }
+
     settings.customerId = settings.customerId.replace(/-/g, '')
 
     let cartItems: CartItemInterface[] = []

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -262,6 +262,16 @@ const action: ActionDefinition<Settings, Payload> = {
           'Customer ID is required for this action. Please set it in destination settings.'
         )
       }
+
+      // GCLID, GBRAID and WBRAID are mutually exclusive. Only one of them can be set.
+      // Per Google, for iOS, GCLID does not exist if user never gave consent to track their data.
+      // GBRAID and WBRAID are used for iOS 14 and later.
+      if (payload.gclid && (payload.gbraid || payload.wbraid)) {
+        throw new PayloadValidationError(
+          'GCLID, GBRAID and WBRAID are mutually exclusive. Only one of them can be set.'
+        )
+      }
+
       settings.customerId = settings.customerId.replace(/-/g, '')
 
       let cartItems: CartItemInterface[] = []


### PR DESCRIPTION
Per Google:

> "Considering that for iOS, `gclid` is sent if your user has given consent on iOS, and `gbraid` if the user has not given consent, it makes no sense to send Advanced Conversions email data requesting consent if `gbraid` is sent at the same time which implies no consent."

Our integration allows a customer to send all the three parameters together, resulting in cryptic errors in the destination.

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
