### PR TITLE
Update field descriptions to be in line with Amplitude functionality

### DIFF
--- a/packages/destination-actions/src/destinations/amplitude/logEventV2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEventV2/generated-types.ts
@@ -178,7 +178,7 @@ export interface Payload {
     [k: string]: unknown
   }[]
   /**
-   * The following fields will be set only once per session when using AJS2 as the source.
+   * The following fields will only be set as user properties if they do not already have a value.
    */
   setOnce?: {
     /**
@@ -193,7 +193,7 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * The following fields will be set every session when using AJS2 as the source.
+   * The following fields will be set as user properties for every event.
    */
   setAlways?: {
     referrer?: string

--- a/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
@@ -88,7 +88,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     setOnce: {
       label: 'Set Once',
-      description: 'The following fields will be set only once per session when using AJS2 as the source.',
+      description: 'The following fields will only be set as user properties if they do not already have a value.',
       type: 'object',
       additionalProperties: true,
       properties: {
@@ -129,7 +129,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     setAlways: {
       label: 'Set Always',
-      description: 'The following fields will be set every session when using AJS2 as the source.',
+      description: 'The following fields will be set as user properties for every event.',
       type: 'object',
       additionalProperties: true,
       properties: {


### PR DESCRIPTION
The functionality of `$setOnce` and `$set` does not change based on whether there is a session_id present in the payload. As confirmed by a user, as well as Amplitude: 

<img width="1104" alt="Screenshot 2024-12-18 at 9 18 55 AM" src="https://github.com/user-attachments/assets/a11fce7d-9565-40a0-8a3c-96b6a53abdd8" />

This updates the descriptions to be in line with what is actually defined in the Amplitude docs: https://amplitude.com/docs/apis/analytics/identify#userproperties-supported-operations

## Testing

N/A
