### PR TITLE
[STRATCONN-5445] - Fixes process consent casing in DV360 Actions

### DIFF
--- a/packages/destination-actions/src/destinations/display-video-360/__tests__/shared.test.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/__tests__/shared.test.ts
@@ -135,9 +135,11 @@ describe('shared', () => {
     })
 
     it('should return an array of UserOperation objects with Android Advertising ID', () => {
-      oneMockPayload.mobile_advertising_id = '3b6e47b314374ba2b3c9446e4d0cd1e5'
-
-      const results = assembleRawOps(oneMockPayload, 'remove')
+      const mockPayload = {
+        ...oneMockPayload,
+        mobile_advertising_id: '3b6e47b314374ba2b3c9446e4d0cd1e5'
+      }
+      const results = assembleRawOps(mockPayload, 'remove')
       expect(results).toEqual([
         {
           UserId: 'CAESEHIV8HXNp0pFdHgi2rElMfk',

--- a/packages/destination-actions/src/destinations/display-video-360/__tests__/shared.test.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/__tests__/shared.test.ts
@@ -199,6 +199,10 @@ describe('shared', () => {
     it('should create an UpdateUsersDataRequest object with the correct number of operations', () => {
       const r = createUpdateRequest(manyMockPayloads, 'add')
       expect(r.ops.length).toEqual(5)
+      expect(r.processConsent).toEqual(true)
+      expect(r.toJsonString()).toMatchInlineSnapshot(
+        `"{\\"ops\\":[{\\"userId\\":\\"CAESEHIV8HXNp0pFdHgi2rElMfk\\",\\"userIdType\\":\\"GOOGLE_USER_ID\\",\\"userListId\\":\\"456\\",\\"delete\\":false},{\\"userId\\":\\"3b6e47b3-1437-4ba2-b3c9-446e4d0cd1e5\\",\\"userIdType\\":\\"IDFA\\",\\"userListId\\":\\"456\\",\\"delete\\":false},{\\"userId\\":\\"my-anon-id-42\\",\\"userIdType\\":\\"PARTNER_PROVIDED_ID\\",\\"userListId\\":\\"456\\",\\"delete\\":false},{\\"userId\\":\\"my-anon-id-43\\",\\"userIdType\\":\\"PARTNER_PROVIDED_ID\\",\\"userListId\\":\\"456\\",\\"delete\\":false},{\\"userId\\":\\"XNp0pFdHgi2rElMfk\\",\\"userIdType\\":\\"GOOGLE_USER_ID\\",\\"userListId\\":\\"456\\",\\"delete\\":false}],\\"processConsent\\":true}"`
+      )
     })
 
     it('should throw an error when unable to create UpdateUsersDataRequest', () => {

--- a/packages/destination-actions/src/destinations/display-video-360/proto/protofile.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/proto/protofile.ts
@@ -459,6 +459,11 @@ export class UpdateUsersDataRequest extends Message<UpdateUsersDataRequest> {
     return proto2.util.equals(UpdateUsersDataRequest, a, b)
   }
 
+  /**
+   * https://developers.google.com/authorized-buyers/rtb/bulk-uploader#process_consent_in_bulk_upload_request
+   *
+   * @generated from field: optional bool process_consent = 3 [default = true];
+   */
   processConsent: boolean = false
 }
 

--- a/packages/destination-actions/src/destinations/display-video-360/proto/protofile.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/proto/protofile.ts
@@ -429,7 +429,15 @@ export class UpdateUsersDataRequest extends Message<UpdateUsersDataRequest> {
   static readonly typeName = 'UpdateUsersDataRequest'
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: 'ops', kind: 'message', T: UserDataOperation, repeated: true },
-    { no: 2, name: 'send_notifications', kind: 'scalar', T: 8 /* ScalarType.BOOL */, opt: true, default: false }
+    { no: 2, name: 'send_notifications', kind: 'scalar', T: 8 /* ScalarType.BOOL */, opt: true, default: false },
+    {
+      no: 3,
+      name: 'process_consent',
+      kind: 'scalar',
+      T: 8 /* ScalarType.BOOL */,
+      opt: true,
+      default: false
+    }
   ])
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): UpdateUsersDataRequest {
@@ -451,7 +459,7 @@ export class UpdateUsersDataRequest extends Message<UpdateUsersDataRequest> {
     return proto2.util.equals(UpdateUsersDataRequest, a, b)
   }
 
-  process_consent: boolean = false
+  processConsent: boolean = false
 }
 
 /**

--- a/packages/destination-actions/src/destinations/display-video-360/shared.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/shared.ts
@@ -175,7 +175,7 @@ export const createUpdateRequest = (
   })
 
   // Backed by deletion and suppression features in Segment.
-  updateRequest.process_consent = true
+  updateRequest.processConsent = true
 
   return updateRequest
 }


### PR DESCRIPTION
This PR changes casing of process consent boolean flag from snake case to camel case so that it gets processed by protobuf lib properly.  Currently our customers have raised concerns that process consent flag is not being set properly ([JIRA](https://segment.atlassian.net/browse/STRATCONN-5445)).

Probuf lib we use expect us to use lowerCamelCase for fields ([ref](https://github.com/bufbuild/protobuf-es/blob/main/MANUAL.md#field-names)).

## Testing

Tested successfully in staging for positive scenario

![image](https://github.com/user-attachments/assets/cbcf4dd4-4816-48b9-8bb3-c2fbcb989f2f)

Added unit tests to ensure processConsent is set. Similar toBinary, toJSON serializes class based on contract.

**Before**
toJSON didn't include processConsent
![image](https://github.com/user-attachments/assets/6a56b055-038b-47d5-a672-e2148f1aa0d1)

**After**
toJSON includes processConsent
![image](https://github.com/user-attachments/assets/1ef0d616-af05-4698-913f-49158af6f41d)

This change is not expected to cause any regression as this feature wasn't working before.


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
