### PR TITLE
[Hubspot] - STRATCONN-4331 - trim white space from string properties

### DIFF
--- a/packages/browser-destinations/destinations/hubspot-web/src/upsertContact/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/hubspot-web/src/upsertContact/__tests__/index.test.ts
@@ -204,4 +204,52 @@ describe('Hubspot.upsertContact', () => {
       }
     ])
   })
+
+  test('trims string traits', async () => {
+    const context = new Context({
+      type: 'identify',
+      userId: 'mike',
+      traits: {
+        friendly: false,
+        email: 'mike_eh@lph.com',
+        address: {
+          street: '6th St',
+          city: '  San Francisco  ', // to be trimmed
+          state: 'CA',
+          postalCode: '94103',
+          country: 'USA'
+        },
+        equipment: {
+          type: '🚘',
+          color: '  red  ', // to be trimmed
+          make: {
+            make: 'Tesla',
+            model: 'Model S',
+            year: 2019
+          }
+        }
+      }
+    })
+
+    await upsertContactEvent.identify?.(context)
+    expect(mockHubspot.push).toHaveBeenCalledTimes(1)
+    expect(mockHubspot.push).toHaveBeenCalledWith([
+      'identify',
+      {
+        email: 'mike_eh@lph.com',
+        id: 'mike',
+        friendly: false,
+        address: '6th St',
+        country: 'USA',
+        state: 'CA',
+        city: 'San Francisco',
+        zip: '94103',
+        equipment_type: '🚘',
+        equipment_color: 'red',
+        equipment_make_make: 'Tesla',
+        equipment_make_model: 'Model S',
+        equipment_make_year: 2019
+      }
+    ])
+  })
 })

--- a/packages/browser-destinations/destinations/hubspot-web/src/upsertContact/index.ts
+++ b/packages/browser-destinations/destinations/hubspot-web/src/upsertContact/index.ts
@@ -30,7 +30,8 @@ const action: BrowserActionDefinition<Settings, Hubspot, Payload> = {
       }
     },
     custom_properties: {
-      description: 'A list of key-value pairs that describe the contact. Please see [HubSpot`s documentation](https://knowledge.hubspot.com/account/prevent-contact-properties-update-through-tracking-code-api) for limitations in updating contact properties.',
+      description:
+        'A list of key-value pairs that describe the contact. Please see [HubSpot`s documentation](https://knowledge.hubspot.com/account/prevent-contact-properties-update-through-tracking-code-api) for limitations in updating contact properties.',
       label: 'Custom Properties',
       type: 'object',
       required: false,
@@ -102,6 +103,15 @@ const action: BrowserActionDefinition<Settings, Hubspot, Payload> = {
     if (!payload.email) {
       return
     }
+
+    payload.email = payload.email?.trim()
+    payload.id = payload.id?.trim()
+    payload.company = payload.company?.trim()
+    payload.country = payload.country?.trim()
+    payload.state = payload.state?.trim()
+    payload.city = payload.city?.trim()
+    payload.address = payload.address?.trim()
+    payload.zip = payload.zip?.trim()
 
     // custom properties should be key-value pairs of strings, therefore, filtering out any non-primitive
     const { custom_properties, ...rest } = payload

--- a/packages/browser-destinations/destinations/hubspot-web/src/utils/flatten.ts
+++ b/packages/browser-destinations/destinations/hubspot-web/src/utils/flatten.ts
@@ -23,7 +23,9 @@ export function flatten(
       const flattened = flatten(data[key] as Properties, `${prefix}_${key}`, skipList, keyTransformation)
       result = { ...result, ...flattened }
     } else {
-      result[keyTransformation(`${prefix}_${key}`.replace(/^_/, ''))] = data[key] as JSONPrimitive
+      result[keyTransformation(`${prefix}_${key}`.replace(/^_/, ''))] = (
+        typeof data[key] === 'string' ? (data[key] as string).trim() : data[key]
+      ) as JSONPrimitive
     }
   }
   return result


### PR DESCRIPTION
This PR adds code to trim properties for for Hubspot Web Mode Actions which interact with Objects.

For background on the need for this PR please see https://segment.atlassian.net/browse/STRATCONN-4331

## Testing

Unit test added. 
