### PR TITLE
[FUNK-1648] Custom Params support for Extensible Webhook Destination

### DIFF
--- a/packages/destination-actions/src/destinations/webhook-extensible/auth-utils.ts
+++ b/packages/destination-actions/src/destinations/webhook-extensible/auth-utils.ts
@@ -1,0 +1,76 @@
+import { RefreshTokenResponse } from './types'
+import { RefreshAccessTokenResult } from '../../../../core/src/destination-kit'
+import { RequestClient } from '../../../../core/src/create-request-client'
+import { RequestOptions } from '../../../../core/src/request-client'
+
+export const sendRefreshTokenReq = async (
+  request: RequestClient,
+  settings: any,
+  auth: any
+): Promise<RefreshAccessTokenResult> => {
+  let res
+  const { oauth } = settings.dynamicAuthSettings
+
+  if (oauth.type === 'authCode') {
+    res = await request<RefreshTokenResponse>(getRequestUrl(oauth), getRequestOptions(oauth, auth))
+    return {
+      accessToken: res.data.access_token,
+      refreshToken: res.data.refresh_token
+    }
+  } else {
+    res = await request<RefreshTokenResponse>(getRequestUrl(oauth), getRequestOptions(oauth, auth))
+    return { accessToken: res.data.access_token }
+  }
+}
+
+const getRequestUrl = (oauth: any) => {
+  if (oauth?.customParams?.refreshRequest?.sendIn === 'url') {
+    const customParamVal = new URLSearchParams(oauth.customParams.refreshRequest.val)
+    return `${oauth.refreshTokenServerUrl}?${customParamVal ?? ''}`
+  }
+  return oauth.refreshTokenServerUrl
+}
+
+const getRequestOptions = (oauth: any, auth: any): RequestOptions => {
+  let bodyParams = {}
+  const { clientId, clientSecret } = auth
+  let headers = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+    Authorization: `Basic ${Buffer.from(clientId + ':' + clientSecret).toString('base64')}`
+  }
+
+  if (oauth.type === 'authCode') {
+    bodyParams = {
+      grant_type: 'refresh_token',
+      refresh_token: auth.refreshToken ?? oauth.access.refresh_token,
+      scope: oauth.scopes,
+      client_id: clientId,
+      client_secret: clientSecret
+    }
+  } else {
+    bodyParams = {
+      grant_type: 'client_credentials',
+      scope: oauth.scopes
+    }
+  }
+
+  if (oauth?.customParams?.refreshRequest?.sendIn === 'body') {
+    bodyParams = {
+      ...bodyParams,
+      ...oauth.customParams.refreshRequest.val
+    }
+  } else if (oauth?.customParams?.refreshRequest?.sendIn === 'headers') {
+    headers = {
+      ...headers,
+      ...oauth.customParams.refreshRequest.val
+    }
+  }
+
+  const body = new URLSearchParams(bodyParams)
+
+  return {
+    method: 'POST',
+    headers,
+    body
+  }
+}

--- a/packages/destination-actions/src/destinations/webhook-extensible/index.ts
+++ b/packages/destination-actions/src/destinations/webhook-extensible/index.ts
@@ -1,6 +1,6 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
-import { RefreshTokenResponse } from './types'
+import { sendRefreshTokenReq } from './auth-utils'
 
 import send from './send'
 
@@ -22,43 +22,8 @@ const destination: DestinationDefinition<SettingsWithDynamicAuth> = {
       }
     },
     refreshAccessToken: async (request, { settings, auth }) => {
-      let res
-      const { clientId, clientSecret } = auth
-      const { oauth } = settings.dynamicAuthSettings
-
-      if (oauth.type === 'authCode') {
-        res = await request<RefreshTokenResponse>(oauth.refreshTokenServerUrl, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            Authorization: `Basic ${Buffer.from(clientId + ':' + clientSecret).toString('base64')}`
-          },
-          body: new URLSearchParams({
-            grant_type: 'refresh_token',
-            refresh_token: auth.refreshToken ?? oauth.access.refresh_token,
-            scope: oauth.scopes,
-            client_id: clientId,
-            client_secret: clientSecret
-          })
-        })
-        return {
-          accessToken: res.data.access_token,
-          refreshToken: res.data.refresh_token
-        }
-      } else {
-        res = await request<RefreshTokenResponse>(oauth.refreshTokenServerUrl, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            Authorization: `Basic ${Buffer.from(clientId + ':' + clientSecret).toString('base64')}`
-          },
-          body: new URLSearchParams({
-            grant_type: 'client_credentials',
-            scope: oauth.scopes
-          })
-        })
-        return { accessToken: res.data.access_token }
-      }
+      const res = await sendRefreshTokenReq(request, settings, auth)
+      return res
     }
   },
   extendRequest: ({ settings, auth }) => {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

https://segment.atlassian.net/browse/FUNK-1648
Support has been added to send custom params for refresh token request for Extensible Webhook Destination.

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
