### PR TITLE
Stackadapt (ITE-146) Update Segment Engage Destination to handle onDelete events

### DIFF
--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/index.test.ts
@@ -1,0 +1,97 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import nock from 'nock'
+import Definition from '../index'
+import { GQL_ENDPOINT } from '../functions'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('StackAdapt Audiences - Destination Tests', () => {
+  const mockSettings = { apiKey: 'test-api-key' }
+  const gqlHostUrl = 'https://api.stackadapt.com'
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  describe('testAuthentication', () => {
+    it('should validate authentication inputs', async () => {
+      nock(GQL_ENDPOINT, {
+        reqheaders: {
+          authorization: `Bearer ${mockSettings.apiKey}`,
+          'content-type': 'application/json'
+        }
+      })
+        .post('', {
+          query: /tokenInfo/
+        })
+        .reply(200, {
+          data: {
+            tokenInfo: {
+              scopesByAdvertiser: {
+                nodes: [
+                  {
+                    advertiser: { name: 'Test Advertiser' },
+                    scopes: ['WRITE']
+                  }
+                ]
+              }
+            }
+          }
+        })
+
+      await expect(testDestination.testAuthentication(mockSettings)).resolves.not.toThrowError()
+    })
+
+    it('should fail if authentication is invalid', async () => {
+      nock(GQL_ENDPOINT).post('').reply(403, {})
+
+      await expect(testDestination.testAuthentication(mockSettings)).rejects.toThrowError('403Forbidden')
+    })
+  })
+
+  describe('onDelete', () => {
+    it('should delete a user with a given userId', async () => {
+      const userId = '9999'
+      const event = createTestEvent({ userId, type: 'identify' })
+
+      // Mock the GraphQL deleteProfilesWithExternalIds mutation
+      nock(gqlHostUrl)
+        .post('/graphql', (body) => {
+          return body.query.includes('deleteProfilesWithExternalIds') && body.query.includes(userId)
+        })
+        .reply(200, {
+          data: { deleteProfilesWithExternalIds: { userErrors: [] } }
+        })
+
+      const response = await testDestination.onDelete!(event, {
+        apiKey: 'test-api-key'
+      })
+
+      expect(response).toMatchObject({
+        data: { deleteProfilesWithExternalIds: { userErrors: [] } }
+      })
+    })
+
+    it('should throw an error if profile deletion fails with userErrors', async () => {
+      const userId = '9999'
+      const event = createTestEvent({ userId, type: 'identify' })
+
+      // Mock the GraphQL deleteProfilesWithExternalIds mutation with an error
+      nock(gqlHostUrl)
+        .post('/graphql')
+        .reply(200, {
+          data: {
+            deleteProfilesWithExternalIds: {
+              userErrors: [{ message: 'Deletion failed' }]
+            }
+          }
+        })
+
+      await expect(
+        testDestination.onDelete!(event, {
+          apiKey: 'test-api-key'
+        })
+      ).rejects.toThrowError('Profile deletion was not successful: Deletion failed')
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
@@ -1,10 +1,10 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
-
+import { IntegrationError } from '@segment/actions-core'
 import forwardProfile from './forwardProfile'
 import forwardAudienceEvent from './forwardAudienceEvent'
 import { AdvertiserScopesResponse } from './types'
-import { GQL_ENDPOINT } from './functions'
+import { GQL_ENDPOINT, EXTERNAL_PROVIDER, sha256hash } from './functions'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'StackAdapt Audiences',
@@ -59,6 +59,52 @@ const destination: DestinationDefinition<Settings> = {
       }
     }
   },
+  onDelete: async (request, { payload }) => {
+    const userId = payload.userId
+    const formattedExternalIds = `["${userId}"]`
+
+    const syncId = sha256hash(String(userId))
+
+    const mutation = `mutation {
+      deleteProfilesWithExternalIds(
+        externalIds: ${formattedExternalIds},
+        externalProvider: "${EXTERNAL_PROVIDER}",
+        syncId: "${syncId}"
+      ) {
+        userErrors {
+          message
+          path
+        }
+      }
+    }`
+
+    try {
+      const response = await request(GQL_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: mutation })
+      })
+
+      const result = await response.json()
+
+      if (result.data.deleteProfilesWithExternalIds.userErrors.length > 0) {
+        const errorMessages = result.data.deleteProfilesWithExternalIds.userErrors.map((e: any) => e.message).join(', ')
+        throw new IntegrationError(`Profile deletion was not successful: ${errorMessages}`, 'DELETE_FAILED', 400)
+      }
+
+      return result
+    } catch (error) {
+      if (error instanceof IntegrationError) {
+        throw error
+      }
+      throw new IntegrationError(
+        `Unexpected error occurred in onDelete: ${error instanceof Error ? error.message : String(error)}`,
+        'UNKNOWN_ERROR',
+        400
+      )
+    }
+  },
+
   actions: {
     forwardProfile,
     forwardAudienceEvent

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
@@ -62,7 +62,6 @@ const destination: DestinationDefinition<Settings> = {
   onDelete: async (request, { payload }) => {
     const userId = payload.userId
     const formattedExternalIds = `["${userId}"]`
-
     const syncId = sha256hash(String(userId))
 
     const mutation = `mutation {
@@ -78,31 +77,25 @@ const destination: DestinationDefinition<Settings> = {
       }
     }`
 
-    try {
-      const response = await request(GQL_ENDPOINT, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ query: mutation })
-      })
+    const response = await request(GQL_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: mutation })
+    })
 
-      const result = await response.json()
-
-      if (result.data.deleteProfilesWithExternalIds.userErrors.length > 0) {
-        const errorMessages = result.data.deleteProfilesWithExternalIds.userErrors.map((e: any) => e.message).join(', ')
-        throw new IntegrationError(`Profile deletion was not successful: ${errorMessages}`, 'DELETE_FAILED', 400)
+    const result: {
+      data: {
+        deleteProfilesWithExternalIds: {
+          userErrors: { message: string }[]
+        }
       }
+    } = await response.json()
 
-      return result
-    } catch (error) {
-      if (error instanceof IntegrationError) {
-        throw error
-      }
-      throw new IntegrationError(
-        `Unexpected error occurred in onDelete: ${error instanceof Error ? error.message : String(error)}`,
-        'UNKNOWN_ERROR',
-        400
-      )
+    if (result.data.deleteProfilesWithExternalIds.userErrors.length > 0) {
+      const errorMessages = result.data.deleteProfilesWithExternalIds.userErrors.map((e) => e.message).join(', ')
+      throw new IntegrationError(`Profile deletion was not successful: ${errorMessages}`, 'DELETE_FAILED', 400)
     }
+    return result
   },
 
   actions: {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->
Update Segment Engage Destination to handle onDelete events
Added onDelete property to the Stackadapt destination, when used, calls a graphQL API in Stackadapt to delete profiles.


<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->
Unit test passing for Stackadapt audiences:
<img width="997" alt="Screenshot 2024-11-18 at 4 58 00 PM" src="https://github.com/user-attachments/assets/1370e1b6-2810-4d1e-baf5-5d10281365df">

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._
Added onDelete property and test to Stackadapt audience.
## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
The API it calls is tested on the Stackadapt side:
<img width="1409" alt="Screenshot 2024-11-07 at 3 16 13 PM" src="https://github.com/user-attachments/assets/1db242b5-fded-437e-9d9f-486ecfbc1c98">

End to end testing was also conducted on Stackadapt production, but I didn't save any media. The QA team is testing something on prod so I can't rerun it at the moment, but if screenshots are needed, I will request to test later.

