### PR TITLE
Adds yarn clean-build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ yarn test-partners
 
 # For segment employees, you can run:
 yarn test
+
+# to reset all caches and rebuild again
+yarn clean
+yarn install
+yarn build
 ```
 
 ### Actions CLI

--- a/README.md
+++ b/README.md
@@ -83,9 +83,7 @@ yarn test-partners
 yarn test
 
 # to reset all caches and rebuild again
-yarn clean
-yarn install
-yarn build
+yarn clean-build
 ```
 
 ### Actions CLI

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "alpha": "lerna version prerelease --allow-branch $(git branch --show-current) --preid $(git branch --show-current) --no-push --no-git-tag-version",
     "browser": "yarn workspace @segment/browser-destinations",
     "build": "nx run-many -t build && yarn build:browser-bundles",
+    "clean-build": "yarn clean && yarn build",
     "build:browser-bundles": "nx build @segment/destinations-manifest && nx build-web @segment/browser-destinations",
     "canary": "./scripts/canary.sh",
     "clean": "sh scripts/clean.sh",

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -5,4 +5,6 @@
 rm -rf node_modules/.cache .eslintcache
 find . \( -name "dist" -o -iname "*.tsbuildinfo" \) ! -path "*/node_modules/*" -print0 | xargs -0 rm -rf
 
+# clears nx cache
+nx reset
 echo "Build files and cache deleted."


### PR DESCRIPTION
This PR includes nx reset script the clean script we have and also adds a new command `clean-build`.

## Testing

Testing completed successfully in local

![image](https://github.com/user-attachments/assets/4a15424e-36e9-4fb5-ad1d-de32f568baf9)


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
