### PR TITLE
fix(Jimo): prevent losing ref of client

### DIFF
--- a/packages/browser-destinations/destinations/jimo/src/init-script.ts
+++ b/packages/browser-destinations/destinations/jimo/src/init-script.ts
@@ -11,7 +11,9 @@ export function initScript(settings: Settings) {
   window.jimo = []
   window.segmentJimo = {
     initialized: !manualInit,
-    client: window.jimo
+    client: function () {
+      return window.jimo
+    }
   }
   window['JIMO_MANUAL_INIT'] = manualInit
   window['JIMO_PROJECT_ID'] = settings.projectId

--- a/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/__tests__/index.test.ts
@@ -5,9 +5,10 @@ import { Payload } from '../generated-types'
 
 describe('Jimo - Send Track Event', () => {
   test('do:segmentio:track is called', async () => {
+    const mockedPush = jest.fn()
     const client = {
       client() {
-        return { push: jest.fn() }
+        return { push: mockedPush }
       }
     } as any as JimoClient
 

--- a/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/__tests__/index.test.ts
@@ -6,7 +6,9 @@ import { Payload } from '../generated-types'
 describe('Jimo - Send Track Event', () => {
   test('do:segmentio:track is called', async () => {
     const client = {
-      client: { push: jest.fn() }
+      client() {
+        return { push: jest.fn() }
+      }
     } as any as JimoClient
 
     const context = new Context({
@@ -29,8 +31,8 @@ describe('Jimo - Send Track Event', () => {
       } as Payload
     })
 
-    expect(client.client.push).toHaveBeenCalled()
-    expect(client.client.push).toHaveBeenCalledWith([
+    expect(client.client().push).toHaveBeenCalled()
+    expect(client.client().push).toHaveBeenCalledWith([
       'do',
       'segmentio:track',
       [

--- a/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/index.ts
+++ b/packages/browser-destinations/destinations/jimo/src/sendTrackEvent/index.ts
@@ -68,11 +68,14 @@ const action: BrowserActionDefinition<Settings, JimoClient, Payload> = {
     const { event_name, userId, anonymousId, timestamp, messageId, properties } = payload
     const receivedAt = timestamp
 
-    jimo.client.push([
-      'do',
-      'segmentio:track',
-      [{ event: event_name, userId, anonymousId, messageId, timestamp, receivedAt, properties }]
-    ])
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    jimo
+      .client()
+      .push([
+        'do',
+        'segmentio:track',
+        [{ event: event_name, userId, anonymousId, messageId, timestamp, receivedAt, properties }]
+      ])
     window.dispatchEvent(new CustomEvent(`jimo-segmentio-track:${event_name}`))
   }
 }

--- a/packages/browser-destinations/destinations/jimo/src/sendUserData/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/jimo/src/sendUserData/__tests__/index.test.ts
@@ -6,9 +6,10 @@ import { Payload } from '../generated-types'
 
 describe('Jimo - Send User Data', () => {
   test('user id', async () => {
+    const mockedPush = jest.fn()
     const segmentJimo = {
       client() {
-        return { push: jest.fn() }
+        return { push: mockedPush }
       }
     } as any as JimoClient
 
@@ -29,9 +30,10 @@ describe('Jimo - Send User Data', () => {
     expect(segmentJimo.client().push).toHaveBeenCalledWith(['do', 'identify', ['u1', expect.any(Function)]])
   })
   test('user id then email and attributes', async () => {
+    const mockedPush = jest.fn()
     const segmentJimo = {
       client() {
-        return { push: jest.fn() }
+        return { push: mockedPush }
       }
     } as any as JimoClient
 
@@ -56,9 +58,10 @@ describe('Jimo - Send User Data', () => {
     expect(segmentJimo.client().push).toHaveBeenCalledWith(['do', 'identify', ['u1', expect.any(Function)]])
   })
   test('user email', async () => {
+    const mockedPush = jest.fn()
     const segmentJimo = {
       client() {
-        return { push: jest.fn() }
+        return { push: mockedPush }
       }
     } as any as JimoClient
 
@@ -79,9 +82,10 @@ describe('Jimo - Send User Data', () => {
     expect(segmentJimo.client().push).toHaveBeenCalledWith(['set', 'user:email', ['foo@bar.com']])
   })
   test('user traits', async () => {
+    const mockedPush = jest.fn()
     const segmentJimo = {
       client() {
-        return { push: jest.fn() }
+        return { push: mockedPush }
       }
     } as any as JimoClient
 
@@ -118,9 +122,10 @@ describe('Jimo - Send User Data', () => {
     ])
   })
   test('user traits with experience refetching', async () => {
+    const mockedPush = jest.fn()
     const segmentJimo = {
       client() {
-        return { push: jest.fn() }
+        return { push: mockedPush }
       }
     } as any as JimoClient
 

--- a/packages/browser-destinations/destinations/jimo/src/sendUserData/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/jimo/src/sendUserData/__tests__/index.test.ts
@@ -7,7 +7,9 @@ import { Payload } from '../generated-types'
 describe('Jimo - Send User Data', () => {
   test('user id', async () => {
     const segmentJimo = {
-      client: { push: jest.fn() }
+      client() {
+        return { push: jest.fn() }
+      }
     } as any as JimoClient
 
     const context = new Context({
@@ -23,12 +25,14 @@ describe('Jimo - Send User Data', () => {
       } as Payload
     })
 
-    expect(segmentJimo.client.push).toHaveBeenCalled()
-    expect(segmentJimo.client.push).toHaveBeenCalledWith(['do', 'identify', ['u1', expect.any(Function)]])
+    expect(segmentJimo.client().push).toHaveBeenCalled()
+    expect(segmentJimo.client().push).toHaveBeenCalledWith(['do', 'identify', ['u1', expect.any(Function)]])
   })
   test('user id then email and attributes', async () => {
     const segmentJimo = {
-      client: { push: jest.fn() }
+      client() {
+        return { push: jest.fn() }
+      }
     } as any as JimoClient
 
     const context = new Context({
@@ -48,12 +52,14 @@ describe('Jimo - Send User Data', () => {
       } as Payload
     })
 
-    expect(segmentJimo.client.push).toHaveBeenCalled()
-    expect(segmentJimo.client.push).toHaveBeenCalledWith(['do', 'identify', ['u1', expect.any(Function)]])
+    expect(segmentJimo.client().push).toHaveBeenCalled()
+    expect(segmentJimo.client().push).toHaveBeenCalledWith(['do', 'identify', ['u1', expect.any(Function)]])
   })
   test('user email', async () => {
     const segmentJimo = {
-      client: { push: jest.fn() }
+      client() {
+        return { push: jest.fn() }
+      }
     } as any as JimoClient
 
     const context = new Context({
@@ -69,12 +75,14 @@ describe('Jimo - Send User Data', () => {
       } as Payload
     })
 
-    expect(segmentJimo.client.push).toHaveBeenCalled()
-    expect(segmentJimo.client.push).toHaveBeenCalledWith(['set', 'user:email', ['foo@bar.com']])
+    expect(segmentJimo.client().push).toHaveBeenCalled()
+    expect(segmentJimo.client().push).toHaveBeenCalledWith(['set', 'user:email', ['foo@bar.com']])
   })
   test('user traits', async () => {
     const segmentJimo = {
-      client: { push: jest.fn() }
+      client() {
+        return { push: jest.fn() }
+      }
     } as any as JimoClient
 
     const context = new Context({
@@ -94,8 +102,8 @@ describe('Jimo - Send User Data', () => {
       } as Payload
     })
 
-    expect(segmentJimo.client.push).toHaveBeenCalled()
-    expect(segmentJimo.client.push).toHaveBeenCalledWith([
+    expect(segmentJimo.client().push).toHaveBeenCalled()
+    expect(segmentJimo.client().push).toHaveBeenCalledWith([
       'set',
       'user:attributes',
       [
@@ -111,7 +119,9 @@ describe('Jimo - Send User Data', () => {
   })
   test('user traits with experience refetching', async () => {
     const segmentJimo = {
-      client: { push: jest.fn() }
+      client() {
+        return { push: jest.fn() }
+      }
     } as any as JimoClient
 
     const context = new Context({
@@ -131,8 +141,8 @@ describe('Jimo - Send User Data', () => {
       } as Payload
     })
 
-    expect(segmentJimo.client.push).toHaveBeenCalled()
-    expect(segmentJimo.client.push).toHaveBeenCalledWith([
+    expect(segmentJimo.client().push).toHaveBeenCalled()
+    expect(segmentJimo.client().push).toHaveBeenCalledWith([
       'set',
       'user:attributes',
       [

--- a/packages/browser-destinations/destinations/jimo/src/sendUserData/index.ts
+++ b/packages/browser-destinations/destinations/jimo/src/sendUserData/index.ts
@@ -46,23 +46,21 @@ const action: BrowserActionDefinition<Settings, JimoClient, Payload> = {
     const pushEmail = () => {
       if (payload.email == null) return
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      jimo.client.push(['set', 'user:email', [payload.email]])
+      jimo.client().push(['set', 'user:email', [payload.email]])
     }
     const pushTraits = () => {
       if (payload.traits == null) return
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      jimo.client.push([
-        'set',
-        'user:attributes',
-        [payload.traits, settings.refetchExperiencesOnTraitsUpdate ?? false, true]
-      ])
+      jimo
+        .client()
+        .push(['set', 'user:attributes', [payload.traits, settings.refetchExperiencesOnTraitsUpdate ?? false, true]])
     }
 
     // If a userId is passed, we need to make sure email and attributes changes only happen in the
     // after the identify flow is done, that's why we pass it as a callback of the identify method
     if (payload.userId != null) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      jimo.client.push([
+      jimo.client().push([
         'do',
         'identify',
         [

--- a/packages/browser-destinations/destinations/jimo/src/types.ts
+++ b/packages/browser-destinations/destinations/jimo/src/types.ts
@@ -4,5 +4,5 @@ export interface JimoSDK {
 
 export interface JimoClient {
   initialized: boolean
-  client: JimoSDK | any[]
+  client: () => JimoSDK | any[]
 }


### PR DESCRIPTION
Use a getter instead of the direct value to prevent not having the most updated version of the client post initialisation.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
