### PR TITLE
[Facebook Conversions] Adding Test Event Code to all mappings.

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/addToCart.test.ts
@@ -484,6 +484,65 @@ describe('FacebookConversionsApi', () => {
       )
     })
 
+    it('should send test_event_code if present in the mapping', async () => {
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Product Added',
+        userId: 'abc123',
+        timestamp: '1631210000',
+        properties: {
+          action_source: 'email',
+          currency: 'USD',
+          value: 12.12,
+          email: 'nicholas.aguilar@segment.com',
+          traits: {
+            city: 'Gotham',
+            country: 'United States',
+            last_name: 'Wayne'
+          },
+          test_event_code: '2345678901'
+        }
+      })
+
+      const responses = await testDestination.testAction('addToCart', {
+        event,
+        settings: settings,
+        mapping: {
+          currency: {
+            '@path': '$.properties.currency'
+          },
+          value: {
+            '@path': '$.properties.value'
+          },
+          user_data: {
+            email: {
+              '@path': '$.properties.email'
+            }
+          },
+          action_source: {
+            '@path': '$.properties.action_source'
+          },
+          event_time: {
+            '@path': '$.timestamp'
+          },
+          custom_data: {
+            '@path': '$.properties.traits'
+          },
+          test_event_code: {
+            '@path': '$.properties.test_event_code'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"AddToCart\\",\\"event_time\\":\\"1631210000\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"city\\":\\"Gotham\\",\\"country\\":\\"United States\\",\\"last_name\\":\\"Wayne\\",\\"currency\\":\\"USD\\",\\"value\\":12.12}}],\\"test_event_code\\":\\"2345678901\\"}"`
+      )
+    })
+
     it('should send app events without anon_id and madId using default mappings correctly', async () => {
       nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/custom.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/custom.test.ts
@@ -227,5 +227,63 @@ describe('FacebookConversionsApi', () => {
         `"{\\"data\\":[{\\"event_name\\":\\"identify\\",\\"event_time\\":\\"2015-02-23T22:28:55.111Z\\",\\"action_source\\":\\"website\\",\\"event_id\\":\\"022bb90c-bbac-11e4-8dfc-aa07a5b093db\\",\\"user_data\\":{\\"external_id\\":[\\"df73b86ff613b9d7008c175ae3c3aa3f2c1ea1674a80cac85274d58048e44127\\"],\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36\\"},\\"custom_data\\":{\\"action_source\\":\\"website\\",\\"timestamp\\":\\"1633473963\\"}}],\\"test_event_code\\":\\"1234567890\\"}"`
       )
     })
+
+    it('should send test_event_code if present in the mapping', async () => {
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
+
+      const event = createTestEvent({
+        anonymousId: '507f191e810c19729de860ea',
+        context: {
+          ip: '8.8.8.8',
+          userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36'
+        },
+        messageId: '022bb90c-bbac-11e4-8dfc-aa07a5b093db',
+        receivedAt: '2015-02-23T22:28:55.387Z',
+        sentAt: '2015-02-23T22:28:55.111Z',
+        timestamp: '2015-02-23T22:28:55.111Z',
+        traits: {
+          name: 'Peter Gibbons',
+          email: 'peter@example.com',
+          plan: 'premium',
+          logins: 5,
+          address: {
+            street: '6th St',
+            city: 'San Francisco',
+            state: 'CA',
+            postalCode: '94103',
+            country: 'USA'
+          }
+        },
+        properties: {
+          action_source: 'website',
+          timestamp: '1633473963',
+          test_event_code: '2345678901'
+        },
+        type: 'identify',
+        userId: '97980cfea0067',
+        event: 'identify'
+      })
+
+      const responses = await testDestination.testAction('custom', {
+        event,
+        settings: settingsWithTestEventCode,
+        useDefaultMappings: true,
+        mapping: {
+          action_source: { '@path': '$.properties.action_source' },
+          custom_data: { '@path': '$.properties' },
+          test_event_code: {
+            '@path': '$.properties.test_event_code'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"identify\\",\\"event_time\\":\\"2015-02-23T22:28:55.111Z\\",\\"action_source\\":\\"website\\",\\"event_id\\":\\"022bb90c-bbac-11e4-8dfc-aa07a5b093db\\",\\"user_data\\":{\\"external_id\\":[\\"df73b86ff613b9d7008c175ae3c3aa3f2c1ea1674a80cac85274d58048e44127\\"],\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36\\"},\\"custom_data\\":{\\"action_source\\":\\"website\\",\\"timestamp\\":\\"1633473963\\",\\"test_event_code\\":\\"2345678901\\"}}],\\"test_event_code\\":\\"2345678901\\"}"`
+      )
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/custom2.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/custom2.test.ts
@@ -266,5 +266,64 @@ describe('FacebookConversionsApi', () => {
         `"{\\"data\\":[{\\"event_name\\":\\"identify\\",\\"event_time\\":\\"2015-02-23T22:28:55.111Z\\",\\"action_source\\":\\"website\\",\\"event_id\\":\\"022bb90c-bbac-11e4-8dfc-aa07a5b093db\\",\\"user_data\\":{\\"external_id\\":[\\"df73b86ff613b9d7008c175ae3c3aa3f2c1ea1674a80cac85274d58048e44127\\"],\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36\\"},\\"custom_data\\":{\\"action_source\\":\\"website\\",\\"timestamp\\":\\"1633473963\\"}}],\\"test_event_code\\":\\"1234567890\\"}"`
       )
     })
