### PR TITLE
Dynamic field queries

### DIFF
--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -259,7 +259,7 @@ function setupRoutes(def: DestinationDefinition | null): void {
     '/refreshAccessToken',
     asyncHandler(async (req: express.Request, res: express.Response) => {
       try {
-        const settings = {}
+        const settings = req.body.settings || {}
         const data = await destination.refreshAccessToken(settings, req.body)
         res.status(200).json({ ok: true, data })
       } catch (e) {
@@ -334,8 +334,10 @@ function setupRoutes(def: DestinationDefinition | null): void {
                 payload: req.body.payload || {},
                 page: req.body.page || 1,
                 auth: req.body.auth || {},
-                audienceSettings: req.body.audienceSettings || {}
+                audienceSettings: req.body.audienceSettings || {},
+                dynamicFieldContext: req.body.dynamicFieldContext || {}
               }
+
               const action = destination.actions[actionSlug]
               const result = await action.executeDynamicField(field, data)
 
@@ -404,8 +406,10 @@ function setupRoutes(def: DestinationDefinition | null): void {
                   page: req.body.page || 1,
                   auth: req.body.auth || {},
                   audienceSettings: req.body.audienceSettings || {},
-                  hookInputs: req.body.hookInputs || {}
+                  hookInputs: req.body.hookInputs || {},
+                  dynamicFieldContext: req.body.dynamicFieldContext || {}
                 }
+
                 const action = destination.actions[actionSlug]
                 const dynamicFn = dynamicInputs[fieldKey] as RequestFn<any, any, any, any>
                 const result = await action.executeDynamicField(fieldKey, data, dynamicFn)

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -36,6 +36,8 @@ export interface DynamicFieldContext {
   selectedArrayIndex?: number
   /** The key within a dynamic object for which we are requesting values */
   selectedKey?: string
+  /** The RichInput dropdown search query the user has entered */
+  query?: string
 }
 
 export interface ExecuteInput<


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR adds a query parameter when running dynamic field requests. This is useful for when an endpoint returns many items and a user would want to filter them. In the case of Salesforce Marketing Cloud a query param is required to fetch a list of data extensions to send data to.

## Testing
Tested successfully in local against the new SFMC "Get Data Extensions" dynamic field, which requires a query param.

<img width="849" alt="Screenshot 2025-02-10 at 10 10 38 AM" src="https://github.com/user-attachments/assets/b665ac1b-2bc5-4174-99b2-1b507fccf12b" />


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
