### PR TITLE
STRATCONN-4169 | Events to Klaviyo destination is failing for delivery

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/functions.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/functions.ts
@@ -408,3 +408,34 @@ export function validatePhoneNumber(phone?: string): boolean {
   const e164Regex = /^\+[1-9]\d{1,14}$/
   return e164Regex.test(phone)
 }
+
+export function roundTimestamp(timestamp: string): string {
+  // Split the timestamp into date and time components
+  const [datePart, timePart] = timestamp.split('T')
+
+  // If there's no timePart, return the original timestamp directly
+  if (!timePart) {
+    return timestamp
+  }
+
+  // Split the time part into seconds and milliseconds
+  const [time, milliseconds] = timePart.split('.')
+
+  // If milliseconds exist, round them if they have more than 3 digits
+  if (milliseconds) {
+    const hasZ = milliseconds.endsWith('Z')
+    const msValue = hasZ ? milliseconds.slice(0, -1) : milliseconds // Remove 'Z' for processing
+
+    const msValueLength = msValue.length
+
+    if (msValueLength > 3) {
+      const divisor = Math.pow(10, msValueLength - 3) // Round upto 3 digits
+      const roundedValue = Math.round(parseFloat(msValue) / divisor)
+      const roundedMilliseconds = roundedValue.toString()
+      return `${datePart}T${time}.${roundedMilliseconds}${hasZ ? 'Z' : ''}`
+    }
+  }
+
+  // If milliseconds are 3 digits or fewer, return the original timestamp
+  return timestamp // Return the original timestamp
+}

--- a/packages/destination-actions/src/destinations/klaviyo/functions.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/functions.ts
@@ -408,34 +408,3 @@ export function validatePhoneNumber(phone?: string): boolean {
   const e164Regex = /^\+[1-9]\d{1,14}$/
   return e164Regex.test(phone)
 }
