### PR TITLE
[Multistatus] Fix error reporter

### DIFF
--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -542,9 +542,16 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
 
           // Check if response is a failed response
           if (response instanceof ActionDestinationErrorResponse) {
+            const responseValue = response.value()
+
+            // Check if the error has a 'sent' or 'body' field set, we assume it to be an error from the API Call
+            // Else we assume it to be an error from the Integration validations
             multiStatusResponse[i] = {
-              ...response.value(),
-              errorreporter: MultiStatusErrorReporter.DESTINATION
+              ...responseValue,
+              errorreporter:
+                responseValue.sent || responseValue.body
+                  ? MultiStatusErrorReporter.DESTINATION
+                  : MultiStatusErrorReporter.INTEGRATIONS
             }
 
             // Add datadog stats for events that are discarded by Destination

--- a/packages/destination-actions/src/destinations/braze/__tests__/multistatus.test.ts
+++ b/packages/destination-actions/src/destinations/braze/__tests__/multistatus.test.ts
@@ -88,7 +88,7 @@ describe('MultiStatus', () => {
         status: 400,
         errortype: 'PAYLOAD_VALIDATION_FAILED',
         errormessage: 'One of "external_id" or "user_alias" or "braze_id" or "email" is required.',
-        errorreporter: 'DESTINATION'
+        errorreporter: 'INTEGRATIONS'
       })
     })
 
@@ -326,7 +326,7 @@ describe('MultiStatus', () => {
         status: 400,
         errortype: 'PAYLOAD_VALIDATION_FAILED',
         errormessage: 'This event was not sent to Braze because it did not contain any products.',
-        errorreporter: 'DESTINATION'
+        errorreporter: 'INTEGRATIONS'
       })
 
       // The forth event fails as pre-request validation fails for not having a valid user identifier
@@ -334,7 +334,7 @@ describe('MultiStatus', () => {
         status: 400,
         errortype: 'PAYLOAD_VALIDATION_FAILED',
         errormessage: 'One of "external_id" or "user_alias" or "braze_id" or "email" is required.',
-        errorreporter: 'DESTINATION'
+        errorreporter: 'INTEGRATIONS'
       })
     })
 
@@ -441,7 +441,7 @@ describe('MultiStatus', () => {
         status: 400,
         errortype: 'PAYLOAD_VALIDATION_FAILED',
         errormessage: 'This event was not sent to Braze because it did not contain any products.',
-        errorreporter: 'DESTINATION'
+        errorreporter: 'INTEGRATIONS'
       })
     })
 
@@ -547,7 +547,7 @@ describe('MultiStatus', () => {
           status: 400,
           errormessage: 'This event was not sent to Braze because it did not contain any products.',
           errortype: 'PAYLOAD_VALIDATION_FAILED',
-          errorreporter: 'DESTINATION'
+          errorreporter: 'INTEGRATIONS'
         }
       ])
     })
@@ -630,7 +630,7 @@ describe('MultiStatus', () => {
         status: 400,
         errortype: 'PAYLOAD_VALIDATION_FAILED',
         errormessage: 'One of "external_id" or "user_alias" or "braze_id" or "email" is required.',
-        errorreporter: 'DESTINATION'
+        errorreporter: 'INTEGRATIONS'
       })
     })
 
@@ -809,13 +809,13 @@ describe('MultiStatus', () => {
       expect(response).toMatchObject([
         {
           errormessage: 'Invalid syncMode, must be set to "add" or "update"',
-          errorreporter: 'DESTINATION',
+          errorreporter: 'INTEGRATIONS',
           errortype: 'PAYLOAD_VALIDATION_FAILED',
           status: 400
         },
         {
           errormessage: 'Invalid syncMode, must be set to "add" or "update"',
-          errorreporter: 'DESTINATION',
+          errorreporter: 'INTEGRATIONS',
           errortype: 'PAYLOAD_VALIDATION_FAILED',
           status: 400
         }
@@ -880,13 +880,13 @@ describe('MultiStatus', () => {
       expect(response).toMatchObject([
         {
           errormessage: 'Invalid syncMode, must be set to "add" or "update"',
-          errorreporter: 'DESTINATION',
+          errorreporter: 'INTEGRATIONS',
           errortype: 'PAYLOAD_VALIDATION_FAILED',
           status: 400
         },
         {
           errormessage: 'Invalid syncMode, must be set to "add" or "update"',
-          errorreporter: 'DESTINATION',
+          errorreporter: 'INTEGRATIONS',
           errortype: 'PAYLOAD_VALIDATION_FAILED',
           status: 400
         }
@@ -947,13 +947,13 @@ describe('MultiStatus', () => {
       expect(response).toMatchObject([
         {
           errormessage: 'Invalid syncMode, must be set to "add" or "update"',
-          errorreporter: 'DESTINATION',
+          errorreporter: 'INTEGRATIONS',
           errortype: 'PAYLOAD_VALIDATION_FAILED',
           status: 400
         },
         {
           errormessage: 'Invalid syncMode, must be set to "add" or "update"',
-          errorreporter: 'DESTINATION',
+          errorreporter: 'INTEGRATIONS',
           errortype: 'PAYLOAD_VALIDATION_FAILED',
           status: 400
         }


### PR DESCRIPTION
The `multistatus` response from performBatch block always has `errorreporter` set to Destination. This fix will check if `sent` and `body` is set and set the errorreporter as DESTINATION else it will be set to INTEGRATIONS.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
