### PR TITLE
add "autoPageView" setting & Pageview event preset

### DIFF
--- a/packages/browser-destinations/destinations/tiktok-pixel/src/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/tiktok-pixel/src/__tests__/index.test.ts
@@ -1,0 +1,116 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import { Subscription } from '@segment/browser-destination-runtime'
+import TikTokDestination, { destination } from '../index'
+import { TikTokPixel } from '../types'
+
+describe('TikTokPixel init', () => {
+  const settings = {
+    pixelCode: '1234',
+    autoPageView: true,
+    useExistingPixel: false
+  }
+
+  let mockTtp: TikTokPixel
+  let reportWebEvent: any
+  beforeEach(async () => {
+    jest.restoreAllMocks()
+    jest.spyOn(destination, 'initialize').mockImplementation(() => {
+      mockTtp = {
+        page: jest.fn(),
+        identify: jest.fn(),
+        track: jest.fn(),
+        instance: jest.fn(() => mockTtp)
+      }
+      return Promise.resolve(mockTtp)
+    })
+  })
+
+  test('TikTok pixel send Pageview event', async () => {
+    const subscriptions: Subscription[] = [
+      {
+        partnerAction: 'reportWebEvent',
+        name: 'Place an Order',
+        enabled: true,
+        subscribe: 'event = "Order Completed"',
+        mapping: {
+          event_id: {
+            '@path': '$.messageId'
+          },
+          anonymousId: {
+            '@path': '$.anonymousId'
+          },
+          external_id: {
+            '@path': '$.userId'
+          },
+          phone_number: {
+            '@path': '$.properties.phone'
+          },
+          email: {
+            '@path': '$.properties.email'
+          },
+          last_name: {
+            '@path': '$.context.traits.last_name'
+          },
+          first_name: {
+            '@path': '$.context.traits.first_name'
+          },
+          address: {
+            city: {
+              '@path': '$.context.traits.address.city'
+            },
+            state: {
+              '@path': '$.context.traits.address.state'
+            },
+            country: {
+              '@path': '$.context.traits.address.country'
+            }
+          },
+          groupId: {
+            '@path': '$.groupId'
+          },
+          event: 'PlaceAnOrder',
+          contents: {
+            '@arrayPath': [
+              '$.properties.products',
+              {
+                price: {
+                  '@path': '$.price'
+                },
+                quantity: {
+                  '@path': '$.quantity'
+                },
+                content_type: {
+                  '@path': '$.category'
+                },
+                content_id: {
+                  '@path': '$.product_id'
+                }
+              }
+            ]
+          },
+          currency: {
+            '@path': '$.properties.currency'
+          },
+          value: {
+            '@path': '$.properties.value'
+          },
+          query: {
+            '@path': '$.properties.query'
+          },
+          description: {
+            '@path': '$.properties.description'
+          }
+        }
+      }
+    ]
+
+    const [webEvent] = await TikTokDestination({
+      ...settings,
+      subscriptions
+    })
+    reportWebEvent = webEvent
+
+    await reportWebEvent.load(Context.system(), {} as Analytics)
+    expect(destination.initialize).toHaveBeenCalled()
+  })
+})

--- a/packages/browser-destinations/destinations/tiktok-pixel/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/tiktok-pixel/src/generated-types.ts
@@ -10,6 +10,10 @@ export interface Settings {
    */
   ldu?: boolean
   /**
+   * If true, TikTok Pixel will fire a "Pageview" event whenevent the pixel is loaded on the page.
+   */
+  autoPageView?: boolean
+  /**
    * Deprecated. Please do not provide any value.
    */
   useExistingPixel?: boolean

--- a/packages/browser-destinations/destinations/tiktok-pixel/src/index.ts
+++ b/packages/browser-destinations/destinations/tiktok-pixel/src/index.ts
@@ -230,9 +230,9 @@ export const destination: BrowserDestinationDefinition<Settings, TikTokPixel> = 
         'In order to help facilitate advertiser\'s compliance with the right to opt-out of sale and sharing of personal data under certain U.S. state privacy laws, TikTok offers a Limited Data Use ("LDU") feature. For more information, please refer to TikTok\'s [documentation page](https://business-api.tiktok.com/portal/docs?id=1770092377990145).'
     },
     autoPageView: {
-      label: 'Auto Page View Event Trigger',
+      label: 'Fire TikTok Pixel Pageview event on page load.',
       type: 'boolean',
-      description: 'Configure TikTok Pixel to fire "Pageview" event whenevent the pixel is loaded on the page.',
+      description: 'If true, TikTok Pixel will fire a "Pageview" event whenevent the pixel is loaded on the page.',
       default: true
     },
     useExistingPixel: {

--- a/packages/browser-destinations/destinations/tiktok-pixel/src/index.ts
+++ b/packages/browser-destinations/destinations/tiktok-pixel/src/index.ts
@@ -66,6 +66,15 @@ export const destination: BrowserDestinationDefinition<Settings, TikTokPixel> = 
   mode: 'device',
   presets: [
     {
+      name: 'Page View',
+      subscribe: 'type = "page"',
+      partnerAction: 'reportWebEvent',
+      mapping: {
+        event: 'Pageview'
+      },
+      type: 'automatic'
+    },
+    {
       name: 'Complete Payment',
       subscribe: 'event = "Order Completed"',
       partnerAction: 'reportWebEvent',
@@ -219,6 +228,12 @@ export const destination: BrowserDestinationDefinition<Settings, TikTokPixel> = 
       type: 'boolean',
       description:
         'In order to help facilitate advertiser\'s compliance with the right to opt-out of sale and sharing of personal data under certain U.S. state privacy laws, TikTok offers a Limited Data Use ("LDU") feature. For more information, please refer to TikTok\'s [documentation page](https://business-api.tiktok.com/portal/docs?id=1770092377990145).'
+    },
+    autoPageView: {
+      label: 'Auto Page View Event Trigger',
+      type: 'boolean',
+      description: 'Configure TikTok Pixel to fire "Pageview" event whenevent the pixel is loaded on the page.',
+      default: true
     },
     useExistingPixel: {
       // TODO: HOW TO DELETE (reusing will not include Segment Partner name)

--- a/packages/browser-destinations/destinations/tiktok-pixel/src/init-script.ts
+++ b/packages/browser-destinations/destinations/tiktok-pixel/src/init-script.ts
@@ -48,6 +48,8 @@ export function initScript(settings) {
     ttq.load(settings.pixelCode, {
       limited_data_use: settings.ldu ? settings.ldu : false
     })
-    ttq.instance(settings.pixelCode).page()
+    if (settings.autoPageView) {
+      ttq.instance(settings.pixelCode).page()
+    }
   })(window, document, 'ttq')
 }

--- a/packages/browser-destinations/destinations/tiktok-pixel/src/init-script.ts
+++ b/packages/browser-destinations/destinations/tiktok-pixel/src/init-script.ts
@@ -48,7 +48,7 @@ export function initScript(settings) {
     ttq.load(settings.pixelCode, {
       limited_data_use: settings.ldu ? settings.ldu : false
     })
-    if (settings.autoPageView) {
+    if (settings.autoPageView === undefined || settings.autoPageView === true) {
       ttq.instance(settings.pixelCode).page()
     }
   })(window, document, 'ttq')

--- a/packages/browser-destinations/destinations/tiktok-pixel/src/reportWebEvent/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/tiktok-pixel/src/reportWebEvent/__tests__/index.test.ts
@@ -24,6 +24,65 @@ describe('TikTokPixel.reportWebEvent', () => {
     })
   })
 
