### PR TITLE
Add "Recombee (Actions)" destination

### DIFF
--- a/packages/destination-actions/src/destinations/recombee/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/recombee/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,228 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-recombee destination: addBookmark action - all fields 1`] = `
+Object {
+  "additionalData": Object {
+    "testType": "7(iq3vwM",
+  },
+  "cascadeCreate": true,
+  "itemId": "7(iq3vwM",
+  "recommId": "7(iq3vwM",
+  "timestamp": "7(iq3vwM",
+  "userId": "7(iq3vwM",
+}
+`;
+
+exports[`Testing snapshot for actions-recombee destination: addBookmark action - required fields 1`] = `
+Object {
+  "cascadeCreate": true,
+  "itemId": "7(iq3vwM",
+  "userId": "7(iq3vwM",
+}
+`;
+
+exports[`Testing snapshot for actions-recombee destination: addCartAddition action - all fields 1`] = `
+Object {
+  "requests": Array [
+    Object {
+      "method": "POST",
+      "params": Object {
+        "additionalData": Object {
+          "testType": "fSK%!$(3gz2peZ!&@L@D",
+        },
+        "amount": 85450379273175.05,
+        "cascadeCreate": true,
+        "itemId": "fSK%!$(3gz2peZ!&@L@D",
+        "price": 85450379273175.05,
+        "recommId": "fSK%!$(3gz2peZ!&@L@D",
+        "timestamp": "fSK%!$(3gz2peZ!&@L@D",
+        "userId": "fSK%!$(3gz2peZ!&@L@D",
+      },
+      "path": "/cartadditions/",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for actions-recombee destination: addCartAddition action - required fields 1`] = `
+Object {
+  "requests": Array [
+    Object {
+      "method": "POST",
+      "params": Object {
+        "cascadeCreate": true,
+        "itemId": "fSK%!$(3gz2peZ!&@L@D",
+        "userId": "fSK%!$(3gz2peZ!&@L@D",
+      },
+      "path": "/cartadditions/",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for actions-recombee destination: addDetailView action - all fields 1`] = `
+Object {
+  "additionalData": Object {
+    "testType": "VhiOfa#s6#B[CQDV",
+  },
+  "cascadeCreate": true,
+  "duration": 4043918945550336,
+  "itemId": "VhiOfa#s6#B[CQDV",
+  "recommId": "VhiOfa#s6#B[CQDV",
+  "timestamp": "VhiOfa#s6#B[CQDV",
+  "userId": "VhiOfa#s6#B[CQDV",
+}
+`;
+
+exports[`Testing snapshot for actions-recombee destination: addDetailView action - required fields 1`] = `
+Object {
+  "cascadeCreate": true,
+  "itemId": "VhiOfa#s6#B[CQDV",
+  "userId": "VhiOfa#s6#B[CQDV",
+}
+`;
+
+exports[`Testing snapshot for actions-recombee destination: addPurchase action - all fields 1`] = `
+Object {
+  "requests": Array [
+    Object {
+      "method": "POST",
+      "params": Object {
+        "additionalData": Object {
+          "testType": "!D2A1H%v%jv&r",
+        },
+        "amount": 3316018504007.68,
+        "cascadeCreate": true,
+        "itemId": "!D2A1H%v%jv&r",
+        "price": 3316018504007.68,
+        "profit": 3316018504007.68,
+        "recommId": "!D2A1H%v%jv&r",
+        "timestamp": "!D2A1H%v%jv&r",
+        "userId": "!D2A1H%v%jv&r",
+      },
+      "path": "/purchases/",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for actions-recombee destination: addPurchase action - required fields 1`] = `
+Object {
+  "requests": Array [
+    Object {
+      "method": "POST",
+      "params": Object {
+        "cascadeCreate": true,
+        "itemId": "!D2A1H%v%jv&r",
+        "userId": "!D2A1H%v%jv&r",
+      },
+      "path": "/purchases/",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for actions-recombee destination: addRating action - all fields 1`] = `
+Object {
+  "additionalData": Object {
+    "testType": "X9m9Urlsqof(&*PN!s",
+  },
+  "cascadeCreate": true,
+  "itemId": "X9m9Urlsqof(&*PN!s",
+  "rating": 63040185947914.24,
+  "recommId": "X9m9Urlsqof(&*PN!s",
+  "timestamp": "X9m9Urlsqof(&*PN!s",
+  "userId": "X9m9Urlsqof(&*PN!s",
+}
+`;
+
+exports[`Testing snapshot for actions-recombee destination: addRating action - required fields 1`] = `
+Object {
+  "cascadeCreate": true,
+  "itemId": "X9m9Urlsqof(&*PN!s",
+  "rating": 63040185947914.24,
+  "userId": "X9m9Urlsqof(&*PN!s",
+}
+`;
+
+exports[`Testing snapshot for actions-recombee destination: deleteBookmark action - all fields 1`] = `
+Object {
+  "itemId": "Sy@zJ0^",
+  "timestamp": "Sy@zJ0^",
+  "userId": "Sy@zJ0^",
+}
+`;
+
+exports[`Testing snapshot for actions-recombee destination: deleteBookmark action - required fields 1`] = `
+Object {
+  "itemId": "Sy@zJ0^",
+  "userId": "Sy@zJ0^",
+}
+`;
+
+exports[`Testing snapshot for actions-recombee destination: deleteCartAddition action - all fields 1`] = `
+Object {
+  "itemId": "BGNilpbMGk^JyT",
+  "timestamp": "BGNilpbMGk^JyT",
+  "userId": "BGNilpbMGk^JyT",
+}
+`;
+
+exports[`Testing snapshot for actions-recombee destination: deleteCartAddition action - required fields 1`] = `
+Object {
+  "itemId": "BGNilpbMGk^JyT",
+  "userId": "BGNilpbMGk^JyT",
+}
+`;
+
+exports[`Testing snapshot for actions-recombee destination: mergeUsers action - all fields 1`] = `Object {}`;
+
+exports[`Testing snapshot for actions-recombee destination: mergeUsers action - required fields 1`] = `Object {}`;
+
+exports[`Testing snapshot for actions-recombee destination: setViewPortion action - all fields 1`] = `
+Object {
+  "additionalData": Object {
+    "testType": "D9^z[P*Zv",
+  },
+  "cascadeCreate": true,
+  "itemId": "D9^z[P*Zv",
+  "portion": -42971588743659.52,
+  "recommId": "D9^z[P*Zv",
+  "sessionId": "D9^z[P*Zv",
+  "timestamp": "D9^z[P*Zv",
+  "userId": "D9^z[P*Zv",
+}
+`;
+
+exports[`Testing snapshot for actions-recombee destination: setViewPortion action - required fields 1`] = `
+Object {
+  "cascadeCreate": true,
+  "itemId": "D9^z[P*Zv",
+  "portion": -42971588743659.52,
+  "userId": "D9^z[P*Zv",
+}
+`;
+
+exports[`Testing snapshot for actions-recombee destination: setViewPortionFromWatchTime action - all fields 1`] = `
+Object {
+  "additionalData": Object {
+    "testType": "gpLV6!FLD#$6^LR77nTN",
+  },
+  "cascadeCreate": true,
+  "itemId": "gpLV6!FLD#$6^LR77nTN",
+  "portion": 1,
+  "recommId": "gpLV6!FLD#$6^LR77nTN",
+  "sessionId": "gpLV6!FLD#$6^LR77nTN",
+  "timestamp": "gpLV6!FLD#$6^LR77nTN",
+  "userId": "gpLV6!FLD#$6^LR77nTN",
+}
+`;
+
+exports[`Testing snapshot for actions-recombee destination: setViewPortionFromWatchTime action - required fields 1`] = `
+Object {
+  "cascadeCreate": true,
+  "itemId": "gpLV6!FLD#$6^LR77nTN",
+  "portion": 1,
+  "userId": "gpLV6!FLD#$6^LR77nTN",
+}
+`;

--- a/packages/destination-actions/src/destinations/recombee/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/__tests__/index.test.ts
@@ -1,0 +1,65 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+import { Settings } from '../generated-types'
+
+const testDestination = createTestIntegration(Definition)
+const DATABASE_ID = 'test-database'
+
+describe('Recombee', () => {
+  describe('testAuthentication', () => {
+    it('should validate authentication inputs', async () => {
+      nock('https://rapi-eu-west.recombee.com/')
+        .post(`/${DATABASE_ID}/batch/`)
+        .query({
+          hmac_timestamp: /.*/,
+          hmac_sign: /.*/
+        })
+        .reply(200, [])
+
+      const authData: Settings = {
+        privateToken: 'VALID_TOKEN',
+        databaseId: DATABASE_ID,
+        databaseRegion: 'eu-west'
+      }
+
+      await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
+    })
+
+    it('should throw error when no API Key', async () => {
+      nock('https://rapi-eu-west.recombee.com/')
+        .post(`/${DATABASE_ID}/batch/`)
+        .query({
+          hmac_timestamp: /.*/,
+          hmac_sign: /.*/
+        })
+        .reply(401, [])
+
+      const authData: Settings = {
+        privateToken: '',
+        databaseId: DATABASE_ID,
+        databaseRegion: 'eu-west'
+      }
+
+      await expect(testDestination.testAuthentication(authData)).rejects.toThrowError(/401/)
+    })
+
+    it('should throw error when API Key invalid', async () => {
+      nock('https://rapi-eu-west.recombee.com/')
+        .post(`/${DATABASE_ID}/batch/`)
+        .query({
+          hmac_timestamp: /.*/,
+          hmac_sign: /.*/
+        })
+        .reply(401, [])
+
+      const authData: Settings = {
+        privateToken: 'INVALID_TOKEN',
+        databaseId: DATABASE_ID,
+        databaseRegion: 'eu-west'
+      }
+
+      await expect(testDestination.testAuthentication(authData)).rejects.toThrowError(/401/)
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-recombee'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+      nock(/.*/).persist().delete(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+      nock(/.*/).persist().delete(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/recombee/addBookmark/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/recombee/addBookmark/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Recombee's addBookmark destination action: all fields 1`] = `
+Object {
+  "additionalData": Object {
+    "testType": "GxFzk&V2a4R8iF62G9]q",
+  },
+  "cascadeCreate": true,
+  "itemId": "GxFzk&V2a4R8iF62G9]q",
+  "recommId": "GxFzk&V2a4R8iF62G9]q",
+  "timestamp": "GxFzk&V2a4R8iF62G9]q",
+  "userId": "GxFzk&V2a4R8iF62G9]q",
+}
+`;
+
+exports[`Testing snapshot for Recombee's addBookmark destination action: required fields 1`] = `
+Object {
+  "cascadeCreate": true,
+  "itemId": "GxFzk&V2a4R8iF62G9]q",
+  "userId": "GxFzk&V2a4R8iF62G9]q",
+}
+`;

--- a/packages/destination-actions/src/destinations/recombee/addBookmark/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/addBookmark/__tests__/index.test.ts
@@ -1,0 +1,110 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { Settings } from '../../generated-types'
+import { randomUUID } from 'crypto'
+
+const testDestination = createTestIntegration(Destination)
+
+const DATABASE_ID = 'test-database'
+const SETTINGS: Settings = {
+  databaseId: DATABASE_ID,
+  privateToken: 'VALID_TOKEN',
+  databaseRegion: 'eu-west'
+}
+
+describe('addBookmark', () => {
+  it('should validate action fields', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .post(`/${DATABASE_ID}/bookmarks/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/
+      })
+      .reply(200, 'ok')
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id'
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('addBookmark', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true
+    })
+
+    expect(await response[0].request.json()).toMatchObject({
+      userId: 'user-id',
+      itemId: 'product-id',
+      timestamp: '2021-09-01T00:00:00.000Z',
+      cascadeCreate: true
+    })
+  })
+
+  it('should validate action fields with recommId and additionalData', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .post(`/${DATABASE_ID}/bookmarks/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/
+      })
+      .reply(200, 'ok')
+
+    const recommId = randomUUID()
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id',
+        recomm_id: recommId
+      },
+      traits: {
+        region: 'region'
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('addBookmark', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true,
+      mapping: {
+        additionalData: {
+          region: {
+            '@path': '$.traits.region'
+          }
+        }
+      }
+    })
+
+    expect(await response[0].request.json()).toMatchObject({
+      userId: 'user-id',
+      itemId: 'product-id',
+      timestamp: '2021-09-01T00:00:00.000Z',
+      cascadeCreate: true,
+      recommId,
+      additionalData: {
+        region: 'region'
+      }
+    })
+  })
+
+  it('should throw an error when fields are not mapped', async () => {
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {}
+    })
+
+    await expect(
+      testDestination.testAction('addBookmark', {
+        event,
+        settings: SETTINGS,
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError(/itemId/)
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/addBookmark/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/addBookmark/__tests__/snapshot.test.ts
@@ -1,0 +1,71 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'addBookmark'
+const destinationSlug = 'Recombee'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/addBookmark/generated-types.ts
+++ b/packages/destination-actions/src/destinations/recombee/addBookmark/generated-types.ts
@@ -1,0 +1,26 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID of the user who bookmarked the item.
+   */
+  userId: string
+  /**
+   * The bookmarked item.
+   */
+  itemId: string
+  /**
+   * The UTC timestamp of when the bookmark event occurred.
+   */
+  timestamp?: string
+  /**
+   * The ID of the clicked recommendation (if the bookmark is based on a recommendation request).
+   */
+  recommId?: string
+  /**
+   * Additional data to be stored with the bookmark. *Keep this field empty unless instructed by the Recombee Support team.*
+   */
+  additionalData?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/recombee/addBookmark/index.ts
+++ b/packages/destination-actions/src/destinations/recombee/addBookmark/index.ts
@@ -1,0 +1,57 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { AddBookmark, Batch, RecombeeApiClient } from '../recombeeApiClient'
+import { interactionFields } from '../commonFields'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Add Bookmark',
+  description: 'Adds a bookmark of the given item made by the given user.',
+  defaultSubscription: 'type = "track" and ( event = "Product Added to Wishlist" or event = "Product Shared" )',
+  fields: {
+    userId: {
+      label: 'User ID',
+      description: 'The ID of the user who bookmarked the item.',
+      type: 'string',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      }
+    },
+    itemId: {
+      label: 'Item ID',
+      description: 'The bookmarked item.',
+      type: 'string',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.properties.product_id' },
+          then: { '@path': '$.properties.product_id' },
+          else: { '@path': '$.properties.asset_id' }
+        }
+      }
+    },
+    timestamp: {
+      label: 'Timestamp',
+      description: 'The UTC timestamp of when the bookmark event occurred.',
+      type: 'string',
+      required: false,
+      default: { '@path': '$.timestamp' }
+    },
+    ...interactionFields('bookmark')
+  },
+  perform: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(new AddBookmark(data.payload))
+  },
+  performBatch: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(new Batch(data.payload.map((payload) => new AddBookmark(payload))))
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/recombee/addCartAddition/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/recombee/addCartAddition/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Recombee's addCartAddition destination action: all fields 1`] = `
+Object {
+  "requests": Array [
+    Object {
+      "method": "POST",
+      "params": Object {
+        "additionalData": Object {
+          "testType": "E$o]!yX^hLQ^46#)",
+        },
+        "amount": 34128252129771.52,
+        "cascadeCreate": true,
+        "itemId": "E$o]!yX^hLQ^46#)",
+        "price": 34128252129771.52,
+        "recommId": "E$o]!yX^hLQ^46#)",
+        "timestamp": "E$o]!yX^hLQ^46#)",
+        "userId": "E$o]!yX^hLQ^46#)",
+      },
+      "path": "/cartadditions/",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for Recombee's addCartAddition destination action: required fields 1`] = `
+Object {
+  "requests": Array [
+    Object {
+      "method": "POST",
+      "params": Object {
+        "cascadeCreate": true,
+        "itemId": "E$o]!yX^hLQ^46#)",
+        "userId": "E$o]!yX^hLQ^46#)",
+      },
+      "path": "/cartadditions/",
+    },
+  ],
+}
+`;

--- a/packages/destination-actions/src/destinations/recombee/addCartAddition/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/addCartAddition/__tests__/index.test.ts
@@ -1,0 +1,211 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { Settings } from '../../generated-types'
+import { randomUUID } from 'crypto'
+
+const testDestination = createTestIntegration(Destination)
+
+const DATABASE_ID = 'test-database'
+const SETTINGS: Settings = {
+  databaseId: DATABASE_ID,
+  privateToken: 'VALID_TOKEN',
+  databaseRegion: 'eu-west'
+}
+
+describe('addCartAddition', () => {
+  it('should validate action fields', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .post(`/${DATABASE_ID}/batch/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/
+      })
+      .reply(200, [{ code: 200, json: 'ok' }])
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id'
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('addCartAddition', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true
+    })
+
+    expect(await response[0].request.json()).toMatchObject({
+      requests: [
+        {
+          method: 'POST',
+          path: '/cartadditions/',
+          params: {
+            userId: 'user-id',
+            itemId: 'product-id',
+            timestamp: '2021-09-01T00:00:00.000Z',
+            cascadeCreate: true
+          }
+        }
+      ]
+    })
+  })
+
+  it('should validate action fields with recommId and additionalData', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .post(`/${DATABASE_ID}/batch/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/
+      })
+      .reply(200, [{ code: 200, json: 'ok' }])
+
+    const recommId = randomUUID()
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id',
+        recomm_id: recommId
+      },
+      traits: {
+        region: 'region'
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('addCartAddition', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true,
+      mapping: {
+        additionalData: {
+          region: {
+            '@path': '$.traits.region'
+          }
+        }
+      }
+    })
+
+    expect(await response[0].request.json()).toMatchObject({
+      requests: [
+        {
+          method: 'POST',
+          path: '/cartadditions/',
+          params: {
+            userId: 'user-id',
+            itemId: 'product-id',
+            timestamp: '2021-09-01T00:00:00.000Z',
+            cascadeCreate: true,
+            recommId,
+            additionalData: {
+              region: 'region'
+            }
+          }
+        }
+      ]
+    })
+  })
+
+  it('should validate action fields with multiple items', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .post(`/${DATABASE_ID}/batch/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/
+      })
+      .reply(200, [
+        { code: 200, json: 'ok' },
+        { code: 200, json: 'ok' }
+      ])
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        products: [
+          {
+            product_id: 'item-1',
+            quantity: 1,
+            price: 100
+          },
+          {
+            product_id: 'item-2',
+            quantity: 2,
+            price: 200
+          }
+        ]
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('addCartAddition', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true,
+      mapping: {
+        items: {
+          '@arrayPath': [
+            '$.properties.products',
+            {
+              itemId: {
+                '@path': '$.product_id'
+              },
+              amount: {
+                '@path': '$.quantity'
+              },
+              price: {
+                '@path': '$.price'
+              }
+            }
+          ]
+        }
+      }
+    })
+
+    expect(await response[0].request.json()).toMatchObject({
+      requests: [
+        {
+          method: 'POST',
+          path: '/cartadditions/',
+          params: {
+            userId: 'user-id',
+            itemId: 'item-1',
+            timestamp: '2021-09-01T00:00:00.000Z',
+            cascadeCreate: true,
+            amount: 1,
+            price: 100
+          }
+        },
+        {
+          method: 'POST',
+          path: '/cartadditions/',
+          params: {
+            userId: 'user-id',
+            itemId: 'item-2',
+            timestamp: '2021-09-01T00:00:00.000Z',
+            cascadeCreate: true,
+            amount: 2,
+            price: 200
+          }
+        }
+      ]
+    })
+  })
+
+  it('should throw an error when fields are not mapped', async () => {
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {}
+    })
+
+    await expect(
+      testDestination.testAction('addCartAddition', {
+        event,
+        settings: SETTINGS,
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError(/itemId/)
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/addCartAddition/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/addCartAddition/__tests__/snapshot.test.ts
@@ -1,0 +1,71 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'addCartAddition'
+const destinationSlug = 'Recombee'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/addCartAddition/generated-types.ts
+++ b/packages/destination-actions/src/destinations/recombee/addCartAddition/generated-types.ts
@@ -1,0 +1,39 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID of the user who added the item to the cart.
+   */
+  userId: string
+  /**
+   * The items that were added to the cart.
+   */
+  items: {
+    /**
+     * ID of the item.
+     */
+    itemId: string
+    /**
+     * The amount (number) of the item added to the cart.
+     */
+    amount?: number
+    /**
+     * The price of the added item. If `amount` is greater than 1, the price of one item should be given.
+     */
+    price?: number
+  }[]
+  /**
+   * The UTC timestamp of when the cart addition occurred.
+   */
+  timestamp?: string
+  /**
+   * The ID of the clicked recommendation (if the cart addition is based on a recommendation request).
+   */
+  recommId?: string
+  /**
+   * Additional data to be stored with the cart addition. *Keep this field empty unless instructed by the Recombee Support team.*
+   */
+  additionalData?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/recombee/addCartAddition/index.ts
+++ b/packages/destination-actions/src/destinations/recombee/addCartAddition/index.ts
@@ -1,0 +1,107 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { AddCartAddition, Batch, RecombeeApiClient } from '../recombeeApiClient'
+import { interactionFields } from '../commonFields'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Add Cart Addition',
+  description: 'Adds a cart addition of the given item made by the given user.',
+  defaultSubscription: 'type = "track" and event = "Product Added"',
+  fields: {
+    userId: {
+      label: 'User ID',
+      description: 'The ID of the user who added the item to the cart.',
+      type: 'string',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      }
+    },
+    items: {
+      label: 'Items',
+      description: 'The items that were added to the cart.',
+      type: 'object',
+      multiple: true,
+      required: true,
+      properties: {
+        itemId: {
+          label: 'Item ID',
+          description: 'ID of the item.',
+          type: 'string',
+          required: true
+        },
+        amount: {
+          label: 'Amount',
+          description: 'The amount (number) of the item added to the cart.',
+          type: 'number',
+          required: false,
+          default: 1
+        },
+        price: {
+          label: 'Price (per item)',
+          description:
+            'The price of the added item. If `amount` is greater than 1, the price of one item should be given.',
+          type: 'number',
+          required: false
+        }
+      },
+      default: {
+        // Product Added is an event with a single product
+        '@arrayPath': [
+          '$.properties',
+          {
+            itemId: {
+              '@if': {
+                exists: { '@path': '$.product_id' },
+                then: { '@path': '$.product_id' },
+                else: { '@path': '$.asset_id' }
+              }
+            },
+            amount: {
+              '@path': '$.quantity'
+            },
+            price: {
+              '@path': '$.price'
+            }
+          }
+        ]
+      }
+    },
+    timestamp: {
+      label: 'Timestamp',
+      description: 'The UTC timestamp of when the cart addition occurred.',
+      type: 'string',
+      required: false,
+      default: { '@path': '$.timestamp' }
+    },
+    ...interactionFields('cart addition')
+  },
+  perform: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(new Batch(payloadToInteractions(data.payload)))
+  },
+  performBatch: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(new Batch(data.payload.flatMap(payloadToInteractions)))
+  }
+}
+
+function payloadToInteractions(payload: Payload): AddCartAddition[] {
+  return payload.items.map(
+    (item) =>
+      new AddCartAddition({
+        userId: payload.userId,
+        ...item,
+        timestamp: payload.timestamp,
+        recommId: payload.recommId,
+        additionalData: payload.additionalData
+      })
+  )
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/recombee/addDetailView/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/recombee/addDetailView/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Recombee's addDetailView destination action: all fields 1`] = `
+Object {
+  "additionalData": Object {
+    "testType": "nW8&[lpB",
+  },
+  "cascadeCreate": true,
+  "duration": -5422425906872320,
+  "itemId": "nW8&[lpB",
+  "recommId": "nW8&[lpB",
+  "timestamp": "nW8&[lpB",
+  "userId": "nW8&[lpB",
+}
+`;
+
+exports[`Testing snapshot for Recombee's addDetailView destination action: required fields 1`] = `
+Object {
+  "cascadeCreate": true,
+  "itemId": "nW8&[lpB",
+  "userId": "nW8&[lpB",
+}
+`;

--- a/packages/destination-actions/src/destinations/recombee/addDetailView/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/addDetailView/__tests__/index.test.ts
@@ -1,0 +1,100 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { Settings } from '../../generated-types'
+import { randomUUID } from 'crypto'
+
+const testDestination = createTestIntegration(Destination)
+
+const DATABASE_ID = 'test-database'
+const SETTINGS: Settings = {
+  databaseId: DATABASE_ID,
+  privateToken: 'VALID_TOKEN',
+  databaseRegion: 'eu-west'
+}
+
+describe('addDetailView', () => {
+  it('should validate action fields', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .post(`/${DATABASE_ID}/detailviews/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/
+      })
+      .reply(200, 'ok')
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id'
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('addDetailView', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true
+    })
+
+    expect(await response[0].request.json()).toMatchObject({
+      userId: 'user-id',
+      itemId: 'product-id',
+      timestamp: '2021-09-01T00:00:00.000Z',
+      cascadeCreate: true
+    })
+  })
+
+  it('should validate action fields with recommId and additionalData', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .post(`/${DATABASE_ID}/detailviews/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/
+      })
+      .reply(200, [{ code: 200, json: 'ok' }])
+
+    const recommId = randomUUID()
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id',
+        recomm_id: recommId,
+        duration: 10
+      },
+      traits: {
+        region: 'region'
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('addDetailView', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true,
+      mapping: {
+        additionalData: {
+          region: {
+            '@path': '$.traits.region'
+          }
+        },
+        duration: {
+          '@path': '$.properties.duration'
+        }
+      }
+    })
+
+    expect(await response[0].request.json()).toMatchObject({
+      userId: 'user-id',
+      itemId: 'product-id',
+      timestamp: '2021-09-01T00:00:00.000Z',
+      duration: 10,
+      cascadeCreate: true,
+      recommId,
+      additionalData: {
+        region: 'region'
+      }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/addDetailView/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/addDetailView/__tests__/snapshot.test.ts
@@ -1,0 +1,71 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'addDetailView'
+const destinationSlug = 'Recombee'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/addDetailView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/recombee/addDetailView/generated-types.ts
@@ -1,0 +1,30 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID of the user who viewed the item.
+   */
+  userId: string
+  /**
+   * The viewed item.
+   */
+  itemId: string
+  /**
+   * The UTC timestamp of when the view occurred.
+   */
+  timestamp?: string
+  /**
+   * The duration of the view in seconds.
+   */
+  duration?: number
+  /**
+   * The ID of the clicked recommendation (if the view is based on a recommendation request).
+   */
+  recommId?: string
+  /**
+   * Additional data to be stored with the view. *Keep this field empty unless instructed by the Recombee Support team.*
+   */
+  additionalData?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/recombee/addDetailView/index.ts
+++ b/packages/destination-actions/src/destinations/recombee/addDetailView/index.ts
@@ -1,0 +1,62 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { AddDetailView, Batch, RecombeeApiClient } from '../recombeeApiClient'
+import { interactionFields } from '../commonFields'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Add Detail View',
+  description: 'Adds a detail view of the given item made by the given user.',
+  fields: {
+    userId: {
+      label: 'User ID',
+      description: 'The ID of the user who viewed the item.',
+      type: 'string',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      }
+    },
+    itemId: {
+      label: 'Item ID',
+      description: 'The viewed item.',
+      type: 'string',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.properties.product_id' },
+          then: { '@path': '$.properties.product_id' },
+          else: { '@path': '$.properties.asset_id' }
+        }
+      }
+    },
+    timestamp: {
+      label: 'Timestamp',
+      description: 'The UTC timestamp of when the view occurred.',
+      type: 'string',
+      required: false,
+      default: { '@path': '$.timestamp' }
+    },
+    duration: {
+      label: 'Duration',
+      description: 'The duration of the view in seconds.',
+      type: 'integer',
+      required: false
+    },
+    ...interactionFields('view')
+  },
+  perform: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(new AddDetailView(data.payload))
+  },
+  performBatch: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(new Batch(data.payload.map((payload) => new AddDetailView(payload))))
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/recombee/addPurchase/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/recombee/addPurchase/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Recombee's addPurchase destination action: all fields 1`] = `
+Object {
+  "requests": Array [
+    Object {
+      "method": "POST",
+      "params": Object {
+        "additionalData": Object {
+          "testType": "o@fME^0ckHa[VN6e&Zv*",
+        },
+        "amount": 89304067955752.95,
+        "cascadeCreate": true,
+        "itemId": "o@fME^0ckHa[VN6e&Zv*",
+        "price": 89304067955752.95,
+        "profit": 89304067955752.95,
+        "recommId": "o@fME^0ckHa[VN6e&Zv*",
+        "timestamp": "o@fME^0ckHa[VN6e&Zv*",
+        "userId": "o@fME^0ckHa[VN6e&Zv*",
+      },
+      "path": "/purchases/",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for Recombee's addPurchase destination action: required fields 1`] = `
+Object {
+  "requests": Array [
+    Object {
+      "method": "POST",
+      "params": Object {
+        "cascadeCreate": true,
+        "itemId": "o@fME^0ckHa[VN6e&Zv*",
+        "userId": "o@fME^0ckHa[VN6e&Zv*",
+      },
+      "path": "/purchases/",
+    },
+  ],
+}
+`;

