### PR TITLE
Advanced logging of payloads from Salesforce based on a feature flag

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/account/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account/index.ts
@@ -224,7 +224,7 @@ const action: ActionDefinition<Settings, Payload> = {
       return await sf.deleteRecord(payload, OBJECT_NAME)
     }
   },
-  performBatch: async (request, { settings, payload, statsContext, logger }) => {
+  performBatch: async (request, { settings, payload, features, statsContext, logger }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, await generateSalesforceRequest(settings, request))
 
     if (payload[0].operation === 'upsert') {
@@ -233,7 +233,12 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
 
-    return sf.bulkHandler(payload, OBJECT_NAME, statsContext, logger)
+    let shouldShowAdvancedLogging = false
+    if (features && features['salesforce-advanced-logging']) {
+      shouldShowAdvancedLogging = true
+    }
+
+    return sf.bulkHandler(payload, OBJECT_NAME, { shouldLog: shouldShowAdvancedLogging, stats: statsContext, logger })
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/account2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/account2/index.ts
@@ -233,7 +233,7 @@ const action: ActionDefinition<Settings, Payload> = {
       return await sf.deleteRecord(payload, OBJECT_NAME)
     }
   },
-  performBatch: async (request, { settings, payload, syncMode, statsContext, logger }) => {
+  performBatch: async (request, { settings, payload, syncMode, features, statsContext, logger }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, await generateSalesforceRequest(settings, request))
 
     if (syncMode === 'upsert') {
@@ -242,7 +242,16 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
 
-    return sf.bulkHandlerWithSyncMode(payload, OBJECT_NAME, syncMode, statsContext, logger)
+    let shouldShowAdvancedLogging = false
+    if (features && features['salesforce-advanced-logging']) {
+      shouldShowAdvancedLogging = true
+    }
+
+    return sf.bulkHandlerWithSyncMode(payload, OBJECT_NAME, syncMode, {
+      shouldLog: shouldShowAdvancedLogging,
+      stats: statsContext,
+      logger
+    })
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/cases/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases/index.ts
@@ -57,10 +57,15 @@ const action: ActionDefinition<Settings, Payload> = {
       return await sf.deleteRecord(payload, OBJECT_NAME)
     }
   },
-  performBatch: async (request, { settings, payload, statsContext, logger }) => {
+  performBatch: async (request, { settings, payload, features, statsContext, logger }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, await generateSalesforceRequest(settings, request))
 
-    return sf.bulkHandler(payload, OBJECT_NAME, statsContext, logger)
+    let shouldShowAdvancedLogging = false
+    if (features && features['salesforce-advanced-logging']) {
+      shouldShowAdvancedLogging = true
+    }
+
+    return sf.bulkHandler(payload, OBJECT_NAME, { shouldLog: shouldShowAdvancedLogging, stats: statsContext, logger })
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/cases2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/cases2/index.ts
@@ -66,10 +66,19 @@ const action: ActionDefinition<Settings, Payload> = {
       return await sf.deleteRecord(payload, OBJECT_NAME)
     }
   },
-  performBatch: async (request, { settings, payload, syncMode, statsContext, logger }) => {
+  performBatch: async (request, { settings, payload, syncMode, features, statsContext, logger }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, await generateSalesforceRequest(settings, request))
 
-    return sf.bulkHandlerWithSyncMode(payload, OBJECT_NAME, syncMode, statsContext, logger)
+    let shouldShowAdvancedLogging = false
+    if (features && features['salesforce-advanced-logging']) {
+      shouldShowAdvancedLogging = true
+    }
+
+    return sf.bulkHandlerWithSyncMode(payload, OBJECT_NAME, syncMode, {
+      shouldLog: shouldShowAdvancedLogging,
+      stats: statsContext,
+      logger
+    })
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/contact/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact/index.ts
@@ -168,7 +168,7 @@ const action: ActionDefinition<Settings, Payload> = {
       return await sf.deleteRecord(payload, OBJECT_NAME)
     }
   },
-  performBatch: async (request, { settings, payload, statsContext, logger }) => {
+  performBatch: async (request, { settings, payload, features, statsContext, logger }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, await generateSalesforceRequest(settings, request))
 
     if (payload[0].operation === 'upsert') {
@@ -177,7 +177,12 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
 
-    return sf.bulkHandler(payload, OBJECT_NAME, statsContext, logger)
+    let shouldShowAdvancedLogging = false
+    if (features && features['salesforce-advanced-logging']) {
+      shouldShowAdvancedLogging = true
+    }
+
+    return sf.bulkHandler(payload, OBJECT_NAME, { shouldLog: shouldShowAdvancedLogging, stats: statsContext, logger })
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/contact2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/contact2/index.ts
@@ -177,7 +177,7 @@ const action: ActionDefinition<Settings, Payload> = {
       return await sf.deleteRecord(payload, OBJECT_NAME)
     }
   },
-  performBatch: async (request, { settings, payload, syncMode, statsContext, logger }) => {
+  performBatch: async (request, { settings, payload, syncMode, features, statsContext, logger }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, await generateSalesforceRequest(settings, request))
 
     if (syncMode === 'upsert') {
@@ -186,7 +186,16 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
 
-    return sf.bulkHandlerWithSyncMode(payload, OBJECT_NAME, syncMode, statsContext, logger)
+    let shouldShowAdvancedLogging = false
+    if (features && features['salesforce-advanced-logging']) {
+      shouldShowAdvancedLogging = true
+    }
+
+    return sf.bulkHandlerWithSyncMode(payload, OBJECT_NAME, syncMode, {
+      shouldLog: shouldShowAdvancedLogging,
+      stats: statsContext,
+      logger
+    })
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject/index.ts
@@ -72,14 +72,23 @@ const action: ActionDefinition<Settings, Payload> = {
       return await sf.deleteRecord(payload, payload.customObjectName)
     }
   },
-  performBatch: async (request, { settings, payload, statsContext, logger }) => {
+  performBatch: async (request, { settings, payload, features, statsContext, logger }) => {
     if (OPERATIONS_WITH_CUSTOM_FIELDS.includes(payload[0].operation) && !payload[0].customFields) {
       throw new PayloadValidationError('Custom fields are required for this operation.')
     }
 
     const sf: Salesforce = new Salesforce(settings.instanceUrl, await generateSalesforceRequest(settings, request))
 
-    return sf.bulkHandler(payload, payload[0].customObjectName, statsContext, logger)
+    let shouldShowAdvancedLogging = false
+    if (features && features['salesforce-advanced-logging']) {
+      shouldShowAdvancedLogging = true
+    }
+
+    return sf.bulkHandler(payload, payload[0].customObjectName, {
+      shouldLog: shouldShowAdvancedLogging,
+      stats: statsContext,
+      logger
+    })
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/customObject2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/customObject2/index.ts
@@ -85,7 +85,7 @@ const action: ActionDefinition<Settings, Payload> = {
       return await sf.deleteRecord(payload, payload.customObjectName)
     }
   },
-  performBatch: async (request, { settings, payload, syncMode, statsContext, logger }) => {
+  performBatch: async (request, { settings, payload, syncMode, features, statsContext, logger }) => {
     if (!syncMode) {
       throw new IntegrationError('syncMode is required', 'Undefined syncMode', 400)
     }
@@ -96,7 +96,16 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const sf: Salesforce = new Salesforce(settings.instanceUrl, await generateSalesforceRequest(settings, request))
 
-    return sf.bulkHandlerWithSyncMode(payload, payload[0].customObjectName, syncMode, statsContext, logger)
+    let shouldShowAdvancedLogging = false
+    if (features && features['salesforce-advanced-logging']) {
+      shouldShowAdvancedLogging = true
+    }
+
+    return sf.bulkHandlerWithSyncMode(payload, payload[0].customObjectName, syncMode, {
+      shouldLog: shouldShowAdvancedLogging,
+      stats: statsContext,
+      logger
+    })
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/lead/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead/index.ts
@@ -177,7 +177,7 @@ const action: ActionDefinition<Settings, Payload> = {
       return await sf.deleteRecord(payload, OBJECT_NAME)
     }
   },
-  performBatch: async (request, { settings, payload, statsContext, logger }) => {
+  performBatch: async (request, { settings, payload, features, statsContext, logger }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, await generateSalesforceRequest(settings, request))
 
     if (payload[0].operation === 'upsert') {
@@ -186,7 +186,12 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
 
-    return sf.bulkHandler(payload, OBJECT_NAME, statsContext, logger)
+    let shouldShowAdvancedLogging = false
+    if (features && features['salesforce-advanced-logging']) {
+      shouldShowAdvancedLogging = true
+    }
+
+    return sf.bulkHandler(payload, OBJECT_NAME, { shouldLog: shouldShowAdvancedLogging, stats: statsContext, logger })
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/lead2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/lead2/index.ts
@@ -184,7 +184,7 @@ const action: ActionDefinition<Settings, Payload> = {
       return await sf.deleteRecord(payload, OBJECT_NAME)
     }
   },
-  performBatch: async (request, { settings, payload, syncMode, statsContext, logger }) => {
+  performBatch: async (request, { settings, payload, syncMode, features, statsContext, logger }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, await generateSalesforceRequest(settings, request))
 
     if (syncMode === 'upsert') {
@@ -193,7 +193,16 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
 
-    return sf.bulkHandlerWithSyncMode(payload, OBJECT_NAME, syncMode, statsContext, logger)
+    let shouldShowAdvancedLogging = false
+    if (features && features['salesforce-advanced-logging']) {
+      shouldShowAdvancedLogging = true
+    }
+
+    return sf.bulkHandlerWithSyncMode(payload, OBJECT_NAME, syncMode, {
+      shouldLog: shouldShowAdvancedLogging,
+      stats: statsContext,
+      logger
+    })
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/opportunity/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity/index.ts
@@ -88,7 +88,7 @@ const action: ActionDefinition<Settings, Payload> = {
       return await sf.deleteRecord(payload, OBJECT_NAME)
     }
   },
-  performBatch: async (request, { settings, payload, statsContext, logger }) => {
+  performBatch: async (request, { settings, payload, features, statsContext, logger }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, await generateSalesforceRequest(settings, request))
 
     if (payload[0].operation === 'upsert') {
@@ -97,7 +97,12 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
 
-    return sf.bulkHandler(payload, OBJECT_NAME, statsContext, logger)
+    let shouldShowAdvancedLogging = false
+    if (features && features['salesforce-advanced-logging']) {
+      shouldShowAdvancedLogging = true
+    }
+
+    return sf.bulkHandler(payload, OBJECT_NAME, { shouldLog: shouldShowAdvancedLogging, stats: statsContext, logger })
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/opportunity2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/opportunity2/index.ts
@@ -97,7 +97,7 @@ const action: ActionDefinition<Settings, Payload> = {
       return await sf.deleteRecord(payload, OBJECT_NAME)
     }
   },
-  performBatch: async (request, { settings, payload, syncMode, statsContext, logger }) => {
+  performBatch: async (request, { settings, payload, syncMode, features, statsContext, logger }) => {
     const sf: Salesforce = new Salesforce(settings.instanceUrl, await generateSalesforceRequest(settings, request))
 
     if (syncMode === 'upsert') {
@@ -106,7 +106,16 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
 
-    return sf.bulkHandlerWithSyncMode(payload, OBJECT_NAME, syncMode, statsContext, logger)
+    let shouldShowAdvancedLogging = false
+    if (features && features['salesforce-advanced-logging']) {
+      shouldShowAdvancedLogging = true
+    }
+
+    return sf.bulkHandlerWithSyncMode(payload, OBJECT_NAME, syncMode, {
+      shouldLog: shouldShowAdvancedLogging,
+      stats: statsContext,
+      logger
+    })
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
@@ -225,17 +225,21 @@ export default class Salesforce {
     return await this.baseDelete(recordId, sobject)
   }
 
-  bulkHandler = async (payloads: GenericPayload[], sobject: string, statsContext?: StatsContext, logger?: Logger) => {
+  bulkHandler = async (
+    payloads: GenericPayload[],
+    sobject: string,
+    logging?: { shouldLog: boolean; logger?: Logger; stats?: StatsContext }
+  ) => {
     if (!payloads[0].enable_batching) {
       throwBulkMismatchError()
     }
 
     if (payloads[0].operation === 'upsert') {
-      return await this.bulkUpsert(payloads, sobject, statsContext, logger)
+      return await this.bulkUpsert(payloads, sobject, logging)
     } else if (payloads[0].operation === 'update') {
-      return await this.bulkUpdate(payloads, sobject, statsContext, logger)
+      return await this.bulkUpdate(payloads, sobject, logging)
     } else if (payloads[0].operation === 'create') {
-      return await this.bulkInsert(payloads, sobject, statsContext, logger)
+      return await this.bulkInsert(payloads, sobject, logging)
     }
 
     if (payloads[0].operation === 'delete') {
@@ -251,8 +255,7 @@ export default class Salesforce {
     payloads: GenericPayload[],
     sobject: string,
     syncMode: string | undefined,
-    statsContext?: StatsContext,
-    logger?: Logger
+    logging?: { shouldLog: boolean; logger?: Logger; stats?: StatsContext }
   ) => {
     if (!payloads[0].enable_batching) {
       throwBulkMismatchError()
@@ -271,13 +274,13 @@ export default class Salesforce {
     }
 
     if (syncMode === 'upsert') {
-      return await this.bulkUpsert(payloads, sobject, statsContext, logger)
+      return await this.bulkUpsert(payloads, sobject, logging)
     } else if (syncMode === 'update') {
-      return await this.bulkUpdate(payloads, sobject, statsContext, logger)
+      return await this.bulkUpdate(payloads, sobject, logging)
     } else if (syncMode === 'add') {
       // Sync Mode does not have a "create" operation. We call it "add".
       // "add" will be transformed into "create" in the bulkInsert function.
-      return await this.bulkInsert(payloads, sobject, statsContext, logger)
+      return await this.bulkInsert(payloads, sobject, logging)
     }
   }
 
@@ -318,18 +321,16 @@ export default class Salesforce {
   private bulkInsert = async (
     payloads: GenericPayload[],
     sobject: string,
-    statsContext?: StatsContext,
-    logger?: Logger
+    logging?: { shouldLog: boolean; logger?: Logger; stats?: StatsContext }
   ) => {
     // The idField is purposely passed as an empty string since the field is not required.
-    return this.handleBulkJob(payloads, sobject, '', 'insert', statsContext, logger)
+    return this.handleBulkJob(payloads, sobject, '', 'insert', logging)
   }
 
   private bulkUpsert = async (
     payloads: GenericPayload[],
     sobject: string,
-    statsContext?: StatsContext,
-    logger?: Logger
+    logging?: { shouldLog: boolean; logger?: Logger; stats?: StatsContext }
   ) => {
     if (
       !payloads[0].bulkUpsertExternalId ||
@@ -343,14 +344,13 @@ export default class Salesforce {
       )
     }
     const externalIdFieldName = payloads[0].bulkUpsertExternalId.externalIdName
-    return this.handleBulkJob(payloads, sobject, externalIdFieldName, 'upsert', statsContext, logger)
+    return this.handleBulkJob(payloads, sobject, externalIdFieldName, 'upsert', logging)
   }
 
   private bulkUpdate = async (
     payloads: GenericPayload[],
     sobject: string,
-    statsContext?: StatsContext,
-    logger?: Logger
+    logging?: { shouldLog: boolean; logger?: Logger; stats?: StatsContext }
   ) => {
     if (!payloads[0].bulkUpdateRecordId) {
       throw new IntegrationError(
@@ -360,7 +360,7 @@ export default class Salesforce {
       )
     }
 
-    return this.handleBulkJob(payloads, sobject, 'Id', 'update', statsContext, logger)
+    return this.handleBulkJob(payloads, sobject, 'Id', 'update', logging)
   }
 
   private async handleBulkJob(
@@ -368,52 +368,56 @@ export default class Salesforce {
     sobject: string,
     idField: string,
     operation: string,
-    statsContext?: StatsContext,
-    logger?: Logger
+    logging?: { shouldLog: boolean; logger?: Logger; stats?: StatsContext }
   ): Promise<ModifiedResponse<unknown>> {
     // construct the CSV data to catch errors before creating a bulk job
     const csv = buildCSVData(payloads, idField, operation)
-    const jobId = await this.createBulkJob(sobject, idField, operation)
+    const jobId = await this.createBulkJob(sobject, idField, operation, logging)
     try {
-      await this.uploadBulkCSV(jobId, csv)
+      await this.uploadBulkCSV(jobId, csv, logging)
     } catch (err) {
       // always close the "bulk job" otherwise it will get
       // stuck in "pending".
       //
       // run in background to ensure this service has time to respond
       // with useful information before the connection closes.
-      this.closeBulkJob(jobId).catch((_) => {
+      this.closeBulkJob(jobId, logging).catch((_) => {
         // ignore close error to avoid masking the root error
         const message = err.response?.data[0]?.message || 'Failed to parse message'
         const code = err.response?.data[0]?.errorCode || 'Failed to parse code'
 
-        const statsClient = statsContext?.statsClient
-        const tags = statsContext?.tags
+        const statsClient = logging?.stats?.statsClient
+        const tags = logging?.stats?.tags
         tags?.push('jobId:' + jobId)
         statsClient?.incr('bulkJobError.caughUploadError', 1, tags)
-        logger?.crit(`Failed to close bulk job: ${jobId}. Message: ${message}. Code: ${code}`)
+        logging?.logger?.crit(`Failed to close bulk job: ${jobId}. Message: ${message}. Code: ${code}`)
       })
       throw err
     }
 
     try {
-      return await this.closeBulkJob(jobId)
+      return await this.closeBulkJob(jobId, logging)
     } catch (err) {
       const message = err.response?.data[0]?.message || 'Failed to parse message'
       const code = err.response?.data[0]?.errorCode || 'Failed to parse code'
 
-      const statsClient = statsContext?.statsClient
-      const tags = statsContext?.tags
+      const statsClient = logging?.stats?.statsClient
+      const tags = logging?.stats?.tags
 
       tags?.push('jobId:' + jobId)
       statsClient?.incr('bulkJobError', 1, tags)
-      logger?.crit(`Failed to close bulk job: ${jobId}. Message: ${message}. Code: ${code}`)
+      logging?.logger?.crit(`Failed to close bulk job: ${jobId}. Message: ${message}. Code: ${code}`)
 
       throw err
     }
   }
 
-  private createBulkJob = async (sobject: string, externalIdFieldName: string, operation: string) => {
+  private createBulkJob = async (
+    sobject: string,
+    externalIdFieldName: string,
+    operation: string,
+    logging?: { shouldLog: boolean; logger?: Logger; stats?: StatsContext }
+  ) => {
     const jsonData: { object: string; contentType: 'CSV'; operation: string; externalIdFieldName?: string } = {
       object: sobject,
       contentType: 'CSV',
@@ -436,10 +440,33 @@ export default class Salesforce {
       throw new IntegrationError('Failed to create bulk job', 'Failed to create bulk job', 500)
     }
 
+    if (logging?.shouldLog) {
+      logging.logger?.crit(`Created bulk job: ${res.data.id} with data: ${JSON.stringify(jsonData)}`)
+
+      const statsClient = logging.stats?.statsClient
+      const tags = logging.stats?.tags
+
+      tags?.push('jobId:' + res.data.id)
+      statsClient?.incr('bulkJob.createBulkJob', 1, tags)
+    }
+
     return res.data.id
   }
 
-  private uploadBulkCSV = async (jobId: string, csv: string) => {
+  private uploadBulkCSV = async (
+    jobId: string,
+    csv: string,
+    logging?: { shouldLog: boolean; logger?: Logger; stats?: StatsContext }
+  ) => {
+    if (logging?.shouldLog) {
+      logging.logger?.crit(`Uploading CSV to job: ${jobId}\nCSV: ${csv}`)
+
+      const statsClient = logging.stats?.statsClient
+      const tags = logging.stats?.tags
+      tags?.push('jobId:' + jobId)
+      statsClient?.incr('bulkJob.uploadCSV', 1, tags)
+    }
+
     return this.request(`${this.instanceUrl}services/data/${API_VERSION}/jobs/ingest/${jobId}/batches`, {
       method: 'put',
       headers: {
@@ -450,7 +477,19 @@ export default class Salesforce {
     })
   }
 
-  private closeBulkJob = async (jobId: string) => {
+  private closeBulkJob = async (
+    jobId: string,
+    logging?: { shouldLog: boolean; logger?: Logger; stats?: StatsContext }
+  ) => {
+    if (logging?.shouldLog) {
+      logging.logger?.crit(`Closing job: ${jobId}`)
+
+      const statsClient = logging.stats?.statsClient
+      const tags = logging.stats?.tags
+      tags?.push('jobId:' + jobId)
+      statsClient?.incr('bulkJob.closeBulkJob', 1, tags)
+    }
+
     return this.request(`${this.instanceUrl}services/data/${API_VERSION}/jobs/ingest/${jobId}`, {
       method: 'PATCH',
       json: {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR adds logging for Salesforce behind a flagon gate. This will allow inspection of the jobs created and the CSVs uploaded.

## Testing
Tested successfully in staging - logs come back as expected.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
