### PR TITLE
[S3] - renaming new s3 destination

### DIFF
--- a/packages/destination-actions/src/destinations/s3/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/s3/__tests__/index.test.ts
@@ -11,7 +11,7 @@ describe('S3 Destination', () => {
 
   it('should have the correct destination structure', () => {
     expect(destination).toBeDefined()
-    expect(destination.definition.name).toEqual('AWS S3')
+    expect(destination.definition.name).toEqual('AWS S3 (Actions)')
     expect(destination.definition.slug).toEqual('actions-s3')
     expect(destination.definition.mode).toEqual('cloud')
     expect(destination.definition.description).toEqual('Sync Segment event data to AWS S3.')

--- a/packages/destination-actions/src/destinations/s3/index.ts
+++ b/packages/destination-actions/src/destinations/s3/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from './generated-types'
 import syncToS3 from './syncToS3'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'AWS S3',
+  name: 'AWS S3 (Actions)',
   slug: 'actions-s3',
   mode: 'cloud',
   description: 'Sync Segment event data to AWS S3.',


### PR DESCRIPTION
Renaming new S3 Destination to avoid name clash 

## Testing
None needed. 