--- a/packages/destination-actions/src/destinations/recombee/addPurchase/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/addPurchase/__tests__/index.test.ts
@@ -1,0 +1,190 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { Settings } from '../../generated-types'
+import { randomUUID } from 'crypto'
+
+const testDestination = createTestIntegration(Destination)
+
+const DATABASE_ID = 'test-database'
+const SETTINGS: Settings = {
+  databaseId: DATABASE_ID,
+  privateToken: 'VALID_TOKEN',
+  databaseRegion: 'eu-west'
+}
+
+describe('addPurchase', () => {
+  it('should validate action fields', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .post(`/${DATABASE_ID}/batch/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/
+      })
+      .reply(200, [
+        { code: 200, json: 'ok' },
+        { code: 200, json: 'ok' }
+      ])
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        products: [
+          {
+            product_id: 'item-1',
+            quantity: 1,
+            price: 100
+          },
+          {
+            product_id: 'item-2',
+            quantity: 2,
+            price: 200
+          }
+        ]
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('addPurchase', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true
+    })
+
+    expect(await response[0].request.json()).toMatchObject({
+      requests: [
+        {
+          method: 'POST',
+          path: '/purchases/',
+          params: {
+            userId: 'user-id',
+            itemId: 'item-1',
+            timestamp: '2021-09-01T00:00:00.000Z',
+            cascadeCreate: true,
+            amount: 1,
+            price: 100
+          }
+        },
+        {
+          method: 'POST',
+          path: '/purchases/',
+          params: {
+            userId: 'user-id',
+            itemId: 'item-2',
+            timestamp: '2021-09-01T00:00:00.000Z',
+            cascadeCreate: true,
+            amount: 2,
+            price: 200
+          }
+        }
+      ]
+    })
+  })
+
+  it('should validate action fields with profit, recommId and additionalData', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .post(`/${DATABASE_ID}/batch/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/
+      })
+      .reply(200, [
+        { code: 200, json: 'ok' },
+        { code: 200, json: 'ok' }
+      ])
+
+    const recommId = randomUUID()
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        products: [
+          {
+            product_id: 'item-1',
+            quantity: 1,
+            price: 100,
+            profit: 15
+          },
+          {
+            product_id: 'item-2',
+            quantity: 2,
+            price: 200,
+            profit: 40
+          }
+        ],
+        recomm_id: recommId
+      },
+      traits: {
+        region: 'region'
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('addPurchase', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true,
+      mapping: {
+        additionalData: {
+          region: {
+            '@path': '$.traits.region'
+          }
+        }
+      }
+    })
+
+    expect(await response[0].request.json()).toMatchObject({
+      requests: [
+        {
+          method: 'POST',
+          path: '/purchases/',
+          params: {
+            userId: 'user-id',
+            itemId: 'item-1',
+            timestamp: '2021-09-01T00:00:00.000Z',
+            cascadeCreate: true,
+            amount: 1,
+            price: 100,
+            profit: 15,
+            recommId,
+            additionalData: {
+              region: 'region'
+            }
+          }
+        },
+        {
+          method: 'POST',
+          path: '/purchases/',
+          params: {
+            userId: 'user-id',
+            itemId: 'item-2',
+            timestamp: '2021-09-01T00:00:00.000Z',
+            cascadeCreate: true,
+            amount: 2,
+            price: 200,
+            profit: 40,
+            recommId,
+            additionalData: {
+              region: 'region'
+            }
+          }
+        }
+      ]
+    })
+  })
+
+  it('should throw an error when fields are not mapped', async () => {
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {}
+    })
+
+    await expect(
+      testDestination.testAction('addPurchase', {
+        event,
+        settings: SETTINGS,
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError(/items/)
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/addPurchase/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/addPurchase/__tests__/snapshot.test.ts
@@ -1,0 +1,71 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'addPurchase'
+const destinationSlug = 'Recombee'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/addPurchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/recombee/addPurchase/generated-types.ts
@@ -1,0 +1,43 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID of the user who purchased the item(s).
+   */
+  userId: string
+  /**
+   * The items that were purchased.
+   */
+  items: {
+    /**
+     * ID of the item.
+     */
+    itemId: string
+    /**
+     * The amount (number) of the item purchased.
+     */
+    amount?: number
+    /**
+     * The price of the purchased item. If `amount` is greater than 1, the price of one item should be given.
+     */
+    price?: number
+    /**
+     * The profit of the purchased item. If `amount` is greater than 1, the profit per one item should be given.
+     */
+    profit?: number
+  }[]
+  /**
+   * The UTC timestamp of when the purchase occurred.
+   */
+  timestamp?: string
+  /**
+   * The ID of the clicked recommendation (if the purchase is based on a recommendation request).
+   */
+  recommId?: string
+  /**
+   * Additional data to be stored with the purchase. *Keep this field empty unless instructed by the Recombee Support team.*
+   */
+  additionalData?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/recombee/addPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/recombee/addPurchase/index.ts
@@ -1,0 +1,116 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { AddPurchase, Batch, RecombeeApiClient } from '../recombeeApiClient'
+import { interactionFields } from '../commonFields'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Add Purchase',
+  description: 'Adds a purchase of the given item(s) made by the given user.',
+  fields: {
+    userId: {
+      label: 'User ID',
+      description: 'The ID of the user who purchased the item(s).',
+      type: 'string',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      }
+    },
+    items: {
+      label: 'Items',
+      description: 'The items that were purchased.',
+      type: 'object',
+      multiple: true,
+      required: true,
+      properties: {
+        itemId: {
+          label: 'Item ID',
+          description: 'ID of the item.',
+          type: 'string',
+          required: true
+        },
+        amount: {
+          label: 'Amount',
+          description: 'The amount (number) of the item purchased.',
+          type: 'number',
+          required: false,
+          default: 1
+        },
+        price: {
+          label: 'Price (per item)',
+          description:
+            'The price of the purchased item. If `amount` is greater than 1, the price of one item should be given.',
+          type: 'number',
+          required: false
+        },
+        profit: {
+          label: 'Profit (per item)',
+          description:
+            'The profit of the purchased item. If `amount` is greater than 1, the profit per one item should be given.',
+          type: 'number',
+          required: false
+        }
+      },
+      default: {
+        // Order Completed is an event with an array of products
+        '@arrayPath': [
+          '$.properties.products',
+          {
+            itemId: {
+              '@if': {
+                exists: { '@path': '$.product_id' },
+                then: { '@path': '$.product_id' },
+                else: { '@path': '$.sku' }
+              }
+            },
+            amount: {
+              '@path': '$.quantity'
+            },
+            price: {
+              '@path': '$.price'
+            },
+            profit: {
+              '@path': '$.profit'
+            }
+          }
+        ]
+      }
+    },
+    timestamp: {
+      label: 'Timestamp',
+      description: 'The UTC timestamp of when the purchase occurred.',
+      type: 'string',
+      required: false,
+      default: { '@path': '$.timestamp' }
+    },
+    ...interactionFields('purchase')
+  },
+  perform: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(new Batch(payloadToInteractions(data.payload)))
+  },
+  performBatch: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(new Batch(data.payload.flatMap(payloadToInteractions)))
+  }
+}
+
+function payloadToInteractions(payload: Payload): AddPurchase[] {
+  return payload.items.map(
+    (item) =>
+      new AddPurchase({
+        userId: payload.userId,
+        ...item,
+        timestamp: payload.timestamp,
+        recommId: payload.recommId,
+        additionalData: payload.additionalData
+      })
+  )
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/recombee/addRating/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/recombee/addRating/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Recombee's addRating destination action: all fields 1`] = `
+Object {
+  "additionalData": Object {
+    "testType": "ANsNPl1sV!#5(%#",
+  },
+  "cascadeCreate": true,
+  "itemId": "ANsNPl1sV!#5(%#",
+  "rating": 29019912231976.96,
+  "recommId": "ANsNPl1sV!#5(%#",
+  "timestamp": "ANsNPl1sV!#5(%#",
+  "userId": "ANsNPl1sV!#5(%#",
+}
+`;
+
+exports[`Testing snapshot for Recombee's addRating destination action: required fields 1`] = `
+Object {
+  "cascadeCreate": true,
+  "itemId": "ANsNPl1sV!#5(%#",
+  "rating": 29019912231976.96,
+  "userId": "ANsNPl1sV!#5(%#",
+}
+`;

--- a/packages/destination-actions/src/destinations/recombee/addRating/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/addRating/__tests__/index.test.ts
@@ -1,0 +1,126 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { Settings } from '../../generated-types'
+import { randomUUID } from 'crypto'
+
+const testDestination = createTestIntegration(Destination)
+
+const DATABASE_ID = 'test-database'
+const SETTINGS: Settings = {
+  databaseId: DATABASE_ID,
+  privateToken: 'VALID_TOKEN',
+  databaseRegion: 'eu-west'
+}
+
+describe('addRating', () => {
+  it('should validate action fields', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .post(`/${DATABASE_ID}/ratings/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/
+      })
+      .reply(200, 'ok')
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id',
+        rating: 0.5
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('addRating', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true
+    })
+
+    expect(await response[0].request.json()).toMatchObject({
+      userId: 'user-id',
+      itemId: 'product-id',
+      timestamp: '2021-09-01T00:00:00.000Z',
+      rating: 0.5,
+      cascadeCreate: true
+    })
+  })
+
+  it('should validate action fields with recommId and additionalData', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .post(`/${DATABASE_ID}/ratings/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/
+      })
+      .reply(200, 'ok')
+
+    const recommId = randomUUID()
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id',
+        recomm_id: recommId,
+        rating: 0.5
+      },
+      traits: {
+        region: 'region'
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('addRating', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true,
+      mapping: {
+        additionalData: {
+          region: {
+            '@path': '$.traits.region'
+          }
+        }
+      }
+    })
+
+    expect(await response[0].request.json()).toMatchObject({
+      userId: 'user-id',
+      itemId: 'product-id',
+      timestamp: '2021-09-01T00:00:00.000Z',
+      rating: 0.5,
+      cascadeCreate: true,
+      recommId,
+      additionalData: {
+        region: 'region'
+      }
+    })
+  })
+
+  it('should fail when rating is out of bounds', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .post(`/${DATABASE_ID}/ratings/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/
+      })
+      .reply(400, { message: 'Rating must be a real number from [-1.0,1.0]' })
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id',
+        rating: 1.5
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    await expect(
+      testDestination.testAction('addRating', {
+        event,
+        settings: SETTINGS,
+        useDefaultMappings: true
+      })
+    ).rejects.toThrow()
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/addRating/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/addRating/__tests__/snapshot.test.ts
@@ -1,0 +1,71 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'addRating'
+const destinationSlug = 'Recombee'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/addRating/generated-types.ts
+++ b/packages/destination-actions/src/destinations/recombee/addRating/generated-types.ts
@@ -1,0 +1,30 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID of the user who submitted the rating.
+   */
+  userId: string
+  /**
+   * The rated item.
+   */
+  itemId: string
+  /**
+   * The UTC timestamp of when the rating occurred.
+   */
+  timestamp?: string
+  /**
+   * The rating of the item rescaled to interval [-1.0,1.0], where -1.0 means the worst rating possible, 0.0 means neutral, and 1.0 means absolutely positive rating. For example, in the case of 5-star evaluations, rating = (numStars-3)/2 formula may be used for the conversion.
+   */
+  rating: number
+  /**
+   * The ID of the clicked recommendation (if the rating is based on a recommendation request).
+   */
+  recommId?: string
+  /**
+   * Additional data to be stored with the rating. *Keep this field empty unless instructed by the Recombee Support team.*
+   */
+  additionalData?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/recombee/addRating/index.ts
+++ b/packages/destination-actions/src/destinations/recombee/addRating/index.ts
@@ -1,0 +1,64 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { AddRating, Batch, RecombeeApiClient } from '../recombeeApiClient'
+import { interactionFields } from '../commonFields'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Add Rating',
+  description: 'Adds a rating of the given item made by the given user.',
+  fields: {
+    userId: {
+      label: 'User ID',
+      description: 'The ID of the user who submitted the rating.',
+      type: 'string',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      }
+    },
+    itemId: {
+      label: 'Item ID',
+      description: 'The rated item.',
+      type: 'string',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.properties.product_id' },
+          then: { '@path': '$.properties.product_id' },
+          else: { '@path': '$.properties.asset_id' }
+        }
+      }
+    },
+    timestamp: {
+      label: 'Timestamp',
+      description: 'The UTC timestamp of when the rating occurred.',
+      type: 'string',
+      required: false,
+      default: { '@path': '$.timestamp' }
+    },
+    rating: {
+      label: 'Rating',
+      description:
+        'The rating of the item rescaled to interval [-1.0,1.0], where -1.0 means the worst rating possible, 0.0 means neutral, and 1.0 means absolutely positive rating. For example, in the case of 5-star evaluations, rating = (numStars-3)/2 formula may be used for the conversion.',
+      type: 'number',
+      required: true,
+      default: { '@path': '$.properties.rating' }
+    },
+    ...interactionFields('rating')
+  },
+  perform: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(new AddRating(data.payload))
+  },
+  performBatch: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(new Batch(data.payload.map((payload) => new AddRating(payload))))
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/recombee/commonFields.ts
+++ b/packages/destination-actions/src/destinations/recombee/commonFields.ts
@@ -1,0 +1,42 @@
+import { InputField } from '@segment/actions-core'
+
+export function interactionFields(interactionName: string): Record<string, InputField> {
+  return {
+    recommId: {
+      label: 'Recommendation ID',
+      description: `The ID of the clicked recommendation (if the ${interactionName} is based on a recommendation request).`,
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.properties.recomm_id'
+      }
+    },
+    additionalData: {
+      label: 'Additional Data',
+      description: `Additional data to be stored with the ${interactionName}. *Keep this field empty unless instructed by the Recombee Support team.*`,
+      type: 'object',
+      required: false,
+      displayMode: 'collapsed'
+    }
+  }
+}
+
+export const ecommerceIdMapping = {
+  itemId: {
+    '@if': {
+      exists: { '@path': '$.product_id' },
+      then: { '@path': '$.product_id' },
+      else: { '@path': '$.sku' }
+    }
+  }
+}
+
+export const videoIdMapping = {
+  itemId: {
+    '@if': {
+      exists: { '@path': '$.properties.content_asset_id' },
+      then: { '@path': '$.properties.content_asset_id' },
+      else: { '@path': '$.properties.content_asset_ids[0]' }
+    }
+  }
+}

