### PR TITLE
[Magellan AI] Add client metadata mappings

### DIFF
--- a/packages/destination-actions/src/destinations/magellan-ai/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -3,12 +3,14 @@
 exports[`Testing snapshot for actions-magellan-ai destination: addToCart action - all fields 1`] = `
 Object {
   "currency": "NIO",
+  "ip": "36.184.84.10",
   "productId": "1ycI^2r",
   "productName": "1ycI^2r",
   "productType": "1ycI^2r",
   "productVendor": "1ycI^2r",
   "quantity": -64992310240215.04,
   "token": "1ycI^2r",
+  "ua": "1ycI^2r",
   "value": -64992310240215.04,
   "variantId": "1ycI^2r",
   "variantName": "1ycI^2r",
@@ -18,8 +20,10 @@ Object {
 exports[`Testing snapshot for actions-magellan-ai destination: addToCart action - required fields 1`] = `
 Object {
   "currency": "NIO",
+  "ip": "36.184.84.10",
   "quantity": -64992310240215.04,
   "token": "1ycI^2r",
+  "ua": "1ycI^2r",
   "value": -64992310240215.04,
 }
 `;
@@ -29,6 +33,7 @@ Object {
   "currency": "MDL",
   "discountCode": "TIKRkwh0SbShPf)0A#[",
   "id": "TIKRkwh0SbShPf)0A#[",
+  "ip": "238.158.118.124",
   "lineItems": Array [
     Object {
       "productId": "TIKRkwh0SbShPf)0A#[",
@@ -43,6 +48,7 @@ Object {
   ],
   "quantity": 78081917945118.72,
   "token": "TIKRkwh0SbShPf)0A#[",
+  "ua": "TIKRkwh0SbShPf)0A#[",
   "value": 78081917945118.72,
 }
 `;
