### PR TITLE
Feature parity between InputField and GlobalSetting

### DIFF
--- a/packages/cli/src/commands/generate/types.ts
+++ b/packages/cli/src/commands/generate/types.ts
@@ -1,6 +1,10 @@
 import { Command, flags } from '@oclif/command'
 import { fieldsToJsonSchema } from '@segment/actions-core'
-import type { InputField, DestinationDefinition as CloudDestinationDefinition } from '@segment/actions-core'
+import type {
+  InputField,
+  DestinationDefinition as CloudDestinationDefinition,
+  GlobalSetting
+} from '@segment/actions-core'
 import type { BrowserDestinationDefinition } from '@segment/destinations-manifest'
 import chokidar from 'chokidar'
 import fs from 'fs-extra'
@@ -186,7 +190,11 @@ export default class GenerateTypes extends Command {
   }
 }
 
-async function generateTypes(fields: Record<string, InputField> = {}, name: string, bannerComment?: string) {
+async function generateTypes(
+  fields: Record<string, InputField | GlobalSetting> = {},
+  name: string,
+  bannerComment?: string
+) {
   const schema = prepareSchema(fields)
 
   return compile(schema, name, {
@@ -195,7 +203,7 @@ async function generateTypes(fields: Record<string, InputField> = {}, name: stri
   })
 }
 
-function prepareSchema(fields: Record<string, InputField>): JSONSchema4 {
+function prepareSchema(fields: Record<string, InputField | GlobalSetting>): JSONSchema4 {
   let schema = fieldsToJsonSchema(fields, { tsType: true })
   // Remove extra properties so it produces cleaner output
   schema = removeExtra(schema)

--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -8,7 +8,11 @@ import { renderTemplates } from '../lib/templates'
 import fs from 'fs-extra'
 import { camelCase, startCase } from 'lodash'
 import { fieldsToJsonSchema } from '@segment/actions-core'
-import type { InputField, DestinationDefinition as CloudDestinationDefinition } from '@segment/actions-core'
+import type {
+  InputField,
+  DestinationDefinition as CloudDestinationDefinition,
+  GlobalSetting
+} from '@segment/actions-core'
 import type { BrowserDestinationDefinition } from '@segment/destinations-manifest'
 import { JSONSchema4 } from 'json-schema'
 import { compile } from 'json-schema-to-typescript'
@@ -253,7 +257,7 @@ export default class Init extends Command {
   }
 }
 
-async function generateTypes(fields: Record<string, InputField> = {}, name: string) {
+async function generateTypes(fields: Record<string, InputField | GlobalSetting> = {}, name: string) {
   const schema = prepareSchema(fields)
 
   return compile(schema, name, {
@@ -262,7 +266,7 @@ async function generateTypes(fields: Record<string, InputField> = {}, name: stri
   })
 }
 
-function prepareSchema(fields: Record<string, InputField>): JSONSchema4 {
+function prepareSchema(fields: Record<string, InputField | GlobalSetting>): JSONSchema4 {
   let schema = fieldsToJsonSchema(fields, { tsType: true })
   // Remove extra properties so it produces cleaner output
   schema = removeExtra(schema)

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -102,7 +102,13 @@ export interface DynamicFieldItem {
 }
 
 /** The shape of authentication and top-level settings */
-export interface GlobalSetting extends Omit<InputField, 'allowNull' | 'additionalProperties' | 'dynamic'> {
+export interface GlobalSetting
+  extends Omit<
+    InputField,
+    | 'additionalProperties' // Settings cannot be an object
+    | 'defaultObjectUI' // Settings cannot be an object
+    | 'dynamic' // This type is redeclared
+  > {
   /** A subset of the available DestinationMetadataOption types */
   type: 'boolean' | 'string' | 'password' | 'number'
   /**

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -101,15 +101,9 @@ export interface DynamicFieldItem {
 }
 
 /** The shape of authentication and top-level settings */
-export interface GlobalSetting {
-  /** A short, human-friendly label for the field */
-  label: string
-  /** A human-friendly description of the field */
-  description: string
+export interface GlobalSetting extends InputField {
   /** A subset of the available DestinationMetadataOption types */
   type: 'boolean' | 'string' | 'password' | 'number'
-  /** Whether or not the field accepts more than one of its `type` */
-  multiple?: boolean
   /**
    * A predefined set of options for the setting.
    * Only relevant for `type: 'string'` or `type: 'number'`.
@@ -120,11 +114,7 @@ export interface GlobalSetting {
     /** A human-friendly label for the option */
     label: string
   }>
-  required?: boolean
   default?: string | number | boolean
-  properties?: InputField['properties']
-  format?: InputField['format']
-  depends_on?: InputField['depends_on']
 }
 
 /** The supported field type names */

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -5,7 +5,8 @@ import {
   TransactionContext,
   EngageDestinationCache,
   ActionHookType,
-  SubscriptionMetadata
+  SubscriptionMetadata,
+  RequestFn
 } from './index'
 import type { RequestOptions } from '../request-client'
 import type { JSONLikeObject, JSONObject } from '../json-object'
@@ -101,7 +102,7 @@ export interface DynamicFieldItem {
 }
 
 /** The shape of authentication and top-level settings */
-export interface GlobalSetting extends Omit<InputField, 'allowNull' | 'additionalProperties'> {
+export interface GlobalSetting extends Omit<InputField, 'allowNull' | 'additionalProperties' | 'dynamic'> {
   /** A subset of the available DestinationMetadataOption types */
   type: 'boolean' | 'string' | 'password' | 'number'
   /**
@@ -115,6 +116,8 @@ export interface GlobalSetting extends Omit<InputField, 'allowNull' | 'additiona
     label: string
   }>
   default?: string | number | boolean
+
+  dynamic?: RequestFn<Record<string, boolean | string | number>, {}>
 }
 
 /** The supported field type names */

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -101,7 +101,7 @@ export interface DynamicFieldItem {
 }
 
 /** The shape of authentication and top-level settings */
-export interface GlobalSetting extends InputField {
+export interface GlobalSetting extends Omit<InputField, 'allowNull' | 'additionalProperties'> {
   /** A subset of the available DestinationMetadataOption types */
   type: 'boolean' | 'string' | 'password' | 'number'
   /**


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

This PR is the first in a series that will upgrade `GlobalSetting` (top level settings) to support all of the UI features which have been developed for `InputField` (standard mapping-editor level fields). This will also apply to the AudienceDestination `audienceFields` options, which are top-level settings for audience destinations.

The main new UI functionality which will be added to GlobalSetting which it did not previously have is dynamic fields.

Related PRs:
* Control-Plane migration: https://github.com/segmentio/control-plane/pull/5345
* Control-Plane feature branch: https://github.com/segmentio/control-plane/pull/5378
* Action-CLI command updates: Todo

## Testing

Testing completed successfully via unit tests and successful build. These are type changes only.

Also tested the `yarn types` command with a dynamic audience setting and it still correctly works:
<img width="1484" alt="Screenshot 2024-10-29 at 3 29 39 PM" src="https://github.com/user-attachments/assets/734ac528-5ad3-4ac4-a9fb-def5ba104837">


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
