### PR TITLE
Simplifies type generation for hooks

### DIFF
--- a/packages/cli/src/commands/generate/types.ts
+++ b/packages/cli/src/commands/generate/types.ts
@@ -142,8 +142,7 @@ export default class GenerateTypes extends Command {
 
       if (action.hooks) {
         const hooks: ActionHookDefinition<any, any, any, any, any> = action.hooks
-        let hookBundle = ''
-        const hookFields: Record<string, any> = {}
+
         for (const [hookName, hook] of Object.entries(hooks)) {
           if (!hookTypeStrings.includes(hookName as ActionHookType)) {
             throw new Error(`Hook name ${hookName} is not a valid ActionHookType`)
@@ -155,30 +154,16 @@ export default class GenerateTypes extends Command {
             continue
           }
 
-          const hookSchema = {
-            type: 'object',
-            required: true,
-            properties: {
-              inputs: {
-                label: `${hookName} hook inputs`,
-                type: 'object',
-                properties: inputs
-              },
-              outputs: {
-                label: `${hookName} hook outputs`,
-                type: 'object',
-                properties: outputs
-              }
-            }
+          if (inputs) {
+            const inputTypes = await generateTypes(inputs, `${hookName}Inputs`)
+            types += inputTypes
           }
-          hookFields[hookName] = hookSchema
+
+          if (outputs) {
+            const outputTypes = await generateTypes(outputs, `${hookName}Outputs`)
+            types += outputTypes
+          }
         }
-        hookBundle = await generateTypes(
-          hookFields,
-          'HookBundle',
-          `// Generated bundle for hooks. DO NOT MODIFY IT BY HAND.`
-        )
-        types += hookBundle
       }
 
       if (fs.pathExistsSync(path.join(parentDir, `${slug}`))) {

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -73,13 +73,6 @@ export interface BaseActionDefinition {
 type HookValueTypes = string | boolean | number | Array<string | boolean | number>
 type GenericActionHookValues = Record<string, HookValueTypes>
 
-type GenericActionHookBundle = {
-  [K in ActionHookType]?: {
-    inputs?: GenericActionHookValues
-    outputs?: GenericActionHookValues
-  }
-}
-
 // Utility type to check if T is an array
 type IsArray<T> = T extends (infer U)[] ? U : never
 
@@ -94,7 +87,9 @@ export interface ActionDefinition<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   AudienceSettings = any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  GeneratedActionHookBundle extends GenericActionHookBundle = any
+  GeneratedActionHookInputs = any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  GeneratedActionHookOutputs = any
 > extends BaseActionDefinition {
   /**
    * A way to "register" dynamic fields.
@@ -139,8 +134,8 @@ export interface ActionDefinition<
       Settings,
       Payload,
       AudienceSettings,
-      NonNullable<GeneratedActionHookBundle[K]>['outputs'],
-      NonNullable<GeneratedActionHookBundle[K]>['inputs']
+      NonNullable<GeneratedActionHookInputs>,
+      NonNullable<GeneratedActionHookOutputs>
     >
   }
 
@@ -170,8 +165,8 @@ export interface ActionHookDefinition<
   Settings,
   Payload,
   AudienceSettings,
-  GeneratedActionHookOutputs,
-  GeneratedActionHookTypesInputs
+  GeneratedActionHookTypesInputs,
+  GeneratedActionHookOutputs
 > {
   /** The display title for this hook. */
   label: string

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/generated-types.ts
@@ -70,33 +70,31 @@ export interface Payload {
    */
   batch_size: number
 }
-// Generated bundle for hooks. DO NOT MODIFY IT BY HAND.
+// Generated file. DO NOT MODIFY IT BY HAND.
 
-export interface HookBundle {
-  retlOnMappingSave: {
-    inputs?: {
-      /**
-       * Choose to either create a new custom audience or use an existing one. If you opt to create a new audience, we will display the required fields for audience creation. If you opt to use an existing audience, a drop-down menu will appear, allowing you to select from all the custom audiences in your ad account.
-       */
-      operation?: string
-      /**
-       * The name of the audience in Facebook.
-       */
-      audienceName?: string
-      /**
-       * The ID of the audience in Facebook.
-       */
-      existingAudienceId?: string
-    }
-    outputs?: {
-      /**
-       * The name of the audience in Facebook this mapping is connected to.
-       */
-      audienceName: string
-      /**
-       * The ID of the audience in Facebook.
-       */
-      audienceId: string
-    }
-  }
+export interface RetlOnMappingSaveInputs {
+  /**
+   * Choose to either create a new custom audience or use an existing one. If you opt to create a new audience, we will display the required fields for audience creation. If you opt to use an existing audience, a drop-down menu will appear, allowing you to select from all the custom audiences in your ad account.
+   */
+  operation?: string
+  /**
+   * The name of the audience in Facebook.
+   */
+  audienceName?: string
+  /**
+   * The ID of the audience in Facebook.
+   */
+  existingAudienceId?: string
+}
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface RetlOnMappingSaveOutputs {
+  /**
+   * The name of the audience in Facebook this mapping is connected to.
+   */
+  audienceName: string
+  /**
+   * The ID of the audience in Facebook.
+   */
+  audienceId: string
 }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/generated-types.ts
@@ -62,41 +62,39 @@ export interface Payload {
    */
   event_name?: string
 }
-// Generated bundle for hooks. DO NOT MODIFY IT BY HAND.
+// Generated file. DO NOT MODIFY IT BY HAND.
 
-export interface HookBundle {
-  retlOnMappingSave: {
-    inputs?: {
-      /**
-       * The ID of an existing Google list that you would like to sync users to. If you provide this, we will not create a new list.
-       */
-      list_id?: string
-      /**
-       * The name of the Google list that you would like to create.
-       */
-      list_name?: string
-      /**
-       * Customer match upload key types.
-       */
-      external_id_type: string
-      /**
-       * A string that uniquely identifies a mobile application from which the data was collected. Required if external ID type is mobile advertising ID
-       */
-      app_id?: string
-    }
-    outputs?: {
-      /**
-       * The ID of the Google Customer Match User list that users will be synced to.
-       */
-      id?: string
-      /**
-       * The name of the Google Customer Match User list that users will be synced to.
-       */
-      name?: string
-      /**
-       * Customer match upload key types.
-       */
-      external_id_type?: string
-    }
-  }
+export interface RetlOnMappingSaveInputs {
+  /**
+   * The ID of an existing Google list that you would like to sync users to. If you provide this, we will not create a new list.
+   */
+  list_id?: string
+  /**
+   * The name of the Google list that you would like to create.
+   */
+  list_name?: string
+  /**
+   * Customer match upload key types.
+   */
+  external_id_type: string
+  /**
+   * A string that uniquely identifies a mobile application from which the data was collected. Required if external ID type is mobile advertising ID
+   */
+  app_id?: string
+}
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface RetlOnMappingSaveOutputs {
+  /**
+   * The ID of the Google Customer Match User list that users will be synced to.
+   */
+  id?: string
+  /**
+   * The name of the Google Customer Match User list that users will be synced to.
+   */
+  name?: string
+  /**
+   * Customer match upload key types.
+   */
+  external_id_type?: string
 }

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/generated-types.ts
@@ -73,29 +73,27 @@ export interface Payload {
    */
   override_list_id?: string
 }
-// Generated bundle for hooks. DO NOT MODIFY IT BY HAND.
+// Generated file. DO NOT MODIFY IT BY HAND.
 
-export interface HookBundle {
-  retlOnMappingSave: {
-    inputs?: {
-      /**
-       * The ID of the list in Klaviyo that users will be synced to. If defined, we will not create a new list.
-       */
-      list_identifier?: string
-      /**
-       * The name of the list that you would like to create in Klaviyo.
-       */
-      list_name?: string
-    }
-    outputs?: {
-      /**
-       * The ID of the created Klaviyo list that users will be synced to.
-       */
-      id?: string
-      /**
-       * The name of the created Klaviyo list that users will be synced to.
-       */
-      name?: string
-    }
-  }
+export interface RetlOnMappingSaveInputs {
+  /**
+   * The ID of the list in Klaviyo that users will be synced to. If defined, we will not create a new list.
+   */
+  list_identifier?: string
+  /**
+   * The name of the list that you would like to create in Klaviyo.
+   */
+  list_name?: string
+}
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface RetlOnMappingSaveOutputs {
+  /**
+   * The ID of the created Klaviyo list that users will be synced to.
+   */
+  id?: string
+  /**
+   * The name of the created Klaviyo list that users will be synced to.
+   */
+  name?: string
 }

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/api.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/api.test.ts
@@ -2,7 +2,7 @@ import nock from 'nock'
 import createRequestClient from '../../../../../core/src/create-request-client'
 import { LinkedInConversions } from '../api'
 import { BASE_URL } from '../constants'
-import { HookBundle } from '../streamConversion/generated-types'
+import { OnMappingSaveInputs, OnMappingSaveOutputs } from '../streamConversion/generated-types'
 
 const requestClient = createRequestClient()
 
@@ -10,7 +10,7 @@ describe('LinkedIn Conversions', () => {
   describe('conversionRule methods', () => {
     const linkedIn: LinkedInConversions = new LinkedInConversions(requestClient)
     const adAccountId = 'urn:li:sponsoredAccount:123456'
-    const hookInputs: HookBundle['onMappingSave']['inputs'] = {
+    const hookInputs: OnMappingSaveInputs = {
       adAccountId,
       name: 'A different name that should trigger an update',
       conversionType: 'PURCHASE',
@@ -19,7 +19,7 @@ describe('LinkedIn Conversions', () => {
       view_through_attribution_window_size: 7
     }
 
-    const hookOutputs: HookBundle['onMappingSave']['outputs'] = {
+    const hookOutputs: OnMappingSaveOutputs = {
       id: '56789',
       name: 'The original name',
       conversionType: 'LEAD',

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -18,7 +18,7 @@ import type {
   GetConversionRuleResponse,
   ConversionRuleUpdateResponse
 } from '../types'
-import type { Payload, HookBundle } from '../streamConversion/generated-types'
+import type { Payload, OnMappingSaveInputs, OnMappingSaveOutputs } from '../streamConversion/generated-types'
 import { createHash } from 'crypto'
 
 interface ConversionRuleUpdateValues {
@@ -84,7 +84,7 @@ export class LinkedInConversions {
   getConversionRule = async (
     adAccount: string,
     conversionRuleId: string
-  ): Promise<ActionHookResponse<HookBundle['onMappingSave']['outputs']>> => {
+  ): Promise<ActionHookResponse<OnMappingSaveOutputs>> => {
     try {
       const { data } = await this.request<GetConversionRuleResponse>(`${BASE_URL}/conversions/${conversionRuleId}`, {
         method: 'get',
@@ -116,8 +116,8 @@ export class LinkedInConversions {
   }
 
   createConversionRule = async (
-    hookInputs: HookBundle['onMappingSave']['inputs']
-  ): Promise<ActionHookResponse<HookBundle['onMappingSave']['outputs']>> => {
+    hookInputs: OnMappingSaveInputs | undefined
+  ): Promise<ActionHookResponse<OnMappingSaveOutputs>> => {
     if (!hookInputs?.adAccountId) {
       return {
         error: {
@@ -169,9 +169,9 @@ export class LinkedInConversions {
   }
 
   updateConversionRule = async (
-    hookInputs: HookBundle['onMappingSave']['inputs'],
-    hookOutputs: HookBundle['onMappingSave']['outputs']
-  ): Promise<ActionHookResponse<HookBundle['onMappingSave']['outputs']>> => {
+    hookInputs: OnMappingSaveInputs | undefined,
+    hookOutputs: OnMappingSaveOutputs
+  ): Promise<ActionHookResponse<OnMappingSaveOutputs>> => {
     if (!hookOutputs) {
       return {
         error: {
@@ -576,8 +576,8 @@ export class LinkedInConversions {
   }
 
   private conversionRuleValuesUpdated = (
-    hookInputs: HookBundle['onMappingSave']['inputs'],
-    hookOutputs: Partial<HookBundle['onMappingSave']['outputs']>
+    hookInputs: OnMappingSaveInputs,
+    hookOutputs: Partial<OnMappingSaveOutputs>
   ): ConversionRuleUpdateValues => {
     const valuesChanged: ConversionRuleUpdateValues = {}
 

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/generated-types.ts
@@ -57,69 +57,67 @@ export interface Payload {
    */
   batch_size?: number
 }
-// Generated bundle for hooks. DO NOT MODIFY IT BY HAND.
+// Generated file. DO NOT MODIFY IT BY HAND.
 
-export interface HookBundle {
-  onMappingSave: {
-    inputs?: {
-      /**
-       * The ad account to use when creating the conversion event. (When updating a conversion rule after initially creating it, changes to this field will be ignored. LinkedIn does not allow Ad Account IDs to be updated for a conversion rule.)
-       */
-      adAccountId: string
-      /**
-       * Select one or more advertising campaigns from your ad account to associate with the configured conversion rule. Segment will only add the selected campaigns to the conversion rule. Deselecting a campaign will not disassociate it from the conversion rule.
-       */
-      campaignId?: string[]
-      /**
-       * The ID of an existing conversion rule to stream events to. If defined, we will not create a new conversion rule.
-       */
-      conversionRuleId?: string
-      /**
-       * The name of the conversion rule.
-       */
-      name?: string
-      /**
-       * The type of conversion rule.
-       */
-      conversionType?: string
-      /**
-       * The attribution type for the conversion rule.
-       */
-      attribution_type?: string
-      /**
-       * Conversion window timeframe (in days) of a member clicking on a LinkedIn Ad (a post-click conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 30.
-       */
-      post_click_attribution_window_size?: number
-      /**
-       * Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 7.
-       */
-      view_through_attribution_window_size?: number
-    }
-    outputs?: {
-      /**
-       * The ID of the conversion rule.
-       */
-      id: string
-      /**
-       * The name of the conversion rule.
-       */
-      name: string
-      /**
-       * The type of conversion rule.
-       */
-      conversionType: string
-      /**
-       * The attribution type for the conversion rule.
-       */
-      attribution_type: string
-      /**
-       * Conversion window timeframe (in days) of a member clicking on a LinkedIn Ad (a post-click conversion) within which conversions will be attributed to a LinkedIn ad.
-       */
-      post_click_attribution_window_size: number
-      /**
-       * Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 7.
-       */
-      view_through_attribution_window_size: number
-    }
-  }
+export interface OnMappingSaveInputs {
+  /**
+   * The ad account to use when creating the conversion event. (When updating a conversion rule after initially creating it, changes to this field will be ignored. LinkedIn does not allow Ad Account IDs to be updated for a conversion rule.)
+   */
+  adAccountId: string
+  /**
+   * Select one or more advertising campaigns from your ad account to associate with the configured conversion rule. Segment will only add the selected campaigns to the conversion rule. Deselecting a campaign will not disassociate it from the conversion rule.
+   */
+  campaignId?: string[]
+  /**
+   * The ID of an existing conversion rule to stream events to. If defined, we will not create a new conversion rule.
+   */
+  conversionRuleId?: string
+  /**
+   * The name of the conversion rule.
+   */
+  name?: string
+  /**
+   * The type of conversion rule.
+   */
+  conversionType?: string
+  /**
+   * The attribution type for the conversion rule.
+   */
+  attribution_type?: string
+  /**
+   * Conversion window timeframe (in days) of a member clicking on a LinkedIn Ad (a post-click conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 30.
+   */
+  post_click_attribution_window_size?: number
+  /**
+   * Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 7.
+   */
+  view_through_attribution_window_size?: number
+}
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface OnMappingSaveOutputs {
+  /**
+   * The ID of the conversion rule.
+   */
+  id: string
+  /**
+   * The name of the conversion rule.
+   */
+  name: string
+  /**
+   * The type of conversion rule.
+   */
+  conversionType: string
+  /**
+   * The attribution type for the conversion rule.
+   */
+  attribution_type: string
+  /**
+   * Conversion window timeframe (in days) of a member clicking on a LinkedIn Ad (a post-click conversion) within which conversions will be attributed to a LinkedIn ad.
+   */
+  post_click_attribution_window_size: number
+  /**
+   * Conversion window timeframe (in days) of a member seeing a LinkedIn Ad (a view-through conversion) within which conversions will be attributed to a LinkedIn ad. Allowed values are 1, 7, 30 or 90. Default is 7.
+   */
+  view_through_attribution_window_size: number
 }

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -3,10 +3,10 @@ import { ErrorCodes, IntegrationError, PayloadValidationError, InvalidAuthentica
 import type { Settings } from '../generated-types'
 import { LinkedInConversions } from '../api'
 import { CONVERSION_TYPE_OPTIONS, SUPPORTED_LOOKBACK_WINDOW_CHOICES, DEPENDS_ON_CONVERSION_RULE_ID } from '../constants'
-import type { Payload, HookBundle } from './generated-types'
+import type { Payload, OnMappingSaveInputs, OnMappingSaveOutputs } from './generated-types'
 import { LinkedInError } from '../types'
 
-const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
+const action: ActionDefinition<Settings, Payload, undefined, OnMappingSaveInputs, OnMappingSaveOutputs> = {
   title: 'Stream Conversion Event',
   description: 'Directly streams conversion events to a specific conversion rule.',
   defaultSubscription: 'type = "track"',
@@ -140,13 +140,13 @@ const action: ActionDefinition<Settings, Payload, undefined, HookBundle> = {
       performHook: async (request, { hookInputs, hookOutputs }) => {
         const linkedIn = new LinkedInConversions(request)
 
-        let hookReturn: ActionHookResponse<HookBundle['onMappingSave']['outputs']>
+        let hookReturn: ActionHookResponse<OnMappingSaveOutputs>
         if (hookOutputs?.onMappingSave?.outputs) {
           linkedIn.setConversionRuleId(hookOutputs.onMappingSave.outputs.id)
 
           hookReturn = await linkedIn.updateConversionRule(
             hookInputs,
-            hookOutputs.onMappingSave.outputs as HookBundle['onMappingSave']['outputs']
+            hookOutputs.onMappingSave.outputs as OnMappingSaveOutputs
           )
         } else {
           hookReturn = await linkedIn.createConversionRule(hookInputs)

--- a/packages/destination-actions/src/destinations/marketo-static-lists/addToList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/addToList/generated-types.ts
@@ -32,29 +32,27 @@ export interface Payload {
    */
   event_name: string
 }
-// Generated bundle for hooks. DO NOT MODIFY IT BY HAND.
+// Generated file. DO NOT MODIFY IT BY HAND.
 
-export interface HookBundle {
-  retlOnMappingSave: {
-    inputs?: {
-      /**
-       * The ID of the Marketo Static List that users will be synced to. If defined, we will not create a new list.
-       */
-      list_id?: string
-      /**
-       * The name of the Marketo Static List that you would like to create.
-       */
-      list_name?: string
-    }
-    outputs?: {
-      /**
-       * The ID of the created Marketo Static List that users will be synced to.
-       */
-      id?: string
-      /**
-       * The name of the created Marketo Static List that users will be synced to.
-       */
-      name?: string
-    }
-  }
+export interface RetlOnMappingSaveInputs {
+  /**
+   * The ID of the Marketo Static List that users will be synced to. If defined, we will not create a new list.
+   */
+  list_id?: string
+  /**
+   * The name of the Marketo Static List that you would like to create.
+   */
+  list_name?: string
+}
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface RetlOnMappingSaveOutputs {
+  /**
+   * The ID of the created Marketo Static List that users will be synced to.
+   */
+  id?: string
+  /**
+   * The name of the created Marketo Static List that users will be synced to.
+   */
+  name?: string
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR addresses an issue that came up when adding object type hook input fields. The type generation couldn't properly define the nested shape of the properties and would incorrectly generate something like this:
```
export interface HookBundle {
  onMappingSave: {
    [k: string]: unknown
  }
}
```
In general the `HookBundle` previously would have a shape such as this:
```
export interface HookBundle {
  onMappingSave: {
    inputs?: { ... }
    outputs?: { ... }
  }
}
```
And I've updated it to flatter shape which cleanly generates nested object properties like this:
```
export interface OnMappingSaveInputs {
  name: string
  ...
  columns?: {
    name: string
    ...
  }[]
}

export interface OnMappingSaveOutputs {
...
}

```

## Testing
This change should be non-functional, since it only applies to action hook types.
Tested successfully in stage against LinkedIn Conversions API: Could successfully create a Conversion rule with the actions onMappingSave hook

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
