### PR TITLE
Increase timeout for tests

### DIFF
--- a/packages/cli/src/__tests__/init.test.ts
+++ b/packages/cli/src/__tests__/init.test.ts
@@ -14,7 +14,7 @@ import * as path from 'path'
 import * as prompt from '../lib/prompt'
 import * as rimraf from 'rimraf'
 
-jest.setTimeout(10000)
+jest.setTimeout(15000)
 
 describe('cli init command', () => {
   const testDir = path.join('.', 'testResults')


### PR DESCRIPTION
Increase timeout to handle test failures on main branch

![image](https://github.com/user-attachments/assets/d51beda3-ffc4-4b78-9658-0f1ae209e928)
https://github.com/segmentio/action-destinations/actions/runs/10989071601/job/30506577262

The tests failed on `main` because of timeout issues.

The same tests are working fine on feature branch.
Example: https://github.com/segmentio/action-destinations/actions/runs/10811922802/job/29992393888


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
