### PR TITLE
Add flagon support to Audience methods

### DIFF
--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -114,6 +114,8 @@ export type CreateAudienceInput<Settings = unknown, AudienceSettings = unknown> 
   audienceName: string
 
   statsContext?: StatsContext
+
+  features?: Features
 }
 
 export type GetAudienceInput<Settings = unknown, AudienceSettings = unknown> = {
@@ -124,6 +126,8 @@ export type GetAudienceInput<Settings = unknown, AudienceSettings = unknown> = {
   externalId: string
 
   statsContext?: StatsContext
+
+  features?: Features
 }
 
 export interface AudienceDestinationConfiguration {


### PR DESCRIPTION
Adds flagon support to audience methods. 

Should be deployed with https://github.com/segmentio/integrations/pull/3021

## Testing

Tested by adding flagon to webhooks audience destination and seeing the flagons appear in the call to createAudience.

The family that's accessible to these methods is: `centrifuge-destinations`.

![Screenshot 2024-10-15 at 9 14 21 AM](https://github.com/user-attachments/assets/b3a1f62f-5e6c-4cc9-8f68-2a3ecf7eab77)

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
