### PR TITLE
[LinkedIn Audiences] Necessary fixes for `updateAudience` mapping.

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-audiences/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/api/index.ts
@@ -56,7 +56,7 @@ export class LinkedInAudiences {
     })
   }
 
-  async batchUpdate(dmpSegmentId: string, elements: Record<string, string>[]): Promise<ModifiedResponse> {
+  async batchUpdate(dmpSegmentId: string, elements: Record<string, unknown>[]): Promise<ModifiedResponse> {
     return this.request(`${BASE_URL}/dmpSegments/${dmpSegmentId}/users`, {
       method: 'POST',
       headers: {

--- a/packages/destination-actions/src/destinations/linkedin-audiences/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/api/index.ts
@@ -1,4 +1,5 @@
 import type { RequestClient, ModifiedResponse } from '@segment/actions-core'
+
 import type { Settings } from '../generated-types'
 import type { Payload } from '../updateAudience/generated-types'
 import { BASE_URL, LINKEDIN_SOURCE_PLATFORM } from '../constants'

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/__tests__/index.test.ts
@@ -120,7 +120,7 @@ describe('LinkedinAudiences.updateAudience', () => {
       .get(/.*/)
       .query(urlParams)
       .reply(200, { elements: [{ id: 'dmp_segment_id' }] })
-    nock(`${BASE_URL}/dmpSegments`).persist().post(/.*/, createDmpSegmentRequestBody).reply(200)
+    nock(`${BASE_URL}/dmpSegments`).post(/.*/, createDmpSegmentRequestBody).reply(200)
     nock(`${BASE_URL}/dmpSegments/dmp_segment_id/users`).post(/.*/, updateUsersRequestBody).reply(200)
 
     await expect(

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/__tests__/index.test.ts
@@ -70,25 +70,6 @@ const createDmpSegmentRequestBody = {
 }
 
 describe('LinkedinAudiences.updateAudience', () => {
-  it('should fail if `personas_audience_key` field does not match the `source_segment_id` field', async () => {
-    await expect(
-      testDestination.testAction('updateAudience', {
-        event,
-        settings: {
-          ad_account_id: '123',
-          send_email: true,
-          send_google_advertising_id: true
-        },
-        useDefaultMappings: true,
-        auth,
-        mapping: {
-          personas_audience_key: 'mismatched_audience',
-          dmp_user_action: null
-        }
-      })
-    ).rejects.toThrow('The value of `source_segment_id` and `personas_audience_key` must match.')
-  })
-
   it('should fail if both `send_email` and `send_google_advertising_id` settings are set to false', async () => {
     await expect(
       testDestination.testAction('updateAudience', {
@@ -139,7 +120,7 @@ describe('LinkedinAudiences.updateAudience', () => {
       .get(/.*/)
       .query(urlParams)
       .reply(200, { elements: [{ id: 'dmp_segment_id' }] })
-    nock(`${BASE_URL}/dmpSegments`).post(/.*/, createDmpSegmentRequestBody).reply(200)
+    nock(`${BASE_URL}/dmpSegments`).persist().post(/.*/, createDmpSegmentRequestBody).reply(200)
     nock(`${BASE_URL}/dmpSegments/dmp_segment_id/users`).post(/.*/, updateUsersRequestBody).reply(200)
 
     await expect(
@@ -183,25 +164,6 @@ describe('LinkedinAudiences.updateAudience', () => {
         }
       })
     ).resolves.not.toThrowError()
-  })
-
-  it('should fail if `personas_audience_key` field does not match the `source_segment_id` field, and `dmp_user_action` is set to auto', async () => {
-    await expect(
-      testDestination.testAction('updateAudience', {
-        event,
-        settings: {
-          ad_account_id: '123',
-          send_email: true,
-          send_google_advertising_id: true
-        },
-        useDefaultMappings: true,
-        auth,
-        mapping: {
-          personas_audience_key: 'mismatched_audience',
-          dmp_user_action: 'AUTO'
-        }
-      })
-    ).rejects.toThrow('The value of `source_segment_id` and `personas_audience_key` must match.')
   })
 
   it('should set action to "ADD" if `dmp_user_action` is "ADD"', async () => {

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/__tests__/index.test.ts
@@ -70,9 +70,96 @@ const createDmpSegmentRequestBody = {
 }
 
 describe('LinkedinAudiences.updateAudience', () => {
-  it('should fail if `personas_audience_key` field does not match the `source_segment_id` field', async () => {
-    await expect(
-      testDestination.testAction('updateAudience', {
+  describe('Successful cases', () => {
+    it('should succeed if an existing DMP Segment is found', async () => {
+      nock(`${BASE_URL}/dmpSegments`)
+        .get(/.*/)
+        .query(urlParams)
+        .reply(200, { elements: [{ id: 'dmp_segment_id' }] })
+      nock(`${BASE_URL}/dmpSegments/dmp_segment_id/users`).post(/.*/, updateUsersRequestBody).reply(200)
+
+      await expect(
+        testDestination.testAction('updateAudience', {
+          event,
+          settings: {
+            ad_account_id: '123',
+            send_email: true,
+            send_google_advertising_id: true
+          },
+          useDefaultMappings: true,
+          auth,
+          mapping: {
+            personas_audience_key: 'personas_test_audience'
+          }
+        })
+      ).resolves.not.toThrowError()
+    })
+
+    it('should successfully create a new DMP Segment if an existing Segment is not found', async () => {
+      urlParams.account = 'urn:li:sponsoredAccount:456'
+
+      nock(`${BASE_URL}/dmpSegments`).get(/.*/).query(urlParams).reply(200, { elements: [] })
+      nock(`${BASE_URL}/dmpSegments`)
+        .get(/.*/)
+        .query(urlParams)
+        .reply(200, { elements: [{ id: 'dmp_segment_id' }] })
+      nock(`${BASE_URL}/dmpSegments`).post(/.*/, createDmpSegmentRequestBody).reply(200)
+      nock(`${BASE_URL}/dmpSegments/dmp_segment_id/users`).post(/.*/, updateUsersRequestBody).reply(200)
+
+      await expect(
+        testDestination.testAction('updateAudience', {
+          event,
+          settings: {
+            ad_account_id: '456',
+            send_email: true,
+            send_google_advertising_id: true
+          },
+          useDefaultMappings: true,
+          auth,
+          mapping: {
+            personas_audience_key: 'personas_test_audience'
+          }
+        })
+      ).resolves.not.toThrowError()
+    })
+
+    it('should not throw an error if `dmp_user_action` is not "AUTO", even if `source_segment_id` does not match `personas_audience_key`', async () => {
+      nock(`${BASE_URL}/dmpSegments`)
+        .get(/.*/)
+        .query(() => true)
+        .reply(200, { elements: [{ id: 'dmp_segment_id' }] })
+      nock(`${BASE_URL}/dmpSegments/dmp_segment_id/users`).post(/.*/, updateUsersRequestBody).reply(200)
+
+      await expect(
+        testDestination.testAction('updateAudience', {
+          event,
+          settings: {
+            ad_account_id: '123',
+            send_email: true,
+            send_google_advertising_id: true
+          },
+          useDefaultMappings: true,
+          auth,
+          mapping: {
+            source_segment_id: 'mismatched_segment',
+            personas_audience_key: 'personas_test_audience',
+            dmp_user_action: 'ADD'
+          }
+        })
+      ).resolves.not.toThrowError()
+    })
+
+    it('should set action to "ADD" if `dmp_user_action` is "ADD"', async () => {
+      nock(`${BASE_URL}/dmpSegments`)
+        .get(/.*/)
+        .query(() => true)
+        .reply(200, { elements: [{ id: 'dmp_segment_id' }] })
+
+      nock(`${BASE_URL}/dmpSegments/dmp_segment_id/users`)
+        .post(/.*/, (body) => body.elements[0].action === 'ADD')
+        .reply(200)
+
+      const response = await testDestination.testAction('updateAudience', {
         event,
         settings: {
           ad_account_id: '123',
@@ -82,111 +169,25 @@ describe('LinkedinAudiences.updateAudience', () => {
         useDefaultMappings: true,
         auth,
         mapping: {
-          personas_audience_key: 'mismatched_audience',
-          dmp_user_action: null
-        }
-      })
-    ).rejects.toThrow('The value of `source_segment_id` and `personas_audience_key` must match.')
-  })
-  it('should fail if both `send_email` and `send_google_advertising_id` settings are set to false', async () => {
-    await expect(
-      testDestination.testAction('updateAudience', {
-        event,
-        settings: {
-          ad_account_id: '123',
-          send_email: false,
-          send_google_advertising_id: false
-        },
-        useDefaultMappings: true,
-        auth,
-        mapping: {
-          personas_audience_key: 'personas_test_audience'
-        }
-      })
-    ).rejects.toThrow('At least one of `Send Email` or `Send Google Advertising ID` must be set to `true`.')
-  })
-
-  it('should succeed if an exisitng DMP Segment is found', async () => {
-    nock(`${BASE_URL}/dmpSegments`)
-      .get(/.*/)
-      .query(urlParams)
-      .reply(200, { elements: [{ id: 'dmp_segment_id' }] })
-    nock(`${BASE_URL}/dmpSegments/dmp_segment_id/users`).post(/.*/, updateUsersRequestBody).reply(200)
-
-    await expect(
-      testDestination.testAction('updateAudience', {
-        event,
-        settings: {
-          ad_account_id: '123',
-          send_email: true,
-          send_google_advertising_id: true
-        },
-        useDefaultMappings: true,
-        auth,
-        mapping: {
-          personas_audience_key: 'personas_test_audience'
-        }
-      })
-    ).resolves.not.toThrowError()
-  })
-
-  it('should successfully create a new DMP Segment if an existing Segment is not found', async () => {
-    urlParams.account = 'urn:li:sponsoredAccount:456'
-
-    nock(`${BASE_URL}/dmpSegments`).get(/.*/).query(urlParams).reply(200, { elements: [] })
-    nock(`${BASE_URL}/dmpSegments`)
-      .get(/.*/)
-      .query(urlParams)
-      .reply(200, { elements: [{ id: 'dmp_segment_id' }] })
-    nock(`${BASE_URL}/dmpSegments`).post(/.*/, createDmpSegmentRequestBody).reply(200)
-    nock(`${BASE_URL}/dmpSegments/dmp_segment_id/users`).post(/.*/, updateUsersRequestBody).reply(200)
-
-    await expect(
-      testDestination.testAction('updateAudience', {
-        event,
-        settings: {
-          ad_account_id: '456',
-          send_email: true,
-          send_google_advertising_id: true
-        },
-        useDefaultMappings: true,
-        auth,
-        mapping: {
-          personas_audience_key: 'personas_test_audience'
-        }
-      })
-    ).resolves.not.toThrowError()
-  })
-
-  it('should not throw an error if `dmp_user_action` is not "AUTO", even if `source_segment_id` does not match `personas_audience_key`', async () => {
-    nock(`${BASE_URL}/dmpSegments`)
-      .get(/.*/)
-      .query(() => true)
-      .reply(200, { elements: [{ id: 'dmp_segment_id' }] })
-    nock(`${BASE_URL}/dmpSegments/dmp_segment_id/users`).post(/.*/, updateUsersRequestBody).reply(200)
-
-    await expect(
-      testDestination.testAction('updateAudience', {
-        event,
-        settings: {
-          ad_account_id: '123',
-          send_email: true,
-          send_google_advertising_id: true
-        },
-        useDefaultMappings: true,
-        auth,
-        mapping: {
-          source_segment_id: 'mismatched_segment',
           personas_audience_key: 'personas_test_audience',
           dmp_user_action: 'ADD'
         }
       })
-    ).resolves.not.toThrowError()
-  })
 
-  it('should fail if `personas_audience_key` field does not match the `source_segment_id` field, and `dmp_user_action` is set to auto', async () => {
-    await expect(
-      testDestination.testAction('updateAudience', {
+      expect(response).toBeTruthy()
+    })
+
+    it('should set action to "REMOVE" if `dmp_user_action` is "REMOVE"', async () => {
+      nock(`${BASE_URL}/dmpSegments`)
+        .get(/.*/)
+        .query(() => true)
+        .reply(200, { elements: [{ id: 'dmp_segment_id' }] })
+
+      nock(`${BASE_URL}/dmpSegments/dmp_segment_id/users`)
+        .post(/.*/, (body) => body.elements[0].action === 'REMOVE')
+        .reply(200)
+
+      const response = await testDestination.testAction('updateAudience', {
         event,
         settings: {
           ad_account_id: '123',
@@ -196,66 +197,166 @@ describe('LinkedinAudiences.updateAudience', () => {
         useDefaultMappings: true,
         auth,
         mapping: {
-          personas_audience_key: 'mismatched_audience',
-          dmp_user_action: 'AUTO'
+          personas_audience_key: 'personas_test_audience',
+          dmp_user_action: 'REMOVE'
         }
       })
-    ).rejects.toThrow('The value of `source_segment_id` and `personas_audience_key` must match.')
-  })
 
-  it('should set action to "ADD" if `dmp_user_action` is "ADD"', async () => {
-    nock(`${BASE_URL}/dmpSegments`)
-      .get(/.*/)
-      .query(() => true)
-      .reply(200, { elements: [{ id: 'dmp_segment_id' }] })
-
-    nock(`${BASE_URL}/dmpSegments/dmp_segment_id/users`)
-      .post(/.*/, (body) => body.elements[0].action === 'ADD')
-      .reply(200)
-
-    const response = await testDestination.testAction('updateAudience', {
-      event,
-      settings: {
-        ad_account_id: '123',
-        send_email: true,
-        send_google_advertising_id: true
-      },
-      useDefaultMappings: true,
-      auth,
-      mapping: {
-        personas_audience_key: 'personas_test_audience',
-        dmp_user_action: 'ADD'
-      }
+      expect(response).toBeTruthy()
     })
 
-    expect(response).toBeTruthy()
-  })
+    it('Email comes from traits.email', async () => {
+      const eventWithTraits = createTestEvent({
+        event: 'Audience Entered',
+        type: 'track',
+        properties: {
+          audience_key: 'personas_test_audience'
+        },
+        traits: {
+          email: 'testing@testing.com'
+        },
+        context: {
+          device: {
+            advertisingId: '123'
+          }
+        }
+      })
 
-  it('should set action to "REMOVE" if `dmp_user_action` is "REMOVE"', async () => {
-    nock(`${BASE_URL}/dmpSegments`)
-      .get(/.*/)
-      .query(() => true)
-      .reply(200, { elements: [{ id: 'dmp_segment_id' }] })
+      nock(`${BASE_URL}/dmpSegments`)
+        .get(/.*/)
+        .query(() => true)
+        .reply(200, { elements: [{ id: 'dmp_segment_id' }] })
 
-    nock(`${BASE_URL}/dmpSegments/dmp_segment_id/users`)
-      .post(/.*/, (body) => body.elements[0].action === 'REMOVE')
-      .reply(200)
+      nock(`${BASE_URL}/dmpSegments/dmp_segment_id/users`)
+        .post(/.*/, (body) => body.elements[0].action === 'ADD')
+        .reply(200)
 
-    const response = await testDestination.testAction('updateAudience', {
-      event,
-      settings: {
-        ad_account_id: '123',
-        send_email: true,
-        send_google_advertising_id: true
-      },
-      useDefaultMappings: true,
-      auth,
-      mapping: {
-        personas_audience_key: 'personas_test_audience',
-        dmp_user_action: 'REMOVE'
-      }
+      const responses = await testDestination.testAction('updateAudience', {
+        event: eventWithTraits,
+        settings: {
+          ad_account_id: '123',
+          send_email: true,
+          send_google_advertising_id: true
+        },
+        useDefaultMappings: true,
+        auth,
+        mapping: {
+          personas_audience_key: 'personas_test_audience',
+          dmp_user_action: 'ADD'
+        }
+      })
+
+      expect(responses).toBeTruthy()
+      expect(responses).toHaveLength(2)
+      expect(responses[1].options.body).toMatchInlineSnapshot(
+        '"{\\"elements\\":[{\\"action\\":\\"ADD\\",\\"userIds\\":[{\\"idType\\":\\"SHA256_EMAIL\\",\\"idValue\\":\\"584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777\\"},{\\"idType\\":\\"GOOGLE_AID\\",\\"idValue\\":\\"123\\"}]}]}"'
+      )
     })
 
-    expect(response).toBeTruthy()
+    it('Email is already a SHA256 hash', async () => {
+      const eventWithTraits = createTestEvent({
+        event: 'Audience Entered',
+        type: 'track',
+        properties: {
+          audience_key: 'personas_test_audience'
+        },
+        traits: {
+          email: '584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777'
+        },
+        context: {
+          device: {
+            advertisingId: '123'
+          }
+        }
+      })
+
+      nock(`${BASE_URL}/dmpSegments`)
+        .get(/.*/)
+        .query(() => true)
+        .reply(200, { elements: [{ id: 'dmp_segment_id' }] })
+
+      nock(`${BASE_URL}/dmpSegments/dmp_segment_id/users`)
+        .post(/.*/, (body) => body.elements[0].action === 'ADD')
+        .reply(200)
+
+      const responses = await testDestination.testAction('updateAudience', {
+        event: eventWithTraits,
+        settings: {
+          ad_account_id: '123',
+          send_email: true,
+          send_google_advertising_id: true
+        },
+        useDefaultMappings: true,
+        auth,
+        mapping: {
+          personas_audience_key: 'personas_test_audience',
+          dmp_user_action: 'ADD'
+        }
+      })
+
+      expect(responses).toBeTruthy()
+      expect(responses).toHaveLength(2)
+      expect(responses[1].options.body).toMatchInlineSnapshot(
+        '"{\\"elements\\":[{\\"action\\":\\"ADD\\",\\"userIds\\":[{\\"idType\\":\\"SHA256_EMAIL\\",\\"idValue\\":\\"584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777\\"},{\\"idType\\":\\"GOOGLE_AID\\",\\"idValue\\":\\"123\\"}]}]}"'
+      )
+    })
+  })
+
+  describe('Error cases', () => {
+    it('should fail if `personas_audience_key` field does not match the `source_segment_id` field', async () => {
+      await expect(
+        testDestination.testAction('updateAudience', {
+          event,
+          settings: {
+            ad_account_id: '123',
+            send_email: true,
+            send_google_advertising_id: true
+          },
+          useDefaultMappings: true,
+          auth,
+          mapping: {
+            personas_audience_key: 'mismatched_audience',
+            dmp_user_action: null
+          }
+        })
+      ).rejects.toThrow('The value of `source_segment_id` and `personas_audience_key` must match.')
+    })
+
+    it('should fail if both `send_email` and `send_google_advertising_id` settings are set to false', async () => {
+      await expect(
+        testDestination.testAction('updateAudience', {
+          event,
+          settings: {
+            ad_account_id: '123',
+            send_email: false,
+            send_google_advertising_id: false
+          },
+          useDefaultMappings: true,
+          auth,
+          mapping: {
+            personas_audience_key: 'personas_test_audience'
+          }
+        })
+      ).rejects.toThrow('At least one of `Send Email` or `Send Google Advertising ID` must be set to `true`.')
+    })
+
+    it('should fail if `personas_audience_key` field does not match the `source_segment_id` field, and `dmp_user_action` is set to auto', async () => {
+      await expect(
+        testDestination.testAction('updateAudience', {
+          event,
+          settings: {
+            ad_account_id: '123',
+            send_email: true,
+            send_google_advertising_id: true
+          },
+          useDefaultMappings: true,
+          auth,
+          mapping: {
+            personas_audience_key: 'mismatched_audience',
+            dmp_user_action: 'AUTO'
+          }
+        })
+      ).rejects.toThrow('The value of `source_segment_id` and `personas_audience_key` must match.')
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/__tests__/index.test.ts
@@ -70,6 +70,24 @@ const createDmpSegmentRequestBody = {
 }
 
 describe('LinkedinAudiences.updateAudience', () => {
+  it('should fail if `personas_audience_key` field does not match the `source_segment_id` field', async () => {
+    await expect(
+      testDestination.testAction('updateAudience', {
+        event,
+        settings: {
+          ad_account_id: '123',
+          send_email: true,
+          send_google_advertising_id: true
+        },
+        useDefaultMappings: true,
+        auth,
+        mapping: {
+          personas_audience_key: 'mismatched_audience',
+          dmp_user_action: null
+        }
+      })
+    ).rejects.toThrow('The value of `source_segment_id` and `personas_audience_key` must match.')
+  })
   it('should fail if both `send_email` and `send_google_advertising_id` settings are set to false', async () => {
     await expect(
       testDestination.testAction('updateAudience', {
@@ -164,6 +182,25 @@ describe('LinkedinAudiences.updateAudience', () => {
         }
       })
     ).resolves.not.toThrowError()
+  })
+
+  it('should fail if `personas_audience_key` field does not match the `source_segment_id` field, and `dmp_user_action` is set to auto', async () => {
+    await expect(
+      testDestination.testAction('updateAudience', {
+        event,
+        settings: {
+          ad_account_id: '123',
+          send_email: true,
+          send_google_advertising_id: true
+        },
+        useDefaultMappings: true,
+        auth,
+        mapping: {
+          personas_audience_key: 'mismatched_audience',
+          dmp_user_action: 'AUTO'
+        }
+      })
+    ).rejects.toThrow('The value of `source_segment_id` and `personas_audience_key` must match.')
   })
 
   it('should set action to "ADD" if `dmp_user_action` is "ADD"', async () => {

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/generated-types.ts
@@ -18,6 +18,10 @@ export interface Payload {
    */
   google_advertising_id?: string
   /**
+   * A Segment-specific key associated with the LinkedIn DMP Segment. This is the lookup key Segment uses to fetch the DMP Segment from LinkedIn's API.
+   */
+  source_segment_id?: string
+  /**
    * The `audience_key` of the Engage audience you want to sync to LinkedIn. This value must be a hard-coded string variable, e.g. `personas_test_audience`, in order for batching to work properly.
    */
   personas_audience_key: string

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/generated-types.ts
@@ -18,10 +18,6 @@ export interface Payload {
    */
   google_advertising_id?: string
   /**
-   * A Segment-specific key associated with the LinkedIn DMP Segment. This is the lookup key Segment uses to fetch the DMP Segment from LinkedIn's API.
-   */
-  source_segment_id?: string
-  /**
    * The `audience_key` of the Engage audience you want to sync to LinkedIn. This value must be a hard-coded string variable, e.g. `personas_test_audience`, in order for batching to work properly.
    */
   personas_audience_key: string

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
@@ -88,7 +88,6 @@ async function processPayload(
   payloads: Payload[],
   statsContext: StatsContext | undefined
 ) {
-  // validate(settings, payloads)
   validate(settings)
 
   const linkedinApiClient: LinkedInAudiences = new LinkedInAudiences(request)
@@ -124,7 +123,6 @@ async function processPayload(
   return res
 }
 
-// function validate(settings: Settings, payloads: Payload[]): void {
 function validate(settings: Settings): void {
   if (!settings.send_google_advertising_id && !settings.send_email) {
     throw new IntegrationError(

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
@@ -1,8 +1,7 @@
 import type { ActionDefinition, StatsContext } from '@segment/actions-core'
-import { RequestClient, RetryableError, IntegrationError } from '@segment/actions-core'
+import { RequestClient, RetryableError, IntegrationError, sha256SmartHash } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { createHash } from 'crypto'
 import { LinkedInAudiences } from '../api'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -31,9 +30,9 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       default: {
         '@if': {
-          exists: { '@path': '$.traits.email' },
-          then: { '@path': '$.traits.email' },
-          else: { '@path': '$.context.traits.email' }
+          exists: { '@path': '$.context.traits.email' },
+          then: { '@path': '$.context.traits.email' },
+          else: { '@path': '$.traits.email' }
         }
       }
     },
@@ -224,15 +223,9 @@ function getUserIds(settings: Settings, payload: Payload): Record<string, string
   const users = []
 
   if (payload.email && settings.send_email === true) {
-    let email = payload.email
-    const isHashed = new RegExp(/[0-9abcdef]{64}/gi).test(payload.email)
-    if (!isHashed) {
-      email = createHash('sha256').update(payload.email).digest('hex')
-    }
-
     users.push({
       idType: 'SHA256_EMAIL',
-      idValue: email
+      idValue: sha256SmartHash(payload.email)
     })
   }
 


### PR DESCRIPTION
- User Email is not always `context.traits.email`;
- Bypass `email` if it is already hashed.

## Motivation

- Some customers have emails as normal traits, not identifiers;
- Some customers have different spellings for their emails;
- Some customers use trait enrichment for emails, and they come as properties;
- Some customers don't send plain emails to Segment: they already hash emails using SHA256.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
