### PR TITLE
STRAT-5398 | Klaviyo(Actions) |Allow user to configure event name and product event name in OrderCompleted Action.

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -38,7 +38,7 @@ Object {
       "metric": Object {
         "data": Object {
           "attributes": Object {
-            "name": "Order Completed",
+            "name": "PE*zlOgIPA]mVozMLBaL",
           },
           "type": "metric",
         },

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -7,7 +7,7 @@ Object {
       "metric": Object {
         "data": Object {
           "attributes": Object {
-            "name": "Order Completed",
+            "name": "923^%f]tQn]lN2o",
           },
           "type": "metric",
         },

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/index.test.ts
@@ -226,7 +226,6 @@ describe('Order Completed', () => {
 
     const mapping = {
       profile,
-      metric_name: metricName,
       properties,
       value,
       products: products,

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/__tests__/index.test.ts
@@ -215,10 +215,10 @@ describe('Order Completed', () => {
 
     const profile = { email: 'test@example.com', phone_number: '+14155552671' }
     const properties = { key: 'value' }
-    const metricName = 'Order Completed'
+    const metricName = 'Product Purchase Completed'
     const value = 10
-    const eventName = 'Order Completed'
-
+    const eventName = 'Product Purchase Completed'
+    const productEventName = 'Order Products'
     const event = createTestEvent({
       type: 'track',
       timestamp: '2022-01-01T00:00:00.000Z'
@@ -230,7 +230,8 @@ describe('Order Completed', () => {
       properties,
       value,
       products: products,
-      event_name: eventName
+      event_name: eventName,
+      product_event_name: productEventName
     }
 
     const requestBodyForEvent = createRequestBody(properties, value, metricName, profile)
@@ -251,7 +252,7 @@ describe('Order Completed', () => {
           body.data.attributes.metric.data &&
           body.data.attributes.metric.data.type === `metric` &&
           body.data.attributes.metric.data.attributes &&
-          body.data.attributes.metric.data.attributes.name === `Ordered Product` &&
+          body.data.attributes.metric.data.attributes.name === productEventName &&
           body.data.attributes.profile
         )
       })
@@ -335,10 +336,10 @@ describe('Order Completed', () => {
 
     const profile = { email: 'test@example.com', phone_number: '+14155552671' }
     const properties = { key: 'value', name: 'Order Completed' }
-    const metricName = 'Order Completed'
+    const metricName = 'Product Puchase Completed'
     const value = 10
-    const eventName = 'Order Completed'
-
+    const eventName = 'Product Puchase Completed'
+    const productEventName = 'Product Puchase'
     const event = createTestEvent({
       type: 'track',
       timestamp: '2022-01-01T00:00:00.000Z'
@@ -350,7 +351,8 @@ describe('Order Completed', () => {
       properties,
       value,
       products: products,
-      event_name: eventName
+      event_name: eventName,
+      product_event_name: productEventName
     }
 
     const requestBodyForEvent = createRequestBody(properties, value, metricName, profile)
@@ -373,7 +375,7 @@ describe('Order Completed', () => {
           body.data.attributes.metric.data &&
           body.data.attributes.metric.data.type === `metric` &&
           body.data.attributes.metric.data.attributes &&
-          body.data.attributes.metric.data.attributes.name === `Ordered Product` &&
+          body.data.attributes.metric.data.attributes.name === productEventName &&
           body.data.attributes.profile
         )
       })

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
@@ -53,11 +53,11 @@ export interface Payload {
     [k: string]: unknown
   }[]
   /**
-   * Name of the event. This will be used as the metric name in Klaviyo.It must be configured in Klaviyo.
+   * Name of the event. This will be used as the metric name for order completed event sent to Klaviyo. It must be configured in Klaviyo.
    */
   event_name?: string
   /**
-   * Name of the Product Event. This will be used as the metric name for Product event in Klaviyo.It must be configured in Klaviyo.
+   * Name of the Product Event. This will be used as the metric name for each ordered product configured in the product list sent to Klaviyo. It must be configured in Klaviyo.
    */
   product_event_name?: string
 }

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
@@ -56,4 +56,8 @@ export interface Payload {
    * Name of the event. This will be used as the metric name in Klaviyo.
    */
   event_name?: string
+  /**
+   * Name of the event. This will be used as the metric name in Klaviyo.
+   */
+  product_event_name?: string
 }

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/generated-types.ts
@@ -53,11 +53,11 @@ export interface Payload {
     [k: string]: unknown
   }[]
   /**
-   * Name of the event. This will be used as the metric name in Klaviyo.
+   * Name of the event. This will be used as the metric name in Klaviyo.It must be configured in Klaviyo.
    */
   event_name?: string
   /**
-   * Name of the event. This will be used as the metric name in Klaviyo.
+   * Name of the Product Event. This will be used as the metric name for Product event in Klaviyo.It must be configured in Klaviyo.
    */
   product_event_name?: string
 }

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
@@ -153,14 +153,14 @@ const action: ActionDefinition<Settings, Payload> = {
     event_name: {
       label: 'Event Name',
       description:
-        'Name of the event. This will be used as the metric name in Klaviyo.It must be configured in Klaviyo.',
+        'Name of the event. This will be used as the metric name for order completed event sent to Klaviyo. It must be configured in Klaviyo.',
       default: 'Order Completed',
       type: 'string'
     },
     product_event_name: {
       label: 'Product Event Name',
       description:
-        'Name of the Product Event. This will be used as the metric name for Product event in Klaviyo.It must be configured in Klaviyo.',
+        'Name of the Product Event. This will be used as the metric name for each ordered product configured in the product list sent to Klaviyo. It must be configured in Klaviyo.',
       default: 'Ordered Product',
       type: 'string'
     }

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
@@ -21,7 +21,7 @@ const createEventData = (payload: Payload) => ({
         data: {
           type: 'metric',
           attributes: {
-            name: payload.event_name
+            name: payload.event_name ?? 'Order Completed'
           }
         }
       },
@@ -52,7 +52,7 @@ const sendProductRequests = async (payload: Payload, orderEventData: EventData, 
             data: {
               type: 'metric',
               attributes: {
-                name: payload.product_event_name
+                name: payload.product_event_name ?? 'Ordered Product'
               }
             }
           },

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
@@ -21,7 +21,7 @@ const createEventData = (payload: Payload) => ({
         data: {
           type: 'metric',
           attributes: {
-            name: 'Order Completed'
+            name: payload.event_name
           }
         }
       },
@@ -52,7 +52,7 @@ const sendProductRequests = async (payload: Payload, orderEventData: EventData, 
             data: {
               type: 'metric',
               attributes: {
-                name: 'Ordered Product'
+                name: payload.product_event_name
               }
             }
           },
@@ -154,6 +154,12 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Event Name',
       description: 'Name of the event. This will be used as the metric name in Klaviyo.',
       default: 'Order Completed',
+      type: 'string'
+    },
+    product_event_name: {
+      label: 'Product Event Name',
+      description: 'Name of the Product Event. This will be used as the metric name for Product event in Klaviyo.',
+      default: 'Ordered Product',
       type: 'string'
     }
   },

--- a/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/orderCompleted/index.ts
@@ -152,13 +152,15 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     event_name: {
       label: 'Event Name',
-      description: 'Name of the event. This will be used as the metric name in Klaviyo.',
+      description:
+        'Name of the event. This will be used as the metric name in Klaviyo.It must be configured in Klaviyo.',
       default: 'Order Completed',
       type: 'string'
     },
     product_event_name: {
       label: 'Product Event Name',
-      description: 'Name of the Product Event. This will be used as the metric name for Product event in Klaviyo.',
+      description:
+        'Name of the Product Event. This will be used as the metric name for Product event in Klaviyo.It must be configured in Klaviyo.',
       default: 'Ordered Product',
       type: 'string'
     }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pull request is to allow user to configure Event Name and Product Event Name in OrderCompleted Actions.
Jira ticket:- https://segment.atlassian.net/jira/software/c/projects/STRATCONN/boards/310?assignee=63617339fc0cc7a600b03c6b&selectedIssue=STRATCONN-5398

Tested it in [Staging](https://docs.google.com/document/d/15dZn_tHL_Occ2e2EoXD-_9sQweK1R-kAztP4qsjPKJ4/edit?tab=t.0#heading=h.qt2yy6xbeark) Environment.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
