### PR TITLE
Increasing timeout for Google Campaign Manager 360 (https://github.com/segmentio/eks-configuration/pull/7957 follow-up)

### DIFF
--- a/packages/destination-actions/src/destinations/google-campaign-manager-360/index.ts
+++ b/packages/destination-actions/src/destinations/google-campaign-manager-360/index.ts
@@ -1,4 +1,5 @@
 import type { DestinationDefinition } from '@segment/actions-core'
+import { DEFAULT_REQUEST_TIMEOUT } from '@segment/actions-core/*'
 import type { Settings } from './generated-types'
 
 import conversionUpload from './conversionUpload'
@@ -57,7 +58,8 @@ const destination: DestinationDefinition<Settings> = {
     return {
       headers: {
         authorization: `Bearer ${auth?.accessToken}`
-      }
+      },
+      timeout: Math.max(30_000, DEFAULT_REQUEST_TIMEOUT)
     }
   },
 


### PR DESCRIPTION
Increasing timeout for Google Campaign Manager 360 (https://github.com/segmentio/eks-configuration/pull/7957 follow-up)

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
