### PR TITLE
fix gitleaks-rules.toml

### DIFF
--- a/.husky/gitleaks-rules.toml
+++ b/.husky/gitleaks-rules.toml
@@ -12,6 +12,7 @@ paths = [
 regexes = ['''219-09-9999''', '''078-05-1120''', '''(9[0-9]{2}|666)-\d{2}-\d{4}''']
 
 [[rules]]
+id = "facebook-system-user-token"
 description = "Facebook System User Access Token"
 regex = '''EAA[0-9A-Za-z]{100,}'''
 tags = ["token", "Facebook Token"]


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR fixes the following error when running the `pre-commit` hook:
```
FTL Failed to load config error="rule |id| is missing or empty, regex: EAA[0-9A-Za-z]{100,}"
```
## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