--- a/packages/destination-actions/src/destinations/recombee/deleteBookmark/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/recombee/deleteBookmark/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Recombee's deleteBookmark destination action: all fields 1`] = `
+Object {
+  "itemId": "[$3KBO5bBa",
+  "timestamp": "[$3KBO5bBa",
+  "userId": "[$3KBO5bBa",
+}
+`;
+
+exports[`Testing snapshot for Recombee's deleteBookmark destination action: required fields 1`] = `
+Object {
+  "itemId": "[$3KBO5bBa",
+  "userId": "[$3KBO5bBa",
+}
+`;

--- a/packages/destination-actions/src/destinations/recombee/deleteBookmark/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/deleteBookmark/__tests__/index.test.ts
@@ -1,0 +1,113 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { Settings } from '../../generated-types'
+
+const testDestination = createTestIntegration(Destination)
+
+const DATABASE_ID = 'test-database'
+const SETTINGS: Settings = {
+  databaseId: DATABASE_ID,
+  privateToken: 'VALID_TOKEN',
+  databaseRegion: 'eu-west'
+}
+
+describe('deleteBookmark', () => {
+  it('should validate action fields', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .delete(`/${DATABASE_ID}/bookmarks/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/,
+        userId: 'user-id',
+        itemId: 'product-id'
+      })
+      .reply(200, 'ok')
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id'
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('deleteBookmark', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true
+    })
+
+    expect(response[0].request.url).toMatch(/.*\/?.*(userId=user-id&itemId=product-id).*/)
+  })
+
+  it('should validate action fields with timestamp as string', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .delete(`/${DATABASE_ID}/bookmarks/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/,
+        userId: 'user-id',
+        itemId: 'product-id',
+        timestamp: /.*/
+      })
+      .reply(200, 'ok')
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id',
+        originalTimestamp: '2021-09-01T00:00:00.000Z'
+      },
+      timestamp: '2021-09-02T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('deleteBookmark', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true,
+      mapping: {
+        timestamp: {
+          '@path': '$.properties.originalTimestamp'
+        }
+      }
+    })
+
+    expect(response[0].request.url).toMatch(/.*\/?.*(userId=user-id&itemId=product-id&timestamp=1630454400000).*/)
+  })
+
+  it('should validate action fields with timestamp as Unix number', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .delete(`/${DATABASE_ID}/bookmarks/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/,
+        userId: 'user-id',
+        itemId: 'product-id',
+        timestamp: /.*/
+      })
+      .reply(200, 'ok')
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id',
+        originalTimestamp: 1630454000000
+      },
+      timestamp: '2021-09-02T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('deleteBookmark', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true,
+      mapping: {
+        timestamp: {
+          '@path': '$.properties.originalTimestamp'
+        }
+      }
+    })
+
+    expect(response[0].request.url).toMatch(/.*\/?.*(userId=user-id&itemId=product-id&timestamp=1630454000000).*/)
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/deleteBookmark/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/deleteBookmark/__tests__/snapshot.test.ts
@@ -1,0 +1,71 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'deleteBookmark'
+const destinationSlug = 'Recombee'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().delete(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().delete(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/deleteBookmark/generated-types.ts
+++ b/packages/destination-actions/src/destinations/recombee/deleteBookmark/generated-types.ts
@@ -1,0 +1,16 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID of the user who bookmarked the item.
+   */
+  userId: string
+  /**
+   * The item that was bookmarked.
+   */
+  itemId: string
+  /**
+   * The UTC timestamp of when the bookmark occurred. If the timestamp is omitted, then all the bookmarks with the given `userId` and `itemId` are deleted.
+   */
+  timestamp?: string
+}

--- a/packages/destination-actions/src/destinations/recombee/deleteBookmark/index.ts
+++ b/packages/destination-actions/src/destinations/recombee/deleteBookmark/index.ts
@@ -1,0 +1,55 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { Batch, DeleteBookmark, RecombeeApiClient } from '../recombeeApiClient'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Delete Bookmark',
+  description: 'Deletes a bookmark of the given item made by the given user.',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    userId: {
+      label: 'User ID',
+      description: 'The ID of the user who bookmarked the item.',
+      type: 'string',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      }
+    },
+    itemId: {
+      label: 'Item ID',
+      description: 'The item that was bookmarked.',
+      type: 'string',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.properties.product_id' },
+          then: { '@path': '$.properties.product_id' },
+          else: { '@path': '$.properties.asset_id' }
+        }
+      }
+    },
+    timestamp: {
+      label: 'Timestamp',
+      description:
+        'The UTC timestamp of when the bookmark occurred. If the timestamp is omitted, then all the bookmarks with the given `userId` and `itemId` are deleted.',
+      type: 'string',
+      required: false
+    }
+  },
+  perform: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(new DeleteBookmark(data.payload))
+  },
+  performBatch: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(new Batch(data.payload.map((payload) => new DeleteBookmark(payload))))
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/recombee/deleteCartAddition/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/recombee/deleteCartAddition/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Recombee's deleteCartAddition destination action: all fields 1`] = `
+Object {
+  "itemId": "IvOr9H3r",
+  "timestamp": "IvOr9H3r",
+  "userId": "IvOr9H3r",
+}
+`;
+
+exports[`Testing snapshot for Recombee's deleteCartAddition destination action: required fields 1`] = `
+Object {
+  "itemId": "IvOr9H3r",
+  "userId": "IvOr9H3r",
+}
+`;

--- a/packages/destination-actions/src/destinations/recombee/deleteCartAddition/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/deleteCartAddition/__tests__/index.test.ts
@@ -1,0 +1,113 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { Settings } from '../../generated-types'
+
+const testDestination = createTestIntegration(Destination)
+
+const DATABASE_ID = 'test-database'
+const SETTINGS: Settings = {
+  databaseId: DATABASE_ID,
+  privateToken: 'VALID_TOKEN',
+  databaseRegion: 'eu-west'
+}
+
+describe('deleteCartAddition', () => {
+  it('should validate action fields', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .delete(`/${DATABASE_ID}/cartadditions/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/,
+        userId: 'user-id',
+        itemId: 'product-id'
+      })
+      .reply(200, 'ok')
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id'
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('deleteCartAddition', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true
+    })
+
+    expect(response[0].request.url).toMatch(/.*\/?.*(userId=user-id&itemId=product-id).*/)
+  })
+
+  it('should validate action fields with timestamp as string', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .delete(`/${DATABASE_ID}/cartadditions/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/,
+        userId: 'user-id',
+        itemId: 'product-id',
+        timestamp: /.*/
+      })
+      .reply(200, 'ok')
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id',
+        originalTimestamp: '2021-09-01T00:00:00.000Z'
+      },
+      timestamp: '2021-09-02T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('deleteCartAddition', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true,
+      mapping: {
+        timestamp: {
+          '@path': '$.properties.originalTimestamp'
+        }
+      }
+    })
+
+    expect(response[0].request.url).toMatch(/.*\/?.*(userId=user-id&itemId=product-id&timestamp=1630454400000).*/)
+  })
+
+  it('should validate action fields with timestamp as Unix number', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .delete(`/${DATABASE_ID}/cartadditions/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/,
+        userId: 'user-id',
+        itemId: 'product-id',
+        timestamp: /.*/
+      })
+      .reply(200, 'ok')
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id',
+        originalTimestamp: 1630454000000
+      },
+      timestamp: '2021-09-02T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('deleteCartAddition', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true,
+      mapping: {
+        timestamp: {
+          '@path': '$.properties.originalTimestamp'
+        }
+      }
+    })
+
+    expect(response[0].request.url).toMatch(/.*\/?.*(userId=user-id&itemId=product-id&timestamp=1630454000000).*/)
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/deleteCartAddition/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/deleteCartAddition/__tests__/snapshot.test.ts
@@ -1,0 +1,71 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'deleteCartAddition'
+const destinationSlug = 'Recombee'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().delete(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().delete(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/deleteCartAddition/generated-types.ts
+++ b/packages/destination-actions/src/destinations/recombee/deleteCartAddition/generated-types.ts
@@ -1,0 +1,16 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID of the user who added the item to the cart.
+   */
+  userId: string
+  /**
+   * The item that was added to the cart.
+   */
+  itemId: string
+  /**
+   * The UTC timestamp of when the bookmark occurred. If the timestamp is omitted, then all the bookmarks with the given `userId` and `itemId` are deleted.
+   */
+  timestamp?: string
+}

--- a/packages/destination-actions/src/destinations/recombee/deleteCartAddition/index.ts
+++ b/packages/destination-actions/src/destinations/recombee/deleteCartAddition/index.ts
@@ -1,0 +1,55 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { Batch, DeleteCartAddition, RecombeeApiClient } from '../recombeeApiClient'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Delete Cart Addition',
+  description: 'Deletes a cart addition of the given item made by the given user.',
+  defaultSubscription: 'type = "track" and event = "Product Removed"',
+  fields: {
+    userId: {
+      label: 'User ID',
+      description: 'The ID of the user who added the item to the cart.',
+      type: 'string',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      }
+    },
+    itemId: {
+      label: 'Item ID',
+      description: 'The item that was added to the cart.',
+      type: 'string',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.properties.product_id' },
+          then: { '@path': '$.properties.product_id' },
+          else: { '@path': '$.properties.asset_id' }
+        }
+      }
+    },
+    timestamp: {
+      label: 'Timestamp',
+      description:
+        'The UTC timestamp of when the bookmark occurred. If the timestamp is omitted, then all the bookmarks with the given `userId` and `itemId` are deleted.',
+      type: 'string',
+      required: false
+    }
+  },
+  perform: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(new DeleteCartAddition(data.payload))
+  },
+  performBatch: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(new Batch(data.payload.map((payload) => new DeleteCartAddition(payload))))
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/recombee/generated-types.ts
+++ b/packages/destination-actions/src/destinations/recombee/generated-types.ts
@@ -1,0 +1,20 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * The ID of the Recombee Database into which the interactions will be sent.
+   */
+  databaseId: string
+  /**
+   * The private token for the Recombee Database used.
+   */
+  privateToken: string
+  /**
+   * The Recombee cluster where your Database is located. [Learn more](https://docs.recombee.com/regions)
+   */
+  databaseRegion: string
+  /**
+   * URI of the Recombee API that should be used. *Keep this field empty unless you are calling the Recombee cluster based in a specific region or you were assigned a custom URI by the Recombee Support team.*
+   */
+  apiUri?: string
+}