-
-export function roundTimestamp(timestamp: string): string {
-  // Split the timestamp into date and time components
-  const [datePart, timePart] = timestamp.split('T')
-
-  // If there's no timePart, return the original timestamp directly
-  if (!timePart) {
-    return timestamp
-  }
-
-  // Split the time part into seconds and milliseconds
-  const [time, milliseconds] = timePart.split('.')
-
-  // If milliseconds exist, round them if they have more than 3 digits
-  if (milliseconds) {
-    const hasZ = milliseconds.endsWith('Z')
-    const msValue = hasZ ? milliseconds.slice(0, -1) : milliseconds // Remove 'Z' for processing
-
-    const msValueLength = msValue.length
-
-    if (msValueLength > 3) {
-      const divisor = Math.pow(10, msValueLength - 3) // Round upto 3 digits
-      const roundedValue = Math.round(parseFloat(msValue) / divisor)
-      const roundedMilliseconds = roundedValue.toString()
-      return `${datePart}T${time}.${roundedMilliseconds}${hasZ ? 'Z' : ''}`
-    }
-  }
-
-  // If milliseconds are 3 digits or fewer, return the original timestamp
-  return timestamp // Return the original timestamp
-}

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/index.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Order Completed should not pass time property in API when it is not mapped 1`] = `"{\\"data\\":{\\"type\\":\\"event\\",\\"attributes\\":{\\"properties\\":{\\"key\\":\\"value\\"},\\"value\\":10,\\"metric\\":{\\"data\\":{\\"type\\":\\"metric\\",\\"attributes\\":{\\"name\\":\\"Order Completed\\"}}},\\"profile\\":{\\"data\\":{\\"type\\":\\"profile\\",\\"attributes\\":{\\"anonymous_id\\":\\"an0nym0u51d\\"}}}}}}"`;
+
+exports[`Order Completed should not throw an error when the time property has more than three digits in the milliseconds and should convert the time to ISO format. 1`] = `"{\\"data\\":{\\"type\\":\\"event\\",\\"attributes\\":{\\"properties\\":{\\"key\\":\\"value\\"},\\"time\\":\\"2024-07-22T20:08:49.891Z\\",\\"value\\":10,\\"metric\\":{\\"data\\":{\\"type\\":\\"metric\\",\\"attributes\\":{\\"name\\":\\"Order Completed\\"}}},\\"profile\\":{\\"data\\":{\\"type\\":\\"profile\\",\\"attributes\\":{\\"anonymous_id\\":\\"an0nym0u51d\\"}}}}}}"`;
+
+exports[`Order Completed should successfully convert the timestamp for the time property to ISO format. 1`] = `"{\\"data\\":{\\"type\\":\\"event\\",\\"attributes\\":{\\"properties\\":{\\"key\\":\\"value\\"},\\"time\\":\\"2024-07-22T20:08:49.890Z\\",\\"value\\":10,\\"metric\\":{\\"data\\":{\\"type\\":\\"metric\\",\\"attributes\\":{\\"name\\":\\"Order Completed\\"}}},\\"profile\\":{\\"data\\":{\\"type\\":\\"profile\\",\\"attributes\\":{\\"anonymous_id\\":\\"an0nym0u51d\\"}}}}}}"`;

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/index.test.ts
@@ -230,8 +230,8 @@ describe('Order Completed', () => {
     })
 
     const mapping = { profile, metric_name: metricName, properties, value, event_name: eventName, time: timestamp }
-
-    await expect(testDestination.testAction('orderCompleted', { event, mapping, settings })).resolves.not.toThrowError()
+    const res = await testDestination.testAction('orderCompleted', { event, mapping, settings })
+    expect(res[0].options.body).toMatchSnapshot()
   })
 
   it('should successfully convert the timestamp for the time property to ISO format.', async () => {
@@ -252,7 +252,28 @@ describe('Order Completed', () => {
     })
 
     const mapping = { profile, metric_name: metricName, properties, value, event_name: eventName, time: timestamp }
+    const res = await testDestination.testAction('orderCompleted', { event, mapping, settings })
+    expect(res[0].options.body).toMatchSnapshot()
+  })
+  it('should not pass time property in API when it is not mapped', async () => {
+    const profile = { anonymous_id: 'an0nym0u51d' }
+    const properties = { key: 'value' }
+    const metricName = 'Order Completed'
+    const value = 10
+    const eventName = 'Order Completed'
+    const timestamp = '2024-07-22T20:08:49.89191341Z'
+    const requestBody = createRequestBody(properties, value, metricName, profile)
 
-    await expect(testDestination.testAction('orderCompleted', { event, mapping, settings })).resolves.not.toThrowError()
+    nock(`${API_URL}`).post('/events/', requestBody).reply(200, {})
+
+    const event = createTestEvent({
+      type: 'track',
+      timestamp
+    })
+
+    const mapping = { profile, metric_name: metricName, properties, value, event_name: eventName }
+
+    const res = await testDestination.testAction('orderCompleted', { event, mapping, settings })
+    expect(res[0].options.body).toMatchSnapshot()
   })
 })

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/index.test.ts
@@ -212,13 +212,13 @@ describe('Order Completed', () => {
     await expect(testDestination.testAction(`orderCompleted`, { event, mapping, settings })).resolves.not.toThrowError()
   })
 
-  it('should successfully round the timestamp for time property that have more than three digits the milliseconds.', async () => {
+  it('should not throw an error when the time property has more than three digits in the milliseconds and should convert the time to ISO format.', async () => {
     const profile = { anonymous_id: 'an0nym0u51d' }
     const properties = { key: 'value' }
     const metricName = 'Order Completed'
     const value = 10
     const eventName = 'Order Completed'
-    const time = '2024-07-22T20:08:49.892Z' // round the timestamp from '2024-07-22T20:08:49.89191341Z'
+    const time = '2024-07-22T20:08:49.891Z' // convert the timestamp from '2024-07-22T20:08:49.89191341Z'
     const timestamp = '2024-07-22T20:08:49.89191341Z'
     const requestBody = createRequestBody(properties, value, metricName, profile, time)
 
@@ -234,13 +234,13 @@ describe('Order Completed', () => {
     await expect(testDestination.testAction('orderCompleted', { event, mapping, settings })).resolves.not.toThrowError()
   })
 
-  it('should not round the timestamp for time property that have not more than three digits the milliseconds.', async () => {
+  it('should successfully convert the timestamp for the time property to ISO format.', async () => {
     const profile = { anonymous_id: 'an0nym0u51d' }
     const properties = { key: 'value' }
     const metricName = 'Order Completed'
     const value = 10
     const eventName = 'Order Completed'
-    const time = '2024-07-22T20:08:49.89Z'
+    const time = '2024-07-22T20:08:49.890Z'
     const timestamp = '2024-07-22T20:08:49.89Z'
     const requestBody = createRequestBody(properties, value, metricName, profile, time)
 

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
@@ -5,14 +5,15 @@ import { PayloadValidationError, RequestClient } from '@segment/actions-core'
 import { API_URL } from '../config'
 import { EventData } from '../types'
 import { v4 as uuidv4 } from '@lukeed/uuid'
-import { validatePhoneNumber, roundTimestamp } from '../functions'
+import { validatePhoneNumber } from '../functions'
+import dayjs from 'dayjs'
 
 const createEventData = (payload: Payload) => ({
   data: {
     type: 'event',
     attributes: {
       properties: { ...payload.properties },
-      time: payload.time ? roundTimestamp(`${payload.time}`) : undefined,
+      time: payload.time ? dayjs(payload.time).toISOString() : undefined,
       value: payload.value,
       unique_id: payload.unique_id,
       metric: {

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
@@ -5,14 +5,14 @@ import { PayloadValidationError, RequestClient } from '@segment/actions-core'
 import { API_URL } from '../config'
 import { EventData } from '../types'
 import { v4 as uuidv4 } from '@lukeed/uuid'
-import { validatePhoneNumber } from '../functions'
+import { validatePhoneNumber, roundTimestamp } from '../functions'
 
 const createEventData = (payload: Payload) => ({
   data: {
     type: 'event',
     attributes: {
       properties: { ...payload.properties },
-      time: payload.time,
+      time: payload.time ? roundTimestamp(`${payload.time}`) : undefined,
       value: payload.value,
       unique_id: payload.unique_id,
       metric: {

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/__tests__/__snapshots__/index.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Track Event should not pass time property in API when it is not mapped or defined 1`] = `"{\\"data\\":{\\"type\\":\\"event\\",\\"attributes\\":{\\"properties\\":{\\"key\\":\\"value\\"},\\"value\\":10,\\"unique_id\\":\\"text-example-xyz\\",\\"metric\\":{\\"data\\":{\\"type\\":\\"metric\\",\\"attributes\\":{\\"name\\":\\"event_name\\"}}},\\"profile\\":{\\"data\\":{\\"type\\":\\"profile\\",\\"attributes\\":{\\"anonymous_id\\":\\"an0nym0u51d\\"}}}}}}"`;
+
+exports[`Track Event should not throw an error when the time property has more than three digits in the milliseconds and should convert the time to ISO format. 1`] = `"{\\"data\\":{\\"type\\":\\"event\\",\\"attributes\\":{\\"properties\\":{\\"key\\":\\"value\\"},\\"time\\":\\"2024-09-11T20:08:49.891Z\\",\\"value\\":10,\\"unique_id\\":\\"text-example-xyz\\",\\"metric\\":{\\"data\\":{\\"type\\":\\"metric\\",\\"attributes\\":{\\"name\\":\\"event_name\\"}}},\\"profile\\":{\\"data\\":{\\"type\\":\\"profile\\",\\"attributes\\":{\\"anonymous_id\\":\\"an0nym0u51d\\"}}}}}}"`;

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/__tests__/index.test.ts
@@ -239,13 +239,13 @@ describe('Track Event', () => {
     ).rejects.toThrowError('Internal Server Error')
   })
 
