### PR TITLE
fix preset mappings

### DIFF
--- a/packages/destination-actions/src/destinations/snap-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/snap-audiences/index.ts
@@ -65,7 +65,17 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       subscribe: 'type = "track" and context.traits.email exists',
       partnerAction: 'syncAudience',
       mapping: {
-        schema_type: 'EMAIL_SHA256'
+        schema_type: 'EMAIL_SHA256',
+        external_audience_id: {
+          '@path': '$.context.personas.external_audience_id'
+        },
+        audienceKey: {
+          '@path': '$.context.personas.computation_key'
+        },
+        props: {
+          '@path': '$.properties'
+        },
+        enable_batching: true
       },
       type: 'automatic'
     },
@@ -74,7 +84,17 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       subscribe: 'type = "track" and properties.phone exists',
       partnerAction: 'syncAudience',
       mapping: {
-        schema_type: 'PHONE_SHA256'
+        schema_type: 'PHONE_SHA256',
+        external_audience_id: {
+          '@path': '$.context.personas.external_audience_id'
+        },
+        audienceKey: {
+          '@path': '$.context.personas.computation_key'
+        },
+        props: {
+          '@path': '$.properties'
+        },
+        enable_batching: true
       },
       type: 'automatic'
     },
@@ -83,7 +103,17 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       subscribe: 'type = "track" and context.device.advertisingId exists',
       partnerAction: 'syncAudience',
       mapping: {
-        schema_type: 'MOBILE_AD_ID_SHA256'
+        schema_type: 'MOBILE_AD_ID_SHA256',
+        external_audience_id: {
+          '@path': '$.context.personas.external_audience_id'
+        },
+        audienceKey: {
+          '@path': '$.context.personas.computation_key'
+        },
+        props: {
+          '@path': '$.properties'
+        },
+        enable_batching: true
       },
       type: 'automatic'
     }


### PR DESCRIPTION
Currently, you can't create the destination because the preset mappings are missing values for required fields, this fixes that. 

```
"external_audience_id is missing a value, but is required."
Field: settings.external_audience_id

"audienceKey is missing a value, but is required."
Field: settings.audienceKey

"props is missing a value, but is required."
Field: settings.props

"enable_batching is missing a value, but is required."
Field: settings.enable_batching
```

## Testing

N/A
