### PR TITLE
Increasing timeout for Criteo Audiences (https://github.com/segmentio/eks-configuration/pull/7957 follow-up)

### DIFF
--- a/packages/destination-actions/src/destinations/criteo-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/criteo-audiences/index.ts
@@ -1,4 +1,6 @@
 import type { DestinationDefinition } from '@segment/actions-core'
+import { DEFAULT_REQUEST_TIMEOUT } from '@segment/actions-core/*'
+
 import type { Settings } from './generated-types'
 import addUserToAudience from './addUserToAudience'
 import removeUserFromAudience from './removeUserFromAudience'
@@ -38,6 +40,11 @@ const destination: DestinationDefinition<Settings> = {
         client_secret: settings.client_secret
       })
       return credentials.access_token
+    }
+  },
+  extendRequest() {
+    return {
+      timeout: Math.max(30_000, DEFAULT_REQUEST_TIMEOUT)
     }
   },
   actions: {


### PR DESCRIPTION
Increasing timeout for Criteo Audiences (https://github.com/segmentio/eks-configuration/pull/7957 follow-up)

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
