### PR TITLE
[STRATCONN-5380] - Fix google enhanced conversion error parsing

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/userList.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/userList.test.ts
@@ -443,27 +443,24 @@ describe('GoogleEnhancedConversions', () => {
       nock(`https://googleads.googleapis.com/${API_VERSION}/offlineDataJob:addOperations`)
         .post(/.*/)
         .reply(400, {
-          data: {
-            error: {
-              code: 400,
-              details: [
-                {
-                  '@type': 'type.googleapis.com/google.ads.googleads.v17.errors.GoogleAdsFailure',
-                  errors: [
-                    {
-                      errorCode: {
-                        databaseError: 'CONCURRENT_MODIFICATION'
-                      },
-                      message:
-                        'Multiple requests were attempting to modify the same resource at once. Retry the request.'
-                    }
-                  ],
-                  requestId: 'OZ5_72C-3qFN9a87mjE7_w'
-                }
-              ],
-              message: 'Request contains an invalid argument.',
-              status: 'INVALID_ARGUMENT'
-            }
+          error: {
+            code: 400,
+            details: [
+              {
+                '@type': 'type.googleapis.com/google.ads.googleads.v17.errors.GoogleAdsFailure',
+                errors: [
+                  {
+                    errorCode: {
+                      databaseError: 'CONCURRENT_MODIFICATION'
+                    },
+                    message: 'Multiple requests were attempting to modify the same resource at once. Retry the request.'
+                  }
+                ],
+                requestId: 'OZ5_72C-3qFN9a87mjE7_w'
+              }
+            ],
+            message: 'Request contains an invalid argument.',
+            status: 'INVALID_ARGUMENT'
           }
         })
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/userList.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/userList.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { createTestEvent, createTestIntegration, RetryableError } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration, HTTPError, RetryableError } from '@segment/actions-core'
 import GoogleEnhancedConversions from '../index'
 import { API_VERSION } from '../functions'
 import { SegmentEvent } from '@segment/actions-core'
@@ -392,7 +392,7 @@ describe('GoogleEnhancedConversions', () => {
       )
     })
 
-    it('handles concurrent_modification error correctly from addOperations API', async () => {
+    it('rethrows concurrent_modification error from addOperations API as retryable error', async () => {
       const events: SegmentEvent[] = [
         createTestEvent({
           timestamp,
@@ -487,7 +487,103 @@ describe('GoogleEnhancedConversions', () => {
       await expect(responses).rejects.toThrowError(RetryableError)
     })
 
-    it('handles concurrent_modification error correctly from create offlineUserDataJobs API', async () => {
+    it('bubbles up errors other than concurrent_modification from addOperations API', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}/offlineUserDataJobs:create`)
+        .post(/.*/)
+        .reply(200, { data: 'offlineDataJob' })
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/offlineDataJob:addOperations`)
+        .post(/.*/)
+        .reply(400, {
+          error: {
+            code: 400,
+            details: [
+              {
+                '@type': 'type.googleapis.com/google.ads.googleads.v17.errors.GoogleAdsFailure',
+                errors: [
+                  {
+                    errorCode: {
+                      databaseError: 'DATA_CONSTRAINT_VIOLATION'
+                    },
+                    message:
+                      'The request conflicted with existing data. This error will usually be replaced with a more specific error if the request is retried.'
+                  }
+                ],
+                requestId: 'OZ5_72C-3qFN9a87mjE7_w'
+              }
+            ],
+            message: 'Request contains an invalid argument.',
+            status: 'INVALID_ARGUMENT'
+          }
+        })
+
+      const responses = testDestination.testBatchAction('userList', {
+        events,
+        mapping: {
+          ad_user_data_consent_state: 'GRANTED',
+          ad_personalization_consent_state: 'GRANTED',
+          external_audience_id: '1234',
+          retlOnMappingSave: {
+            outputs: {
+              id: '1234',
+              name: 'Test List',
+              external_id_type: 'CONTACT_INFO'
+            }
+          }
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      await expect(responses).rejects.toThrowError(HTTPError)
+    })
+
+    it('rethrows concurrent_modification error from create offlineUserDataJobs API as retryable error', async () => {
       const events: SegmentEvent[] = [
         createTestEvent({
           timestamp,
@@ -578,7 +674,99 @@ describe('GoogleEnhancedConversions', () => {
       await expect(responses).rejects.toThrowError(RetryableError)
     })
 
-    it('handles concurrent_modification error correctly from run offlineUserDataJobs API', async () => {
+    it('bubbles up errors other than concurrent_modification from create offlineUserDataJobs API', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}/offlineUserDataJobs:create`)
+        .post(/.*/)
+        .reply(400, {
+          error: {
+            code: 400,
+            details: [
+              {
+                '@type': 'type.googleapis.com/google.ads.googleads.v17.errors.GoogleAdsFailure',
+                errors: [
+                  {
+                    errorCode: {
+                      someotherError: 'DATA_CONSTRAINT_VIOLATION'
+                    },
+                    message:
+                      'The request conflicted with existing data. This error will usually be replaced with a more specific error if the request is retried.'
+                  }
+                ],
+                requestId: 'OZ5_72C-3qFN9a87mjE7_w'
+              }
+            ],
+            message: 'Request contains an invalid argument.',
+            status: 'INVALID_ARGUMENT'
+          }
+        })
+
+      const responses = testDestination.testBatchAction('userList', {
+        events,
+        mapping: {
+          ad_user_data_consent_state: 'GRANTED',
+          ad_personalization_consent_state: 'GRANTED',
+          external_audience_id: '1234',
+          retlOnMappingSave: {
+            outputs: {
+              id: '1234',
+              name: 'Test List',
+              external_id_type: 'CONTACT_INFO'
+            }
+          }
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      await expect(responses).rejects.toThrowError(HTTPError)
+    })
+
+    it('rethrows concurrent_modification error from run offlineUserDataJobs API as retryable error', async () => {
       const events: SegmentEvent[] = [
         createTestEvent({
           timestamp,
@@ -675,6 +863,106 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       await expect(responses).rejects.toThrowError(RetryableError)
+    })
+
+    it('bubbles up errors other than concurrent_modification from run offlineUserDataJobs API', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          properties: {
+            gclid: '54321',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            phone: '1234567890',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            currency: 'USD',
+            value: '123',
+            address: {
+              street: '123 Street SW',
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '982004'
+            }
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}/offlineUserDataJobs:create`)
+        .post(/.*/)
+        .reply(200, { data: 'offlineDataJob' })
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/offlineDataJob:addOperations`)
+        .post(/.*/)
+        .reply(200, { data: 'offlineDataJob' })
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/offlineDataJob:run`)
+        .post(/.*/)
+        .reply(400, {
+          error: {
+            code: 400,
+            details: [
+              {
+                '@type': 'type.googleapis.com/google.ads.googleads.v17.errors.GoogleAdsFailure',
+                errors: [
+                  {
+                    errorCode: {
+                      someotherError: 'DATA_CONSTRAINT_VIOLATION'
+                    },
+                    message:
+                      'The request conflicted with existing data. This error will usually be replaced with a more specific error if the request is retried.'
+                  }
+                ],
+                requestId: 'OZ5_72C-3qFN9a87mjE7_w'
+              }
+            ],
+            message: 'Request contains an invalid argument.',
+            status: 'INVALID_ARGUMENT'
+          }
+        })
+
+      const responses = testDestination.testBatchAction('userList', {
+        events,
+        mapping: {
+          ad_user_data_consent_state: 'GRANTED',
+          ad_personalization_consent_state: 'GRANTED',
+          external_audience_id: '1234',
+          retlOnMappingSave: {
+            outputs: {
+              id: '1234',
+              name: 'Test List',
+              external_id_type: 'CONTACT_INFO'
+            }
+          }
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      await expect(responses).rejects.toThrowError(HTTPError)
     })
   })
 })

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -32,23 +32,21 @@ export const CANARY_API_VERSION = 'v17'
 export const FLAGON_NAME = 'google-enhanced-canary-version'
 
 type GoogleAdsErrorData = {
-  data: {
-    error: {
-      code: number
-      details: [
-        {
-          '@type': string
-          errors: [
-            {
-              errorCode: { databaseError: string }
-              message: string
-            }
-          ]
-        }
-      ]
-      message: string
-      status: string
-    }
+  error: {
+    code: number
+    details: [
+      {
+        '@type': string
+        errors: [
+          {
+            errorCode: { databaseError: string }
+            message: string
+          }
+        ]
+      }
+    ]
+    message: string
+    status: string
   }
 }
 export class GoogleAdsError extends HTTPError {
@@ -590,7 +588,8 @@ const addOperations = async (
 
     // Google throws 400 error for CONCURRENT_MODIFICATION error which is a retryable error
     // We rewrite this error to a 500 so that Centrifuge can retry the request
-    for (const errorDetails of (error as GoogleAdsError).response?.data?.data?.error?.details) {
+    const errors = (error as GoogleAdsError).response?.data?.error?.details ?? []
+    for (const errorDetails of errors) {
       for (const errorItem of errorDetails.errors) {
         if (errorItem?.errorCode?.databaseError) {
           throw new RetryableError(

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -551,11 +551,11 @@ const createOfflineUserJob = async (
     return (response.data as any).resourceName
   } catch (error) {
     statsContext?.statsClient?.incr('error.createJob', 1, statsContext?.tags)
-    parseAndThrowError(error)
+    handleGoogleAdsError(error)
   }
 }
 
-const parseAndThrowError = (error: any) => {
+const handleGoogleAdsError = (error: any) => {
   // Google throws 400 error for CONCURRENT_MODIFICATION error which is a retryable error
   // We rewrite this error to a 500 so that Centrifuge can retry the request
   const errors = (error as GoogleAdsError).response?.data?.error?.details ?? []
@@ -600,7 +600,7 @@ const addOperations = async (
     return response.data
   } catch (error) {
     statsContext?.statsClient?.incr('error.addOperations', 1, statsContext?.tags)
-    parseAndThrowError(error)
+    handleGoogleAdsError(error)
   }
 }
 
@@ -623,7 +623,7 @@ const runOfflineUserJob = async (
     return response.data
   } catch (error) {
     statsContext?.statsClient?.incr('error.runJob', 1, statsContext?.tags)
-    parseAndThrowError(error)
+    handleGoogleAdsError(error)
   }
 }
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -561,7 +561,8 @@ const handleGoogleAdsError = (error: any) => {
   const errors = (error as GoogleAdsError).response?.data?.error?.details ?? []
   for (const errorDetails of errors) {
     for (const errorItem of errorDetails.errors) {
-      if (errorItem?.errorCode?.databaseError) {
+      // https://developers.google.com/google-ads/api/reference/rpc/v17/DatabaseErrorEnum.DatabaseError
+      if (errorItem?.errorCode?.databaseError === 'CONCURRENT_MODIFICATION') {
         throw new RetryableError(
           errorItem?.message ??
             'Multiple requests were attempting to modify the same resource at once. Retry the request.',

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -551,12 +551,27 @@ const createOfflineUserJob = async (
     return (response.data as any).resourceName
   } catch (error) {
     statsContext?.statsClient?.incr('error.createJob', 1, statsContext?.tags)
-    throw new IntegrationError(
-      (error as GoogleAdsError).response?.statusText,
-      'INVALID_RESPONSE',
-      (error as GoogleAdsError).response?.status
-    )
+    parseAndThrowError(error)
   }
+}
+
+const parseAndThrowError = (error: any) => {
+  // Google throws 400 error for CONCURRENT_MODIFICATION error which is a retryable error
+  // We rewrite this error to a 500 so that Centrifuge can retry the request
+  const errors = (error as GoogleAdsError).response?.data?.error?.details ?? []
+  for (const errorDetails of errors) {
+    for (const errorItem of errorDetails.errors) {
+      if (errorItem?.errorCode?.databaseError) {
+        throw new RetryableError(
+          errorItem?.message ??
+            'Multiple requests were attempting to modify the same resource at once. Retry the request.',
+          500
+        )
+      }
+    }
+  }
+
+  throw error
 }
 
 const addOperations = async (
@@ -585,27 +600,7 @@ const addOperations = async (
     return response.data
   } catch (error) {
     statsContext?.statsClient?.incr('error.addOperations', 1, statsContext?.tags)
-
-    // Google throws 400 error for CONCURRENT_MODIFICATION error which is a retryable error
-    // We rewrite this error to a 500 so that Centrifuge can retry the request
-    const errors = (error as GoogleAdsError).response?.data?.error?.details ?? []
-    for (const errorDetails of errors) {
-      for (const errorItem of errorDetails.errors) {
-        if (errorItem?.errorCode?.databaseError) {
-          throw new RetryableError(
-            errorItem?.message ??
-              'Multiple requests were attempting to modify the same resource at once. Retry the request.',
-            500
-          )
-        }
-      }
-
-      throw new IntegrationError(
-        (error as GoogleAdsError).response?.statusText,
-        'INVALID_RESPONSE',
-        (error as GoogleAdsError).response?.status
-      )
-    }
+    parseAndThrowError(error)
   }
 }
 
@@ -628,11 +623,7 @@ const runOfflineUserJob = async (
     return response.data
   } catch (error) {
     statsContext?.statsClient?.incr('error.runJob', 1, statsContext?.tags)
-    throw new IntegrationError(
-      (error as GoogleAdsError).response?.statusText,
-      'INVALID_RESPONSE',
-      (error as GoogleAdsError).response?.status
-    )
+    parseAndThrowError(error)
   }
 }
 


### PR DESCRIPTION
This PR fixes HTTP error parsing for`userList` action of Google Enhanced Conversions destination.

This PR solves two key issues

- Internal Error due to incorrect response structure parsing. The external `data` wrapper is not needed.
- Handles concurrent modification error and rethrows it as retryable error for all APIs used in userList action. It seems like all APIs `createOfflineJob`, `addOpertions` and `run` (less likely) can throw this exception. (Previous [PR](https://github.com/segmentio/action-destinations/pull/2577))

More on before and after state in [Test Doc](https://docs.google.com/document/d/1AtMj2kzurYcZweIdGj_53Lts592XCJqVC9rHZlEKvXM/edit?tab=t.0) 

This destination could benefit from Multistatus. I'll try to implement it in a different PR whenever I find time next.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
