### PR TITLE
Fix typescript issues in Destinations and CLI

### DIFF
--- a/packages/cli/src/commands/generate/action.ts
+++ b/packages/cli/src/commands/generate/action.ts
@@ -109,7 +109,7 @@ export default class GenerateAction extends Command {
       )
       this.spinner.succeed(`Scaffold action`)
     } catch (err) {
-      this.spinner.fail(`Scaffold action: ${chalk.red(err.message)}`)
+      this.spinner.fail(`Scaffold action: ${chalk.red((err as Error).message)}`)
       this.exit()
     }
 
@@ -127,7 +127,7 @@ export default class GenerateAction extends Command {
         )
         this.spinner.succeed(`Creating snapshot tests for ${chalk.bold(`${destination}'s ${slug}`)} destination action`)
       } catch (err) {
-        this.spinner.fail(`Snapshot test creation failed: ${chalk.red(err.message)}`)
+        this.spinner.fail(`Snapshot test creation failed: ${chalk.red((err as Error).message)}`)
         this.exit()
       }
     }
@@ -142,7 +142,7 @@ export default class GenerateAction extends Command {
       fs.writeFileSync(entryFile, updatedCode, 'utf8')
       this.spinner.succeed()
     } catch (err) {
-      this.spinner.fail(chalk`Failed to update your destination imports: ${err.message}`)
+      this.spinner.fail(chalk`Failed to update your destination imports: ${(err as Error).message}`)
       this.exit()
     }
 
@@ -151,7 +151,7 @@ export default class GenerateAction extends Command {
       await GenerateTypes.run(['--path', entryFile])
       this.spinner.succeed()
     } catch (err) {
-      this.spinner.fail(chalk`Generating types for {magenta ${slug}} action: ${err.message}`)
+      this.spinner.fail(chalk`Generating types for {magenta ${slug}} action: ${(err as Error).message}`)
       this.exit()
     }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -131,7 +131,7 @@ export default class Init extends Command {
       renderTemplates(templatePath, targetDirectory, { ...answers, slugWithoutActions })
       this.spinner.succeed(`Scaffold integration`)
     } catch (err) {
-      this.spinner.fail(`Scaffold integration: ${chalk.red(err.message)}`)
+      this.spinner.fail(`Scaffold integration: ${chalk.red((err as Error).message)}`)
       this.exit()
     }
 
@@ -140,7 +140,7 @@ export default class Init extends Command {
       await GenerateTypes.run(['--path', entryPath])
       this.spinner.succeed()
     } catch (err) {
-      this.spinner.fail(chalk`Generating types for {magenta ${slug}} destination: ${err.message}`)
+      this.spinner.fail(chalk`Generating types for {magenta ${slug}} destination: ${(err as Error).message}`)
     }
 
     if (!isBrowserTemplate) {
@@ -156,7 +156,7 @@ export default class Init extends Command {
         )
         this.spinner.succeed(`Created snapshot tests for ${slug} destination`)
       } catch (err) {
-        this.spinner.fail(`Snapshot test creation failed: ${chalk.red(err.message)}`)
+        this.spinner.fail(`Snapshot test creation failed: ${chalk.red((err as Error).message)}`)
         this.exit()
       }
     }

