### PR TITLE
Update unit tests exposing URLSearchParams

### DIFF
--- a/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
@@ -788,17 +788,9 @@ describe('Amplitude', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       expect(responses[0].data).toMatchObject({})
-      expect(responses[0].options.body).toMatchInlineSnapshot(`
-        URLSearchParams {
-          Symbol(query): Array [
-            "api_key",
-            "undefined",
-            "mapping",
-            "[{\\"user_id\\":\\"some-previous-user-id\\",\\"global_user_id\\":\\"some-user-id\\"}]",
-          ],
-          Symbol(context): null,
-        }
-      `)
+      expect(responses[0].options.body?.toString()).toMatchInlineSnapshot(
+        `"api_key=undefined&mapping=%5B%7B%22user_id%22%3A%22some-previous-user-id%22%2C%22global_user_id%22%3A%22some-user-id%22%7D%5D"`
+      )
     })
 
     it('should send data to the EU endpoint', async () => {
@@ -822,17 +814,9 @@ describe('Amplitude', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       expect(responses[0].data).toMatchObject({})
-      expect(responses[0].options.body).toMatchInlineSnapshot(`
-        URLSearchParams {
-          Symbol(query): Array [
-            "api_key",
-            "",
-            "mapping",
-            "[{\\"user_id\\":\\"some-previous-user-id\\",\\"global_user_id\\":\\"some-user-id\\"}]",
-          ],
-          Symbol(context): null,
-        }
-      `)
+      expect(responses[0].options.body?.toString()).toMatchInlineSnapshot(
+        `"api_key=&mapping=%5B%7B%22user_id%22%3A%22some-previous-user-id%22%2C%22global_user_id%22%3A%22some-user-id%22%7D%5D"`
+      )
     })
   })
 
