### PR TITLE
[Responsys] Setting timeout to 30 seconds

### DIFF
--- a/packages/destination-actions/src/destinations/responsys/index.ts
+++ b/packages/destination-actions/src/destinations/responsys/index.ts
@@ -1,4 +1,5 @@
-import { DestinationDefinition, IntegrationError } from '@segment/actions-core'
+import { DestinationDefinition, IntegrationError, DEFAULT_REQUEST_TIMEOUT } from '@segment/actions-core'
+
 import type { Settings } from './generated-types'
 import sendCustomTraits from './sendCustomTraits'
 import sendAudience from './sendAudience'
@@ -222,7 +223,8 @@ const destination: DestinationDefinition<Settings> = {
       headers: {
         'Content-Type': 'application/json',
         authorization: `${auth?.accessToken}`
-      }
+      },
+      timeout: Math.max(30_000, DEFAULT_REQUEST_TIMEOUT)
     }
   },
   actions: {

--- a/packages/destination-actions/src/destinations/responsys/sendAudienceAsPet/index.ts
+++ b/packages/destination-actions/src/destinations/responsys/sendAudienceAsPet/index.ts
@@ -19,7 +19,9 @@ const getAllPetsWaitInterval = 60
 
 // createPet (`lists/${settings.profileListName}/listExtensions`, POST): 10 requests per minute.
 // Around 1 request every 6000ms.
-const createPetWaitInterval = 6000
+// However, this wastes a lot of time (Centrifuge in general expects a response in 10 seconds, but this integration works with
+// a 30 second timeout), so we are reducing this to 3 seconds.
+const createPetWaitInterval = 3000
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Audience as PET (Profile Extension Table)',

--- a/packages/destination-actions/src/destinations/responsys/sendToPet/functions.ts
+++ b/packages/destination-actions/src/destinations/responsys/sendToPet/functions.ts
@@ -73,7 +73,9 @@ export const sendToPet = async (
 
   // createPet (`lists/${settings.profileListName}/listExtensions`, POST): 10 requests per minute.
   // Around 1 request every 6000ms.
-  const createPetWaitInterval = 6000
+  // However, this wastes a lot of time (Centrifuge in general expects a response in 10 seconds, but this integration works with
+  // a 30 second timeout), so we are reducing this to 3 seconds.
+  const createPetWaitInterval = 3000
 
   // sendToPet (`lists/${settings.profileListName}/listExtensions/${petName}/members`, POST): 500 requests per minute.
   // Around 1 request every 120ms.


### PR DESCRIPTION
Some of our customers are facing Timeout errors in their Responsys integration. By default, Centrifuge waits up to 10 seconds for an Action to complete. This integration is taking a much longer time to sync large audiences.

This PR expands the Timeout to 30 seconds, as well as waiting 3 seconds to create a PET (the slowest Responsys endpoint). 

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