+  test('sends "Pageview" event', async () => {
+    const subscriptions: Subscription[] = [
+      {
+        partnerAction: 'reportWebEvent',
+        name: 'Page View',
+        enabled: true,
+        subscribe: 'type="page"',
+        mapping: {
+          event: 'Pageview'
+        }
+      }
+    ]
+
+    const context = new Context({
+      messageId: 'ajs-71f386523ee5dfa90c7d0fda28b6b5c6',
+      type: 'page',
+      anonymousId: 'anonymousId',
+      userId: 'userId',
+      context: {
+        traits: {
+          last_name: 'lastName',
+          first_name: 'firstName',
+          address: {
+            city: 'city',
+            state: 'state',
+            country: 'country'
+          }
+        }
+      },
+      properties: {}
+    })
+
+    const [webEvent] = await TikTokDestination({
+      ...settings,
+      subscriptions
+    })
+    reportWebEvent = webEvent
+
+    await reportWebEvent.load(Context.system(), {} as Analytics)
+    await reportWebEvent.track?.(context)
+
+    expect(mockTtp.track).toHaveBeenCalledWith(
+      'Pageview',
+      {
+        content_type: undefined,
+        contents: [],
+        currency: 'USD',
+        description: undefined,
+        order_id: undefined,
+        query: undefined,
+        shop_id: undefined,
+        value: undefined
+      },
+      {
+        event_id: ''
+      }
+    )
+  })
+
   test('maps properties correctly for "PlaceAnOrder" event', async () => {
     const subscriptions: Subscription[] = [
       {


### PR DESCRIPTION
Add "autoPageView" setting & Pageview event preset to support event trigger rule for Pageview events.

Tested manually `init-script.ts` pixel page view trigger - include `alert()` and `console.log()` to test updated settings field for trigger page view event:
```
if (settings.autoPageView === undefined || settings.autoPageView === true) {
      ttq.instance(settings.pixelCode).page()
      alert('hello')
      console.log('after page view')
}
```

`init-script.ts` test code:
![Screenshot 2024-09-11 at 10 52 47 AM](https://github.com/user-attachments/assets/69a23c9a-e8e1-46a2-a808-c5806126fe57)

- `autoPageView`: `true`
Destination settings:
![Screenshot 2024-09-11 at 10 11 50 AM](https://github.com/user-attachments/assets/dc7157a0-032e-40ad-8ad1-57bf019dc361)

Alert:
![Screenshot 2024-09-11 at 10 11 58 AM](https://github.com/user-attachments/assets/b863cb36-cdfd-41a0-a62e-fa152b112b15)

Browser console log:
![Screenshot 2024-09-11 at 10 12 05 AM](https://github.com/user-attachments/assets/bdceae9b-b258-45cb-a8a5-66ba33a53840)

- `autoPageView`: `false`
Destination settings:
![Screenshot 2024-09-11 at 10 12 17 AM](https://github.com/user-attachments/assets/9dc49f43-1df7-4062-a46f-cfd330f49f3c)

Alert: none

Browser console log:
![Screenshot 2024-09-11 at 10 12 25 AM](https://github.com/user-attachments/assets/faf4b309-4d23-4220-9440-0ff17073094d)


