### PR TITLE
[PE-103] Update group action to use created_at as a reserved key

### DIFF
--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/index.test.ts
@@ -13,7 +13,7 @@ describe('Mixpanel.groupIdentifyUser', () => {
     const event = createTestEvent({
       timestamp,
       groupId: 'test-group-id',
-      traits: { hello: 'world', company: 'Mixpanel', name: 'test' }
+      traits: { hello: 'world', company: 'Mixpanel', name: 'test', created_at: timestamp }
     })
 
     nock('https://api.mixpanel.com').post('/groups').reply(200, {})
@@ -40,7 +40,8 @@ describe('Mixpanel.groupIdentifyUser', () => {
           $set: {
             hello: 'world',
             company: 'Mixpanel',
-            $name: 'test'
+            $name: 'test',
+            $created: timestamp
           }
         })
       })

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/index.ts
@@ -47,8 +47,10 @@ const action: ActionDefinition<Settings, Payload> = {
     const group_id = payload.traits[group_key] || payload.group_id
 
     const traits = {
-      ...omit(payload.traits, ['name']),
-      $name: payload.traits.name // transform to Mixpanel reserved property
+      ...omit(payload.traits, ['created', 'createdAt', 'created_at', 'name']),
+      // transform to Mixpanel reserved property
+      $name: payload.traits.name,
+      $created: payload.traits.created ?? payload.traits.createdAt ?? payload.traits.created_at
     }
     const data = {
       $token: settings.projectToken,


### PR DESCRIPTION
Currently, our Mixpanel group action only treats the `name` trait field as a reserved property for Mixpanel.

<img width="716" alt="Screenshot 2024-10-11 at 12 48 23 PM" src="https://github.com/user-attachments/assets/a1e98839-a063-494a-8436-739df670cdd8">

- [Reserved Properties in Mixpanel](https://docs.mixpanel.com/docs/data-structure/property-reference/reserved-properties)

[A customer has raised a concern](https://segment.zendesk.com/agent/tickets/521549) that they would like the created field to be handled in the same way as name. As currently, when `createdAt`, `created`, or `created_at` are not sent as `$created`, these fields are added to group profiles as regular profile properties instead of being treated as reserved properties.

The ask from the customer is to update the group action to operate in the same way that the identify action does regarding reserved properties. Similar to this update: https://github.com/segmentio/action-destinations/pull/801

![image](https://github.com/user-attachments/assets/f7a6aa12-06fb-441d-b237-9722c9153b9b)


## Testing

- ✅  Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- ✅ Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)

### before update
<img width="319" alt="Screenshot 2024-10-11 at 12 22 48 PM" src="https://github.com/user-attachments/assets/1cdc2ee0-ad2e-431e-919b-c46ebfcdf2fc">

### after update
<img width="321" alt="Screenshot 2024-10-11 at 12 22 28 PM" src="https://github.com/user-attachments/assets/089859fe-6aab-49e8-98be-8eaf6d2d3541">





