### PR TITLE
[STRATCONN-4130]- google sheets increase timeout

### DIFF
--- a/packages/destination-actions/src/destinations/google-sheets-dev/postSheet.types.ts
+++ b/packages/destination-actions/src/destinations/google-sheets-dev/postSheet.types.ts
@@ -41,11 +41,11 @@ export interface Payload {
    */
   enable_batching?: boolean
   /**
-   * The number of rows to write to the spreadsheet in a single batch. The maximum value is 1000.
+   * The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.
    */
   batch_size: number
   /**
-   * The number of bytes to write to the spreadsheet in a single batch. The maximum value is 4000000.
+   * The number of bytes to write to the spreadsheet in a single batch. Limit is 2MB.
    */
   batch_bytes: number
 }

--- a/packages/destination-actions/src/destinations/google-sheets-dev/postSheet.types.ts
+++ b/packages/destination-actions/src/destinations/google-sheets-dev/postSheet.types.ts
@@ -40,4 +40,12 @@ export interface Payload {
    * Set as true to ensure Segment sends data to Google Sheets in batches. Please do not set to false.
    */
   enable_batching?: boolean
+  /**
+   * The number of rows to write to the spreadsheet in a single batch. The maximum value is 1000.
+   */
+  batch_size: number
+  /**
+   * The number of bytes to write to the spreadsheet in a single batch. The maximum value is 4000000.
+   */
+  batch_bytes: number
 }

--- a/packages/destination-actions/src/destinations/google-sheets-dev/postSheet.types.ts
+++ b/packages/destination-actions/src/destinations/google-sheets-dev/postSheet.types.ts
@@ -41,7 +41,7 @@ export interface Payload {
    */
   enable_batching?: boolean
   /**
-   * The number of rows to write to the spreadsheet in a single batch. This value is determined by the number of rows * columns (cells) that Segment can process and upload within timeout window.
+   * The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.
    */
   batch_size: number
   /**

--- a/packages/destination-actions/src/destinations/google-sheets-dev/postSheet.types.ts
+++ b/packages/destination-actions/src/destinations/google-sheets-dev/postSheet.types.ts
@@ -41,7 +41,7 @@ export interface Payload {
    */
   enable_batching?: boolean
   /**
-   * The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.
+   * The number of rows to write to the spreadsheet in a single batch. This value is determined by the number of rows * columns (cells) that Segment can process and upload within timeout window.
    */
   batch_size: number
   /**

--- a/packages/destination-actions/src/destinations/google-sheets/__tests__/postSheet.operations.test.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/__tests__/postSheet.operations.test.ts
@@ -43,7 +43,9 @@ describe('Google Sheets', () => {
           spreadsheet_id: 'spreadsheet_id',
           spreadsheet_name: 'spreadsheet_name',
           data_format: 'data_format',
-          fields: { column1: 'value1', column2: 'value2' }
+          fields: { column1: 'value1', column2: 'value2' },
+          batch_size: 1,
+          batch_bytes: 1
         }
       ]
     }

--- a/packages/destination-actions/src/destinations/google-sheets/constants.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/constants.ts
@@ -2,5 +2,5 @@ export const CONSTANTS = {
   /**
    * Based on benchmarks found while testing so we dont reach the timeout limit.
    */
-  MAX_CELLS: 300000
+  MAX_CELLS: 600000
 }

--- a/packages/destination-actions/src/destinations/google-sheets/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/index.ts
@@ -3,6 +3,7 @@ import type { Settings } from './generated-types'
 
 import postSheet from './postSheet'
 import postSheet2 from './postSheet2'
+import { DEFAULT_REQUEST_TIMEOUT } from '@segment/actions-core'
 interface RefreshTokenResponse {
   access_token: string
   scope: string
@@ -42,7 +43,7 @@ const destination: DestinationDefinition<Settings> = {
       headers: {
         authorization: `Bearer ${auth?.accessToken}`
       },
-      timeout: 30000 // 30 seconds.
+      timeout: Math.max(30_000, DEFAULT_REQUEST_TIMEOUT) // 30 seconds.
     }
   },
 

