### PR TITLE
[google sheets] mark batch_size and batch_bytes are non-required field

### DIFF
--- a/packages/destination-actions/src/destinations/google-sheets-dev/postSheet.types.ts
+++ b/packages/destination-actions/src/destinations/google-sheets-dev/postSheet.types.ts
@@ -43,9 +43,9 @@ export interface Payload {
   /**
    * The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.
    */
-  batch_size: number
+  batch_size?: number
   /**
    * The number of bytes to write to the spreadsheet in a single batch. Limit is 2MB.
    */
-  batch_bytes: number
+  batch_bytes?: number
 }

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/generated-types.ts
@@ -43,9 +43,9 @@ export interface Payload {
   /**
    * The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.
    */
-  batch_size: number
+  batch_size?: number
   /**
    * The number of bytes to write to the spreadsheet in a single batch. Limit is 2MB.
    */
-  batch_bytes: number
+  batch_bytes?: number
 }

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet/index.ts
@@ -57,14 +57,14 @@ const action: ActionDefinition<Settings, Payload> = {
     fields: {
       label: 'Fields',
       description: `
-  The fields to write to the spreadsheet. 
+  The fields to write to the spreadsheet.
 
-  On the left-hand side, input the name of the field as it will appear in the Google Sheet. 
-  
+  On the left-hand side, input the name of the field as it will appear in the Google Sheet.
+
   On the right-hand side, select the field from your data model that maps to the given field in your sheet.
-     
+
   ---
-      
+
   `,
       type: 'object',
       required: true,
@@ -82,7 +82,7 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.',
       default: 1001,
-      required: true,
+      required: false,
       unsafe_hidden: true
     },
     batch_bytes: {
@@ -90,7 +90,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch Bytes',
       description: 'The number of bytes to write to the spreadsheet in a single batch. Limit is 2MB.',
       default: 2000000, // 2MB,
-      required: true,
+      required: false,
       unsafe_hidden: true
     }
   },

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet2/generated-types.ts
@@ -39,9 +39,9 @@ export interface Payload {
   /**
    * The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.
    */
-  batch_size: number
+  batch_size?: number
   /**
    * The number of bytes to write to the spreadsheet in a single batch. Limit is 2MB.
    */
-  batch_bytes: number
+  batch_bytes?: number
 }

--- a/packages/destination-actions/src/destinations/google-sheets/postSheet2/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets/postSheet2/index.ts
@@ -94,7 +94,7 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'The number of rows to write to the spreadsheet in a single batch. The value is determined by number of rows * columns that Segment can upload within 30s.',
       default: 1001,
-      required: true,
+      required: false,
       unsafe_hidden: true
     },
     batch_bytes: {
@@ -102,7 +102,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch Bytes',
       description: 'The number of bytes to write to the spreadsheet in a single batch. Limit is 2MB.',
       default: 2000000, // 2MB,
-      required: true,
+      required: false,
       unsafe_hidden: true
     }
   },


### PR DESCRIPTION
Marks batch_size and batch_bytes as non-required fields. There are default values for these two fields even if the value is remain unset. So, it doesn't make sense to have these two are required fields.

## Testing


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
