### PR TITLE
[LinkedIn CAPI] Updates ad account ID description

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
@@ -63,7 +63,7 @@ export interface HookBundle {
   onMappingSave: {
     inputs?: {
       /**
-       * The ad account to use for the conversion event.
+       * The ad account to use when creating the conversion event. (When updating a conversion rule, changes to this field will be ignored. Ad Account IDs cannot be updated for a conversion rule.)
        */
       adAccountId: string
       /**

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -18,7 +18,8 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
       inputFields: {
         adAccountId: {
           label: 'Ad Account',
-          description: 'The ad account to use for the conversion event.',
+          description:
+            'The ad account to use when creating the conversion event. (When updating a conversion rule, changes to this field will be ignored. Ad Account IDs cannot be updated for a conversion rule.)',
           type: 'string',
           required: true,
           dynamic: async (request) => {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

The LinkedIn CAPI Ad Account ID field is required when creating/selecting a conversion rule to connect to the destination. This field cannot be updated once a conversion rule is created however. To communicate this to customers I've updated the description here. 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

Testing not required: This is a non-functional change.

<img width="848" alt="Screenshot 2024-09-24 at 5 05 39 PM" src="https://github.com/user-attachments/assets/63dc691c-eb22-449a-9800-b578bb97fbff">

