### PR TITLE
[STRATCONN-3911] GEC - Fix for retryable errors

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/userList.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/userList.test.ts
@@ -1,7 +1,8 @@
 import nock from 'nock'
-import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration, RetryableError } from '@segment/actions-core'
 import GoogleEnhancedConversions from '../index'
 import { API_VERSION } from '../functions'
+import { SegmentEvent } from '@segment/actions-core'
 
 const testDestination = createTestIntegration(GoogleEnhancedConversions)
 const timestamp = new Date('Thu Jun 10 2021 11:08:04 GMT-0700 (Pacific Daylight Time)').toISOString()
@@ -70,6 +71,104 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[1].options.body).toMatchInlineSnapshot(
         `"{\\"operations\\":[{\\"create\\":{\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8\\"},{\\"addressInfo\\":{\\"hashedFirstName\\":\\"4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332\\",\\"hashedLastName\\":\\"fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7\\",\\"countryCode\\":\\"\\",\\"postalCode\\":\\"\\"}}]}}],\\"enable_warnings\\":true}"`
       )
+    })
+
+    it('handles concurrent_modification error correctly', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}/offlineUserDataJobs:create`)
+        .post(/.*/)
+        .reply(200, { data: 'offlineDataJob' })
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/offlineDataJob:addOperations`)
+        .post(/.*/)
+        .reply(400, {
+          data: {
+            error: {
+              code: 400,
+              details: [
+                {
+                  '@type': 'type.googleapis.com/google.ads.googleads.v17.errors.GoogleAdsFailure',
+                  errors: [
+                    {
+                      errorCode: {
+                        databaseError: 'CONCURRENT_MODIFICATION'
+                      },
+                      message:
+                        'Multiple requests were attempting to modify the same resource at once. Retry the request.'
+                    }
+                  ],
+                  requestId: 'OZ5_72C-3qFN9a87mjE7_w'
+                }
+              ],
+              message: 'Request contains an invalid argument.',
+              status: 'INVALID_ARGUMENT'
+            }
+          }
+        })
+
+      const responses = testDestination.testBatchAction('userList', {
+        events,
+        mapping: {
+          ad_user_data_consent_state: 'GRANTED',
+          ad_personalization_consent_state: 'GRANTED',
+          external_audience_id: '1234',
+          retlOnMappingSave: {
+            outputs: {
+              id: '1234',
+              name: 'Test List',
+              external_id_type: 'CONTACT_INFO'
+            }
+          }
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      await expect(responses).rejects.toThrowError(RetryableError)
     })
   })
 })


### PR DESCRIPTION
While adding audience to GEC, the endpoints sometimes throws `CONCURRENT MODIFICATION` which is a retryable error, but Google responds with a 400 error causing the event to be dropped.

This PR adds a fix to check for `CONCURRENT MODIFICATION` errors and rewrite those errors to retryable 500 errors.

## Testing
Tested via [Hadron](https://segment.datadoghq.com/dashboard/wie-q52-n97/hadron?fromUser=false&refresh_mode=sliding&tpl_var_env=production&tpl_var_experiment=2ohtucmr1ngsvptthokqgwma7qg&tpl_var_specversion=1.0&from_ts=1731320754966&to_ts=1731335154966&live=true)

Result
![image](https://github.com/user-attachments/assets/1420a50d-aadd-4adc-9797-aaf60f343f94)

Diff
![image](https://github.com/user-attachments/assets/8803f14f-bcb2-4f39-9f2c-7b0ed2fbe77f)


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
