### PR TITLE
[Sendgrid Audiences] - adding user attribute and custom field support

### DIFF
--- a/packages/destination-actions/src/destinations/sendgrid-audiences/constants.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/constants.ts
@@ -13,3 +13,5 @@ export const GET_CONTACT_BY_EMAIL_URL = 'https://api.sendgrid.com/v3/marketing/c
 export const SEARCH_CONTACTS_URL = 'https://api.sendgrid.com/v3/marketing/contacts/search'
 
 export const MAX_CHUNK_SIZE_SEARCH = 50
+
+export const GET_CUSTOM_FIELDS_URL = 'https://api.sendgrid.com/v3/marketing/field_definitions'

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/__tests__/index.test.ts
@@ -70,6 +70,7 @@ const mapping = {
     country: { '@path': '$.traits.country' },
     postal_code: { '@path': '$.traits.postal_code' }
   },
+  custom_fields: { '@path': '$.traits.custom_fields' },
   enable_batching: true,
   batch_size: 200
 }
@@ -106,7 +107,7 @@ describe('SendgridAudiences.syncAudience', () => {
     expect(responses[0].status).toBe(200)
   })
 
-  it('should upsert a single Contact with user attributes, and add it to a Sendgrid list correctly', async () => { 
+  it('should upsert a single Contact with user attributes and custom fields, and add it to a Sendgrid list correctly', async () => { 
     const event = createTestEvent({ 
       ...addPayload, 
       traits: { 
@@ -117,7 +118,14 @@ describe('SendgridAudiences.syncAudience', () => {
         city: 'SF', 
         state: 'CA',
         country: 'US',
-        postal_code: "N88EU" 
+        postal_code: "N88EU",
+        custom_fields: {
+          custom_field_1: 'custom_field_1_value',
+          custom_field_2: 2345,
+          custom_field_3: '2024-01-01T00:00:00.000Z',
+          custom_field_4: false, // should be removed 
+          custom_field_5: null // should be removed
+        }
       } 
     })
 
@@ -135,7 +143,12 @@ describe('SendgridAudiences.syncAudience', () => {
           city: 'SF', 
           state_province_region: 'CA',
           country: 'US',
-          postal_code: "N88EU" 
+          postal_code: "N88EU",
+          custom_fields: {
+            custom_field_1: 'custom_field_1_value',
+            custom_field_2: 2345,
+            custom_field_3: '2024-01-01T00:00:00.000Z'
+          }
         }
       ]
     }

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/__tests__/index.test.ts
@@ -65,6 +65,7 @@ const mapping = {
     first_name: { '@path': '$.traits.first_name' },
     last_name: { '@path': '$.traits.last_name' },
     address_line_1: { '@path': '$.traits.street' },
+    address_line_2: { '@path': '$.traits.address_line_2' },
     city: { '@path': '$.traits.city' },
     state_province_region: { '@path': '$.traits.state' },
     country: { '@path': '$.traits.country' },
@@ -115,6 +116,7 @@ describe('SendgridAudiences.syncAudience', () => {
         first_name: 'fname', 
         last_name: 'lname', 
         street: '123 Main St',
+        address_line_2: 123456, // should be stringified
         city: 'SF', 
         state: 'CA',
         country: 'US',
@@ -140,6 +142,7 @@ describe('SendgridAudiences.syncAudience', () => {
           first_name: 'fname',
           last_name: 'lname',
           address_line_1: '123 Main St',
+          address_line_2: '123456',
           city: 'SF', 
           state_province_region: 'CA',
           country: 'US',

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/dynamic-fields.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/dynamic-fields.ts
@@ -1,0 +1,50 @@
+
+import { RequestClient } from '@segment/actions-core'
+import { DynamicFieldResponse } from '@segment/actions-core'
+import { GET_CUSTOM_FIELDS_URL } from '../constants'
+
+export async function dynamicCustomFields(request: RequestClient): Promise<DynamicFieldResponse> {
+    interface ResultItem {
+        id: string
+        name: string
+        field_type: string
+    }
+    interface ResponseType {
+        data: {
+            custom_fields: Array<ResultItem>
+        }
+    }  
+    interface ResultError {
+        response: {
+          data: {
+            errors: Array<{ message: string }>
+          }
+        }
+    }
+
+    try {
+      const response: ResponseType = await request(GET_CUSTOM_FIELDS_URL, {
+        method: 'GET',
+        skipResponseCloning: true
+      })
+  
+      return {
+        choices: response.data.custom_fields.map((field) => {
+          return {
+            label: field.name,
+            value: field.name
+          }
+        })
+      }
+    } catch (err) {      
+      console.log(err)
+      const error = err as ResultError
+      return {
+        choices: [],
+        error: {
+          message: error.response.data.errors.map((e) => e.message).join(';')  ?? 'Unknown error: dynamicCustomFields',
+          code: "404"
+        }
+      }
+    }
+  }

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/fields.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/fields.ts
@@ -95,6 +95,114 @@ export const fields: Record<string, InputField> = {
       }
     }
   },
+  user_attributes: {
+    label: 'User Attributes',
+    description: `Additional user attributes to be included in the request.`,
+    type: 'object',
+    required: false,
+    defaultObjectUI: 'keyvalue',
+    additionalProperties: false,
+    properties: {
+      first_name: {
+        label: 'First Name',
+        description: `The contact's first name.`,
+        type: 'string'
+      },
+      last_name: {
+        label: 'Last Name',
+        description: `The contact's last name.`,
+        type: 'string'
+      },
+      address_line_1: {
+        label: 'Address Line 1',
+        description: `The contact's address line 1.`,
+        type: 'string'
+      },
+      address_line_2: {
+        label: 'Address Line 2',
+        description: `The contact's address line 2.`,
+        type: 'string'
+      },
+      city: {
+        label: 'City',
+        description: `The contact's city.`,
+        type: 'string'
+      },
+      state_province_region: {  
+        label: 'State/Province/Region',
+        description: `The contact's state, province, or region.`,
+        type: 'string'
+      },
+      country: {
+        label: 'Country',
+        description: `The contact's country.`,
+        type: 'string'
+      },
+      postal_code: {
+        label: 'Postal Code',
+        description: `The contact's postal code.`,
+        type: 'string'
+      }
+    },
+    default: {
+      first_name: {       
+        '@if': {
+          exists: { '@path': '$.traits.first_name' },
+          then: { '@path': '$.traits.first_name' },
+          else: { '@path': '$.properties.first_name' }
+        } 
+      },
+      last_name: {       
+        '@if': {
+          exists: { '@path': '$.traits.last_name' },
+          then: { '@path': '$.traits.last_name' },
+          else: { '@path': '$.properties.last_name' }
+        } 
+      },
+      address_line_1: {       
+        '@if': {
+          exists: { '@path': '$.traits.street' },
+          then: { '@path': '$.traits.street' },
+          else: { '@path': '$.properties.street' }
+        } 
+      },
+      address_line_2: {       
+        '@if': {
+          exists: { '@path': '$.traits.address_line_2' },
+          then: { '@path': '$.traits.address_line_2' },
+          else: { '@path': '$.properties.address_line_2' }
+        } 
+      },
+      city: {       
+        '@if': {
+          exists: { '@path': '$.traits.city' },
+          then: { '@path': '$.traits.city' },
+          else: { '@path': '$.properties.city' }
+        } 
+      },
+      state_province_region: {       
+        '@if': {
+          exists: { '@path': '$.traits.state' },
+          then: { '@path': '$.traits.state' },
+          else: { '@path': '$.properties.state' }
+        } 
+      },
+      country: {       
+        '@if': {
+          exists: { '@path': '$.traits.country' },
+          then: { '@path': '$.traits.country' },
+          else: { '@path': '$.properties.country' }
+        } 
+      },
+      postal_code: {       
+        '@if': {
+          exists: { '@path': '$.traits.postal_code' },
+          then: { '@path': '$.traits.postal_code' },
+          else: { '@path': '$.properties.postal_code' }
+        } 
+      }
+    }
+  },
   enable_batching: {
     type: 'boolean',
     label: 'Batch events',

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/fields.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/fields.ts
@@ -203,6 +203,16 @@ export const fields: Record<string, InputField> = {
       }
     }
   },
+  custom_fields: {
+    label: 'Custom Fields',
+    description: `Custom Fields to be added. The Custom Fields must already be defined in Sendgrid.`,
+    type: 'object',
+    required: false,
+    defaultObjectUI: 'keyvalue',
+    additionalProperties: true,
+    dynamic: true,
+    disabledInputMethods: ['literal', 'variable', 'function', 'freeform', 'enrichment']
+  },
   enable_batching: {
     type: 'boolean',
     label: 'Batch events',

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/fields.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/fields.ts
@@ -210,8 +210,7 @@ export const fields: Record<string, InputField> = {
     required: false,
     defaultObjectUI: 'keyvalue',
     additionalProperties: true,
-    dynamic: true,
-    disabledInputMethods: ['literal', 'variable', 'function', 'freeform', 'enrichment']
+    dynamic: true
   },
   enable_batching: {
     type: 'boolean',

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/fields.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/fields.ts
@@ -205,7 +205,7 @@ export const fields: Record<string, InputField> = {
   },
   custom_fields: {
     label: 'Custom Fields',
-    description: `Custom Fields to be added. The Custom Fields must already be defined in Sendgrid.`,
+    description: `Custom Field values to be added to the Contact. The Custom Fields must already be defined in Sendgrid. Custom Field values must be string, numbers or dates.`,
     type: 'object',
     required: false,
     defaultObjectUI: 'keyvalue',

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/generated-types.ts
@@ -73,6 +73,12 @@ export interface Payload {
     postal_code?: string
   }
   /**
+   * Custom Fields to be added. The Custom Fields must already be defined in Sendgrid.
+   */
+  custom_fields?: {
+    [k: string]: unknown
+  }
+  /**
    * When enabled, the action will batch events before sending them to Sendgrid.
    */
   enable_batching: boolean

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/generated-types.ts
@@ -36,6 +36,43 @@ export interface Payload {
    */
   phone_number_id?: string
   /**
+   * Additional user attributes to be included in the request.
+   */
+  user_attributes?: {
+    /**
+     * The contact's first name.
+     */
+    first_name?: string
+    /**
+     * The contact's last name.
+     */
+    last_name?: string
+    /**
+     * The contact's address line 1.
+     */
+    address_line_1?: string
+    /**
+     * The contact's address line 2.
+     */
+    address_line_2?: string
+    /**
+     * The contact's city.
+     */
+    city?: string
+    /**
+     * The contact's state, province, or region.
+     */
+    state_province_region?: string
+    /**
+     * The contact's country.
+     */
+    country?: string
+    /**
+     * The contact's postal code.
+     */
+    postal_code?: string
+  }
+  /**
    * When enabled, the action will batch events before sending them to Sendgrid.
    */
   enable_batching: boolean

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/generated-types.ts
@@ -73,7 +73,7 @@ export interface Payload {
     postal_code?: string
   }
   /**
-   * Custom Fields to be added. The Custom Fields must already be defined in Sendgrid.
+   * Custom Field values to be added to the Contact. The Custom Fields must already be defined in Sendgrid. Custom Field values must be string, numbers or dates.
    */
   custom_fields?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/index.ts
@@ -3,13 +3,23 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { send } from './utils'
 import { fields } from './fields'
+import { dynamicCustomFields } from './dynamic-fields'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Sync Audience',
   description: 'Sync a Segment Engage Audience to a Sendgrid List',
   defaultSubscription: 'type = "identify" or type = "track"',
   fields,
+  dynamicFields: {
+    custom_fields: {
+      __keys__: async (request) => {
+        return await dynamicCustomFields(request)
+      }
+    },
+  },
   perform: async (request, { payload }) => {
+    const x = await dynamicCustomFields(request)
+    console.log(JSON.stringify(x))  
     return await send(request, [payload])
   },
   performBatch: async (request, { payload }) => {

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/index.ts
@@ -12,14 +12,12 @@ const action: ActionDefinition<Settings, Payload> = {
   fields,
   dynamicFields: {
     custom_fields: {
-      __keys__: async (request) => {
-        return await dynamicCustomFields(request)
+      __keys__: async (request, { payload }) => {
+        return await dynamicCustomFields(request, payload)
       }
-    },
+    }
   },
   perform: async (request, { payload }) => {
-    const x = await dynamicCustomFields(request)
-    console.log(JSON.stringify(x))  
     return await send(request, [payload])
   },
   performBatch: async (request, { payload }) => {

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/utils.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/utils.ts
@@ -101,6 +101,13 @@ function validate(payloads: Payload[], ignoreErrors: boolean, invalidEmails?: st
     if (p.email && invalidEmails?.includes(p.email)) {
       delete p.email
     }
+
+    if (p.custom_fields) {
+      p.custom_fields = Object.fromEntries(
+        Object.entries(p.custom_fields).filter(([_, value]) => typeof value === 'string' || typeof value === 'number')
+      )
+    }
+
     const hasRequiredField = [p.email, p.anonymous_id, p.external_id, p.phone_number_id].some(Boolean)
     if (!hasRequiredField && !ignoreErrors) {
       throw new PayloadValidationError(
@@ -128,7 +135,10 @@ function createPayload(payloads: Payload[], externalAudienceId: string): UpsertC
       phone_number_id: payload.phone_number_id ?? undefined,
       external_id: payload.external_id ?? undefined,
       anonymous_id: payload.anonymous_id ?? undefined,
-      ...payload.user_attributes
+      ...payload.user_attributes,
+      custom_fields: payload.custom_fields && Object.keys(payload.custom_fields).length > 0
+      ? payload.custom_fields
+      : undefined
     })) as UpsertContactsReq['contacts']
   }
 

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/utils.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/utils.ts
@@ -127,9 +127,11 @@ function createPayload(payloads: Payload[], externalAudienceId: string): UpsertC
       email: payload.email ?? undefined,
       phone_number_id: payload.phone_number_id ?? undefined,
       external_id: payload.external_id ?? undefined,
-      anonymous_id: payload.anonymous_id ?? undefined
+      anonymous_id: payload.anonymous_id ?? undefined,
+      ...payload.user_attributes
     })) as UpsertContactsReq['contacts']
   }
+
   return json
 }
 

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/utils.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/utils.ts
@@ -108,6 +108,17 @@ function validate(payloads: Payload[], ignoreErrors: boolean, invalidEmails?: st
       )
     }
 
+    if (p.user_attributes) {
+      p.user_attributes = Object.fromEntries(
+        Object.entries(p.user_attributes ?? {}).map(([key, value]) => {
+          if (typeof value !== 'string') {
+            return [key, String(value)]
+          }
+          return [key, value]
+        })
+      );
+    }
+
     const hasRequiredField = [p.email, p.anonymous_id, p.external_id, p.phone_number_id].some(Boolean)
     if (!hasRequiredField && !ignoreErrors) {
       throw new PayloadValidationError(

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/types.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/types.ts
@@ -15,6 +15,14 @@ export interface UpsertContactsReq {
       email?: string
       phone_number_id?: string
       anonymous_id?: string
+      first_name?: string
+      last_name?: string
+      address_line_1?: string
+      address_line_2?: string
+      city?: string
+      state_province_region?: string
+      country?: string
+      postal_code?: string
     } & ({ external_id: string } | { email: string } | { phone_number_id: string } | { anonymous_id: string })
   >
 }

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/types.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/types.ts
@@ -23,6 +23,9 @@ export interface UpsertContactsReq {
       state_province_region?: string
       country?: string
       postal_code?: string
+      custom_fields?: {
+        [k: string]: string | number
+      }
     } & ({ external_id: string } | { email: string } | { phone_number_id: string } | { anonymous_id: string })
   >
 }


### PR DESCRIPTION
Adding user attribute and custom_field support for Sendgrid Audience Destination. 

## Testing
Unit test added. Tested locally. 
Not in use by customers yet. 