### PR TITLE
Fixing "Additional traits or identifiers must be a string but it was an object." error in Iterable Lists.

### DIFF
--- a/packages/destination-actions/src/destinations/iterable-lists/syncAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/syncAudience/generated-types.ts
@@ -12,7 +12,9 @@ export interface Payload {
   /**
    * Comma delimited list containing names of additional traits or identifiers to sync to Iterable. You will need to ensure these traits or obects are included via Event Settings >> Customized Setup.
    */
-  dataFields?: string
+  dataFields?: {
+    [k: string]: unknown
+  }
   /**
    * Traits or Properties object from the identify() or track() call emitted by Engage
    */

--- a/packages/destination-actions/src/destinations/iterable-lists/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/syncAudience/index.ts
@@ -37,7 +37,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
       description:
         'Comma delimited list containing names of additional traits or identifiers to sync to Iterable. You will need to ensure these traits or obects are included via Event Settings >> Customized Setup.',
       required: false,
-      type: 'string'
+      type: 'object'
     },
     traitsOrProperties: {
       label: 'Traits or Properties',
@@ -55,7 +55,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     },
     segmentAudienceKey: {
       label: 'Segment Audience Key',
-      description: 'Segment Audience Key. Maps to the "Name" of the Segment node in Yahoo taxonomy',
+      description: 'Segment Audience Key. Maps to the Iterable List "Name" when the list is created in Iterable.',
       type: 'string',
       unsafe_hidden: true,
       required: true,

--- a/packages/destination-actions/src/destinations/iterable-lists/syncAudience/iterable-client.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/syncAudience/iterable-client.ts
@@ -37,13 +37,13 @@ export class IterableListsClient {
       if (payload.traitsOrProperties[payload.segmentAudienceKey] === true) {
         const subscriber = {
           email: payload?.email ?? undefined,
-          dataFields: payload?.dataFields?.split(',').reduce((acc: { [key: string]: unknown }, item: string) => {
-            acc[item.trim()] = payload.traitsOrProperties[item.trim()]
-            return acc
-          }, {}),
           userId: payload?.userId ?? undefined,
           preferUserId: true
         } as Subscriber
+
+        if (payload?.dataFields) {
+          subscriber.dataFields = payload.dataFields as Record<string, null | boolean | string | number | object>
+        }
 
         if (subscribersGroup.has(listId)) {
           subscribersGroup.get(listId)?.push(subscriber)


### PR DESCRIPTION
Changing `dataFields` to be an object, not a string. [Fixes this problem](https://app.segment.com/segment-leonel-sanches/destinations/actions-iterable-lists/sources/personas_leos-space/instances/66ad24718e2a6debe74b45ad/event-delivery/PAYLOAD_VALIDATION_FAILED?period=past-day):

<img width="1897" alt="image" src="https://github.com/user-attachments/assets/6d5ba3c5-a647-44a5-862d-70089416e4df">


## Testing

Payload for Postman (local):

```json
{
    "settings": {
        "apiKey": "{{iterable-lists-api-key}}"
    },
    "payload": {
        "context": {
            "personas": {
                "computation_key": "the_super_mario_bros_super_audience_2",
                "external_audience_id": "4269566",
                "audience_settings": {
                    "computation_key": "the_super_mario_bros_super_audience_2",
                    "external_audience_id": "4269566"
                }
            }
        },
        "traits": {
            "email": "leonel.sanches@segment.io",
            "the_super_mario_bros_super_audience_2": true,
            "firstName": "Leonel",
            "lastName": "Sanches"
        },
        "userId": "leonel.sanches@segment.io"
    },
    "mapping": {
        "email": {
            "@path": "$.traits.email"
        },
        "dataFields": {
            "@path": "$.traits"
        }
    }
}
```

<img width="914" alt="image" src="https://github.com/user-attachments/assets/c493c00d-02e4-45b9-83ea-b7d1f68d9a6d">


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [X] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
