### PR TITLE
Fix version packages workflow

### DIFF
--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -56,7 +56,7 @@ jobs:
           git push origin ${{ github.event.inputs.branch }}
 
       - name: Install Dependencies
-        run: yarn install --frozen-lockfile --ignore-optional
+        run: yarn install --frozen-lockfile
 
       - name: Configure git
         run: |

--- a/packages/destination-actions/src/destinations/google-sheets-dev/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets-dev/index.ts
@@ -20,7 +20,7 @@ const destination: DestinationDefinition<Settings> = {
     // testAuthentication: (request) => {
     //   // Return a request that tests/validates the user's credentials.
     //   // If you do not have a way to validate the authentication fields safely,
-    //   // you can remove the `testAuthentication` function, though it's discouraged.
+    //   // you can remove the `testAuthentication` function, though discouraged.
     // },
     refreshAccessToken: async (request, { auth }) => {
       if (!auth.refreshTokenUrl) throw new Error('destination misconfigured: missing refresh token URL')

--- a/packages/destination-actions/src/destinations/google-sheets-dev/index.ts
+++ b/packages/destination-actions/src/destinations/google-sheets-dev/index.ts
@@ -20,7 +20,7 @@ const destination: DestinationDefinition<Settings> = {
     // testAuthentication: (request) => {
     //   // Return a request that tests/validates the user's credentials.
     //   // If you do not have a way to validate the authentication fields safely,
-    //   // you can remove the `testAuthentication` function, though discouraged.
+    //   // you can remove the `testAuthentication` function, though it's discouraged.
     // },
     refreshAccessToken: async (request, { auth }) => {
       if (!auth.refreshTokenUrl) throw new Error('destination misconfigured: missing refresh token URL')


### PR DESCRIPTION
Noticed that the version packages workflow didn't finish after the recent lerna upgrade. To fix this, I had to remove --ignore-optional arg to yarn install as platform specific depdencies are required for latest lerna to work.

## Testing

Testing completed successfully. Example success run - https://github.com/segmentio/action-destinations/actions/runs/11386840451/job/31680111802

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
