### PR TITLE
[MAIN] [STRATCONN] 4146 Facebook Anon_id and MadId added in Action Field

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
@@ -484,6 +484,114 @@ describe('FacebookConversionsApi', () => {
       )
     })
 
+    it('should send app events without anon_id and madId using default mappings correctly', async () => {
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Product Added',
+        userId: 'abc123',
+        messageId: '123',
+        timestamp: '1631210000',
+        properties: {
+          action_source: 'email',
+          currency: 'USD',
+          value: 12.12,
+          email: 'nicholas.aguilar@segment.com',
+          product_id: 'abc12345',
+          traits: {
+            city: 'Gotham',
+            country: 'United States',
+            last_name: 'Wayne'
+          }
+        },
+        context: {
+          app: {
+            build: '2',
+            name: 'Krusty Krab ToGo',
+            namespace: 'com.krusty.krab.ios-prod',
+            version: '2.0.1'
+          },
+          device: {
+            id: '1234-5678',
+            manufacturer: 'Apple',
+            model: 'iPhone10,5',
+            name: 'iPhone X',
+            type: 'ios'
+          },
+          locale: 'en-US',
+          timezone: 'America/Los Angeles',
+          screen: {
+            height: 736,
+            width: 414
+          },
+          network: {
+            carrier: 'AT&T',
+            cellular: true,
+            wifi: true
+          },
+          os: {
+            name: 'iOS',
+            version: '16.3.1'
+          }
+        }
+      })
+
+      const responses = await testDestination.testAction('addToCart', {
+        event,
+        settings,
+        mapping: {
+          action_source: { '@path': '$.properties.action_source' },
+          app_data_field: {
+            use_app_data: true,
+            // The default mappings from the app_data object need to be recreated here
+            // since 'use_app_data' is set to true. Otherwise, the default mappings
+            // will not be set.
+            application_tracking_enabled: {
+              '@path': '$.context.device.adTrackingEnabled'
+            },
+            packageName: {
+              '@path': '$.context.app.namespace'
+            },
+            longVersion: {
+              '@path': '$.context.app.version'
+            },
+            osVersion: {
+              '@path': '$.context.os.version'
+            },
+            deviceName: {
+              '@path': '$.context.device.model'
+            },
+            locale: {
+              '@path': '$.context.locale'
+            },
+            carrier: {
+              '@path': '$.context.network.carrier'
+            },
+            width: {
+              '@path': '$.context.screen.width'
+            },
+            height: {
+              '@path': '$.context.screen.height'
+            },
+            density: {
+              '@path': '$.context.screen.density'
+            },
+            deviceTimezone: {
+              '@path': '$.context.timezone'
+            }
+          }
+        },
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"AddToCart\\",\\"event_time\\":\\"1631210000\\",\\"event_id\\":\\"123\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"external_id\\":[\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\"]},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"contents\\":[{\\"id\\":\\"abc12345\\"}]},\\"app_data\\":{\\"advertiser_tracking_enabled\\":0,\\"application_tracking_enabled\\":0,\\"extinfo\\":[\\"\\",\\"com.krusty.krab.ios-prod\\",\\"\\",\\"2.0.1\\",\\"16.3.1\\",\\"iPhone10,5\\",\\"en-US\\",\\"\\",\\"AT&T\\",\\"414\\",\\"736\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"America/Los Angeles\\",\\"\\",\\"\\"]}}]}"`
+      )
+    })
+
     it('should send app events using default mappings correctly', async () => {
       nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
@@ -532,6 +532,12 @@ describe('FacebookConversionsApi', () => {
           os: {
             name: 'iOS',
             version: '16.3.1'
+          },
+          anonId: {
+            anon_id: '1231'
+          },
+          madId: {
+            madid: '2313'
           }
         }
       })
@@ -588,7 +594,7 @@ describe('FacebookConversionsApi', () => {
       expect(responses[0].status).toBe(201)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"data\\":[{\\"event_name\\":\\"AddToCart\\",\\"event_time\\":\\"1631210000\\",\\"event_id\\":\\"123\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"external_id\\":[\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\"]},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"contents\\":[{\\"id\\":\\"abc12345\\"}]},\\"app_data\\":{\\"advertiser_tracking_enabled\\":0,\\"application_tracking_enabled\\":0,\\"extinfo\\":[\\"\\",\\"com.krusty.krab.ios-prod\\",\\"\\",\\"2.0.1\\",\\"16.3.1\\",\\"iPhone10,5\\",\\"en-US\\",\\"\\",\\"AT&T\\",\\"414\\",\\"736\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"America/Los Angeles\\"]}}]}"`
