### PR TITLE
[s3] bump max batch size to 10_000

### DIFF
--- a/packages/destination-actions/src/destinations/s3/fields.ts
+++ b/packages/destination-actions/src/destinations/s3/fields.ts
@@ -186,7 +186,7 @@ export const commonFields: ActionDefinition<Settings>['fields'] = {
   batch_size: {
     label: 'Batch Size',
     description:
-      'Maximum number of events to include in each batch. Actual batch sizes may be lower. Max batch size is 25000.',
+      'Maximum number of events to include in each batch. Actual batch sizes may be lower. Max batch size is 10000.',
     type: 'number',
     required: false,
     default: 5000

--- a/packages/destination-actions/src/destinations/s3/functions.ts
+++ b/packages/destination-actions/src/destinations/s3/functions.ts
@@ -10,8 +10,9 @@ export async function send(payloads: Payload[], settings: Settings, rawMapping: 
   const actionColName = payloads[0]?.audience_action_column_name
   const batchColName = payloads[0]?.batch_size_column_name
 
-  if (batchSize > 5000) {
-    throw new IntegrationError('Batch size cannot exceed 5000', 'Invalid Payload', 400)
+  const maxBatchSize = 10_000
+  if (batchSize > maxBatchSize) {
+    throw new IntegrationError(`Batch size cannot exceed ${maxBatchSize}`, 'Invalid Payload', 400)
   }
 
   const headers: ColumnHeader[] = Object.entries(rawMapping.columns)

--- a/packages/destination-actions/src/destinations/s3/index.ts
+++ b/packages/destination-actions/src/destinations/s3/index.ts
@@ -1,5 +1,6 @@
 import { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
+import { DEFAULT_REQUEST_TIMEOUT } from '@segment/actions-core'
 import syncToS3 from './syncToS3'
 
 const destination: DestinationDefinition<Settings> = {
@@ -36,6 +37,11 @@ const destination: DestinationDefinition<Settings> = {
         description: 'The External ID to your IAM role. Generate a secure string and treat it like a password.',
         type: 'password',
         required: true
+      }
+    },
+    extendRequest() {
+      return {
+        timeout: Math.max(60_000, DEFAULT_REQUEST_TIMEOUT)
       }
     }
   },

--- a/packages/destination-actions/src/destinations/s3/index.ts
+++ b/packages/destination-actions/src/destinations/s3/index.ts
@@ -38,11 +38,11 @@ const destination: DestinationDefinition<Settings> = {
         type: 'password',
         required: true
       }
-    },
-    extendRequest() {
-      return {
-        timeout: Math.max(60_000, DEFAULT_REQUEST_TIMEOUT)
-      }
+    }
+  },
+  extendRequest() {
+    return {
+      timeout: Math.max(60_000, DEFAULT_REQUEST_TIMEOUT)
     }
   },
   actions: {

--- a/packages/destination-actions/src/destinations/s3/syncToS3/generated-types.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/generated-types.ts
@@ -94,7 +94,7 @@ export interface Payload {
    */
   enable_batching: boolean
   /**
-   * Maximum number of events to include in each batch. Actual batch sizes may be lower. Max batch size is 25000.
+   * Maximum number of events to include in each batch. Actual batch sizes may be lower. Max batch size is 10000.
    */
   batch_size?: number
   /**


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This bumps the max s3 batch size from 5,000 to 10,000

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
