### PR TITLE
[TOPSORT] fix: wrong mapping for purchase event & added optional vendor_id

### DIFF
--- a/packages/destination-actions/src/destinations/topsort/purchase/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/topsort/purchase/__tests__/__snapshots__/index.test.ts.snap
@@ -15,3 +15,35 @@ Headers {
   },
 }
 `;
+
+exports[`Topsort.purchase should be successful with default mappings and products object, including brand as vendorId 1`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer bar",
+    ],
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Topsort.purchase should be successful with default mappings and products object, including custom vendorId 1`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer bar",
+    ],
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;

--- a/packages/destination-actions/src/destinations/topsort/purchase/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/topsort/purchase/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -10,6 +10,7 @@ Object {
           "productId": "4mevd8V",
           "quantity": -6621698275147776,
           "unitPrice": -66216982751477.76,
+          "vendorId": "4mevd8V",
         },
       ],
       "occurredAt": "2021-02-01T00:00:00.000Z",

--- a/packages/destination-actions/src/destinations/topsort/purchase/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/topsort/purchase/__tests__/index.test.ts
@@ -50,6 +50,98 @@ describe('Topsort.purchase', () => {
     })
   })
 
+  it('should be successful with default mappings and products object, including brand as vendorId', async () => {
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: {
+        products: [
+          {
+            product_id: '123',
+            price: 100,
+            quantity: 1,
+            brand: 'v123'
+          }
+        ]
+      }
+    })
+
+    const responses = await testDestination.testAction('purchase', {
+      event,
+      settings: {
+        api_key: 'bar'
+      },
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.headers).toMatchSnapshot()
+    expect(responses[0].options.json).toMatchObject({
+      purchases: expect.arrayContaining([
+        expect.objectContaining({
+          id: expect.any(String),
+          occurredAt: expect.any(String),
+          opaqueUserId: expect.any(String),
+          items: [
+            {
+              productId: '123',
+              unitPrice: 100,
+              quantity: 1,
+              vendorId: 'v123'
+            }
+          ]
+        })
+      ])
+    })
+  })
+
+  it('should be successful with default mappings and products object, including custom vendorId', async () => {
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: {
+        products: [
+          {
+            product_id: '123',
+            price: 100,
+            quantity: 1,
+            vendorId: 'v123'
+          }
+        ]
+      }
+    })
+
+    const responses = await testDestination.testAction('purchase', {
+      event,
+      settings: {
+        api_key: 'bar'
+      },
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.headers).toMatchSnapshot()
+    expect(responses[0].options.json).toMatchObject({
+      purchases: expect.arrayContaining([
+        expect.objectContaining({
+          id: expect.any(String),
+          occurredAt: expect.any(String),
+          opaqueUserId: expect.any(String),
+          items: [
+            {
+              productId: '123',
+              unitPrice: 100,
+              quantity: 1,
+              vendorId: 'v123'
+            }
+          ]
+        })
+      ])
+    })
+  })
+
   it('should fail because it misses a required field (products)', async () => {
     nock(/.*/).persist().post(/.*/).reply(200)
 

--- a/packages/destination-actions/src/destinations/topsort/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/topsort/purchase/generated-types.ts
@@ -29,5 +29,9 @@ export interface Payload {
      * Count of products purchased.
      */
     quantity?: number
+    /**
+     * The vendor ID of the product being purchased.
+     */
+    vendorId?: string
   }[]
 }

--- a/packages/destination-actions/src/destinations/topsort/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/topsort/purchase/index.ts
@@ -61,6 +61,12 @@ const action: ActionDefinition<Settings, Payload> = {
           description: 'Count of products purchased.',
           type: 'integer',
           required: false
+        },
+        vendorId: {
+          label: 'Vendor ID',
+          description: 'The vendor ID of the product being purchased.',
+          type: 'string',
+          required: false
         }
       },
       default: {
@@ -69,7 +75,14 @@ const action: ActionDefinition<Settings, Payload> = {
           {
             productId: { '@path': '$.product_id' },
             unitPrice: { '@path': '$.price' },
-            quantity: { '@path': '$.quantity' }
+            quantity: { '@path': '$.quantity' },
+            vendorId: {
+              '@if': {
+                exists: { '@path': '$.vendorId' },
+                then: { '@path': '$.vendorId' },
+                else: { '@path': '$.brand' }
+              }
+            }
           }
         ]
       }


### PR DESCRIPTION
To be able to send vendorId in Order Completed events.
To Do
- [x] Fix default mapping schema from Order Completed (wasn't correctly mapping products object as stated in [Order Completed Specs](https://segment.com/docs/connections/spec/ecommerce/v2/#order-completed))
- [x] Added optional vendorId to purchase products mapping
- [x] Added conditional mapping for custom vendorId field or default brand field
- [x] Added tests for optional and conditional default vendorId field


![imagen](https://github.com/user-attachments/assets/fac96a8b-481a-4bbe-bd38-5aa84ddcbc47)
![imagen](https://github.com/user-attachments/assets/d14999d8-a039-4b6d-95a2-c0b14c1633ce)
