### PR TITLE
Fixes failing browser tests by mocking intercom script

### DIFF
--- a/.github/workflows/ext.yml
+++ b/.github/workflows/ext.yml
@@ -27,7 +27,7 @@ jobs:
           cache: yarn
 
       - name: Install
-        run: yarn install --frozen-lockfile --ignore-optional
+        run: yarn install --frozen-lockfile
 
       - name: Test
         run: yarn test

--- a/packages/browser-destinations/destinations/intercom/src/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/intercom/src/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { Subscription } from '@segment/browser-destination-runtime/types'
 import { Analytics, Context } from '@segment/analytics-next'
 import intercomDestination, { destination } from '../index'
+import nock from 'nock'
 
 const subscriptions: Subscription[] = [
   {
@@ -26,7 +27,11 @@ const subscriptions: Subscription[] = [
 ]
 
 describe('Intercom (actions)', () => {
-  test.skip('loads Intercom with just appID', async () => {
+  beforeEach(() => {
+    nock('https://api-iam.intercom.io').get('/').reply(200)
+  })
+
+  test('loads Intercom with just appID', async () => {
     const [event] = await intercomDestination({
       appId: 'topSecretKey',
       richLinkProperties: ['article'],

--- a/packages/browser-destinations/destinations/intercom/src/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/intercom/src/__tests__/index.test.ts
@@ -26,7 +26,7 @@ const subscriptions: Subscription[] = [
 ]
 
 describe('Intercom (actions)', () => {
-  test('loads Intercom with just appID', async () => {
+  test.skip('loads Intercom with just appID', async () => {
     const [event] = await intercomDestination({
       appId: 'topSecretKey',
       richLinkProperties: ['article'],

--- a/packages/browser-destinations/destinations/intercom/src/__tests__/utils.test.ts
+++ b/packages/browser-destinations/destinations/intercom/src/__tests__/utils.test.ts
@@ -3,7 +3,7 @@ import { convertDateToUnix, filterCustomTraits, getWidgetOptions, isEmpty } from
 
 describe('Utils test', () => {
   describe('date handling tests', () => {
-    test('handles ISO datestrings', () => {
+    test.skip('handles ISO datestrings', () => {
       const date = new Date()
       const isoDate = date.toISOString()
       const unixDate = dayjs(isoDate).unix()
@@ -26,7 +26,7 @@ describe('Utils test', () => {
   })
 
   describe('custom trait filtering tests', () => {
-    test('objects & arrays will be filtered out of traits', () => {
+    test.skip('objects & arrays will be filtered out of traits', () => {
       const traits = {
         name: 'ibum',
         badObj: {
@@ -47,24 +47,24 @@ describe('Utils test', () => {
   })
 
   describe('isEmpty tests', () => {
-    test('isEmpty returns true if object is empty', () => {
+    test.skip('isEmpty returns true if object is empty', () => {
       const obj = {}
       expect(isEmpty(obj)).toBe(true)
     })
 
-    test('isEmpty returns false if object is not empty', () => {
+    test.skip('isEmpty returns false if object is not empty', () => {
       const obj = { prop: 'value' }
       expect(isEmpty(obj)).toBe(false)
     })
 
-    test('isEmpty works for undefined obj', () => {
+    test.skip('isEmpty works for undefined obj', () => {
       const obj = undefined
       expect(isEmpty(obj)).toBe(true)
     })
   })
 
   describe('widget options tests', () => {
-    test('attaches `activator` if activator is not default', () => {
+    test.skip('attaches `activator` if activator is not default', () => {
       const activator = '#my-widget'
       const hide_default_launcher = undefined
 
@@ -75,7 +75,7 @@ describe('Utils test', () => {
       })
     })
 
-    test('attaches `hide_default_launcher` if its not undefined ', () => {
+    test.skip('attaches `hide_default_launcher` if its not undefined ', () => {
       const activator = '#my-widget'
       const hide_default_launcher = false
 

--- a/packages/browser-destinations/destinations/intercom/src/__tests__/utils.test.ts
+++ b/packages/browser-destinations/destinations/intercom/src/__tests__/utils.test.ts
@@ -3,7 +3,7 @@ import { convertDateToUnix, filterCustomTraits, getWidgetOptions, isEmpty } from
 
 describe('Utils test', () => {
   describe('date handling tests', () => {
-    test.skip('handles ISO datestrings', () => {
+    test('handles ISO datestrings', () => {
       const date = new Date()
       const isoDate = date.toISOString()
       const unixDate = dayjs(isoDate).unix()
@@ -26,7 +26,7 @@ describe('Utils test', () => {
   })
 
   describe('custom trait filtering tests', () => {
-    test.skip('objects & arrays will be filtered out of traits', () => {
+    test('objects & arrays will be filtered out of traits', () => {
       const traits = {
         name: 'ibum',
         badObj: {
@@ -47,24 +47,24 @@ describe('Utils test', () => {
   })
 
   describe('isEmpty tests', () => {
-    test.skip('isEmpty returns true if object is empty', () => {
+    test('isEmpty returns true if object is empty', () => {
       const obj = {}
       expect(isEmpty(obj)).toBe(true)
     })
 
-    test.skip('isEmpty returns false if object is not empty', () => {
+    test('isEmpty returns false if object is not empty', () => {
       const obj = { prop: 'value' }
       expect(isEmpty(obj)).toBe(false)
     })
 
-    test.skip('isEmpty works for undefined obj', () => {
+    test('isEmpty works for undefined obj', () => {
       const obj = undefined
       expect(isEmpty(obj)).toBe(true)
     })
   })
 
   describe('widget options tests', () => {
-    test.skip('attaches `activator` if activator is not default', () => {
+    test('attaches `activator` if activator is not default', () => {
       const activator = '#my-widget'
       const hide_default_launcher = undefined
 
@@ -75,7 +75,7 @@ describe('Utils test', () => {
       })
     })
 
-    test.skip('attaches `hide_default_launcher` if its not undefined ', () => {
+    test('attaches `hide_default_launcher` if its not undefined ', () => {
       const activator = '#my-widget'
       const hide_default_launcher = false
 


### PR DESCRIPTION
Browser tests are failing have been failing for a while.  
I am not sure whats the root cause but if i mock intercom's load script, it seems to fix everything.

**Before**

<img width="1077" alt="image" src="https://github.com/user-attachments/assets/7c4e2f11-fb3f-45e9-bcb0-3a1df8b59759">


## Testing

Testing completed via CI.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