--- a/packages/destination-actions/src/destinations/google-sheets/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/index.ts
@@ -41,7 +41,8 @@ const destination: DestinationDefinition<Settings> = {
     return {
       headers: {
         authorization: `Bearer ${auth?.accessToken}`
-      }
+      },
+      timeout: 30000 // 30 seconds.
     }
   },
 

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/generated-types.ts
@@ -41,11 +41,11 @@ export interface Payload {
    */
   enable_batching?: boolean
   /**
-   * The number of rows to write to the spreadsheet in a single batch. The maximum value is 1000.
+   * The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.
    */
   batch_size: number
   /**
-   * The number of bytes to write to the spreadsheet in a single batch. The maximum value is 4000000.
+   * The number of bytes to write to the spreadsheet in a single batch. Limit is 2MB.
    */
   batch_bytes: number
 }

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/generated-types.ts
@@ -40,4 +40,12 @@ export interface Payload {
    * Set as true to ensure Segment sends data to Google Sheets in batches. Please do not set to false.
    */
   enable_batching?: boolean
+  /**
+   * The number of rows to write to the spreadsheet in a single batch. The maximum value is 1000.
+   */
+  batch_size: number
+  /**
+   * The number of bytes to write to the spreadsheet in a single batch. The maximum value is 4000000.
+   */
+  batch_bytes: number
 }

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/generated-types.ts
@@ -41,7 +41,7 @@ export interface Payload {
    */
   enable_batching?: boolean
   /**
-   * The number of rows to write to the spreadsheet in a single batch. This value is determined by the number of rows * columns (cells) that Segment can process and upload within timeout window.
+   * The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.
    */
   batch_size: number
   /**

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/generated-types.ts
@@ -41,7 +41,7 @@ export interface Payload {
    */
   enable_batching?: boolean
   /**
-   * The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.
+   * The number of rows to write to the spreadsheet in a single batch. This value is determined by the number of rows * columns (cells) that Segment can process and upload within timeout window.
    */
   batch_size: number
   /**

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
@@ -57,14 +57,14 @@ const action: ActionDefinition<Settings, Payload> = {
     fields: {
       label: 'Fields',
       description: `
-  The fields to write to the spreadsheet. 
+  The fields to write to the spreadsheet.
 
-  On the left-hand side, input the name of the field as it will appear in the Google Sheet. 
-  
+  On the left-hand side, input the name of the field as it will appear in the Google Sheet.
+
   On the right-hand side, select the field from your data model that maps to the given field in your sheet.
-     
+
   ---
-      
+
   `,
       type: 'object',
       required: true,
@@ -75,6 +75,22 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch Data to Google Sheets',
       description: 'Set as true to ensure Segment sends data to Google Sheets in batches. Please do not set to false.',
       default: true
+    },
+    batch_size: {
+      type: 'number',
+      label: 'Batch Size',
+      description: 'The number of rows to write to the spreadsheet in a single batch. The maximum value is 1000.',
+      default: 500,
+      required: true,
+      unsafe_hidden: true
+    },
+    batch_bytes: {
+      type: 'number',
+      label: 'Batch Bytes',
+      description: 'The number of bytes to write to the spreadsheet in a single batch. The maximum value is 4000000.',
+      default: 2000000, // 2MB,
+      required: true,
+      unsafe_hidden: true
     }
   },
   perform: (request, { payload }) => {

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
@@ -79,15 +79,16 @@ const action: ActionDefinition<Settings, Payload> = {
     batch_size: {
       type: 'number',
       label: 'Batch Size',
-      description: 'The number of rows to write to the spreadsheet in a single batch. The maximum value is 1000.',
-      default: 500,
+      description:
+        'The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.',
+      default: 100,
       required: true,
       unsafe_hidden: true
     },
     batch_bytes: {
       type: 'number',
       label: 'Batch Bytes',
-      description: 'The number of bytes to write to the spreadsheet in a single batch. The maximum value is 4000000.',
+      description: 'The number of bytes to write to the spreadsheet in a single batch. Limit is 2MB.',
       default: 2000000, // 2MB,
       required: true,
       unsafe_hidden: true

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
@@ -81,7 +81,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch Size',
       description:
         'The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.',
-      default: 500,
+      default: 1001,
       required: true,
       unsafe_hidden: true
     },

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
@@ -57,14 +57,14 @@ const action: ActionDefinition<Settings, Payload> = {
     fields: {
       label: 'Fields',
       description: `
-  The fields to write to the spreadsheet.
+  The fields to write to the spreadsheet. 
 
-  On the left-hand side, input the name of the field as it will appear in the Google Sheet.
-
+  On the left-hand side, input the name of the field as it will appear in the Google Sheet. 
+  
   On the right-hand side, select the field from your data model that maps to the given field in your sheet.
-
+     
   ---
-
+      
   `,
       type: 'object',
       required: true,

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
@@ -80,10 +80,10 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'number',
       label: 'Batch Size',
       description:
-        'The number of rows to write to the spreadsheet in a single batch. This value is determined by the number of rows * columns (cells) that Segment can process and upload within timeout window.',
-      default: 100,
-      required: true,
-      unsafe_hidden: true
+        'The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.',
+      default: 500,
+      required: true
+      // unsafe_hidden: true
     },
     batch_bytes: {
       type: 'number',

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
@@ -82,8 +82,8 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.',
       default: 500,
-      required: true
-      // unsafe_hidden: true
+      required: true,
+      unsafe_hidden: true
     },
     batch_bytes: {
       type: 'number',

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
@@ -80,7 +80,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'number',
       label: 'Batch Size',
       description:
-        'The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.',
+        'The number of rows to write to the spreadsheet in a single batch. This value is determined by the number of rows * columns (cells) that Segment can process and upload within timeout window.',
       default: 100,
       required: true,
       unsafe_hidden: true

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/operations.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/operations.ts
@@ -70,11 +70,6 @@ const generateColumnValuesFromFields = (identifier: string, fields: Fields, colu
  */
 function processGetSpreadsheetResponse(response: GetResponse, events: Payload[], mappingSettings: MappingSettings) {
   const numColumns = mappingSettings.columns.length
-  const numRows = response.values?.length
-
-  if (numRows * numColumns > CONSTANTS.MAX_CELLS) {
-    throw new IntegrationError('Sheet has reached maximum limit', 'INVALID_REQUEST_DATA', 400)
-  }
 
   const updateBatch: UpdateBatch[] = []
   const appendBatch: AppendBatch[] = []
@@ -110,6 +105,13 @@ function processGetSpreadsheetResponse(response: GetResponse, events: Payload[],
       })
     }
   })
