### PR TITLE
Update drip identify action phone field

### DIFF
--- a/packages/destination-actions/src/destinations/drip/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/drip/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -9,7 +9,7 @@ Object {
       },
       "email": "mivsaj@pu.co.uk",
       "ip_address": "33.172.51.152",
-      "sms_number": "XoS!vJs",
+      "phone": "XoS!vJs",
       "status": "XoS!vJs",
       "status_updated_at": "2021-02-01T00:00:00.000Z",
       "tags": Array [

--- a/packages/destination-actions/src/destinations/drip/identify/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/drip/identify/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -9,7 +9,7 @@ Object {
       },
       "email": "okavno@kulusof.bg",
       "ip_address": "100.102.165.77",
-      "sms_number": "DVw6A7$UK[I",
+      "phone": "DVw6A7$UK[I",
       "status": "DVw6A7$UK[I",
       "status_updated_at": "2021-02-01T00:00:00.000Z",
       "tags": Array [

--- a/packages/destination-actions/src/destinations/drip/identify/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/drip/identify/__tests__/index.test.ts
@@ -56,7 +56,7 @@ describe('Drip.identify', () => {
           },
           email: 'test@example.com',
           ip_address: '127.0.0.1',
-          sms_number: '1234567890',
+          phone: '1234567890',
           status: 'unsubscribed',
           status_updated_at: '2021-01-01T00:00:00Z',
           tags: ['tag1', 'tag2'],

--- a/packages/destination-actions/src/destinations/drip/identify/index.ts
+++ b/packages/destination-actions/src/destinations/drip/identify/index.ts
@@ -14,7 +14,7 @@ const person = (payload: Payload) => {
     })(),
     email: payload.email,
     ip_address: payload.ip,
-    sms_number: payload.phone,
+    phone: payload.phone,
     status: payload.status,
     status_updated_at: payload.status_updated_at,
     tags: payload.tags?.split(',').map((tag) => tag.trim()),


### PR DESCRIPTION
Changing the phone field of the identity action


- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
