### PR TITLE
[Klaviyo] | Added stats for listId to see the whether entire batch has same listId

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/addProfileToList/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/addProfileToList/index.ts
@@ -64,7 +64,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const profileId = await createProfile(request, email, external_id, phone_number, additionalAttributes)
     return await addProfileToList(request, profileId, list_id)
   },
-  performBatch: async (request, { payload }) => {
+  performBatch: async (request, { payload, statsContext, features }) => {
     // Filtering out profiles that do not contain either an email, external_id or valid phone number.
     payload = payload.filter((profile) => {
       // Validate and convert the phone number using the provided country code
@@ -80,6 +80,16 @@ const action: ActionDefinition<Settings, Payload> = {
       }
       return profile.email || profile.external_id || profile.phone_number
     })
+    const statsClient = statsContext?.statsClient
+    const tags = statsContext?.tags
+
+    if (features && features['klaviyo-list-id']) {
+      const set = new Set()
+      payload.forEach((profile) => {
+        set.add(profile.list_id)
+      })
+      statsClient?.histogram(`klaviyo_list_id`, set.size, tags)
+    }
     const listId = payload[0]?.list_id
     const importJobPayload = createImportJobPayload(payload, listId)
     return sendImportJobRequest(request, importJobPayload)


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pull request is to add stats for listId to understand whether entire batch belongs to same listId or not. Will remove this code later.
Feature Flag :- https://flagon.segment.com/families/centrifuge-destinations/gates/klaviyo-list-id
## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality - NA
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change. - NA
- [ ] [Segmenters] Tested in the staging environment - NA
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.  - NA
