### PR TITLE
Add supports_conversions flag to Google Enhanced conversions

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/generated-types.ts
@@ -14,9 +14,13 @@ export interface Settings {
 
 export interface AudienceSettings {
   /**
+   * Mark true if you are using uploadCallConversion, uploadClickConversion or uploadConversionAdjustment. This destination will only operate with these actions if this is true.
+   */
+  supports_conversions?: boolean
+  /**
    * Customer match upload key types.
    */
-  external_id_type: string
+  external_id_type?: string
   /**
    * A string that uniquely identifies a mobile application from which the data was collected. Required if external ID type is mobile advertising ID
    */

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/generated-types.ts
@@ -18,7 +18,7 @@ export interface AudienceSettings {
    */
   supports_conversions?: boolean
   /**
-   * Customer match upload key types.
+   * Customer match upload key types. Required if you are using UserLists. Not used by the other actions.
    */
   external_id_type?: string
   /**

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/generated-types.ts
@@ -14,7 +14,7 @@ export interface Settings {
 
 export interface AudienceSettings {
   /**
-   * Mark true if you are using uploadCallConversion, uploadClickConversion or uploadConversionAdjustment. This destination will only operate with these actions if this is true.
+   * Mark true if you are using uploadCallConversion, uploadClickConversion or uploadConversionAdjustment. If you plan to use userLists alone or in combination with the others, mark as false.
    */
   supports_conversions?: boolean
   /**

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -88,7 +88,8 @@ const destination: AudienceDestinationDefinition<Settings> = {
     external_id_type: {
       type: 'string',
       label: 'External ID Type',
-      description: 'Customer match upload key types.',
+      description:
+        'Customer match upload key types. Required if you are using UserLists. Not used by the other actions.',
       choices: [
         { label: 'CONTACT INFO', value: 'CONTACT_INFO' },
         { label: 'CRM ID', value: 'CRM_ID' },

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -78,11 +78,17 @@ const destination: AudienceDestinationDefinition<Settings> = {
     }
   },
   audienceFields: {
+    supports_conversions: {
+      type: 'boolean',
+      label: 'Supports Conversions',
+      description:
+        'Mark true if you are using uploadCallConversion, uploadClickConversion or uploadConversionAdjustment. This destination will only operate with these actions if this is true.',
+      default: false
+    },
     external_id_type: {
       type: 'string',
       label: 'External ID Type',
       description: 'Customer match upload key types.',
-      required: true,
       choices: [
         { label: 'CONTACT INFO', value: 'CONTACT_INFO' },
         { label: 'CRM ID', value: 'CRM_ID' },
@@ -112,6 +118,14 @@ const destination: AudienceDestinationDefinition<Settings> = {
       full_audience_sync: false // If true, we send the entire audience. If false, we just send the delta.
     },
     async createAudience(request, createAudienceInput: CreateAudienceInput) {
+      // When supports_conversions is enabled streaming mode is forced for this destination.
+      // This guarantees that uploadCallConversion, uploadClickConversion and uploadConversionAdjustment actions are usable with Engage sources.
+      if (createAudienceInput.audienceSettings.supports_conversions) {
+        return {
+          externalId: 'segment'
+        }
+      }
+
       createAudienceInput.settings.customerId = verifyCustomerId(createAudienceInput.settings.customerId)
       const auth = createAudienceInput.settings.oauth
       const userListId = await createGoogleAudience(

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -82,7 +82,7 @@ const destination: AudienceDestinationDefinition<Settings> = {
       type: 'boolean',
       label: 'Supports Conversions',
       description:
-        'Mark true if you are using uploadCallConversion, uploadClickConversion or uploadConversionAdjustment. This destination will only operate with these actions if this is true.',
+        'Mark true if you are using uploadCallConversion, uploadClickConversion or uploadConversionAdjustment. If you plan to use userLists alone or in combination with the others, mark as false.',
       default: false
     },
     external_id_type: {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/types.ts
@@ -145,8 +145,9 @@ export interface CreateAudienceInput {
     }
   }
   audienceSettings: {
-    external_id_type: string
+    external_id_type?: string
     app_id?: string
+    supports_conversions?: boolean
   }
   statsContext?: StatsContext
 }


### PR DESCRIPTION
Add a flag to the Google Enhanced Conversions destination to support event-destination flows from engage sources.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