+
+  const appendBatchLimit = appendBatch.length * numColumns > CONSTANTS.MAX_CELLS
+  const updateBatchLimit = updateBatch.length * numColumns > CONSTANTS.MAX_CELLS
+
+  if (appendBatchLimit || updateBatchLimit) {
+    throw new IntegrationError('Sheet has reached maximum limit', 'INVALID_REQUEST_DATA', 400)
+  }
 
   return { appendBatch, updateBatch }
 }

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/operations.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/operations.ts
@@ -110,7 +110,11 @@ function processGetSpreadsheetResponse(response: GetResponse, events: Payload[],
   const updateBatchLimit = updateBatch.length * numColumns > CONSTANTS.MAX_CELLS
 
   if (appendBatchLimit || updateBatchLimit) {
-    throw new IntegrationError('Sheet has reached maximum limit', 'INVALID_REQUEST_DATA', 400)
+    throw new IntegrationError(
+      `Sheet has reached maximum limit supported by Segment: ${CONSTANTS.MAX_CELLS} cells.`,
+      'INVALID_REQUEST_DATA',
+      400
+    )
   }
 
   return { appendBatch, updateBatch }

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/operations.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/operations.ts
@@ -35,21 +35,21 @@ const DATA_ROW_OFFSET = 2
 
 /**
  * Utility function that converts the event properties into an array of strings that Google Sheets API can understand.
- * Note that the identifier is forced as the first column. 
+ * Note that the identifier is forced as the first column.
  * @param identifier value used to imbue fields with a uniqueness constraint
  * @param fields list of properties contained in the event
  * @param columns list of properties that will be committed to the spreadsheet
  * @returns a string object that has used the `fields` data to populate the `columns` ordering
- * 
+ *
  * @example
- * fields: 
+ * fields:
     {
       "CLOSE_DATE": "2022-07-08T00:00:00Z",
       "CLOSE_DATE_EOQ": "2022-07-08",
       "ENTRY_POINT": "Website Demo Request",
       "E_ARR_POST_LAUNCH_C": "100000.0",
       "FINANCE_ENTRY_POINT": "Inbound High Intent"
-    } 
+    }
     columns: ["ENTRY_POINT", "MISSING_COLUMN", "CLOSE_DATE"]
 
     return => ["Website Demo Request", "", "2022-07-08T00:00:00Z"]
@@ -65,6 +65,7 @@ const generateColumnValuesFromFields = (identifier: string, fields: Fields, colu
  * Processes the response of the Google Sheets GET call and parses the events into separate operation buckets.
  * @param response result of the Google Sheets API get call
  * @param events data to be written to the spreadsheet
+ * @param mappingSettings
  * @returns
  */
 function processGetSpreadsheetResponse(response: GetResponse, events: Payload[], mappingSettings: MappingSettings) {

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/operations.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/operations.ts
@@ -35,21 +35,21 @@ const DATA_ROW_OFFSET = 2
 
 /**
  * Utility function that converts the event properties into an array of strings that Google Sheets API can understand.
- * Note that the identifier is forced as the first column.
+ * Note that the identifier is forced as the first column. 
  * @param identifier value used to imbue fields with a uniqueness constraint
  * @param fields list of properties contained in the event
  * @param columns list of properties that will be committed to the spreadsheet
  * @returns a string object that has used the `fields` data to populate the `columns` ordering
- *
+ * 
  * @example
- * fields:
+ * fields: 
     {
       "CLOSE_DATE": "2022-07-08T00:00:00Z",
       "CLOSE_DATE_EOQ": "2022-07-08",
       "ENTRY_POINT": "Website Demo Request",
       "E_ARR_POST_LAUNCH_C": "100000.0",
       "FINANCE_ENTRY_POINT": "Inbound High Intent"
-    }
+    } 
     columns: ["ENTRY_POINT", "MISSING_COLUMN", "CLOSE_DATE"]
 
     return => ["Website Demo Request", "", "2022-07-08T00:00:00Z"]
@@ -65,11 +65,15 @@ const generateColumnValuesFromFields = (identifier: string, fields: Fields, colu
  * Processes the response of the Google Sheets GET call and parses the events into separate operation buckets.
  * @param response result of the Google Sheets API get call
  * @param events data to be written to the spreadsheet
- * @param mappingSettings
  * @returns
  */
 function processGetSpreadsheetResponse(response: GetResponse, events: Payload[], mappingSettings: MappingSettings) {
   const numColumns = mappingSettings.columns.length
+  const numRows = response.values?.length
+
+  if (numRows * numColumns > CONSTANTS.MAX_CELLS) {
+    throw new IntegrationError('Sheet has reached maximum limit', 'INVALID_REQUEST_DATA', 400)
+  }
 
   const updateBatch: UpdateBatch[] = []
   const appendBatch: AppendBatch[] = []
@@ -105,17 +109,6 @@ function processGetSpreadsheetResponse(response: GetResponse, events: Payload[],
       })
     }
   })
