### PR TITLE
Worked on fixing braze_id default mappings of  Braze Actions.

### DIFF
--- a/packages/destination-actions/src/destinations/braze/__tests__/__snapshots__/braze.test.ts.snap
+++ b/packages/destination-actions/src/destinations/braze/__tests__/__snapshots__/braze.test.ts.snap
@@ -110,7 +110,7 @@ Object {
   "attributes": Array [
     Object {
       "_update_existing_only": false,
-      "braze_id": undefined,
+      "braze_id": "test_braze_123",
       "country": "United States",
       "current_location": Object {
         "latitude": 40.2964197,

--- a/packages/destination-actions/src/destinations/braze/__tests__/braze.test.ts
+++ b/packages/destination-actions/src/destinations/braze/__tests__/braze.test.ts
@@ -19,7 +19,12 @@ describe('Braze Cloud Mode (Actions)', () => {
 
       const event = createTestEvent({
         type: 'identify',
-        receivedAt
+        receivedAt,
+        integrations: {
+          ['Braze Cloud Mode (Actions)']: {
+            braze_id: 'test_braze_123'
+          } as any
+        }
       })
 
       const responses = await testDestination.testAction('updateUserProfile', {
@@ -27,7 +32,6 @@ describe('Braze Cloud Mode (Actions)', () => {
         settings,
         useDefaultMappings: true
       })
-
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       expect(responses[0].data).toMatchObject({})

--- a/packages/destination-actions/src/destinations/braze/__tests__/multistatus.test.ts
+++ b/packages/destination-actions/src/destinations/braze/__tests__/multistatus.test.ts
@@ -569,7 +569,11 @@ describe('MultiStatus', () => {
         '@path': '$.traits.externalId'
       },
       braze_id: {
-        '@path': '$.traits.brazeId'
+        '@if': {
+          exists: { '@path': '$.integrations.Braze Cloud Mode (Actions).braze_id' },
+          then: { '@path': '$.integrations.Braze Cloud Mode (Actions).braze_id' },
+          else: { '@path': '$.traits.braze_id' }
+        }
       }
     }
 
@@ -596,6 +600,15 @@ describe('MultiStatus', () => {
             email: 'user@example.com'
           }
         }),
+        createTestEvent({
+          type: 'identify',
+          receivedAt,
+          traits: {
+            firstName: 'Example',
+            lastName: 'User',
+            braze_id: 'test-braze-id'
+          }
+        }),
         // Event without any user identifier
         createTestEvent({
           type: 'identify',
@@ -618,15 +631,23 @@ describe('MultiStatus', () => {
         status: 200,
         body: 'success'
       })
-
       // The second event doesn't fail as there is no error reported by Braze API
       expect(response[1]).toMatchObject({
         status: 200,
         body: 'success'
       })
 
-      // The third event fails as pre-request validation fails for not having a valid user identifier
+      // The Third event doesn't fail as there is no error reported by Braze API
       expect(response[2]).toMatchObject({
+        status: 200,
+        body: 'success',
+        sent: expect.objectContaining({
+          braze_id: 'test-braze-id'
+        })
+      })
+
+      // The Fourth event fails as pre-request validation fails for not having a valid user identifier
+      expect(response[3]).toMatchObject({
         status: 400,
         errortype: 'PAYLOAD_VALIDATION_FAILED',
         errormessage: 'One of "external_id" or "user_alias" or "braze_id" or "email" is required.',

--- a/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
+++ b/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
@@ -38,7 +38,11 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       allowNull: true,
       default: {
-        '@path': '$.properties.braze_id'
+        '@if': {
+          exists: { '@path': '$.integrations.Braze Cloud Mode (Actions).braze_id' },
+          then: { '@path': '$.integrations.Braze Cloud Mode (Actions).braze_id' },
+          else: { '@path': '$.traits.braze_id' }
+        }
       }
     },
     country: {

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
@@ -14,7 +14,7 @@ import { batch_size, country_code, enable_batching } from '../properties'
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Remove Profile',
   description: 'Remove profile from list',
-  defaultSubscription: 'event = "Identify"',
+  defaultSubscription: 'type = "Identify"',
   fields: {
     email: {
       label: 'Email',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pull request is to refactor braze_id default mappings of  Braze Actions and small typo fix in defaultSubscription of removeProfile in Klaviyo Actions.
Jira ticket :- https://segment.atlassian.net/jira/software/c/projects/STRATCONN/boards/310?assignee=63617339fc0cc7a600b03c6b&selectedIssue=STRATCONN-3845

<img width="846" alt="Screenshot 2025-01-06 at 3 15 32 PM" src="https://github.com/user-attachments/assets/383a9b10-c640-4783-a5f4-f0163e4e90a9" />


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment - NA
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
