### PR TITLE
Add Unique ID and Key Tracking in SFMC Events

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtension/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtension/index.ts
@@ -33,7 +33,23 @@ const action: ActionDefinition<Settings, Payload> = {
   perform: async (request, { settings, payload }) => {
     return upsertRows(request, settings.subdomain, [payload])
   },
-  performBatch: async (request, { settings, payload }) => {
+  performBatch: async (request, { settings, payload, statsContext, features }) => {
+    if (features && features['enable-sfmc-id-key-stats']) {
+      const statsClient = statsContext?.statsClient
+      const tags = statsContext?.tags
+      const setKey = new Set()
+      const setId = new Set()
+      payload.forEach((profile) => {
+        if (profile.id != undefined && profile.id != null) {
+          setId.add(profile.id)
+        }
+        if (profile.key != undefined && profile.key != null) {
+          setKey.add(profile.key)
+        }
+      })
+      statsClient?.histogram(`sfmc_id`, setId.size, tags)
+      statsClient?.histogram(`sfmc_key`, setKey.size, tags)
+    }
     return upsertRows(request, settings.subdomain, payload)
   }
 }

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtension/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtension/index.ts
@@ -18,7 +18,23 @@ const action: ActionDefinition<Settings, Payload> = {
   perform: async (request, { settings, payload }) => {
     return upsertRows(request, settings.subdomain, [payload])
   },
-  performBatch: async (request, { settings, payload }) => {
+  performBatch: async (request, { settings, payload, statsContext, features }) => {
+    if (features && features['enable-sfmc-id-key-stats']) {
+      const statsClient = statsContext?.statsClient
+      const tags = statsContext?.tags
+      const setKey = new Set()
+      const setId = new Set()
+      payload.forEach((profile) => {
+        if (profile.id != undefined && profile.id != null) {
+          setId.add(profile.id)
+        }
+        if (profile.key != undefined && profile.key != null) {
+          setKey.add(profile.key)
+        }
+      })
+      statsClient?.histogram(`sfmc_id`, setId.size, tags)
+      statsClient?.histogram(`sfmc_key`, setKey.size, tags)
+    }
     return upsertRows(request, settings.subdomain, payload)
   }
 }


### PR DESCRIPTION
Add stats to check if we are getting different keys and ids in events of same payload.
Flag: https://flagon.segment.com/families/centrifuge-destinations/gates/enable-sfmc-id-key-stats
## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
