### PR TITLE
Fix incorrect mapping in mixpanel destination

### DIFF
--- a/packages/destination-actions/src/destinations/mixpanel/mixpanel-properties.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/mixpanel-properties.ts
@@ -248,7 +248,7 @@ export const eventProperties: Record<string, InputField> = {
     type: 'number',
     description: 'Width, in pixels, of the device screen.',
     default: {
-      '@path': '$.context.screen.density'
+      '@path': '$.context.screen.width'
     }
   },
   screen_height: {
@@ -256,7 +256,7 @@ export const eventProperties: Record<string, InputField> = {
     type: 'number',
     description: 'Height, in pixels, of the device screen.',
     default: {
-      '@path': '$.context.screen.density'
+      '@path': '$.context.screen.height'
     }
   },
   screen_density: {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

- `width` and `height` were incorrectly mapped to `screen` field.
- Fix the error: `width` -> `screen.width`; `height` -> `screen.height`

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
