### PR TITLE
[STRATCONN-5516] | Revert "Worked on fixing braze_id default mappings of  Braze Actions."

### DIFF
--- a/packages/destination-actions/src/destinations/braze/__tests__/__snapshots__/braze.test.ts.snap
+++ b/packages/destination-actions/src/destinations/braze/__tests__/__snapshots__/braze.test.ts.snap
@@ -110,7 +110,7 @@ Object {
   "attributes": Array [
     Object {
       "_update_existing_only": false,
-      "braze_id": "test_braze_123",
+      "braze_id": undefined,
       "country": "United States",
       "current_location": Object {
         "latitude": 40.2964197,

--- a/packages/destination-actions/src/destinations/braze/__tests__/braze.test.ts
+++ b/packages/destination-actions/src/destinations/braze/__tests__/braze.test.ts
@@ -19,12 +19,7 @@ describe('Braze Cloud Mode (Actions)', () => {
 
       const event = createTestEvent({
         type: 'identify',
-        receivedAt,
-        integrations: {
-          ['Braze Cloud Mode (Actions)']: {
-            braze_id: 'test_braze_123'
-          } as any
-        }
+        receivedAt
       })
 
       const responses = await testDestination.testAction('updateUserProfile', {
@@ -32,6 +27,7 @@ describe('Braze Cloud Mode (Actions)', () => {
         settings,
         useDefaultMappings: true
       })
+
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       expect(responses[0].data).toMatchObject({})

--- a/packages/destination-actions/src/destinations/braze/__tests__/multistatus.test.ts
+++ b/packages/destination-actions/src/destinations/braze/__tests__/multistatus.test.ts
@@ -569,11 +569,7 @@ describe('MultiStatus', () => {
         '@path': '$.traits.externalId'
       },
       braze_id: {
-        '@if': {
-          exists: { '@path': '$.integrations.Braze Cloud Mode (Actions).braze_id' },
-          then: { '@path': '$.integrations.Braze Cloud Mode (Actions).braze_id' },
-          else: { '@path': '$.traits.braze_id' }
-        }
+        '@path': '$.traits.brazeId'
       }
     }
 
@@ -600,15 +596,6 @@ describe('MultiStatus', () => {
             email: 'user@example.com'
           }
         }),
-        createTestEvent({
-          type: 'identify',
-          receivedAt,
-          traits: {
-            firstName: 'Example',
-            lastName: 'User',
-            braze_id: 'test-braze-id'
-          }
-        }),
         // Event without any user identifier
         createTestEvent({
           type: 'identify',
@@ -631,23 +618,15 @@ describe('MultiStatus', () => {
         status: 200,
         body: 'success'
       })
+
       // The second event doesn't fail as there is no error reported by Braze API
       expect(response[1]).toMatchObject({
         status: 200,
         body: 'success'
       })
 
-      // The Third event doesn't fail as there is no error reported by Braze API
+      // The third event fails as pre-request validation fails for not having a valid user identifier
       expect(response[2]).toMatchObject({
-        status: 200,
-        body: 'success',
-        sent: expect.objectContaining({
-          braze_id: 'test-braze-id'
-        })
-      })
-
-      // The Fourth event fails as pre-request validation fails for not having a valid user identifier
-      expect(response[3]).toMatchObject({
         status: 400,
         errortype: 'PAYLOAD_VALIDATION_FAILED',
         errormessage: 'One of "external_id" or "user_alias" or "braze_id" or "email" is required.',

--- a/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
+++ b/packages/destination-actions/src/destinations/braze/updateUserProfile/index.ts
@@ -38,11 +38,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       allowNull: true,
       default: {
-        '@if': {
-          exists: { '@path': '$.integrations.Braze Cloud Mode (Actions).braze_id' },
-          then: { '@path': '$.integrations.Braze Cloud Mode (Actions).braze_id' },
-          else: { '@path': '$.traits.braze_id' }
-        }
+        '@path': '$.properties.braze_id'
       }
     },
     country: {

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
@@ -14,7 +14,7 @@ import { batch_size, country_code, enable_batching } from '../properties'
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Remove Profile',
   description: 'Remove profile from list',
-  defaultSubscription: 'event = "Identify"',
+  defaultSubscription: 'type = "Identify"',
   fields: {
     email: {
       label: 'Email',

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
@@ -14,7 +14,7 @@ import { batch_size, country_code, enable_batching } from '../properties'
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Remove Profile',
   description: 'Remove profile from list',
-  defaultSubscription: 'type = "Identify"',
+  defaultSubscription: 'event = "Identify"',
   fields: {
     email: {
       label: 'Email',


### PR DESCRIPTION
Reverts segmentio/action-destinations#2666 .
This PR reverts the default mapping of updateUserProfile for Braze Cloud (Actions) due to an issue in the coalesce function, which is causing a 400 Bad Request error.
Jira ticket :- https://segment.atlassian.net/jira/software/c/projects/STRATCONN/boards/310?assignee=63617339fc0cc7a600b03c6b&selectedIssue=STRATCONN-5516
