### PR TITLE
renaming sprig due to clash

### DIFF
--- a/packages/destination-actions/src/destinations/sprig/index.ts
+++ b/packages/destination-actions/src/destinations/sprig/index.ts
@@ -6,7 +6,7 @@ import identifyUser from './identifyUser'
 import trackEvent from './trackEvent'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Sprig (Actions)',
+  name: 'Sprig Cloud (Actions)',
   slug: 'actions-sprig',
   mode: 'cloud',
   description: 'Send Segment analytics events and user profile data to Sprig.',


### PR DESCRIPTION
Renaming to avoid naming clash for new Sprig Cloud Destination

## Testing

Not needed. 