-
-  const appendBatchLimit = appendBatch.length * numColumns > CONSTANTS.MAX_CELLS
-  const updateBatchLimit = updateBatch.length * numColumns > CONSTANTS.MAX_CELLS
-
-  if (appendBatchLimit || updateBatchLimit) {
-    throw new IntegrationError(
-      `Sheet has reached maximum limit supported by Segment: ${CONSTANTS.MAX_CELLS} cells.`,
-      'INVALID_REQUEST_DATA',
-      400
-    )
-  }
 
   return { appendBatch, updateBatch }
 }

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet2/generated-types.ts
@@ -24,7 +24,9 @@ export interface Payload {
    *   On the left-hand side, input the name of the field as it will appear in the Google Sheet.
    *
    *   On the right-hand side, select the field from your data model that maps to the given field in your sheet.
+   *
    *   ---
+   *
    *
    */
   fields: {
@@ -35,7 +37,7 @@ export interface Payload {
    */
   enable_batching?: boolean
   /**
-   * The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.
+   * The number of rows to write to the spreadsheet in a single batch. This value is determined by the number of rows * columns (cells) that Segment can process and upload within timeout window.
    */
   batch_size: number
   /**

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet2/generated-types.ts
@@ -37,7 +37,7 @@ export interface Payload {
    */
   enable_batching?: boolean
   /**
-   * The number of rows to write to the spreadsheet in a single batch. This value is determined by the number of rows * columns (cells) that Segment can process and upload within timeout window.
+   * The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.
    */
   batch_size: number
   /**

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet2/generated-types.ts
@@ -36,4 +36,12 @@ export interface Payload {
    * Set as true to ensure Segment sends data to Google Sheets in batches. Please do not set to false.
    */
   enable_batching?: boolean
+  /**
+   * The number of rows to write to the spreadsheet in a single batch. The maximum value is 1000.
+   */
+  batch_size: number
+  /**
+   * The number of bytes to write to the spreadsheet in a single batch. The maximum value is 4000000.
+   */
+  batch_bytes: number
 }

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet2/generated-types.ts
@@ -24,9 +24,7 @@ export interface Payload {
    *   On the left-hand side, input the name of the field as it will appear in the Google Sheet.
    *
    *   On the right-hand side, select the field from your data model that maps to the given field in your sheet.
-   *
    *   ---
-   *
    *
    */
   fields: {
@@ -37,11 +35,11 @@ export interface Payload {
    */
   enable_batching?: boolean
   /**
-   * The number of rows to write to the spreadsheet in a single batch. The maximum value is 1000.
+   * The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.
    */
   batch_size: number
   /**
-   * The number of bytes to write to the spreadsheet in a single batch. The maximum value is 4000000.
+   * The number of bytes to write to the spreadsheet in a single batch. Limit is 2MB.
    */
   batch_bytes: number
 }

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet2/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet2/index.ts
@@ -93,7 +93,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch Size',
       description:
         'The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.',
-      default: 500,
+      default: 1001,
       required: true,
       unsafe_hidden: true
     },

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet2/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet2/index.ts
@@ -91,18 +91,19 @@ const action: ActionDefinition<Settings, Payload> = {
     batch_size: {
       type: 'number',
       label: 'Batch Size',
-      description: 'The number of rows to write to the spreadsheet in a single batch. The maximum value is 1000.',
+      description:
+        'The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.',
       default: 100,
       required: true,
-      unsafe_hidden: true // TODO: Display this field when min/max is implemented.
+      unsafe_hidden: true
     },
     batch_bytes: {
       type: 'number',
       label: 'Batch Bytes',
-      description: 'The number of bytes to write to the spreadsheet in a single batch. The maximum value is 4000000.',
+      description: 'The number of bytes to write to the spreadsheet in a single batch. Limit is 2MB.',
       default: 2000000, // 2MB,
       required: true,
-      unsafe_hidden: true // TODO: Display this field when min/max is implemented.
+      unsafe_hidden: true
     }
   },
   perform: (request, { payload, syncMode }) => {

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet2/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet2/index.ts
@@ -92,8 +92,8 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'number',
       label: 'Batch Size',
       description:
-        'The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.',
-      default: 100,
+        'The number of rows to write to the spreadsheet in a single batch. This value is determined by the number of rows * columns (cells) that Segment can process and upload within timeout window.',
+      default: 500,
       required: true,
       unsafe_hidden: true
     },

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet2/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet2/index.ts
@@ -92,7 +92,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'number',
       label: 'Batch Size',
       description:
-        'The number of rows to write to the spreadsheet in a single batch. This value is determined by the number of rows * columns (cells) that Segment can process and upload within timeout window.',
+        'The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.',
       default: 500,
       required: true,
       unsafe_hidden: true

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet2/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet2/index.ts
@@ -5,7 +5,7 @@ import type { Payload } from './generated-types'
 import { processData } from './operations2'
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Post Sheet',
+  title: 'Post Sheet V2',
   description: 'Write values to a Google Sheets spreadsheet.',
   defaultSubscription: 'event = "updated" or event = "new"',
   syncMode: {

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet2/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet2/index.ts
@@ -5,7 +5,7 @@ import type { Payload } from './generated-types'
 import { processData } from './operations2'
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Post Sheet V2',
+  title: 'Post Sheet',
   description: 'Write values to a Google Sheets spreadsheet.',
   defaultSubscription: 'event = "updated" or event = "new"',
   syncMode: {
@@ -87,6 +87,22 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch Data to Google Sheets',
       description: 'Set as true to ensure Segment sends data to Google Sheets in batches. Please do not set to false.',
       default: true
+    },
+    batch_size: {
+      type: 'number',
+      label: 'Batch Size',
+      description: 'The number of rows to write to the spreadsheet in a single batch. The maximum value is 1000.',
+      default: 100,
+      required: true,
+      unsafe_hidden: true // TODO: Display this field when min/max is implemented.
+    },
+    batch_bytes: {
+      type: 'number',
+      label: 'Batch Bytes',
+      description: 'The number of bytes to write to the spreadsheet in a single batch. The maximum value is 4000000.',
+      default: 2000000, // 2MB,
+      required: true,
+      unsafe_hidden: true // TODO: Display this field when min/max is implemented.
     }
   },
   perform: (request, { payload, syncMode }) => {

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet2/operations2.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet2/operations2.ts
@@ -79,7 +79,11 @@ function processGetSpreadsheetResponse(
   const numRows = response.values?.length
 
   if (numRows * numColumns > CONSTANTS.MAX_CELLS) {
-    throw new IntegrationError('Sheet has reached maximum limit', 'INVALID_REQUEST_DATA', 400)
+    throw new IntegrationError(
+      `Sheet has reached maximum limit supported by Segment: ${CONSTANTS.MAX_CELLS} cells.`,
+      'INVALID_REQUEST_DATA',
+      400
+    )
   }
 
   const updateBatch: UpdateBatch[] = []


### PR DESCRIPTION
This PR increases google sheets timeout to 30s and doubles the max cell size limit.

Also adds batch_bytes and batch_size properties. Reverting back to 500 as the limit as the original issue was not the batch size but the cell limit.

Refer [here](https://github.com/segmentio/integrations-go/pull/428)

## Testing

Testing completed successfully in staging. [Doc](https://docs.google.com/document/d/1dZdh7S-LonAEYSW_U2gyiYpdjt8rTRtvt9gBcHGzcaA/edit)

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
