### PR TITLE
[Taboola] - making email field visible

### DIFF
--- a/packages/destination-actions/src/destinations/taboola-actions/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/syncAudience/index.ts
@@ -45,7 +45,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
       label: 'Email address',
       description: "The user's email address",
       type: 'string',
-      unsafe_hidden: true,
+      unsafe_hidden: false,
       required: false,
       default: {
         '@if': {


### PR DESCRIPTION
Making the email field visible for the Taboola Destination

## Testing

None needed. 