@@ -51,7 +57,9 @@ exports[`Testing snapshot for actions-magellan-ai destination: checkout action -
 Object {
   "currency": "MDL",
   "id": "TIKRkwh0SbShPf)0A#[",
+  "ip": "238.158.118.124",
   "token": "TIKRkwh0SbShPf)0A#[",
+  "ua": "TIKRkwh0SbShPf)0A#[",
   "value": 78081917945118.72,
 }
 `;
@@ -59,29 +67,37 @@ Object {
 exports[`Testing snapshot for actions-magellan-ai destination: code action - all fields 1`] = `
 Object {
   "code": "*[IgdmoTG@k",
+  "ip": "104.240.250.119",
   "token": "*[IgdmoTG@k",
   "type": "*[IgdmoTG@k",
+  "ua": "*[IgdmoTG@k",
 }
 `;
 
 exports[`Testing snapshot for actions-magellan-ai destination: code action - required fields 1`] = `
 Object {
   "code": "*[IgdmoTG@k",
+  "ip": "104.240.250.119",
   "token": "*[IgdmoTG@k",
   "type": "*[IgdmoTG@k",
+  "ua": "*[IgdmoTG@k",
 }
 `;
 
 exports[`Testing snapshot for actions-magellan-ai destination: identify action - all fields 1`] = `
 Object {
+  "ip": "33.40.35.127",
   "token": "lkK!Vfi",
+  "ua": "lkK!Vfi",
   "userId": "lkK!Vfi",
 }
 `;
 
 exports[`Testing snapshot for actions-magellan-ai destination: identify action - required fields 1`] = `
 Object {
+  "ip": "33.40.35.127",
   "token": "lkK!Vfi",
+  "ua": "lkK!Vfi",
   "userId": "lkK!Vfi",
 }
 `;
@@ -121,10 +137,12 @@ Object {
   "category": "2bsDJl3C^^TnRNgF",
   "currency": "BYR",
   "id": "2bsDJl3C^^TnRNgF",
+  "ip": "184.189.6.66",
   "productId": "2bsDJl3C^^TnRNgF",
   "quantity": 40312441573212.16,
   "token": "2bsDJl3C^^TnRNgF",
   "type": "2bsDJl3C^^TnRNgF",
+  "ua": "2bsDJl3C^^TnRNgF",
   "value": 40312441573212.16,
 }
 `;
@@ -133,7 +151,9 @@ exports[`Testing snapshot for actions-magellan-ai destination: lead action - req
 Object {
   "currency": "BYR",
   "id": "2bsDJl3C^^TnRNgF",
+  "ip": "184.189.6.66",
   "token": "2bsDJl3C^^TnRNgF",
+  "ua": "2bsDJl3C^^TnRNgF",
   "value": 40312441573212.16,
 }
 `;
@@ -141,11 +161,13 @@ Object {
 exports[`Testing snapshot for actions-magellan-ai destination: product action - all fields 1`] = `
 Object {
   "currency": "JPY",
+  "ip": "198.66.204.71",
   "productId": "t7uT6JwnvlnnOV2jL",
   "productName": "t7uT6JwnvlnnOV2jL",
   "productType": "t7uT6JwnvlnnOV2jL",
   "productVendor": "t7uT6JwnvlnnOV2jL",
   "token": "t7uT6JwnvlnnOV2jL",
+  "ua": "t7uT6JwnvlnnOV2jL",
   "value": 50320375514398.72,
   "variantId": "t7uT6JwnvlnnOV2jL",
   "variantName": "t7uT6JwnvlnnOV2jL",
@@ -155,7 +177,9 @@ Object {
 exports[`Testing snapshot for actions-magellan-ai destination: product action - required fields 1`] = `
 Object {
   "currency": "JPY",
+  "ip": "198.66.204.71",
   "token": "t7uT6JwnvlnnOV2jL",
+  "ua": "t7uT6JwnvlnnOV2jL",
   "value": 50320375514398.72,
 }
 `;
@@ -165,6 +189,7 @@ Object {
   "currency": "UGX",
   "discountCode": "!OdP7X6NC",
   "id": "!OdP7X6NC",
+  "ip": "66.217.138.11",
   "isNewCustomer": true,
   "lineItems": Array [
     Object {
@@ -180,6 +205,7 @@ Object {
   ],
   "quantity": -43325033891758.08,
   "token": "!OdP7X6NC",
+  "ua": "!OdP7X6NC",
   "value": -43325033891758.08,
 }
 `;
@@ -188,7 +214,9 @@ exports[`Testing snapshot for actions-magellan-ai destination: purchase action -
 Object {
   "currency": "UGX",
   "id": "!OdP7X6NC",
+  "ip": "66.217.138.11",
   "token": "!OdP7X6NC",
+  "ua": "!OdP7X6NC",
   "value": -43325033891758.08,
 }
 `;
@@ -230,14 +258,18 @@ Object {
 
 exports[`Testing snapshot for actions-magellan-ai destination: view action - all fields 1`] = `
 Object {
+  "ip": "61.213.237.221",
   "token": "9&#iCHP1",
+  "ua": "9&#iCHP1",
   "url": "http://ova.gt/wihsa",
 }
 `;
 
 exports[`Testing snapshot for actions-magellan-ai destination: view action - required fields 1`] = `
 Object {
+  "ip": "61.213.237.221",
   "token": "9&#iCHP1",
+  "ua": "9&#iCHP1",
   "url": "http://ova.gt/wihsa",
 }
 `;

--- a/packages/destination-actions/src/destinations/magellan-ai/addToCart/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/addToCart/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -3,12 +3,14 @@
 exports[`Testing snapshot for MagellanAI's addToCart destination action: all fields 1`] = `
 Object {
   "currency": "NOK",
+  "ip": "174.149.190.63",
   "productId": "R2syV$j)mpbUuxE",
   "productName": "R2syV$j)mpbUuxE",
   "productType": "R2syV$j)mpbUuxE",
   "productVendor": "R2syV$j)mpbUuxE",
   "quantity": 33176727416995.84,
   "token": "R2syV$j)mpbUuxE",
+  "ua": "R2syV$j)mpbUuxE",
   "value": 33176727416995.84,
   "variantId": "R2syV$j)mpbUuxE",
   "variantName": "R2syV$j)mpbUuxE",
@@ -18,8 +20,10 @@ Object {
 exports[`Testing snapshot for MagellanAI's addToCart destination action: required fields 1`] = `
 Object {
   "currency": "NOK",
+  "ip": "174.149.190.63",
   "quantity": 33176727416995.84,
   "token": "R2syV$j)mpbUuxE",
+  "ua": "R2syV$j)mpbUuxE",
   "value": 33176727416995.84,
 }
 `;

--- a/packages/destination-actions/src/destinations/magellan-ai/addToCart/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/addToCart/__tests__/index.test.ts
@@ -8,7 +8,9 @@ const pixelToken = '123abc'
 const requiredFields = {
   value: 1234.56,
   currency: 'AUD',
-  quantity: 10
+  quantity: 10,
+  ip: '12.34.56.78',
+  ua: 'Foo Bar User Agent'
 }
 const optionalFields = {
   productId: 'product_id_0123',

--- a/packages/destination-actions/src/destinations/magellan-ai/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/addToCart/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
 import { buildPerformer } from '../utils'
-import { productFields } from '../schema'
+import { clientFields, productFields } from '../schema'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Add to Cart',
@@ -17,7 +17,8 @@ const action: ActionDefinition<Settings, Payload> = {
       default: { '@path': '$.properties.quantity' },
       required: true
     },
-    ...productFields
+    ...productFields,
+    ...clientFields
   },
   perform: buildPerformer('add_to_cart')
 }

--- a/packages/destination-actions/src/destinations/magellan-ai/checkout/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/checkout/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -5,6 +5,7 @@ Object {
   "currency": "ISK",
   "discountCode": "tsbfmW@",
   "id": "tsbfmW@",
+  "ip": "43.69.65.7",
   "lineItems": Array [
     Object {
       "productId": "tsbfmW@",
@@ -19,6 +20,7 @@ Object {
   ],
   "quantity": -60083978287185.92,
   "token": "tsbfmW@",
+  "ua": "tsbfmW@",
   "value": -60083978287185.92,
 }
 `;
@@ -27,7 +29,9 @@ exports[`Testing snapshot for MagellanAI's checkout destination action: required
 Object {
   "currency": "ISK",
   "id": "tsbfmW@",
+  "ip": "43.69.65.7",
   "token": "tsbfmW@",
+  "ua": "tsbfmW@",
   "value": -60083978287185.92,
 }
 `;

--- a/packages/destination-actions/src/destinations/magellan-ai/checkout/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/checkout/__tests__/index.test.ts
@@ -7,7 +7,9 @@ const testDestination = createTestIntegration(Destination)
 const pixelToken = '123abc'
 const requiredFields = {
   value: 999.99,
-  currency: 'USD'
+  currency: 'USD',
+  ip: '12.34.56.78',
+  ua: 'Foo Bar User Agent'
 }
 const optionalFields = {
   id: 'order_123-abc',

--- a/packages/destination-actions/src/destinations/magellan-ai/checkout/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/checkout/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
 import { buildPerformer } from '../utils'
-import { orderInfoFields, priceFields } from '../schema'
+import { clientFields, orderInfoFields, priceFields } from '../schema'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Checkout',
@@ -11,7 +11,8 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Checkout Started"',
   fields: {
     ...priceFields(),
-    ...orderInfoFields
+    ...orderInfoFields,
+    ...clientFields
   },
   perform: buildPerformer('checkout')
 }

--- a/packages/destination-actions/src/destinations/magellan-ai/code/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/code/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -3,15 +3,19 @@
 exports[`Testing snapshot for MagellanAI's code destination action: all fields 1`] = `
 Object {
   "code": "W6d#2RidC^5]!BUD@%",
+  "ip": "215.169.201.13",
   "token": "W6d#2RidC^5]!BUD@%",
   "type": "W6d#2RidC^5]!BUD@%",
+  "ua": "W6d#2RidC^5]!BUD@%",
 }
 `;
 
 exports[`Testing snapshot for MagellanAI's code destination action: required fields 1`] = `
 Object {
   "code": "W6d#2RidC^5]!BUD@%",
+  "ip": "215.169.201.13",
   "token": "W6d#2RidC^5]!BUD@%",
   "type": "W6d#2RidC^5]!BUD@%",
+  "ua": "W6d#2RidC^5]!BUD@%",
 }
 `;

--- a/packages/destination-actions/src/destinations/magellan-ai/code/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/code/__tests__/index.test.ts
@@ -5,7 +5,12 @@ import Destination from '../../index'
 const testDestination = createTestIntegration(Destination)
 
 const pixelToken = '123abc'
-const requiredFields = { code: 'FOOBAR29', type: 'discount%' }
+const requiredFields = {
+  code: 'FOOBAR29',
+  type: 'discount%',
+  ip: '12.34.56.78',
+  ua: 'Foo Bar User Agent'
+}
 const expectedPayload = { token: pixelToken, ...requiredFields }
 
 describe('MagellanAI.code', () => {
@@ -13,7 +18,12 @@ describe('MagellanAI.code', () => {
     nock('https://mgln.ai').post('/code', expectedPayload).reply(200)
 
     await testDestination.testAction('code', {
-      mapping: { code: 'FOOBAR29', type: 'discount%' },
+      mapping: {
+        code: 'FOOBAR29',
+        type: 'discount%',
+        ip: '12.34.56.78',
+        ua: 'Foo Bar User Agent'
+      },
       settings: { pixelToken: pixelToken }
     })
   })
@@ -35,7 +45,13 @@ describe('MagellanAI.code', () => {
     nock('https://mgln.ai').post('/code', expectedPayload).reply(200)
 
     await testDestination.testAction('code', {
-      mapping: { code: 'FOOBAR29', type: 'discount%', baz: 'bar' },
+      mapping: {
+        code: 'FOOBAR29',
+        type: 'discount%',
+        ip: '12.34.56.78',
+        ua: 'Foo Bar User Agent',
+        baz: 'bar'
+      },
       settings: { pixelToken: pixelToken }
     })
   })

--- a/packages/destination-actions/src/destinations/magellan-ai/code/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/code/index.ts
@@ -3,6 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
 import { buildPerformer } from '../utils'
+import { clientFields } from '../schema'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Code',
@@ -22,7 +23,8 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       default: 'promo',
       required: true
-    }
+    },
+    ...clientFields
   },
   perform: buildPerformer('code')
 }

--- a/packages/destination-actions/src/destinations/magellan-ai/identify/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/identify/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -2,14 +2,18 @@
 
 exports[`Testing snapshot for MagellanAI's identify destination action: all fields 1`] = `
 Object {
+  "ip": "206.160.101.213",
   "token": "UD9DA$2xqXR[KfJmt",
+  "ua": "UD9DA$2xqXR[KfJmt",
   "userId": "UD9DA$2xqXR[KfJmt",
 }
 `;
 
 exports[`Testing snapshot for MagellanAI's identify destination action: required fields 1`] = `
 Object {
+  "ip": "206.160.101.213",
   "token": "UD9DA$2xqXR[KfJmt",
+  "ua": "UD9DA$2xqXR[KfJmt",
   "userId": "UD9DA$2xqXR[KfJmt",
 }
 `;

--- a/packages/destination-actions/src/destinations/magellan-ai/identify/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/identify/index.ts
@@ -3,6 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
 import { buildPerformer } from '../utils'
+import { clientFields } from '../schema'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Identify',
@@ -16,7 +17,8 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       default: { '@path': '$.userId' },
       required: true
-    }
+    },
+    ...clientFields
   },
   perform: buildPerformer('identify')
 }

--- a/packages/destination-actions/src/destinations/magellan-ai/install/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/install/index.ts
@@ -3,13 +3,16 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
 import { buildPerformer } from '../utils'
-import { mobileFields } from '../schema'
+import { clientFields, mobileFields } from '../schema'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Install',
   description: 'Fire this event to track when a user installs your mobile application. (Mobile applications only)',
   defaultSubscription: 'type = "track" and event = "Application Installed"',
-  fields: mobileFields,
+  fields: {
+    ...mobileFields,
+    ...clientFields
+  },
   perform: buildPerformer('install')
 }
 

--- a/packages/destination-actions/src/destinations/magellan-ai/lead/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/lead/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -5,10 +5,12 @@ Object {
   "category": "dtVRL!L9hrw]avE1wNG",
   "currency": "HNL",
   "id": "dtVRL!L9hrw]avE1wNG",
+  "ip": "235.10.66.165",
   "productId": "dtVRL!L9hrw]avE1wNG",
   "quantity": 75893497596477.44,
   "token": "dtVRL!L9hrw]avE1wNG",
   "type": "dtVRL!L9hrw]avE1wNG",
+  "ua": "dtVRL!L9hrw]avE1wNG",
   "value": 75893497596477.44,
 }
 `;
@@ -17,7 +19,9 @@ exports[`Testing snapshot for MagellanAI's lead destination action: required fie
 Object {
   "currency": "HNL",
   "id": "dtVRL!L9hrw]avE1wNG",
+  "ip": "235.10.66.165",
   "token": "dtVRL!L9hrw]avE1wNG",
+  "ua": "dtVRL!L9hrw]avE1wNG",
   "value": 75893497596477.44,
 }
 `;

--- a/packages/destination-actions/src/destinations/magellan-ai/lead/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/lead/__tests__/index.test.ts
@@ -7,7 +7,9 @@ const testDestination = createTestIntegration(Destination)
 const pixelToken = '123abc'
 const requiredFields = {
   value: 1099.99,
-  currency: 'USD'
+  currency: 'USD',
+  ip: '12.34.56.78',
+  ua: 'Foo Bar User Agent'
 }
 const optionalFields = {
   id: 'lead-ID-123',

--- a/packages/destination-actions/src/destinations/magellan-ai/lead/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/lead/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
 import { buildPerformer } from '../utils'
-import { priceFields } from '../schema'
+import { clientFields, priceFields } from '../schema'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Lead',
@@ -44,7 +44,8 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       default: { '@path': '$.properties.category' },
       required: false
-    }
+    },
+    ...clientFields
   },
   perform: buildPerformer('lead')
 }

--- a/packages/destination-actions/src/destinations/magellan-ai/product/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/product/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -3,11 +3,13 @@
 exports[`Testing snapshot for MagellanAI's product destination action: all fields 1`] = `
 Object {
   "currency": "GHS",
+  "ip": "248.237.161.120",
   "productId": "&UIB5u0l0tYL8FZ*gE&f",
   "productName": "&UIB5u0l0tYL8FZ*gE&f",
   "productType": "&UIB5u0l0tYL8FZ*gE&f",
   "productVendor": "&UIB5u0l0tYL8FZ*gE&f",
   "token": "&UIB5u0l0tYL8FZ*gE&f",
+  "ua": "&UIB5u0l0tYL8FZ*gE&f",
   "value": 85171452310978.56,
   "variantId": "&UIB5u0l0tYL8FZ*gE&f",
   "variantName": "&UIB5u0l0tYL8FZ*gE&f",
@@ -17,7 +19,9 @@ Object {
 exports[`Testing snapshot for MagellanAI's product destination action: required fields 1`] = `
 Object {
   "currency": "GHS",
+  "ip": "248.237.161.120",
   "token": "&UIB5u0l0tYL8FZ*gE&f",
+  "ua": "&UIB5u0l0tYL8FZ*gE&f",
   "value": 85171452310978.56,
 }
 `;

--- a/packages/destination-actions/src/destinations/magellan-ai/product/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/product/__tests__/index.test.ts
@@ -7,7 +7,9 @@ const testDestination = createTestIntegration(Destination)
 const pixelToken = '123abc'
 const requiredFields = {
   value: 1099.99,
-  currency: 'CAD'
+  currency: 'CAD',
+  ip: '12.34.56.78',
+  ua: 'Foo Bar User Agent'
 }
 const optionalFields = {
   productId: 'product_id_0123',

--- a/packages/destination-actions/src/destinations/magellan-ai/product/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/product/index.ts
@@ -3,14 +3,17 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
 import { buildPerformer } from '../utils'
-import { productFields } from '../schema'
+import { clientFields, productFields } from '../schema'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Product',
   description:
     'Indicates that a user has visited the page for a specific product or variant of a product. This event is similar to the view event, but allows you to provide more details about the product the user has seen.',
   defaultSubscription: 'type = "track" and event = "Product Viewed"',
-  fields: productFields,
+  fields: {
+    ...productFields,
+    ...clientFields
+  },
   perform: buildPerformer('product')
 }
 

--- a/packages/destination-actions/src/destinations/magellan-ai/purchase/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/purchase/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -5,6 +5,7 @@ Object {
   "currency": "UZS",
   "discountCode": "PDOIxm6D7Wge",
   "id": "PDOIxm6D7Wge",
+  "ip": "119.143.101.141",
   "isNewCustomer": true,
   "lineItems": Array [
     Object {
@@ -20,6 +21,7 @@ Object {
   ],
   "quantity": -5726199338762.24,
   "token": "PDOIxm6D7Wge",
+  "ua": "PDOIxm6D7Wge",
   "value": -5726199338762.24,
 }
 `;
@@ -28,7 +30,9 @@ exports[`Testing snapshot for MagellanAI's purchase destination action: required
 Object {
   "currency": "UZS",
   "id": "PDOIxm6D7Wge",
+  "ip": "119.143.101.141",
   "token": "PDOIxm6D7Wge",
+  "ua": "PDOIxm6D7Wge",
   "value": -5726199338762.24,
 }
 `;

--- a/packages/destination-actions/src/destinations/magellan-ai/purchase/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/purchase/__tests__/index.test.ts
@@ -7,7 +7,9 @@ const testDestination = createTestIntegration(Destination)
 const pixelToken = '123abc'
 const requiredFields = {
   value: 999.99,
-  currency: 'USD'
+  currency: 'USD',
+  ip: '12.34.56.78',
+  ua: 'Foo Bar User Agent'
 }
 const optionalFields = {
   id: 'order_123-abc',

--- a/packages/destination-actions/src/destinations/magellan-ai/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/purchase/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
 import { buildPerformer } from '../utils'
-import { orderInfoFields, priceFields } from '../schema'
+import { clientFields, orderInfoFields, priceFields } from '../schema'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Purchase',
@@ -17,7 +17,8 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'Whether or not this customer is a first-time buyer from your store',
       type: 'boolean',
       required: false
-    }
+    },
+    ...clientFields
   },
   perform: buildPerformer('purchase')
 }

--- a/packages/destination-actions/src/destinations/magellan-ai/schema.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/schema.ts
@@ -1,5 +1,29 @@
 import { InputField } from '@segment/actions-core'
 
+export const clientFields: Record<string, InputField> = {
+  ip: {
+    label: 'IP address',
+    description: 'The IPv4 address of the end user (Note: Segment does not support collecting IPv6 addresses)',
+    type: 'string',
+    format: 'ipv4',
+    default: { '@path': '$.context.ip' },
+    required: true
+  },
+  ua: {
+    label: 'User agent',
+    description: 'The user agent of the end user (Note: not collected by the iOS Segment agent)',
+    type: 'string',
+    default: {
+      '@if': {
+        exists: { '@path': '$.context.userAgent' },
+        then: { '@path': '$.context.userAgent' },
+        else: { '@path': '$.context.library.name' }
+      }
+    },
+    required: true
+  }
+}
+
 export function priceFields(valueSource = 'value'): Record<string, InputField> {
   return {
     value: {
@@ -177,28 +201,6 @@ export const mobileFields: Record<string, InputField> = {
     description: 'The name of the mobile application',
     type: 'string',
     default: { '@path': '$.context.app.name' },
-    required: true
-  },
-  ip: {
-    label: 'IP address',
-    description:
-      'The IPv4 address of the end user who installed the app (Note: Segment does not support collecting IPv6 addresses)',
-    type: 'string',
-    format: 'ipv4',
-    default: { '@path': '$.context.ip' },
-    required: true
-  },
-  ua: {
-    label: 'User agent',
-    description: 'The user agent of the end user who installed the app (Note: not sent by the iOS Segment agent)',
-    type: 'string',
-    default: {
-      '@if': {
-        exists: { '@path': '$.context.userAgent' },
-        then: { '@path': '$.context.userAgent' },
-        else: { '@path': '$.context.library.name' }
-      }
-    },
     required: true
   },
   ts: {

--- a/packages/destination-actions/src/destinations/magellan-ai/thirdPartyEvent/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/thirdPartyEvent/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
 import { buildPerformer } from '../utils'
-import { mobileFields } from '../schema'
+import { clientFields, mobileFields } from '../schema'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Custom third-party event',
@@ -23,7 +23,8 @@ const action: ActionDefinition<Settings, Payload> = {
       default: { '@path': '$.properties' },
       required: false
     },
-    ...mobileFields
+    ...mobileFields,
+    ...clientFields
   },
   perform: buildPerformer('event')
 }

--- a/packages/destination-actions/src/destinations/magellan-ai/view/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/magellan-ai/view/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -2,14 +2,18 @@
 
 exports[`Testing snapshot for MagellanAI's view destination action: all fields 1`] = `
 Object {
+  "ip": "110.152.4.253",
   "token": "Sb]^DX%^W2b",
+  "ua": "Sb]^DX%^W2b",
   "url": "http://buwvu.tt/bardoc",
 }
 `;
 
 exports[`Testing snapshot for MagellanAI's view destination action: required fields 1`] = `
 Object {
+  "ip": "110.152.4.253",
   "token": "Sb]^DX%^W2b",
+  "ua": "Sb]^DX%^W2b",
   "url": "http://buwvu.tt/bardoc",
 }
 `;

--- a/packages/destination-actions/src/destinations/magellan-ai/view/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/view/__tests__/index.test.ts
@@ -5,25 +5,51 @@ import Destination from '../../index'
 const testDestination = createTestIntegration(Destination)
 
 const pixelToken = '123abc'
+const requiredFields = {
+  url: 'https://foo.bar/testing.html',
+  ip: '12.34.56.78',
+  ua: 'Foo Bar User Agent'
+}
+const expectedPayload = { token: pixelToken, ...requiredFields }
 
 describe('MagellanAI.view', () => {
   it('invokes the correct endpoint', async () => {
-    nock('https://mgln.ai').post('/view', { url: 'https://foo.bar/testing.html', token: '123abc' }).reply(200)
+    nock('https://mgln.ai').post('/view', expectedPayload).reply(200)
 
     await testDestination.testAction('view', {
-      mapping: { url: 'https://foo.bar/testing.html' },
+      mapping: {
+        url: 'https://foo.bar/testing.html',
+        ip: '12.34.56.78',
+        ua: 'Foo Bar User Agent'
+      },
       settings: { pixelToken: pixelToken }
     })
   })
 
-  it(`fails if the url field is missing`, async () => {
-    try {
-      await testDestination.testAction('view', {
-        mapping: {},
-        settings: { pixelToken: pixelToken }
-      })
-    } catch (err) {
-      expect(err.message).toContain("The root value is missing the required field 'url'.")
-    }
+  for (const requiredField in requiredFields) {
+    it(`fails if the ${requiredField} field is missing`, async () => {
+      try {
+        await testDestination.testAction('view', {
+          mapping: { ...requiredFields, [requiredField]: undefined },
+          settings: { pixelToken: pixelToken }
+        })
+      } catch (err) {
+        expect(err.message).toContain(`The root value is missing the required field '${requiredField}'.`)
+      }
+    })
+  }
+
+  it('rejects extraneous data', async () => {
+    nock('https://mgln.ai').post('/view', expectedPayload).reply(200)
+
+    await testDestination.testAction('view', {
+      mapping: {
+        url: 'https://foo.bar/testing.html',
+        ip: '12.34.56.78',
+        ua: 'Foo Bar User Agent',
+        foo: 'bar'
+      },
+      settings: { pixelToken: pixelToken }
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/magellan-ai/view/index.ts
+++ b/packages/destination-actions/src/destinations/magellan-ai/view/index.ts
@@ -3,6 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
 import { buildPerformer } from '../utils'
+import { clientFields } from '../schema'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'View',
@@ -16,7 +17,8 @@ const action: ActionDefinition<Settings, Payload> = {
       default: { '@path': '$.context.page.url' },
       format: 'uri',
       required: true
-    }
+    },
+    ...clientFields
   },
   perform: buildPerformer('view')
 }


### PR DESCRIPTION
Adds mappings for IP address and user agent to all actions. The fields are required, but default mappings are provided.

(It makes more sense now why [you asked](https://github.com/segmentio/action-destinations/pull/2008#pullrequestreview-2030726344) whether we need to send user identifiers in our action calls... We assumed the end user's IP address and user agent would be passed through instead of the requests coming from your servers, and somehow we never noticed that in our live testing until now. Sorry, and thanks!)

## Testing

Again, the two new fields are required, but default mappings are provided. The only case where that might be an issue is the user agent field on the iOS Segment library, relevant for the `install` and `thirdPartyEvent` actions, which is already documented and should already have been accounted for by any users already using that action.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
