### PR TITLE
[FUNK-1504] actions-webhook-extensible - Make changes to oauth2 refresh token handler

### DIFF
--- a/packages/destination-actions/src/destinations/webhook-extensible/index.ts
+++ b/packages/destination-actions/src/destinations/webhook-extensible/index.ts
@@ -22,19 +22,43 @@ const destination: DestinationDefinition<SettingsWithDynamicAuth> = {
       }
     },
     refreshAccessToken: async (request, { settings, auth }) => {
-      const res = await request<RefreshTokenResponse>(settings.dynamicAuthSettings.oauth.refreshTokenUrl, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          Authorization: `Basic ${Buffer.from(auth.clientId + ':' + auth.clientSecret).toString('base64')}`
-        },
-        body: new URLSearchParams({
-          grant_type: 'client_credentials',
-          scope: settings.dynamicAuthSettings.oauth.scopes
-        })
-      })
+      let res
+      const { clientId, clientSecret } = auth
+      const { oauth } = settings.dynamicAuthSettings
 
-      return { accessToken: res.data.access_token }
+      if (oauth.type === 'authCode') {
+        res = await request<RefreshTokenResponse>(oauth.refreshTokenServerUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Basic ${Buffer.from(clientId + ':' + clientSecret).toString('base64')}`
+          },
+          body: new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: auth.refreshToken ?? oauth.access.refresh_token,
+            scope: oauth.scopes,
+            client_id: clientId,
+            client_secret: clientSecret
+          })
+        })
+        return {
+          accessToken: res.data.access_token,
+          refreshToken: res.data.refresh_token
+        }
+      } else {
+        res = await request<RefreshTokenResponse>(oauth.refreshTokenServerUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Basic ${Buffer.from(clientId + ':' + clientSecret).toString('base64')}`
+          },
+          body: new URLSearchParams({
+            grant_type: 'client_credentials',
+            scope: oauth.scopes
+          })
+        })
+        return { accessToken: res.data.access_token }
+      }
     }
   },
   extendRequest: ({ settings, auth }) => {

--- a/packages/destination-actions/src/destinations/webhook-extensible/index.ts
+++ b/packages/destination-actions/src/destinations/webhook-extensible/index.ts
@@ -28,15 +28,18 @@ const destination: DestinationDefinition<SettingsWithDynamicAuth> = {
           'Content-Type': 'application/x-www-form-urlencoded',
           Authorization: `Basic ${Buffer.from(auth.clientId + ':' + auth.clientSecret).toString('base64')}`
         },
-        body: '{"grant_type":"client_credentials"}'
+        body: new URLSearchParams({
+          grant_type: 'client_credentials',
+          scope: settings.dynamicAuthSettings.oauth.scopes
+        })
       })
 
       return { accessToken: res.data.access_token }
     }
   },
-  extendRequest: ({ settings }) => {
+  extendRequest: ({ settings, auth }) => {
     const { dynamicAuthSettings } = settings
-    const accessToken = dynamicAuthSettings?.oauth?.access?.access_token
+    const accessToken = auth?.accessToken ?? dynamicAuthSettings?.oauth?.access?.access_token
     return {
       headers: {
         authorization: `Bearer ${accessToken}`

--- a/packages/destination-actions/src/destinations/webhook-extensible/types.ts
+++ b/packages/destination-actions/src/destinations/webhook-extensible/types.ts
@@ -1,5 +1,6 @@
 export interface RefreshTokenResponse {
   access_token: string
+  refresh_token: string
   scope: string
   expires_in: number
   token_type: string


### PR DESCRIPTION
Made changes to to the refreshtoken handler to handle different flows for oauth2.0
Changes limited to action folder

Precursor to removing duplicate oauth object inside dynamicAuthSettings and introducing dynamic auth options into Destination Kit

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
