### PR TITLE
[MAIN] [STRATCONN] 4119 klaviyo fixed blank audience creation.

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/index.test.ts
@@ -15,7 +15,10 @@ const createAudienceInput = {
   settings: {
     api_key: ''
   },
-  audienceName: ''
+  audienceName: '',
+  audienceSettings: {
+    listId: ''
+  }
 }
 
 const getAudienceInput = {
@@ -96,6 +99,12 @@ describe('Klaviyo (actions)', () => {
       expect(r).toEqual({
         externalId: 'XYZABC'
       })
+    })
+
+    it('Should return list_id if list_id is set in audienceSetting', async () => {
+      createAudienceInput.audienceSettings.listId = 'XYZABC'
+      const r = await testDestination.createAudience(createAudienceInput)
+      expect(r).toEqual({ externalId: 'XYZABC' })
     })
   })
 

--- a/packages/destination-actions/src/destinations/klaviyo/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/generated-types.ts
@@ -6,3 +6,11 @@ export interface Settings {
    */
   api_key: string
 }
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface AudienceSettings {
+  /**
+   * 'Insert the ID of the default list that you'd like to subscribe users to when you call .identify().'
+   */
+  listId?: string
+}

--- a/packages/destination-actions/src/destinations/klaviyo/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/generated-types.ts
@@ -10,7 +10,8 @@ export interface Settings {
 
 export interface AudienceSettings {
   /**
-   * 'Insert the ID of the default list that you'd like to subscribe users to when you call .identify().'
+   * Insert the ID of the default list that you'd like to subscribe users to when you call .identify().
+   *        NOTE: List ID takes precedence set within Actions.
    */
   listId?: string
 }

--- a/packages/destination-actions/src/destinations/klaviyo/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/index.ts
@@ -4,7 +4,7 @@ import {
   PayloadValidationError,
   APIError
 } from '@segment/actions-core'
-import type { Settings } from './generated-types'
+import type { Settings, AudienceSettings } from './generated-types'
 
 import { API_URL } from './config'
 import upsertProfile from './upsertProfile'
@@ -18,7 +18,7 @@ import removeProfile from './removeProfile'
 
 import unsubscribeProfile from './unsubscribeProfile'
 
-const destination: AudienceDestinationDefinition<Settings> = {
+const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   name: 'Klaviyo (Actions)',
   slug: 'actions-klaviyo',
   mode: 'cloud',
@@ -64,7 +64,13 @@ const destination: AudienceDestinationDefinition<Settings> = {
       headers: buildHeaders(settings.api_key)
     }
   },
-  audienceFields: {},
+  audienceFields: {
+    listId: {
+      label: 'List Id',
+      description: `'Insert the ID of the default list that you'd like to subscribe users to when you call .identify().'`,
+      type: 'string'
+    }
+  },
   audienceConfig: {
     mode: {
       type: 'synced',
@@ -73,6 +79,12 @@ const destination: AudienceDestinationDefinition<Settings> = {
     async createAudience(request, createAudienceInput) {
       const audienceName = createAudienceInput.audienceName
       const apiKey = createAudienceInput.settings.api_key
+      const defaultAudienceId = createAudienceInput.audienceSettings?.listId
+
+      if (defaultAudienceId) {
+        return { externalId: defaultAudienceId }
+      }
+
       if (!audienceName) {
         throw new PayloadValidationError('Missing audience name value')
       }

--- a/packages/destination-actions/src/destinations/klaviyo/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/index.ts
@@ -67,7 +67,8 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   audienceFields: {
     listId: {
       label: 'List Id',
-      description: `'Insert the ID of the default list that you'd like to subscribe users to when you call .identify().'`,
+      description: `Insert the ID of the default list that you'd like to subscribe users to when you call .identify().
+       NOTE: List ID takes precedence set within Actions.`,
       type: 'string'
     }
   },


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

In this PR resolved the issue creating blank audience (List Id) on klaviyo, 
Now user can add list_id on audience settings page and be able to add audience on existing audience. 

JIRA TICKET: https://segment.atlassian.net/browse/STRATCONN-4119

<img width="1505" alt="Screenshot 2024-09-18 at 7 46 21 PM" src="https://github.com/user-attachments/assets/7769b4e1-f8aa-4449-a878-de5e86452c6e">


\
\
Here, I created a new audience and added list_id on audienceField, Now we can verify that the new list name "Segment Test" is not created in Klaviyo and users are getting added to the provided list_id. 

\
\


<img width="1502" alt="Screenshot 2024-09-19 at 1 03 24 PM" src="https://github.com/user-attachments/assets/693f168c-4ab7-4972-b591-b234c489510f">
<img width="1510" alt="Screenshot 2024-09-19 at 1 03 16 PM" src="https://github.com/user-attachments/assets/7ce63574-3b61-4f8d-a1ea-2066546bea38">
<img width="1509" alt="Screenshot 2024-09-19 at 12 57 38 PM" src="https://github.com/user-attachments/assets/6192406c-fb93-4a3c-a871-e9e06f89de73">



<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [X] [Segmenters] Tested in the staging environment
