### PR TITLE
[STRATCONN-4203] Add new operator "number_not_equals" for number

### DIFF
--- a/packages/destination-subscriptions/src/__tests__/generate-fql.test.ts
+++ b/packages/destination-subscriptions/src/__tests__/generate-fql.test.ts
@@ -211,3 +211,43 @@ test('should handle ast with nested (dot-delimited) and irregular properties', (
 
   expect(generateFql(ast)).toEqual('properties.foo.bar.baz\\ alp.zaz = "hello"')
 })
+
+test('should handle number_not_equals ast', () => {
+  const ast: Subscription = {
+    type: 'group',
+    operator: 'and',
+    children: [
+      {
+        type: 'event-trait',
+        name: 'value',
+        operator: 'number_not_equals',
+        value: '456.0'
+      }
+    ]
+  }
+
+  expect(generateFql(ast)).toEqual('traits.value != 456')
+})
+
+test('should handle both not equal (!=) and number_not_equals ast', () => {
+  const ast: Subscription = {
+    type: 'group',
+    operator: 'and',
+    children: [
+      {
+        type: 'event-property',
+        name: 'value',
+        operator: 'number_not_equals',
+        value: '123'
+      },
+      {
+        type: 'event-trait',
+        name: 'label',
+        operator: '!=',
+        value: '456'
+      }
+    ]
+  }
+
+  expect(generateFql(ast)).toEqual('properties.value != 123 and traits.label != "456"')
+})

--- a/packages/destination-subscriptions/src/__tests__/validate.test.ts
+++ b/packages/destination-subscriptions/src/__tests__/validate.test.ts
@@ -740,3 +740,25 @@ test('event type = "track" and event = "Page Viewed" or event = "Order Completed
     })
   ).toEqual(true)
 })
+
+test('operators -  number_not_equals (numbers)', () => {
+  for (const value of ['456', 456]) {
+    const ast = {
+      type: 'group',
+      operator: 'and',
+      children: [
+        {
+          type: 'event-property',
+          name: 'value',
+          operator: 'number_not_equals',
+          value
+        }
+      ]
+    }
+
+    expect(validate(ast, { properties: { value: 123 } })).toEqual(true)
+
+    expect(validate(ast, { properties: { value: '456' } })).toEqual(false)
+    expect(validate(ast, { properties: { value: 0 } })).toEqual(true)
+  }
+})

--- a/packages/destination-subscriptions/src/generate-fql.ts
+++ b/packages/destination-subscriptions/src/generate-fql.ts
@@ -49,6 +49,8 @@ const fqlExpression = (name: string, operator: Operator, value: string | boolean
       return `${name} ${operator} ${Number(value)}`
     case 'number_equals':
       return `${name} = ${Number(value)}`
+    case 'number_not_equals':
+      return `${name} != ${Number(value)}`
     default:
       return `${name} ${operator} ${stringifyValue(value)}`
   }

--- a/packages/destination-subscriptions/src/parse-fql.ts
+++ b/packages/destination-subscriptions/src/parse-fql.ts
@@ -334,8 +334,8 @@ const parse = (tokens: Token[]): Condition => {
             })
           } else if (isNumberNotEquals) {
             nodes.push({
-              type: 'event-property',
-              name: token.value.replace(/^(properties)\./, ''),
+              type: 'event-trait',
+              name: token.value.replace(/^(traits)\./, ''),
               operator: 'number_not_equals',
               value: getTokenValue(valueToken)
             })
@@ -381,8 +381,8 @@ const parse = (tokens: Token[]): Condition => {
             })
           } else if (isNumberNotEquals) {
             nodes.push({
-              type: 'event-property',
-              name: token.value.replace(/^(properties)\./, ''),
+              type: 'event-context',
+              name: token.value.replace(/^(context)\./, ''),
               operator: 'number_not_equals',
               value: getTokenValue(valueToken)
             })

--- a/packages/destination-subscriptions/src/parse-fql.ts
+++ b/packages/destination-subscriptions/src/parse-fql.ts
@@ -193,6 +193,7 @@ const parse = (tokens: Token[]): Condition => {
         const isExists = operatorToken.value === '!=' && valueToken.value === 'null'
         const isNotExists = operatorToken.value === '=' && valueToken.value === 'null'
         const isNumberEquals = operatorToken.value === '=' && valueToken.type === 'number'
+        const isNumberNotEquals = operatorToken.value === '!=' && valueToken.type === 'number'
 
         if (conditionType === 'event') {
           nodes.push({
@@ -284,6 +285,13 @@ const parse = (tokens: Token[]): Condition => {
               operator: 'number_equals',
               value: getTokenValue(valueToken)
             })
+          } else if (isNumberNotEquals) {
+            nodes.push({
+              type: 'event-property',
+              name: token.value.replace(/^(properties)\./, ''),
+              operator: 'number_not_equals',
+              value: getTokenValue(valueToken)
+            })
           } else {
             nodes.push({
               type: 'event-property',
@@ -324,6 +332,13 @@ const parse = (tokens: Token[]): Condition => {
               operator: 'number_equals',
               value: getTokenValue(valueToken)
             })
+          } else if (isNumberNotEquals) {
+            nodes.push({
+              type: 'event-property',
+              name: token.value.replace(/^(properties)\./, ''),
+              operator: 'number_not_equals',
+              value: getTokenValue(valueToken)
+            })
           } else {
             nodes.push({
               type: 'event-trait',
@@ -362,6 +377,13 @@ const parse = (tokens: Token[]): Condition => {
               type: 'event-context',
               name: token.value.replace(/^(context)\./, ''),
               operator: 'number_equals',
+              value: getTokenValue(valueToken)
+            })
+          } else if (isNumberNotEquals) {
+            nodes.push({
+              type: 'event-property',
+              name: token.value.replace(/^(properties)\./, ''),
+              operator: 'number_not_equals',
               value: getTokenValue(valueToken)
             })
           } else {

--- a/packages/destination-subscriptions/src/types.ts
+++ b/packages/destination-subscriptions/src/types.ts
@@ -84,6 +84,7 @@ export type Operator =
   | 'not_exists'
   | 'is_true'
   | 'is_false'
+  | 'number_not_equals'
 
 export type ConditionType =
   | 'group'

--- a/packages/destination-subscriptions/src/validate.ts
+++ b/packages/destination-subscriptions/src/validate.ts
@@ -77,6 +77,8 @@ const validateValue = (actual: unknown, operator: Operator, expected?: string | 
       return typeof actual === 'number' && Number(actual) === Number(expected)
     case '!=':
       return actual !== String(expected)
+    case 'number_not_equals':
+      return typeof actual === 'number' && Number(actual) !== Number(expected)
     case '<':
       return typeof actual === 'number' && Number(actual) < Number(expected)
     case '<=':


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Addition of a new operator ("number_not_equals") in validate, parse-fql and generate-fql functions in @segment/destination-subscriptions.

**`Is not` works with only string and does not work with type number.** That is the reason to add new operator for number.This operator is only at the AST level and doesn't get stored in the actual fql. Before generating fql, This operator will be transformed into "!=" without stringifying its corresponding value token.

**!!!Important: Please follow these steps after merging.** 
1. Release packages (actions-core, destination-subscription)
2. Add the new package version of actions-core to [integrations service](https://github.com/segmentio/integrations)
3. Add the new package version of destination-subscription to this [App PR](https://github.com/segmentio/app/pull/21774).

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested completed successfully [in the staging environment](https://docs.google.com/document/d/1cvIS7OhK_glHYTpY3tty7hBi1SpzdIWFrjjRE8Digp8/edit#heading=h.dk0meptvpzlq). 