@@ -1999,19 +1983,9 @@ describe('Amplitude', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       expect(responses[0].data).toMatchObject({})
-      expect(responses[0].options.body).toMatchInlineSnapshot(`
-        URLSearchParams {
-          Symbol(query): Array [
-            "api_key",
-            "undefined",
-            "identification",
-            "{\\"os_name\\":\\"iOS\\",\\"os_version\\":\\"9\\",\\"device_manufacturer\\":\\"Apple\\",\\"device_model\\":\\"iPhone\\",\\"device_type\\":\\"mobile\\",\\"user_id\\":\\"some-user-id\\",\\"device_id\\":\\"some-anonymous-id\\",\\"user_properties\\":{\\"some-trait-key\\":\\"some-trait-value\\"},\\"country\\":\\"United States\\",\\"city\\":\\"San Francisco\\",\\"language\\":\\"en-US\\",\\"platform\\":\\"Web\\",\\"library\\":\\"segment\\"}",
-            "options",
-            "undefined",
-          ],
-          Symbol(context): null,
-        }
-      `)
+      expect(responses[0].options.body?.toString()).toMatchInlineSnapshot(
+        `"api_key=undefined&identification=%7B%22os_name%22%3A%22iOS%22%2C%22os_version%22%3A%229%22%2C%22device_manufacturer%22%3A%22Apple%22%2C%22device_model%22%3A%22iPhone%22%2C%22device_type%22%3A%22mobile%22%2C%22user_id%22%3A%22some-user-id%22%2C%22device_id%22%3A%22some-anonymous-id%22%2C%22user_properties%22%3A%7B%22some-trait-key%22%3A%22some-trait-value%22%7D%2C%22country%22%3A%22United+States%22%2C%22city%22%3A%22San+Francisco%22%2C%22language%22%3A%22en-US%22%2C%22platform%22%3A%22Web%22%2C%22library%22%3A%22segment%22%7D&options=undefined"`
+      )
     })
 
     it('should support referrer and utm user_properties', async () => {
@@ -2042,19 +2016,9 @@ describe('Amplitude', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       expect(responses[0].data).toMatchObject({})
-      expect(responses[0].options.body).toMatchInlineSnapshot(`
-        URLSearchParams {
-          Symbol(query): Array [
-            "api_key",
-            "undefined",
-            "identification",
-            "{\\"user_id\\":\\"some-user-id\\",\\"device_id\\":\\"some-anonymous-id\\",\\"user_properties\\":{\\"some-trait-key\\":\\"some-trait-value\\",\\"$set\\":{\\"utm_source\\":\\"Newsletter\\",\\"utm_medium\\":\\"email\\",\\"utm_campaign\\":\\"TPS Innovation Newsletter\\",\\"utm_term\\":\\"tps reports\\",\\"utm_content\\":\\"image link\\",\\"referrer\\":\\"some-referrer\\"},\\"$setOnce\\":{\\"initial_utm_source\\":\\"Newsletter\\",\\"initial_utm_medium\\":\\"email\\",\\"initial_utm_campaign\\":\\"TPS Innovation Newsletter\\",\\"initial_utm_term\\":\\"tps reports\\",\\"initial_utm_content\\":\\"image link\\",\\"initial_referrer\\":\\"some-referrer\\"}},\\"library\\":\\"segment\\"}",
-            "options",
-            "undefined",
-          ],
-          Symbol(context): null,
-        }
-      `)
+      expect(responses[0].options.body?.toString()).toMatchInlineSnapshot(
+        `"api_key=undefined&identification=%7B%22user_id%22%3A%22some-user-id%22%2C%22device_id%22%3A%22some-anonymous-id%22%2C%22user_properties%22%3A%7B%22some-trait-key%22%3A%22some-trait-value%22%2C%22%24set%22%3A%7B%22utm_source%22%3A%22Newsletter%22%2C%22utm_medium%22%3A%22email%22%2C%22utm_campaign%22%3A%22TPS+Innovation+Newsletter%22%2C%22utm_term%22%3A%22tps+reports%22%2C%22utm_content%22%3A%22image+link%22%2C%22referrer%22%3A%22some-referrer%22%7D%2C%22%24setOnce%22%3A%7B%22initial_utm_source%22%3A%22Newsletter%22%2C%22initial_utm_medium%22%3A%22email%22%2C%22initial_utm_campaign%22%3A%22TPS+Innovation+Newsletter%22%2C%22initial_utm_term%22%3A%22tps+reports%22%2C%22initial_utm_content%22%3A%22image+link%22%2C%22initial_referrer%22%3A%22some-referrer%22%7D%7D%2C%22library%22%3A%22segment%22%7D&options=undefined"`
+      )
     })
 
     it('shouldnt append $ keys to user_properties if referrer/utm are not specified', async () => {
@@ -2073,19 +2037,9 @@ describe('Amplitude', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       expect(responses[0].data).toMatchObject({})
-      expect(responses[0].options.body).toMatchInlineSnapshot(`
-        URLSearchParams {
-          Symbol(query): Array [
-            "api_key",
-            "undefined",
-            "identification",
-            "{\\"os_name\\":\\"iOS\\",\\"os_version\\":\\"9\\",\\"device_manufacturer\\":\\"Apple\\",\\"device_model\\":\\"iPhone\\",\\"device_type\\":\\"mobile\\",\\"user_id\\":\\"some-user-id\\",\\"device_id\\":\\"some-anonymous-id\\",\\"user_properties\\":{\\"some-trait-key\\":\\"some-trait-value\\"},\\"country\\":\\"United States\\",\\"city\\":\\"San Francisco\\",\\"language\\":\\"en-US\\",\\"platform\\":\\"Web\\",\\"library\\":\\"segment\\"}",
-            "options",
-            "undefined",
-          ],
-          Symbol(context): null,
-        }
-      `)
+      expect(responses[0].options.body?.toString()).toMatchInlineSnapshot(
+        `"api_key=undefined&identification=%7B%22os_name%22%3A%22iOS%22%2C%22os_version%22%3A%229%22%2C%22device_manufacturer%22%3A%22Apple%22%2C%22device_model%22%3A%22iPhone%22%2C%22device_type%22%3A%22mobile%22%2C%22user_id%22%3A%22some-user-id%22%2C%22device_id%22%3A%22some-anonymous-id%22%2C%22user_properties%22%3A%7B%22some-trait-key%22%3A%22some-trait-value%22%7D%2C%22country%22%3A%22United+States%22%2C%22city%22%3A%22San+Francisco%22%2C%22language%22%3A%22en-US%22%2C%22platform%22%3A%22Web%22%2C%22library%22%3A%22segment%22%7D&options=undefined"`
+      )
     })
 
     it('should support parsing userAgent when the setting is true', async () => {
@@ -2116,19 +2070,9 @@ describe('Amplitude', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       expect(responses[0].data).toMatchObject({})
-      expect(responses[0].options.body).toMatchInlineSnapshot(`
-        URLSearchParams {
-          Symbol(query): Array [
-            "api_key",
-            "undefined",
-            "identification",
-            "{\\"os_name\\":\\"Mac OS\\",\\"os_version\\":\\"53\\",\\"device_model\\":\\"Mac OS\\",\\"user_id\\":\\"some-user-id\\",\\"device_id\\":\\"foo\\",\\"user_properties\\":{\\"some-trait-key\\":\\"some-trait-value\\"},\\"library\\":\\"segment\\"}",
-            "options",
-            "undefined",
-          ],
-          Symbol(context): null,
-        }
-      `)
+      expect(responses[0].options.body?.toString()).toMatchInlineSnapshot(
+        `"api_key=undefined&identification=%7B%22os_name%22%3A%22Mac+OS%22%2C%22os_version%22%3A%2253%22%2C%22device_model%22%3A%22Mac+OS%22%2C%22user_id%22%3A%22some-user-id%22%2C%22device_id%22%3A%22foo%22%2C%22user_properties%22%3A%7B%22some-trait-key%22%3A%22some-trait-value%22%7D%2C%22library%22%3A%22segment%22%7D&options=undefined"`
+      )
     })
 
     it('should not send parsed user agent properties when setting is false', async () => {
@@ -2159,19 +2103,9 @@ describe('Amplitude', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       expect(responses[0].data).toMatchObject({})
-      expect(responses[0].options.body).toMatchInlineSnapshot(`
-        URLSearchParams {
-          Symbol(query): Array [
-            "api_key",
-            "undefined",
-            "identification",
-            "{\\"user_id\\":\\"some-user-id\\",\\"device_id\\":\\"foo\\",\\"user_properties\\":{\\"some-trait-key\\":\\"some-trait-value\\"},\\"library\\":\\"segment\\"}",
-            "options",
-            "undefined",
-          ],
-          Symbol(context): null,
-        }
-      `)
+      expect(responses[0].options.body?.toString()).toMatchInlineSnapshot(
+        `"api_key=undefined&identification=%7B%22user_id%22%3A%22some-user-id%22%2C%22device_id%22%3A%22foo%22%2C%22user_properties%22%3A%7B%22some-trait-key%22%3A%22some-trait-value%22%7D%2C%22library%22%3A%22segment%22%7D&options=undefined"`
+      )
     })
 
     it('should change casing for device type when value is android', async () => {
@@ -2190,19 +2124,9 @@ describe('Amplitude', () => {
 
       nock('https://api2.amplitude.com').post('/identify').reply(200, {})
       const responses = await testDestination.testAction('identifyUser', { event, mapping, useDefaultMappings: true })
-      expect(responses[0].options.body).toMatchInlineSnapshot(`
-        URLSearchParams {
-          Symbol(query): Array [
-            "api_key",
-            "undefined",
-            "identification",
-            "{\\"user_id\\":\\"user1234\\",\\"device_id\\":\\"foo\\",\\"user_properties\\":{},\\"platform\\":\\"Android\\",\\"library\\":\\"segment\\"}",
-            "options",
-            "undefined",
-          ],
-          Symbol(context): null,
-        }
-      `)
+      expect(responses[0].options.body?.toString()).toMatchInlineSnapshot(
+        `"api_key=undefined&identification=%7B%22user_id%22%3A%22user1234%22%2C%22device_id%22%3A%22foo%22%2C%22user_properties%22%3A%7B%7D%2C%22platform%22%3A%22Android%22%2C%22library%22%3A%22segment%22%7D&options=undefined"`
+      )
     })
 
     it('should change casing for device type when value is ios', async () => {
@@ -2221,19 +2145,9 @@ describe('Amplitude', () => {
 
       nock('https://api2.amplitude.com').post('/identify').reply(200, {})
       const responses = await testDestination.testAction('identifyUser', { event, mapping, useDefaultMappings: true })
-      expect(responses[0].options.body).toMatchInlineSnapshot(`
-        URLSearchParams {
-          Symbol(query): Array [
-            "api_key",
-            "undefined",
-            "identification",
-            "{\\"user_id\\":\\"user1234\\",\\"device_id\\":\\"foo\\",\\"user_properties\\":{},\\"platform\\":\\"iOS\\",\\"library\\":\\"segment\\"}",
-            "options",
-            "undefined",
-          ],
-          Symbol(context): null,
-        }
-      `)
+      expect(responses[0].options.body?.toString()).toMatchInlineSnapshot(
+        `"api_key=undefined&identification=%7B%22user_id%22%3A%22user1234%22%2C%22device_id%22%3A%22foo%22%2C%22user_properties%22%3A%7B%7D%2C%22platform%22%3A%22iOS%22%2C%22library%22%3A%22segment%22%7D&options=undefined"`
+      )
     })
 
     it('should send data to the EU endpoint', async () => {
@@ -2260,19 +2174,9 @@ describe('Amplitude', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       expect(responses[0].data).toMatchObject({})
-      expect(responses[0].options.body).toMatchInlineSnapshot(`
-        URLSearchParams {
-          Symbol(query): Array [
-            "api_key",
-            "",
-            "identification",
-            "{\\"os_name\\":\\"iOS\\",\\"os_version\\":\\"9\\",\\"device_manufacturer\\":\\"Apple\\",\\"device_model\\":\\"iPhone\\",\\"device_type\\":\\"mobile\\",\\"user_id\\":\\"some-user-id\\",\\"device_id\\":\\"some-anonymous-id\\",\\"user_properties\\":{\\"some-trait-key\\":\\"some-trait-value\\"},\\"country\\":\\"United States\\",\\"city\\":\\"San Francisco\\",\\"language\\":\\"en-US\\",\\"platform\\":\\"Web\\",\\"library\\":\\"segment\\"}",
-            "options",
-            "undefined",
-          ],
-          Symbol(context): null,
-        }
-      `)
+      expect(responses[0].options.body?.toString()).toMatchInlineSnapshot(
+        `"api_key=&identification=%7B%22os_name%22%3A%22iOS%22%2C%22os_version%22%3A%229%22%2C%22device_manufacturer%22%3A%22Apple%22%2C%22device_model%22%3A%22iPhone%22%2C%22device_type%22%3A%22mobile%22%2C%22user_id%22%3A%22some-user-id%22%2C%22device_id%22%3A%22some-anonymous-id%22%2C%22user_properties%22%3A%7B%22some-trait-key%22%3A%22some-trait-value%22%7D%2C%22country%22%3A%22United+States%22%2C%22city%22%3A%22San+Francisco%22%2C%22language%22%3A%22en-US%22%2C%22platform%22%3A%22Web%22%2C%22library%22%3A%22segment%22%7D&options=undefined"`
+      )
     })
 
     it('should give precedence to OS properties over userAgent properties', async () => {
@@ -2307,19 +2211,9 @@ describe('Amplitude', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       expect(responses[0].data).toMatchObject({})
-      expect(responses[0].options.body).toMatchInlineSnapshot(`
-        URLSearchParams {
-          Symbol(query): Array [
-            "api_key",
-            "undefined",
-            "identification",
-            "{\\"os_name\\":\\"iPhone OS\\",\\"os_version\\":\\"8.1.3\\",\\"device_model\\":\\"Mac OS\\",\\"user_id\\":\\"some-user-id\\",\\"device_id\\":\\"foo\\",\\"user_properties\\":{\\"some-trait-key\\":\\"some-trait-value\\"},\\"library\\":\\"segment\\"}",
-            "options",
-            "undefined",
-          ],
-          Symbol(context): null,
-        }
-      `)
+      expect(responses[0].options.body?.toString()).toMatchInlineSnapshot(
+        `"api_key=undefined&identification=%7B%22os_name%22%3A%22iPhone+OS%22%2C%22os_version%22%3A%228.1.3%22%2C%22device_model%22%3A%22Mac+OS%22%2C%22user_id%22%3A%22some-user-id%22%2C%22device_id%22%3A%22foo%22%2C%22user_properties%22%3A%7B%22some-trait-key%22%3A%22some-trait-value%22%7D%2C%22library%22%3A%22segment%22%7D&options=undefined"`
+      )
     })
   })
 

--- a/packages/destination-actions/src/destinations/twilio/__tests__/twilio.test.ts
+++ b/packages/destination-actions/src/destinations/twilio/__tests__/twilio.test.ts
@@ -45,21 +45,9 @@ describe('Twilio', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(`
-        URLSearchParams {
-          Symbol(query): Array [
-            "From",
-            "+12056065576",
-            "To",
-            "+17758638863",
-            "Body",
-            "Hello, World!",
-            "MediaUrl",
-            "https://demo.twilio.com/owl.png",
-          ],
-          Symbol(context): null,
-        }
-      `)
+      expect(responses[0].options.body?.toString()).toMatchInlineSnapshot(
+        `"From=%2B12056065576&To=%2B17758638863&Body=Hello%2C+World%21&MediaUrl=https%3A%2F%2Fdemo.twilio.com%2Fowl.png"`
+      )
 
       expect(responses[0].request.headers).toMatchInlineSnapshot(`
         Headers {


### PR DESCRIPTION
This PR updates unit tests that directly exposes the URLSearchParams and converts them to their string representation.

## Testing

Testing not required because updating unit tests.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
