### PR TITLE
[Hubspot] - STRATCONN-4331 - trim white space from string properties

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/upsertCompany/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCompany/index.ts
@@ -224,17 +224,17 @@ const action: ActionDefinition<Settings, Payload> = {
 
     // Construct company properties
     const companyProperties = {
-      name: payload.name,
-      description: payload.description,
-      address: payload.address,
-      city: payload.city,
-      state: payload.state,
-      zip: payload.zip,
-      domain: payload.domain,
-      phone: payload.phone,
+      name: payload.name?.trim(),
+      description: payload.description?.trim(),
+      address: payload.address?.trim(),
+      city: payload.city?.trim(),
+      state: payload.state?.trim(),
+      zip: payload.zip?.trim(),
+      domain: payload.domain?.trim(),
+      phone: payload.phone?.trim(),
       numberofemployees: payload.numberofemployees,
-      industry: payload.industry,
-      lifecyclestage: payload.lifecyclestage?.toLocaleLowerCase(),
+      industry: payload.industry?.trim(),
+      lifecyclestage: payload.lifecyclestage?.toLocaleLowerCase().trim(),
       [SEGMENT_UNIQUE_IDENTIFIER]: payload.groupid,
       ...flattenObject(payload.properties)
     }

--- a/packages/destination-actions/src/destinations/hubspot/upsertContact/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertContact/__tests__/index.test.ts
@@ -422,6 +422,108 @@ describe('HubSpot.upsertContact', () => {
       }
     })
   })
+
+  test('should trim string properties', async () => {
+    nock(HUBSPOT_BASE_URL).patch(`/crm/v3/objects/contacts/${testEmail}?idProperty=email`).reply(404, {
+      status: 'error',
+      message: 'resource not found',
+      correlationId: 'be56c5f3-5841-4661-b52f-65b3aacd0244'
+    })
+
+    nock(HUBSPOT_BASE_URL)
+      .post('/crm/v3/objects/contacts')
+      .reply(201, {
+        id: '801',
+        properties: {
+          email: testEmail,
+          firstname: 'John',
+          lastname: 'Doe',
+          country: 'USA',
+          zip: '600001',
+          state: 'California',
+          address: 'Vancover st',
+          city: 'San Francisco',
+          graduation_date: 1664533942262,
+          company: 'Segment',
+          phone: '+13134561129',
+          website: 'segment.inc1'
+        }
+      })
+
+    const testEvent = createTestEvent({
+      type: 'identify',
+      traits: {
+        email: testEmail,
+        first_name: '  John  ', // to be trimmed
+        last_name: 'Doe',
+        address: {
+          city: '  San Francisco  ', // to be trimmed
+          country: 'USA',
+          postal_code: '600001',
+          state: 'California',
+          street: 'Vancover st'
+        },
+        graduation_date: 1664533942262,
+        lifecyclestage: 'subscriber',
+        company: 'Segment',
+        phone: '+13134561129',
+        website: 'segment.inc1',
+        customPropertyOne: [1, 2, 3, 4, 5],
+        customPropertyTwo: {
+          a: 1,
+          b: 2,
+          c: 3
+        },
+        customPropertyThree: [1, 'two', true, { four: 4 }]
+      }
+    })
+
+    const mapping = {
+      properties: {
+        graduation_date: {
+          '@path': '$.traits.graduation_date'
+        },
+        custom_property_1: {
+          '@path': '$.traits.customPropertyOne'
+        },
+        custom_property_2: {
+          '@path': '$.traits.customPropertyTwo'
+        },
+        custom_property_3: {
+          '@path': '$.traits.customPropertyThree'
+        }
+      }
+    }
+
+    const transactionContext: Record<string, string> = {}
+    const setTransactionContext = (key: string, value: string) => (transactionContext[key] = value)
+    const responses = await testDestination.testAction('upsertContact', {
+      mapping,
+      useDefaultMappings: true,
+      event: testEvent,
+      transactionContext: { transaction: {}, setTransaction: setTransactionContext }
+    })
+
+    expect(responses).toHaveLength(2)
+    expect(responses[0].options.json).toMatchObject({
+      properties: {
+        city: 'San Francisco',
+        firstname: 'John',
+        custom_property_1: '1;2;3;4;5',
+        custom_property_2: '{"a":1,"b":2,"c":3}',
+        custom_property_3: '1;two;true;{"four":4}'
+      }
+    })
+    expect(responses[1].options.json).toMatchObject({
+      properties: {
+        city: 'San Francisco',
+        firstname: 'John',
+        custom_property_1: '1;2;3;4;5',
+        custom_property_2: '{"a":1,"b":2,"c":3}',
+        custom_property_3: '1;two;true;{"four":4}'
+      }
+    })
+  })
 })
 
 describe('HubSpot.upsertContactBatch', () => {

--- a/packages/destination-actions/src/destinations/hubspot/upsertContact/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertContact/index.ts
@@ -195,18 +195,18 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: async (request, { payload, transactionContext }) => {
     const contactProperties = {
-      company: payload.company,
-      firstname: payload.firstname,
-      lastname: payload.lastname,
-      phone: payload.phone,
-      address: payload.address,
-      city: payload.city,
-      state: payload.state,
-      country: payload.country,
-      zip: payload.zip,
-      email: payload.email,
-      website: payload.website,
-      lifecyclestage: payload.lifecyclestage?.toLowerCase(),
+      company: payload.company?.trim(),
+      firstname: payload.firstname?.trim(),
+      lastname: payload.lastname?.trim(),
+      phone: payload.phone?.trim(),
+      address: payload.address?.trim(),
+      city: payload.city?.trim(),
+      state: payload.state?.trim(),
+      country: payload.country?.trim(),
+      zip: payload.zip?.trim(),
+      email: payload.email?.trim(),
+      website: payload.website?.trim(),
+      lifecyclestage: payload.lifecyclestage?.toLowerCase().trim(),
       ...flattenObject(payload.properties)
     }
 

--- a/packages/destination-actions/src/destinations/hubspot/utils.ts
+++ b/packages/destination-actions/src/destinations/hubspot/utils.ts
@@ -29,6 +29,12 @@ export function flattenObject(obj: JSONObject) {
       return
     }
 
+    // Trim string values
+    if (typeof obj[key] === 'string') {
+      flattened[key] = (obj[key] as string).trim()
+      return
+    }
+
     flattened[key] = obj[key]
   })
 


### PR DESCRIPTION
This PR adds code to trim properties for for Hubspot Cloud Mode Actions which interact with Objects. 

For background on the need for this PR please see https://segment.atlassian.net/browse/STRATCONN-4331

## Testing

Unit test added, and tested locally. 