### PR TITLE
[STRATCONN-5404] | Upgrade Facebook API in Facebook Custom Audience (Actions) to v21

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/__tests__/index.test.ts
@@ -1,12 +1,17 @@
 import nock from 'nock'
 import { createTestIntegration, IntegrationError } from '@segment/actions-core'
-import Destination, { FACEBOOK_API_VERSION } from '../index'
+import Destination from '../index'
+import { Features } from '@segment/actions-core/mapping-kit'
+import { API_VERSION, CANARY_API_VERSION } from '../constants'
+
+const features: Features = { 'facebook-custom-audience-actions-canary-version': true }
 
 const adAccountId = '1500000000000000'
 const audienceId = '1506489116128966'
 const testDestination = createTestIntegration(Destination)
-const getAudienceUrl = `https://graph.facebook.com/${FACEBOOK_API_VERSION}/`
-const createAudienceUrl = `https://graph.facebook.com/${FACEBOOK_API_VERSION}/act_${adAccountId}`
+const BASE_URL = 'https://graph.facebook.com'
+
+const getAudienceUrl = `https://graph.facebook.com/${API_VERSION}/`
 
 const createAudienceInput = {
   settings: {
@@ -16,7 +21,8 @@ const createAudienceInput = {
   audienceSettings: {
     engageAdAccountId: adAccountId,
     audienceDescription: 'We are the Mario Brothers and plumbing is our game.'
-  }
+  },
+  features: {}
 }
 const getAudienceInput = {
   externalId: audienceId,
@@ -38,12 +44,14 @@ describe('Facebook Custom Audiences', () => {
     })
 
     it('should create a new Facebook Audience', async () => {
-      nock(createAudienceUrl).post('/customaudiences').reply(200, { id: '88888888888888888' })
+      nock(`${BASE_URL}/${CANARY_API_VERSION}/act_${adAccountId}`)
+        .post('/customaudiences')
+        .reply(200, { id: '88888888888888888' })
 
       createAudienceInput.audienceName = 'The Super Mario Brothers Fans'
       createAudienceInput.audienceSettings.engageAdAccountId = adAccountId
 
-      const r = await testDestination.createAudience(createAudienceInput)
+      const r = await testDestination.createAudience({ ...createAudienceInput, features })
       expect(r).toEqual({ externalId: '88888888888888888' })
     })
   })
@@ -60,10 +68,10 @@ describe('Facebook Custom Audiences', () => {
     })
 
     it('should succeed when Segment Audience ID matches FB audience ID', async () => {
-      nock(getAudienceUrl)
+      nock(`${BASE_URL}/${CANARY_API_VERSION}/`)
         .get(`/${audienceId}`)
         .reply(200, { id: `${audienceId}` })
-      const r = await testDestination.getAudience(getAudienceInput)
+      const r = await testDestination.getAudience({ ...getAudienceInput, features })
       expect(r).toEqual({ externalId: audienceId })
     })
   })

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/constants.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/constants.ts
@@ -50,3 +50,7 @@ export const US_STATE_CODES = new Map<string, string>([
   ['wisconsin', 'wi'],
   ['wyoming', 'wy']
 ])
+export const API_VERSION = 'v20.0'
+export const CANARY_API_VERSION = 'v21.0'
+export const BASE_URL = 'https://graph.facebook.com'
+export const FACEBOOK_CUSTOM_AUDIENCE_FLAGON = 'facebook-custom-audience-actions-canary-version'

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/index.ts
@@ -3,8 +3,8 @@ import { IntegrationError } from '@segment/actions-core'
 import type { Settings, AudienceSettings } from './generated-types'
 import { adAccountId } from './fbca-properties'
 import sync from './sync'
+import { getApiVersion } from './fbca-operations'
 
-export const FACEBOOK_API_VERSION = 'v17.0'
 const EXTERNAL_ID_KEY = 'id'
 
 const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
@@ -44,6 +44,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       const audienceName = createAudienceInput.audienceName
       const adAccountId = createAudienceInput.audienceSettings?.engageAdAccountId
       const audienceDescription = createAudienceInput.audienceSettings?.audienceDescription