--- a/packages/destination-actions/src/destinations/recombee/index.ts
+++ b/packages/destination-actions/src/destinations/recombee/index.ts
@@ -1,0 +1,236 @@
+import { defaultValues, DestinationDefinition, RequestClient } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+import { Batch, DeleteUser, RecombeeApiClient } from './recombeeApiClient'
+
+import addBookmark from './addBookmark'
+import addCartAddition from './addCartAddition'
+import addDetailView from './addDetailView'
+import addPurchase from './addPurchase'
+import addRating from './addRating'
+import deleteCartAddition from './deleteCartAddition'
+import mergeUsers from './mergeUsers'
+import setViewPortion from './setViewPortion'
+import setViewPortionFromWatchTime from './setViewPortionFromWatchTime'
+import deleteBookmark from './deleteBookmark'
+import { ecommerceIdMapping, videoIdMapping } from './commonFields'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Recombee',
+  slug: 'actions-recombee',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      databaseId: {
+        label: 'Database ID',
+        description: 'The ID of the Recombee Database into which the interactions will be sent.',
+        type: 'string',
+        required: true
+      },
+      privateToken: {
+        label: 'Private Token',
+        description: 'The private token for the Recombee Database used.',
+        type: 'password',
+        required: true
+      },
+      databaseRegion: {
+        label: 'Database Region',
+        description:
+          'The Recombee cluster where your Database is located. [Learn more](https://docs.recombee.com/regions)',
+        type: 'string',
+        required: true,
+        format: 'hostname',
+        default: 'eu-west',
+        choices: [
+          { value: 'eu-west', label: 'EU' },
+          { value: 'ca-east', label: 'Canada (East Coast)' },
+          { value: 'ap-se', label: 'Australia' },
+          { value: 'us-west', label: 'US (West Coast)' },
+          { value: 'custom', label: 'Custom' }
+        ]
+      },
+      apiUri: {
+        label: 'API URI',
+        description:
+          'URI of the Recombee API that should be used. *Keep this field empty unless you are calling the Recombee cluster based in a specific region or you were assigned a custom URI by the Recombee Support team.*',
+        type: 'string',
+        required: false,
+        format: 'hostname',
+        depends_on: {
+          conditions: [
+            {
+              fieldKey: 'databaseRegion',
+              operator: 'is',
+              value: 'custom'
+            }
+          ]
+        }
+      }
+    },
+    testAuthentication: (request: RequestClient, { settings }) => {
+      const client = new RecombeeApiClient(settings, request)
+      return client.send(new Batch([]))
+    }
+  },
+
+  presets: [
+    {
+      name: 'Page - Viewed',
+      subscribe: 'type = "page"',
+      partnerAction: 'addDetailView',
+      mapping: {
+        ...defaultValues(addDetailView.fields),
+        itemId: { '@path': '$.name' }
+      },
+      type: 'automatic'
+    },
+    {
+      name: 'Track - Ecommerce - Product Viewed',
+      subscribe: 'type = "track" and event = "Product Viewed"',
+      partnerAction: 'addDetailView',
+      mapping: {
+        ...defaultValues(addDetailView.fields),
+        ...ecommerceIdMapping
+      },
+      type: 'automatic'
+    },
+    {
+      name: 'Track - Ecommerce - Product Added',
+      subscribe: 'type = "track" and event = "Product Added"',
+      partnerAction: 'addCartAddition',
+      mapping: {
+        ...defaultValues(addCartAddition.fields),
+        ...ecommerceIdMapping
+      },
+      type: 'automatic'
+    },
+    {
+      name: 'Track - Ecommerce - Product Removed',
+      subscribe: 'type = "track" and event = "Product Removed"',
+      partnerAction: 'deleteCartAddition',
+      mapping: {
+        ...defaultValues(deleteCartAddition.fields),
+        ...ecommerceIdMapping
+      },
+      type: 'automatic'
+    },
+    {
+      name: 'Track - Ecommerce - Order Completed',
+      subscribe: 'type = "track" and event = "Order Completed"',
+      partnerAction: 'addPurchase',
+      mapping: defaultValues(addPurchase.fields),
+      type: 'automatic'
+    },
+    {
+      name: 'Track - Ecommerce - Product Added to Wishlist',
+      subscribe: 'type = "track" and event = "Product Added to Wishlist"',
+      partnerAction: 'addBookmark',
+      mapping: {
+        ...defaultValues(addBookmark.fields),
+        ...ecommerceIdMapping
+      },
+      type: 'automatic'
+    },
+    {
+      name: 'Track - Ecommerce - Product Removed from Wishlist',
+      subscribe: 'type = "track" and event = "Product Removed from Wishlist"',
+      partnerAction: 'deleteBookmark',
+      mapping: {
+        ...defaultValues(deleteBookmark.fields),
+        ...ecommerceIdMapping
+      },
+      type: 'automatic'
+    },
+    {
+      name: 'Track - Ecommerce - Product Shared',
+      subscribe: 'type = "track" and event = "Product Shared"',
+      partnerAction: 'addBookmark',
+      mapping: {
+        ...defaultValues(addBookmark.fields),
+        ...ecommerceIdMapping
+      },
+      type: 'automatic'
+    },
+    {
+      name: 'Track - Video - Video Playback Started',
+      subscribe: 'type = "track" and event = "Video Playback Started"',
+      partnerAction: 'setViewPortion',
+      mapping: {
+        ...defaultValues(setViewPortion.fields),
+        ...videoIdMapping,
+        portion: 0
+      },
+      type: 'automatic'
+    },
+    {
+      name: 'Track - Video - Video Content Playing',
+      subscribe: 'type = "track" and event = "Video Content Playing"',
+      partnerAction: 'setViewPortionFromWatchTime',
+      mapping: {
+        ...defaultValues(setViewPortionFromWatchTime.fields),
+        ...videoIdMapping
+      },
+      type: 'automatic'
+    },
+    {
+      name: 'Track - Video - Video Playback Paused',
+      subscribe: 'type = "track" and event = "Video Playback Paused"',
+      partnerAction: 'setViewPortionFromWatchTime',
+      mapping: {
+        ...defaultValues(setViewPortionFromWatchTime.fields),
+        itemId: { '@path': '$.properties.content_asset_id' }
+      },
+      type: 'automatic'
+    },
+    {
+      name: 'Track - Video - Video Playback Completed',
+      subscribe: 'type = "track" and event = "Video Playback Completed"',
+      partnerAction: 'setViewPortion',
+      mapping: {
+        ...defaultValues(setViewPortion.fields),
+        ...videoIdMapping,
+        portion: 1
+      },
+      type: 'automatic'
+    },
+    {
+      name: 'Screen - Viewed',
+      subscribe: 'type = "screen"',
+      partnerAction: 'addDetailView',
+      mapping: {
+        ...defaultValues(addDetailView.fields),
+        itemId: { '@path': '$.name' }
+      },
+      type: 'automatic'
+    },
+    {
+      name: 'Alias',
+      subscribe: 'type = "alias"',
+      partnerAction: 'mergeUsers',
+      mapping: defaultValues(mergeUsers.fields),
+      type: 'automatic'
+    }
+  ],
+
+  onDelete: async (request: RequestClient, { settings, payload }) => {
+    if (!payload.userId) return
+    const client = new RecombeeApiClient(settings, request)
+    return client.send(new DeleteUser(payload.userId))
+  },
+
+  actions: {
+    addBookmark,
+    addCartAddition,
+    addDetailView,
+    addPurchase,
+    addRating,
+    deleteBookmark,
+    deleteCartAddition,
+    mergeUsers,
+    setViewPortion,
+    setViewPortionFromWatchTime
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/recombee/mergeUsers/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/recombee/mergeUsers/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Recombee's mergeUsers destination action: all fields 1`] = `Object {}`;
+
+exports[`Testing snapshot for Recombee's mergeUsers destination action: required fields 1`] = `Object {}`;

--- a/packages/destination-actions/src/destinations/recombee/mergeUsers/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/mergeUsers/__tests__/index.test.ts
@@ -1,0 +1,58 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { Settings } from '../../generated-types'
+
+const testDestination = createTestIntegration(Destination)
+
+const DATABASE_ID = 'test-database'
+const SETTINGS: Settings = {
+  databaseId: DATABASE_ID,
+  privateToken: 'VALID_TOKEN',
+  databaseRegion: 'eu-west'
+}
+
+const TARGET_USER_ID = 'target-user'
+const SOURCE_USER_ID = 'source-user'
+
+describe('mergeUsers', () => {
+  it('should validate action fields', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .put(`/${DATABASE_ID}/users/${TARGET_USER_ID}/merge/${SOURCE_USER_ID}`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/,
+        cascadeCreate: true
+      })
+      .reply(200, 'ok')
+
+    const event = createTestEvent({
+      type: 'alias',
+      userId: TARGET_USER_ID,
+      previousId: SOURCE_USER_ID
+    })
+
+    const response = await testDestination.testAction('mergeUsers', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true
+    })
+
+    expect(response[0].status).toBe(200)
+    expect(response[0].data).toMatch('ok')
+  })
+
+  it('should throw an error when fields are not mapped', async () => {
+    const event = createTestEvent({
+      userId: TARGET_USER_ID
+    })
+
+    await expect(
+      testDestination.testAction('mergeUsers', {
+        event,
+        settings: SETTINGS,
+        useDefaultMappings: true
+      })
+    ).rejects.toThrow()
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/mergeUsers/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/mergeUsers/__tests__/snapshot.test.ts
@@ -1,0 +1,71 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'mergeUsers'
+const destinationSlug = 'Recombee'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/mergeUsers/generated-types.ts
+++ b/packages/destination-actions/src/destinations/recombee/mergeUsers/generated-types.ts
@@ -1,0 +1,12 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID of the target user that will be **kept** after the merge.
+   */
+  targetUserId: string
+  /**
+   * The ID of the source user that will be **deleted** after the merge.
+   */
+  sourceUserId: string
+}

--- a/packages/destination-actions/src/destinations/recombee/mergeUsers/index.ts
+++ b/packages/destination-actions/src/destinations/recombee/mergeUsers/index.ts
@@ -1,0 +1,39 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { Batch, MergeUsers, RecombeeApiClient } from '../recombeeApiClient'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Merge Users',
+  description:
+    'Merges interactions (purchases, ratings, bookmarks, detail views, ...) of two different users under a single user ID.',
+  defaultSubscription: 'type = "alias"',
+  fields: {
+    targetUserId: {
+      label: 'Target User ID',
+      description: 'The ID of the target user that will be **kept** after the merge.',
+      type: 'string',
+      required: true,
+      default: { '@path': '$.userId' }
+    },
+    sourceUserId: {
+      label: 'Source User ID',
+      description: 'The ID of the source user that will be **deleted** after the merge.',
+      type: 'string',
+      required: true,
+      default: { '@path': '$.previousId' }
+    }
+  },
+  perform: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(new MergeUsers(data.payload.targetUserId, data.payload.sourceUserId))
+  },
+  performBatch: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(
+      new Batch(data.payload.map((payload) => new MergeUsers(payload.targetUserId, payload.sourceUserId)))
+    )
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/recombee/recombeeApiClient.ts
+++ b/packages/destination-actions/src/destinations/recombee/recombeeApiClient.ts
@@ -1,0 +1,222 @@
+import { InvalidAuthenticationError, RequestClient } from '@segment/actions-core'
+import { Settings } from './generated-types'
+import { createHmac } from 'crypto'
+
+enum DatabaseRegion {
+  EU_WEST = 'eu-west',
+  CA_EAST = 'ca-east',
+  AP_SE = 'ap-se',
+  US_WEST = 'us-west',
+  CUSTOM = 'custom'
+}
+
+type AddBookmarkParams = {
+  userId: string
+  itemId: string
+  timestamp?: string | number
+  recommId?: string
+  additionalData?: unknown
+  cascadeCreate?: boolean
+}
+
+type AddCartAdditionParams = {
+  userId: string
+  itemId: string
+  timestamp?: string | number
+  amount?: number
+  price?: number
+  recommId?: string
+  additionalData?: unknown
+  cascadeCreate?: boolean
+}
+
+type AddDetailViewParams = {
+  userId: string
+  itemId: string
+  timestamp?: string | number
+  duration?: number
+  recommId?: string
+  additionalData?: unknown
+  cascadeCreate?: boolean
+}
+
+type AddPurchaseParams = {
+  userId: string
+  itemId: string
+  timestamp?: string | number
+  amount?: number
+  price?: number
+  profit?: number
+  recommId?: string
+  additionalData?: unknown
+  cascadeCreate?: boolean
+}
+
+type AddRatingParams = {
+  userId: string
+  itemId: string
+  rating: number
+  timestamp?: string | number
+  recommId?: string
+  additionalData?: unknown
+  cascadeCreate?: boolean
+}
+
+type DeleteParams = {
+  userId: string
+  itemId: string
+  timestamp?: string // since type in Segment is string, it will always be converted
+}
+
+type SetViewPortionParams = {
+  userId: string
+  itemId: string
+  portion: number
+  sessionId?: string
+  timestamp?: string | number
+  recommId?: string
+  additionalData?: unknown
+  cascadeCreate?: boolean
+}
+
+type BatchParams = {
+  requests: Array<{
+    method: HttpMethod
+    path: string
+    params:
+      | AddBookmarkParams
+      | AddCartAdditionParams
+      | AddDetailViewParams
+      | AddPurchaseParams
+      | AddRatingParams
+      | SetViewPortionParams
+      | DeleteParams
+      | {}
+  }>
+}
+
+type HttpMethod = 'POST' | 'PUT' | 'DELETE'
+
+abstract class Request<Params extends object> {
+  constructor(public params: Params, public method: HttpMethod, public path: string) {}
+}
+
+export class Batch extends Request<BatchParams> {
+  constructor(requests: BatchParams['requests']) {
+    super({ requests }, 'POST', '/batch/')
+  }
+}
+
+export class AddBookmark extends Request<AddBookmarkParams> {
+  constructor(params: AddBookmarkParams) {
+    super({ cascadeCreate: true, ...params }, 'POST', '/bookmarks/')
+  }
+}
+
+export class AddCartAddition extends Request<AddCartAdditionParams> {
+  constructor(params: AddCartAdditionParams) {
+    super({ cascadeCreate: true, ...params }, 'POST', '/cartadditions/')
+  }
+}
+
+export class AddDetailView extends Request<AddDetailViewParams> {
+  constructor(params: AddDetailViewParams) {
+    super({ cascadeCreate: true, ...params }, 'POST', '/detailviews/')
+  }
+}
+
+export class AddPurchase extends Request<AddPurchaseParams> {
+  constructor(params: AddPurchaseParams) {
+    super({ cascadeCreate: true, ...params }, 'POST', '/purchases/')
+  }
+}
+
+export class AddRating extends Request<AddRatingParams> {
+  constructor(params: AddRatingParams) {
+    super({ cascadeCreate: true, ...params }, 'POST', '/ratings/')
+  }
+}
+
+export class SetViewPortion extends Request<SetViewPortionParams> {
+  constructor(params: SetViewPortionParams) {
+    super({ cascadeCreate: true, ...params }, 'POST', '/viewportions/')
+  }
+}
+
+function getDeleteUrl(interactionType: string, params: DeleteParams) {
+  const url = `/${interactionType}/?userId=${params.userId}&itemId=${params.itemId}`
+  if (params.timestamp !== undefined) {
+    if (isNaN(Number(params.timestamp))) {
+      return url + `&timestamp=${new Date(params.timestamp).getTime()}`
+    }
+    return url + `&timestamp=${params.timestamp}`
+  }
+  return url
+}
+
+export class DeleteBookmark extends Request<DeleteParams> {
+  constructor(params: DeleteParams) {
+    super(params, 'DELETE', getDeleteUrl('bookmarks', params))
+  }
+}
+
+export class DeleteCartAddition extends Request<DeleteParams> {
+  constructor(params: DeleteParams) {
+    super(params, 'DELETE', getDeleteUrl('cartadditions', params))
+  }
+}
+
+export class MergeUsers extends Request<{}> {
+  constructor(targetUserId: string, sourceUserId: string) {
+    super({}, 'PUT', `/users/${targetUserId}/merge/${sourceUserId}?cascadeCreate=true`)
+  }
+}
+
+export class DeleteUser extends Request<{}> {
+  constructor(userId: string) {
+    super({}, 'DELETE', `/users/${userId}/`)
+  }
+}
+
+export class RecombeeApiClient {
+  constructor(private settings: Settings, private request: RequestClient) {}
+
+  async send<Params extends object, T extends Request<Params>>(request: T) {
+    const url = 'https://' + this.getBaseUri() + this.signUrl(request.path)
+    const response = await this.request(url, {
+      method: request.method,
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(request.params)
+    })
+    if (response.headers.get('content-type')?.includes('application/json')) {
+      return await response.json()
+    } else {
+      return await response.text()
+    }
+  }
+
+  private getBaseUri() {
+    if (this.settings.databaseRegion === DatabaseRegion.CUSTOM) {
+      if (!this.settings.apiUri) {
+        throw new InvalidAuthenticationError('RAPI URI is required when using custom database region')
+      }
+      return this.settings.apiUri
+    }
+
+    const region = this.settings.databaseRegion || DatabaseRegion.EU_WEST
+    return `rapi-${region}.recombee.com`
+  }
+
+  private signUrl(path: string) {
+    const hash = 'sha1'
+
+    let url = '/' + this.settings.databaseId + path
+    url += (path.indexOf('?') == -1 ? '?' : '&') + 'hmac_timestamp=' + Math.floor(new Date().getTime() / 1000)
+
+    const hmac = createHmac(hash, this.settings.privateToken).update(Buffer.from(url)).digest('hex')
+    url += '&hmac_sign=' + hmac
+    return url
+  }
+}

