### PR TITLE
[Criteo] Audience Destination: set enable_batching to true by default

### DIFF
--- a/packages/destination-actions/src/destinations/criteo-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/criteo-audiences/generated-types.ts
@@ -13,4 +13,8 @@ export interface Settings {
    * Your Criteo Advertiser ID
    */
   advertiser_id: string
+  /**
+   * Important: This setting should remain enabled!
+   */
+  enable_batching?: boolean
 }

--- a/packages/destination-actions/src/destinations/criteo-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/criteo-audiences/index.ts
@@ -30,6 +30,13 @@ const destination: DestinationDefinition<Settings> = {
         description: 'Your Criteo Advertiser ID',
         type: 'string',
         required: true
+      },
+      enable_batching: {
+        type: 'boolean',
+        label: 'Enable Batching',
+        description: 'Important: This setting should remain enabled!',
+        required: true,
+        default: true
       }
     },
     testAuthentication: async (request, { settings }) => {

--- a/packages/destination-actions/src/destinations/criteo-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/criteo-audiences/index.ts
@@ -35,7 +35,7 @@ const destination: DestinationDefinition<Settings> = {
         type: 'boolean',
         label: 'Enable Batching',
         description: 'Important: This setting should remain enabled!',
-        required: true,
+        required: false,
         default: true
       }
     },


### PR DESCRIPTION
Set the enable batching option to true by default as the performances of the Criteo Audience API are optimized for batched requests.

## Testing
- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [X] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