--- a/packages/destination-actions/src/destinations/display-video-360/shared.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/shared.ts
@@ -198,7 +198,11 @@ export const sendUpdateRequest = async (
     await bulkUploaderResponseHandler(response, statsName, statsContext)
   } catch (error) {
     if ((error as HTTPError).response?.status === 500) {
-      throw new IntegrationError((error as HTTPError).message, 'INTERNAL_SERVER_ERROR', 500)
+      throw new IntegrationError(
+        (error as unknown as any).response?.message ?? (error as HTTPError).message,
+        'INTERNAL_SERVER_ERROR',
+        500
+      )
     }
 
     await bulkUploaderResponseHandler((error as HTTPError).response, statsName, statsContext)

--- a/packages/destination-actions/src/destinations/display-video-360/shared.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/shared.ts
@@ -1,4 +1,4 @@
-import { IntegrationError, RequestClient, StatsContext } from '@segment/actions-core'
+import { IntegrationError, RequestClient, StatsContext, HTTPError } from '@segment/actions-core'
 import { OAUTH_URL, USER_UPLOAD_ENDPOINT, SEGMENT_DMP_ID } from './constants'
 import type { RefreshTokenResponse } from './types'
 
@@ -197,11 +197,11 @@ export const sendUpdateRequest = async (
 
     await bulkUploaderResponseHandler(response, statsName, statsContext)
   } catch (error) {
-    if (error.response?.status === 500) {
-      throw new IntegrationError(error.response.message, 'INTERNAL_SERVER_ERROR', 500)
+    if ((error as HTTPError).response?.status === 500) {
+      throw new IntegrationError((error as HTTPError).message, 'INTERNAL_SERVER_ERROR', 500)
     }
 
-    await bulkUploaderResponseHandler(error.response, statsName, statsContext)
+    await bulkUploaderResponseHandler((error as HTTPError).response, statsName, statsContext)
   }
 }
 

--- a/packages/destination-actions/src/destinations/intercom/identifyContact/index.ts
+++ b/packages/destination-actions/src/destinations/intercom/identifyContact/index.ts
@@ -1,4 +1,4 @@
-import { ActionDefinition, RequestClient, RetryableError } from '@segment/actions-core'
+import { ActionDefinition, RequestClient, RetryableError, HTTPError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import { convertValidTimestamp, getUniqueIntercomContact } from '../util'
 import type { Payload } from './generated-types'
@@ -129,7 +129,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
       return await createIntercomContact(request, payload)
     } catch (error) {
-      if (error?.response?.status === 409) {
+      if ((error as HTTPError)?.response?.status === 409) {
         // The contact already exists but the Intercom cache most likely wasn't updated yet
         throw new RetryableError(
           'Contact was reported duplicated but could not be searched for, probably due to Intercom search cache not being updated'

--- a/packages/destination-actions/src/destinations/optimizely-feature-experimentation-actions/trackEvent/functions.ts
+++ b/packages/destination-actions/src/destinations/optimizely-feature-experimentation-actions/trackEvent/functions.ts
@@ -1,4 +1,4 @@
-import { RequestClient } from '@segment/actions-core'
+import { RequestClient, HTTPError, DynamicFieldResponse } from '@segment/actions-core'
 import { VisitorAttribute, Event, ProjectConfig } from '../types'
 import type { Settings } from '../generated-types'
 import reduceRight from 'lodash/reduceRight'
@@ -51,7 +51,7 @@ function isValidValue(value: unknown) {
   return ['string', 'number', 'boolean'].includes(typeof value)
 }
 
-export async function getEventKeys(request: RequestClient, settings: Settings) {
+export async function getEventKeys(request: RequestClient, settings: Settings): Promise<DynamicFieldResponse> {
   try {
     const response = await request<ProjectConfig>(settings.dataFileUrl, {
       skipResponseCloning: true
@@ -67,8 +67,8 @@ export async function getEventKeys(request: RequestClient, settings: Settings) {
     return {
       choices: [],
       error: {
-        message: err?.response?.statusText ?? 'Unknown error',
-        code: err?.response?.status ?? 'Unknown code'
+        message: (err as HTTPError)?.response?.statusText ?? 'Unknown error',
+        code: `${(err as HTTPError)?.response?.status ?? 'Unknown code'}`
       }
     }
   }


### PR DESCRIPTION
This PR aims to fix minor type issues for Node version upgrade with typescript 4.9.5 and simplifies [this](https://github.com/segmentio/action-destinations/pull/2706) PR.

## Testing

Tested locally with unit tests.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
