### PR TITLE
[Pinterest Audiences] Fix testAuthentication method sample payload.

### DIFF
--- a/packages/destination-actions/src/destinations/pinterest-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/index.ts
@@ -39,7 +39,7 @@ const destination: DestinationDefinition<Settings> = {
                 {
                   event_name: 'checkout',
                   action_source: 'app_ios',
-                  event_time: 1678203524,
+                  event_time: Math.floor(Date.now() / 1000),
                   event_id: 'test_eventId',
                   user_data: {
                     em: ['411e44ce1261728ffd2c0686e44e3fffe413c0e2c5adc498bc7da883d476b9c8']


### PR DESCRIPTION
- Jira ticket: https://segment.atlassian.net/browse/STRATCONN-4167
- Fixes `422 Unprocessable Entity` error when attempting to add new and/or save Pinterest Audiences credentials.
- Root cause: The `event_time` parameter in the sample `testAuthentication` payload was too far in the past, resulting in the following error from Pinterest's API:

```
{"code":953,"message":"The action could not be processed properly due to some or all data provided being invalid.","details":{"num_events_processed":0,"num_events_received":1,"events":[{"status":"failed","error_message":"Invalid event_timestamp parameter. Given timestamp is in the past. Current timestamp: 1727469267, Given event_timestamp: 1678203524","warning_message":""}]}}
```

## Testing
- Testing completed locally using `testAuthentication` method in the actions tester:

<img width="1076" alt="Screenshot 2024-09-27 at 1 26 40 PM" src="https://github.com/user-attachments/assets/3f93ebcc-53b5-4901-9803-91db23cd2ba0">

<img width="1083" alt="Screenshot 2024-09-27 at 1 26 48 PM" src="https://github.com/user-attachments/assets/3d2831b7-d866-4390-ae94-32695c408db8">

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment