### PR TITLE
[STRATCONN-4213] - Update hotfix release scripts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,22 +81,3 @@ jobs:
           script: |
             const script = require('./scripts/github-action/create-github-release.js')
             await script({github, context, core, exec})
-
-  # When hotfix is merged back to main, we tag all the packages that were changed in the hotfix commit.
-  tag-hotfix:
-    if: startsWith(github.event.head_commit.message, 'Hotfix:') == true && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Generate Package Specific Tags
-        id: get-release-tag
-        run: ./scripts/generate-package-tags.sh

--- a/scripts/generate-release-tags.sh
+++ b/scripts/generate-release-tags.sh
@@ -52,13 +52,6 @@ else
 fi
 
 
-# For hotfix, we don't tag each package version and we do it when hotfix changes are merged to main branch.
-if [[ $branch == hotfix/* ]];
-then
-  echo "Skipping package tag generation for hotfix branch"
-  exit 0
-fi;
-
 # Generate and push package tags.
 curr_path=$(pwd)
 dir_name=$(dirname $0)

--- a/scripts/github-action/create-github-release.js
+++ b/scripts/github-action/create-github-release.js
@@ -1,14 +1,22 @@
 // This is a github action script and can be run only from github actions. To run this script locally, you need to mock the github object and context object.
 module.exports = async ({ github, context, core, exec }) => {
-  let { GITHUB_SHA, DRY_RUN } = process.env
+  let { GITHUB_SHA, DRY_RUN, GITHUB_REF } = process.env
+
+  // Get the branch name from the GITHUB_REF
+  const branchName = GITHUB_REF.replace('refs/heads/', '')
+  const isHotfixBranch = branchName.startsWith('hotfix/')
 
   if (Boolean(DRY_RUN)) {
     core.info('Running in dry-run mode')
   }
 
-  // Get the last two commits that have the word "Publish" in the commit message along with the date
-  const [newPublish, previousPublish] = await getPreviousTwoPublishCommits(core, exec)
-  const prs = await getPRsBetweenCommits(github, context, core, previousPublish, newPublish)
+  let prs = []
+  // Retrieve PRs merged between the last two publish commits only for normal releases
+  if (!isHotfixBranch) {
+    // Get the last two commits that have the word "Publish" in the commit message along with the date
+    const [newPublish, previousPublish] = await getPreviousTwoPublishCommits(core, exec)
+    prs = await getPRsBetweenCommits(github, context, core, previousPublish, newPublish)
+  }
 
   // Get tag for the current release from the git repository
   const newReleaseTag = await getReleaseTag(core, exec)


### PR DESCRIPTION
This PR applies some fixes to hotfix release scripts

**1. Tag commit with package versions on the hotfix branch itself.**

If we tag the hotfix merge commit on main branch with package version (i.e package tags), the next publish won't work as lerna relies on git tags to figure out the last published commit and decide if new package publish is needed.  
To solve this,

- the special package version tagging step after hotfix merge has been removed from publish.yml workflow
- the if condition to skip adding package tags while running `scripts/generate-release-tags.sh` has been removed so that package version tagging is done on the hotfix branch itself.


**2. Fixes Hotfix Github Release Notes**

Previously, notes of the hotfix release created in Github contained list of PRs merged to main. Instead, it should not list any PRs from main branch because hotfix doesn't include those PRs already on main. It only contains the fix applied on top of the previous release. So, we simply skip generating PR list for Hotfix releases. 


## Testing

Testing completed successfully 

For 1,  I am simply removing a job which was introduced just for hotfix but it is no longer required. So, no testing is required.
For 2,  Here is an [example release created](https://github.com/segmentio/action-destinations/releases/tag/hotfix-2024-11-21.1) while testing.


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
