### PR TITLE
[STRATCONN-5399]-Handles refresh token retry for multistatus responses

### DIFF
--- a/packages/core/src/__tests__/destination-kit.test.ts
+++ b/packages/core/src/__tests__/destination-kit.test.ts
@@ -1940,6 +1940,7 @@ describe('destination kit', () => {
       const mockRefreshToken = jest.fn().mockReturnValue({
         accessToken: 'new-access-token'
       })
+      const mockOnTokenRefresh = jest.fn().mockReturnValue(Promise.resolve())
       const destinationWithOAuth = {
         ...multiStatusCompatibleDestination,
         authentication: {
@@ -1988,10 +1989,12 @@ describe('destination kit', () => {
 
       multiStatusDestination.refreshAccessToken = mockRefreshToken
 
-      const response = await multiStatusDestination.onBatch(events, settings, {})
+      const response = await multiStatusDestination.onBatch(events, settings, {
+        onTokenRefresh: mockOnTokenRefresh
+      })
       // assert that the refresh token was called once
       expect(mockRefreshToken).toHaveBeenCalledTimes(1)
-
+      expect(mockOnTokenRefresh).toHaveBeenCalledWith(expect.objectContaining({ accessToken: 'new-access-token' }))
       expect(response).toMatchInlineSnapshot(`
         Array [
           Object {
@@ -2016,6 +2019,7 @@ describe('destination kit', () => {
       const mockRefreshToken = jest.fn().mockReturnValue({
         accessToken: 'new-access-token'
       })
+      const mockOnTokenRefresh = jest.fn().mockReturnValue(Promise.resolve())
       const destinationWithOAuth = {
         ...multiStatusCompatibleDestination,
         authentication: {
@@ -2064,10 +2068,13 @@ describe('destination kit', () => {
 
       multiStatusDestination.refreshAccessToken = mockRefreshToken
 
-      const response = await multiStatusDestination.onBatch(events, settings, {})
+      const response = await multiStatusDestination.onBatch(events, settings, {
+        onTokenRefresh: mockOnTokenRefresh
+      })
       // assert that the refresh token was called once
       expect(mockRefreshToken).toHaveBeenCalledTimes(1)
-
+      // assert that the onTokenRefresh was called once
+      expect(mockOnTokenRefresh).toHaveBeenCalledWith(expect.objectContaining({ accessToken: 'new-access-token' }))
       expect(response).toMatchInlineSnapshot(`
         Array [
           Object {

--- a/packages/core/src/__tests__/destination-kit.test.ts
+++ b/packages/core/src/__tests__/destination-kit.test.ts
@@ -10,7 +10,9 @@ import {
   TransactionContext,
   AuthenticationScheme,
   RefreshAccessTokenResult,
-  AudienceDestinationDefinition
+  AudienceDestinationDefinition,
+  OAuth2Authentication,
+  OAuthManagedAuthentication
 } from '../destination-kit'
 import { JSONObject } from '../json-object'
 import { SegmentEvent } from '../segment-event'
@@ -374,7 +376,7 @@ const multiStatusCompatibleDestination: DestinationDefinition<JSONObject> = {
           message: 'success'
         }
       },
-      performBatch: (_request, { payload }) => {
+      performBatch: (_request, { payload, auth }) => {
         const response = new MultiStatusResponse()
         payload.forEach((event) => {
           // Emulate an API error
@@ -387,6 +389,21 @@ const multiStatusCompatibleDestination: DestinationDefinition<JSONObject> = {
               body: {
                 events_processed: 0,
                 message: 'Phone number validation failed'
+              }
+            })
+            return
+          }
+
+          // Emulate Auth error
+          if (auth?.accessToken === 'OldToken') {
+            response.pushErrorResponse({
+              status: 401,
+              errortype: ErrorCodes.INVALID_AUTHENTICATION,
+              errormessage: 'Invalid Auth',
+              sent: event,
+              body: {
+                events_processed: 0,
+                message: 'Invalid Auth'
               }
             })
             return
@@ -1913,6 +1930,317 @@ describe('destination kit', () => {
                   "phone": "1234567890",
                 },
                 "status": 400,
+              },
+            ],
+          },
+        ]
+      `)
+    })
+    test('should refresh access token and retry events in case multistatus response contains 401 for oauth2 destinations', async () => {
+      const mockRefreshToken = jest.fn().mockReturnValue({
+        accessToken: 'new-access-token'
+      })
+      const destinationWithOAuth = {
+        ...multiStatusCompatibleDestination,
+        authentication: {
+          scheme: 'oauth2',
+          fields: {},
+          refreshAccessToken: mockRefreshToken
+        } as OAuth2Authentication<any>
+      }
+      const multiStatusDestination = new Destination(destinationWithOAuth)
+
+      const receivedAt = '2024-08-03T17:40:04.055Z'
+
+      const events: SegmentEvent[] = [
+        {
+          event: 'Add to Cart',
+          type: 'track',
+          properties: {
+            email: 'user.one@example.com'
+          },
+          receivedAt
+        },
+        {
+          // Missing required fields
+          event: 'Add to Cart',
+          type: 'track',
+          properties: {},
+          receivedAt
+        }
+      ]
+
+      const settings = {
+        apiSecret: 'test_key',
+        oauth: {
+          access_token: 'OldToken'
+        },
+        subscription: {
+          subscribe: 'type = "track" and event != "Order Completed"',
+          partnerAction: 'trackEvent',
+          mapping: {
+            name: { '@path': '$.event' },
+            email: { '@path': '$.properties.email' },
+            phone: { '@path': '$.properties.phone' }
+          }
+        }
+      }
+
+      multiStatusDestination.refreshAccessToken = mockRefreshToken
+
+      const response = await multiStatusDestination.onBatch(events, settings, {})
+      // assert that the refresh token was called once
+      expect(mockRefreshToken).toHaveBeenCalledTimes(1)
+
+      expect(response).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "multistatus": Array [
+              Object {
+                "body": Object {},
+                "sent": Object {},
+                "status": 200,
+              },
+              Object {
+                "errormessage": "Email is required",
+                "errorreporter": "INTEGRATIONS",
+                "errortype": "PAYLOAD_VALIDATION_FAILED",
+                "status": 400,
+              },
+            ],
+          },
+        ]
+      `)
+    })
+    test('should refresh access token and retry events in case multistatus response contains 401 for oauth-managed destinations', async () => {
+      const mockRefreshToken = jest.fn().mockReturnValue({
+        accessToken: 'new-access-token'
+      })
+      const destinationWithOAuth = {
+        ...multiStatusCompatibleDestination,
+        authentication: {
+          scheme: 'oauth-managed',
+          fields: {},
+          refreshAccessToken: mockRefreshToken
+        } as OAuthManagedAuthentication<any>
+      }
+      const multiStatusDestination = new Destination(destinationWithOAuth)
+
+      const receivedAt = '2024-08-03T17:40:04.055Z'
+
+      const events: SegmentEvent[] = [
+        {
+          event: 'Add to Cart',
+          type: 'track',
+          properties: {
+            email: 'user.one@example.com'
+          },
+          receivedAt
+        },
+        {
+          // Missing required fields
+          event: 'Add to Cart',
+          type: 'track',
+          properties: {},
+          receivedAt
+        }
+      ]
+
+      const settings = {
+        apiSecret: 'test_key',
+        oauth: {
+          access_token: 'OldToken'
+        },
+        subscription: {
+          subscribe: 'type = "track" and event != "Order Completed"',
+          partnerAction: 'trackEvent',
+          mapping: {
+            name: { '@path': '$.event' },
+            email: { '@path': '$.properties.email' },
+            phone: { '@path': '$.properties.phone' }
+          }
+        }
+      }
+
+      multiStatusDestination.refreshAccessToken = mockRefreshToken
+
+      const response = await multiStatusDestination.onBatch(events, settings, {})
+      // assert that the refresh token was called once
+      expect(mockRefreshToken).toHaveBeenCalledTimes(1)
+
+      expect(response).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "multistatus": Array [
+              Object {
+                "body": Object {},
+                "sent": Object {},
+                "status": 200,
+              },
+              Object {
+                "errormessage": "Email is required",
+                "errorreporter": "INTEGRATIONS",
+                "errortype": "PAYLOAD_VALIDATION_FAILED",
+                "status": 400,
+              },
+            ],
+          },
+        ]
+      `)
+    })
+    test('should not retry events in case multistatus response doesnot contain 401 errors for oauth destinations', async () => {
+      const mockRefreshToken = jest.fn().mockReturnValue({
+        accessToken: 'new-access-token'
+      })
+      const destinationWithOAuth = {
+        ...multiStatusCompatibleDestination,
+        authentication: {
+          scheme: 'oauth-managed',
+          fields: {},
+          refreshAccessToken: mockRefreshToken
+        } as OAuthManagedAuthentication<any>
+      }
+      const multiStatusDestination = new Destination(destinationWithOAuth)
+
+      const receivedAt = '2024-08-03T17:40:04.055Z'
+
+      const events: SegmentEvent[] = [
+        {
+          event: 'Add to Cart',
+          type: 'track',
+          properties: {
+            email: 'user.one@example.com'
+          },
+          receivedAt
+        },
+        {
+          // Missing required fields
+          event: 'Add to Cart',
+          type: 'track',
+          properties: {},
+          receivedAt
+        }
+      ]
+
+      const settings = {
+        apiSecret: 'test_key',
+        oauth: {},
+        subscription: {
+          subscribe: 'type = "track" and event != "Order Completed"',
+          partnerAction: 'trackEvent',
+          mapping: {
+            name: { '@path': '$.event' },
+            email: { '@path': '$.properties.email' },
+            phone: { '@path': '$.properties.phone' }
+          }
+        }
+      }
+
+      const response = await multiStatusDestination.onBatch(events, settings, {})
+      expect(mockRefreshToken).not.toHaveBeenCalled()
+      expect(response).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "multistatus": Array [
+              Object {
+                "body": Object {},
+                "sent": Object {},
+                "status": 200,
+              },
+              Object {
+                "errormessage": "Email is required",
+                "errorreporter": "INTEGRATIONS",
+                "errortype": "PAYLOAD_VALIDATION_FAILED",
+                "status": 400,
+              },
+            ],
+          },
+        ]
+      `)
+    })
+    test('should not retry events more than max retry attempts for 401 errors', async () => {
+      const mockRefreshToken = jest.fn().mockReturnValue({
+        accessToken: 'OldToken'
+      })
+      const destinationWithOAuth = {
+        ...multiStatusCompatibleDestination,
+        authentication: {
+          scheme: 'oauth-managed',
+          fields: {},
+          refreshAccessToken: mockRefreshToken
+        } as OAuthManagedAuthentication<any>
+      }
+      const multiStatusDestination = new Destination(destinationWithOAuth)
+
+      const receivedAt = '2024-08-03T17:40:04.055Z'
+
+      const events: SegmentEvent[] = [
+        {
+          event: 'Add to Cart',
+          type: 'track',
+          properties: {
+            email: 'user.one@example.com'
+          },
+          receivedAt
+        },
+        {
+          // Missing required fields
+          event: 'Add to Cart',
+          type: 'track',
+          properties: {},
+          receivedAt
+        }
+      ]
+
+      const settings = {
+        apiSecret: 'test_key',
+        oauth: {
+          access_token: 'OldToken'
+        },
+        subscription: {
+          subscribe: 'type = "track" and event != "Order Completed"',
+          partnerAction: 'trackEvent',
+          mapping: {
+            name: { '@path': '$.event' },
+            email: { '@path': '$.properties.email' },
+            phone: { '@path': '$.properties.phone' }
+          }
+        }
+      }
+
+      const response = await multiStatusDestination.onBatch(events, settings, {})
+      // Default retry attempts is 2
+      expect(mockRefreshToken).toHaveBeenCalledTimes(2)
+      expect(response).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "multistatus": Array [
+              Object {
+                "body": Object {
+                  "events_processed": 0,
+                  "message": "Invalid Auth",
+                },
+                "errormessage": "Invalid Auth",
+                "errorreporter": "DESTINATION",
+                "errortype": "INVALID_AUTHENTICATION",
+                "sent": Object {
+                  "email": "user.one@example.com",
+                  "name": "Add to Cart",
+                },
+                "status": 401,
+              },
+              Object {
+                "body": Object {
+                  "events_processed": 0,
+                  "message": "Invalid Auth",
+                },
+                "errormessage": "Invalid Auth",
+                "errorreporter": "DESTINATION",
+                "errortype": "INVALID_AUTHENTICATION",
+                "sent": Object {
+                  "name": "Add to Cart",
+                },
+                "status": 401,
               },
             ],
           },

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -2,6 +2,8 @@ interface RetryOptions {
   retries?: number
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onFailedAttempt?: (error: any, attemptCount: number) => PromiseLike<void> | void
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  shouldRetry?: (response: any, attemptCount: number) => PromiseLike<boolean> | boolean
 }
 
 const DEFAULT_RETRY_ATTEMPTS = 2
@@ -14,7 +16,14 @@ export async function retry<T>(
 
   for (let attemptCount = 1; attemptCount <= retries; attemptCount++) {
     try {
-      return await input(attemptCount)
+      const response = await input(attemptCount)
+      if (options?.shouldRetry) {
+        const success = await options.shouldRetry(response, attemptCount)
+        if (!success && attemptCount < retries) {
+          continue
+        }
+      }
+      return response
     } catch (error) {
       if (options?.onFailedAttempt) {
         await options.onFailedAttempt(error, attemptCount)


### PR DESCRIPTION
This PR handles 401 refresh token retries for multistatus responses. Previously, we threw 401 exception for refresh token retries. However, for handling multistatus, developers now return a `MultistatusResponse` object from `performBatch` block. This PR ensures that if any of the events in multistatus response has 401 status, the batch will be retried with new refresh token for oauth enabled destinations.

Related but not dependent - https://github.com/segmentio/integrations/pull/3079

## Testing

Testing completed successfully in staging - [Test Doc](https://docs.google.com/document/d/1Q-sIszXK_1EFDarVemfCknOxsmRcOm9AWI0LmU0KFGQ/edit?tab=t.0)

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
