### PR TITLE
[Marketo] Reduce batch_size for remove action

### DIFF
--- a/packages/destination-actions/src/destinations/marketo-static-lists/removeFromList/index.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/removeFromList/index.ts
@@ -13,7 +13,7 @@ const action: ActionDefinition<Settings, Payload> = {
     lookup_field: { ...lookup_field },
     field_value: { ...field_value },
     enable_batching: { ...enable_batching },
-    batch_size: { ...batch_size },
+    batch_size: { ...batch_size, default: 300 },
     event_name: { ...event_name }
   },
   perform: async (request, { settings, payload, statsContext }) => {


### PR DESCRIPTION
The endpoint `/rest/v1/leads.json` is used to look up the leads in the Marketo database so they can be deleted can only take requests of up to 300. Currently the default`batch_size` is > 300 so we need to reduce it and then run [this migration](https://github.com/segmentio/control-plane/pull/5281) to make all of the current configurations also 300. 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
