### PR TITLE
Remove error tracking logs for Snap Audiences

### DIFF
--- a/packages/destination-actions/src/destinations/snap-audiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/snap-audiences/__tests__/index.test.ts
@@ -20,15 +20,6 @@ const createAudienceInput = {
 
 describe('Snap Audiences', () => {
   describe('createAudience', () => {
-    beforeEach(() => {
-      // Catch all Segment API requests and return 200
-      nock('https://api.segment.io').persist().post('/v1/track').reply(200)
-    })
-
-    afterEach(() => {
-      nock.cleanAll()
-    })
-
     it('should fail if Segment audience name is available', async () => {
       createAudienceInput.audienceName = ''
       await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(IntegrationError)


### PR DESCRIPTION
I was able to discover that there is an issue with refreshing the access token for the `createAudience` request: will create a seperate JIRA for this for Audience dest service. 

Removing the Segment tracking logs to revert to original state. 

## Testing

n/a