### PR TITLE
Mantle: add platform plan name option to identify

### DIFF
--- a/packages/destination-actions/src/destinations/mantle/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/mantle/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -10,6 +10,7 @@ Object {
   "name": "f$gKO(@kXal",
   "platform": "shopify",
   "platformId": "f$gKO(@kXal",
+  "platformPlanName": "f$gKO(@kXal",
 }
 `;
 

--- a/packages/destination-actions/src/destinations/mantle/identify/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/mantle/identify/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -10,6 +10,7 @@ Object {
   "name": "P%L*#Z]I@",
   "platform": "shopify",
   "platformId": "P%L*#Z]I@",
+  "platformPlanName": "P%L*#Z]I@",
 }
 `;
 

--- a/packages/destination-actions/src/destinations/mantle/identify/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mantle/identify/generated-types.ts
@@ -18,6 +18,10 @@ export interface Payload {
    */
   email?: string
   /**
+   * The name of the plan the customer is on on the platform (Shopify)
+   */
+  platformPlanName?: string
+  /**
    * The custom fields of the customer / shop
    */
   customFields?: {

--- a/packages/destination-actions/src/destinations/mantle/identify/index.ts
+++ b/packages/destination-actions/src/destinations/mantle/identify/index.ts
@@ -38,6 +38,13 @@ const action: ActionDefinition<Settings, Payload> = {
       required: false,
       default: { '@path': '$.traits.email' }
     },
+    platformPlanName: {
+      label: 'Platform Plan Name',
+      description: 'The name of the plan the customer is on on the platform (Shopify)',
+      type: 'string',
+      required: false,
+      default: { '@path': '$.traits.platformPlanName' }
+    },
     customFields: {
       label: 'Custom Fields',
       description: 'The custom fields of the customer / shop',
@@ -58,6 +65,7 @@ const action: ActionDefinition<Settings, Payload> = {
         myshopifyDomain: data.payload.myshopifyDomain,
         name: data.payload.name,
         email: data.payload.email,
+        ...(data.payload.platformPlanName ? { platformPlanName: data.payload.platformPlanName } : {}),
         ...(data.payload.customFields ? { customFields: data.payload.customFields } : {})
       }
     })


### PR DESCRIPTION
Adds mapping for platformPlanName optional field in the Mantle action.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
