### PR TITLE
Enable bulk_batching for Iterable updateUser action

### DIFF
--- a/packages/destination-actions/src/destinations/iterable/updateUser/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/updateUser/index.ts
@@ -74,7 +74,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'number',
       unsafe_hidden: true,
       required: false,
-      default: 500
+      default: 1001
     }
   },
   perform: (request, { payload, settings }) => {


### PR DESCRIPTION
Follow up to https://github.com/segmentio/action-destinations/pull/2343 to enable bulk batching for Iterable updateUser action.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
