### PR TITLE
Allowing pre-hashed emails for Criteo Audiences.

### DIFF
--- a/packages/destination-actions/src/destinations/criteo-audiences/addUserToAudience/index.ts
+++ b/packages/destination-actions/src/destinations/criteo-audiences/addUserToAudience/index.ts
@@ -22,8 +22,7 @@ const getOperationFromPayload = async (
   for (const event of payload) {
     let email = undefined
 
-    if (!audience_key && event.audience_key)
-      audience_key = event.audience_key
+    if (!audience_key && event.audience_key) audience_key = event.audience_key
 
     email = event.hash_emails ? hash(event.email) : event.email
     if (email) add_user_list.push(email)
@@ -31,23 +30,19 @@ const getOperationFromPayload = async (
 
   const contactlist_id = await getContactListId(request, advertiser_id, audience_key, credentials)
   const operation: Operation = {
-    operation_type: "add",
+    operation_type: 'add',
     contactlist_id: contactlist_id,
-    user_list: add_user_list,
+    user_list: add_user_list
   }
-  return operation;
+  return operation
 }
 
-const processPayload = async (
-  request: RequestClient,
-  settings: Settings,
-  payload: Payload[]
-): Promise<Response> => {
+const processPayload = async (request: RequestClient, settings: Settings, payload: Payload[]): Promise<Response> => {
   const credentials: ClientCredentials = {
     client_id: settings.client_id,
     client_secret: settings.client_secret
   }
-  const operation: Operation = await getOperationFromPayload(request, settings.advertiser_id, payload, credentials);
+  const operation: Operation = await getOperationFromPayload(request, settings.advertiser_id, payload, credentials)
   return await patchContactList(request, operation, credentials)
 }
 
@@ -58,7 +53,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     audience_key: {
       label: 'Audience key',
-      description: "Unique name for personas audience",
+      description: 'Unique name for personas audience',
       type: 'string',
       default: {
         '@path': '$.properties.audience_key'
@@ -66,7 +61,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     event: {
       label: 'Event name',
-      description: "Event for audience entering or exiting",
+      description: 'Event for audience entering or exiting',
       type: 'string',
       default: {
         '@path': '$.event'
@@ -76,18 +71,18 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Email',
       description: "The user's email",
       type: 'string',
-      format: 'email',
       default: {
         '@path': '$.context.traits.email'
       }
     },
     hash_emails: {
       label: 'Hash Emails',
-      description: "Hash emails before sending them to Criteo (may lower your audience's match rate). If deactivated, emails will be sent unhashed to Criteo's API and will be hashed upon reception at Criteo's server.",
+      description:
+        "Hash emails before sending them to Criteo (may lower your audience's match rate). If deactivated, emails will be sent unhashed to Criteo's API and will be hashed upon reception at Criteo's server.",
       type: 'boolean',
       default: false,
       required: false
-    },
+    }
   },
   perform: async (request, { settings, payload }) => {
     return await processPayload(request, settings, [payload])
@@ -95,7 +90,6 @@ const action: ActionDefinition<Settings, Payload> = {
 
   performBatch: async (request, { settings, payload }) => {
     return await processPayload(request, settings, payload)
-
   }
 }
 export default action

--- a/packages/destination-actions/src/destinations/criteo-audiences/removeUserFromAudience/index.ts
+++ b/packages/destination-actions/src/destinations/criteo-audiences/removeUserFromAudience/index.ts
@@ -5,7 +5,6 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import type { RequestClient } from '@segment/actions-core'
 
-
 const getOperationFromPayload = async (
   request: RequestClient,
   advertiser_id: string,
@@ -18,8 +17,7 @@ const getOperationFromPayload = async (
   for (const event of payload) {
     let email = undefined
 
-    if (!audience_key && event.audience_key)
-      audience_key = event.audience_key
+    if (!audience_key && event.audience_key) audience_key = event.audience_key
 
     email = event.hash_emails ? hash(event.email) : event.email
     if (email) remove_user_list.push(email)
@@ -28,24 +26,19 @@ const getOperationFromPayload = async (
   const contactlist_id = await getContactListId(request, advertiser_id, audience_key, credentials)
 
   const operation: Operation = {
-    operation_type: "remove",
+    operation_type: 'remove',
     contactlist_id: contactlist_id,
-    user_list: remove_user_list,
+    user_list: remove_user_list
   }
-  return operation;
+  return operation
 }
 
-const processPayload = async (
-  request: RequestClient,
-  settings: Settings,
-  payload: Payload[]
-): Promise<Response> => {
-
+const processPayload = async (request: RequestClient, settings: Settings, payload: Payload[]): Promise<Response> => {
   const credentials: ClientCredentials = {
     client_id: settings.client_id,
     client_secret: settings.client_secret
   }
-  const operation: Operation = await getOperationFromPayload(request, settings.advertiser_id, payload, credentials);
+  const operation: Operation = await getOperationFromPayload(request, settings.advertiser_id, payload, credentials)
   return await patchContactList(request, operation, credentials)
 }
 
@@ -56,7 +49,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     audience_key: {
       label: 'Audience key',
-      description: "Unique name for personas audience",
+      description: 'Unique name for personas audience',
       type: 'string',
       default: {
         '@path': '$.properties.audience_key'
@@ -64,7 +57,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     event: {
       label: 'Event name',
-      description: "Event for audience entering or exiting",
+      description: 'Event for audience entering or exiting',
       type: 'string',
       default: {
         '@path': '$.event'
@@ -74,18 +67,18 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Email',
       description: "The user's email",
       type: 'string',
-      format: 'email',
       default: {
         '@path': '$.context.traits.email'
       }
     },
     hash_emails: {
       label: 'Hash Emails',
-      description: "Hash emails before sending them to Criteo (may lower your audience's match rate). If deactivated, emails will be sent unhashed to Criteo's API and will be hashed upon reception at Criteo's server.",
+      description:
+        "Hash emails before sending them to Criteo (may lower your audience's match rate). If deactivated, emails will be sent unhashed to Criteo's API and will be hashed upon reception at Criteo's server.",
       type: 'boolean',
       default: false,
       required: false
-    },
+    }
   },
   perform: async (request, { settings, payload }) => {
     return await processPayload(request, settings, [payload])
@@ -94,6 +87,5 @@ const action: ActionDefinition<Settings, Payload> = {
     return await processPayload(request, settings, payload)
   }
 }
-
 
 export default action


### PR DESCRIPTION
Some of our customers want to send a pre-hashed email in their events. This PR allows that.

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
