### PR TITLE
[Google Ads] Send non-American country codes correctly

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/functions.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/functions.test.ts
@@ -1,7 +1,7 @@
 import { createTestIntegration, DynamicFieldResponse } from '@segment/actions-core'
 import { Features } from '@segment/actions-core/mapping-kit'
 import nock from 'nock'
-import { CANARY_API_VERSION } from '../functions'
+import { CANARY_API_VERSION, formatToE164 } from '../functions'
 import destination from '../index'
 
 const testDestination = createTestIntegration(destination)
@@ -139,5 +139,32 @@ describe('.getConversionActionId', () => {
     expect(responses.choices.length).toBe(0)
     expect(responses.error?.message).toEqual(errorResponse.response.statusText)
     expect(responses.error?.code).toEqual(errorResponse.response.status)
+  })
+})
+
+describe.only('phone number formatting', () => {
+  it('should format a US phone number', async () => {
+    expect(formatToE164('16195551000', '+1')).toEqual('+16195551000')
+    expect(formatToE164('6195551000', '+1')).toEqual('+16195551000')
+    expect(formatToE164('6195551000', '1')).toEqual('+16195551000')
+    expect(formatToE164('6195551000', '+1')).toEqual('+16195551000')
+  })
+
+  it('should format a UK phone number', async () => {
+    expect(formatToE164('44 20 7123 4567', '44')).toEqual('+442071234567')
+    expect(formatToE164('20 7123 4567', '44')).toEqual('+442071234567')
+    expect(formatToE164('2071234567', '44')).toEqual('+442071234567')
+    expect(formatToE164('442071234567', '44')).toEqual('+442071234567')
+    expect(formatToE164('+44 20 7123 4567', '44')).toEqual('+442071234567')
+    expect(formatToE164('+44 20 7123 4567', '+44')).toEqual('+442071234567')
+  })
+
+  it('should format a German phone number', async () => {
+    expect(formatToE164('49 30 1234567', '49')).toEqual('+49301234567')
+    expect(formatToE164('30 1234567', '49')).toEqual('+49301234567')
+    expect(formatToE164('301234567', '49')).toEqual('+49301234567')
+    expect(formatToE164('49301234567', '+49')).toEqual('+49301234567')
+    expect(formatToE164('+49 30 1234567', '49')).toEqual('+49301234567')
+    expect(formatToE164('+49 30 1234567', '49')).toEqual('+49301234567')
   })
 })

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -477,7 +477,7 @@ const extractUserIdentifiers = (payloads: UserListPayload[], idType: string, syn
       }
       if (payload.phone) {
         identifiers.push({
-          hashedPhoneNumber: formatPhone(payload.phone, payload.country_code)
+          hashedPhoneNumber: formatPhone(payload.phone, payload.phone_country_code)
         })
       }
       if (payload.first_name || payload.last_name || payload.country_code || payload.postal_code) {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -432,14 +432,16 @@ const formatEmail = (email: string): string => {
 
 // Standardize phone number to E.164 format, This format represents a phone number as a number up to fifteen digits
 // in length starting with a + sign, for example, +12125650000 or +442070313000.
-function formatToE164(phoneNumber: string, defaultCountryCode: string): string {
+// exported for unit testing
+export function formatToE164(phoneNumber: string, countryCode: string): string {
   // Remove any non-numeric characters
   const numericPhoneNumber = phoneNumber.replace(/\D/g, '')
 
   // Check if the phone number starts with the country code
   let formattedPhoneNumber = numericPhoneNumber
-  if (!numericPhoneNumber.startsWith(defaultCountryCode)) {
-    formattedPhoneNumber = defaultCountryCode + numericPhoneNumber
+  const formattedCountryCode = countryCode.replace(/\D/g, '')
+  if (!numericPhoneNumber.startsWith(formattedCountryCode)) {
+    formattedPhoneNumber = formattedCountryCode + numericPhoneNumber
   }
 
   // Ensure the formatted phone number starts with '+'
@@ -450,8 +452,8 @@ function formatToE164(phoneNumber: string, defaultCountryCode: string): string {
   return formattedPhoneNumber
 }
 
-const formatPhone = (phone: string): string => {
-  const formattedPhone = formatToE164(phone, '1')
+const formatPhone = (phone: string, countryCode?: string): string => {
+  const formattedPhone = formatToE164(phone, countryCode ?? '+1')
   return sha256SmartHash(formattedPhone)
 }
 
@@ -475,7 +477,7 @@ const extractUserIdentifiers = (payloads: UserListPayload[], idType: string, syn
       }
       if (payload.phone) {
         identifiers.push({
-          hashedPhoneNumber: formatPhone(payload.phone)
+          hashedPhoneNumber: formatPhone(payload.phone, payload.country_code)
         })
       }
       if (payload.first_name || payload.last_name || payload.country_code || payload.postal_code) {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/generated-types.ts
@@ -18,6 +18,10 @@ export interface Payload {
    */
   phone?: string
   /**
+   * The numeric country code to associate with the phone number. If not provided Segment will default to '+1'. If the country code does not start with '+' Segment will add it.
+   */
+  phone_country_code?: string
+  /**
    * 2-letter country code in ISO-3166-1 alpha-2 of the user's address
    */
   country_code?: string

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/index.ts
@@ -69,8 +69,13 @@ const action: ActionDefinition<Settings, Payload> = {
         }
       }
     },
+    phone_country_code: {
+      label: 'Phone Number Country Code',
+      description: `The numeric country code to associate with the phone number. If not provided Segment will default to '+1'. If the country code does not start with '+' Segment will add it.`,
+      type: 'string'
+    },
     country_code: {
-      label: 'Country Code',
+      label: 'Address Country Code',
       description: "2-letter country code in ISO-3166-1 alpha-2 of the user's address",
       type: 'string'
     },


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

At the moment Google Ads will always automatically prepend phone numbers with '+1'. This behavior is documented in this ticket: https://segment.atlassian.net/browse/STRATCONN-5386

This PR updates the phone number formatting logic to use the new `phone_country_code` field when formatting a phone number.  This field is distinct from the existing `country_code` field, which expects non-numeric values such as 'US'.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

Tested successfully in local + staging.

Local Test: The phone number is correctly formatted as `payload.phone_country_code + payload.phone`. 
This value is hashed before sending so manually console.logging it before that:
<img width="453" alt="Screenshot 2025-01-17 at 11 33 37 AM" src="https://github.com/user-attachments/assets/4996f7c0-1640-4ed7-8516-b4fca6054045" />

Stage Test
Syncs continue to succeed after the new country code field is introduced and mapped to:
<img width="1384" alt="Screenshot 2025-01-16 at 8 20 37 PM" src="https://github.com/user-attachments/assets/ea98cb25-d200-47b9-8ac1-6d6d1ccf218a" />

<img width="1249" alt="Screenshot 2025-01-16 at 8 20 15 PM" src="https://github.com/user-attachments/assets/7618aedf-f3ea-4f5d-9307-e6873334893f" />



- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
