### PR TITLE
TikTok - STRATCONN-5346 - changing default object UI view for content field

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-conversions/common_fields.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/common_fields.ts
@@ -245,6 +245,7 @@ export const commonFields: Record<string, InputField> = {
     type: 'object',
     multiple: true,
     description: 'Related item details for the event.',
+    defaultObjectUI: 'keyvalue',
     properties: {
       price: {
         label: 'Price',

--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions/common_fields.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions/common_fields.ts
@@ -161,6 +161,7 @@ export const commonFields: Record<string, InputField> = {
     type: 'object',
     multiple: true,
     description: 'Related item details for the event.',
+    defaultObjectUI: 'keyvalue',
     properties: {
       price: {
         label: 'Price',


### PR DESCRIPTION
Changing the default field UI view so that it displays the key:value pairs for the TikTok Content field. 

This doesn't fix any bug - it might help customers understand how to use the field better. 

## Testing

None needed. 
