### PR TITLE
[Iterable Lists] Adding logic to not create an audience if an existing audience already exists with the same name.

### DIFF
--- a/packages/destination-actions/src/destinations/iterable-lists/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/__tests__/index.test.ts
@@ -19,7 +19,8 @@ describe('Iterable Lists', () => {
 
   describe('createAudience', () => {
     it('should create an audience', async () => {
-      nock('https://api.iterable.com/api').post('/lists').reply(200, {})
+      nock('https://api.iterable.com/api').get('/lists').times(1).reply(200, { lists: [] })
+      nock('https://api.iterable.com/api').post('/lists').times(1).reply(200, {})
 
       const settings = {
         apiKey: '123456'
@@ -46,7 +47,7 @@ describe('Iterable Lists', () => {
           lists: [
             {
               id: 123,
-              name: 'Test Audience'
+              name: 'test'
             }
           ]
         })
@@ -67,8 +68,7 @@ describe('Iterable Lists', () => {
         }
       }
 
-      await expect(testDestination.createAudience(createAudienceInput)).resolves.toEqual({ externalId: 123 })
-      // expect(listsEndpoint.).toBe(true)
+      await expect(testDestination.createAudience(createAudienceInput)).resolves.toEqual({ externalId: '123' })
     })
 
     it('should throw error when `personas` object is not provided in audience settings', async () => {
@@ -90,7 +90,7 @@ describe('Iterable Lists', () => {
     })
 
     it('should throw error when `computation_key` is not provided under `personas` object, under audience settings', async () => {
-      nock('https://api.iterable.com/api').post('/lists').reply(200, {})
+      nock('https://api.iterable.com/api').post('/lists').times(0).reply(200, { lists: [] })
 
       const settings = {
         apiKey: '123456'

--- a/packages/destination-actions/src/destinations/iterable-lists/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/__tests__/index.test.ts
@@ -38,6 +38,39 @@ describe('Iterable Lists', () => {
       await expect(testDestination.createAudience(createAudienceInput)).resolves.not.toThrowError()
     })
 
+    it('should return externalId of existing audience', async () => {
+      nock('https://api.iterable.com/api')
+        .get('/lists')
+        .times(2)
+        .reply(200, {
+          lists: [
+            {
+              id: 123,
+              name: 'Test Audience'
+            }
+          ]
+        })
+
+      nock('https://api.iterable.com/api').post('/lists').times(0).reply(200, {})
+
+      const settings = {
+        apiKey: '123456'
+      }
+
+      const createAudienceInput = {
+        settings,
+        audienceName: 'Test Audience',
+        personas: {
+          computation_key: 'test',
+          computation_id: '12342352452562',
+          namespace: 'spa_12312414212412'
+        }
+      }
+
+      await expect(testDestination.createAudience(createAudienceInput)).resolves.toEqual({ externalId: 123 })
+      // expect(listsEndpoint.).toBe(true)
+    })
+
     it('should throw error when `personas` object is not provided in audience settings', async () => {
       nock('https://api.iterable.com/api').post('/lists').reply(200, {})
 

--- a/packages/destination-actions/src/destinations/iterable-lists/index.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/index.ts
@@ -71,6 +71,23 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       }
 
       const audienceKey = personasSettings.computation_key
+
+      // If the list already exists, return its externalId
+      const getAudienceResponse = await request('https://api.iterable.com/api/lists', {
+        method: 'GET',
+        skipResponseCloning: true,
+        headers: { 'Api-Key': settings.apiKey }
+      })
+
+      const getAudienceResponseJson = await getAudienceResponse.json()
+      const existingAudience = (getAudienceResponseJson.lists as { id: number; name: string }[]).find(
+        (list: { id: number; name: string }) => list.name === audienceKey
+      )
+
+      if (existingAudience) {
+        return { externalId: existingAudience.id }
+      }
+
       const createAudienceResponse = await request('https://api.iterable.com/api/lists', {
         method: 'POST',
         headers: { 'Api-Key': settings.apiKey },

--- a/packages/destination-actions/src/destinations/iterable-lists/index.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/index.ts
@@ -101,7 +101,7 @@ async function getAudience(
     headers: { 'Api-Key': settings.apiKey }
   })
 
-  const json = (await response.data) as GetAudienceResp
+  const json: GetAudienceResp = (await response.data) as GetAudienceResp
   const audience = json.lists.find((list: { id: number; name: string }) => list.name === audienceKey)
   return audience?.id.toString() ?? undefined
 }

--- a/packages/destination-actions/src/destinations/iterable-lists/types.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/types.ts
@@ -1,24 +1,31 @@
 export interface IterableSubscribePayload {
-  listId: number,
-  subscribers: Array<Subscriber>,
+  listId: number
+  subscribers: Array<Subscriber>
   updateExistingUsersOnly?: boolean
 }
 
 export interface Subscriber {
-  email?: string,
-  dataFields?: Record<string, null | boolean | string | number | object>,
-  userId?: string,
+  email?: string
+  dataFields?: Record<string, null | boolean | string | number | object>
+  userId?: string
   preferUserId?: boolean
 }
 
 export interface IterableUnsubscribePayload {
-  listId: number,
-  subscribers: Array<Unsubscriber>,
-  campaignId?: string,
+  listId: number
+  subscribers: Array<Unsubscriber>
+  campaignId?: string
   channelUnsubscribe?: boolean
 }
 
 export interface Unsubscriber {
-  email?: string,
+  email?: string
   userId?: string
+}
+
+export interface GetAudienceResp {
+  lists: {
+    id: number
+    name: string
+  }[]
 }


### PR DESCRIPTION
After testing Iterable Lists destination with the customer, we found out that the audience lifecycle tries to create an audience more than once, which it generates errors on Iterable, preventing the audience to sync correctly. 

Here I add logic to first verify whether the corresponding list already exists. If it exists, the logic returns its id.

## Testing

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [X] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