+        `"{\\"data\\":[{\\"event_name\\":\\"AddToCart\\",\\"event_time\\":\\"1631210000\\",\\"event_id\\":\\"123\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"external_id\\":[\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\"]},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"contents\\":[{\\"id\\":\\"abc12345\\"}]},\\"app_data\\":{\\"advertiser_tracking_enabled\\":0,\\"application_tracking_enabled\\":0,\\"extinfo\\":[\\"\\",\\"com.krusty.krab.ios-prod\\",\\"\\",\\"2.0.1\\",\\"16.3.1\\",\\"iPhone10,5\\",\\"en-US\\",\\"\\",\\"AT&T\\",\\"414\\",\\"736\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"America/Los Angeles\\",\\"\\",\\"\\"]}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
@@ -645,7 +645,7 @@ describe('FacebookConversionsApi', () => {
             anon_id: '1231'
           },
           madId: {
-            madid: '2313'
+            madId: '2313'
           }
         }
       })
@@ -692,6 +692,12 @@ describe('FacebookConversionsApi', () => {
             },
             deviceTimezone: {
               '@path': '$.context.timezone'
+            },
+            anonId: {
+              '@path': '$.context.anonId.anon_id'
+            },
+            madId: {
+              '@path': '$.context.madId.madId'
             }
           }
         },
@@ -702,7 +708,7 @@ describe('FacebookConversionsApi', () => {
       expect(responses[0].status).toBe(201)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"data\\":[{\\"event_name\\":\\"AddToCart\\",\\"event_time\\":\\"1631210000\\",\\"event_id\\":\\"123\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"external_id\\":[\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\"]},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"contents\\":[{\\"id\\":\\"abc12345\\"}]},\\"app_data\\":{\\"advertiser_tracking_enabled\\":0,\\"application_tracking_enabled\\":0,\\"extinfo\\":[\\"\\",\\"com.krusty.krab.ios-prod\\",\\"\\",\\"2.0.1\\",\\"16.3.1\\",\\"iPhone10,5\\",\\"en-US\\",\\"\\",\\"AT&T\\",\\"414\\",\\"736\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"America/Los Angeles\\",\\"\\",\\"\\"]}}]}"`
+        `"{\\"data\\":[{\\"event_name\\":\\"AddToCart\\",\\"event_time\\":\\"1631210000\\",\\"event_id\\":\\"123\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"external_id\\":[\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\"]},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"contents\\":[{\\"id\\":\\"abc12345\\"}]},\\"app_data\\":{\\"advertiser_tracking_enabled\\":0,\\"application_tracking_enabled\\":0,\\"extinfo\\":[\\"\\",\\"com.krusty.krab.ios-prod\\",\\"\\",\\"2.0.1\\",\\"16.3.1\\",\\"iPhone10,5\\",\\"en-US\\",\\"\\",\\"AT&T\\",\\"414\\",\\"736\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"America/Los Angeles\\",\\"1231\\",\\"2313\\"]}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart2.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart2.test.ts
@@ -637,6 +637,12 @@ describe('FacebookConversionsApi', () => {
             },
             deviceTimezone: {
               '@path': '$.context.timezone'
+            },
+            anonId: {
+              '@path': '$.context.anonId.anon_id'
+            },
+            madId: {
+              '@path': '$.context.madId.madid'
             }
           }
         },
@@ -647,7 +653,7 @@ describe('FacebookConversionsApi', () => {
       expect(responses[0].status).toBe(201)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"data\\":[{\\"event_name\\":\\"AddToCart\\",\\"event_time\\":\\"1631210000\\",\\"event_id\\":\\"123\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"external_id\\":[\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\"]},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"contents\\":[{\\"id\\":\\"abc12345\\"}]},\\"app_data\\":{\\"advertiser_tracking_enabled\\":0,\\"application_tracking_enabled\\":0,\\"extinfo\\":[\\"\\",\\"com.krusty.krab.ios-prod\\",\\"\\",\\"2.0.1\\",\\"16.3.1\\",\\"iPhone10,5\\",\\"en-US\\",\\"\\",\\"AT&T\\",\\"414\\",\\"736\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"America/Los Angeles\\",\\"\\",\\"\\"]}}]}"`
