### PR TITLE
Adds scripts and configurations to support hotfix release workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,7 +82,7 @@ jobs:
             const script = require('./scripts/github-action/create-github-release.js')
             await script({github, context, core, exec})
 
-  # When hotfix is merged bacak to main, we tag all the packages that were changed in the hotfix commit.
+  # When hotfix is merged back to main, we tag all the packages that were changed in the hotfix commit.
   tag-hotfix:
     if: startsWith(github.event.head_commit.message, 'Hotfix:') == true && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,9 +48,9 @@ jobs:
           npm set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_PUBLISH_TOKEN }}
           npm whoami
 
-      # - name: Publish
-      #   run: |
-      #     yarn lerna publish from-package --yes --loglevel=verbose --dist-tag latest
+      - name: Publish
+        run: |
+          yarn lerna publish from-package --yes --loglevel=verbose --dist-tag latest
 
   release:
     needs: build-and-publish # comment when testing locally with https://github.com/nektos/act

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - main
-      - release
+      - hotfix/**
 
 jobs:
   build-and-publish:
@@ -48,9 +48,9 @@ jobs:
           npm set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_PUBLISH_TOKEN }}
           npm whoami
 
-      - name: Publish
-        run: |
-          yarn lerna publish from-package --yes --allowBranch=main --loglevel=verbose --dist-tag latest
+      # - name: Publish
+      #   run: |
+      #     yarn lerna publish from-package --yes --loglevel=verbose --dist-tag latest
 
   release:
     needs: build-and-publish # comment when testing locally with https://github.com/nektos/act
@@ -68,7 +68,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Generate Release Tag
+      - name: Generate Tags
         id: get-release-tag
         run: ./scripts/generate-release-tags.sh
 
@@ -81,3 +81,22 @@ jobs:
           script: |
             const script = require('./scripts/github-action/create-github-release.js')
             await script({github, context, core, exec})
+
+  # When hotfix is merged bacak to main, we tag all the packages that were changed in the hotfix commit.
+  tag-hotfix:
+    if: startsWith(github.event.head_commit.message, 'Hotfix:') == true && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Generate Package Specific Tags
+        id: get-release-tag
+        run: ./scripts/generate-package-tags.sh

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Version Packages
         run: |
-          # action is minor for main branch and patch for other branches
+          # minor version bump for main branch and patch for hotfixes
           if [ "${{ github.event.inputs.base_branch }}" == "main" ]; then
             yarn lerna version minor --yes --allow-branch ${{ github.event.inputs.branch }} --no-git-tag-version --no-commit-hooks --no-private
           else

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -12,10 +12,6 @@ on:
         description: 'Base branch to create PR to'
         required: true
         default: 'main'
-        type: choice
-        options:
-          - main
-          - release
       run_id:
         description: 'Unique identifier for the run'
         required: false
@@ -29,9 +25,6 @@ jobs:
       HUSKY: 0
       NX_DISABLE_DB: true
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
     steps:
       - name: Echo Inputs
         run: |
@@ -67,7 +60,13 @@ jobs:
         run: NODE_ENV=production yarn build
 
       - name: Version Packages
-        run: yarn lerna version minor --yes --allow-branch ${{ github.event.inputs.branch }} --no-git-tag-version --no-commit-hooks --no-private
+        run: |
+          # action is minor for main branch and patch for other branches
+          if [ "${{ github.event.inputs.base_branch }}" == "main" ]; then
+            yarn lerna version minor --yes --allow-branch ${{ github.event.inputs.branch }} --no-git-tag-version --no-commit-hooks --no-private
+          else
+            yarn lerna version patch --yes --allow-branch ${{ github.event.inputs.branch }} --no-git-tag-version --no-commit-hooks --no-private
+          fi
 
       - name: Commit and push
         id: commit_and_push

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -25,6 +25,9 @@ jobs:
       HUSKY: 0
       NX_DISABLE_DB: true
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - name: Echo Inputs
         run: |

--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,7 @@
       "npmClientArgs": ["--ignore-engines", "--ignore-optional"]
     },
     "version": {
-      "allowBranch": ["main", "release"]
+      "allowBranch": ["main", "hotfix/*"]
     }
   }
 }

--- a/scripts/generate-package-tags.sh
+++ b/scripts/generate-package-tags.sh
@@ -1,0 +1,14 @@
+
+#!/bin/bash
+
+set -e # exit on error
+
+# this script assumes the last commit was publish commit and gets all package.json files changed in the last commit
+# and generates tags for each package.json file.
+files=$(git show --pretty="" --name-only HEAD | grep -Ei '^packages/.*package\.json$')
+for file in $files; do
+  tag=$(cat $file | jq -r '.name + "@" + .version')
+  echo "Tagging $sha with $tag"
+  git tag -a $tag -m "Release $tag" --force
+  git push origin $tag
+done

--- a/scripts/github-action/create-github-release.js
+++ b/scripts/github-action/create-github-release.js
@@ -27,7 +27,7 @@ module.exports = async ({ github, context, core, exec }) => {
   const latestReleaseTag = latestRelease ? latestRelease.data.tag_name : null
 
   // Extract package tags that are published in the current release by lerna version
-  const packageTags = await extractPackageTags(GITHUB_SHA, exec, core)
+  const packageTags = await extractPackageNames(GITHUB_SHA, exec, core)
   const tagsContext = { currentRelease: newReleaseTag, prevRelease: latestReleaseTag, packageTags }
   const changeLog = formatChangeLog(prs, tagsContext, context)
 
@@ -81,7 +81,8 @@ async function getReleaseTag(core, exec) {
     'describe',
     '--abbrev=0',
     '--tags',
-    '--match=release-*'
+    '--match=release-*',
+    '--match=hotfix-*'
   ])
   if (exitCode !== 0) {
     // if the release tag is not found, then we cannot proceed further
@@ -90,18 +91,27 @@ async function getReleaseTag(core, exec) {
   return stdout.trim()
 }
 
-// Extract package tags that are published in the current release by lerna version
-async function extractPackageTags(sha, exec, core) {
-  const { stdout, stderr, exitCode } = await exec.getExecOutput('git', ['tag', '--points-at', sha])
+// Extract packages published in the current release
+async function extractPackageNames(sha, exec, core) {
+  const { stdout, stderr, exitCode } = await exec.getExecOutput('git', ['show', '--pretty=""', '--name-only', sha])
   if (exitCode !== 0) {
     // if the package tags are not found, then we cannot proceed further
     core.error(`Failed to extract package tags: ${stderr}`)
   }
-  // filter out only the tags that are related to segment packages
-  return stdout
-    .split('\n')
-    .filter(Boolean)
-    .filter((tag) => tag.includes('@segment/') && !tag.includes('staging'))
+  // filter out files that are not package.json
+  const files = stdout.split('\n').filter((file) => file.startsWith('packages/') && file.endsWith('package.json'))
+  // get the package versions and names from package.json files
+  const packageTags = await Promise.all(
+    files.map(async (file) => {
+      const { stdout, stderr, exitCode } = await exec.getExecOutput('cat', [file])
+      if (exitCode !== 0) {
+        core.error(`Failed to extract package tags: ${stderr}`)
+      }
+      const pkg = JSON.parse(stdout)
+      return `${pkg.name}@${pkg.version}`
+    })
+  )
+  return packageTags
 }
 
 // Get PRs between two commits
@@ -227,7 +237,7 @@ function formatTable(prs, tableConfig, title = '') {
     `
 }
 /*
-  * Map PR with affected destinations
+ * Map PR with affected destinations
  */
 function mapPRWithAffectedDestinations(pr) {
   let affectedDestinations = []

--- a/scripts/github-action/create-github-release.js
+++ b/scripts/github-action/create-github-release.js
@@ -93,7 +93,13 @@ async function getReleaseTag(core, exec) {
 
 // Extract packages published in the current release
 async function extractPackageNames(sha, exec, core) {
-  const { stdout, stderr, exitCode } = await exec.getExecOutput('git', ['show', '--pretty=""', '--name-only', sha])
+  const { stdout, stderr, exitCode } = await exec.getExecOutput('git', [
+    'diff-tree',
+    '--no-commit-id',
+    '--name-only',
+    sha,
+    '-r'
+  ])
   if (exitCode !== 0) {
     // if the package tags are not found, then we cannot proceed further
     core.error(`Failed to extract package tags: ${stderr}`)


### PR DESCRIPTION
This PR updates existing scripts and workflows to support hotfix releases.

Notes on the implementation and context [here](https://docs.google.com/document/d/1S6neoL6swFn5OvkBUIC7nmG9B_YHXC8H-SuOSKUCJLM/edit?tab=t.lus1dnmyzvkv#heading=h.uzvbfp72c2z1)

This repo doesn't have a solid hotfix release strategy. As a result, we are not merging PRs to main as soon as the PRs are ready and only merge them during the release.

Having a solid hotfix release strategy should help us get over this bottleneck and help us ship at greater speed.

TLDR;
- All hotfixes will go via hotfix/* branches. External devs won't be able to push or create hotfix/* branches as per this rule set [here](https://github.com/segmentio/action-destinations/settings/rules/2448350).
- New CLI command will be added to internal action cli for auto creating hotfix branch from the latest deployed action destinations. ([Logic here](https://github.com/segmentio/action-cli/pull/190))
- The code fix should be pushed to these branches.
- New CLI command to release hotfixes. Hotfixes will be published from hotfix branch. The CLI command will auto-create a PR to main branch. Before next reelase, this PR has to be merged or closed.


## Testing

- Sample [Publish](https://github.com/segmentio/action-destinations/actions/runs/11594895169) run from hotfix branch.
- Sample [hotfix merge PR](https://github.com/segmentio/action-destinations/pull/2553) to main created.
- I'll be able to test package release tagging after merging these changes to main branch.