### PR TITLE
fix: sanitised vwo pageview event name

### DIFF
--- a/packages/destination-actions/src/destinations/vwo/pageVisit/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/vwo/pageVisit/__tests__/index.test.ts
@@ -7,7 +7,7 @@ const testDestination = createTestIntegration(Destination)
 const BASE_ENDPOINT = 'https://dev.visualwebsiteoptimizer.com'
 const VWO_ACCOUNT_ID = 654331
 const VWO_UUID = 'ABC123'
-const EVENT_NAME = 'vwo_pageView'
+const EVENT_NAME = 'segment.pageView'
 const SDK_KEY = 'sample-api-key'
 const SANITISED_USERID = '57CC1A3D57215E67824E461010E43F53'
 

--- a/packages/destination-actions/src/destinations/vwo/pageVisit/index.ts
+++ b/packages/destination-actions/src/destinations/vwo/pageVisit/index.ts
@@ -1,7 +1,7 @@
 import { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import {formatPayload, hosts} from '../utility'
+import { formatPayload, hosts, sanitiseEventName } from '../utility'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Page Visit',
@@ -64,7 +64,7 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   defaultSubscription: 'type = "page"',
   perform: (request, { settings, payload }) => {
-    const eventName = 'vwo_pageView'
+    const eventName = sanitiseEventName('pageView')
     const { headers, structuredPayload } = formatPayload(
       eventName,
       payload,
@@ -74,7 +74,7 @@ const action: ActionDefinition<Settings, Payload> = {
       settings.vwoAccountId
     )
     structuredPayload.d.event.props['url'] = payload.url
-    const region = settings.region || "US"
+    const region = settings.region || 'US'
     const host = hosts[region]
     const endpoint = `${host}/events/t?en=${eventName}&a=${settings.vwoAccountId}`
     return request(endpoint, {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

We have replaced the VWO standard pageview event with a custom event for third-party pageviews as part of internal system improvements. Backward compatibility has been ensured on our end.

## Testing

- [X] Updated [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)