### PR TITLE
[SFMC] Remove stats for SFMC

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtension/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtension/index.ts
@@ -33,23 +33,7 @@ const action: ActionDefinition<Settings, Payload> = {
   perform: async (request, { settings, payload }) => {
     return upsertRows(request, settings.subdomain, [payload])
   },
-  performBatch: async (request, { settings, payload, statsContext, features }) => {
-    if (features && features['enable-sfmc-id-key-stats']) {
-      const statsClient = statsContext?.statsClient
-      const tags = statsContext?.tags
-      const setKey = new Set()
-      const setId = new Set()
-      payload.forEach((profile) => {
-        if (profile.id != undefined && profile.id != null) {
-          setId.add(profile.id)
-        }
-        if (profile.key != undefined && profile.key != null) {
-          setKey.add(profile.key)
-        }
-      })
-      statsClient?.histogram(`sfmc_id`, setId.size, tags)
-      statsClient?.histogram(`sfmc_key`, setKey.size, tags)
-    }
+  performBatch: async (request, { settings, payload }) => {
     return upsertRows(request, settings.subdomain, payload)
   }
 }

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtension/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtension/index.ts
@@ -18,23 +18,7 @@ const action: ActionDefinition<Settings, Payload> = {
   perform: async (request, { settings, payload }) => {
     return upsertRows(request, settings.subdomain, [payload])
   },
-  performBatch: async (request, { settings, payload, statsContext, features }) => {
-    if (features && features['enable-sfmc-id-key-stats']) {
-      const statsClient = statsContext?.statsClient
-      const tags = statsContext?.tags
-      const setKey = new Set()
-      const setId = new Set()
-      payload.forEach((profile) => {
-        if (profile.id != undefined && profile.id != null) {
-          setId.add(profile.id)
-        }
-        if (profile.key != undefined && profile.key != null) {
-          setKey.add(profile.key)
-        }
-      })
-      statsClient?.histogram(`sfmc_id`, setId.size, tags)
-      statsClient?.histogram(`sfmc_key`, setKey.size, tags)
-    }
+  performBatch: async (request, { settings, payload }) => {
     return upsertRows(request, settings.subdomain, payload)
   }
 }


### PR DESCRIPTION
Remove the stats code for SFMC since we have completed the investigation regarding uniqueness of key and id of events in payload.

We are only seeing 1 key/id per payload hence all events in a payload have similar key/id according to the stats.
![image (2)](https://github.com/user-attachments/assets/4b55a8a0-beb0-49ce-962a-37befe86c222)


## Testing
Testing is not required since we are removing code only added for checking stats.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality - NR
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) - NR
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change. - NR
- [ ] [Segmenters] Tested in the staging environment - NR
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. - NR
