### PR TITLE
[STRATCONN-5384] Update LiveRamp phone_number hashing algo

### DIFF
--- a/packages/core/src/__tests__/hashing-utils.test.ts
+++ b/packages/core/src/__tests__/hashing-utils.test.ts
@@ -1,4 +1,4 @@
-import { sha256SmartHash, SmartHashing } from '../hashing-utils'
+import { sha1Hash, sha256SmartHash, SmartHashing } from '../hashing-utils'
 
 describe('hashing utilities', () => {
   it('should hash a non-hashed value', async () => {
@@ -11,6 +11,12 @@ describe('hashing utilities', () => {
     const value = '4f7f6a4ae46676d9751fdccdf15ae1e6a200ed0de5653e06390148928c642006'
 
     expect(sha256SmartHash(value)).toEqual(value)
+  })
+
+  it('sha-1 hashing', async () => {
+    const value = 'test_value'
+
+    expect(sha1Hash(value)).toEqual('b6dfecf3684e6a40de435195509ac724c7349c03')
   })
 })
 

--- a/packages/core/src/hashing-utils.ts
+++ b/packages/core/src/hashing-utils.ts
@@ -12,6 +12,10 @@ export function sha256SmartHash(value: string): string {
   return crypto.createHash('sha256').update(value).digest('hex')
 }
 
+export function sha1Hash(value: string): string {
+  return crypto.createHash('sha1').update(value).digest('hex')
+}
+
 export class SmartHashing {
   encryptionMethod: 'sha256'
   preHashed: boolean

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,7 +48,7 @@ export { retry } from './retry'
 export { get } from './get'
 export { omit } from './omit'
 export { removeUndefined } from './remove-undefined'
-export { sha256SmartHash, SmartHashing } from './hashing-utils'
+export { sha256SmartHash, SmartHashing, sha1Hash } from './hashing-utils'
 export { time, duration } from './time'
 
 export { realTypeOf, isObject, isArray, isString } from './real-type-of'

--- a/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/operations.test.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/operations.test.ts
@@ -1,25 +1,26 @@
-import { enquoteIdentifier, generateFile, hash, normalize, hashPhoneNumber } from '../operations'
+import { enquoteIdentifier, generateFile, normalize } from '../operations'
 import type { Payload } from '../audienceEnteredSftp/generated-types'
+import { sha256SmartHash, sha1Hash } from '@segment/actions-core/hashing-utils'
 
 describe('Test operations', () => {
   describe('hash', () => {
     it('produces consistent SHA-256 hash for a given input', () => {
       const input = 'test input'
-      expect(hash(input)).toBe('9dfe6f15d1ab73af898739394fd22fd72a03db01834582f24bb2e1c66c7aaeae')
+      expect(sha256SmartHash(input)).toBe('9dfe6f15d1ab73af898739394fd22fd72a03db01834582f24bb2e1c66c7aaeae')
     })
   })
 
   describe('hashPhoneNumber', () => {
     it('produces consistent SHA-1 hash for a given phone number', () => {
       const phoneNumber = '123-456-7890'
-      expect(hashPhoneNumber(phoneNumber)).toBe('d94cf047843c27e4ebf4495804dfb264a2181d45')
+      expect(sha1Hash(phoneNumber)).toBe('d94cf047843c27e4ebf4495804dfb264a2181d45')
     })
   })
 
   describe('hashEmail', () => {
     it('produces consistent SHA-256 hash for a given email address', () => {
       const email = 'user@example.com'
-      expect(hash(email)).toBe('b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514')
+      expect(sha256SmartHash(email)).toBe('b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514')
     })
   })
 
@@ -103,7 +104,7 @@ describe('Test operations', () => {
         }
       ]
       const normalizedName = normalize('name', 'John Doe')
-      const hashedName = hash(normalizedName)
+      const hashedName = sha256SmartHash(normalizedName)
       const result = generateFile(payloads)
       const expected = `audience_key,name,email\n${enquoteIdentifier('1002')},${enquoteIdentifier(
         hashedName
@@ -130,8 +131,8 @@ describe('Test operations', () => {
           enable_batching: true
         }
       ]
-      const hashedAlice = hash(normalize('name', 'Alice'))
-      const hashedBob = hash(normalize('name', 'Bob'))
+      const hashedAlice = sha256SmartHash(normalize('name', 'Alice'))
+      const hashedBob = sha256SmartHash(normalize('name', 'Bob'))
       const result = generateFile(payloads)
       const expected = `audience_key,name,email\n${enquoteIdentifier('1003')},${enquoteIdentifier(
         hashedAlice
@@ -152,7 +153,7 @@ describe('Test operations', () => {
           enable_batching: true
         }
       ]
-      const hashedEve = hash(normalize('name', 'Eve'))
+      const hashedEve = sha256SmartHash(normalize('name', 'Eve'))
       const result = generateFile(payloads)
       const expected = `audience_key,name\n${enquoteIdentifier('1005')},${enquoteIdentifier(hashedEve)}`
       expect(result.fileContents.toString()).toBe(expected)
@@ -169,7 +170,7 @@ describe('Test operations', () => {
           enable_batching: true
         }
       ]
-      const hashedNote = hash('Hello, "John"\nNew line')
+      const hashedNote = sha256SmartHash('Hello, "John"\nNew line')
       const result = generateFile(payloads)
       const expected = `audience_key,note,email\n${enquoteIdentifier('1006')},${enquoteIdentifier(
         hashedNote
@@ -409,7 +410,7 @@ describe('Test operations', () => {
         }
       ]
 
-      const hashedUnhashedEmail = hash(normalize('email', 'unhashed@example.com'))
+      const hashedUnhashedEmail = sha256SmartHash(normalize('email', 'unhashed@example.com'))
 
       const result = generateFile(payloads)
       const expected = `audience_key,email\n${enquoteIdentifier('1016')},${enquoteIdentifier(hashedUnhashedEmail)}`
@@ -485,7 +486,7 @@ describe('Test operations', () => {
         }
       ]
 
-      const hashedUniqueValue = hash(normalize('unique_value', '424242'))
+      const hashedUniqueValue = sha256SmartHash(normalize('unique_value', '424242'))
       const result = generateFile(payloads)
 
       // Expected headers are audience_key, first_name, email, liveramp_test, unique_value
@@ -568,8 +569,8 @@ describe('Test operations', () => {
 
       const result = generateFile(payloads)
 
-      const hashedCountry = hash(normalize('country', 'US'))
-      const hashedUniqueValue = hash(normalize('unique_value', 'only_in_third'))
+      const hashedCountry = sha256SmartHash(normalize('country', 'US'))
+      const hashedUniqueValue = sha256SmartHash(normalize('unique_value', 'only_in_third'))
 
       const expected = [
         `audience_key,first_name,email,liveramp_test,country,unique_value`,

--- a/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/operations.test.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/operations.test.ts
@@ -1,4 +1,4 @@
-import { enquoteIdentifier, generateFile, hash, normalize } from '../operations'
+import { enquoteIdentifier, generateFile, hash, normalize, hashPhoneNumber } from '../operations'
 import type { Payload } from '../audienceEnteredSftp/generated-types'
 
 describe('Test operations', () => {
@@ -6,6 +6,20 @@ describe('Test operations', () => {
     it('produces consistent SHA-256 hash for a given input', () => {
       const input = 'test input'
       expect(hash(input)).toBe('9dfe6f15d1ab73af898739394fd22fd72a03db01834582f24bb2e1c66c7aaeae')
+    })
+  })
+
+  describe('hashPhoneNumber', () => {
+    it('produces consistent SHA-1 hash for a given phone number', () => {
+      const phoneNumber = '123-456-7890'
+      expect(hashPhoneNumber(phoneNumber)).toBe('d94cf047843c27e4ebf4495804dfb264a2181d45')
+    })
+  })
+
+  describe('hashEmail', () => {
+    it('produces consistent SHA-256 hash for a given email address', () => {
+      const email = 'user@example.com'
+      expect(hash(email)).toBe('b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514')
     })
   })
 

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/index.ts
@@ -85,6 +85,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, { payload, features, rawData }: ExecuteInputRaw<Settings, Payload, RawData>) => {
+    console.log('Payload1', payload)
     return processData({
       request,
       payloads: [payload],

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/index.ts
@@ -85,7 +85,6 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, { payload, features, rawData }: ExecuteInputRaw<Settings, Payload, RawData>) => {
-    console.log('Payload1', payload)
     return processData({
       request,
       payloads: [payload],

--- a/packages/destination-actions/src/destinations/liveramp-audiences/operations.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/operations.ts
@@ -143,4 +143,4 @@ const normalize = (key: string, value: string): string => {
   return value
 }
 
-export { generateFile, enquoteIdentifier, normalize, hash, hashPhoneNumber }
+export { generateFile, enquoteIdentifier, normalize }

--- a/packages/destination-actions/src/destinations/liveramp-audiences/operations.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/operations.ts
@@ -74,7 +74,11 @@ function generateFile(payloads: s3Payload[] | sftpPayload[]) {
       for (const key of Object.keys(payload.unhashed_identifier_data)) {
         const index = headerArray.indexOf(key)
         unhashedKeys.add(key)
-        row[index] = `"${hash(normalize(key, String(payload.unhashed_identifier_data[key])))}"`
+        if (key === 'phone_number') {
+          row[index] = `"${hashPhoneNumber(normalize(key, String(payload.unhashed_identifier_data[key])))}"`
+        } else {
+          row[index] = `"${hash(normalize(key, String(payload.unhashed_identifier_data[key])))}"`
+        }
       }
     }
 
@@ -119,6 +123,12 @@ const hash = (value: string): string => {
   return hash.digest('hex')
 }
 
+const hashPhoneNumber = (value: string): string => {
+  const hash = createHash('sha1')
+  hash.update(value)
+  return hash.digest('hex')
+}
+
 /*
   Identifiers need to be hashed according to LiveRamp spec's:
   https://docs.liveramp.com/connect/en/formatting-identifiers.html
@@ -147,4 +157,4 @@ const normalize = (key: string, value: string): string => {
   return value
 }
 
-export { generateFile, enquoteIdentifier, normalize, hash }
+export { generateFile, enquoteIdentifier, normalize, hash, hashPhoneNumber }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_LiveRamp requires phone_number to be hashed with SHA-1 or sent in plaintext, but currently, it's being hashed with SHA-256._

Changes:
Update the destination code to hash phone_number with SHA-1 or send it in plaintext, as per LiveRamp's requirements._

## Testing

<img width="648" alt="image" src="https://github.com/user-attachments/assets/e91dea20-bd2b-438c-8715-1815fd94a45f" />


_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
