### PR TITLE
[Hubspot] [STRATCONN-4366] - correcting custom object reference to use canonical identifier

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/customEvent/functions/dynamic-field-functions.ts
+++ b/packages/destination-actions/src/destinations/hubspot/customEvent/functions/dynamic-field-functions.ts
@@ -78,7 +78,7 @@ async function dynamicReadEventNames(request: RequestClient): Promise<DynamicFie
 async function dynamicReadObjectTypes(request: RequestClient): Promise<DynamicFieldResponse> {
   interface ResultItem {
     labels: { singular: string; plural: string }
-    name: string
+    fullyQualifiedName: string
   }
 
   interface ResponseType {
@@ -96,7 +96,7 @@ async function dynamicReadObjectTypes(request: RequestClient): Promise<DynamicFi
     })
     const choices = response.data.results.map((schema) => ({
       label: `${schema.labels.plural} (Custom)`,
-      value: schema.name
+      value: schema.fullyQualifiedName
     }))
     return {
       choices: [...choices, ...defaultChoices].sort((a, b) =>


### PR DESCRIPTION
Update to force Hubspot customEvent Action to reference Custom Objects via the canonical identifier rather than the friendlier name. The friendlier name is being deprecated by Hubspot in 2025. 

## Testing

Tested locally
<img width="545" alt="image" src="https://github.com/user-attachments/assets/5769160a-3eee-4261-adba-a1d8357ff9c1">
