### PR TITLE
Braze regions and v5.7 [STRATCONN-5592]

### DIFF
--- a/packages/browser-destinations/destinations/braze/package.json
+++ b/packages/browser-destinations/destinations/braze/package.json
@@ -33,7 +33,7 @@
   },
   "typings": "./dist/esm",
   "dependencies": {
-    "@braze/web-sdk": "npm:@braze/web-sdk@^4.1.0",
+    "@braze/web-sdk": "npm:@braze/web-sdk@^5",
     "@braze/web-sdk-v3": "npm:@braze/web-sdk@^3.5.1",
     "@segment/actions-core": "^3.146.0",
     "@segment/browser-destination-runtime": "^1.75.0"

--- a/packages/browser-destinations/destinations/braze/src/__tests__/__snapshots__/integration.test.ts.snap
+++ b/packages/browser-destinations/destinations/braze/src/__tests__/__snapshots__/integration.test.ts.snap
@@ -74,7 +74,7 @@ NodeList [
 exports[`loads different versions from CDN undefined version: 
       NodeList [
         <script
-          src="https://js.appboycdn.com/web-sdk/4.6/braze.no-module.min.js"
+          src="https://js.appboycdn.com/web-sdk/5.6/braze.no-module.min.js"
           status="loaded"
           type="text/javascript"
         />,
@@ -85,7 +85,7 @@ exports[`loads different versions from CDN undefined version:
      1`] = `
 NodeList [
   <script
-    src="https://js.appboycdn.com/web-sdk/4.10/braze.no-module.min.js"
+    src="https://js.appboycdn.com/web-sdk/5.7/braze.no-module.min.js"
     status="loaded"
     type="text/javascript"
   />,

--- a/packages/browser-destinations/destinations/braze/src/__tests__/integration.test.ts
+++ b/packages/browser-destinations/destinations/braze/src/__tests__/integration.test.ts
@@ -143,7 +143,7 @@ describe('loads different versions from CDN', () => {
     expect(scripts).toMatchSnapshot(`
       NodeList [
         <script
-          src="https://js.appboycdn.com/web-sdk/4.6/braze.no-module.min.js"
+          src="https://js.appboycdn.com/web-sdk/5.6/braze.no-module.min.js"
           status="loaded"
           type="text/javascript"
         />,

--- a/packages/browser-destinations/destinations/braze/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/braze/src/generated-types.ts
@@ -18,7 +18,7 @@ export interface Settings {
    */
   allowCrawlerActivity?: boolean
   /**
-   * To indicate that you trust the Braze dashboard users to write non-malicious Javascript click actions, set this property to true. If enableHtmlInAppMessages is true, this option will also be set to true. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)
+   * To indicate that you trust the Braze dashboard users to write non-malicious Javascript click actions, set this property to true. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)
    */
   allowUserSuppliedJavascript?: boolean
   /**

--- a/packages/browser-destinations/destinations/braze/src/index.ts
+++ b/packages/browser-destinations/destinations/braze/src/index.ts
@@ -1,7 +1,7 @@
 import type { Settings } from './generated-types'
 import type { BrowserDestinationDefinition } from '@segment/browser-destination-runtime/types'
 import { browserDestination } from '@segment/browser-destination-runtime/shim'
-import type braze from '@braze/web-sdk'
+import * as braze from '@braze/web-sdk'
 import type appboy from '@braze/web-sdk-v3'
 import trackEvent from './trackEvent'
 import updateUserProfile from './updateUserProfile'
@@ -18,25 +18,26 @@ declare global {
   }
 }
 
-const defaultVersion = '4.10'
+const defaultVersion = '5.7'
 
 const presets: DestinationDefinition['presets'] = [
   {
     name: 'Identify Calls',
+    type: 'automatic',
     subscribe: 'type = "identify" or type = "group"',
     partnerAction: 'updateUserProfile',
-    mapping: defaultValues(updateUserProfile.fields),
-    type: 'automatic'
+    mapping: defaultValues(updateUserProfile.fields)
   },
   {
     name: 'Order Completed calls',
+    type: 'automatic',
     subscribe: 'type = "track" and event = "Order Completed"',
     partnerAction: 'trackPurchase',
-    mapping: defaultValues(trackPurchase.fields),
-    type: 'automatic'
+    mapping: defaultValues(trackPurchase.fields)
   },
   {
     name: 'Track Calls',
+    type: 'automatic',
     subscribe: 'type = "track" and event != "Order Completed"',
     partnerAction: 'trackEvent',
     mapping: {
@@ -47,8 +48,7 @@ const presets: DestinationDefinition['presets'] = [
       eventProperties: {
         '@path': '$.properties'
       }
-    },
-    type: 'automatic'
+    }
   }
 ]
 
@@ -93,6 +93,10 @@ export const destination: BrowserDestinationDefinition<Settings, BrazeDestinatio
         {
           value: '5.4',
           label: '5.4'
+        },
+        {
+          value: '5.7',
+          label: '5.7'
         }
       ],
       default: defaultVersion,
@@ -120,9 +124,11 @@ export const destination: BrowserDestinationDefinition<Settings, BrazeDestinatio
         { label: 'US-07	(https://dashboard-07.braze.com)', value: 'sdk.iad-07.braze.com' },
         { label: 'US-08	(https://dashboard-08.braze.com)', value: 'sdk.iad-08.braze.com' },
         { label: 'US-09	(https://dashboard-09.braze.com)', value: 'sdk.iad-09.braze.com' },
+        { label: 'US-10	(https://dashboard-10.braze.com)', value: 'sdk.iad-10.braze.com' },
         { label: 'EU-01	(https://dashboard-01.braze.eu)', value: 'sdk.fra-01.braze.eu' },
         { label: 'EU-02	(https://dashboard-02.braze.eu)', value: 'sdk.fra-02.braze.eu' },
-        { label: 'AU-01 (https://dashboard.au-01.braze.com)', value: 'sdk.au-01.braze.com' }
+        { label: 'AU-01 (https://dashboard.au-01.braze.com)', value: 'sdk.au-01.braze.com' },
+        { label: 'ID-01 (https://dashboard.id-01.braze.com)', value: 'sdk.id-01.braze.com' }
       ],
       default: 'sdk.iad-01.braze.com',
       required: true
@@ -137,7 +143,7 @@ export const destination: BrowserDestinationDefinition<Settings, BrazeDestinatio
     },
     allowUserSuppliedJavascript: {
       description:
-        'To indicate that you trust the Braze dashboard users to write non-malicious Javascript click actions, set this property to true. If enableHtmlInAppMessages is true, this option will also be set to true. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)',
+        'To indicate that you trust the Braze dashboard users to write non-malicious Javascript click actions, set this property to true. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)',
       label: 'Allow User Supplied Javascript',
       default: false,
       type: 'boolean',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1600,10 +1600,10 @@
   resolved "https://registry.yarnpkg.com/@braze/web-sdk/-/web-sdk-3.5.1.tgz#04cd8e7021e13a690cd9c2ad7e7a3b5028d06178"
   integrity sha512-Quvqs2RqTZK7+VUCwsGMT9EHYwiXUYwWJk441ly2F0yj64WK2GPvXy3XdIpXLCgWVhGg42WNJ4X6WBgfaF+3EQ==
 
-"@braze/web-sdk@npm:@braze/web-sdk@^4.1.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@braze/web-sdk/-/web-sdk-4.7.0.tgz#5adb930690d78dd3bc77a93dececde360a08d0f7"
-  integrity sha512-fYdCyjlZqBswlebO8XmbPj04soLycHxnSvCQ/bWpi4OB00fz/ne34vv1LzIP3d0V5++jwjsutxdEi5mRiiMK1Q==
+"@braze/web-sdk@npm:@braze/web-sdk@^5":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@braze/web-sdk/-/web-sdk-5.7.0.tgz#f2166922da112cc359e5259753964e3e2f9ae5a9"
+  integrity sha512-JG7WC00GevlyOLVaA7K8PBPE5WsaCaPhSnbitDZ0JySRgFM7tY19X6V8cynoTeBbIHBwD6CcHOCGNHQeLk2PCA==
 
 "@bucketco/tracking-sdk@^2.0.0":
   version "2.1.6"
@@ -15895,16 +15895,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15962,7 +15953,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15989,13 +15980,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -17512,7 +17496,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -17534,15 +17518,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Adds v5.7 and new regions to Braze browser destination

## Testing
<img width="660" alt="image" src="https://github.com/user-attachments/assets/cbd1a729-2ed6-4666-bb71-826a5ab5c002" />

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