+        `"{\\"data\\":[{\\"event_name\\":\\"AddToCart\\",\\"event_time\\":\\"1631210000\\",\\"event_id\\":\\"123\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"external_id\\":[\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\"]},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"contents\\":[{\\"id\\":\\"abc12345\\"}]},\\"app_data\\":{\\"advertiser_tracking_enabled\\":0,\\"application_tracking_enabled\\":0,\\"extinfo\\":[\\"\\",\\"com.krusty.krab.ios-prod\\",\\"\\",\\"2.0.1\\",\\"16.3.1\\",\\"iPhone10,5\\",\\"en-US\\",\\"\\",\\"AT&T\\",\\"414\\",\\"736\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"America/Los Angeles\\",\\"1231\\",\\"2313\\"]}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart2.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart2.test.ts
@@ -651,6 +651,115 @@ describe('FacebookConversionsApi', () => {
       )
     })
 
+    it('should send app events without anon_id and madId using default mappings correctly', async () => {
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Product Added',
+        userId: 'abc123',
+        messageId: '123',
+        timestamp: '1631210000',
+        properties: {
+          action_source: 'email',
+          currency: 'USD',
+          value: 12.12,
+          email: 'nicholas.aguilar@segment.com',
+          product_id: 'abc12345',
+          traits: {
+            city: 'Gotham',
+            country: 'United States',
+            last_name: 'Wayne'
+          }
+        },
+        context: {
+          app: {
+            build: '2',
+            name: 'Krusty Krab ToGo',
+            namespace: 'com.krusty.krab.ios-prod',
+            version: '2.0.1'
+          },
+          device: {
+            id: '1234-5678',
+            manufacturer: 'Apple',
+            model: 'iPhone10,5',
+            name: 'iPhone X',
+            type: 'ios'
+          },
+          locale: 'en-US',
+          timezone: 'America/Los Angeles',
+          screen: {
+            height: 736,
+            width: 414
+          },
+          network: {
+            carrier: 'AT&T',
+            cellular: true,
+            wifi: true
+          },
+          os: {
+            name: 'iOS',
+            version: '16.3.1'
+          }
+        }
+      })
+
+      const responses = await testDestination.testAction('addToCart2', {
+        event,
+        settings,
+        mapping: {
+          __segment_internal_sync_mode: 'add',
+          action_source: { '@path': '$.properties.action_source' },
+          app_data_field: {
+            use_app_data: true,
+            // The default mappings from the app_data object need to be recreated here
+            // since 'use_app_data' is set to true. Otherwise, the default mappings
+            // will not be set.
+            application_tracking_enabled: {
+              '@path': '$.context.device.adTrackingEnabled'
+            },
+            packageName: {
+              '@path': '$.context.app.namespace'
+            },
+            longVersion: {
+              '@path': '$.context.app.version'
+            },
+            osVersion: {
+              '@path': '$.context.os.version'
+            },
+            deviceName: {
+              '@path': '$.context.device.model'
+            },
+            locale: {
+              '@path': '$.context.locale'
+            },
+            carrier: {
+              '@path': '$.context.network.carrier'
+            },
+            width: {
+              '@path': '$.context.screen.width'
+            },
+            height: {
+              '@path': '$.context.screen.height'
+            },
+            density: {
+              '@path': '$.context.screen.density'
+            },
+            deviceTimezone: {
+              '@path': '$.context.timezone'
+            }
+          }
+        },
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"AddToCart\\",\\"event_time\\":\\"1631210000\\",\\"event_id\\":\\"123\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"external_id\\":[\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\"]},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"contents\\":[{\\"id\\":\\"abc12345\\"}]},\\"app_data\\":{\\"advertiser_tracking_enabled\\":0,\\"application_tracking_enabled\\":0,\\"extinfo\\":[\\"\\",\\"com.krusty.krab.ios-prod\\",\\"\\",\\"2.0.1\\",\\"16.3.1\\",\\"iPhone10,5\\",\\"en-US\\",\\"\\",\\"AT&T\\",\\"414\\",\\"736\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"America/Los Angeles\\",\\"\\",\\"\\"]}}]}"`
+      )
+    })
+
     it('should not send app events by default', async () => {
       nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart2.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart2.test.ts
@@ -584,6 +584,12 @@ describe('FacebookConversionsApi', () => {
           os: {
             name: 'iOS',
             version: '16.3.1'
+          },
+          anonId: {
+            anon_id: '1231'
+          },
+          madId: {
+            madid: '2313'
           }
         }
       })
@@ -641,7 +647,7 @@ describe('FacebookConversionsApi', () => {
       expect(responses[0].status).toBe(201)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"data\\":[{\\"event_name\\":\\"AddToCart\\",\\"event_time\\":\\"1631210000\\",\\"event_id\\":\\"123\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"external_id\\":[\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\"]},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"contents\\":[{\\"id\\":\\"abc12345\\"}]},\\"app_data\\":{\\"advertiser_tracking_enabled\\":0,\\"application_tracking_enabled\\":0,\\"extinfo\\":[\\"\\",\\"com.krusty.krab.ios-prod\\",\\"\\",\\"2.0.1\\",\\"16.3.1\\",\\"iPhone10,5\\",\\"en-US\\",\\"\\",\\"AT&T\\",\\"414\\",\\"736\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"America/Los Angeles\\"]}}]}"`
