### PR TITLE
Remove the track event subscribe

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/index.ts
@@ -94,9 +94,6 @@ const destination: DestinationDefinition<Settings> = {
       name: 'Track Event',
       subscribe: `
         type = "track"
-        and event != "Application Installed"
-        and event != "Application Opened"
-        and event != "Application Uninstalled"
         and event != "Relationship Deleted"
         and event != "User Deleted"
         and event != "User Suppressed"

--- a/packages/destination-actions/src/destinations/customerio/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/customerio/trackEvent/index.ts
@@ -8,9 +8,6 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Track an event for a known or anonymous person.',
   defaultSubscription: `
     type = "track"
-    and event != "Application Installed"
-    and event != "Application Opened"
-    and event != "Application Uninstalled"
     and event != "Relationship Deleted"
     and event != "User Deleted"
     and event != "User Suppressed"


### PR DESCRIPTION

The pull request removes the default exclusion of 
```typescript
"Application Installed", "Application Opened", and "Application Uninstalled" 
``` 
for the customerio track event.
This change removes these events by default , giving users more flexibility in their event tracking setup.


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
