### PR TITLE
[STRATCONN-5484] Add new field to send raw user_agent

### DIFF
--- a/packages/destination-actions/src/destinations/amplitude/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/identifyUser/generated-types.ts
@@ -94,6 +94,10 @@ export interface Payload {
    */
   userAgentParsing?: boolean
   /**
+   * Enabling this setting will send user_agent based on the raw user agent string provided in the userAgent field
+   */
+  includeRawUserAgent?: boolean
+  /**
    * UTM Tracking Properties
    */
   utm_properties?: {

--- a/packages/destination-actions/src/destinations/amplitude/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/identifyUser/index.ts
@@ -185,6 +185,13 @@ const action: ActionDefinition<Settings, Payload> = {
         'Enabling this setting will set the Device manufacturer, Device Model and OS Name properties based on the user agent string provided in the userAgent field',
       default: true
     },
+    includeRawUserAgent: {
+      label: 'User Agent Parsing',
+      type: 'boolean',
+      description:
+        'Enabling this setting will send user_agent based on the raw user agent string provided in the userAgent field',
+      default: false
+    },
     utm_properties: {
       label: 'UTM Properties',
       type: 'object',
@@ -247,8 +254,17 @@ const action: ActionDefinition<Settings, Payload> = {
   },
 
   perform: (request, { payload, settings }) => {
-    const { utm_properties, referrer, userAgent, userAgentParsing, userAgentData, min_id_length, library, ...rest } =
-      payload
+    const {
+      utm_properties,
+      referrer,
+      userAgent,
+      userAgentParsing,
+      includeRawUserAgent,
+      userAgentData,
+      min_id_length,
+      library,
+      ...rest
+    } = payload
 
     let options
     const properties = rest as AmplitudeEvent
@@ -276,6 +292,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const identification = JSON.stringify({
       // Conditionally parse user agent using amplitude's library
       ...(userAgentParsing && parseUserAgentProperties(userAgent, userAgentData)),
+      ...(includeRawUserAgent && { user_agent: userAgent }),
       // Make sure any top-level properties take precedence over user-agent properties
       ...removeUndefined(properties),
       library: 'segment'

--- a/packages/destination-actions/src/destinations/amplitude/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/identifyUser/index.ts
@@ -186,7 +186,7 @@ const action: ActionDefinition<Settings, Payload> = {
       default: true
     },
     includeRawUserAgent: {
-      label: 'User Agent Parsing',
+      label: 'Include Raw User Agent',
       type: 'boolean',
       description:
         'Enabling this setting will send user_agent based on the raw user agent string provided in the userAgent field',

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/generated-types.ts
@@ -190,6 +190,10 @@ export interface Payload {
    */
   userAgentParsing?: boolean
   /**
+   * Enabling this setting will send user_agent based on the raw user agent string provided in the userAgent field
+   */
+  includeRawUserAgent?: boolean
+  /**
    * UTM Tracking Properties
    */
   utm_properties?: {

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
@@ -111,7 +111,7 @@ const action: ActionDefinition<Settings, Payload> = {
       default: true
     },
     includeRawUserAgent: {
-      label: 'User Agent Parsing',
+      label: 'Include Raw User Agent',
       type: 'boolean',
       description:
         'Enabling this setting will send user_agent based on the raw user agent string provided in the userAgent field',

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
@@ -110,6 +110,13 @@ const action: ActionDefinition<Settings, Payload> = {
         'Enabling this setting will set the Device manufacturer, Device Model and OS Name properties based on the user agent string provided in the userAgent field',
       default: true
     },
+    includeRawUserAgent: {
+      label: 'User Agent Parsing',
+      type: 'boolean',
+      description:
+        'Enabling this setting will send user_agent based on the raw user agent string provided in the userAgent field',
+      default: false
+    },
     utm_properties: {
       label: 'UTM Properties',
       type: 'object',
@@ -169,6 +176,7 @@ const action: ActionDefinition<Settings, Payload> = {
       session_id,
       userAgent,
       userAgentParsing,
+      includeRawUserAgent,
       userAgentData,
       utm_properties,
       referrer,
@@ -211,6 +219,7 @@ const action: ActionDefinition<Settings, Payload> = {
       {
         // Conditionally parse user agent using amplitude's library
         ...(userAgentParsing && parseUserAgentProperties(userAgent, userAgentData)),
+        ...(includeRawUserAgent && { user_agent: userAgent }),
         // Make sure any top-level properties take precedence over user-agent properties
         ...removeUndefined(properties),
         library: 'segment'

--- a/packages/destination-actions/src/destinations/amplitude/logEventV2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEventV2/generated-types.ts
@@ -223,6 +223,10 @@ export interface Payload {
    */
   userAgentParsing?: boolean
   /**
+   * Enabling this setting will send user_agent based on the raw user agent string provided in the userAgent field
+   */
+  includeRawUserAgent?: boolean
+  /**
    * Amplitude has a default minimum id length of 5 characters for user_id and device_id fields. This field allows the minimum to be overridden to allow shorter id lengths.
    */
   min_id_length?: number | null

--- a/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
@@ -197,6 +197,13 @@ const action: ActionDefinition<Settings, Payload> = {
         'Enabling this setting will set the Device manufacturer, Device Model and OS Name properties based on the user agent string provided in the userAgent field.',
       default: true
     },
+    includeRawUserAgent: {
+      label: 'User Agent Parsing',
+      type: 'boolean',
+      description:
+        'Enabling this setting will send user_agent based on the raw user agent string provided in the userAgent field',
+      default: false
+    },
     min_id_length: {
       label: 'Minimum ID Length',
       description:
@@ -212,6 +219,7 @@ const action: ActionDefinition<Settings, Payload> = {
       session_id,
       userAgent,
       userAgentParsing,
+      includeRawUserAgent,
       userAgentData,
       min_id_length,
       library,
@@ -260,6 +268,7 @@ const action: ActionDefinition<Settings, Payload> = {
       {
         // Conditionally parse user agent using amplitude's library
         ...(userAgentParsing && parseUserAgentProperties(userAgent, userAgentData)),
+        ...(includeRawUserAgent && { user_agent: userAgent }),
         // Make sure any top-level properties take precedence over user-agent properties
         ...removeUndefined(properties),
         library: 'segment'

--- a/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
@@ -198,7 +198,7 @@ const action: ActionDefinition<Settings, Payload> = {
       default: true
     },
     includeRawUserAgent: {
-      label: 'User Agent Parsing',
+      label: 'Include Raw User Agent',
       type: 'boolean',
       description:
         'Enabling this setting will send user_agent based on the raw user agent string provided in the userAgent field',

--- a/packages/destination-actions/src/destinations/amplitude/logPurchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logPurchase/generated-types.ts
@@ -194,6 +194,10 @@ export interface Payload {
    */
   userAgentParsing?: boolean
   /**
+   * Enabling this setting will send user_agent based on the raw user agent string provided in the userAgent field
+   */
+  includeRawUserAgent?: boolean
+  /**
    * UTM Tracking Properties
    */
   utm_properties?: {

--- a/packages/destination-actions/src/destinations/amplitude/logPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logPurchase/index.ts
@@ -160,6 +160,13 @@ const action: ActionDefinition<Settings, Payload> = {
         'Enabling this setting will set the Device manufacturer, Device Model and OS Name properties based on the user agent string provided in the userAgent field',
       default: true
     },
+    includeRawUserAgent: {
+      label: 'User Agent Parsing',
+      type: 'boolean',
+      description:
+        'Enabling this setting will send user_agent based on the raw user agent string provided in the userAgent field',
+      default: false
+    },
     utm_properties: {
       label: 'UTM Properties',
       type: 'object',
@@ -221,6 +228,7 @@ const action: ActionDefinition<Settings, Payload> = {
       session_id,
       userAgent,
       userAgentParsing,
+      includeRawUserAgent,
       userAgentData,
       utm_properties,
       referrer,
@@ -263,6 +271,7 @@ const action: ActionDefinition<Settings, Payload> = {
       {
         // Conditionally parse user agent using amplitude's library
         ...(userAgentParsing && parseUserAgentProperties(userAgent, userAgentData)),
+        ...(includeRawUserAgent && { user_agent: userAgent }),
         // Make sure any top-level properties take precedence over user-agent properties
         ...removeUndefined(properties),
         // Conditionally track revenue with main event

--- a/packages/destination-actions/src/destinations/amplitude/logPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logPurchase/index.ts
@@ -161,7 +161,7 @@ const action: ActionDefinition<Settings, Payload> = {
       default: true
     },
     includeRawUserAgent: {
-      label: 'User Agent Parsing',
+      label: 'Include Raw User Agent',
       type: 'boolean',
       description:
         'Enabling this setting will send user_agent based on the raw user agent string provided in the userAgent field',


### PR DESCRIPTION
[Jira](https://segment.atlassian.net/browse/STRATCONN-5484)

This PR adds a new flag to send the user_agent field unparsed to Amplitude. Currently if customers have `userAgentParsing` set to false they don't send any user_agent field. If they set `includeRawUserAgent` they can send the userAgent field as a raw string.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._
https://docs.google.com/document/d/1kFtoVidh_w2gR-YDtQXiFH420fDZD9kKn2axooGeAyk/edit?tab=t.0



- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
