### PR TITLE
[Klaviyo] Update Properties in Ordered Product Call

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
@@ -46,7 +46,7 @@ const sendProductRequests = async (payload: Payload, orderEventData: EventData, 
       data: {
         type: 'event',
         attributes: {
-          properties: { ...product, ...orderEventData.data.attributes.properties },
+          properties: { ...orderEventData.data.attributes.properties, ...product },
           unique_id: uuidv4(),
           metric: {
             data: {


### PR DESCRIPTION
Update the properties of ordered product event so that the product properties will override the Order Completed event properties.
Need this because if there is a name property in the Order completed event properties, it was overriding the product name.

JIRA -> https://segment.atlassian.net/browse/STRATCONN-4350

## Testing
Testing Completed Successfully in staging using Event tester.

[Stage Testing Document](https://docs.google.com/document/d/198tjcbk8hPJva-WnhhxFS62n-XrbsLhA-me0VWvPvPA/edit?usp=sharing)

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
