### PR TITLE
[FUNK-1643] add bearer token to webhook extensible

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,17 +86,7 @@
     }
   },
   "lint-staged": {
-    "**/{browser-destinations,destinations}/**/*.ts": [
-      "./bin/run generate:types -p",
-      "git add **/generated-types.ts"
-    ],
-    "!(**/templates/**)/*.ts": [
-      "eslint --fix --cache",
-      "prettier --write"
-    ],
-    "*.{yml,md,json}": [
-      "prettier --write"
-    ]
+
   },
   "prettier": {
     "semi": false,

--- a/package.json
+++ b/package.json
@@ -86,7 +86,17 @@
     }
   },
   "lint-staged": {
-
+    "**/{browser-destinations,destinations}/**/*.ts": [
+      "./bin/run generate:types -p",
+      "git add **/generated-types.ts"
+    ],
+    "!(**/templates/**)/*.ts": [
+      "eslint --fix --cache",
+      "prettier --write"
+    ],
+    "*.{yml,md,json}": [
+      "prettier --write"
+    ]
   },
   "prettier": {
     "semi": false,

--- a/packages/destination-actions/src/destinations/webhook-extensible/index.ts
+++ b/packages/destination-actions/src/destinations/webhook-extensible/index.ts
@@ -63,7 +63,12 @@ const destination: DestinationDefinition<SettingsWithDynamicAuth> = {
   },
   extendRequest: ({ settings, auth }) => {
     const { dynamicAuthSettings } = settings
-    const accessToken = auth?.accessToken ?? dynamicAuthSettings?.oauth?.access?.access_token
+    let accessToken
+    if (dynamicAuthSettings.bearer) {
+      accessToken = dynamicAuthSettings.bearer.bearerToken
+    } else {
+      accessToken = auth?.accessToken ?? dynamicAuthSettings?.oauth?.access?.access_token
+    }
     return {
       headers: {
         authorization: `Bearer ${accessToken}`

--- a/packages/destination-actions/src/destinations/webhook-extensible/index.ts
+++ b/packages/destination-actions/src/destinations/webhook-extensible/index.ts
@@ -64,8 +64,8 @@ const destination: DestinationDefinition<SettingsWithDynamicAuth> = {
   extendRequest: ({ settings, auth }) => {
     const { dynamicAuthSettings } = settings
     let accessToken
-    if (dynamicAuthSettings.bearer) {
-      accessToken = dynamicAuthSettings.bearer.bearerToken
+    if (dynamicAuthSettings?.bearer) {
+      accessToken = dynamicAuthSettings?.bearer?.bearerToken
     } else {
       accessToken = auth?.accessToken ?? dynamicAuthSettings?.oauth?.access?.access_token
     }


### PR DESCRIPTION
Added bearer token support if it is present added it to the auth header

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