--- a/packages/destination-actions/src/destinations/recombee/setViewPortion/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/recombee/setViewPortion/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Recombee's setViewPortion destination action: all fields 1`] = `
+Object {
+  "additionalData": Object {
+    "testType": "Np8pbQ",
+  },
+  "cascadeCreate": true,
+  "itemId": "Np8pbQ",
+  "portion": -70298178955509.76,
+  "recommId": "Np8pbQ",
+  "sessionId": "Np8pbQ",
+  "timestamp": "Np8pbQ",
+  "userId": "Np8pbQ",
+}
+`;
+
+exports[`Testing snapshot for Recombee's setViewPortion destination action: required fields 1`] = `
+Object {
+  "cascadeCreate": true,
+  "itemId": "Np8pbQ",
+  "portion": -70298178955509.76,
+  "userId": "Np8pbQ",
+}
+`;

--- a/packages/destination-actions/src/destinations/recombee/setViewPortion/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/setViewPortion/__tests__/index.test.ts
@@ -1,0 +1,128 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { Settings } from '../../generated-types'
+import { randomUUID } from 'crypto'
+
+const testDestination = createTestIntegration(Destination)
+
+const DATABASE_ID = 'test-database'
+const SETTINGS: Settings = {
+  databaseId: DATABASE_ID,
+  privateToken: 'VALID_TOKEN',
+  databaseRegion: 'eu-west'
+}
+
+describe('setViewPortion', () => {
+  it('should validate action fields', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .post(`/${DATABASE_ID}/viewportions/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/
+      })
+      .reply(200, 'ok')
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id',
+        portion: 0.5
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('setViewPortion', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true
+    })
+
+    expect(await response[0].request.json()).toMatchObject({
+      userId: 'user-id',
+      itemId: 'product-id',
+      timestamp: '2021-09-01T00:00:00.000Z',
+      portion: 0.5,
+      cascadeCreate: true
+    })
+  })
+
+  it('should validate action fields with recommId and additionalData', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .post(`/${DATABASE_ID}/viewportions/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/
+      })
+      .reply(200, 'ok')
+
+    const recommId = randomUUID()
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id',
+        recomm_id: recommId,
+        portion: 0.5,
+        session: 'session-id'
+      },
+      traits: {
+        region: 'region'
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('setViewPortion', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true,
+      mapping: {
+        additionalData: {
+          region: {
+            '@path': '$.traits.region'
+          }
+        }
+      }
+    })
+
+    expect(await response[0].request.json()).toMatchObject({
+      userId: 'user-id',
+      itemId: 'product-id',
+      timestamp: '2021-09-01T00:00:00.000Z',
+      portion: 0.5,
+      sessionId: 'session-id',
+      cascadeCreate: true,
+      recommId,
+      additionalData: {
+        region: 'region'
+      }
+    })
+  })
+
+  it('should fail when portion is out of bounds', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .post(`/${DATABASE_ID}/viewportions/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/
+      })
+      .reply(400, { message: 'Invalid numeric value "1.5" for property portion: must be from interval [0,1]' })
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id',
+        portion: 1.5
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    await expect(
+      testDestination.testAction('setViewPortion', {
+        event,
+        settings: SETTINGS,
+        useDefaultMappings: true
+      })
+    ).rejects.toThrow()
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/setViewPortion/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/setViewPortion/__tests__/snapshot.test.ts
@@ -1,0 +1,71 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'setViewPortion'
+const destinationSlug = 'Recombee'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/setViewPortion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/recombee/setViewPortion/generated-types.ts
@@ -1,0 +1,34 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID of the user who viewed a portion of the item.
+   */
+  userId: string
+  /**
+   * The viewed item.
+   */
+  itemId: string
+  /**
+   * The UTC timestamp of when the view portion occurred.
+   */
+  timestamp?: string
+  /**
+   * The viewed portion of the item in the interval [0.0,1.0], where 0.0 means the user viewed nothing and 1.0 means the full item was viewed. It should be the actual viewed part of the item, no matter the seeking. For example, if the user seeked immediately to half of the item and then viewed 10% of the item, the `portion` should still be `0.1`.
+   */
+  portion: number
+  /**
+   * The ID of the session in which the user viewed the item.
+   */
+  sessionId?: string
+  /**
+   * The ID of the clicked recommendation (if the view portion is based on a recommendation request).
+   */
+  recommId?: string
+  /**
+   * Additional data to be stored with the view portion. *Keep this field empty unless instructed by the Recombee Support team.*
+   */
+  additionalData?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/recombee/setViewPortion/index.ts
+++ b/packages/destination-actions/src/destinations/recombee/setViewPortion/index.ts
@@ -1,0 +1,72 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { SetViewPortion, RecombeeApiClient, Batch } from '../recombeeApiClient'
+import { interactionFields } from '../commonFields'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Set View Portion',
+  description:
+    'Sets the viewed portion of a given item (e.g. a video or article) by the given user. **Use this action when you have the viewed portion as a number between 0 and 1.**',
+  fields: {
+    userId: {
+      label: 'User ID',
+      description: 'The ID of the user who viewed a portion of the item.',
+      type: 'string',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      }
+    },
+    itemId: {
+      label: 'Item ID',
+      description: 'The viewed item.',
+      type: 'string',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.properties.product_id' },
+          then: { '@path': '$.properties.product_id' },
+          else: { '@path': '$.properties.asset_id' }
+        }
+      }
+    },
+    timestamp: {
+      label: 'Timestamp',
+      description: 'The UTC timestamp of when the view portion occurred.',
+      type: 'string',
+      required: false,
+      default: { '@path': '$.timestamp' }
+    },
+    portion: {
+      label: 'Portion',
+      description:
+        'The viewed portion of the item in the interval [0.0,1.0], where 0.0 means the user viewed nothing and 1.0 means the full item was viewed. It should be the actual viewed part of the item, no matter the seeking. For example, if the user seeked immediately to half of the item and then viewed 10% of the item, the `portion` should still be `0.1`.',
+      type: 'number',
+      required: true,
+      default: { '@path': '$.properties.portion' }
+    },
+    sessionId: {
+      label: 'Session ID',
+      description: 'The ID of the session in which the user viewed the item.',
+      type: 'string',
+      required: false,
+      default: { '@path': '$.properties.session' }
+    },
+    ...interactionFields('view portion')
+  },
+  perform: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(new SetViewPortion(data.payload))
+  },
+  performBatch: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(new Batch(data.payload.map((event) => new SetViewPortion(event))))
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/recombee/setViewPortionFromWatchTime/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/recombee/setViewPortionFromWatchTime/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Recombee's setViewPortionFromWatchTime destination action: all fields 1`] = `
+Object {
+  "additionalData": Object {
+    "testType": "FcP0tLN]UE",
+  },
+  "cascadeCreate": true,
+  "itemId": "FcP0tLN]UE",
+  "portion": 1,
+  "recommId": "FcP0tLN]UE",
+  "sessionId": "FcP0tLN]UE",
+  "timestamp": "FcP0tLN]UE",
+  "userId": "FcP0tLN]UE",
+}
+`;
+
+exports[`Testing snapshot for Recombee's setViewPortionFromWatchTime destination action: required fields 1`] = `
+Object {
+  "cascadeCreate": true,
+  "itemId": "FcP0tLN]UE",
+  "portion": 1,
+  "userId": "FcP0tLN]UE",
+}
+`;

--- a/packages/destination-actions/src/destinations/recombee/setViewPortionFromWatchTime/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/setViewPortionFromWatchTime/__tests__/index.test.ts
@@ -1,0 +1,131 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { Settings } from '../../generated-types'
+import { randomUUID } from 'crypto'
+
+const testDestination = createTestIntegration(Destination)
+
+const DATABASE_ID = 'test-database'
+const SETTINGS: Settings = {
+  databaseId: DATABASE_ID,
+  privateToken: 'VALID_TOKEN',
+  databaseRegion: 'eu-west'
+}
+
+describe('setViewPortionFromWatchTime', () => {
+  it('should validate action fields', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .post(`/${DATABASE_ID}/viewportions/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/
+      })
+      .reply(200, 'ok')
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id',
+        total_length: 5,
+        position: 2
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('setViewPortionFromWatchTime', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true
+    })
+
+    expect(await response[0].request.json()).toMatchObject({
+      userId: 'user-id',
+      itemId: 'product-id',
+      timestamp: '2021-09-01T00:00:00.000Z',
+      portion: 0.4,
+      cascadeCreate: true
+    })
+  })
+
+  it('should validate action fields with recommId and additionalData', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .post(`/${DATABASE_ID}/viewportions/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/
+      })
+      .reply(200, 'ok')
+
+    const recommId = randomUUID()
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id',
+        recomm_id: recommId,
+        total_length: 100,
+        position: 50,
+        session: 'session-id'
+      },
+      traits: {
+        region: 'region'
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    const response = await testDestination.testAction('setViewPortionFromWatchTime', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true,
+      mapping: {
+        additionalData: {
+          region: {
+            '@path': '$.traits.region'
+          }
+        }
+      }
+    })
+
+    expect(await response[0].request.json()).toMatchObject({
+      userId: 'user-id',
+      itemId: 'product-id',
+      timestamp: '2021-09-01T00:00:00.000Z',
+      portion: 0.5,
+      sessionId: 'session-id',
+      cascadeCreate: true,
+      recommId,
+      additionalData: {
+        region: 'region'
+      }
+    })
+  })
+
+  it('should fail when portion is out of bounds', async () => {
+    nock('https://rapi-eu-west.recombee.com/')
+      .post(`/${DATABASE_ID}/viewportions/`)
+      .query({
+        hmac_timestamp: /.*/,
+        hmac_sign: /.*/
+      })
+      .reply(400, { message: 'Invalid numeric value "2" for property portion: must be from interval [0,1]' })
+
+    const event = createTestEvent({
+      userId: 'user-id',
+      properties: {
+        product_id: 'product-id',
+        total_length: 5,
+        position: 10
+      },
+      timestamp: '2021-09-01T00:00:00.000Z'
+    })
+
+    await expect(
+      testDestination.testAction('setViewPortionFromWatchTime', {
+        event,
+        settings: SETTINGS,
+        useDefaultMappings: true
+      })
+    ).rejects.toThrow()
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/setViewPortionFromWatchTime/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/setViewPortionFromWatchTime/__tests__/snapshot.test.ts
@@ -1,0 +1,71 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'setViewPortionFromWatchTime'
+const destinationSlug = 'Recombee'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/recombee/setViewPortionFromWatchTime/generated-types.ts
+++ b/packages/destination-actions/src/destinations/recombee/setViewPortionFromWatchTime/generated-types.ts
@@ -1,0 +1,43 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID of the user who viewed a portion of the item.
+   */
+  userId: string
+  /**
+   * The viewed item.
+   */
+  itemId: string
+  /**
+   * The UTC timestamp of when the view portion occurred.
+   */
+  timestamp?: string
+  /**
+   * The portion of the item that the user viewed.
+   */
+  portion: {
+    /**
+     * The total length of the item that the user can view.
+     */
+    totalLength: number
+    /**
+     * The user's watched time of the item.
+     */
+    watchTime: number
+  }
+  /**
+   * The ID of the session in which the user viewed the item.
+   */
+  sessionId?: string
+  /**
+   * The ID of the clicked recommendation (if the view portion is based on a recommendation request).
+   */
+  recommId?: string
+  /**
+   * Additional data to be stored with the view portion. *Keep this field empty unless instructed by the Recombee Support team.*
+   */
+  additionalData?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/recombee/setViewPortionFromWatchTime/index.ts
+++ b/packages/destination-actions/src/destinations/recombee/setViewPortionFromWatchTime/index.ts
@@ -1,0 +1,100 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { SetViewPortion, RecombeeApiClient, Batch } from '../recombeeApiClient'
+import { interactionFields } from '../commonFields'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Set View Portion from Watch Time',
+  description:
+    'Sets the viewed portion of a given item (e.g. a video or article) by the given user. **Use this action when you have the watch time of the item (e.g. in seconds) instead of the portion watched.**',
+  fields: {
+    userId: {
+      label: 'User ID',
+      description: 'The ID of the user who viewed a portion of the item.',
+      type: 'string',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      }
+    },
+    itemId: {
+      label: 'Item ID',
+      description: 'The viewed item.',
+      type: 'string',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.properties.product_id' },
+          then: { '@path': '$.properties.product_id' },
+          else: { '@path': '$.properties.asset_id' }
+        }
+      }
+    },
+    timestamp: {
+      label: 'Timestamp',
+      description: 'The UTC timestamp of when the view portion occurred.',
+      type: 'string',
+      required: false,
+      default: { '@path': '$.timestamp' }
+    },
+    portion: {
+      label: 'Portion',
+      description: 'The portion of the item that the user viewed.',
+      type: 'object',
+      required: true,
+      properties: {
+        totalLength: {
+          label: 'Total Length',
+          description: 'The total length of the item that the user can view.',
+          type: 'number',
+          required: true
+        },
+        watchTime: {
+          label: 'Watch Time',
+          description: "The user's watched time of the item.",
+          type: 'number',
+          required: true
+        }
+      },
+      default: {
+        totalLength: { '@path': '$.properties.total_length' },
+        watchTime: { '@path': '$.properties.position' }
+      }
+    },
+    sessionId: {
+      label: 'Session ID',
+      description: 'The ID of the session in which the user viewed the item.',
+      type: 'string',
+      required: false,
+      default: { '@path': '$.properties.session' }
+    },
+    ...interactionFields('view portion')
+  },
+  perform: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(payloadToViewPortion(data.payload))
+  },
+  performBatch: async (request, data) => {
+    const client = new RecombeeApiClient(data.settings, request)
+    await client.send(new Batch(data.payload.map(payloadToViewPortion)))
+  }
+}
+
+function payloadToViewPortion(payload: Payload): SetViewPortion {
+  return new SetViewPortion({
+    userId: payload.userId,
+    itemId: payload.itemId,
+    timestamp: payload.timestamp,
+    portion: payload.portion.watchTime / payload.portion.totalLength,
+    sessionId: payload.sessionId,
+    additionalData: payload.additionalData,
+    recommId: payload.recommId
+  })
+}
+
+export default action


### PR DESCRIPTION
Hello,

Here at Recombee, we were asked to develop a new version of our existing [Recombee AI](https://segment.com/docs/connections/destinations/catalog/recombee-ai/) destination that would use the new Action Destinations framework.

This pull request contains the implementation of that destination, called _Recombee (Actions)_. It includes presets, as well as all the actions that should be relevant to end users (there are some new ones compared to the old destination).

The `performBatch` function is implemented for all actions, though it is not necessary to enable batch support for now. We implemented it mostly due to batch events being very easy to implement by default in our API client.

## Testing

We created and ran unit tests for all available actions (including generating snapshots). We also tested the general types of events used in the presets via the local testing server.

However, we were unable to fully test the settings UI, since one of the authentication fields (`apiUri`) depends on the value of another field (`databaseRegion` needs to be set to `custom`) and this is not reflected in the Actions Tester UI (the field is always shown). If this can't be tested by you in the staging environment, we will test it in the private beta.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment