### PR TITLE
Adds a performBatch implementation to the Iterable trackEvent destination

### DIFF
--- a/packages/destination-actions/src/destinations/iterable/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/iterable/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -2,12 +2,14 @@
 
 exports[`Testing snapshot for Iterable's trackEvent destination action: all fields 1`] = `
 Object {
+  "batch_size": -56259557415976.96,
   "campaignId": -5625955741597696,
   "createdAt": 1612137600,
   "dataFields": Object {
     "testType": ")nhfnX#8",
   },
   "email": "ra@hiluh.za",
+  "enable_batching": true,
   "eventName": ")nhfnX#8",
   "id": ")nhfnX#8",
   "templateId": -5625955741597696,

--- a/packages/destination-actions/src/destinations/iterable/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/iterable/trackEvent/__tests__/index.test.ts
@@ -5,223 +5,321 @@ import Destination from '../../index'
 const testDestination = createTestIntegration(Destination)
 
 describe('Iterable.trackEvent', () => {
-  it('works with default mappings', async () => {
-    const event = createTestEvent({
-      type: 'track',
-      event: 'Test Event',
-      properties: {
-        email: 'test@iterable.com'
-      }
-    })
+  describe('perform', () => {
+    it('works with default mappings', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Test Event',
+        properties: {
+          email: 'test@iterable.com'
+        }
+      })
 
-    nock('https://api.iterable.com/api').post('/events/track').reply(200, {})
+      nock('https://api.iterable.com/api').post('/events/track').reply(200, {})
 
-    const responses = await testDestination.testAction('trackEvent', {
-      event,
-      useDefaultMappings: true
-    })
-
-    expect(responses[0].status).toBe(200)
-  })
-
-  it('throws an error if `email` or `userId` are not defined', async () => {
-    const event = createTestEvent({
-      type: 'track',
-      userId: null
-    })
-
-    await expect(
-      testDestination.testAction('trackEvent', {
+      const responses = await testDestination.testAction('trackEvent', {
         event,
         useDefaultMappings: true
       })
-    ).rejects.toThrowError(PayloadValidationError)
-  })
 
-  it('converts a date into a standard Iterable format', async () => {
-    const event = createTestEvent({
-      type: 'track',
-      userId: 'user1234',
-      properties: {
-        myDate: '2023-05-17T22:49:53.310Z'
-      }
+      expect(responses[0].status).toBe(200)
     })
 
-    nock('https://api.iterable.com/api').post('/events/track').reply(200, {})
+    it('throws an error if `email` or `userId` are not defined', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        userId: null
+      })
 
-    const responses = await testDestination.testAction('trackEvent', {
-      event,
-      useDefaultMappings: true
+      await expect(
+        testDestination.testAction('trackEvent', {
+          event,
+          useDefaultMappings: true
+        })
+      ).rejects.toThrowError(PayloadValidationError)
     })
 
-    expect(responses.length).toBe(1)
-    expect(responses[0].options.json).toMatchObject({
-      userId: 'user1234',
-      dataFields: {
-        myDate: '2023-05-17 22:49:53 +00:00'
-      }
-    })
-  })
-
-  it('does not modify a yyyy-mm-dd date', async () => {
-    const event = createTestEvent({
-      type: 'track',
-      userId: 'user1234',
-      properties: {
-        myDate: '2023-05-17'
-      }
-    })
-
-    nock('https://api.iterable.com/api').post('/events/track').reply(200, {})
-
-    const responses = await testDestination.testAction('trackEvent', {
-      event,
-      useDefaultMappings: true
-    })
-
-    expect(responses.length).toBe(1)
-    expect(responses[0].options.json).toMatchObject({
-      userId: 'user1234',
-      dataFields: {
-        myDate: '2023-05-17'
-      }
-    })
-  })
-
-  it('does not alter a midnight UTC datetime', async () => {
-    const event = createTestEvent({
-      type: 'track',
-      userId: 'user1234',
-      properties: {
-        myDate: '2023-05-17T00:00:00.000Z'
-      }
-    })
-
-    nock('https://api.iterable.com/api').post('/events/track').reply(200, {})
-
-    const responses = await testDestination.testAction('trackEvent', {
-      event,
-      useDefaultMappings: true
-    })
-
-    expect(responses.length).toBe(1)
-    expect(responses[0].options.json).toMatchObject({
-      userId: 'user1234',
-      dataFields: {
-        myDate: '2023-05-17 00:00:00 +00:00'
-      }
-    })
-  })
-
-  it('does not convert a non date string into a standard Iterable date format', async () => {
-    const event = createTestEvent({
-      type: 'track',
-      userId: 'user1234',
-      properties: {
-        badDate1: '1234',
-        badDate2: '1234-12',
-        badDate3: '1234-12-00',
-        badDate4: '1234-12-99',
-        myGoodDate: '2023-05-17T22:49:53.310Z'
-      }
-    })
-
-    nock('https://api.iterable.com/api').post('/events/track').reply(200, {})
-
-    const responses = await testDestination.testAction('trackEvent', {
-      event,
-      useDefaultMappings: true
-    })
-
-    expect(responses.length).toBe(1)
-    expect(responses[0].options.json).toMatchObject({
-      userId: 'user1234',
-      dataFields: {
-        badDate1: '1234',
-        badDate2: '1234-12',
-        badDate3: '1234-12-00',
-        badDate4: '1234-12-99',
-        myGoodDate: '2023-05-17 22:49:53 +00:00'
-      }
-    })
-  })
-
-  it('should success with mapping of preset and Entity Added event(presets) ', async () => {
-    const event = createTestEvent({
-      type: 'track',
-      event: 'Entity Added',
-      properties: {
-        email: 'test@iterable.com'
-      }
-    })
-
-    nock('https://api.iterable.com/api').post('/events/track').reply(200, {})
-
-    const responses = await testDestination.testAction('trackEvent', {
-      event,
-      // Using the mapping of presets with event type 'track'
-      mapping: {
-        dataFields: {
-          '@path': '$.properties'
+    it('converts a date into a standard Iterable format', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        userId: 'user1234',
+        properties: {
+          myDate: '2023-05-17T22:49:53.310Z'
         }
-      },
-      useDefaultMappings: true
+      })
+
+      nock('https://api.iterable.com/api').post('/events/track').reply(200, {})
+
+      const responses = await testDestination.testAction('trackEvent', {
+        event,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].options.json).toMatchObject({
+        userId: 'user1234',
+        dataFields: {
+          myDate: '2023-05-17 22:49:53 +00:00'
+        }
+      })
     })
 
-    expect(responses.length).toBe(1)
-    expect(responses[0].status).toBe(200)
-  })
+    it('does not modify a yyyy-mm-dd date', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        userId: 'user1234',
+        properties: {
+          myDate: '2023-05-17'
+        }
+      })
 
-  it('should success with mapping of preset and Journey Step Entered event(presets)', async () => {
-    const event = createTestEvent({
-      type: 'track',
-      event: 'Journey Step Entered',
-      properties: {
-        journey_metadata: {
-          journey_id: 'test-journey-id',
-          journey_name: 'test-journey-name',
-          step_id: 'test-step-id',
-          step_name: 'test-step-name'
+      nock('https://api.iterable.com/api').post('/events/track').reply(200, {})
+
+      const responses = await testDestination.testAction('trackEvent', {
+        event,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].options.json).toMatchObject({
+        userId: 'user1234',
+        dataFields: {
+          myDate: '2023-05-17'
+        }
+      })
+    })
+
+    it('does not alter a midnight UTC datetime', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        userId: 'user1234',
+        properties: {
+          myDate: '2023-05-17T00:00:00.000Z'
+        }
+      })
+
+      nock('https://api.iterable.com/api').post('/events/track').reply(200, {})
+
+      const responses = await testDestination.testAction('trackEvent', {
+        event,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].options.json).toMatchObject({
+        userId: 'user1234',
+        dataFields: {
+          myDate: '2023-05-17 00:00:00 +00:00'
+        }
+      })
+    })
+
+    it('does not convert a non date string into a standard Iterable date format', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        userId: 'user1234',
+        properties: {
+          badDate1: '1234',
+          badDate2: '1234-12',
+          badDate3: '1234-12-00',
+          badDate4: '1234-12-99',
+          myGoodDate: '2023-05-17T22:49:53.310Z'
+        }
+      })
+
+      nock('https://api.iterable.com/api').post('/events/track').reply(200, {})
+
+      const responses = await testDestination.testAction('trackEvent', {
+        event,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].options.json).toMatchObject({
+        userId: 'user1234',
+        dataFields: {
+          badDate1: '1234',
+          badDate2: '1234-12',
+          badDate3: '1234-12-00',
+          badDate4: '1234-12-99',
+          myGoodDate: '2023-05-17 22:49:53 +00:00'
+        }
+      })
+    })
+
+    it('should success with mapping of preset and Entity Added event(presets) ', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Entity Added',
+        properties: {
+          email: 'test@iterable.com'
+        }
+      })
+
+      nock('https://api.iterable.com/api').post('/events/track').reply(200, {})
+
+      const responses = await testDestination.testAction('trackEvent', {
+        event,
+        // Using the mapping of presets with event type 'track'
+        mapping: {
+          dataFields: {
+            '@path': '$.properties'
+          }
         },
-        journey_context: {
-          appointment_booked: {
-            type: 'track',
-            event: 'Appointment Booked',
-            timestamp: '2021-09-01T00:00:00.000Z',
-            properties: {
-              appointment_id: 'test-appointment-id',
-              appointment_date: '2021-09-01T00:00:00.000Z',
-              appointment_type: 'test-appointment-type'
-            }
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+    })
+
+    it('should success with mapping of preset and Journey Step Entered event(presets)', async () => {
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Journey Step Entered',
+        properties: {
+          journey_metadata: {
+            journey_id: 'test-journey-id',
+            journey_name: 'test-journey-name',
+            step_id: 'test-step-id',
+            step_name: 'test-step-name'
           },
-          appointment_confirmed: {
-            type: 'track',
-            event: 'Appointment Confirmed',
-            timestamp: '2021-09-01T00:00:00.000Z',
-            properties: {
-              appointment_id: 'test-appointment-id',
-              appointment_date: '2021-09-01T00:00:00.000Z',
-              appointment_type: 'test-appointment-type'
+          journey_context: {
+            appointment_booked: {
+              type: 'track',
+              event: 'Appointment Booked',
+              timestamp: '2021-09-01T00:00:00.000Z',
+              properties: {
+                appointment_id: 'test-appointment-id',
+                appointment_date: '2021-09-01T00:00:00.000Z',
+                appointment_type: 'test-appointment-type'
+              }
+            },
+            appointment_confirmed: {
+              type: 'track',
+              event: 'Appointment Confirmed',
+              timestamp: '2021-09-01T00:00:00.000Z',
+              properties: {
+                appointment_id: 'test-appointment-id',
+                appointment_date: '2021-09-01T00:00:00.000Z',
+                appointment_type: 'test-appointment-type'
+              }
             }
           }
         }
-      }
+      })
+
+      nock('https://api.iterable.com/api').post('/events/track').reply(200, {})
+
+      const responses = await testDestination.testAction('trackEvent', {
+        event,
+        // Using the mapping of presets with event type 'track'
+        mapping: {
+          dataFields: {
+            '@path': '$.properties'
+          }
+        },
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
     })
+  })
+  describe('performBatch', () => {
+    it('works with default mappings for a userId-based event', async () => {
+      const events = [
+        createTestEvent({
+          type: 'track',
+          event: 'Test Event',
+          userId: 'abcd',
+          properties: {
+            eventSequence: 1
+          }
+        }),
+        createTestEvent({
+          type: 'track',
+          event: 'Test Event 2',
+          userId: 'efgh',
+          properties: {
+            eventSequence: 2
+          }
+        })
+      ]
 
-    nock('https://api.iterable.com/api').post('/events/track').reply(200, {})
+      nock('https://api.iterable.com/api').post('/events/trackBulk').reply(200, {})
 
-    const responses = await testDestination.testAction('trackEvent', {
-      event,
-      // Using the mapping of presets with event type 'track'
-      mapping: {
-        dataFields: {
-          '@path': '$.properties'
-        }
-      },
-      useDefaultMappings: true
+      const responses = await testDestination.testBatchAction('trackEvent', {
+        events,
+        useDefaultMappings: true
+      })
+
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        events: [
+          {
+            userId: 'abcd',
+            eventName: 'Test Event',
+            dataFields: {
+              eventSequence: 1
+            }
+          },
+          {
+            userId: 'efgh',
+            eventName: 'Test Event 2',
+            dataFields: {
+              eventSequence: 2
+            }
+          }
+        ]
+      })
     })
+    it('works with default mappings for an email-based event', async () => {
+      const events = [
+        createTestEvent({
+          type: 'track',
+          event: 'Test Event',
+          properties: {
+            email: 'test@iterable.com',
+            eventSequence: 1
+          }
+        }),
+        createTestEvent({
+          type: 'track',
+          event: 'Test Event 2',
+          properties: {
+            email: 'test@iterable.com',
+            eventSequence: 2
+          }
+        })
+      ]
 
-    expect(responses.length).toBe(1)
-    expect(responses[0].status).toBe(200)
+      nock('https://api.iterable.com/api').post('/events/trackBulk').reply(200, {})
+
+      const responses = await testDestination.testBatchAction('trackEvent', {
+        events,
+        useDefaultMappings: true
+      })
+
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        events: [
+          {
+            email: 'test@iterable.com',
+            eventName: 'Test Event',
+            dataFields: {
+              eventSequence: 1
+            }
+          },
+          {
+            email: 'test@iterable.com',
+            eventName: 'Test Event 2',
+            dataFields: {
+              eventSequence: 2
+            }
+          }
+        ]
+      })
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/iterable/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/trackEvent/index.ts
@@ -13,6 +13,33 @@ import {
 } from '../shared-fields'
 import { convertDatesInObject, getRegionalEndpoint } from '../utils'
 
+interface TrackEventRequest {
+  email?: string
+  userId?: string
+  eventName: string
+  id?: string
+  createdAt?: number
+  dataFields?: {
+    [k: string]: unknown
+  }
+  campaignId?: number
+  templateId?: number
+}
+
+interface BulkTrackEventRequest {
+  events: TrackEventRequest[]
+}
+
+const transformIterableEventPayload = (payload: Payload): TrackEventRequest => {
+  const formattedDataFields = convertDatesInObject(payload.dataFields ?? {})
+  const trackEventRequest: TrackEventRequest = {
+    ...payload,
+    dataFields: formattedDataFields,
+    createdAt: dayjs(payload.createdAt).unix()
+  }
+  return trackEventRequest
+}
+
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Custom Event',
   description: 'Track a custom event to a user profile',
@@ -49,6 +76,21 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     templateId: {
       ...TEMPLATE_ID_FIELD
+    },
+    enable_batching: {
+      label: 'Enable Batching',
+      description: 'When enabled, Segment will send data to Iterable in batches of up to 1001',
+      type: 'boolean',
+      required: false,
+      default: true
+    },
+    batch_size: {
+      label: 'Batch Size',
+      description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
+      type: 'number',
+      unsafe_hidden: true,
+      required: false,
+      default: 1001
     }
   },
   perform: (request, { payload, settings }) => {
@@ -56,31 +98,26 @@ const action: ActionDefinition<Settings, Payload> = {
       throw new PayloadValidationError('Must include email or userId.')
     }
 
-    interface TrackEventRequest {
-      email?: string
-      userId?: string
-      eventName: string
-      id?: string
-      createdAt?: number
-      dataFields?: {
-        [k: string]: unknown
-      }
-      campaignId?: number
-      templateId?: number
-    }
-
-    const formattedDataFields = convertDatesInObject(payload.dataFields ?? {})
-    const trackEventRequest: TrackEventRequest = {
-      ...payload,
-      dataFields: formattedDataFields,
-      createdAt: dayjs(payload.createdAt).unix()
-    }
+    const trackEventRequest = transformIterableEventPayload(payload)
 
     const endpoint = getRegionalEndpoint('trackEvent', settings.dataCenterLocation as DataCenterLocation)
 
     return request(endpoint, {
       method: 'post',
       json: trackEventRequest,
+      timeout: Math.max(30_000, DEFAULT_REQUEST_TIMEOUT)
+    })
+  },
+  performBatch: async (request, { settings, payload }) => {
+    const bulkTrackEventRequest: BulkTrackEventRequest = {
+      events: payload.map(transformIterableEventPayload)
+    }
+
+    const endpoint = getRegionalEndpoint('bulkTrackEvent', settings.dataCenterLocation as DataCenterLocation)
+
+    return request(endpoint, {
+      method: 'post',
+      json: bulkTrackEventRequest,
       timeout: Math.max(30_000, DEFAULT_REQUEST_TIMEOUT)
     })
   }

--- a/packages/destination-actions/src/destinations/iterable/updateUser/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/updateUser/index.ts
@@ -63,7 +63,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     enable_batching: {
       label: 'Enable Batching',
-      description: 'When enabled, Segment will send data to Iterable in batches of up to 500',
+      description: 'When enabled, Segment will send data to Iterable in batches of up to 1001',
       type: 'boolean',
       required: false,
       default: false

--- a/packages/destination-actions/src/destinations/iterable/utils.ts
+++ b/packages/destination-actions/src/destinations/iterable/utils.ts
@@ -94,6 +94,7 @@ export const apiEndpoints = {
   updateUser: '/api/users/update',
   bulkUpdateUser: '/api/users/bulkUpdate',
   trackEvent: '/api/events/track',
+  bulkTrackEvent: '/api/events/trackBulk',
   updateCart: '/api/commerce/updateCart',
   trackPurchase: '/api/commerce/trackPurchase',
   getWebhooks: '/api/webhooks'


### PR DESCRIPTION
Also refactors some of the payload transformation code from the perform method, to be reused in the performBatch.

## Testing

_video incoming_

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
