### PR TITLE
Update: Format Date type objects to permissible Iterable date string

### DIFF
--- a/packages/destination-actions/src/destinations/iterable/utils.ts
+++ b/packages/destination-actions/src/destinations/iterable/utils.ts
@@ -47,6 +47,8 @@ export function convertDatesInObject(obj: Record<string, unknown>) {
       } else {
         obj[prop] = dateToIterableDateStringFormat(value)
       }
+    } else if (value instanceof Date) {
+      obj[prop] = dateToIterableDateStringFormat(value.toISOString())
     } else if (typeof value === 'object' && value !== null) {
       convertDatesInObject(value as Record<string, unknown>)
     } else {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Hello 👋 

We noticed when attempting to map the `receivedAt` property from Segment's UI to an Iterable destination field, Iterable was dropping the property (we used Iterable's Data-Schema-Management to define the property as a `Date` ahead of time). We discovered that this is very likely due to `receivedAt` being a `Date` which was not handled by the [`convertDatesInObject`](https://github.com/segmentio/action-destinations/blob/6955920f1a4c6194e86ce6486a510f82a64b7d4e/packages/destination-actions/src/destinations/iterable/utils.ts#L36) function.

We're looking for feedback on this update which would check against `Date` types and format them to be compatible with Iterable's permitted date string format.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
