### PR TITLE
Fix Mixpanel distinct_id for anonymous events

### DIFF
--- a/packages/destination-actions/src/destinations/mixpanel/trackEvent/functions.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/trackEvent/functions.ts
@@ -17,12 +17,24 @@ export function getEventProperties(payload: Payload, settings: Settings): Mixpan
     browserVersion = getBrowserVersion(payload.userAgent)
   }
   const integration = payload.context?.integration as Record<string, string>
+
+  // When the `distinct_id` property is undefined we add the property in as a blank string,
+  // so that we can support Mixpanel events that aren't tied to a specific user.
+  //
+  // The `distinct_id` property is, according to documentation, supposed to
+  // ALWAYS be present, either with an identifying value or with an empty
+  // string value to denote that the event should be excluded from behavioral
+  // analysis.
+  //
+  // @see https://developer.mixpanel.com/reference/import-events#propertiesdistinct_id
+  const distinct_id = payload.distinct_id ?? ''
+
   return {
     time: time,
     ip: payload.ip,
     id: payload.distinct_id,
     $anon_id: payload.anonymous_id,
-    distinct_id: payload.distinct_id,
+    distinct_id,
     $app_build_number: payload.app_build,
     $app_version_string: payload.app_version,
     $app_namespace: payload.app_namespace,


### PR DESCRIPTION
This PR adds support for anonymous Mixpanel events by allowing the `distinct_id` property to be empty, [as documented](https://developer.mixpanel.com/reference/import-events#propertiesdistinct_id) by Mixpanel:

> If the event is not associated with any user, set distinct_id to the empty string. Events with an empty distinct_id will be excluded from all behavioral analysis.

Before this PR (when distinct_id is empty):

<img width="638" alt="Screenshot 2025-01-16 at 11 12 42" src="https://github.com/user-attachments/assets/0c5a2299-24f3-490c-86b0-a2d872cc35ee" />

After this PR:

<img width="645" alt="Screenshot 2025-01-16 at 11 12 58" src="https://github.com/user-attachments/assets/6f8efdab-6854-4127-b43d-3f8e52fd78c2" />

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
