### PR TITLE
Add new India region for mixpanel

### DIFF
--- a/packages/destination-actions/src/destinations/mixpanel/alias/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/alias/__tests__/index.test.ts
@@ -70,6 +70,35 @@ describe('Mixpanel.alias', () => {
     )
   })
 
+  it('should use IN server URL', async () => {
+    const event = createTestEvent({ previousId: 'test-prev-id' })
+    nock('https://api-in.mixpanel.com').post('/track').reply(200, {})
+    const responses = await testDestination.testAction('alias', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        projectToken: MIXPANEL_PROJECT_TOKEN,
+        apiSecret: MIXPANEL_API_SECRET,
+        apiRegion: ApiRegions.IN
+      }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.body).toMatchObject(
+      new URLSearchParams({
+        data: JSON.stringify({
+          event: '$create_alias',
+          properties: {
+            distinct_id: 'test-prev-id',
+            alias: 'user1234',
+            token: MIXPANEL_PROJECT_TOKEN
+          }
+        })
+      })
+    )
+  })
+
   it('should default to US endpoint if apiRegion setting is undefined', async () => {
     const event = createTestEvent({ previousId: 'test-prev-id' })
 

--- a/packages/destination-actions/src/destinations/mixpanel/common/utils.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/common/utils.ts
@@ -16,7 +16,8 @@ export function getConcatenatedName(firstName: unknown, lastName: unknown, name:
 export function getApiServerUrl(apiRegion: string | undefined) {
   if (apiRegion == ApiRegions.EU) {
     return 'https://api-eu.mixpanel.com'
-  } else if (apiRegion == ApiRegions.IN) {
+  }
+  if (apiRegion == ApiRegions.IN) {
     return 'https://api-in.mixpanel.com'
   }
   return 'https://api.mixpanel.com' // Default US endpoint

--- a/packages/destination-actions/src/destinations/mixpanel/common/utils.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/common/utils.ts
@@ -1,6 +1,7 @@
 export enum ApiRegions {
   US = 'US 🇺🇸',
-  EU = 'EU 🇪🇺'
+  EU = 'EU 🇪🇺',
+  IN = 'IN 🇮🇳'
 }
 
 export enum StrictMode {
@@ -15,8 +16,10 @@ export function getConcatenatedName(firstName: unknown, lastName: unknown, name:
 export function getApiServerUrl(apiRegion: string | undefined) {
   if (apiRegion == ApiRegions.EU) {
     return 'https://api-eu.mixpanel.com'
+  } else if (apiRegion == ApiRegions.IN) {
+    return 'https://api-in.mixpanel.com'
   }
-  return 'https://api.mixpanel.com'
+  return 'https://api.mixpanel.com' // Default US endpoint
 }
 
 export function getBrowser(userAgent: string): string {

--- a/packages/destination-actions/src/destinations/mixpanel/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/generated-types.ts
@@ -10,7 +10,7 @@ export interface Settings {
    */
   apiSecret: string
   /**
-   * Learn about [EU data residency](https://help.mixpanel.com/hc/en-us/articles/360039135652-Data-Residency-in-EU)
+   * Learn about [EU data residency](https://docs.mixpanel.com/docs/privacy/eu-residency) and [India data residency](https://docs.mixpanel.com/docs/privacy/in-residency)
    */
   apiRegion?: string
   /**

--- a/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/groupIdentifyUser/__tests__/index.test.ts
@@ -156,6 +156,40 @@ describe('Mixpanel.groupIdentifyUser', () => {
     )
   })
 
+  it('should use IN server URL', async () => {
+    const event = createTestEvent({
+      timestamp,
+      groupId: 'test-group-id',
+      traits: { hello: 'world', company: 'Mixpanel' }
+    })
+    nock('https://api-in.mixpanel.com').post('/groups').reply(200, {})
+    const responses = await testDestination.testAction('groupIdentifyUser', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        projectToken: MIXPANEL_PROJECT_TOKEN,
+        apiSecret: MIXPANEL_API_SECRET,
+        apiRegion: ApiRegions.IN
+      }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.body).toMatchObject(
+      new URLSearchParams({
+        data: JSON.stringify({
+          $token: MIXPANEL_PROJECT_TOKEN,
+          $group_key: '$group_id',
+          $group_id: 'test-group-id',
+          $set: {
+            hello: 'world',
+            company: 'Mixpanel'
+          }
+        })
+      })
+    )
+  })
+
   it('should default to US endpoint if apiRegion setting is undefined', async () => {
     const event = createTestEvent({
       timestamp,

--- a/packages/destination-actions/src/destinations/mixpanel/incrementProperties/__test__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/incrementProperties/__test__/index.test.ts
@@ -42,6 +42,38 @@ describe('Mixpanel.incrementProperties', () => {
     )
   })
 
+  it('should use IN server URL', async () => {
+    const event = createTestEvent({ timestamp, event: 'search', properties: defaultProperties })
+
+    nock('https://api-in.mixpanel.com').post('/engage').reply(200, {})
+    nock('https://api-in.mixpanel.com').post('/track').reply(200, {})
+
+    const responses = await testDestination.testAction('incrementProperties', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        projectToken: MIXPANEL_PROJECT_TOKEN,
+        apiSecret: MIXPANEL_API_SECRET,
+        apiRegion: ApiRegions.IN
+      }
+    })
+
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.body).toMatchObject(
+      new URLSearchParams({
+        data: JSON.stringify({
+          $token: MIXPANEL_PROJECT_TOKEN,
+          $distinct_id: 'user1234',
+          $ip: '8.8.8.8',
+          $add: {
+            searches: 1
+          }
+        })
+      })
+    )
+  })
+
   it('should default to US endpoint if apiRegion setting is undefined', async () => {
     const event = createTestEvent({ timestamp, event: 'search', properties: defaultProperties })
 

--- a/packages/destination-actions/src/destinations/mixpanel/index.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/index.ts
@@ -91,7 +91,7 @@ const destination: DestinationDefinition<Settings> = {
       apiRegion: {
         label: 'Data Residency',
         description:
-          'Learn about [EU data residency](https://help.mixpanel.com/hc/en-us/articles/360039135652-Data-Residency-in-EU)',
+          'Learn about [EU data residency](https://docs.mixpanel.com/docs/privacy/eu-residency) and [India data residency](https://docs.mixpanel.com/docs/privacy/in-residency)',
         type: 'string',
         choices: Object.values(ApiRegions).map((apiRegion) => ({ label: apiRegion, value: apiRegion })),
         default: ApiRegions.US

--- a/packages/destination-actions/src/destinations/mixpanel/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackEvent/__tests__/index.test.ts
@@ -71,6 +71,31 @@ describe('Mixpanel.trackEvent', () => {
     ])
   })
 
+  it('should use IN server URL', async () => {
+    const event = createTestEvent({ timestamp, event: 'Test Event' })
+
+    nock('https://api-in.mixpanel.com').post('/import?strict=1').reply(200, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        projectToken: MIXPANEL_PROJECT_TOKEN,
+        apiSecret: MIXPANEL_API_SECRET,
+        apiRegion: ApiRegions.IN
+      }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].data).toMatchObject({})
+    expect(responses[0].options.json).toMatchObject([
+      {
+        event: 'Test Event',
+        properties: expect.objectContaining(expectedProperties)
+      }
+    ])
+  })
+
   it('should default to US endpoint if apiRegion setting is undefined', async () => {
     const event = createTestEvent({ timestamp, event: 'Test Event' })
 

--- a/packages/destination-actions/src/destinations/mixpanel/trackPurchase/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackPurchase/__tests__/index.test.ts
@@ -106,6 +106,24 @@ describe('Mixpanel.trackPurchase', () => {
     expect(responses[0].status).toBe(200)
   })
 
+  it('should use IN server URL', async () => {
+    const event = createTestEvent(orderCompletedEvent)
+
+    nock('https://api-in.mixpanel.com').post('/import?strict=1').reply(200, {})
+
+    const responses = await testDestination.testAction('trackPurchase', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        projectToken: MIXPANEL_PROJECT_TOKEN,
+        apiSecret: MIXPANEL_API_SECRET,
+        apiRegion: ApiRegions.IN
+      }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+  })
+
   it('should default to US endpoint if apiRegion setting is undefined', async () => {
     const event = createTestEvent(orderCompletedEvent)
 


### PR DESCRIPTION
This update introduces a new endpoint for the Mixpanel India region, a feature requested by the Mixpanel partnerships team: https://segment.zendesk.com/agent/tickets/556710

- https://mixpanel.com/blog/india-data-residency/
- https://docs.mixpanel.com/docs/privacy/in-residency

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)

<img width="501" alt="Screenshot 2024-12-04 at 8 31 26 AM" src="https://github.com/user-attachments/assets/d394c63a-8207-4404-bf20-63b07629cc8c">
<img width="771" alt="Screenshot 2024-12-04 at 8 30 45 AM" src="https://github.com/user-attachments/assets/101ac134-d24e-40f2-8ed4-91fdbe552107">



