### PR TITLE
AAD-427 Fix group call: pass through userId and anonymousId

### DIFF
--- a/packages/destination-actions/src/destinations/accoil-analytics/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/accoil-analytics/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Testing snapshot for actions-accoil-analytics destination: group action - all fields 1`] = `
 Object {
+  "anonymousId": "[t@95I7lqH",
   "groupId": "[t@95I7lqH",
   "timestamp": Any<String>,
   "traits": Object {
@@ -13,6 +14,7 @@ Object {
     "testType": "[t@95I7lqH",
   },
   "type": "group",
+  "userId": "[t@95I7lqH",
 }
 `;
 

--- a/packages/destination-actions/src/destinations/accoil-analytics/group/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/accoil-analytics/group/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Testing snapshot for AccoilAnalytics's group destination action: all fields 1`] = `
 Object {
+  "anonymousId": "x5]MKB8gueWVltH2",
   "groupId": "x5]MKB8gueWVltH2",
   "timestamp": Any<String>,
   "traits": Object {
@@ -13,6 +14,7 @@ Object {
     "testType": "x5]MKB8gueWVltH2",
   },
   "type": "group",
+  "userId": "x5]MKB8gueWVltH2",
 }
 `;
 

--- a/packages/destination-actions/src/destinations/accoil-analytics/group/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/accoil-analytics/group/__tests__/index.test.ts
@@ -11,6 +11,8 @@ describe('AccoilAnalytics.group', () => {
     const responses = await testDestination.testAction('group', {
       settings: { api_key: 'apikey' },
       event: createTestEvent({
+        userId: 'user1234',
+        anonymousId: 'anon1234',
         groupId: 'group123',
         traits: { mrr: 10, plan: 'starter', status: 'trial', createdAt: '2018-01-01T00:00:00.000Z', name: 'Group X' }
       }),
@@ -20,6 +22,8 @@ describe('AccoilAnalytics.group', () => {
     expect(responses.length).toBe(1)
     expect(responses[0].status).toBe(200)
     expect(responses[0].options.body).toMatch(/"type":\s*"group"/g)
+    expect(responses[0].options.body).toMatch(/"userId":\s*"user1234"/g)
+    expect(responses[0].options.body).toMatch(/"anonymousId":\s*"anon1234"/g)
     expect(responses[0].options.body).toContain('group123')
     expect(responses[0].options.body).toContain('Group X')
     expect(responses[0].options.body).toContain('starter')

--- a/packages/destination-actions/src/destinations/accoil-analytics/group/generated-types.ts
+++ b/packages/destination-actions/src/destinations/accoil-analytics/group/generated-types.ts
@@ -2,6 +2,14 @@
 
 export interface Payload {
   /**
+   * Anonymous id
+   */
+  anonymousId?: string
+  /**
+   * The ID associated with the user
+   */
+  userId?: string
+  /**
    * The group id
    */
   groupId: string

--- a/packages/destination-actions/src/destinations/accoil-analytics/group/index.ts
+++ b/packages/destination-actions/src/destinations/accoil-analytics/group/index.ts
@@ -9,6 +9,18 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Identify Accounts (groups) in Accoil',
   defaultSubscription: 'type = "group"',
   fields: {
+    anonymousId: {
+      type: 'string',
+      description: 'Anonymous id',
+      label: 'Anonymous ID',
+      default: { '@path': '$.anonymousId' }
+    },
+    userId: {
+      type: 'string',
+      description: 'The ID associated with the user',
+      label: 'User ID',
+      default: { '@path': '$.userId' }
+    },
     groupId: {
       type: 'string',
       description: 'The group id',
@@ -69,6 +81,8 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'post',
       json: {
         type: 'group',
+        anonymousId: payload.anonymousId,
+        userId: payload.userId,
         groupId: payload.groupId,
         traits: traits,
         timestamp: payload.timestamp


### PR DESCRIPTION
We noticed problems with our group call becase userId/anonymousId were not being passed through. This PR adds those to the group payload. I've also added some tests to make sure it shows up.

In our live testing we also notice the old action "Post to Accoil" is still in the mapping configuration even though it was previously removed as this action isn't public yet. Is there a way to clean that up or should it be reinstated?

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
