### PR TITLE
[Marketo] - Add MultiStatus Support

### DIFF
--- a/packages/destination-actions/src/destinations/marketo-static-lists/addToList/index.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/addToList/index.ts
@@ -2,7 +2,7 @@ import type { IntegrationError, ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { external_id, lookup_field, data, enable_batching, batch_size, event_name } from '../properties'
-import { addToList, createList, getList } from '../functions'
+import { addToList, addToListBatch, createList, getList } from '../functions'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Add to List',
@@ -94,11 +94,11 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: async (request, { settings, payload, statsContext, hookOutputs }) => {
     statsContext?.statsClient?.incr('addToAudience', 1, statsContext?.tags)
-    return addToList(request, settings, [payload], statsContext, hookOutputs?.retlOnMappingSave?.outputs)
+    return addToList(request, settings, payload, statsContext, hookOutputs?.retlOnMappingSave?.outputs)
   },
   performBatch: async (request, { settings, payload, statsContext, hookOutputs }) => {
     statsContext?.statsClient?.incr('addToAudience.batch', 1, statsContext?.tags)
-    return addToList(request, settings, payload, statsContext, hookOutputs?.retlOnMappingSave?.outputs)
+    return addToListBatch(request, settings, payload, statsContext, hookOutputs?.retlOnMappingSave?.outputs)
   }
 }
 

--- a/packages/destination-actions/src/destinations/marketo-static-lists/functions.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/functions.ts
@@ -28,6 +28,7 @@ import {
   CREATE_LIST_ENDPOINT,
   GET_LIST_ENDPOINT
 } from './constants'
+import { JSONLikeObject } from '@segment/actions-core/*'
 
 // Keep only the scheme and host from the endpoint
 // Marketo UI shows endpoint with trailing "/rest", which we don't want
