### PR TITLE
[algolia-insights] update presets for conversion events

### DIFF
--- a/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/index.ts
@@ -14,7 +14,7 @@ const notUndef = (thing: unknown) => typeof thing !== 'undefined'
 export const conversionEvents: ActionDefinition<Settings, Payload> = {
   title: 'Conversion Events',
   description:
-    'In ecommerce, conversions are purchase events often but not always involving multiple products. Outside of a conversion can be any positive signal associated with an index record. Query ID is optional and indicates that the view events is the result of a search query.',
+    'In ecommerce, conversions are purchase or add-to-cart events often but not always involving multiple products. Outside of ecommerce, a conversion can be any positive signal associated with an index record. Query ID is optional and indicates that the event is the result of a search query.',
   fields: {
     eventSubtype: {
       label: 'Event Subtype',
@@ -188,10 +188,24 @@ export const conversionEvents: ActionDefinition<Settings, Payload> = {
 }
 
 /** used in the quick setup */
-export const conversionPresets: Preset = {
-  name: 'Send conversion events to Algolia',
+export const purchasePreset: Preset = {
+  name: 'Send purchase events to Algolia',
   subscribe: conversionEvents.defaultSubscription as string,
   partnerAction: 'conversionEvents',
   mapping: defaultValues(conversionEvents.fields),
+  type: 'automatic'
+}
+
+const getAddToCartFields = () => {
+  const out = structuredClone(conversionEvents.fields)
+  out.eventSubtype.default = 'addToCart'
+  return out
+}
+
+export const addToCartPreset: Preset = {
+  name: 'Send add-to-cart events to Algolia',
+  subscribe: 'type = "track" and event = "Product Added"',
+  partnerAction: 'conversionEvents',
+  mapping: defaultValues(getAddToCartFields()),
   type: 'automatic'
 }

--- a/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/conversionEvents/index.ts
@@ -1,4 +1,4 @@
-import type { ActionDefinition, Preset } from '@segment/actions-core'
+import type { ActionDefinition, BaseActionDefinition, Preset } from '@segment/actions-core'
 import { defaultValues } from '@segment/actions-core'
 import {
   AlgoliaBehaviourURL,
@@ -11,147 +11,149 @@ import type { Payload } from './generated-types'
 
 const notUndef = (thing: unknown) => typeof thing !== 'undefined'
 
+const getEventFields = (subtype: AlgoliaEventSubtype = 'purchase'): BaseActionDefinition['fields'] => ({
+  eventSubtype: {
+    label: 'Event Subtype',
+    description: 'Sub-type of the event, "purchase" or "addToCart".',
+    type: 'string',
+    required: false,
+    choices: [
+      { value: 'purchase', label: 'Purchase' },
+      { value: 'addToCart', label: 'Add To Cart' }
+    ],
+    default: subtype
+  },
+  products: {
+    label: 'Product Details',
+    description:
+      'Populates the ObjectIDs field in the Algolia Insights API. An array of objects representing the purchased items. Each object must contain a product_id field.',
+    type: 'object',
+    multiple: true,
+    defaultObjectUI: 'keyvalue',
+    properties: {
+      product_id: { label: 'product_id', type: 'string', required: true },
+      price: { label: 'price', type: 'number', required: false },
+      quantity: { label: 'quantity', type: 'number', required: false },
+      discount: { label: 'discount', type: 'number', required: false },
+      queryID: { label: 'queryID', type: 'string', required: false }
+    },
+    required: true,
+    default: {
+      '@arrayPath': [
+        '$.properties.products',
+        {
+          product_id: {
+            '@path': '$.product_id'
+          },
+          price: {
+            '@path': '$.price'
+          },
+          quantity: {
+            '@path': '$.quantity'
+          },
+          discount: {
+            '@path': '$.discount'
+          },
+          queryID: {
+            '@path': '$.queryID'
+          }
+        }
+      ]
+    }
+  },
+  index: {
+    label: 'Index',
+    description: 'Name of the targeted search index.',
+    type: 'string',
+    required: true,
+    default: {
+      '@path': '$.properties.search_index'
+    }
+  },
+  queryID: {
+    label: 'Query ID',
+    description: 'Query ID of the list on which the item was purchased.',
+    type: 'string',
+    required: false,
+    default: {
+      '@if': {
+        exists: { '@path': '$.properties.query_id' },
+        then: { '@path': '$.properties.query_id' },
+        else: { '@path': '$.integrations.Algolia Insights (Actions).query_id' }
+      }
+    }
+  },
+  userToken: {
+    type: 'string',
+    required: true,
+    description: 'The ID associated with the user.',
+    label: 'User Token',
+    default: {
+      '@if': {
+        exists: { '@path': '$.userId' },
+        then: { '@path': '$.userId' },
+        else: { '@path': '$.anonymousId' }
+      }
+    }
+  },
+  timestamp: {
+    type: 'string',
+    required: false,
+    description: 'The timestamp of the event.',
+    label: 'Timestamp',
+    default: { '@path': '$.timestamp' }
+  },
+  value: {
+    type: 'number',
+    required: false,
+    description: 'The value of the cart that is being converted.',
+    label: 'Value',
+    default: { '@path': '$.properties.value' }
+  },
+  currency: {
+    type: 'string',
+    required: false,
+    description:
+      'Currency of the objects associated with the event in 3-letter ISO 4217 format. Required when `value` or `price` is set.',
+    label: 'Currency',
+    default: { '@path': '$.properties.currency' }
+  },
+  extraProperties: {
+    label: 'Extra Properties',
+    required: false,
+    description:
+      'Additional fields for this event. This field may be useful for Algolia Insights fields which are not mapped in Segment.',
+    type: 'object',
+    default: {
+      '@path': '$.properties'
+    }
+  },
+  eventName: {
+    label: 'Event Name',
+    description: "The name of the event to send to Algolia. Defaults to 'Conversion Event'",
+    type: 'string',
+    required: false,
+    default: 'Conversion Event'
+  },
+  eventType: {
+    label: 'Event Type',
+    description: "The type of event to send to Algolia. Defaults to 'conversion'",
+    type: 'string',
+    required: false,
+    default: 'conversion',
+    choices: [
+      { label: 'View', value: 'view' },
+      { label: 'Conversion', value: 'conversion' },
+      { label: 'Click', value: 'click' }
+    ]
+  }
+})
+
 export const conversionEvents: ActionDefinition<Settings, Payload> = {
   title: 'Conversion Events',
   description:
     'In ecommerce, conversions are purchase or add-to-cart events often but not always involving multiple products. Outside of ecommerce, a conversion can be any positive signal associated with an index record. Query ID is optional and indicates that the event is the result of a search query.',
-  fields: {
-    eventSubtype: {
-      label: 'Event Subtype',
-      description: 'Sub-type of the event, "purchase" or "addToCart".',
-      type: 'string',
-      required: false,
-      choices: [
-        { value: 'purchase', label: 'Purchase' },
-        { value: 'addToCart', label: 'Add To Cart' }
-      ],
-      default: 'purchase'
-    },
-    products: {
-      label: 'Product Details',
-      description:
-        'Populates the ObjectIDs field in the Algolia Insights API. An array of objects representing the purchased items. Each object must contain a product_id field.',
-      type: 'object',
-      multiple: true,
-      defaultObjectUI: 'keyvalue',
-      properties: {
-        product_id: { label: 'product_id', type: 'string', required: true },
-        price: { label: 'price', type: 'number', required: false },
-        quantity: { label: 'quantity', type: 'number', required: false },
-        discount: { label: 'discount', type: 'number', required: false },
-        queryID: { label: 'queryID', type: 'string', required: false }
-      },
-      required: true,
-      default: {
-        '@arrayPath': [
-          '$.properties.products',
-          {
-            product_id: {
-              '@path': '$.product_id'
-            },
-            price: {
-              '@path': '$.price'
-            },
-            quantity: {
-              '@path': '$.quantity'
-            },
-            discount: {
-              '@path': '$.discount'
-            },
-            queryID: {
-              '@path': '$.queryID'
-            }
-          }
-        ]
-      }
-    },
-    index: {
-      label: 'Index',
-      description: 'Name of the targeted search index.',
-      type: 'string',
-      required: true,
-      default: {
-        '@path': '$.properties.search_index'
-      }
-    },
-    queryID: {
-      label: 'Query ID',
-      description: 'Query ID of the list on which the item was purchased.',
-      type: 'string',
-      required: false,
-      default: {
-        '@if': {
-          exists: { '@path': '$.properties.query_id' },
-          then: { '@path': '$.properties.query_id' },
-          else: { '@path': '$.integrations.Algolia Insights (Actions).query_id' }
-        }
-      }
-    },
-    userToken: {
-      type: 'string',
-      required: true,
-      description: 'The ID associated with the user.',
-      label: 'User Token',
-      default: {
-        '@if': {
-          exists: { '@path': '$.userId' },
-          then: { '@path': '$.userId' },
-          else: { '@path': '$.anonymousId' }
-        }
-      }
-    },
-    timestamp: {
-      type: 'string',
-      required: false,
-      description: 'The timestamp of the event.',
-      label: 'Timestamp',
-      default: { '@path': '$.timestamp' }
-    },
-    value: {
-      type: 'number',
-      required: false,
-      description: 'The value of the cart that is being converted.',
-      label: 'Value',
-      default: { '@path': '$.properties.value' }
-    },
-    currency: {
-      type: 'string',
-      required: false,
-      description:
-        'Currency of the objects associated with the event in 3-letter ISO 4217 format. Required when `value` or `price` is set.',
-      label: 'Currency',
-      default: { '@path': '$.properties.currency' }
-    },
-    extraProperties: {
-      label: 'Extra Properties',
-      required: false,
-      description:
-        'Additional fields for this event. This field may be useful for Algolia Insights fields which are not mapped in Segment.',
-      type: 'object',
-      default: {
-        '@path': '$.properties'
-      }
-    },
-    eventName: {
-      label: 'Event Name',
-      description: "The name of the event to send to Algolia. Defaults to 'Conversion Event'",
-      type: 'string',
-      required: false,
-      default: 'Conversion Event'
-    },
-    eventType: {
-      label: 'Event Type',
-      description: "The type of event to send to Algolia. Defaults to 'conversion'",
-      type: 'string',
-      required: false,
-      default: 'conversion',
-      choices: [
-        { label: 'View', value: 'view' },
-        { label: 'Conversion', value: 'conversion' },
-        { label: 'Click', value: 'click' }
-      ]
-    }
-  },
+  fields: getEventFields(),
   defaultSubscription: 'type = "track" and event = "Order Completed"',
   perform: (request, data) => {
     const objectData = data.payload.products.some(({ queryID, price, discount, quantity }) => {
@@ -196,16 +198,10 @@ export const purchasePreset: Preset = {
   type: 'automatic'
 }
 
-const getAddToCartFields = () => {
-  const out = structuredClone(conversionEvents.fields)
-  out.eventSubtype.default = 'addToCart'
-  return out
-}
-
 export const addToCartPreset: Preset = {
   name: 'Send add-to-cart events to Algolia',
   subscribe: 'type = "track" and event = "Product Added"',
   partnerAction: 'conversionEvents',
-  mapping: defaultValues(getAddToCartFields()),
+  mapping: defaultValues(getEventFields('addToCart')),
   type: 'automatic'
 }

--- a/packages/destination-actions/src/destinations/algolia-insights/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/index.ts
@@ -8,7 +8,7 @@ import { conversionEvents, conversionPresets } from './conversionEvents'
 import { productViewedEvents, productViewedPresets } from './productViewedEvents'
 import { AlgoliaApiPermissions, algoliaApiPermissionsUrl } from './algolia-insight-api'
 
-import { productAddedEvents, productAddedPresets } from './productAddedEvents'
+import { productAddedEvents } from './productAddedEvents'
 
 import { productListFilteredEvents, productListFilteredPresets } from './productListFilteredEvents'
 
@@ -66,7 +66,6 @@ const destination: DestinationDefinition<Settings> = {
     productClickPresets,
     conversionPresets,
     productViewedPresets,
-    productAddedPresets,
     productListFilteredPresets
   ],
   actions: {

--- a/packages/destination-actions/src/destinations/algolia-insights/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from './generated-types'
 
 import { productClickedEvents, productClickPresets } from './productClickedEvents'
 
-import { conversionEvents, conversionPresets } from './conversionEvents'
+import { conversionEvents, purchasePreset, addToCartPreset } from './conversionEvents'
 
 import { productViewedEvents, productViewedPresets } from './productViewedEvents'
 import { AlgoliaApiPermissions, algoliaApiPermissionsUrl } from './algolia-insight-api'
@@ -64,7 +64,8 @@ const destination: DestinationDefinition<Settings> = {
       type: 'automatic'
     },
     productClickPresets,
-    conversionPresets,
+    purchasePreset,
+    addToCartPreset,
     productViewedPresets,
     productListFilteredPresets
   ],

--- a/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/index.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/productAddedEvents/index.ts
@@ -1,13 +1,12 @@
-import type { ActionDefinition, Preset } from '@segment/actions-core'
-import { defaultValues } from '@segment/actions-core'
+import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { AlgoliaBehaviourURL, AlgoliaConversionEvent, AlgoliaEventType } from '../algolia-insight-api'
 
 export const productAddedEvents: ActionDefinition<Settings, Payload> = {
-  title: 'Product Added Events',
+  title: '[Deprecated] Product Added Events',
   description:
-    'Product added events for ecommerce use cases for a customer adding an item to their cart. Query ID is optional and indicates that the event was the result of a search query.',
+    'Product added events for ecommerce use cases for a customer adding an item to their cart. Query ID is optional and indicates that the event was the result of a search query. **Important** This Action is deprecated. Use the **Conversion Events** Action instead.',
   fields: {
     product: {
       label: 'Product ID',
@@ -110,12 +109,4 @@ export const productAddedEvents: ActionDefinition<Settings, Payload> = {
       json: insightPayload
     })
   }
-}
-
-export const productAddedPresets: Preset = {
-  name: 'Send product added events to Algolia',
-  subscribe: productAddedEvents.defaultSubscription as string,
-  partnerAction: 'productAddedEvents',
-  mapping: defaultValues(productAddedEvents.fields),
-  type: 'automatic'
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

## Summary

Update the available presets / pre-built mappings to make configuring ecommerce conversions less confusing (current presets shown in screenshot).

![Screenshot 2025-02-27 at 3 58 17 pm](https://github.com/user-attachments/assets/7d95cc09-f60a-4bb7-b509-29e265876cfa)

* Split **Send conversion events to Algolia** preset into **Send purchase events to Algolia** and **Send add-to-cart events to Algolia**. We already treat a generic **Conversion Event** as a purchase, so this makes it clearer.
* Update **Conversion Events** action description.
* Mark the **Product Added** action as deprecated and remove **Send product added events to Algolia** preset. This maps more closely to our [Insights API spec](https://www.algolia.com/doc/rest-api/insights/#tag/events/operation/pushEvents) where we consider add-to-carts and purchases "subtypes" of a conversion-type event. The generic conversion event also enables specifying revenue data for multiple objects, which the **Product Added** event does not.

## Testing

This change mainly involved updating the presets. The only change to the actual Destination Actions were in the descriptions, lmk if there's some way I should be testing that.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
