### PR TITLE
[CF-768][Braze] Increase braze timeout to 30s for all APIs

### DIFF
--- a/packages/destination-actions/src/destinations/braze/index.ts
+++ b/packages/destination-actions/src/destinations/braze/index.ts
@@ -1,6 +1,6 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
-import { defaultValues } from '@segment/actions-core'
+import { DEFAULT_REQUEST_TIMEOUT, defaultValues } from '@segment/actions-core'
 import createAlias from './createAlias'
 import identifyUser from './identifyUser'
 import trackEvent from './trackEvent'
@@ -63,7 +63,8 @@ const destination: DestinationDefinition<Settings> = {
     return {
       headers: {
         Authorization: `Bearer ${settings.api_key}`
-      }
+      },
+      timeout: Math.max(30_000, DEFAULT_REQUEST_TIMEOUT)
     }
   },
   actions: {


### PR DESCRIPTION
Increases braze timeout to 30s for all APIS

[CF-768 Assess Braze Request for Execution Timeout Increase](https://segment.atlassian.net/browse/CF-768?atlOrigin=eyJpIjoiMThkM2UwNjQyMzUwNGIwZGJiNWUyNDVhMGUwMTI5NTIiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Testing

Testing not required as this simply increases the timeout

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