+      const { features, statsContext } = createAudienceInput
 
       if (!audienceName) {
         throw new IntegrationError('Missing audience name value', 'MISSING_REQUIRED_FIELD', 400)
@@ -53,7 +54,10 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         throw new IntegrationError('Missing ad account ID value', 'MISSING_REQUIRED_FIELD', 400)
       }
 
-      const createAudienceUrl = `https://graph.facebook.com/${FACEBOOK_API_VERSION}/act_${adAccountId}/customaudiences`
+      const createAudienceUrl = `https://graph.facebook.com/${getApiVersion(
+        features,
+        statsContext
+      )}/act_${adAccountId}/customaudiences`
       const payload = {
         name: audienceName,
         description: audienceDescription || '',
@@ -79,7 +83,10 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       }
     },
     async getAudience(request, getAudienceInput) {
-      const getAudienceUrl = `https://graph.facebook.com/${FACEBOOK_API_VERSION}/${getAudienceInput.externalId}`
+      const { features, statsContext } = getAudienceInput
+      const getAudienceUrl = `https://graph.facebook.com/${getApiVersion(features, statsContext)}/${
+        getAudienceInput.externalId
+      }`
 
       const response = await request(getAudienceUrl, { method: 'GET' })
 

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/index.test.ts
@@ -1,9 +1,9 @@
 import { createTestEvent, createTestIntegration, sha256SmartHash } from '@segment/actions-core'
 import Destination from '../../index'
-import { BASE_URL } from '../../fbca-operations'
 import nock from 'nock'
 import { SCHEMA_PROPERTIES } from '../../fbca-properties'
 import { normalizationFunctions } from '../../fbca-properties'
+import { BASE_URL, CANARY_API_VERSION, API_VERSION } from '../../constants'
 
 const testDestination = createTestIntegration(Destination)
 const auth = {
@@ -40,8 +40,84 @@ describe('FacebookCustomAudiences.sync', () => {
       }
     })
 
-    it('should sync a single user', async () => {
-      nock(`${BASE_URL}`)
+    it('should sync a single user with a CANARY_API_VERSION', async () => {
+      nock(`${BASE_URL}/${CANARY_API_VERSION}`)
+        .post(`/${hookOutputs.audienceId}/users`, {
+          payload: {
+            schema: SCHEMA_PROPERTIES,
+            data: [
+              [
+                event.properties?.id, // external_id
+                '816341caf0c06dbc4c156d3465323f52b3cb62533241d5f9247c008f657e8343', // email
+                sha256SmartHash(normalizationFunctions.get('phone')!((event.properties?.phone as string) || '')),
+                EMPTY, // gender
+                EMPTY, // year
+                EMPTY, // month
+                EMPTY, // day
+                EMPTY, // last_name
+                EMPTY, // first_name
+                EMPTY, // first_initial
+                sha256SmartHash(normalizationFunctions.get('city')!((event.properties?.city as string) || '')),
+                sha256SmartHash(normalizationFunctions.get('state')!((event.properties?.state as string) || '')),
+                sha256SmartHash(normalizationFunctions.get('zip')!((event.properties?.zip_code as string) || '')),
+                '2024', // mobile_advertiser_id,
+                sha256SmartHash(normalizationFunctions.get('country')!('US'))
+              ]
+            ],
+            app_ids: ['2024']
+          }
+        })
+        .reply(200, { test: 'test' })
+
+      const responses = await testDestination.testAction('sync', {
+        event,
+        settings: retlSettings,
+        auth,
+        features: { 'facebook-custom-audience-actions-canary-version': true },
+        mapping: {
+          __segment_internal_sync_mode: 'upsert',
+          email: { '@path': '$.properties.email' },
+          phone: { '@path': '$.properties.phone' },
+          city: { '@path': '$.properties.city' },
+          state: { '@path': '$.properties.state' },
+          zip: { '@path': '$.properties.zip_code' },
+          country: 'US',
+          externalId: { '@path': '$.properties.id' },
+          appId: { '@path': '$.properties.appleIDFA' },
+          mobileAdId: { '@path': '$.properties.appleIDFA' },
+          retlOnMappingSave: {
+            inputs: {},
+            outputs: hookOutputs
+          },
+          enable_batching: true,
+          batch_size: 10000
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].request.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "authorization": Array [
+              "Bearer 123",
+            ],
+            "content-type": Array [
+              "application/json",
+            ],
+            "user-agent": Array [
+              "Segment (Actions)",
+            ],
+          },
+        }
+      `)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"payload\\":{\\"schema\\":[\\"EXTERN_ID\\",\\"EMAIL\\",\\"PHONE\\",\\"GEN\\",\\"DOBY\\",\\"DOBM\\",\\"DOBD\\",\\"LN\\",\\"FN\\",\\"FI\\",\\"CT\\",\\"ST\\",\\"ZIP\\",\\"MADID\\",\\"COUNTRY\\"],\\"data\\":[[\\"1234\\",\\"816341caf0c06dbc4c156d3465323f52b3cb62533241d5f9247c008f657e8343\\",\\"a5ad7e6d5225ad00c5f05ddb6bb3b1597a843cc92f6cf188490ffcb88a1ef4ef\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"\\",\\"1a6bd4d9d79dc0a79b53795c70d3349fa9e38968a3fbefbfe8783efb1d2b6aac\\",\\"6959097001d10501ac7d54c0bdb8db61420f658f2922cc26e46d536119a31126\\",\\"ad16c1a6866c5887c5b59c1803cb1fc09769f1b403b6f1d9d0f10ad6ab4d5d50\\",\\"2024\\",\\"79adb2a2fce5c6ba215fe5f27f532d4e7edbac4b6a5e09e1ef3a08084a904621\\"]],\\"app_ids\\":[\\"2024\\"]}}"`
+      )
+    })
+    it('should sync a single user with a default API_VERSION', async () => {
+      nock(`${BASE_URL}/${API_VERSION}`)
         .post(`/${hookOutputs.audienceId}/users`, {
           payload: {
             schema: SCHEMA_PROPERTIES,
@@ -95,7 +171,6 @@ describe('FacebookCustomAudiences.sync', () => {
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
-
       expect(responses[0].request.headers).toMatchInlineSnapshot(`
         Headers {
           Symbol(map): Object {

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/index.ts
@@ -257,12 +257,12 @@ const action: ActionDefinition<Settings, Payload> = {
     enable_batching,
     batch_size
   },
-  perform: async (request, { settings, payload, hookOutputs, syncMode }) => {
-    const fbClient = new FacebookClient(request, settings.retlAdAccountId)
+  perform: async (request, { settings, payload, hookOutputs, syncMode, features, statsContext }) => {
+    const fbClient = new FacebookClient(request, settings.retlAdAccountId, features, statsContext)
 
     if (syncMode && ['upsert', 'delete'].includes(syncMode)) {
       return await fbClient.syncAudience({
-        audienceId: hookOutputs?.retlOnMappingSave.outputs.audienceId,
+        audienceId: hookOutputs?.retlOnMappingSave?.outputs?.audienceId,
         payloads: [payload],
         deleteUsers: syncMode === 'delete' ? true : false
       })
@@ -270,12 +270,12 @@ const action: ActionDefinition<Settings, Payload> = {
 
     throw new IntegrationError('Sync mode is required for perform', 'MISSING_REQUIRED_FIELD', 400)
   },
-  performBatch: async (request, { settings, payload, hookOutputs, syncMode }) => {
-    const fbClient = new FacebookClient(request, settings.retlAdAccountId)
+  performBatch: async (request, { settings, payload, hookOutputs, syncMode, features, statsContext }) => {
+    const fbClient = new FacebookClient(request, settings.retlAdAccountId, features, statsContext)
 
     if (syncMode && ['upsert', 'delete'].includes(syncMode)) {
       return await fbClient.syncAudience({
-        audienceId: hookOutputs?.retlOnMappingSave.outputs.audienceId,
+        audienceId: hookOutputs?.retlOnMappingSave?.outputs?.audienceId,
         payloads: payload,
         deleteUsers: syncMode === 'delete' ? true : false
       })


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pull request is to upgrade Facebook API Version in Facebook Custom Audiences (Actions).
Added a canary version support with feature flagon.
Jira ticket :- https://segment.atlassian.net/browse/STRATCONN-5404

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
