### PR TITLE
[STRATCONN-4282] Braze validation and multi-status fix

### DIFF
--- a/packages/destination-actions/src/destinations/braze/__tests__/__snapshots__/braze.test.ts.snap
+++ b/packages/destination-actions/src/destinations/braze/__tests__/__snapshots__/braze.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Braze Cloud Mode (Actions) trackEvent should require one of braze_id, user_alias, or external_id 1`] = `"One of \\"external_id\\" or \\"user_alias\\" or \\"braze_id\\" is required."`;
+exports[`Braze Cloud Mode (Actions) trackEvent should require one of braze_id, user_alias, or external_id 1`] = `"One of \\"external_id\\" or \\"user_alias\\" or \\"braze_id\\" or \\"email\\" is required."`;
 
 exports[`Braze Cloud Mode (Actions) trackEvent should work with batched events 1`] = `
 Headers {
@@ -75,7 +75,7 @@ Headers {
 }
 `;
 
-exports[`Braze Cloud Mode (Actions) trackPurchase should require one of braze_id, user_alias, or external_id 1`] = `"One of \\"external_id\\" or \\"user_alias\\" or \\"braze_id\\" is required."`;
+exports[`Braze Cloud Mode (Actions) trackPurchase should require one of braze_id, user_alias, or external_id 1`] = `"One of \\"external_id\\" or \\"user_alias\\" or \\"braze_id\\" or \\"email\\" is required."`;
 
 exports[`Braze Cloud Mode (Actions) trackPurchase should work with default mappings 1`] = `
 Headers {

--- a/packages/destination-actions/src/destinations/braze/__tests__/multistatus.test.ts
+++ b/packages/destination-actions/src/destinations/braze/__tests__/multistatus.test.ts
@@ -46,6 +46,15 @@ describe('MultiStatus', () => {
             externalId: 'test-external-id'
           }
         }),
+        // Valid Event
+        createTestEvent({
+          type: 'identify',
+          receivedAt,
+          traits: {
+            name: 'Example User Two',
+            email: 'user@example.com'
+          }
+        }),
         // Event without any user identifier
         createTestEvent({
           type: 'identify',
@@ -68,11 +77,17 @@ describe('MultiStatus', () => {
         body: 'success'
       })
 
-      // The third event fails as pre-request validation fails for not having a valid user identifier
+      // The second event doesn't fail as there is no error reported by Braze API
       expect(response[1]).toMatchObject({
+        status: 200,
+        body: 'success'
+      })
+
+      // The third event fails as pre-request validation fails for not having a valid user identifier
+      expect(response[2]).toMatchObject({
         status: 400,
         errortype: 'PAYLOAD_VALIDATION_FAILED',
-        errormessage: 'One of "external_id" or "user_alias" or "braze_id" is required.',
+        errormessage: 'One of "external_id" or "user_alias" or "braze_id" or "email" is required.',
         errorreporter: 'DESTINATION'
       })
     })
@@ -201,6 +216,9 @@ describe('MultiStatus', () => {
   describe('trackPurchase', () => {
     const mapping = {
       time: receivedAt,
+      email: {
+        '@path': '$.properties.email'
+      },
       external_id: {
         '@path': '$.properties.externalId'
       },
@@ -220,6 +238,28 @@ describe('MultiStatus', () => {
           receivedAt,
           properties: {
             externalId: 'test-external-id',
+            products: [
+              {
+                product_id: 'test-product-id',
+                currency: 'USD',
+                price: 99.99,
+                quantity: 1
+              },
+              {
+                product_id: 'test-product-id',
+                currency: 'USD',
+                price: 99.99,
+                quantity: 1
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          event: 'Order Completed',
+          type: 'track',
+          receivedAt,
+          properties: {
+            email: 'user@example.com',
             products: [
               {
                 product_id: 'test-product-id',
@@ -276,19 +316,24 @@ describe('MultiStatus', () => {
         body: 'success'
       })
 
-      // The second event fails as it doesn't have any products
       expect(response[1]).toMatchObject({
+        status: 200,
+        body: 'success'
+      })
+
+      // The third event fails as it doesn't have any products
+      expect(response[2]).toMatchObject({
         status: 400,
         errortype: 'PAYLOAD_VALIDATION_FAILED',
         errormessage: 'This event was not sent to Braze because it did not contain any products.',
         errorreporter: 'DESTINATION'
       })
 
-      // The third event fails as pre-request validation fails for not having a valid user identifier
-      expect(response[2]).toMatchObject({
+      // The forth event fails as pre-request validation fails for not having a valid user identifier
+      expect(response[3]).toMatchObject({
         status: 400,
         errortype: 'PAYLOAD_VALIDATION_FAILED',
-        errormessage: 'One of "external_id" or "user_alias" or "braze_id" is required.',
+        errormessage: 'One of "external_id" or "user_alias" or "braze_id" or "email" is required.',
         errorreporter: 'DESTINATION'
       })
     })
@@ -542,6 +587,15 @@ describe('MultiStatus', () => {
             externalId: 'test-external-id'
           }
         }),
+        createTestEvent({
+          type: 'identify',
+          receivedAt,
+          traits: {
+            firstName: 'Example',
+            lastName: 'User',
+            email: 'user@example.com'
+          }
+        }),
         // Event without any user identifier
         createTestEvent({
           type: 'identify',
@@ -565,11 +619,17 @@ describe('MultiStatus', () => {
         body: 'success'
       })
 
-      // The third event fails as pre-request validation fails for not having a valid user identifier
+      // The second event doesn't fail as there is no error reported by Braze API
       expect(response[1]).toMatchObject({
+        status: 200,
+        body: 'success'
+      })
+
+      // The third event fails as pre-request validation fails for not having a valid user identifier
+      expect(response[2]).toMatchObject({
         status: 400,
         errortype: 'PAYLOAD_VALIDATION_FAILED',
-        errormessage: 'One of "external_id" or "user_alias" or "braze_id" is required.',
+        errormessage: 'One of "external_id" or "user_alias" or "braze_id" or "email" is required.',
         errorreporter: 'DESTINATION'
       })
     })


### PR DESCRIPTION
Context
Earlier Braze required on the the 3 fields to be present to be considered an event to be valid, they were `braze_id`, `user_alias` and `external_id`. Later `email` was added, however this validation was missing from the MultiStatus flow.

PR Contents
- Adds email as one of the required fields
- Fixes couple of error messages to represent that email is one the fields used in validation
- Fixes a MultiStatus bug where `sent` was to the original batch payload instead of what was actually sent.

## Testing

Testes locally.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
