### PR TITLE
[STRATCONN-4149][Braze] - updates default trackevent mapping for email

### DIFF
--- a/packages/destination-actions/src/destinations/braze/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/braze/trackEvent/index.ts
@@ -37,7 +37,11 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'The user email',
       type: 'string',
       default: {
-        '@path': '$.traits.email'
+        '@if': {
+          exists: { '@path': '$.context.traits.email' },
+          then: { '@path': '$.context.traits.email' },
+          else: { '@path': '$.properties.email' }
+        }
       }
     },
     braze_id: {


### PR DESCRIPTION
This PR fixes the default email mapping for trackEvent action in Braze. trackEvent is by default subscribed with `track` event. But email property is mapped with traits.email. Track event has no traits node. This updates the default maping to `coalesce(context.traits.email or properties.email)`

## Testing

Testing completed successfully. I'll only be running push and not push default.

New preset.

![image](https://github.com/user-attachments/assets/afef56c4-5d4d-4330-82f0-4616e199e96d)


New track mapping

<img width="1511" alt="Screenshot 2024-09-11 at 3 41 20 PM" src="https://github.com/user-attachments/assets/87e9a0fd-647e-4c24-a8b8-6c816f26b958">


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
