### PR TITLE
Update required-field-check.yml

### DIFF
--- a/.github/workflows/required-field-check.yml
+++ b/.github/workflows/required-field-check.yml
@@ -1,7 +1,7 @@
 name: Required Field Check
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/required-field-check.yml
+++ b/.github/workflows/required-field-check.yml
@@ -7,7 +7,9 @@ on:
 jobs:
   required-field-check:
     runs-on: ubuntu-20.04
-
+    permissions:
+      contents: read
+      pull-requests: write
     timeout-minutes: 5
 
     steps:


### PR DESCRIPTION
This PR updates required-field-check to run on `pull_request_target` instead of `pull_request` event.

This is much safer especially when commenting/labelling of PRs from fork.



## Testing

N/A

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
