### PR TITLE
[Iterable] - STRATCONN-3861 - enabling batching by default for batch enabled Actions

### DIFF
--- a/packages/destination-actions/src/destinations/iterable/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/trackEvent/index.ts
@@ -81,7 +81,7 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'When enabled, Segment will send data to Iterable in batches of up to 1001',
       type: 'boolean',
       required: false,
-      default: false
+      default: true
     },
     batch_size: {
       label: 'Batch Size',

--- a/packages/destination-actions/src/destinations/iterable/updateUser/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/updateUser/index.ts
@@ -66,7 +66,7 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'When enabled, Segment will send data to Iterable in batches of up to 1001',
       type: 'boolean',
       required: false,
-      default: false
+      default: true
     },
     batch_size: {
       label: 'Batch Size',


### PR DESCRIPTION
Enabling batching by default for Iterable Actions which support batching. 

## Testing

Not needed. Batching has been available on these Actions for months. 