+
+    it('should send test_event_code if present in the mapping', async () => {
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
+
+      const event = createTestEvent({
+        anonymousId: '507f191e810c19729de860ea',
+        context: {
+          ip: '8.8.8.8',
+          userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36'
+        },
+        messageId: '022bb90c-bbac-11e4-8dfc-aa07a5b093db',
+        receivedAt: '2015-02-23T22:28:55.387Z',
+        sentAt: '2015-02-23T22:28:55.111Z',
+        timestamp: '2015-02-23T22:28:55.111Z',
+        traits: {
+          name: 'Peter Gibbons',
+          email: 'peter@example.com',
+          plan: 'premium',
+          logins: 5,
+          address: {
+            street: '6th St',
+            city: 'San Francisco',
+            state: 'CA',
+            postalCode: '94103',
+            country: 'USA'
+          }
+        },
+        properties: {
+          action_source: 'website',
+          timestamp: '1633473963',
+          test_event_code: '2345678901'
+        },
+        type: 'identify',
+        userId: '97980cfea0067',
+        event: 'identify'
+      })
+
+      const responses = await testDestination.testAction('custom2', {
+        event,
+        settings: settingsWithTestEventCode,
+        useDefaultMappings: true,
+        mapping: {
+          __segment_internal_sync_mode: 'add',
+          action_source: { '@path': '$.properties.action_source' },
+          custom_data: { '@path': '$.properties' },
+          test_event_code: {
+            '@path': '$.properties.test_event_code'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"identify\\",\\"event_time\\":\\"2015-02-23T22:28:55.111Z\\",\\"action_source\\":\\"website\\",\\"event_id\\":\\"022bb90c-bbac-11e4-8dfc-aa07a5b093db\\",\\"user_data\\":{\\"external_id\\":[\\"df73b86ff613b9d7008c175ae3c3aa3f2c1ea1674a80cac85274d58048e44127\\"],\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36\\"},\\"custom_data\\":{\\"action_source\\":\\"website\\",\\"timestamp\\":\\"1633473963\\",\\"test_event_code\\":\\"2345678901\\"}}],\\"test_event_code\\":\\"2345678901\\"}"`
+      )
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/initiateCheckout.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/initiateCheckout.test.ts
@@ -227,6 +227,46 @@ describe('FacebookConversionsApi', () => {
       )
     })
 
+    it('should send test_event_code if present in the mapping', async () => {
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Checkout Started',
+        timestamp: '1631210020',
+        messageId: 'test',
+        properties: {
+          userId: 'testuser1234',
+          action_source: 'email',
+          currency: 'USD',
+          revenue: 12.12,
+          products: [
+            { product_id: '123', quantity: 1, price: 100 },
+            { product_id: '345', quantity: 2, price: 50 }
+          ],
+          test_event_code: '2345678901'
+        }
+      })
+
+      const responses = await testDestination.testAction('initiateCheckout', {
+        event,
+        settings: settingsWithTestEventCode,
+        useDefaultMappings: true,
+        mapping: {
+          action_source: { '@path': '$.properties.action_source' },
+          test_event_code: {
+            '@path': '$.properties.test_event_code'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"InitiateCheckout\\",\\"event_time\\":\\"1631210020\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"test\\",\\"user_data\\":{\\"external_id\\":[\\"831c237928e6212bedaa4451a514ace3174562f6761f6a157a2fe5082b36e2fb\\"],\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"contents\\":[{\\"id\\":\\"123\\",\\"quantity\\":1,\\"item_price\\":100},{\\"id\\":\\"345\\",\\"quantity\\":2,\\"item_price\\":50}]}}],\\"test_event_code\\":\\"2345678901\\"}"`
+      )
+    })
+
     it('should handle basic event mapping with mutiple externalId', async () => {
       nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/initiateCheckout2.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/initiateCheckout2.test.ts
@@ -278,6 +278,47 @@ describe('FacebookConversionsApi', () => {
       )
     })
 
+    it('should send test_event_code if present in the mapping', async () => {
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Checkout Started',
+        timestamp: '1631210020',
+        messageId: 'test',
+        properties: {
+          userId: 'testuser1234',
+          action_source: 'email',
+          currency: 'USD',
+          revenue: 12.12,
+          products: [
+            { product_id: '123', quantity: 1, price: 100 },
+            { product_id: '345', quantity: 2, price: 50 }
+          ],
+          test_event_code: '2345678901'
+        }
+      })
+
+      const responses = await testDestination.testAction('initiateCheckout2', {
+        event,
+        settings: settingsWithTestEventCode,
+        useDefaultMappings: true,
+        mapping: {
+          __segment_internal_sync_mode: 'add',
+          action_source: { '@path': '$.properties.action_source' },
+          test_event_code: {
+            '@path': '$.properties.test_event_code'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"InitiateCheckout\\",\\"event_time\\":\\"1631210020\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"test\\",\\"user_data\\":{\\"external_id\\":[\\"831c237928e6212bedaa4451a514ace3174562f6761f6a157a2fe5082b36e2fb\\"],\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"contents\\":[{\\"id\\":\\"123\\",\\"quantity\\":1,\\"item_price\\":100},{\\"id\\":\\"345\\",\\"quantity\\":2,\\"item_price\\":50}]}}],\\"test_event_code\\":\\"2345678901\\"}"`
+      )
+    })
+
     it('should handle basic event mapping with mutiple externalId', async () => {
       nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/pageView.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/pageView.test.ts
@@ -192,6 +192,42 @@ describe('FacebookConversionsApi', () => {
       )
     })
 
+    it('should send test_event_code if present in the mapping', async () => {
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
+
+      const event = createTestEvent({
+        type: 'page',
+        userId: 'abc123',
+        timestamp: '1631210020',
+        messageId: 'test',
+        properties: {
+          timestamp: 1631210000,
+          action_source: 'email',
+          email: 'nicholas.aguilar@segment.com',
+          test_event_code: '2345678901'
+        }
+      })
+
+      const responses = await testDestination.testAction('pageView', {
+        event,
+        settings: settingsWithTestEventCode,
+        useDefaultMappings: true,
+        mapping: {
+          action_source: { '@path': '$.properties.action_source' },
+          test_event_code: {
+            '@path': '$.properties.test_event_code'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"PageView\\",\\"event_time\\":\\"1631210020\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"test\\",\\"user_data\\":{\\"external_id\\":[\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\"],\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"}}],\\"test_event_code\\":\\"2345678901\\"}"`
+      )
+    })
+
     it('should handle a basic  event with multiple external Ids', async () => {
       nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/pageView2.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/pageView2.test.ts
@@ -236,7 +236,44 @@ describe('FacebookConversionsApi', () => {
       )
     })
 
-    it('should handle a basic  event with multiple external Ids', async () => {
+    it('should send test_event_code if present in the mapping', async () => {
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
+
+      const event = createTestEvent({
+        type: 'page',
+        userId: 'abc123',
+        timestamp: '1631210020',
+        messageId: 'test',
+        properties: {
+          timestamp: 1631210000,
+          action_source: 'email',
+          email: 'nicholas.aguilar@segment.com',
+          test_event_code: '2345678901'
+        }
+      })
+
+      const responses = await testDestination.testAction('pageView2', {
+        event,
+        settings: settingsWithTestEventCode,
+        useDefaultMappings: true,
+        mapping: {
+          __segment_internal_sync_mode: 'add',
+          action_source: { '@path': '$.properties.action_source' },
+          test_event_code: {
+            '@path': '$.properties.test_event_code'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"PageView\\",\\"event_time\\":\\"1631210020\\",\\"action_source\\":\\"email\\",\\"event_source_url\\":\\"https://segment.com/academy/\\",\\"event_id\\":\\"test\\",\\"user_data\\":{\\"external_id\\":[\\"6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090\\"],\\"client_ip_address\\":\\"8.8.8.8\\",\\"client_user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"}}],\\"test_event_code\\":\\"2345678901\\"}"`
+      )
+    })
+
+    it('should handle a basic event with multiple external Ids', async () => {
       nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 
       const event = createTestEvent({

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/purchase2.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/purchase2.test.ts
@@ -330,6 +330,81 @@ describe('purchase2', () => {
     )
   })
 
+  it('should send test_event_code if present in the mapping', async () => {
+    nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
+
+    const event = createTestEvent({
+      event: 'Order Completed',
+      userId: 'abc123',
+      timestamp: '1631210063',
+      properties: {
+        action_source: 'email',
+        currency: 'USD',
+        value: 12.12,
+        email: 'nicholas.aguilar@segment.com',
+        content_name: 'Shoes',
+        content_type: 'product',
+        contents: [
+          { id: 'ABC123', quantity: 2 },
+          { id: 'XYZ789', quantity: 3 }
+        ],
+        content_ids: ['ABC123', 'XYZ789'],
+        num_items: 2,
+        test_event_code: '2345678901'
+      }
+    })
+
+    const responses = await testDestination.testAction('purchase2', {
+      event,
+      settings: settingsWithTestEventCode,
+      mapping: {
+        __segment_internal_sync_mode: 'add',
+        currency: {
+          '@path': '$.properties.currency'
+        },
+        value: {
+          '@path': '$.properties.value'
+        },
+        user_data: {
+          email: {
+            '@path': '$.properties.email'
+          }
+        },
+        action_source: {
+          '@path': '$.properties.action_source'
+        },
+        event_time: {
+          '@path': '$.timestamp'
+        },
+        contents: {
+          '@path': '$.properties.contents'
+        },
+        num_items: {
+          '@path': '$.properties.num_items'
+        },
+        content_name: {
+          '@path': '$.properties.content_name'
+        },
+        content_type: {
+          '@path': '$.properties.content_type'
+        },
+        content_ids: {
+          '@path': '$.properties.content_ids'
+        },
+        test_event_code: {
+          '@path': '$.properties.test_event_code'
+        }
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(201)
+
+    expect(responses[0].options.body).toMatchInlineSnapshot(
+      `"{\\"data\\":[{\\"event_name\\":\\"Purchase\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"content_ids\\":[\\"ABC123\\",\\"XYZ789\\"],\\"content_name\\":\\"Shoes\\",\\"content_type\\":\\"product\\",\\"contents\\":[{\\"id\\":\\"ABC123\\",\\"quantity\\":2},{\\"id\\":\\"XYZ789\\",\\"quantity\\":3}],\\"num_items\\":2}}],\\"test_event_code\\":\\"2345678901\\"}"`
+    )
+  })
+
   it('should handle a basic event with mutiple external Ids', async () => {
     nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
 

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/search.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/search.test.ts
@@ -232,5 +232,75 @@ describe('FacebookConversionsApi', () => {
         `"{\\"data\\":[{\\"event_name\\":\\"Search\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"content_ids\\":[\\"ABC123\\",\\"XYZ789\\"],\\"contents\\":[{\\"id\\":\\"ABC123\\",\\"quantity\\":2},{\\"id\\":\\"XYZ789\\",\\"quantity\\":3}],\\"content_category\\":\\"Cookies\\",\\"value\\":12.12,\\"search_string\\":\\"Oreo\`s Quadruple Stack\\"}}],\\"test_event_code\\":\\"1234567890\\"}"`
       )
     })
+
+    it('should send test_event_code if present in the mapping', async () => {
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Products Searched',
+        userId: 'abc123',
+        timestamp: '1631210063',
+        properties: {
+          action_source: 'email',
+          currency: 'USD',
+          value: 12.12,
+          email: 'nicholas.aguilar@segment.com',
+          content_category: 'Cookies',
+          content_ids: ['ABC123', 'XYZ789'],
+          contents: [
+            { id: 'ABC123', quantity: 2 },
+            { id: 'XYZ789', quantity: 3 }
+          ],
+          search_string: 'Oreo`s Quadruple Stack',
+          test_event_code: '2345678901'
+        }
+      })
+
+      const responses = await testDestination.testAction('search', {
+        event,
+        settings: settingsWithTestEventCode,
+        mapping: {
+          currency: {
+            '@path': '$.properties.currency'
+          },
+          value: {
+            '@path': '$.properties.value'
+          },
+          user_data: {
+            email: {
+              '@path': '$.properties.email'
+            }
+          },
+          action_source: {
+            '@path': '$.properties.action_source'
+          },
+          event_time: {
+            '@path': '$.timestamp'
+          },
+          search_string: {
+            '@path': '$.properties.search_string'
+          },
+          contents: {
+            '@path': '$.properties.contents'
+          },
+          content_ids: {
+            '@path': '$.properties.content_ids'
+          },
+          content_category: {
+            '@path': '$.properties.content_category'
+          },
+          test_event_code: {
+            '@path': '$.properties.test_event_code'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"Search\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"content_ids\\":[\\"ABC123\\",\\"XYZ789\\"],\\"contents\\":[{\\"id\\":\\"ABC123\\",\\"quantity\\":2},{\\"id\\":\\"XYZ789\\",\\"quantity\\":3}],\\"content_category\\":\\"Cookies\\",\\"value\\":12.12,\\"search_string\\":\\"Oreo\`s Quadruple Stack\\"}}],\\"test_event_code\\":\\"2345678901\\"}"`
+      )
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/search2.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/search2.test.ts
@@ -286,5 +286,76 @@ describe('FacebookConversionsApi', () => {
         `"{\\"data\\":[{\\"event_name\\":\\"Search\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"content_ids\\":[\\"ABC123\\",\\"XYZ789\\"],\\"contents\\":[{\\"id\\":\\"ABC123\\",\\"quantity\\":2},{\\"id\\":\\"XYZ789\\",\\"quantity\\":3}],\\"content_category\\":\\"Cookies\\",\\"value\\":12.12,\\"search_string\\":\\"Oreo\`s Quadruple Stack\\"}}],\\"test_event_code\\":\\"1234567890\\"}"`
       )
     })
+
+    it('should send test_event_code if present in the mapping', async () => {
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Products Searched',
+        userId: 'abc123',
+        timestamp: '1631210063',
+        properties: {
+          action_source: 'email',
+          currency: 'USD',
+          value: 12.12,
+          email: 'nicholas.aguilar@segment.com',
+          content_category: 'Cookies',
+          content_ids: ['ABC123', 'XYZ789'],
+          contents: [
+            { id: 'ABC123', quantity: 2 },
+            { id: 'XYZ789', quantity: 3 }
+          ],
+          search_string: 'Oreo`s Quadruple Stack',
+          test_event_code: '2345678901'
+        }
+      })
+
+      const responses = await testDestination.testAction('search2', {
+        event,
+        settings: settingsWithTestEventCode,
+        mapping: {
+          __segment_internal_sync_mode: 'add',
+          currency: {
+            '@path': '$.properties.currency'
+          },
+          value: {
+            '@path': '$.properties.value'
+          },
+          user_data: {
+            email: {
+              '@path': '$.properties.email'
+            }
+          },
+          action_source: {
+            '@path': '$.properties.action_source'
+          },
+          event_time: {
+            '@path': '$.timestamp'
+          },
+          search_string: {
+            '@path': '$.properties.search_string'
+          },
+          contents: {
+            '@path': '$.properties.contents'
+          },
+          content_ids: {
+            '@path': '$.properties.content_ids'
+          },
+          content_category: {
+            '@path': '$.properties.content_category'
+          },
+          test_event_code: {
+            '@path': '$.properties.test_event_code'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"Search\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"content_ids\\":[\\"ABC123\\",\\"XYZ789\\"],\\"contents\\":[{\\"id\\":\\"ABC123\\",\\"quantity\\":2},{\\"id\\":\\"XYZ789\\",\\"quantity\\":3}],\\"content_category\\":\\"Cookies\\",\\"value\\":12.12,\\"search_string\\":\\"Oreo\`s Quadruple Stack\\"}}],\\"test_event_code\\":\\"2345678901\\"}"`
+      )
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/viewContent2.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/__tests__/viewContent2.test.ts
@@ -291,5 +291,83 @@ describe('FacebookConversionsApi', () => {
         `"{\\"data\\":[{\\"event_name\\":\\"ViewContent\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"content_ids\\":[\\"ABC123\\",\\"XYZ789\\"],\\"content_name\\":\\"Oreo's Quadruple Stack\\",\\"content_type\\":\\"product\\",\\"contents\\":[{\\"id\\":\\"ABC123\\",\\"quantity\\":2},{\\"id\\":\\"XYZ789\\",\\"quantity\\":3}],\\"content_category\\":\\"Cookies\\"}}],\\"test_event_code\\":\\"1234567890\\"}"`
       )
     })
+
+    it('should send test_event_code if present in the mapping', async () => {
+      nock(`https://graph.facebook.com/v${API_VERSION}/${settings.pixelId}`).post(`/events`).reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Product Viewed',
+        userId: 'abc123',
+        timestamp: '1631210063',
+        properties: {
+          action_source: 'email',
+          currency: 'USD',
+          value: 12.12,
+          email: 'nicholas.aguilar@segment.com',
+          content_category: 'Cookies',
+          content_name: "Oreo's Quadruple Stack",
+          content_type: 'product',
+          content_ids: ['ABC123', 'XYZ789'],
+          contents: [
+            { id: 'ABC123', quantity: 2 },
+            { id: 'XYZ789', quantity: 3 }
+          ],
+          test_event_code: '2345678901'
+        }
+      })
+
+      const responses = await testDestination.testAction('viewContent2', {
+        event,
+        settings: settingsWithTestEventCode,
+        mapping: {
+          __segment_internal_sync_mode: 'add',
+          currency: {
+            '@path': '$.properties.currency'
+          },
+          value: {
+            '@path': '$.properties.value'
+          },
+          user_data: {
+            email: {
+              '@path': '$.properties.email'
+            }
+          },
+          action_source: {
+            '@path': '$.properties.action_source'
+          },
+          event_time: {
+            '@path': '$.timestamp'
+          },
+          search_string: {
+            '@path': '$.properties.search_string'
+          },
+          contents: {
+            '@path': '$.properties.contents'
+          },
+          content_ids: {
+            '@path': '$.properties.content_ids'
+          },
+          content_category: {
+            '@path': '$.properties.content_category'
+          },
+          content_type: {
+            '@path': '$.properties.content_type'
+          },
+          content_name: {
+            '@path': '$.properties.content_name'
+          },
+          test_event_code: {
+            '@path': '$.properties.test_event_code'
+          }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"data\\":[{\\"event_name\\":\\"ViewContent\\",\\"event_time\\":\\"1631210063\\",\\"action_source\\":\\"email\\",\\"user_data\\":{\\"em\\":\\"eeaf810ee0e3cef3307089f22c3804f54c79eed19ef29bf70df864b43862c380\\"},\\"custom_data\\":{\\"currency\\":\\"USD\\",\\"value\\":12.12,\\"content_ids\\":[\\"ABC123\\",\\"XYZ789\\"],\\"content_name\\":\\"Oreo's Quadruple Stack\\",\\"content_type\\":\\"product\\",\\"contents\\":[{\\"id\\":\\"ABC123\\",\\"quantity\\":2},{\\"id\\":\\"XYZ789\\",\\"quantity\\":3}],\\"content_category\\":\\"Cookies\\"}}],\\"test_event_code\\":\\"2345678901\\"}"`
+      )
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/generated-types.ts
@@ -263,4 +263,8 @@ export interface Payload {
    * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
   data_processing_options_state?: number
+  /**
+   * Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. This property overrides the test event code defined in Settings. You'll want to remove your Test Event Code when sending real traffic through this integration.
+   */
+  test_event_code?: string
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart/index.ts
@@ -17,7 +17,8 @@ import {
   data_processing_options,
   data_processing_options_country,
   data_processing_options_state,
-  dataProcessingOptions
+  dataProcessingOptions,
+  test_event_code
 } from '../fb-capi-properties'
 import { CURRENCY_ISO_CODES } from '../constants'
 import { hash_user_data, user_data_field } from '../fb-capi-user-data'
@@ -63,7 +64,8 @@ const action: ActionDefinition<Settings, Payload> = {
     custom_data: custom_data,
     data_processing_options: data_processing_options,
     data_processing_options_country: data_processing_options_country,
-    data_processing_options_state: data_processing_options_state
+    data_processing_options_state: data_processing_options_state,
+    test_event_code: test_event_code
   },
 
   perform: (request, { payload, settings, features, statsContext }) => {
@@ -98,6 +100,8 @@ const action: ActionDefinition<Settings, Payload> = {
       payload.data_processing_options_state
     )
 
+    const testEventCode = payload.test_event_code || settings.testEventCode
+
     return request(
       `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
       {
@@ -126,7 +130,7 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_state: state_code
             }
           ],
-          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+          ...(testEventCode && { test_event_code: testEventCode })
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart2/generated-types.ts
@@ -263,4 +263,8 @@ export interface Payload {
    * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
   data_processing_options_state?: number
+  /**
+   * Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. This property overrides the test event code defined in Settings. You'll want to remove your Test Event Code when sending real traffic through this integration.
+   */
+  test_event_code?: string
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart2/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/addToCart2/index.ts
@@ -17,7 +17,8 @@ import {
   data_processing_options,
   data_processing_options_country,
   data_processing_options_state,
-  dataProcessingOptions
+  dataProcessingOptions,
+  test_event_code
 } from '../fb-capi-properties'
 import { CURRENCY_ISO_CODES } from '../constants'
 import { hash_user_data, user_data_field } from '../fb-capi-user-data'
@@ -69,7 +70,8 @@ const action: ActionDefinition<Settings, Payload> = {
     custom_data: custom_data,
     data_processing_options: data_processing_options,
     data_processing_options_country: data_processing_options_country,
-    data_processing_options_state: data_processing_options_state
+    data_processing_options_state: data_processing_options_state,
+    test_event_code: test_event_code
   },
 
   perform: (request, { payload, settings, features, statsContext, syncMode }) => {
@@ -105,6 +107,8 @@ const action: ActionDefinition<Settings, Payload> = {
         payload.data_processing_options_state
       )
 
+      const testEventCode = payload.test_event_code || settings.testEventCode
+
       return request(
         `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
         {
@@ -133,7 +137,7 @@ const action: ActionDefinition<Settings, Payload> = {
                 data_processing_options_state: state_code
               }
             ],
-            ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+            ...(testEventCode && { test_event_code: testEventCode })
           }
         }
       )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom/generated-types.ts
@@ -226,4 +226,8 @@ export interface Payload {
    * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
   data_processing_options_state?: number
+  /**
+   * Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. This property overrides the test event code defined in Settings. You'll want to remove your Test Event Code when sending real traffic through this integration.
+   */
+  test_event_code?: string
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom/index.ts
@@ -8,7 +8,8 @@ import {
   data_processing_options,
   data_processing_options_country,
   data_processing_options_state,
-  dataProcessingOptions
+  dataProcessingOptions,
+  test_event_code
 } from '../fb-capi-properties'
 import { hash_user_data, user_data_field } from '../fb-capi-user-data'
 import type { Settings } from '../generated-types'
@@ -39,7 +40,8 @@ const action: ActionDefinition<Settings, Payload> = {
     event_source_url: event_source_url,
     data_processing_options: data_processing_options,
     data_processing_options_country: data_processing_options_country,
-    data_processing_options_state: data_processing_options_state
+    data_processing_options_state: data_processing_options_state,
+    test_event_code: test_event_code
   },
   perform: (request, { payload, settings, features, statsContext }) => {
     if (!payload.user_data) {
@@ -51,6 +53,8 @@ const action: ActionDefinition<Settings, Payload> = {
       payload.data_processing_options_country,
       payload.data_processing_options_state
     )
+
+    const testEventCode = payload.test_event_code || settings.testEventCode
 
     return request(
       `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
@@ -72,7 +76,7 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_state: state_code
             }
           ],
-          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+          ...(testEventCode && { test_event_code: testEventCode })
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom2/generated-types.ts
@@ -226,4 +226,8 @@ export interface Payload {
    * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
   data_processing_options_state?: number
+  /**
+   * Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. This property overrides the test event code defined in Settings. You'll want to remove your Test Event Code when sending real traffic through this integration.
+   */
+  test_event_code?: string
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/custom2/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/custom2/index.ts
@@ -8,7 +8,8 @@ import {
   data_processing_options,
   data_processing_options_country,
   data_processing_options_state,
-  dataProcessingOptions
+  dataProcessingOptions,
+  test_event_code
 } from '../fb-capi-properties'
 import { hash_user_data, user_data_field } from '../fb-capi-user-data'
 import type { Settings } from '../generated-types'
@@ -45,7 +46,8 @@ const action: ActionDefinition<Settings, Payload> = {
     event_source_url: event_source_url,
     data_processing_options: data_processing_options,
     data_processing_options_country: data_processing_options_country,
-    data_processing_options_state: data_processing_options_state
+    data_processing_options_state: data_processing_options_state,
+    test_event_code: test_event_code
   },
   perform: (request, { payload, settings, features, statsContext, syncMode }) => {
     if (syncMode === 'add') {
@@ -58,6 +60,8 @@ const action: ActionDefinition<Settings, Payload> = {
         payload.data_processing_options_country,
         payload.data_processing_options_state
       )
+
+      const testEventCode = payload.test_event_code || settings.testEventCode
 
       return request(
         `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
@@ -79,7 +83,7 @@ const action: ActionDefinition<Settings, Payload> = {
                 data_processing_options_state: state_code
               }
             ],
-            ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+            ...(testEventCode && { test_event_code: testEventCode })
           }
         }
       )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-properties.ts
@@ -212,3 +212,11 @@ export const event_id: InputField = {
     '@path': '$.messageId'
   }
 }
+
+export const test_event_code: InputField = {
+  label: 'Test Event Code',
+  type: 'string',
+  description:
+    'Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. This property overrides the test event code defined in Settings. You\'ll want to remove your Test Event Code when sending real traffic through this integration.',
+  required: false
+}

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/generated-types.ts
@@ -6,7 +6,7 @@ export interface Settings {
    */
   pixelId: string
   /**
-   * Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. You'll want to remove your Test Event Code when sending real traffic through this integration.
+   * Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. This can be overridden by the Test Event Code defined in the mapping. You'll want to remove your Test Event Code when sending real traffic through this integration.
    */
   testEventCode?: string
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/index.ts
@@ -34,7 +34,7 @@ const destination: DestinationDefinition<Settings> = {
         label: 'Test Event Code',
         type: 'string',
         description:
-          'Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. You\'ll want to remove your Test Event Code when sending real traffic through this integration.',
+          'Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. This can be overridden by the Test Event Code defined in the mapping. You\'ll want to remove your Test Event Code when sending real traffic through this integration.',
         required: false
       }
     }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/generated-types.ts
@@ -263,4 +263,8 @@ export interface Payload {
    * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
   data_processing_options_state?: number
+  /**
+   * Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. This property overrides the test event code defined in Settings. You'll want to remove your Test Event Code when sending real traffic through this integration.
+   */
+  test_event_code?: string
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout/index.ts
@@ -18,7 +18,8 @@ import {
   data_processing_options,
   data_processing_options_country,
   data_processing_options_state,
-  dataProcessingOptions
+  dataProcessingOptions,
+  test_event_code
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import { get_api_version } from '../utils'
@@ -66,7 +67,8 @@ const action: ActionDefinition<Settings, Payload> = {
     custom_data: custom_data,
     data_processing_options: data_processing_options,
     data_processing_options_country: data_processing_options_country,
-    data_processing_options_state: data_processing_options_state
+    data_processing_options_state: data_processing_options_state,
+    test_event_code: test_event_code
   },
   perform: (request, { payload, settings, features, statsContext }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.has(payload.currency)) {
@@ -100,6 +102,8 @@ const action: ActionDefinition<Settings, Payload> = {
       payload.data_processing_options_state
     )
 
+    const testEventCode = payload.test_event_code || settings.testEventCode
+
     return request(
       `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
       {
@@ -128,7 +132,7 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_state: state_code
             }
           ],
-          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+          ...(testEventCode && { test_event_code: testEventCode })
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout2/generated-types.ts
@@ -263,4 +263,8 @@ export interface Payload {
    * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
   data_processing_options_state?: number
+  /**
+   * Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. This property overrides the test event code defined in Settings. You'll want to remove your Test Event Code when sending real traffic through this integration.
+   */
+  test_event_code?: string
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout2/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/initiateCheckout2/index.ts
@@ -18,7 +18,8 @@ import {
   data_processing_options,
   data_processing_options_country,
   data_processing_options_state,
-  dataProcessingOptions
+  dataProcessingOptions,
+  test_event_code
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import { get_api_version } from '../utils'
@@ -72,7 +73,8 @@ const action: ActionDefinition<Settings, Payload> = {
     custom_data: custom_data,
     data_processing_options: data_processing_options,
     data_processing_options_country: data_processing_options_country,
-    data_processing_options_state: data_processing_options_state
+    data_processing_options_state: data_processing_options_state,
+    test_event_code: test_event_code
   },
   perform: (request, { payload, settings, features, statsContext, syncMode }) => {
     if (syncMode === 'add') {
@@ -107,6 +109,8 @@ const action: ActionDefinition<Settings, Payload> = {
         payload.data_processing_options_state
       )
 
+      const testEventCode = payload.test_event_code || settings.testEventCode
+
       return request(
         `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
         {
@@ -135,7 +139,7 @@ const action: ActionDefinition<Settings, Payload> = {
                 data_processing_options_state: state_code
               }
             ],
-            ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+            ...(testEventCode && { test_event_code: testEventCode })
           }
         }
       )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/generated-types.ts
@@ -222,4 +222,8 @@ export interface Payload {
    * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
   data_processing_options_state?: number
+  /**
+   * Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. This property overrides the test event code defined in Settings. You'll want to remove your Test Event Code when sending real traffic through this integration.
+   */
+  test_event_code?: string
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView/index.ts
@@ -8,7 +8,8 @@ import {
   data_processing_options,
   data_processing_options_country,
   data_processing_options_state,
-  dataProcessingOptions
+  dataProcessingOptions,
+  test_event_code
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import type { Settings } from '../generated-types'
@@ -30,7 +31,8 @@ const action: ActionDefinition<Settings, Payload> = {
     custom_data: custom_data,
     data_processing_options: data_processing_options,
     data_processing_options_country: data_processing_options_country,
-    data_processing_options_state: data_processing_options_state
+    data_processing_options_state: data_processing_options_state,
+    test_event_code: test_event_code
   },
   perform: (request, { payload, settings, features, statsContext }) => {
     if (!payload.user_data) {
@@ -51,6 +53,8 @@ const action: ActionDefinition<Settings, Payload> = {
       payload.data_processing_options_state
     )
 
+    const testEventCode = payload.test_event_code || settings.testEventCode
+
     return request(
       `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
       {
@@ -70,7 +74,7 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_state: state_code
             }
           ],
-          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+          ...(testEventCode && { test_event_code: testEventCode })
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView2/generated-types.ts
@@ -222,4 +222,8 @@ export interface Payload {
    * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
   data_processing_options_state?: number
+  /**
+   * Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. This property overrides the test event code defined in Settings. You'll want to remove your Test Event Code when sending real traffic through this integration.
+   */
+  test_event_code?: string
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/pageView2/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/pageView2/index.ts
@@ -8,7 +8,8 @@ import {
   data_processing_options,
   data_processing_options_country,
   data_processing_options_state,
-  dataProcessingOptions
+  dataProcessingOptions,
+  test_event_code
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import type { Settings } from '../generated-types'
@@ -36,7 +37,8 @@ const action: ActionDefinition<Settings, Payload> = {
     custom_data: custom_data,
     data_processing_options: data_processing_options,
     data_processing_options_country: data_processing_options_country,
-    data_processing_options_state: data_processing_options_state
+    data_processing_options_state: data_processing_options_state,
+    test_event_code: test_event_code
   },
   perform: (request, { payload, settings, features, statsContext, syncMode }) => {
     if (syncMode === 'add') {
@@ -58,6 +60,8 @@ const action: ActionDefinition<Settings, Payload> = {
         payload.data_processing_options_state
       )
 
+      const testEventCode = payload.test_event_code || settings.testEventCode
+
       return request(
         `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
         {
@@ -77,7 +81,7 @@ const action: ActionDefinition<Settings, Payload> = {
                 data_processing_options_state: state_code
               }
             ],
-            ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+            ...(testEventCode && { test_event_code: testEventCode })
           }
         }
       )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/generated-types.ts
@@ -267,4 +267,8 @@ export interface Payload {
    * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
   data_processing_options_state?: number
+  /**
+   * Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. This property overrides the test event code defined in Settings. You'll want to remove your Test Event Code when sending real traffic through this integration.
+   */
+  test_event_code?: string
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase/index.ts
@@ -20,7 +20,8 @@ import {
   data_processing_options,
   data_processing_options_country,
   data_processing_options_state,
-  dataProcessingOptions
+  dataProcessingOptions,
+  test_event_code
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import { generate_app_data, app_data_field } from '../fb-capi-app-data'
@@ -69,7 +70,8 @@ const action: ActionDefinition<Settings, Payload> = {
     custom_data: custom_data,
     data_processing_options: data_processing_options,
     data_processing_options_country: data_processing_options_country,
-    data_processing_options_state: data_processing_options_state
+    data_processing_options_state: data_processing_options_state,
+    test_event_code: test_event_code
   },
   perform: (request, { payload, settings, features, statsContext }) => {
     if (!CURRENCY_ISO_CODES.has(payload.currency)) {
@@ -98,6 +100,8 @@ const action: ActionDefinition<Settings, Payload> = {
       payload.data_processing_options_country,
       payload.data_processing_options_state
     )
+
+    const testEventCode = payload.test_event_code || settings.testEventCode
 
     return request(
       `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
@@ -128,7 +132,7 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_state: state_code
             }
           ],
-          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+          ...(testEventCode && { test_event_code: testEventCode })
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase2/generated-types.ts
@@ -267,4 +267,8 @@ export interface Payload {
    * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
   data_processing_options_state?: number
+  /**
+   * Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. This property overrides the test event code defined in Settings. You'll want to remove your Test Event Code when sending real traffic through this integration.
+   */
+  test_event_code?: string
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/purchase2/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/purchase2/index.ts
@@ -20,7 +20,8 @@ import {
   data_processing_options,
   data_processing_options_country,
   data_processing_options_state,
-  dataProcessingOptions
+  dataProcessingOptions,
+  test_event_code
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import { generate_app_data, app_data_field } from '../fb-capi-app-data'
@@ -75,7 +76,8 @@ const action: ActionDefinition<Settings, Payload> = {
     custom_data: custom_data,
     data_processing_options: data_processing_options,
     data_processing_options_country: data_processing_options_country,
-    data_processing_options_state: data_processing_options_state
+    data_processing_options_state: data_processing_options_state,
+    test_event_code: test_event_code
   },
   perform: (request, { payload, settings, features, statsContext, syncMode }) => {
     if (syncMode === 'add') {
@@ -106,6 +108,8 @@ const action: ActionDefinition<Settings, Payload> = {
         payload.data_processing_options_state
       )
 
+      const testEventCode = payload.test_event_code || settings.testEventCode
+
       return request(
         `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
         {
@@ -135,7 +139,7 @@ const action: ActionDefinition<Settings, Payload> = {
                 data_processing_options_state: state_code
               }
             ],
-            ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+            ...(testEventCode && { test_event_code: testEventCode })
           }
         }
       )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/generated-types.ts
@@ -263,4 +263,8 @@ export interface Payload {
    * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
   data_processing_options_state?: number
+  /**
+   * Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. This property overrides the test event code defined in Settings. You'll want to remove your Test Event Code when sending real traffic through this integration.
+   */
+  test_event_code?: string
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search/index.ts
@@ -18,7 +18,8 @@ import {
   data_processing_options,
   data_processing_options_country,
   data_processing_options_state,
-  dataProcessingOptions
+  dataProcessingOptions,
+  test_event_code
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import { generate_app_data, app_data_field } from '../fb-capi-app-data'
@@ -69,7 +70,8 @@ const action: ActionDefinition<Settings, Payload> = {
     custom_data: custom_data,
     data_processing_options: data_processing_options,
     data_processing_options_country: data_processing_options_country,
-    data_processing_options_state: data_processing_options_state
+    data_processing_options_state: data_processing_options_state,
+    test_event_code: test_event_code
   },
   perform: (request, { payload, settings, features, statsContext }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.has(payload.currency)) {
@@ -103,6 +105,8 @@ const action: ActionDefinition<Settings, Payload> = {
       payload.data_processing_options_state
     )
 
+    const testEventCode = payload.test_event_code || settings.testEventCode
+
     return request(
       `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
       {
@@ -131,7 +135,7 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_state: state_code
             }
           ],
-          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+          ...(testEventCode && { test_event_code: testEventCode })
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search2/generated-types.ts
@@ -263,4 +263,8 @@ export interface Payload {
    * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
   data_processing_options_state?: number
+  /**
+   * Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. This property overrides the test event code defined in Settings. You'll want to remove your Test Event Code when sending real traffic through this integration.
+   */
+  test_event_code?: string
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/search2/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/search2/index.ts
@@ -18,7 +18,8 @@ import {
   data_processing_options,
   data_processing_options_country,
   data_processing_options_state,
-  dataProcessingOptions
+  dataProcessingOptions,
+  test_event_code
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import { generate_app_data, app_data_field } from '../fb-capi-app-data'
@@ -75,7 +76,8 @@ const action: ActionDefinition<Settings, Payload> = {
     custom_data: custom_data,
     data_processing_options: data_processing_options,
     data_processing_options_country: data_processing_options_country,
-    data_processing_options_state: data_processing_options_state
+    data_processing_options_state: data_processing_options_state,
+    test_event_code: test_event_code
   },
   perform: (request, { payload, settings, features, statsContext, syncMode }) => {
     if (syncMode === 'add') {
@@ -110,6 +112,8 @@ const action: ActionDefinition<Settings, Payload> = {
         payload.data_processing_options_state
       )
 
+      const testEventCode = payload.test_event_code || settings.testEventCode
+
       return request(
         `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
         {
@@ -138,7 +142,7 @@ const action: ActionDefinition<Settings, Payload> = {
                 data_processing_options_state: state_code
               }
             ],
-            ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+            ...(testEventCode && { test_event_code: testEventCode })
           }
         }
       )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/generated-types.ts
@@ -267,4 +267,8 @@ export interface Payload {
    * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
   data_processing_options_state?: number
+  /**
+   * Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. This property overrides the test event code defined in Settings. You'll want to remove your Test Event Code when sending real traffic through this integration.
+   */
+  test_event_code?: string
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent/index.ts
@@ -16,7 +16,8 @@ import {
   data_processing_options,
   data_processing_options_country,
   data_processing_options_state,
-  dataProcessingOptions
+  dataProcessingOptions,
+  test_event_code
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import type { Settings } from '../generated-types'
@@ -65,7 +66,8 @@ const action: ActionDefinition<Settings, Payload> = {
     custom_data: custom_data,
     data_processing_options: data_processing_options,
     data_processing_options_country: data_processing_options_country,
-    data_processing_options_state: data_processing_options_state
+    data_processing_options_state: data_processing_options_state,
+    test_event_code: test_event_code
   },
   perform: (request, { payload, settings, features, statsContext }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.has(payload.currency)) {
@@ -99,6 +101,8 @@ const action: ActionDefinition<Settings, Payload> = {
       payload.data_processing_options_state
     )
 
+    const testEventCode = payload.test_event_code || settings.testEventCode
+
     return request(
       `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
       {
@@ -128,7 +132,7 @@ const action: ActionDefinition<Settings, Payload> = {
               data_processing_options_state: state_code
             }
           ],
-          ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+          ...(testEventCode && { test_event_code: testEventCode })
         }
       }
     )

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent2/generated-types.ts
@@ -267,4 +267,8 @@ export interface Payload {
    * A state that you want to associate to the Data Processing Options. Accepted values are 1000, for California, or 0, to request that Facebook geolocates the event using IP address. This is required if Data Processing Options is set to true. If nothing is provided, Segment will send 0.
    */
   data_processing_options_state?: number
+  /**
+   * Use this field to specify that events should be test events rather than actual traffic. You can find your Test Event Code in your Facebook Events Manager under the "Test events" tab. This property overrides the test event code defined in Settings. You'll want to remove your Test Event Code when sending real traffic through this integration.
+   */
+  test_event_code?: string
 }

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent2/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/viewContent2/index.ts
@@ -16,7 +16,8 @@ import {
   data_processing_options,
   data_processing_options_country,
   data_processing_options_state,
-  dataProcessingOptions
+  dataProcessingOptions,
+  test_event_code
 } from '../fb-capi-properties'
 import { user_data_field, hash_user_data } from '../fb-capi-user-data'
 import type { Settings } from '../generated-types'
@@ -71,7 +72,8 @@ const action: ActionDefinition<Settings, Payload> = {
     custom_data: custom_data,
     data_processing_options: data_processing_options,
     data_processing_options_country: data_processing_options_country,
-    data_processing_options_state: data_processing_options_state
+    data_processing_options_state: data_processing_options_state,
+    test_event_code: test_event_code
   },
   perform: (request, { payload, settings, features, statsContext, syncMode }) => {
     if (syncMode === 'add') {
@@ -106,6 +108,8 @@ const action: ActionDefinition<Settings, Payload> = {
         payload.data_processing_options_state
       )
 
+      const testEventCode = payload.test_event_code || settings.testEventCode
+
       return request(
         `https://graph.facebook.com/v${get_api_version(features, statsContext)}/${settings.pixelId}/events`,
         {
@@ -135,7 +139,7 @@ const action: ActionDefinition<Settings, Payload> = {
                 data_processing_options_state: state_code
               }
             ],
-            ...(settings.testEventCode && { test_event_code: settings.testEventCode })
+            ...(testEventCode && { test_event_code: testEventCode })
           }
         }
       )


### PR DESCRIPTION
Customers don't want to set the Test Event Code in Settings for all mapping. Suppose a customer with 10+ mappings: is it a good approach setting a Test Event Code when the intention is to test one mapping?

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
