### PR TITLE
Remove checkout PR branch from required-field-check

### DIFF
--- a/.github/workflows/required-field-check.yml
+++ b/.github/workflows/required-field-check.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Checkout the PR branch again
         if: steps.get_files.outputs.no_files_changed != 'true'
-        run: git checkout ${{ github.head_ref }}
+        run: git checkout -
 
       - name: Add comment on PR if there is diff in required fields
         if: steps.get_files.outputs.no_files_changed != 'true'

--- a/.github/workflows/required-field-check.yml
+++ b/.github/workflows/required-field-check.yml
@@ -57,10 +57,6 @@ jobs:
           REQUIRED_FIELDS_MAIN_BRANCH=$(./bin/run list-required-fields -p ${{ steps.get_files.outputs.files }} | jq -c .)
           echo "REQUIRED_FIELDS_MAIN_BRANCH=$REQUIRED_FIELDS_MAIN_BRANCH" >> $GITHUB_ENV
 
-      - name: Checkout the PR branch again
-        if: steps.get_files.outputs.no_files_changed != 'true'
-        run: git checkout -
-
       - name: Add comment on PR if there is diff in required fields
         if: steps.get_files.outputs.no_files_changed != 'true'
         uses: actions/github-script@v7


### PR DESCRIPTION
This PR updates required-field-check to fix an issue we are running into while running this check from PRs from the fork branch.

## Testing


Testing completed via this PR. I can only check if it works on forks after merging this to main branch.