### PR TITLE
[required fields v2] Fixes an issue with schema validation in a specific case

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/schema-validation.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/schema-validation.test.ts.snap
@@ -67,6 +67,9 @@ Object {
             "const": true,
           },
         },
+        "required": Array [
+          "a",
+        ],
       },
       "then": Object {
         "required": Array [
@@ -108,6 +111,9 @@ Object {
             "const": 10,
           },
         },
+        "required": Array [
+          "a",
+        ],
       },
       "then": Object {
         "required": Array [
@@ -732,6 +738,9 @@ Object {
             "const": "a_value",
           },
         },
+        "required": Array [
+          "a",
+        ],
       },
       "then": Object {
         "properties": Object {
@@ -1225,6 +1234,9 @@ Object {
             "const": "a_value",
           },
         },
+        "required": Array [
+          "a",
+        ],
       },
       "then": Object {
         "required": Array [
@@ -1256,6 +1268,94 @@ Object {
 }
 `;
 
+exports[`conditionally required fields should validate a single conditional requirement should validate b when it is required and when it is not required 2`] = `
+Object {
+  "$schema": "http://json-schema.org/schema#",
+  "additionalProperties": false,
+  "allOf": Array [
+    Object {
+      "if": Object {
+        "properties": Object {
+          "a": Object {
+            "const": "a_value",
+          },
+        },
+        "required": Array [
+          "a",
+        ],
+      },
+      "then": Object {
+        "required": Array [
+          "b",
+        ],
+      },
+    },
+  ],
+  "properties": Object {
+    "a": Object {
+      "default": undefined,
+      "description": "a",
+      "format": undefined,
+      "title": "a",
+      "type": "string",
+    },
+    "b": Object {
+      "default": undefined,
+      "description": "b",
+      "format": undefined,
+      "title": "b",
+      "type": "string",
+    },
+  },
+  "required": Array [],
+  "type": "object",
+}
+`;
+
+exports[`conditionally required fields should validate multiple conditional requirements on different fields should validate when a field depends on an empty string field 1`] = `
+Object {
+  "$schema": "http://json-schema.org/schema#",
+  "additionalProperties": false,
+  "allOf": Array [
+    Object {
+      "if": Object {
+        "properties": Object {
+          "a": Object {
+            "const": "a_value",
+          },
+        },
+        "required": Array [
+          "a",
+        ],
+      },
+      "then": Object {
+        "required": Array [
+          "b",
+        ],
+      },
+    },
+  ],
+  "properties": Object {
+    "a": Object {
+      "default": undefined,
+      "description": "a",
+      "format": undefined,
+      "title": "a",
+      "type": "string",
+    },
+    "b": Object {
+      "default": undefined,
+      "description": "b",
+      "format": undefined,
+      "title": "b",
+      "type": "string",
+    },
+  },
+  "required": Array [],
+  "type": "object",
+}
+`;
+
 exports[`conditionally required fields should validate multiple conditional requirements on different fields should validate when both b and c are required 1`] = `
 Object {
   "$schema": "http://json-schema.org/schema#",
@@ -1268,6 +1368,9 @@ Object {
             "const": "a_value",
           },
         },
+        "required": Array [
+          "a",
+        ],
       },
       "then": Object {
         "required": Array [
@@ -1284,6 +1387,9 @@ Object {
             },
           },
         },
+        "required": Array [
+          "a",
+        ],
       },
       "then": Object {
         "required": Array [
@@ -1334,6 +1440,9 @@ Object {
             "const": "a_value",
           },
         },
+        "required": Array [
+          "a",
+        ],
       },
       "then": Object {
         "required": Array [
@@ -1348,6 +1457,9 @@ Object {
             "const": "value",
           },
         },
+        "required": Array [
+          "a",
+        ],
       },
       "then": Object {
         "required": Array [
@@ -1398,6 +1510,9 @@ Object {
             "const": "a_value",
           },
         },
+        "required": Array [
+          "a",
+        ],
       },
       "then": Object {
         "required": Array [
@@ -1412,6 +1527,9 @@ Object {
             "const": "value",
           },
         },
+        "required": Array [
+          "a",
+        ],
       },
       "then": Object {
         "required": Array [
@@ -1462,6 +1580,9 @@ Object {
             "const": "a_value",
           },
         },
+        "required": Array [
+          "a",
+        ],
       },
       "then": Object {
         "required": Array [
@@ -1476,6 +1597,9 @@ Object {
             "const": "value",
           },
         },
+        "required": Array [
+          "a",
+        ],
       },
       "then": Object {
         "required": Array [

--- a/packages/core/src/__tests__/schema-validation.test.ts
+++ b/packages/core/src/__tests__/schema-validation.test.ts
@@ -106,6 +106,47 @@ describe('conditionally required fields', () => {
       isValid = validateSchema(b_not_required_mapping[1], schema, { throwIfInvalid: false })
       expect(isValid).toBe(true)
     })
+
+    it('should validate b when it is required and when it is not required', async () => {
+      mockActionFields['a'] = {
+        label: 'a',
+        type: 'string',
+        description: 'a'
+      }
+
+      mockActionFields['b'] = {
+        label: 'b',
+        type: 'string',
+        description: 'b',
+        required: {
+          conditions: [{ fieldKey: 'a', operator: 'is', value: 'a_value' }]
+        }
+      }
+
+      const schema = fieldsToJsonSchema(mockActionFields)
+      expect(schema).toMatchSnapshot()
+      const b_required_mappings = [{ a: 'a_value' }, { a: 'a_value', b: 'b_value' }]
+      const b_not_required_mapping = [{ a: 'not value' }, { a: 'not value', b: 'b_value' }, {}, { a: undefined }]
+
+      let isValid
+      isValid = validateSchema(b_required_mappings[0], schema, { throwIfInvalid: false })
+      expect(isValid).toBe(false)
+
+      isValid = validateSchema(b_required_mappings[1], schema, { throwIfInvalid: false })
+      expect(isValid).toBe(true)
+
+      isValid = validateSchema(b_not_required_mapping[0], schema, { throwIfInvalid: false })
+      expect(isValid).toBe(true)
+
+      isValid = validateSchema(b_not_required_mapping[1], schema, { throwIfInvalid: false })
+      expect(isValid).toBe(true)
+
+      isValid = validateSchema(b_not_required_mapping[2], schema, { throwIfInvalid: false })
+      expect(isValid).toBe(true)
+
+      isValid = validateSchema(b_not_required_mapping[3], schema, { throwIfInvalid: false })
+      expect(isValid).toBe(true)
+    })
   })
 
   describe('should validate multiple conditional requirements on different fields', () => {
@@ -324,6 +365,39 @@ describe('conditionally required fields', () => {
 
       isValid = validateSchema(both_required, schema, { throwIfInvalid: false })
       expect(isValid).toBe(false)
+    })
+
+    it('should validate when a field depends on an empty string field', async () => {
+      mockActionFields['a'] = {
+        label: 'a',
+        type: 'string',
+        description: 'a'
+      }
+
+      mockActionFields['b'] = {
+        label: 'b',
+        type: 'string',
+        description: 'b',
+        required: {
+          conditions: [{ fieldKey: 'a', operator: 'is', value: 'a_value' }]
+        }
+      }
+
+      const b_required_mappings = [{ a: 'a_value' }, { a: 'a_value', b: 'b_value' }]
+      const empty = {}
+
+      const schema = fieldsToJsonSchema(mockActionFields)
+      expect(schema).toMatchSnapshot()
+
+      let isValid
+      isValid = validateSchema(b_required_mappings[0], schema, { throwIfInvalid: false })
+      expect(isValid).toBe(false)
+
+      isValid = validateSchema(b_required_mappings[1], schema, { throwIfInvalid: false })
+      expect(isValid).toBe(true)
+
+      isValid = validateSchema(empty, schema, { throwIfInvalid: false })
+      expect(isValid).toBe(true)
     })
   })
 
