### PR TITLE
Set Default version to v21 in Facebook Conversion API

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-conversions-api/constants.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/constants.ts
@@ -1,4 +1,4 @@
-export const API_VERSION = '20.0'
+export const API_VERSION = '21.0'
 export const CANARY_API_VERSION = '21.0'
 export const CURRENCY_ISO_CODES = new Set([
   'AED',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->
Clean up and Rollout out of v20.0 APIs:https://github.com/segmentio/action-destinations/pull/2720
This PR is to set Default Version to V21 . 
Jira ticket :- https://segment.atlassian.net/browse/STRATCONN-5408

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
