### PR TITLE
[Publish] Fix linting issues in unit tests

### DIFF
--- a/packages/browser-destinations/destinations/adobe-target/src/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/adobe-target/src/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { Analytics, Context } from '@segment/analytics-next'
 import adobeTarget, { destination } from '../index'
 import { Subscription } from '@segment/browser-destination-runtime/types'
+import { JSONArray } from '@segment/actions-core'
 
 describe('Adobe Target Web', () => {
   test('can load ATJS', async () => {
@@ -19,7 +20,7 @@ describe('Adobe Target Web', () => {
       version: '2.8.0',
       cookie_domain: 'segment.com',
       mbox_name: 'target-global-mbox',
-      subscriptions
+      subscriptions: subscriptions as unknown as JSONArray
     })
 
     jest.spyOn(destination, 'initialize')

--- a/packages/browser-destinations/destinations/adobe-target/src/triggerView/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/adobe-target/src/triggerView/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { Analytics, Context } from '@segment/analytics-next'
 import adobeTarget, { destination } from '../../index'
 import { Subscription } from '@segment/browser-destination-runtime/types'
+import { JSONArray } from '@segment/actions-core'
 
 describe('Adobe Target Web', () => {
   describe('#page', () => {
@@ -44,7 +45,7 @@ describe('Adobe Target Web', () => {
 
       const [event] = await adobeTarget({
         ...targetSettings,
-        subscriptions
+        subscriptions: subscriptions as unknown as JSONArray
       })
 
       jest.spyOn(destination, 'initialize')

--- a/packages/browser-destinations/destinations/adobe-target/src/upsertProfile/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/adobe-target/src/upsertProfile/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { Analytics, Context } from '@segment/analytics-next'
 import adobeTarget, { destination } from '../../index'
 import { Subscription } from '@segment/browser-destination-runtime/types'
+import { JSONArray } from '@segment/actions-core'
 
 describe('Adobe Target Web', () => {
   describe('#identify', () => {
@@ -52,7 +53,7 @@ describe('Adobe Target Web', () => {
 
       const [event] = await adobeTarget({
         ...targetSettings,
-        subscriptions
+        subscriptions: subscriptions as unknown as JSONArray
       })
 
       jest.spyOn(destination, 'initialize')

--- a/packages/browser-destinations/destinations/bucket/src/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/bucket/src/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import { Analytics, Context, User } from '@segment/analytics-next'
 import bucketWebDestination, { destination } from '../index'
 import { Subscription } from '@segment/browser-destination-runtime/types'
-import { JSONArray } from '@segment/actions-core/*'
+import { JSONArray } from '@segment/actions-core'
 import { bucketTestHooks, getBucketCallLog } from '../test-utils'
 
 const subscriptions: Subscription[] = [

--- a/packages/browser-destinations/destinations/bucket/src/group/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/bucket/src/group/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import { Analytics, Context, User } from '@segment/analytics-next'
 import bucketWebDestination, { destination } from '../../index'
 import { Subscription } from '@segment/browser-destination-runtime/types'
-import { JSONArray } from '@segment/actions-core/*'
+import { JSONArray } from '@segment/actions-core'
 import { bucketTestHooks, getBucketCallLog } from '../../test-utils'
 
 const subscriptions: Subscription[] = [

--- a/packages/browser-destinations/destinations/bucket/src/identifyUser/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/bucket/src/identifyUser/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import { Analytics, Context } from '@segment/analytics-next'
 import bucketWebDestination, { destination } from '../../index'
 import { Subscription } from '@segment/browser-destination-runtime/types'
-import { JSONArray } from '@segment/actions-core/*'
+import { JSONArray } from '@segment/actions-core'
 import { bucketTestHooks, getBucketCallLog } from '../../test-utils'
 
 const subscriptions: Subscription[] = [

--- a/packages/browser-destinations/destinations/bucket/src/trackEvent/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/bucket/src/trackEvent/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import { Analytics, Context, User } from '@segment/analytics-next'
 import bucketWebDestination, { destination } from '../../index'
 import { Subscription } from '@segment/browser-destination-runtime/types'
-import { JSONArray } from '@segment/actions-core/*'
+import { JSONArray } from '@segment/actions-core'
 import { bucketTestHooks, getBucketCallLog } from '../../test-utils'
 
 const subscriptions: Subscription[] = [


### PR DESCRIPTION
This PR addresses linting and type issues in unit tests.

## Testing
Testing not required as PR contains minor type and linting fixes.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