@@ -1012,7 +1086,7 @@ describe('conditionally required fields', () => {
 
       const b_required_mappings = [{ a: true }, { a: true, b: 'b_value' }]
 
-      const b_not_required_mappings = [{ a: false }, { a: false, b: 'b_value' }]
+      const b_not_required_mappings = [{ a: false }, { a: false, b: 'b_value' }, {}, { a: undefined }, { b: 'b_value' }]
 
       let isValid
       isValid = validateSchema(b_required_mappings[0], schema, { throwIfInvalid: false })
@@ -1025,6 +1099,15 @@ describe('conditionally required fields', () => {
       expect(isValid).toBe(true)
 
       isValid = validateSchema(b_not_required_mappings[1], schema, { throwIfInvalid: false })
+      expect(isValid).toBe(true)
+
+      isValid = validateSchema(b_not_required_mappings[2], schema, { throwIfInvalid: true })
+      expect(isValid).toBe(true)
+
+      isValid = validateSchema(b_not_required_mappings[3], schema, { throwIfInvalid: false })
+      expect(isValid).toBe(true)
+
+      isValid = validateSchema(b_not_required_mappings[4], schema, { throwIfInvalid: false })
       expect(isValid).toBe(true)
     })
 

--- a/packages/core/src/destination-kit/fields-to-jsonschema.ts
+++ b/packages/core/src/destination-kit/fields-to-jsonschema.ts
@@ -109,6 +109,7 @@ const simpleConditionToJSONSchema = (
 
   return {
     if: {
+      required: [dependantFieldKey],
       properties: { [dependantFieldKey]: dependantValueToJSONSchema }
     },
     then: generateThenStatement(fieldKey)


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR fixes an issue I found with conditionally required fields where this condition did not generate a correct schema:

```
    isSendable: {
      label: 'Is Sendable',
      type: 'boolean',
      ...
    },
    sendableCustomObjectField: {
      label: 'Sendable Custom Object Field',
      type: 'string',
      required: {
        match: 'all',
        conditions: [{ fieldKey: 'isSendable', operator: 'is', value: true }]
      }
    },
    sendableSubscriberField: {
      label: 'Sendable Subscriber Field',
      type: 'string',
      required: {
        match: 'all',
        conditions: [{ fieldKey: 'isSendable', operator: 'is', value: true }]
      }
    },
```
When 'isSendable' was not included in the mapping at all, the validation would fail and incorrectly require both 'sendableCustomObjectField' and 'sendableSubscriberField'
## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
