### PR TITLE
[Hubspot] Custom Object V2 - bug fix for textarea field type

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/upsertObject/types.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertObject/types.ts
@@ -29,7 +29,8 @@ export const HSPropTypeFieldType = {
   NumberNumber: 'number:number',
   DateTimeDate: 'datetime:date',
   DateDate: 'date:date',
-  EnumerationBooleanCheckbox: 'enumeration:booleancheckbox'
+  EnumerationBooleanCheckbox: 'enumeration:booleancheckbox',
+  StringTextArea: 'string:textarea'
 } as const
 
 export type HSPropTypeFieldType = typeof HSPropTypeFieldType[keyof typeof HSPropTypeFieldType]
@@ -49,7 +50,8 @@ export const HSPropFieldType = {
   Number: 'number',
   Date: 'date',
   BooleanCheckbox: 'booleancheckbox',
-  Select: 'select'
+  Select: 'select',
+  TextArea: 'textarea'
 } as const
 
 export type HSPropFieldType = typeof HSPropFieldType[keyof typeof HSPropFieldType]

--- a/packages/destination-actions/src/destinations/hubspot/upsertObject/utils.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertObject/utils.ts
@@ -188,6 +188,8 @@ function formatHS(type: HSPropType, fieldType: HSPropFieldType): HSPropTypeField
     return HSPropTypeFieldType.DateTimeDate
   } else if (type === 'enumeration' && fieldType === 'booleancheckbox') {
     return HSPropTypeFieldType.EnumerationBooleanCheckbox
+  } else if (type === 'string' && fieldType === 'textarea') {
+    return HSPropTypeFieldType.StringTextArea
   }
   throw new IntegrationError('Property type not supported', 'HUBSPOT_PROPERTY_TYPE_NOT_SUPPORTED', 400)
 }
@@ -602,6 +604,16 @@ function checkForIncompatiblePropTypes(prop: Prop, hubspotProp?: Result) {
     return
   }
 
+  if (
+    hubspotProp.fieldType === 'textarea' &&
+    hubspotProp.type === 'string' &&
+    prop.fieldType === 'text' &&
+    prop.type === 'string'
+  ) {
+    // string:text is OK to match to string:textarea
+    return
+  }
+
   throw new IntegrationError(
     `Payload property with name ${prop.name} has a different type to the property in HubSpot. Expected: type = ${prop.type} fieldType = ${prop.fieldType}. Received: type = ${hubspotProp.type} fieldType = ${hubspotProp.fieldType}`,
     'HUBSPOT_PROPERTY_TYPE_MISMATCH',
@@ -638,6 +650,7 @@ export async function createProperties(client: Client, schemaDiff: SchemaDiff, p
           fieldType: 'number'
         }
       case HSPropTypeFieldType.StringText:
+      case HSPropTypeFieldType.StringTextArea:
         return {
           name: prop.name,
           label: prop.name,


### PR DESCRIPTION
[Hubspot] Custom Object V2 - bug fix for textarea field type

## Testing

See video below which shows reproduction and bug fix: 


https://github.com/user-attachments/assets/5536cc54-9ba5-4ea3-bc24-15444068877e



- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
