### PR TITLE
[STRATCONN-5449] Update GEC - userList action to common hashed function

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/functions.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/functions.test.ts
@@ -1,7 +1,7 @@
 import { createTestIntegration, DynamicFieldResponse } from '@segment/actions-core'
 import { Features } from '@segment/actions-core/mapping-kit'
 import nock from 'nock'
-import { CANARY_API_VERSION, formatToE164 } from '../functions'
+import { CANARY_API_VERSION, formatToE164, commonHashedEmailValidation } from '../functions'
 import destination from '../index'
 
 const testDestination = createTestIntegration(destination)
@@ -142,7 +142,20 @@ describe('.getConversionActionId', () => {
   })
 })
 
-describe.only('phone number formatting', () => {
+describe('email formatting', () => {
+  it('should format a non-hashed value', async () => {
+    expect(commonHashedEmailValidation('test@gmail.com')).toEqual(
+      '87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674'
+    )
+  })
+  it('should return hashed value as is', async () => {
+    expect(commonHashedEmailValidation('87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674')).toEqual(
+      '87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674'
+    )
+  })
+})
+
+describe('phone number formatting', () => {
   it('should format a US phone number', async () => {
     expect(formatToE164('16195551000', '+1')).toEqual('+16195551000')
     expect(formatToE164('6195551000', '+1')).toEqual('+16195551000')

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -418,18 +418,6 @@ export async function getGoogleAudience(
   return response.data as UserListResponse
 }
 
-const formatEmail = (email: string): string => {
-  const googleDomain = new RegExp('^(gmail|googlemail).s*', 'g')
-  let normalizedEmail = email.toLowerCase().trim()
-  const emailParts = normalizedEmail.split('@')
-  if (emailParts.length > 1 && emailParts[1].match(googleDomain)) {
-    emailParts[0] = emailParts[0].replace('.', '')
-    normalizedEmail = `${emailParts[0]}@${emailParts[1]}`
-  }
-
-  return sha256SmartHash(normalizedEmail)
-}
-
 // Standardize phone number to E.164 format, This format represents a phone number as a number up to fifteen digits
 // in length starting with a + sign, for example, +12125650000 or +442070313000.
 // exported for unit testing
@@ -472,7 +460,7 @@ const extractUserIdentifiers = (payloads: UserListPayload[], idType: string, syn
       const identifiers = []
       if (payload.email) {
         identifiers.push({
-          hashedEmail: formatEmail(payload.email)
+          hashedEmail: commonHashedEmailValidation(payload.email)
         })
       }
       if (payload.phone) {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Goal is to use a Standard Function: commonHashedEmailValidation for email hashing. The only action that needs an updates is the addUserList action. 

_The commonHashedEmailValidation function will now be used in place of formatEmail for the userList action to ensure consistency and improve validation efficiency across email handling.This will not introduce any new functionality._

## Testing

A unit test was added to verify the functionality of commonHashedEmailValidation and ensure that the hashed values are generated correctly.

Since this is for Engage, I was unable to run a full E2E test to verify the payload sent. However, I did test this locally, and everything appears to be functioning as expected.

formatEmail
`Input: test@gmail.com
Output (hashed): 87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674`

commonHashedEmailValidation
`Input: test@gmail.com
Output (hashed): 87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674`

formatEmail
`Input: 87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674
Output : 87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674`

commonHashedEmailValidation
`Input: 87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674
Output: 87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674`



_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._



- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