+        `"{\\"data\\":[{\\"event_name\\":\\"AddToCart\\",\\"event_time\\":\\"1631210000\\",\\"event_id\\":\\"123\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"external_id\\":[\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\"]},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"contents\\":[{\\"id\\":\\"abc12345\\"}]},\\"app_data\\":{\\"advertiser_tracking_enabled\\":0,\\"application_tracking_enabled\\":0,\\"extinfo\\":[\\"\\",\\"com.krusty.krab.ios-prod\\",\\"\\",\\"2.0.1\\",\\"16.3.1\\",\\"iPhone10,5\\",\\"en-US\\",\\"\\",\\"AT&T\\",\\"414\\",\\"736\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"America/Los Angeles\\",\\"\\",\\"\\"]}}]}"`
       )
     })
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/app-data.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/app-data.test.ts
@@ -33,13 +33,13 @@ describe('FacebookConversionsApi', () => {
     it('generated app data should always have a length 16 exinfo array', () => {
       let appData: GeneratedAppData | undefined = generate_app_data(sampleAppDataComplete)
       if (appData) {
-        expect(appData.extinfo.length).toBe(16)
+        expect(appData.extinfo.length).toBe(18)
       }
       expect(appData).toBeDefined()
 
       appData = generate_app_data(sampleAppDataIncomplete)
       if (appData) {
-        expect(appData.extinfo.length).toBe(16)
+        expect(appData.extinfo.length).toBe(18)
       }
       expect(appData).toBeDefined()
     })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/app-data.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/app-data.test.ts
@@ -30,7 +30,7 @@ describe('FacebookConversionsApi', () => {
     delete sampleAppDataIncomplete.carrier
     delete sampleAppDataIncomplete.deviceTimezone
 
-    it('generated app data should always have a length 16 exinfo array', () => {
+    it('generated app data should always have a length 18 exinfo array', () => {
       let appData: GeneratedAppData | undefined = generate_app_data(sampleAppDataComplete)
       if (appData) {
         expect(appData.extinfo.length).toBe(18)

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
@@ -90,6 +90,10 @@ export interface Payload {
      */
     anonId?: string
     /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string
@@ -143,6 +147,14 @@ export interface Payload {
      * Example: 'iPhone5,1'.
      */
     deviceName?: string
+    /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
     /**
      * Example: 'En_US'.
      */

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart2/generated-types.ts
@@ -90,6 +90,10 @@ export interface Payload {
      */
     anonId?: string
     /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string
@@ -143,6 +147,14 @@ export interface Payload {
      * Example: 'iPhone5,1'.
      */
     deviceName?: string
+    /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
     /**
      * Example: 'En_US'.
      */

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom/generated-types.ts
@@ -94,6 +94,10 @@ export interface Payload {
      */
     anonId?: string
     /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string
@@ -147,6 +151,14 @@ export interface Payload {
      * Example: 'iPhone5,1'.
      */
     deviceName?: string
+    /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
     /**
      * Example: 'En_US'.
      */

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom2/generated-types.ts
@@ -94,6 +94,10 @@ export interface Payload {
      */
     anonId?: string
     /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string
@@ -147,6 +151,14 @@ export interface Payload {
      * Example: 'iPhone5,1'.
      */
     deviceName?: string
+    /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
     /**
      * Example: 'En_US'.
      */

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
@@ -108,7 +108,7 @@ export const app_data_field: InputField = {
       type: 'string'
     },
     madId: {
-      label: 'advertiser ID (madid)',
+      label: 'Advertiser ID (madid)',
       description:
         'Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.',
       type: 'string'

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
@@ -33,7 +33,9 @@ export const generate_app_data = (app_data: AppData): GeneratedAppData | undefin
       app_data?.cpuCores ?? '',
       app_data?.storageSize ?? '',
       app_data?.freeStorage ?? '',
-      app_data?.deviceTimezone ?? ''
+      app_data?.deviceTimezone ?? '',
+      app_data?.anonId ?? '',
+      app_data?.madId ?? ''
     ]
   }
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
@@ -202,7 +202,7 @@ export const app_data_field: InputField = {
       '@path': '$.context.anon_id'
     },
     madId: {
-      '@path': '$.context.madid'
+      '@path': '$.context.madId'
     }
   }
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-app-data.ts
@@ -41,7 +41,7 @@ export const generate_app_data = (app_data: AppData): GeneratedAppData | undefin
 export const app_data_field: InputField = {
   label: 'App Events Fields',
   description: `These fields support sending app events to Facebook through the Conversions API. For more information about app events support in the Conversions API, see the Facebook docs [here](https://developers.facebook.com/docs/marketing-api/conversions-api/app-events).
-  App events sent through the Conversions API must be associated with a dataset. 
+  App events sent through the Conversions API must be associated with a dataset.
   Instructions for creating a dataset can be found [here](https://www.facebook.com/business/help/750785952855662?id=490360542427371). Once a dataset is created, the dataset ID
   can be substituted for the pixel ID in the destination settings.`,
   type: 'object',
@@ -97,6 +97,18 @@ export const app_data_field: InputField = {
     deviceName: {
       label: 'Device Model Name',
       description: `Example: 'iPhone5,1'.`,
+      type: 'string'
+    },
+    anonId: {
+      label: 'Install ID (anon_id)',
+      description:
+        'This field represents unique application installation instances. Note: This parameter is for app events only.',
+      type: 'string'
+    },
+    madId: {
+      label: 'advertiser ID (madid)',
+      description:
+        'Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.',
       type: 'string'
     },
     locale: {
@@ -183,6 +195,12 @@ export const app_data_field: InputField = {
     },
     deviceTimezone: {
       '@path': '$.context.timezone'
+    },
+    anonId: {
+      '@path': '$.context.anon_id'
+    },
+    madId: {
+      '@path': '$.context.madid'
     }
   }
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-user-data.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-user-data.ts
@@ -114,7 +114,7 @@ export const user_data_field: InputField = {
       type: 'string'
     },
     madId: {
-      label: 'advertiser ID (madid)',
+      label: 'Advertiser ID (madid)',
       description:
         'Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.',
       type: 'string'

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-user-data.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-user-data.ts
@@ -113,6 +113,12 @@ export const user_data_field: InputField = {
         'This field represents unique application installation instances. Note: This parameter is for app events only.',
       type: 'string'
     },
+    madId: {
+      label: 'advertiser ID (madid)',
+      description:
+        'Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.',
+      type: 'string'
+    },
     partner_id: {
       label: 'Partner ID',
       description: 'The ID issued by Facebook identity partner.',
@@ -284,6 +290,7 @@ export const hash_user_data = (payload: UserData): Object => {
     subscription_id: payload.user_data?.subscriptionID,
     lead_id: payload.user_data?.leadID,
     anon_id: payload.user_data?.anonId,
+    madid: payload.user_data?.madId,
     fb_login_id: payload.user_data?.fbLoginID,
     partner_id: payload.user_data?.partner_id,
     partner_name: payload.user_data?.partner_name

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
@@ -90,6 +90,10 @@ export interface Payload {
      */
     anonId?: string
     /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string
@@ -143,6 +147,14 @@ export interface Payload {
      * Example: 'iPhone5,1'.
      */
     deviceName?: string
+    /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
     /**
      * Example: 'En_US'.
      */

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout2/generated-types.ts
@@ -90,6 +90,10 @@ export interface Payload {
      */
     anonId?: string
     /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string
@@ -143,6 +147,14 @@ export interface Payload {
      * Example: 'iPhone5,1'.
      */
     deviceName?: string
+    /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
     /**
      * Example: 'En_US'.
      */

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
@@ -90,6 +90,10 @@ export interface Payload {
      */
     anonId?: string
     /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string
@@ -143,6 +147,14 @@ export interface Payload {
      * Example: 'iPhone5,1'.
      */
     deviceName?: string
+    /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
     /**
      * Example: 'En_US'.
      */

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView2/generated-types.ts
@@ -90,6 +90,10 @@ export interface Payload {
      */
     anonId?: string
     /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string
@@ -143,6 +147,14 @@ export interface Payload {
      * Example: 'iPhone5,1'.
      */
     deviceName?: string
+    /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
     /**
      * Example: 'En_US'.
      */

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
@@ -94,6 +94,10 @@ export interface Payload {
      */
     anonId?: string
     /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string
@@ -147,6 +151,14 @@ export interface Payload {
      * Example: 'iPhone5,1'.
      */
     deviceName?: string
+    /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
     /**
      * Example: 'En_US'.
      */

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase2/generated-types.ts
@@ -94,6 +94,10 @@ export interface Payload {
      */
     anonId?: string
     /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string
@@ -147,6 +151,14 @@ export interface Payload {
      * Example: 'iPhone5,1'.
      */
     deviceName?: string
+    /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
     /**
      * Example: 'En_US'.
      */

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
@@ -90,6 +90,10 @@ export interface Payload {
      */
     anonId?: string
     /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string
@@ -143,6 +147,14 @@ export interface Payload {
      * Example: 'iPhone5,1'.
      */
     deviceName?: string
+    /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
     /**
      * Example: 'En_US'.
      */

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search2/generated-types.ts
@@ -90,6 +90,10 @@ export interface Payload {
      */
     anonId?: string
     /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string
@@ -143,6 +147,14 @@ export interface Payload {
      * Example: 'iPhone5,1'.
      */
     deviceName?: string
+    /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
     /**
      * Example: 'En_US'.
      */

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
@@ -90,6 +90,10 @@ export interface Payload {
      */
     anonId?: string
     /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string
@@ -143,6 +147,14 @@ export interface Payload {
      * Example: 'iPhone5,1'.
      */
     deviceName?: string
+    /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
     /**
      * Example: 'En_US'.
      */

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent2/generated-types.ts
@@ -90,6 +90,10 @@ export interface Payload {
      */
     anonId?: string
     /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
+    /**
      * The ID issued by Facebook identity partner.
      */
     partner_id?: string
@@ -143,6 +147,14 @@ export interface Payload {
      * Example: 'iPhone5,1'.
      */
     deviceName?: string
+    /**
+     * This field represents unique application installation instances. Note: This parameter is for app events only.
+     */
+    anonId?: string
+    /**
+     * Your mobile advertiser ID, the advertising ID from an Android device or the Advertising Identifier (IDFA) from an Apple device.
+     */
+    madId?: string
     /**
      * Example: 'En_US'.
      */


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

Tested successfully in stage, the parameter is sent to FB and accepted:

<img width="1295" alt="Screenshot 2024-10-03 at 12 22 23 PM" src="https://github.com/user-attachments/assets/4af36a53-ba5b-41f6-a718-09e28df86134">


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [X] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
