### PR TITLE
[Google Enhanced Conversions] Bump default API version from v15 to v17.

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -26,7 +26,7 @@ import type { Payload as UserListPayload } from './userList/generated-types'
 import { sha256SmartHash } from '@segment/actions-core'
 import { RefreshTokenResponse } from '.'
 
-export const API_VERSION = 'v15'
+export const API_VERSION = 'v17'
 export const CANARY_API_VERSION = 'v17'
 export const FLAGON_NAME = 'google-enhanced-canary-version'
 


### PR DESCRIPTION
This PR bumps the Google Enhanced Conversion destination's default API version from `v15` to `v17`. `v15` is deprecated as of Sept. 25, 2024 ([ref](https://developers.google.com/google-ads/api/docs/sunset-dates)).

## Testing

Additional testing not required. All traffic for this destination in production has been flowing to the `v17` endpoint since Sept. 11, 2024 ([ref1](https://segment.datadoghq.com/notebook/4959722/google-ads-api-migration-notebook?range=2678400000&tpl_var_env%5B0%5D=production&start=1724714149898&live=true), [ref2](https://flagon.segment.com/families/centrifuge-destinations/gates/google-enhanced-canary-version)).

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
