### PR TITLE
[Smart Hashing] [LinkedIn Conversions] Use Smart Hashing Util for Hashing Email

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -3,7 +3,8 @@ import {
   ModifiedResponse,
   DynamicFieldResponse,
   ActionHookResponse,
-  PayloadValidationError
+  PayloadValidationError,
+  Features
 } from '@segment/actions-core'
 import { BASE_URL, DEFAULT_POST_CLICK_LOOKBACK_WINDOW, DEFAULT_VIEW_THROUGH_LOOKBACK_WINDOW } from '../constants'
 import type {
@@ -19,7 +20,7 @@ import type {
   ConversionRuleUpdateResponse
 } from '../types'
 import type { Payload, OnMappingSaveInputs, OnMappingSaveOutputs } from '../streamConversion/generated-types'
-import { createHash } from 'crypto'
+import { processHashing } from '../../../lib/hashing-utils'
 
 interface ConversionRuleUpdateValues {
   name?: string
@@ -415,17 +416,18 @@ export class LinkedInConversions {
     return email.toLowerCase()
   }
 
-  private hashValue = (val: string): string => {
-    const hash = createHash('sha256')
-    hash.update(val)
-    return hash.digest('hex')
-  }
-
-  private buildUserIdsArray = (payload: Payload): UserID[] => {
+  private buildUserIdsArray = (payload: Payload, features?: Features): UserID[] => {
     const userIds: UserID[] = []
 
     if (payload.email) {
-      const hashedEmail = this.hashValue(this.normalizeEmail(payload.email))
+      const hashedEmail = processHashing(
+        payload.email,
+        'sha256',
+        'hex',
+        features ?? {},
+        'LinkedIn Conversions API',
+        this.normalizeEmail
+      )
       userIds.push({
         idType: 'SHA256_EMAIL',
         idValue: hashedEmail
@@ -456,8 +458,12 @@ export class LinkedInConversions {
     return userIds
   }
 
-  async streamConversionEvent(payload: Payload, conversionTime: number): Promise<ModifiedResponse> {
-    const userIds = this.buildUserIdsArray(payload)
+  async streamConversionEvent(
+    payload: Payload,
+    conversionTime: number,
+    features?: Features
+  ): Promise<ModifiedResponse> {
+    const userIds = this.buildUserIdsArray(payload, features)
     return this.request(`${BASE_URL}/conversionEvents`, {
       method: 'POST',
       json: {
@@ -473,7 +479,7 @@ export class LinkedInConversions {
     })
   }
 
-  async batchConversionAdd(payloads: Payload[]): Promise<ModifiedResponse> {
+  async batchConversionAdd(payloads: Payload[], features?: Features): Promise<ModifiedResponse> {
     return this.request(`${BASE_URL}/conversionEvents`, {
       method: 'post',
       headers: {
@@ -487,7 +493,7 @@ export class LinkedInConversions {
               : Number(payload.conversionHappenedAt)
             validate(payload, conversionTime)
 
-            const userIds = this.buildUserIdsArray(payload)
+            const userIds = this.buildUserIdsArray(payload, features)
             return {
               conversion: `urn:lla:llaPartnerConversion:${this.conversionRuleId}`,
               conversionHappenedAt: conversionTime,

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -425,7 +425,7 @@ export class LinkedInConversions {
         'sha256',
         'hex',
         features ?? {},
-        'LinkedIn Conversions API',
+        'actions-linkedin-conversions',
         this.normalizeEmail
       )
       userIds.push({

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
@@ -16,6 +16,7 @@ const event = createTestEvent({
     traits: {
       email: 'testing@testing.com',
       upperCaseEmail: 'WHYAREYOUYELLING@EMAIL.com',
+      preHashedEmail: '584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777',
       first_name: 'mike',
       last_name: 'smith',
       title: 'software engineer',
@@ -423,6 +424,45 @@ describe('LinkedinConversions.streamConversion', () => {
         }
       })
     ).rejects.toThrowError("User Info is missing the required field 'lastName'.")
+  })
+
+  it('should detect hashed email if feature flag for smart hashing is passed', async () => {
+    nock(`${BASE_URL}/conversionEvents`)
+      .post('', {
+        conversion: 'urn:lla:llaPartnerConversion:789123',
+        conversionHappenedAt: currentTimestamp,
+        user: {
+          userIds: [
+            {
+              idType: 'SHA256_EMAIL',
+              idValue: '584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777'
+            }
+          ]
+        }
+      })
+      .reply(201)
+
+    await expect(
+      testDestination.testAction('streamConversion', {
+        event,
+        settings,
+        mapping: {
+          email: { '@path': '$.context.traits.preHashedEmail' },
+          conversionHappenedAt: {
+            '@path': '$.timestamp'
+          },
+          onMappingSave: {
+            inputs: {},
+            outputs: {
+              id: payload.conversionId
+            }
+          },
+          enable_batching: true,
+          batch_size: 5000
+        },
+        features: { 'smart-hashing': true }
+      })
+    ).resolves.not.toThrowError()
   })
 })
 

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -296,7 +296,7 @@ const action: ActionDefinition<Settings, Payload, undefined, OnMappingSaveInputs
       unsafe_hidden: true
     }
   },
-  perform: async (request, { payload, hookOutputs }) => {
+  perform: async (request, { payload, hookOutputs, features }) => {
     const conversionTime = isNotEpochTimestampInMilliseconds(payload.conversionHappenedAt)
       ? convertToEpochMillis(payload.conversionHappenedAt)
       : Number(payload.conversionHappenedAt)
@@ -315,12 +315,12 @@ const action: ActionDefinition<Settings, Payload, undefined, OnMappingSaveInputs
     linkedinApiClient.setConversionRuleId(conversionRuleId)
 
     try {
-      return linkedinApiClient.streamConversionEvent(payload, conversionTime)
+      return linkedinApiClient.streamConversionEvent(payload, conversionTime, features)
     } catch (error) {
       throw handleRequestError(error)
     }
   },
-  performBatch: async (request, { payload: payloads, hookOutputs }) => {
+  performBatch: async (request, { payload: payloads, hookOutputs, features }) => {
     const linkedinApiClient: LinkedInConversions = new LinkedInConversions(request)
     const conversionRuleId = hookOutputs?.onMappingSave?.outputs?.id
 
@@ -331,7 +331,7 @@ const action: ActionDefinition<Settings, Payload, undefined, OnMappingSaveInputs
     linkedinApiClient.setConversionRuleId(conversionRuleId)
 
     try {
-      return linkedinApiClient.batchConversionAdd(payloads)
+      return linkedinApiClient.batchConversionAdd(payloads, features)
     } catch (error) {
       throw handleRequestError(error)
     }


### PR DESCRIPTION
This PR implements the [smart hashing utility](https://github.com/segmentio/action-destinations/pull/2756) for LinkedIn Conversions. 

In the previous implementation, if an event contained a pre-hashed email, it would be rehashed. With the new smart hashing utility, the system will now detect pre-hashed emails in the event and will avoid double hashing them.

JIRA -> https://segment.atlassian.net/browse/STRATCONN-5513

Flagon -> https://flagon.segment.com/families/centrifuge-destinations/gates/smart-hashing

## Testing

[Testing Document](https://docs.google.com/document/d/10-776AUC9pQKt3IEjsdnN-ulOQcr_ZP2ui6S6WzwUrE/edit?usp=sharing)

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
