### PR TITLE
extend actions-s3 batch size max to 100k

### DIFF
--- a/packages/destination-actions/src/destinations/s3/functions.ts
+++ b/packages/destination-actions/src/destinations/s3/functions.ts
@@ -10,7 +10,7 @@ export async function send(payloads: Payload[], settings: Settings, rawMapping: 
   const actionColName = payloads[0]?.audience_action_column_name
   const batchColName = payloads[0]?.batch_size_column_name
 
-  const maxBatchSize = 10_000
+  const maxBatchSize = 100_000
   if (batchSize > maxBatchSize) {
     throw new IntegrationError(`Batch size cannot exceed ${maxBatchSize}`, 'Invalid Payload', 400)
   }


### PR DESCRIPTION
Increasing the maximum batch size for actions-s3 to 100k. This is to support larger batch sizes for this destination for Fidelity.

## Testing

This was tested end-to-end in stage in conjunction with the new batching feature in Centrifuge. We were able to achieve 100k batches delivered to s3:

![image](https://github.com/user-attachments/assets/36a14b86-a3fe-46a4-89c5-d71950cf7d3c)

```
wc -l < 2024-12-02T19-44-43-081Z.csv
  100000
```

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 