-  it('should successfully round the timestamp for time property that have more than three digits the milliseconds.', async () => {
+  it('should not throw an error when the time property has more than three digits in the milliseconds and should convert the time to ISO format.', async () => {
     const requestBody = {
       data: {
         type: 'event',
         attributes: {
           properties: { key: 'value' },
-          time: '2024-07-22T20:08:49.792Z', // round the timestamp from '2024-07-22T20:08:49.79191341Z'
+          time: '2024-07-22T20:08:49.791Z', // convert the timestamp from '2024-07-22T20:08:49.79191341Z'
           value: 10,
           unique_id: 'text-example-xyz',
           metric: {
@@ -288,13 +288,13 @@ describe('Track Event', () => {
     ).resolves.not.toThrowError()
   })
 
-  it('should not round the timestamp for time property that have not more than three digits the milliseconds.', async () => {
+  it('should successfully convert the timestamp for the time property to ISO format.', async () => {
     const requestBody = {
       data: {
         type: 'event',
         attributes: {
           properties: { key: 'value' },
-          time: '2024-07-22T20:08:49.79Z',
+          time: '2024-07-22T20:08:49.790Z',
           value: 10,
           unique_id: 'text-example-xyz',
           metric: {

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/__tests__/index.test.ts
@@ -238,4 +238,102 @@ describe('Track Event', () => {
       testDestination.testAction('trackEvent', { event, mapping, settings, useDefaultMappings: true })
     ).rejects.toThrowError('Internal Server Error')
   })
+
+  it('should successfully round the timestamp for time property that have more than three digits the milliseconds.', async () => {
+    const requestBody = {
+      data: {
+        type: 'event',
+        attributes: {
+          properties: { key: 'value' },
+          time: '2024-07-22T20:08:49.792Z', // round the timestamp from '2024-07-22T20:08:49.79191341Z'
+          value: 10,
+          unique_id: 'text-example-xyz',
+          metric: {
+            data: {
+              type: 'metric',
+              attributes: {
+                name: 'event_name'
+              }
+            }
+          },
+          profile: {
+            data: {
+              type: 'profile',
+              attributes: {
+                anonymous_id: 'an0nym0u51d'
+              }
+            }
+          }
+        }
+      }
+    }
+
+    nock(`${API_URL}`).post('/events/', requestBody).reply(200, {})
+
+    const event = createTestEvent({
+      type: 'track',
+      timestamp: '2024-07-22T20:08:49.79191341Z'
+    })
+
+    const mapping = {
+      profile: { anonymous_id: 'an0nym0u51d' },
+      metric_name: 'event_name',
+      properties: { key: 'value' },
+      value: 10,
+      unique_id: 'text-example-xyz'
+    }
+
+    await expect(
+      testDestination.testAction('trackEvent', { event, mapping, settings, useDefaultMappings: true })
+    ).resolves.not.toThrowError()
+  })
+
+  it('should not round the timestamp for time property that have not more than three digits the milliseconds.', async () => {
+    const requestBody = {
+      data: {
+        type: 'event',
+        attributes: {
+          properties: { key: 'value' },
+          time: '2024-07-22T20:08:49.79Z',
+          value: 10,
+          unique_id: 'text-example-xyz',
+          metric: {
+            data: {
+              type: 'metric',
+              attributes: {
+                name: 'event_name'
+              }
+            }
+          },
+          profile: {
+            data: {
+              type: 'profile',
+              attributes: {
+                anonymous_id: 'an0nym0u51d'
+              }
+            }
+          }
+        }
+      }
+    }
+
+    nock(`${API_URL}`).post('/events/', requestBody).reply(200, {})
+
+    const event = createTestEvent({
+      type: 'track',
+      timestamp: '2024-07-22T20:08:49.79Z'
+    })
+
+    const mapping = {
+      profile: { anonymous_id: 'an0nym0u51d' },
+      metric_name: 'event_name',
+      properties: { key: 'value' },
+      value: 10,
+      unique_id: 'text-example-xyz'
+    }
+
+    await expect(
+      testDestination.testAction('trackEvent', { event, mapping, settings, useDefaultMappings: true })
+    ).resolves.not.toThrowError()
+  })
 })

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/index.ts
@@ -4,7 +4,7 @@ import type { Payload } from './generated-types'
 
 import { PayloadValidationError } from '@segment/actions-core'
 import { API_URL } from '../config'
-import { validatePhoneNumber } from '../functions'
+import { validatePhoneNumber, roundTimestamp } from '../functions'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track Event',
@@ -98,13 +98,12 @@ const action: ActionDefinition<Settings, Payload> = {
     if (phone_number && !validatePhoneNumber(phone_number)) {
       throw new PayloadValidationError(`${phone_number} is not a valid E.164 phone number.`)
     }
-
     const eventData = {
       data: {
         type: 'event',
         attributes: {
           properties: { ...payload.properties },
-          time: payload.time,
+          time: payload?.time ? roundTimestamp(`${payload.time}`) : undefined,
           value: payload.value,
           unique_id: payload.unique_id,
           metric: {

--- a/packages/destination-actions/src/destinations/klaviyo/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/trackEvent/index.ts
@@ -4,7 +4,8 @@ import type { Payload } from './generated-types'
 
 import { PayloadValidationError } from '@segment/actions-core'
 import { API_URL } from '../config'
-import { validatePhoneNumber, roundTimestamp } from '../functions'
+import { validatePhoneNumber } from '../functions'
+import dayjs from 'dayjs'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track Event',
@@ -103,7 +104,7 @@ const action: ActionDefinition<Settings, Payload> = {
         type: 'event',
         attributes: {
           properties: { ...payload.properties },
-          time: payload?.time ? roundTimestamp(`${payload.time}`) : undefined,
+          time: payload?.time ? dayjs(payload.time).toISOString() : undefined,
           value: payload.value,
           unique_id: payload.unique_id,
           metric: {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pull request is to fix the event delivery issue in TrackEvent and OrderCompleted Actions of Klaviyo (Actions)due to time property. So we are converting the timestamp to ISO Format .To understand more about the problem and solution , Please do go through this testing doc [here](https://docs.google.com/document/d/1lKKg4pyDrTf52N_B89ABO-GSE-YY6_SsWg-vccEANS8/edit#heading=h.x9dgiyfuowsl).

Jira ticket :- https://segment.atlassian.net/jira/software/c/projects/STRATCONN/boards/310?assignee=63617339fc0cc7a600b03c6b&selectedIssue=STRATCONN-4169
## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment . Please have a look [here](https://docs.google.com/document/d/1lKKg4pyDrTf52N_B89ABO-GSE-YY6_SsWg-vccEANS8/edit#heading=h.x9dgiyfuowsl) 
