### PR TITLE
[Sendgrid Audience] - renaming sendgrid lists destination to avoid clash

### DIFF
--- a/packages/destination-actions/src/destinations/sendgrid-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/index.ts
@@ -5,7 +5,7 @@ import { CREATE_LIST_URL } from './constants'
 import { CreateAudienceReq, CreateAudienceResp } from './types'
 
 const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
-  name: 'SendGrid Audiences',
+  name: 'SendGrid Lists (Actions)',
   slug: 'actions-sendgrid-audiences',
   mode: 'cloud',
   description: 'Sync Segment Engage Audiences to Sengrid Lists.',

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/index.ts
@@ -5,7 +5,7 @@ import { CREATE_LIST_URL } from './constants'
 import { CreateAudienceReq, CreateAudienceResp } from './types'
 
 const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
-  name: 'SendGrid Lists',
+  name: 'SendGrid Audiences',
   slug: 'actions-sendgrid-audiences',
   mode: 'cloud',
   description: 'Sync Segment Engage Audiences to Sengrid Lists.',
@@ -48,16 +48,13 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       full_audience_sync: false
     },
     async createAudience(request, createAudienceInput) {
-      const response = await request<CreateAudienceResp>(
-        CREATE_LIST_URL,
-        {
-          method: 'POST',
-          throwHttpErrors: false,
-          json: {
-            name: createAudienceInput?.audienceSettings?.listName ?? createAudienceInput.audienceName 
-          } as CreateAudienceReq
-        }
-      )
+      const response = await request<CreateAudienceResp>(CREATE_LIST_URL, {
+        method: 'POST',
+        throwHttpErrors: false,
+        json: {
+          name: createAudienceInput?.audienceSettings?.listName ?? createAudienceInput.audienceName
+        } as CreateAudienceReq
+      })
       const json = await response.json()
       return { externalId: json.id }
     },

--- a/packages/destination-actions/src/destinations/sprig/index.ts
+++ b/packages/destination-actions/src/destinations/sprig/index.ts
@@ -6,7 +6,7 @@ import identifyUser from './identifyUser'
 import trackEvent from './trackEvent'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Sprig',
+  name: 'Sprig (Actions)',
   slug: 'actions-sprig',
   mode: 'cloud',
   description: 'Send Segment analytics events and user profile data to Sprig.',


### PR DESCRIPTION
Renaming to avoid naming clash for new Sendgrid Audience Destination

## Testing

Not needed. 
