### PR TITLE
Upgrade Github Actions Runner to Ubuntu 22.02 and actions/cache to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       matrix:
@@ -54,7 +54,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     strategy:
       matrix:
@@ -88,7 +88,7 @@ jobs:
 
   validate:
     name: Validate
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     strategy:
       matrix:
@@ -135,7 +135,7 @@ jobs:
     # env: # Disable saucelabs - we blew through our quota.
     #   SAUCE_USERNAME: ${{secrets.SAUCE_USERNAME}}
     #   SAUCE_ACCESS_KEY: ${{secrets.SAUCE_ACCESS_KEY}}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     strategy:
       matrix:
@@ -171,7 +171,7 @@ jobs:
 
   browser-tests-core:
     name: 'Browser tests: actions-core'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     timeout-minutes: 10
 
@@ -192,7 +192,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -214,7 +214,7 @@ jobs:
 
   snyk:
     name: Snyk
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     timeout-minutes: 5
 
@@ -237,7 +237,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/ext.yml
+++ b/.github/workflows/ext.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       HUSKY: 0
       NX_DISABLE_DB: true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     timeout-minutes: 20
 

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   pr-labeler:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -11,7 +11,7 @@ jobs:
       HUSKY: 0
       NX_DISABLE_DB: true
     if: startsWith(github.event.head_commit.message, 'Publish') == true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     timeout-minutes: 15
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       HUSKY: 0
       NX_DISABLE_DB: true
     if: startsWith(github.event.head_commit.message, 'Publish') == true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     timeout-minutes: 15
 

--- a/.github/workflows/required-field-check.yml
+++ b/.github/workflows/required-field-check.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   required-field-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     timeout-minutes: 5
 
@@ -88,7 +88,7 @@ jobs:
                     }
                   }
                 } else {
-                  
+
                   // If key is not present in requiredFieldsOnMain, then all fields are added recently
                   const getActionKeys = Object.keys(requiredFieldsOnBranch[key])
                   for(const actionKey of getActionKeys) {
@@ -109,7 +109,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo
             })
-            const diffComment = comments.data.find(comment => comment.body.includes('<!--REQUIRED_FIELD_DIFF-->')) 
+            const diffComment = comments.data.find(comment => comment.body.includes('<!--REQUIRED_FIELD_DIFF-->'))
 
             const comment = fs.readFileSync("./.github/REQUIRED_FIELD_WARNING_TEMPLATE.md", "utf8")
             const commentBody = comment.replace('{{FIELDS_ADDED}}', fieldsAdded.join('\n'))


### PR DESCRIPTION
Upgrades Github Actions Runner image to `Ubuntu 22.04` and `actions/cache@v3`.
[Notice from Github on deprecating the Ubuntu 20.04 runner image.](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down)


## Testing

Testing performed on CI.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
