### PR TITLE
[Taboola Audiences] - Supporting computation key to be used when creating Audiences

### DIFF
--- a/packages/destination-actions/src/destinations/taboola-actions/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/__tests__/index.test.ts
@@ -37,7 +37,13 @@ describe('Taboola (actions)', () => {
       const createAudienceInput1 = {
         settings: {
           client_id: 'test_client_id',
-          client_secret: 'test_client'
+          client_secret: 'test_client',
+          audience_identifier: 'audience_name'
+        },
+        personas: {
+          computation_key: 'test_computation_key',
+          computation_id: '2345678iuhgfdcvbjk',
+          namespace: 'test-namespace'
         },
         audienceName: '',
         audienceSettings: {
@@ -82,6 +88,72 @@ describe('Taboola (actions)', () => {
           client_secret: 'test_client'
         },
         audienceName: 'Test Audience',
+        audienceSettings: {
+          ttl_in_hours: 1024,
+          exclude_from_campaigns: false,
+          account_id:accountId
+        }
+      }
+      const r = await testDestination.createAudience(createAudienceInput3)
+      expect(r).toEqual({ externalId: '1234' })
+    })
+
+    it('should create a new Taboola Audience with computation_key', async () => {
+      
+      const expectedCreateAudienceReq = {
+        audience_name:"test_computation_key",
+        ttl_in_hours:1024,
+        exclude_from_campaigns:false
+      }
+      
+      nock('https://backstage.taboola.com').post('/backstage/oauth/token').reply(200, { accessToken: 'some_token' })
+      nock(createAudienceUrl).post('/audience_onboarding/create', expectedCreateAudienceReq).reply(200, { audience_id: '1234' })
+
+      const createAudienceInput3 = {
+        settings: {
+          client_id: 'test_client_id',
+          client_secret: 'test_client',
+          audience_identifier: 'computation_key'
+        },
+        personas: {
+          computation_key: 'test_computation_key',
+          computation_id: '2345678iuhgfdcvbjk',
+          namespace: 'test-namespace'
+        },
+        audienceName: 'Test Audience',
+        audienceSettings: {
+          ttl_in_hours: 1024,
+          exclude_from_campaigns: false,
+          account_id:accountId
+        }
+      }
+      const r = await testDestination.createAudience(createAudienceInput3)
+      expect(r).toEqual({ externalId: '1234' })
+    })
+
+    it('should create a new Taboola Audience with audience_name', async () => {
+      
+      const expectedCreateAudienceReq = {
+        audience_name:"test_audience_name",
+        ttl_in_hours:1024,
+        exclude_from_campaigns:false
+      }
+      
+      nock('https://backstage.taboola.com').post('/backstage/oauth/token').reply(200, { accessToken: 'some_token' })
+      nock(createAudienceUrl).post('/audience_onboarding/create', expectedCreateAudienceReq).reply(200, { audience_id: '1234' })
+
+      const createAudienceInput3 = {
+        settings: {
+          client_id: 'test_client_id',
+          client_secret: 'test_client',
+          audience_identifier: 'audience_name'
+        },
+        personas: {
+          computation_key: 'test_computation_key',
+          computation_id: '2345678iuhgfdcvbjk',
+          namespace: 'test-namespace'
+        },
+        audienceName: 'test_audience_name',
         audienceSettings: {
           ttl_in_hours: 1024,
           exclude_from_campaigns: false,

--- a/packages/destination-actions/src/destinations/taboola-actions/generated-types.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/generated-types.ts
@@ -9,6 +9,10 @@ export interface Settings {
    * The client's secret from your Taboola account.
    */
   client_secret: string
+  /**
+   * The audience identifier from your Taboola account.
+   */
+  audience_identifier?: string
 }
 // Generated file. DO NOT MODIFY IT BY HAND.
 

--- a/packages/destination-actions/src/destinations/taboola-actions/index.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/index.ts
@@ -24,6 +24,17 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         description: "The client's secret from your Taboola account.",
         type: 'string',
         required: true
+      },
+      audience_identifier: {
+        label: 'Audience Identifier',
+        description: 'The audience identifier from your Taboola account.',
+        type: 'string',
+        choices: [
+          {label: 'Audience Computation Key', value: 'computation_key'},
+          {label: 'Audience Name', value: 'audience_name'}
+        ],
+        required: false,
+        default: 'computation_key'
       }
     },
     refreshAccessToken: async (request, { settings }) => {
@@ -66,7 +77,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       full_audience_sync: false
     },
     async createAudience(request, createAudienceInput) {
-      const audienceName = createAudienceInput.audienceName
+      const audienceName = createAudienceInput.settings?.audience_identifier === 'computation_key' ? createAudienceInput.personas?.computation_key : createAudienceInput.audienceName
       const ttlInHours = createAudienceInput.audienceSettings?.ttl_in_hours
       const excludeFromCampaigns = createAudienceInput.audienceSettings?.exclude_from_campaigns
       const accountId = createAudienceInput.audienceSettings?.account_id


### PR DESCRIPTION
Adding a new setting field to allow for computation key to be used during Audience creation. 

Required by some customers who are migrating from a Custom Function, and need the Audience names to match so they don't have duplicate Audiences created in Taboola. 

## Testing

Unit tests added. 
