### PR TITLE
add app_id field required for contact device id audience types

### DIFF
--- a/packages/destination-actions/src/destinations/first-party-dv360/functions.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/functions.ts
@@ -8,6 +8,7 @@ interface createAudienceRequestParams {
   description?: string
   membershipDurationDays: string
   audienceType: string
+  appId?: string
   token?: string
 }
 
@@ -21,7 +22,7 @@ export const createAudienceRequest = (
   request: RequestClient,
   params: createAudienceRequestParams
 ): Promise<Response> => {
-  const { advertiserId, audienceName, description, membershipDurationDays, audienceType, token } = params
+  const { advertiserId, audienceName, description, membershipDurationDays, audienceType, appId, token } = params
 
   const endpoint = DV360API + `?advertiserId=${advertiserId}`
 
@@ -37,7 +38,8 @@ export const createAudienceRequest = (
       membershipDurationDays: membershipDurationDays,
       description: description,
       audienceSource: 'AUDIENCE_SOURCE_UNSPECIFIED',
-      firstAndThirdPartyAudienceType: 'FIRST_AND_THIRD_PARTY_AUDIENCE_TYPE_FIRST_PARTY'
+      firstAndThirdPartyAudienceType: 'FIRST_AND_THIRD_PARTY_AUDIENCE_TYPE_FIRST_PARTY',
+      appId: appId
     }
   })
 }

--- a/packages/destination-actions/src/destinations/first-party-dv360/generated-types.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/generated-types.ts
@@ -17,6 +17,10 @@ export interface AudienceSettings {
    */
   description?: string
   /**
+   * The appId matches with the type of the mobileDeviceIds being uploaded. **Required for CUSTOMER_MATCH_DEVICE_ID Audience Types.**
+   */
+  appId?: string
+  /**
    * The duration in days that an entry remains in the audience after the qualifying event. If the audience has no expiration, set the value of this field to 10000. Otherwise, the set value must be greater than 0 and less than or equal to 540.
    */
   membershipDurationDays: string

--- a/packages/destination-actions/src/destinations/first-party-dv360/index.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/index.ts
@@ -32,6 +32,13 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       required: false,
       description: 'The description of the audience.'
     },
+    appId: {
+      type: 'string',
+      label: 'App ID',
+      required: false,
+      description:
+        'The appId matches with the type of the mobileDeviceIds being uploaded. **Required for CUSTOMER_MATCH_DEVICE_ID Audience Types.**'
+    },
     membershipDurationDays: {
       type: 'string',
       label: 'Membership Duration Days',
@@ -68,6 +75,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       const description = audienceSettings?.description
       const membershipDurationDays = audienceSettings?.membershipDurationDays
       const audienceType = audienceSettings?.audienceType
+      const appId = audienceSettings?.appId
       const token = audienceSettings?.token // Temporary token variable
 
       // Update statistics tags and sends a call metric to Datadog. Ensures that datadog is infomred 'createAudience' operation was invoked
@@ -108,6 +116,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         description,
         membershipDurationDays,
         audienceType,
+        appId,
         token
       })
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
