### PR TITLE
Normalize email addresses for Google Enhanced Conversions

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
@@ -522,6 +522,125 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
     })
+
+    it('normalizes Google email addresses', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        properties: {
+          gclid: '54321',
+          email: 'test.user@gmail.com',
+          orderId: '1234',
+          total: '200',
+          currency: 'USD',
+          products: [
+            {
+              product_id: '1234',
+              quantity: 3,
+              price: 10.99
+            }
+          ]
+        }
+      })
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testAction('uploadClickConversion', {
+        event,
+        mapping: { conversion_action: '12345' },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      // The hash should match 'testuser@gmail.com' (no dots)
+      expect(responses[0].options.body).toContain('dae9c7c55697ba170d6b494c458649bd469af525520280d0dcfc98d74d13b17e')
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('handles googlemail.com domain', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        properties: {
+          gclid: '54321',
+          email: 'test.user@googlemail.com',
+          orderId: '1234',
+          total: '200',
+          currency: 'USD',
+          products: [
+            {
+              product_id: '1234',
+              quantity: 3,
+              price: 10.99
+            }
+          ]
+        }
+      })
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testAction('uploadClickConversion', {
+        event,
+        mapping: { conversion_action: '12345' },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      // The hash should match 'testuser@googlemail.com' (no dots)
+      expect(responses[0].options.body).toContain('06bfc6aa38674253530e62f2b585d63e3786cbb759b81b73df34ae80894d8813')
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('preserves dots in non-Google email addresses', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        properties: {
+          gclid: '54321',
+          email: 'test.user@example.com',
+          orderId: '1234',
+          total: '200',
+          currency: 'USD',
+          products: [
+            {
+              product_id: '1234',
+              quantity: 3,
+              price: 10.99
+            }
+          ]
+        }
+      })
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testAction('uploadClickConversion', {
+        event,
+        mapping: { conversion_action: '12345' },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      // The hash should be different from the normalized Google email hash
+      expect(responses[0].options.body).not.toContain(
+        '87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674'
+      )
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
   })
 
   describe('uploadClickConversion Batch Event', () => {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -231,8 +231,15 @@ export const commonHashedEmailValidation = (email: string): string => {
   if (!(fullFormats.email as RegExp).test(email)) {
     throw new PayloadValidationError("Email provided doesn't seem to be in a valid format.")
   }
+  const googleDomain = new RegExp('^(gmail|googlemail).s*', 'g')
+  let normalizedEmail = email.toLowerCase().trim()
+  const emailParts = normalizedEmail.split('@')
+  if (emailParts.length > 1 && emailParts[1].match(googleDomain)) {
+    emailParts[0] = emailParts[0].replace('.', '')
+    normalizedEmail = `${emailParts[0]}@${emailParts[1]}`
+  }
 
-  return String(hash(email))
+  return String(hash(normalizedEmail))
 }
 
 export async function getListIds(


### PR DESCRIPTION
Rocket Mortgage is experiencing an issue with low match rates for [Google Enhanced Conversions](https://segment.com/docs/connections/destinations/catalog/actions-google-enhanced-conversions/). Although the data is being sent successfully, the match rate is below 1%.

During troubleshooting, we identified that email addresses are not being normalized according to Google’s specifications when using the endpoint. While this discrepancy is unlikely to fully explain the low match rate, it is an issue worth addressing since normalization is outlined as a requirement in both [our documentation](https://segment.com/docs/connections/destinations/catalog/actions-google-enhanced-conversions/) and [Google’s documentation](https://developers.google.com/google-ads/api/docs/remarketing/audience-segments/customer-match/get-started#add-user).

## Testing

### hashing currently

```
  input: 'test@gmail.com',
  hash: '87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674'


  input: 'Test@gmail.com',
  hash: '60b7750a8ee074c6a8b1a2e8178e4da4c5cffc5309b5236a12355b7b21a985d6'

  input: 'testuser@googlemail.com'
  hash: '06bfc6aa38674253530e62f2b585d63e3786cbb759b81b73df34ae80894d8813'

  input: 'test.user@googlemail.com'
  hash: 'f60f8555710483f6d082157013ca06779173aa5454a6f0255dcf2258f007a834'
```
### hashing with this PR

```
  input: 'test@gmail.com',
  hash: '87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674'

```
Stage Test 

![image](https://github.com/user-attachments/assets/a9b1b7fa-8a71-4f46-b471-8ef438a7a326)


```
  // converts to lowercase before hashing
  input: 'Test@gmail.com',
  hash: '87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674'

```
  
  Stage Test 
  
  
![image](https://github.com/user-attachments/assets/8134c088-7a11-4f06-b626-c674ae8b25f6)

```
  input: 'testuser@googlemail.com'
  hash: '06bfc6aa38674253530e62f2b585d63e3786cbb759b81b73df34ae80894d8813'
```
  
  Stage Test
  
  
![image](https://github.com/user-attachments/assets/496a055a-437b-46ef-8514-f8939059182b)

```
  // removes period before @ for google domains
  input: 'test.user@googlemail.com'
  hash: '06bfc6aa38674253530e62f2b585d63e3786cbb759b81b73df34ae80894d8813'
```

Stage Test 

![image](https://github.com/user-attachments/assets/35211aab-e979-49c3-affc-cac756b3d293)



- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality

## Note

There is currently a failing test for `userLists`. I didn't touch any of the functionality here, as this is also failing in main.