@@ -38,27 +39,64 @@ export function formatEndpoint(endpoint: string) {
 export async function addToList(
   request: RequestClient,
   settings: Settings,
+  payload: AddToListPayload,
+  statsContext?: StatsContext,
+  hookOutputs?: { id: string; name: string }
+) {
+  // If the list ID is provided in the hook outputs, use it
+  const list_id = hookOutputs?.id ?? payload.external_id
+
+  if (!list_id) {
+    const errormessage = 'No list ID found in payload'
+    throw new IntegrationError(errormessage, ErrorCodes.PAYLOAD_VALIDATION_FAILED, 400)
+  }
+
+  const api_endpoint = formatEndpoint(settings.api_endpoint)
+
+  const csvData = formatData([payload])
+  const csvSize = Buffer.byteLength(csvData, 'utf8')
+  if (csvSize > CSV_LIMIT) {
+    const errormessage = `CSV data size exceeds limit of ${CSV_LIMIT} bytes`
+    statsContext?.statsClient?.incr('addToAudience.error', 1, statsContext?.tags)
+    throw new IntegrationError(errormessage, 'PAYLOAD_TOO_LARGE', 400)
+  }
+
+  const url =
+    api_endpoint + BULK_IMPORT_ENDPOINT.replace('externalId', list_id).replace('fieldToLookup', payload.lookup_field)
+
+  const response = await request<MarketoBulkImportResponse>(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'multipart/form-data; boundary=--SEGMENT-DATA--'
+    },
+    body: createFormData(csvData)
+  })
+
+  if (!response.data.success) {
+    statsContext?.statsClient?.incr('addToAudience.error', 1, statsContext?.tags)
+    parseErrorResponse(response.data)
+  }
+
+  statsContext?.statsClient?.incr('addToAudience.success', 1, statsContext?.tags)
+  return response.data
+}
+
+export async function addToListBatch(
+  request: RequestClient,
+  settings: Settings,
   payloads: AddToListPayload[],
   statsContext?: StatsContext,
   hookOutputs?: { id: string; name: string }
 ) {
-  const isBatchPayload = payloads.length > 1
-
   // If the list ID is provided in the hook outputs, use it
   const list_id = hookOutputs?.id ?? payloads[0].external_id
 
   if (!list_id) {
-    const errormessage = 'No list ID found in payload'
-
-    if (isBatchPayload) {
-      return setMultiStatusErrorResponse(payloads.length, {
-        status: 400,
-        errortype: ErrorCodes.PAYLOAD_VALIDATION_FAILED,
-        errormessage
-      })
-    }
-
-    throw new IntegrationError(errormessage, ErrorCodes.PAYLOAD_VALIDATION_FAILED, 400)
+    return buildMultiStatusErrorResponse(payloads.length, {
+      status: 400,
+      errortype: ErrorCodes.PAYLOAD_VALIDATION_FAILED,
+      errormessage: 'No list ID found in payload'
+    })
   }
 
   const api_endpoint = formatEndpoint(settings.api_endpoint)
@@ -66,19 +104,12 @@ export async function addToList(
   const csvData = formatData(payloads)
   const csvSize = Buffer.byteLength(csvData, 'utf8')
   if (csvSize > CSV_LIMIT) {
-    const errormessage = `CSV data size exceeds limit of ${CSV_LIMIT} bytes`
-
-    if (isBatchPayload) {
-      statsContext?.statsClient?.incr('addToAudience.error', payloads.length, statsContext?.tags)
-      return setMultiStatusErrorResponse(payloads.length, {
-        status: 400,
-        errortype: ErrorCodes.PAYLOAD_TOO_LARGE,
-        errormessage
-      })
-    }
-
-    statsContext?.statsClient?.incr('addToAudience.error', 1, statsContext?.tags)
-    throw new IntegrationError(errormessage, 'PAYLOAD_TOO_LARGE', 400)
+    statsContext?.statsClient?.incr('addToAudience.error', payloads.length, statsContext?.tags)
+    return buildMultiStatusErrorResponse(payloads.length, {
+      status: 400,
+      errortype: ErrorCodes.PAYLOAD_TOO_LARGE,
+      errormessage: `CSV data size exceeds limit of ${CSV_LIMIT} bytes`
+    })
   }
 
   const url =
@@ -94,33 +125,94 @@ export async function addToList(
   })
 
   if (!response.data.success) {
-    statsContext?.statsClient?.incr('addToAudience.error', 1, statsContext?.tags)
-    parseErrorResponse(response.data)
+    statsContext?.statsClient?.incr('addToAudience.error', payloads.length, statsContext?.tags)
+    return parseErrorResponseBatch(response.data, payloads.length)
   }
-  statsContext?.statsClient?.incr('addToAudience.success', 1, statsContext?.tags)
-  return response.data
+
+  statsContext?.statsClient?.incr('addToAudience.success', payloads.length, statsContext?.tags)
+
+  // Build a MultiStatusResponse and return it
+  const multiStatusResponse = new MultiStatusResponse()
+
+  for (let i = 0; i < payloads.length; i++) {
+    multiStatusResponse.setSuccessResponseAtIndex(i, {
+      status: 200,
+      // CSV data could be as large as 10 MB, so we truncate it to upto 50 characters
+      sent: `${csvData.substring(0, 50)}...`,
+      // response.data is an API Response, we can safely cast it to JSONLikeObject
+      body: response.data as unknown as JSONLikeObject
+    })
+  }
+
+  return multiStatusResponse
 }
 
 export async function removeFromList(
   request: RequestClient,
   settings: Settings,
+  payload: RemoveFromListPayload,
+  statsContext?: StatsContext
+) {
+  if (!payload.external_id) {
+    throw new IntegrationError('No "external_id" found in payload', ErrorCodes.PAYLOAD_VALIDATION_FAILED, 400)
+  }
+
+  const api_endpoint = formatEndpoint(settings.api_endpoint)
+  const usersToRemove = extractFilterData([payload])
+
+  const getLeadsUrl =
+    api_endpoint +
+    GET_LEADS_ENDPOINT.replace('field', payload.lookup_field).replace(
+      'emailsToFilter',
+      encodeURIComponent(usersToRemove)
+    )
+
+  // Get lead ids from Marketo
+  const getLeadsResponse = await request<MarketoGetLeadsResponse>(getLeadsUrl, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+
+  if (!getLeadsResponse.data.success) {
+    statsContext?.statsClient?.incr('removeFromAudience.error', 1, statsContext?.tags)
+    parseErrorResponse(getLeadsResponse.data)
+  }
+
+  const leadIds = extractLeadIds(getLeadsResponse.data.result)
+
+  const deleteLeadsUrl =
+    api_endpoint + REMOVE_USERS_ENDPOINT.replace('listId', payload.external_id).replace('idsToDelete', leadIds)
+
+  // DELETE lead ids from list in Marketo
+  const deleteLeadsResponse = await request<MarketoDeleteLeadsResponse>(deleteLeadsUrl, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+
+  if (!deleteLeadsResponse.data.success) {
+    statsContext?.statsClient?.incr('removeFromAudience.error', 1, statsContext?.tags)
+    parseErrorResponse(deleteLeadsResponse.data)
+  }
+  statsContext?.statsClient?.incr('removeFromAudience.success', 1, statsContext?.tags)
+  return deleteLeadsResponse.data
+}
+
+export async function removeFromListBatch(
+  request: RequestClient,
+  settings: Settings,
   payloads: RemoveFromListPayload[],
   statsContext?: StatsContext
 ) {
-  const isBatchPayload = payloads.length > 1
-
   if (!payloads[0].external_id) {
-    const errormessage = 'No "external_id" found in payload'
-
-    if (isBatchPayload) {
-      setMultiStatusErrorResponse(payloads.length, {
-        status: 400,
-        errortype: ErrorCodes.PAYLOAD_VALIDATION_FAILED,
-        errormessage
-      })
-    }
-
-    throw new IntegrationError(errormessage, ErrorCodes.PAYLOAD_VALIDATION_FAILED, 400)
+    return buildMultiStatusErrorResponse(payloads.length, {
+      status: 400,
+      errortype: ErrorCodes.PAYLOAD_VALIDATION_FAILED,
+      errormessage: 'No "external_id" found in payload'
+    })
   }
 
   const api_endpoint = formatEndpoint(settings.api_endpoint)
@@ -142,8 +234,8 @@ export async function removeFromList(
   })
 
   if (!getLeadsResponse.data.success) {
-    statsContext?.statsClient?.incr('removeFromAudience.error', 1, statsContext?.tags)
-    parseErrorResponse(getLeadsResponse.data)
+    statsContext?.statsClient?.incr('removeFromAudience.error', payloads.length, statsContext?.tags)
+    return parseErrorResponseBatch(getLeadsResponse.data, payloads.length)
   }
 
   const leadIds = extractLeadIds(getLeadsResponse.data.result)
@@ -160,11 +252,24 @@ export async function removeFromList(
   })
 
   if (!deleteLeadsResponse.data.success) {
-    statsContext?.statsClient?.incr('removeFromAudience.error', 1, statsContext?.tags)
-    parseErrorResponse(deleteLeadsResponse.data)
+    statsContext?.statsClient?.incr('removeFromAudience.error', payloads.length, statsContext?.tags)
+    return parseErrorResponse(deleteLeadsResponse.data)
   }
-  statsContext?.statsClient?.incr('removeFromAudience.success', 1, statsContext?.tags)
-  return deleteLeadsResponse.data
+  statsContext?.statsClient?.incr('removeFromAudience.success', payloads.length, statsContext?.tags)
+
+  // Build a MultiStatusResponse and return it
+  const multiStatusResponse = new MultiStatusResponse()
+
+  for (let i = 0; i < payloads.length; i++) {
+    multiStatusResponse.setSuccessResponseAtIndex(i, {
+      status: 200,
+      sent: '',
+      // response.data is an API Response, we can safely cast it to JSONLikeObject
+      body: deleteLeadsResponse.data as unknown as JSONLikeObject
+    })
+  }
+
+  return multiStatusResponse
 }
 
 function createFormData(csvData: string) {
@@ -202,14 +307,40 @@ function extractLeadIds(leads: MarketoLeads[]) {
 
 function parseErrorResponse(response: MarketoResponse) {
   if (response.errors[0].code === '601' || response.errors[0].code === '602') {
-    throw new IntegrationError(response.errors[0].message, 'INVALID_OAUTH_TOKEN', 401)
+    throw new IntegrationError(response.errors[0].message, 'INVALID_AUTHENTICATION', 401)
   }
+
   if (response.errors[0].code === '1019') {
     throw new RetryableError(
       'Error while attempting to upload users to the list in Marketo. This batch will be retried.'
     )
   }
-  throw new IntegrationError(response.errors[0].message, 'INVALID_RESPONSE', 400)
+
+  throw new IntegrationError(response.errors[0].message, 'NOT_ACCEPTABLE', 400)
+}
+
+function parseErrorResponseBatch(response: MarketoResponse, payloadSize: number) {
+  if (response.errors[0].code === '601' || response.errors[0].code === '602') {
+    return buildMultiStatusErrorResponse(payloadSize, {
+      status: 401,
+      errortype: ErrorCodes.INVALID_AUTHENTICATION,
+      errormessage: response.errors[0].message
+    })
+  }
+
+  if (response.errors[0].code === '1019') {
+    return buildMultiStatusErrorResponse(payloadSize, {
+      status: 500,
+      errortype: ErrorCodes.RETRYABLE_ERROR,
+      errormessage: 'Error while attempting to upload users to the list in Marketo. This batch will be retried.'
+    })
+  }
+
+  return buildMultiStatusErrorResponse(payloadSize, {
+    status: 400,
+    errortype: ErrorCodes.NOT_ACCEPTABLE,
+    errormessage: response.errors[0].message
+  })
 }
 
 export async function getAccessToken(request: RequestClient, settings: Settings) {
@@ -321,7 +452,7 @@ export async function createList(request: RequestClient, input: CreateListInput,
   return listId
 }
 
-const setMultiStatusErrorResponse = (payloadSize: number, error: ActionDestinationErrorResponseType) => {
+const buildMultiStatusErrorResponse = (payloadSize: number, error: ActionDestinationErrorResponseType) => {
   const multiStatusResponse = new MultiStatusResponse()
 
   for (let i = 0; i < payloadSize; i++) {
@@ -330,84 +461,3 @@ const setMultiStatusErrorResponse = (payloadSize: number, error: ActionDestinati
 
   return multiStatusResponse
 }
-
-type ErrorCodeMapDefinition = {
-  status: number
-  description: string
-}
-
-export const MarketoErrorCodes = new Map<number, ErrorCodeMapDefinition>([
-  // [502, { status: 502, description: 'Bad Gateway' }],
-  [601, { status: 401, description: 'Access token invalid' }],
-  [602, { status: 401, description: 'Access token expired' }],
-  [603, { status: 403, description: 'Access denied' }],
-  [604, { status: 504, description: 'Request time-out' }],
-  [605, { status: 405, description: 'HTTP Method not supported' }],
-  [606, { status: 429, description: 'Max rate limit exceeded' }],
-  [607, { status: 429, description: 'Daily quota reached' }],
-  [608, { status: 503, description: 'API Temporarily Unavailable' }],
-  [609, { status: 400, description: 'Invalid JSON' }],
-  [610, { status: 404, description: 'Requested resource not found' }],
-  [611, { status: 500, description: 'System error' }],
-  [612, { status: 400, description: 'Invalid Content Type' }],
-  [613, { status: 400, description: 'Invalid Multipart Request' }],
-  [614, { status: 404, description: 'Invalid Subscription' }],
-  [615, { status: 429, description: 'Concurrent access limit reached' }],
-  [616, { status: 400, description: 'Invalid subscription type' }],
-  [701, { status: 400, description: '%s cannot be blank' }],
-  [702, { status: 404, description: 'No data found for a given search scenario' }],
-  [703, { status: 404, description: 'The feature is not enabled for the subscription' }],
-  [704, { status: 400, description: 'Invalid date format' }],
-  [709, { status: 400, description: 'Business Rule Violation' }],
-  [710, { status: 404, description: 'Parent Folder Not Found' }],
-  [711, { status: 400, description: 'Incompatible Folder Type' }],
-  [712, { status: 400, description: 'Merge to person Account operation is invalid' }],
-  [713, { status: 503, description: 'Transient Error' }],
-  [714, { status: 404, description: 'Unable to find the default record type' }],
-  [718, { status: 404, description: 'ExternalSalesPersonID not found' }],
-  [719, { status: 500, description: 'Lock wait timeout exception' }],
-  //
-  [1001, { status: 400, description: 'Invalid value, Required type is different' }],
-  [1002, { status: 400, description: 'Missing value for the required parameter' }],
-  [1003, { status: 400, description: 'Invalid data' }],
-  [1004, { status: 400, description: 'Lead not found' }],
-  [1005, { status: 400, description: 'Lead already exists' }],
-  [1006, { status: 400, description: 'Field not found' }],
-  [1007, { status: 400, description: 'Multiple leads match the lookup criteria' }],
-  [1008, { status: 400, description: 'Access denied to partition' }],
-  [1009, { status: 400, description: 'Partition name must be specified' }],
-  [1010, { status: 400, description: 'Partition update not allowed' }],
-  [1011, { status: 400, description: 'Field not supported' }],
-  [1012, { status: 400, description: 'Invalid cookie value' }],
-  [1013, { status: 400, description: 'Object not found' }],
-  [1014, { status: 400, description: 'Failed to create Object' }],
-  [1015, { status: 400, description: 'Lead not in list' }],
-  [1016, { status: 400, description: 'Too many imports' }],
-  [1017, { status: 400, description: 'Object already exists' }],
-  [1018, { status: 400, description: 'CRM Enabled' }],
-  [1019, { status: 400, description: 'Import in progress' }],
-  [1020, { status: 400, description: 'Too many clones to program' }],
-  [1021, { status: 400, description: 'Company update not allowed' }],
-  [1022, { status: 400, description: 'Object in use' }],
-  [1025, { status: 400, description: 'Program status not found' }],
-  [1026, { status: 400, description: 'Custom object not enabled' }],
-  [1027, { status: 400, description: 'Max Activity Type Limit Reached' }],
-  [1028, { status: 400, description: 'Max field limit reached' }],
-  [1029, { status: 400, description: 'Too many jobs in queue' }],
-  [1035, { status: 400, description: 'Unsupported filter type' }],
-  [1036, { status: 400, description: 'Duplicate object found in input' }],
-  [1037, { status: 400, description: 'Lead was skipped' }],
-  [1042, { status: 400, description: 'Invalid runAt date' }],
-  [1048, { status: 400, description: 'Custom Object Discard Draft Failed' }],
-  [1049, { status: 400, description: 'Failed to Create Activity' }],
-  [1076, { status: 400, description: 'Merge Leads call with mergeInCRM flag is 4' }],
-  [1077, { status: 400, description: 'Merge Leads call failed due to `SFDC Field` length' }],
-  [
-    1078,
-    {
-      status: 400,
-      description:
-        "Merge Leads call failed due to deleted entity, not a lead/contact, or field filter criteria doesn't match"
-    }
-  ]
-])

--- a/packages/destination-actions/src/destinations/marketo-static-lists/functions.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/functions.ts
@@ -1,4 +1,12 @@
-import { IntegrationError, RetryableError, RequestClient, StatsContext } from '@segment/actions-core'
+import {
+  MultiStatusResponse,
+  ErrorCodes,
+  IntegrationError,
+  RetryableError,
+  RequestClient,
+  StatsContext
+} from '@segment/actions-core'
+import { ActionDestinationErrorResponseType } from '@segment/actions-core/destination-kit/types'
 import { Settings } from './generated-types'
 import { Payload as AddToListPayload } from './addToList/generated-types'
 import { Payload as RemoveFromListPayload } from './removeFromList/generated-types'
@@ -34,11 +42,23 @@ export async function addToList(
   statsContext?: StatsContext,
   hookOutputs?: { id: string; name: string }
 ) {
+  const isBatchPayload = payloads.length > 1
+
   // If the list ID is provided in the hook outputs, use it
   const list_id = hookOutputs?.id ?? payloads[0].external_id
 
   if (!list_id) {
-    throw new IntegrationError('No list ID found in payload', 'INVALID_REQUEST_DATA', 400)
+    const errormessage = 'No list ID found in payload'
+
+    if (isBatchPayload) {
+      setMultiStatusErrorResponse(payloads.length, {
+        status: 400,
+        errortype: ErrorCodes.PAYLOAD_VALIDATION_FAILED,
+        errormessage
+      })
+    }
+
+    throw new IntegrationError(errormessage, ErrorCodes.PAYLOAD_VALIDATION_FAILED, 400)
   }
 
   const api_endpoint = formatEndpoint(settings.api_endpoint)
@@ -46,8 +66,18 @@ export async function addToList(
   const csvData = formatData(payloads)
   const csvSize = Buffer.byteLength(csvData, 'utf8')
   if (csvSize > CSV_LIMIT) {
+    const errormessage = `CSV data size exceeds limit of ${CSV_LIMIT} bytes`
+
+    if (isBatchPayload) {
+      setMultiStatusErrorResponse(payloads.length, {
+        status: 400,
+        errortype: ErrorCodes.PAYLOAD_TOO_LARGE,
+        errormessage
+      })
+    }
+
     statsContext?.statsClient?.incr('addToAudience.error', 1, statsContext?.tags)
-    throw new IntegrationError(`CSV data size exceeds limit of ${CSV_LIMIT} bytes`, 'INVALID_REQUEST_DATA', 400)
+    throw new IntegrationError(errormessage, 'PAYLOAD_TOO_LARGE', 400)
   }
 
   const url =
@@ -76,8 +106,20 @@ export async function removeFromList(
   payloads: RemoveFromListPayload[],
   statsContext?: StatsContext
 ) {
+  const isBatchPayload = payloads.length > 1
+
   if (!payloads[0].external_id) {
-    throw new IntegrationError('No external_id found in payload', 'INVALID_REQUEST_DATA', 400)
+    const errormessage = 'No "external_id" found in payload'
+
+    if (isBatchPayload) {
+      setMultiStatusErrorResponse(payloads.length, {
+        status: 400,
+        errortype: ErrorCodes.PAYLOAD_VALIDATION_FAILED,
+        errormessage
+      })
+    }
+
+    throw new IntegrationError(errormessage, ErrorCodes.PAYLOAD_VALIDATION_FAILED, 400)
   }
 
   const api_endpoint = formatEndpoint(settings.api_endpoint)
@@ -277,3 +319,94 @@ export async function createList(request: RequestClient, input: CreateListInput,
 
   return listId
 }
+
+const setMultiStatusErrorResponse = (payloadSize: number, error: ActionDestinationErrorResponseType) => {
+  const multiStatusResponse = new MultiStatusResponse()
+
+  for (let i = 0; i < payloadSize; i++) {
+    multiStatusResponse.setErrorResponseAtIndex(i, error)
+  }
+
+  return multiStatusResponse
+}
+
+type ErrorCodeMapDefinition = {
+  status: number
+  description: string
+}
+
+export const MarketoErrorCodes = new Map<number, ErrorCodeMapDefinition>([
+  // [502, { status: 502, description: 'Bad Gateway' }],
+  [601, { status: 401, description: 'Access token invalid' }],
+  [602, { status: 401, description: 'Access token expired' }],
+  [603, { status: 403, description: 'Access denied' }],
+  [604, { status: 504, description: 'Request time-out' }],
+  [605, { status: 405, description: 'HTTP Method not supported' }],
+  [606, { status: 429, description: 'Max rate limit exceeded' }],
+  [607, { status: 429, description: 'Daily quota reached' }],
+  [608, { status: 503, description: 'API Temporarily Unavailable' }],
+  [609, { status: 400, description: 'Invalid JSON' }],
+  [610, { status: 404, description: 'Requested resource not found' }],
+  [611, { status: 500, description: 'System error' }],
+  [612, { status: 400, description: 'Invalid Content Type' }],
+  [613, { status: 400, description: 'Invalid Multipart Request' }],
+  [614, { status: 404, description: 'Invalid Subscription' }],
+  [615, { status: 429, description: 'Concurrent access limit reached' }],
+  [616, { status: 400, description: 'Invalid subscription type' }],
+  [701, { status: 400, description: '%s cannot be blank' }],
+  [702, { status: 404, description: 'No data found for a given search scenario' }],
+  [703, { status: 404, description: 'The feature is not enabled for the subscription' }],
+  [704, { status: 400, description: 'Invalid date format' }],
+  [709, { status: 400, description: 'Business Rule Violation' }],
+  [710, { status: 404, description: 'Parent Folder Not Found' }],
+  [711, { status: 400, description: 'Incompatible Folder Type' }],
+  [712, { status: 400, description: 'Merge to person Account operation is invalid' }],
+  [713, { status: 503, description: 'Transient Error' }],
+  [714, { status: 404, description: 'Unable to find the default record type' }],
+  [718, { status: 404, description: 'ExternalSalesPersonID not found' }],
+  [719, { status: 500, description: 'Lock wait timeout exception' }],
+  //
+  [1001, { status: 400, description: 'Invalid value, Required type is different' }],
+  [1002, { status: 400, description: 'Missing value for the required parameter' }],
+  [1003, { status: 400, description: 'Invalid data' }],
+  [1004, { status: 400, description: 'Lead not found' }],
+  [1005, { status: 400, description: 'Lead already exists' }],
+  [1006, { status: 400, description: 'Field not found' }],
+  [1007, { status: 400, description: 'Multiple leads match the lookup criteria' }],
+  [1008, { status: 400, description: 'Access denied to partition' }],
+  [1009, { status: 400, description: 'Partition name must be specified' }],
+  [1010, { status: 400, description: 'Partition update not allowed' }],
+  [1011, { status: 400, description: 'Field not supported' }],
+  [1012, { status: 400, description: 'Invalid cookie value' }],
+  [1013, { status: 400, description: 'Object not found' }],
+  [1014, { status: 400, description: 'Failed to create Object' }],
+  [1015, { status: 400, description: 'Lead not in list' }],
+  [1016, { status: 400, description: 'Too many imports' }],
+  [1017, { status: 400, description: 'Object already exists' }],
+  [1018, { status: 400, description: 'CRM Enabled' }],
+  [1019, { status: 400, description: 'Import in progress' }],
+  [1020, { status: 400, description: 'Too many clones to program' }],
+  [1021, { status: 400, description: 'Company update not allowed' }],
+  [1022, { status: 400, description: 'Object in use' }],
+  [1025, { status: 400, description: 'Program status not found' }],
+  [1026, { status: 400, description: 'Custom object not enabled' }],
+  [1027, { status: 400, description: 'Max Activity Type Limit Reached' }],
+  [1028, { status: 400, description: 'Max field limit reached' }],
+  [1029, { status: 400, description: 'Too many jobs in queue' }],
+  [1035, { status: 400, description: 'Unsupported filter type' }],
+  [1036, { status: 400, description: 'Duplicate object found in input' }],
+  [1037, { status: 400, description: 'Lead was skipped' }],
+  [1042, { status: 400, description: 'Invalid runAt date' }],
+  [1048, { status: 400, description: 'Custom Object Discard Draft Failed' }],
+  [1049, { status: 400, description: 'Failed to Create Activity' }],
+  [1076, { status: 400, description: 'Merge Leads call with mergeInCRM flag is 4' }],
+  [1077, { status: 400, description: 'Merge Leads call failed due to `SFDC Field` length' }],
+  [
+    1078,
+    {
+      status: 400,
+      description:
+        "Merge Leads call failed due to deleted entity, not a lead/contact, or field filter criteria doesn't match"
+    }
+  ]
+])

--- a/packages/destination-actions/src/destinations/marketo-static-lists/functions.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/functions.ts
@@ -51,7 +51,7 @@ export async function addToList(
     const errormessage = 'No list ID found in payload'
 
     if (isBatchPayload) {
-      setMultiStatusErrorResponse(payloads.length, {
+      return setMultiStatusErrorResponse(payloads.length, {
         status: 400,
         errortype: ErrorCodes.PAYLOAD_VALIDATION_FAILED,
         errormessage
@@ -69,7 +69,8 @@ export async function addToList(
     const errormessage = `CSV data size exceeds limit of ${CSV_LIMIT} bytes`
 
     if (isBatchPayload) {
-      setMultiStatusErrorResponse(payloads.length, {
+      statsContext?.statsClient?.incr('addToAudience.error', payloads.length, statsContext?.tags)
+      return setMultiStatusErrorResponse(payloads.length, {
         status: 400,
         errortype: ErrorCodes.PAYLOAD_TOO_LARGE,
         errormessage

--- a/packages/destination-actions/src/destinations/marketo-static-lists/removeFromList/index.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/removeFromList/index.ts
@@ -2,7 +2,7 @@ import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { external_id, lookup_field, field_value, enable_batching, batch_size, event_name } from '../properties'
-import { removeFromList } from '../functions'
+import { removeFromList, removeFromListBatch } from '../functions'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Remove From List',
@@ -18,11 +18,11 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: async (request, { settings, payload, statsContext }) => {
     statsContext?.statsClient?.incr('removeFromAudience', 1, statsContext?.tags)
-    return removeFromList(request, settings, [payload], statsContext)
+    return removeFromList(request, settings, payload, statsContext)
   },
   performBatch: async (request, { settings, payload, statsContext }) => {
     statsContext?.statsClient?.incr('removeFromAudience.batch', 1, statsContext?.tags)
-    return removeFromList(request, settings, payload, statsContext)
+    return removeFromListBatch(request, settings, payload, statsContext)
   }
 }
 


### PR DESCRIPTION
This PR adds MultiStatus support to Marketo destination.

## Testing

Testing in progress

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
