### PR TITLE
[LAB-1682] Create presets for each standard audience action destination

### DIFF
--- a/packages/destination-actions/src/destinations/amazon-amc/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/index.ts
@@ -246,10 +246,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'syncAudiencesToDSP',
       mapping: {
-        ...defaultValues(syncAudiencesToDSP.fields),
-        properties: {
-          '@path': '$.properties'
-        }
+        ...defaultValues(syncAudiencesToDSP.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'

--- a/packages/destination-actions/src/destinations/amazon-amc/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/index.ts
@@ -1,4 +1,9 @@
-import { AudienceDestinationDefinition, InvalidAuthenticationError, IntegrationError } from '@segment/actions-core'
+import {
+  AudienceDestinationDefinition,
+  InvalidAuthenticationError,
+  IntegrationError,
+  defaultValues
+} from '@segment/actions-core'
 import type { RefreshTokenResponse, AmazonTestAuthenticationError } from './types'
 import type { Settings, AudienceSettings } from './generated-types'
 import {
@@ -235,7 +240,21 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   },
   actions: {
     syncAudiencesToDSP
-  }
+  },
+  presets: [
+    {
+      name: 'Entities Audience Membership Changed',
+      partnerAction: 'syncAudiencesToDSP',
+      mapping: {
+        ...defaultValues(syncAudiencesToDSP.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_membership_changed_identify'
+    }
+  ]
 }
 
 export default destination

--- a/packages/destination-actions/src/destinations/aws-s3/index.ts
+++ b/packages/destination-actions/src/destinations/aws-s3/index.ts
@@ -103,10 +103,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'syncAudienceToCSV',
       mapping: {
-        ...defaultValues(syncAudienceToCSV.fields),
-        properties: {
-          '@path': '$.properties'
-        }
+        ...defaultValues(syncAudienceToCSV.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'

--- a/packages/destination-actions/src/destinations/aws-s3/index.ts
+++ b/packages/destination-actions/src/destinations/aws-s3/index.ts
@@ -1,4 +1,4 @@
-import { AudienceDestinationDefinition, IntegrationError } from '@segment/actions-core'
+import { AudienceDestinationDefinition, defaultValues, IntegrationError } from '@segment/actions-core'
 import type { AudienceSettings, Settings } from './generated-types'
 
 import syncAudienceToCSV from './syncAudienceToCSV'
@@ -94,9 +94,24 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       return { externalId: audience_id }
     }
   },
+
   actions: {
     syncAudienceToCSV
-  }
+  },
+  presets: [
+    {
+      name: 'Entities Audience Membership Changed',
+      partnerAction: 'syncAudienceToCSV',
+      mapping: {
+        ...defaultValues(syncAudienceToCSV.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_membership_changed_identify'
+    }
+  ]
 }
 
 export default destination

--- a/packages/destination-actions/src/destinations/aws-s3/index.ts
+++ b/packages/destination-actions/src/destinations/aws-s3/index.ts
@@ -102,9 +102,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'syncAudienceToCSV',
-      mapping: {
-        ...defaultValues(syncAudienceToCSV.fields)
-      },
+      mapping: defaultValues(syncAudienceToCSV.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
     }

--- a/packages/destination-actions/src/destinations/delivrai-activate/index.ts
+++ b/packages/destination-actions/src/destinations/delivrai-activate/index.ts
@@ -43,10 +43,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'updateSegment',
       mapping: {
-        ...defaultValues(updateSegment.fields),
-        properties: {
-          '@path': '$.properties'
-        }
+        ...defaultValues(updateSegment.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'

--- a/packages/destination-actions/src/destinations/delivrai-activate/index.ts
+++ b/packages/destination-actions/src/destinations/delivrai-activate/index.ts
@@ -1,4 +1,4 @@
-import type { AudienceDestinationDefinition } from '@segment/actions-core'
+import { defaultValues, AudienceDestinationDefinition } from '@segment/actions-core'
 import type { Settings, AudienceSettings } from './generated-types'
 import updateSegment from './updateSegment'
 
@@ -37,6 +37,20 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
 
   actions: {
     updateSegment
-  }
+  },
+  presets: [
+    {
+      name: 'Entities Audience Membership Changed',
+      partnerAction: 'updateSegment',
+      mapping: {
+        ...defaultValues(updateSegment.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_membership_changed_identify'
+    }
+  ]
 }
 export default destination

--- a/packages/destination-actions/src/destinations/display-video-360/index.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/index.ts
@@ -1,4 +1,4 @@
-import { AudienceDestinationDefinition, IntegrationError } from '@segment/actions-core'
+import { AudienceDestinationDefinition, defaultValues, IntegrationError } from '@segment/actions-core'
 
 import type { Settings, AudienceSettings } from './generated-types'
 
@@ -166,7 +166,34 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   actions: {
     addToAudience,
     removeFromAudience
-  }
+  },
+  presets: [
+    {
+      name: 'Entities Audience Entered',
+      partnerAction: 'addToAudience',
+      mapping: {
+        ...defaultValues(addToAudience.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_entered_track'
+    },
+
+    {
+      name: 'Entities Audience Exited',
+      partnerAction: 'removeFromAudience',
+      mapping: {
+        ...defaultValues(removeFromAudience.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_exited_track'
+    }
+  ]
 }
 
 export default destination

--- a/packages/destination-actions/src/destinations/display-video-360/index.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/index.ts
@@ -172,10 +172,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       name: 'Entities Audience Entered',
       partnerAction: 'addToAudience',
       mapping: {
-        ...defaultValues(addToAudience.fields),
-        properties: {
-          '@path': '$.properties'
-        }
+        ...defaultValues(addToAudience.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_entered_track'
@@ -185,10 +182,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       name: 'Entities Audience Exited',
       partnerAction: 'removeFromAudience',
       mapping: {
-        ...defaultValues(removeFromAudience.fields),
-        properties: {
-          '@path': '$.properties'
-        }
+        ...defaultValues(removeFromAudience.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_exited_track'

--- a/packages/destination-actions/src/destinations/display-video-360/index.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/index.ts
@@ -171,9 +171,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     {
       name: 'Entities Audience Entered',
       partnerAction: 'addToAudience',
-      mapping: {
-        ...defaultValues(addToAudience.fields)
-      },
+      mapping: defaultValues(addToAudience.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_entered_track'
     },
@@ -181,9 +179,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     {
       name: 'Entities Audience Exited',
       partnerAction: 'removeFromAudience',
-      mapping: {
-        ...defaultValues(removeFromAudience.fields)
-      },
+      mapping: defaultValues(removeFromAudience.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_exited_track'
     }

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/index.ts
@@ -142,10 +142,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'syncAudience',
       mapping: {
-        ...defaultValues(syncAudience.fields),
-        properties: {
-          '@path': '$.properties'
-        }
+        ...defaultValues(syncAudience.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/index.ts
@@ -1,4 +1,4 @@
-import { AudienceDestinationDefinition, IntegrationError } from '@segment/actions-core'
+import { AudienceDestinationDefinition, defaultValues, IntegrationError } from '@segment/actions-core'
 import type { Settings, AudienceSettings } from './generated-types'
 import syncAudience from './syncAudience'
 import { getCreateAudienceURL, hashAndEncodeToInt, getDataCenter, getSectionId } from './helpers'
@@ -80,11 +80,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     },
 
     async createAudience(request, createAudienceInput) {
-      const {
-        settings,
-        audienceSettings: { audience_name } = {},
-        personas
-      } = createAudienceInput
+      const { settings, audienceSettings: { audience_name } = {}, personas } = createAudienceInput
 
       if (!audience_name) {
         throw new IntegrationError('Missing Audience Name', 'MISSING_REQUIRED_FIELD', 400)
@@ -140,7 +136,21 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   },
   actions: {
     syncAudience
-  }
+  },
+  presets: [
+    {
+      name: 'Entities Audience Membership Changed',
+      partnerAction: 'syncAudience',
+      mapping: {
+        ...defaultValues(syncAudience.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_membership_changed_identify'
+    }
+  ]
 }
 
 export default destination

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/index.ts
@@ -104,9 +104,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'sync',
-      mapping: {
-        ...defaultValues(sync.fields)
-      },
+      mapping: defaultValues(sync.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
     }

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/index.ts
@@ -1,5 +1,5 @@
 import type { AudienceDestinationDefinition } from '@segment/actions-core'
-import { IntegrationError } from '@segment/actions-core'
+import { defaultValues, IntegrationError } from '@segment/actions-core'
 import type { Settings, AudienceSettings } from './generated-types'
 import { adAccountId } from './fbca-properties'
 import sync from './sync'
@@ -99,7 +99,21 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   },
   actions: {
     sync
-  }
+  },
+  presets: [
+    {
+      name: 'Entities Audience Membership Changed',
+      partnerAction: 'sync',
+      mapping: {
+        ...defaultValues(sync.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_membership_changed_identify'
+    }
+  ]
 }
 
 export default destination

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/index.ts
@@ -105,10 +105,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'sync',
       mapping: {
-        ...defaultValues(sync.fields),
-        properties: {
-          '@path': '$.properties'
-        }
+        ...defaultValues(sync.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'

--- a/packages/destination-actions/src/destinations/first-party-dv360/index.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/index.ts
@@ -1,4 +1,4 @@
-import { AudienceDestinationDefinition, IntegrationError } from '@segment/actions-core'
+import { AudienceDestinationDefinition, defaultValues, IntegrationError } from '@segment/actions-core'
 import type { AudienceSettings, Settings } from './generated-types'
 import { createAudienceRequest, getAudienceRequest, getAuthSettings, getAuthToken } from './functions'
 import removeFromAudContactInfo from './removeFromAudContactInfo'
@@ -171,7 +171,34 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     addToAudMobileDeviceId,
     removeFromAudContactInfo,
     removeFromAudMobileDeviceId
-  }
+  },
+  presets: [
+    {
+      name: 'Entities Audience Entered',
+      partnerAction: 'addToAudContactInfo',
+      mapping: {
+        ...defaultValues(addToAudContactInfo.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_entered_track'
+    },
+
+    {
+      name: 'Entities Audience Exited',
+      partnerAction: 'removeFromAudContactInfo',
+      mapping: {
+        ...defaultValues(removeFromAudContactInfo.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_exited_track'
+    }
+  ]
 }
 
 export default destination

--- a/packages/destination-actions/src/destinations/first-party-dv360/index.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/index.ts
@@ -179,7 +179,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       mapping: {
         ...defaultValues(addToAudContactInfo.fields),
         properties: {
-          '@path': '$.properties'
+          '@path': '$.context.traits'
         }
       },
       type: 'specificEvent',
@@ -192,7 +192,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       mapping: {
         ...defaultValues(removeFromAudContactInfo.fields),
         properties: {
-          '@path': '$.properties'
+          '@path': '$.context.traits'
         }
       },
       type: 'specificEvent',

--- a/packages/destination-actions/src/destinations/first-party-dv360/index.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/index.ts
@@ -176,9 +176,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     {
       name: 'Entities Audience Entered',
       partnerAction: 'addToAudContactInfo',
-      mapping: {
-        ...defaultValues(addToAudContactInfo.fields)
-      },
+      mapping: defaultValues(addToAudContactInfo.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_entered_track'
     },
@@ -186,9 +184,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     {
       name: 'Entities Audience Exited',
       partnerAction: 'removeFromAudContactInfo',
-      mapping: {
-        ...defaultValues(removeFromAudContactInfo.fields)
-      },
+      mapping: defaultValues(removeFromAudContactInfo.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_exited_track'
     }

--- a/packages/destination-actions/src/destinations/first-party-dv360/index.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/index.ts
@@ -177,10 +177,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       name: 'Entities Audience Entered',
       partnerAction: 'addToAudContactInfo',
       mapping: {
-        ...defaultValues(addToAudContactInfo.fields),
-        properties: {
-          '@path': '$.context.traits'
-        }
+        ...defaultValues(addToAudContactInfo.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_entered_track'
@@ -190,10 +187,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       name: 'Entities Audience Exited',
       partnerAction: 'removeFromAudContactInfo',
       mapping: {
-        ...defaultValues(removeFromAudContactInfo.fields),
-        properties: {
-          '@path': '$.context.traits'
-        }
+        ...defaultValues(removeFromAudContactInfo.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_exited_track'

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -178,10 +178,9 @@ const destination: AudienceDestinationDefinition<Settings> = {
   presets: [
     {
       name: 'Entities Audience Membership Changed',
-      partnerAction: 'uploadConversionAdjustment',
+      partnerAction: 'userList',
       mapping: {
-        // TODO: See if we use the original or the v2 action
-        ...defaultValues(uploadConversionAdjustment.fields),
+        ...defaultValues(userList.fields),
         properties: {
           '@path': '$.properties'
         }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -1,4 +1,4 @@
-import { AudienceDestinationDefinition } from '@segment/actions-core'
+import { AudienceDestinationDefinition, defaultValues } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import postConversion from './postConversion'
 import uploadCallConversion from './uploadCallConversion'
@@ -174,7 +174,22 @@ const destination: AudienceDestinationDefinition<Settings> = {
     uploadClickConversion2,
     uploadCallConversion2,
     userList
-  }
+  },
+  presets: [
+    {
+      name: 'Entities Audience Membership Changed',
+      partnerAction: 'uploadConversionAdjustment',
+      mapping: {
+        // TODO: See if we use the original or the v2 action
+        ...defaultValues(uploadConversionAdjustment.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_membership_changed_identify'
+    }
+  ]
 }
 
 export default destination

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -179,9 +179,7 @@ const destination: AudienceDestinationDefinition<Settings> = {
     {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'userList',
-      mapping: {
-        ...defaultValues(userList.fields)
-      },
+      mapping: defaultValues(userList.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
     }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -180,10 +180,7 @@ const destination: AudienceDestinationDefinition<Settings> = {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'userList',
       mapping: {
-        ...defaultValues(userList.fields),
-        properties: {
-          '@path': '$.properties'
-        }
+        ...defaultValues(userList.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'

--- a/packages/destination-actions/src/destinations/iterable-lists/index.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/index.ts
@@ -92,9 +92,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'syncAudience',
-      mapping: {
-        ...defaultValues(syncAudience.fields)
-      },
+      mapping: defaultValues(syncAudience.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
     }

--- a/packages/destination-actions/src/destinations/iterable-lists/index.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/index.ts
@@ -1,4 +1,4 @@
-import { IntegrationError, AudienceDestinationDefinition, RequestClient } from '@segment/actions-core'
+import { IntegrationError, AudienceDestinationDefinition, RequestClient, defaultValues } from '@segment/actions-core'
 import type { AudienceSettings, Settings } from './generated-types'
 
 import syncAudience from './syncAudience'
@@ -87,7 +87,21 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
 
   actions: {
     syncAudience
-  }
+  },
+  presets: [
+    {
+      name: 'Entities Audience Membership Changed',
+      partnerAction: 'syncAudience',
+      mapping: {
+        ...defaultValues(syncAudience.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_membership_changed_identify'
+    }
+  ]
 }
 
 async function getAudience(

--- a/packages/destination-actions/src/destinations/iterable-lists/index.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/index.ts
@@ -93,10 +93,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'syncAudience',
       mapping: {
-        ...defaultValues(syncAudience.fields),
-        properties: {
-          '@path': '$.properties'
-        }
+        ...defaultValues(syncAudience.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'

--- a/packages/destination-actions/src/destinations/iterable/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/index.ts
@@ -93,10 +93,7 @@ const destination: DestinationDefinition<Settings> = {
       name: 'Associated Entity Added',
       partnerAction: 'trackEvent',
       mapping: {
-        ...defaultValues(trackEvent.fields),
-        dataFields: {
-          '@path': '$.properties'
-        }
+        ...defaultValues(trackEvent.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_entity_added_track'

--- a/packages/destination-actions/src/destinations/klaviyo/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/index.ts
@@ -2,7 +2,8 @@ import {
   IntegrationError,
   AudienceDestinationDefinition,
   PayloadValidationError,
-  APIError
+  APIError,
+  defaultValues
 } from '@segment/actions-core'
 import type { Settings, AudienceSettings } from './generated-types'
 
@@ -146,7 +147,33 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     subscribeProfile,
     unsubscribeProfile,
     removeProfile
-  }
+  },
+  presets: [
+    {
+      name: 'Entities Audience Entered',
+      partnerAction: 'upsertProfile',
+      mapping: {
+        ...defaultValues(upsertProfile.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_entered_track'
+    },
+    {
+      name: 'Entities Audience Exited',
+      partnerAction: 'removeProfile',
+      mapping: {
+        ...defaultValues(removeProfile.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_exited_track'
+    }
+  ]
 }
 
 export default destination

--- a/packages/destination-actions/src/destinations/klaviyo/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/index.ts
@@ -153,10 +153,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       name: 'Entities Audience Entered',
       partnerAction: 'upsertProfile',
       mapping: {
-        ...defaultValues(upsertProfile.fields),
-        properties: {
-          '@path': '$.properties'
-        }
+        ...defaultValues(upsertProfile.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_entered_track'

--- a/packages/destination-actions/src/destinations/klaviyo/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/index.ts
@@ -152,9 +152,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     {
       name: 'Entities Audience Entered',
       partnerAction: 'upsertProfile',
-      mapping: {
-        ...defaultValues(upsertProfile.fields)
-      },
+      mapping: defaultValues(upsertProfile.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_entered_track'
     },

--- a/packages/destination-actions/src/destinations/klaviyo/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/index.ts
@@ -159,12 +159,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     {
       name: 'Entities Audience Exited',
       partnerAction: 'removeProfile',
-      mapping: {
-        ...defaultValues(removeProfile.fields),
-        properties: {
-          '@path': '$.properties'
-        }
-      },
+      mapping: defaultValues(removeProfile.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_exited_track'
     }

--- a/packages/destination-actions/src/destinations/marketo-static-lists/index.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/index.ts
@@ -1,5 +1,5 @@
 import type { AudienceDestinationDefinition } from '@segment/actions-core'
-import { IntegrationError } from '@segment/actions-core'
+import { defaultValues, IntegrationError } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
 import addToList from './addToList'
@@ -97,7 +97,34 @@ const destination: AudienceDestinationDefinition<Settings> = {
   actions: {
     addToList,
     removeFromList
-  }
+  },
+  presets: [
+    {
+      name: 'Entities Audience Entered',
+      partnerAction: 'addToList',
+      mapping: {
+        ...defaultValues(addToList.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_entered_track'
+    },
+
+    {
+      name: 'Entities Audience Exited',
+      partnerAction: 'removeFromList',
+      mapping: {
+        ...defaultValues(removeFromList.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_exited_track'
+    }
+  ]
 }
 
 export default destination

--- a/packages/destination-actions/src/destinations/marketo-static-lists/index.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/index.ts
@@ -102,12 +102,7 @@ const destination: AudienceDestinationDefinition<Settings> = {
     {
       name: 'Entities Audience Entered',
       partnerAction: 'addToList',
-      mapping: {
-        ...defaultValues(addToList.fields),
-        properties: {
-          '@path': '$.properties'
-        }
-      },
+      mapping: { ...defaultValues(addToList.fields) },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_entered_track'
     },

--- a/packages/destination-actions/src/destinations/marketo-static-lists/index.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/index.ts
@@ -110,12 +110,7 @@ const destination: AudienceDestinationDefinition<Settings> = {
     {
       name: 'Entities Audience Exited',
       partnerAction: 'removeFromList',
-      mapping: {
-        ...defaultValues(removeFromList.fields),
-        properties: {
-          '@path': '$.properties'
-        }
-      },
+      mapping: defaultValues(removeFromList.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_exited_track'
     }

--- a/packages/destination-actions/src/destinations/reddit-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/reddit-audiences/index.ts
@@ -90,9 +90,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'syncAudience',
-      mapping: {
-        ...defaultValues(syncAudience.fields)
-      },
+      mapping: defaultValues(syncAudience.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
     }

--- a/packages/destination-actions/src/destinations/reddit-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/reddit-audiences/index.ts
@@ -91,10 +91,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'syncAudience',
       mapping: {
-        ...defaultValues(syncAudience.fields),
-        properties: {
-          '@path': '$.properties'
-        }
+        ...defaultValues(syncAudience.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'

--- a/packages/destination-actions/src/destinations/reddit-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/reddit-audiences/index.ts
@@ -1,4 +1,4 @@
-import type { AudienceDestinationDefinition } from '@segment/actions-core'
+import { defaultValues, AudienceDestinationDefinition } from '@segment/actions-core'
 import type { Settings, AudienceSettings } from './generated-types'
 import syncAudience from './syncAudience'
 import { CreateAudienceReq, CreateAudienceResp } from './types'
@@ -82,9 +82,24 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       }
     }
   },
+
   actions: {
     syncAudience
-  }
+  },
+  presets: [
+    {
+      name: 'Entities Audience Membership Changed',
+      partnerAction: 'syncAudience',
+      mapping: {
+        ...defaultValues(syncAudience.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_membership_changed_identify'
+    }
+  ]
 }
 
 export default destination

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/index.ts
@@ -87,9 +87,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'syncAudience',
-      mapping: {
-        ...defaultValues(syncAudience.fields)
-      },
+      mapping: defaultValues(syncAudience.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
     }

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/index.ts
@@ -1,4 +1,4 @@
-import { AudienceDestinationDefinition, RequestClient, IntegrationError } from '@segment/actions-core'
+import { AudienceDestinationDefinition, RequestClient, IntegrationError, defaultValues } from '@segment/actions-core'
 import type { Settings, AudienceSettings } from './generated-types'
 import syncAudience from './syncAudience'
 import { GET_LIST_URL, CREATE_LIST_URL } from './constants'
@@ -79,9 +79,24 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       }
     }
   },
+
   actions: {
     syncAudience
-  }
+  },
+  presets: [
+    {
+      name: 'Entities Audience Membership Changed',
+      partnerAction: 'syncAudience',
+      mapping: {
+        ...defaultValues(syncAudience.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_membership_changed_identify'
+    }
+  ]
 }
 
 export async function getAudienceIdByName(request: RequestClient, name: string): Promise<string | undefined> {

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/index.ts
@@ -88,10 +88,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'syncAudience',
       mapping: {
-        ...defaultValues(syncAudience.fields),
-        properties: {
-          '@path': '$.properties'
-        }
+        ...defaultValues(syncAudience.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'

--- a/packages/destination-actions/src/destinations/snap-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/snap-audiences/index.ts
@@ -68,10 +68,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'syncAudience',
       mapping: {
-        ...defaultValues(syncAudience.fields),
-        properties: {
-          '@path': '$.properties'
-        }
+        ...defaultValues(syncAudience.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'

--- a/packages/destination-actions/src/destinations/snap-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/snap-audiences/index.ts
@@ -67,9 +67,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'syncAudience',
-      mapping: {
-        ...defaultValues(syncAudience.fields)
-      },
+      mapping: defaultValues(syncAudience.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
     },

--- a/packages/destination-actions/src/destinations/snap-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/snap-audiences/index.ts
@@ -59,7 +59,23 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       }
     }
   },
+
+  actions: {
+    syncAudience
+  },
   presets: [
+    {
+      name: 'Entities Audience Membership Changed',
+      partnerAction: 'syncAudience',
+      mapping: {
+        ...defaultValues(syncAudience.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_membership_changed_identify'
+    },
     {
       name: 'Sync Audience with Email',
       subscribe: 'type = "track" and context.traits.email exists',
@@ -151,9 +167,6 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
 
       return { externalId: snapAudienceId }
     }
-  },
-  actions: {
-    syncAudience
   }
 }
 

--- a/packages/destination-actions/src/destinations/taboola-actions/index.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/index.ts
@@ -150,10 +150,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'syncAudience',
       mapping: {
-        ...defaultValues(syncAudience.fields),
-        properties: {
-          '@path': '$.properties'
-        }
+        ...defaultValues(syncAudience.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'

--- a/packages/destination-actions/src/destinations/taboola-actions/index.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/index.ts
@@ -1,6 +1,6 @@
 import type { AudienceDestinationDefinition } from '@segment/actions-core'
 import type { Settings, AudienceSettings } from './generated-types'
-import { IntegrationError } from '@segment/actions-core'
+import { defaultValues, IntegrationError } from '@segment/actions-core'
 import { TaboolaClient } from './syncAudience/client'
 
 import syncAudience from './syncAudience'
@@ -30,8 +30,8 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         description: 'The audience identifier from your Taboola account.',
         type: 'string',
         choices: [
-          {label: 'Audience Computation Key', value: 'computation_key'},
-          {label: 'Audience Name', value: 'audience_name'}
+          { label: 'Audience Computation Key', value: 'computation_key' },
+          { label: 'Audience Name', value: 'audience_name' }
         ],
         required: false,
         default: 'computation_key'
@@ -77,7 +77,10 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       full_audience_sync: false
     },
     async createAudience(request, createAudienceInput) {
-      const audienceName = createAudienceInput.settings?.audience_identifier === 'computation_key' ? createAudienceInput.personas?.computation_key : createAudienceInput.audienceName
+      const audienceName =
+        createAudienceInput.settings?.audience_identifier === 'computation_key'
+          ? createAudienceInput.personas?.computation_key
+          : createAudienceInput.audienceName
       const ttlInHours = createAudienceInput.audienceSettings?.ttl_in_hours
       const excludeFromCampaigns = createAudienceInput.audienceSettings?.exclude_from_campaigns
       const accountId = createAudienceInput.audienceSettings?.account_id
@@ -141,7 +144,21 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   },
   actions: {
     syncAudience
-  }
+  },
+  presets: [
+    {
+      name: 'Entities Audience Membership Changed',
+      partnerAction: 'syncAudience',
+      mapping: {
+        ...defaultValues(syncAudience.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_membership_changed_identify'
+    }
+  ]
 }
 
 export default destination

--- a/packages/destination-actions/src/destinations/taboola-actions/index.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/index.ts
@@ -149,9 +149,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'syncAudience',
-      mapping: {
-        ...defaultValues(syncAudience.fields)
-      },
+      mapping: defaultValues(syncAudience.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
     }

--- a/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
@@ -167,10 +167,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       name: 'Entities Audience Entered',
       partnerAction: 'addToAudience',
       mapping: {
-        ...defaultValues(addToAudience.fields),
-        properties: {
-          '@path': '$.properties'
-        }
+        ...defaultValues(addToAudience.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_entered_track'
@@ -179,10 +176,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       name: 'Entities Audience Exited',
       partnerAction: 'removeFromAudience',
       mapping: {
-        ...defaultValues(removeFromAudience.fields),
-        properties: {
-          '@path': '$.properties'
-        }
+        ...defaultValues(removeFromAudience.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_exited_track'

--- a/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
@@ -166,18 +166,14 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     {
       name: 'Entities Audience Entered',
       partnerAction: 'addToAudience',
-      mapping: {
-        ...defaultValues(addToAudience.fields)
-      },
+      mapping: defaultValues(addToAudience.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_entered_track'
     },
     {
       name: 'Entities Audience Exited',
       partnerAction: 'removeFromAudience',
-      mapping: {
-        ...defaultValues(removeFromAudience.fields)
-      },
+      mapping: defaultValues(removeFromAudience.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_exited_track'
     }

--- a/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
@@ -1,5 +1,5 @@
 import type { AudienceDestinationDefinition } from '@segment/actions-core'
-import { IntegrationError, InvalidAuthenticationError } from '@segment/actions-core'
+import { defaultValues, IntegrationError, InvalidAuthenticationError } from '@segment/actions-core'
 import type { Settings, AudienceSettings } from './generated-types'
 import addUser from './addUser'
 import removeUser from './removeUser'
@@ -161,7 +161,33 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     addUser,
     removeUser,
     createAudience
-  }
+  },
+  presets: [
+    {
+      name: 'Entities Audience Entered',
+      partnerAction: 'addToAudience',
+      mapping: {
+        ...defaultValues(addToAudience.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_entered_track'
+    },
+    {
+      name: 'Entities Audience Exited',
+      partnerAction: 'removeFromAudience',
+      mapping: {
+        ...defaultValues(removeFromAudience.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_exited_track'
+    }
+  ]
 }
 
 export default destination

--- a/packages/destination-actions/src/destinations/webhook-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/webhook-audiences/index.ts
@@ -2,7 +2,7 @@ import type { ActionDefinition, AudienceDestinationDefinition } from '@segment/a
 import type { Settings, AudienceSettings } from './generated-types'
 
 import send from '../webhook/send'
-import { IntegrationError } from '@segment/actions-core'
+import { defaultValues, IntegrationError } from '@segment/actions-core'
 import { createHmac } from 'crypto'
 import { Payload } from './send.types'
 const externalIdKey = 'externalId'
@@ -159,7 +159,21 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         })
       }
     } as ActionDefinition<Settings, Payload>
-  }
+  },
+  presets: [
+    {
+      name: 'Entities Audience Membership Changed',
+      partnerAction: 'send',
+      mapping: {
+        ...defaultValues(send.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_membership_changed_identify'
+    }
+  ]
 }
 
 const parseExtraSettingsJson = (extraSettingsJson?: string): object => {

--- a/packages/destination-actions/src/destinations/webhook-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/webhook-audiences/index.ts
@@ -165,10 +165,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'send',
       mapping: {
-        ...defaultValues(send.fields),
-        properties: {
-          '@path': '$.properties'
-        }
+        ...defaultValues(send.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'

--- a/packages/destination-actions/src/destinations/webhook-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/webhook-audiences/index.ts
@@ -164,9 +164,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'send',
-      mapping: {
-        ...defaultValues(send.fields)
-      },
+      mapping: defaultValues(send.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
     }

--- a/packages/destination-actions/src/destinations/yahoo-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/index.ts
@@ -1,5 +1,5 @@
 import type { AudienceDestinationDefinition, ModifiedResponse } from '@segment/actions-core'
-import { IntegrationError } from '@segment/actions-core'
+import { defaultValues, IntegrationError } from '@segment/actions-core'
 import type { Settings, AudienceSettings } from './generated-types'
 import { generate_jwt } from './utils-rt'
 import updateSegment from './updateSegment'
@@ -168,6 +168,20 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
 
   actions: {
     updateSegment
-  }
+  },
+  presets: [
+    {
+      name: 'Entities Audience Membership Changed',
+      partnerAction: 'updateSegment',
+      mapping: {
+        ...defaultValues(updateSegment.fields),
+        properties: {
+          '@path': '$.properties'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_membership_changed_identify'
+    }
+  ]
 }
 export default destination

--- a/packages/destination-actions/src/destinations/yahoo-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/index.ts
@@ -173,9 +173,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'updateSegment',
-      mapping: {
-        ...defaultValues(updateSegment.fields)
-      },
+      mapping: defaultValues(updateSegment.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
     }

--- a/packages/destination-actions/src/destinations/yahoo-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/index.ts
@@ -174,10 +174,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       name: 'Entities Audience Membership Changed',
       partnerAction: 'updateSegment',
       mapping: {
-        ...defaultValues(updateSegment.fields),
-        properties: {
-          '@path': '$.properties'
-        }
+        ...defaultValues(updateSegment.fields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR adds presets (of the `specificEvent` kind) for each of the standard (not full sync) _audience_ action destinations in our catalog. These presets will be used in filtering out actions which are extraneous to event emitter creation, leaving only the ones used for syncing profiles.


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
