### PR TITLE
allow custom global key for Koala 

### DIFF
--- a/packages/browser-destinations/destinations/koala/src/init-script.ts
+++ b/packages/browser-destinations/destinations/koala/src/init-script.ts
@@ -1,11 +1,13 @@
 /* eslint-disable */
 // @ts-nocheck
 export function initScript() {
-  if (window.ko) {
+  const ns = window.globalKoalaKey || 'ko'
+
+  if (window[ns]) {
     return
   }
 
-  window.ko = []
+  const ko = (window[ns] = [])
   ;['identify', 'track', 'removeListeners', 'open', 'on', 'off', 'qualify', 'ready'].forEach(function (method) {
     ko[method] = function () {
       let args = Array.from(arguments)


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

We've found some instances where customer code encounters conflicts with `window.ko` and we're modifying the install snippet to respect their custom `globalKoalaKey`.

## Testing

Tested this version of the init script manually. Koala can load with a custom namespace when `window.globalKoalaKey` is set.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
