### PR TITLE
[FUNK-1707] Make the token prefix dynamic

### DIFF
--- a/packages/destination-actions/src/destinations/webhook-extensible/__test__/webhook.test.ts
+++ b/packages/destination-actions/src/destinations/webhook-extensible/__test__/webhook.test.ts
@@ -45,10 +45,14 @@ const expectedRequest = {
   client_secret: 'clientSecret'
 }
 
-const customParams = {
-  param1: 'val1',
-  param2: 'val2'
-}
+const customParams = [
+  { key: 'param1', value: 'val1', sendIn: 'header' },
+  { key: 'param2', value: 'val2', sendIn: 'header' },
+  { key: 'param3', value: 'val3', sendIn: 'body' },
+  { key: 'param4', value: 'val4', sendIn: 'body' },
+  { key: 'param5', value: 'val5', sendIn: 'query' },
+  { key: 'param6', value: 'val6', sendIn: 'query' }
+]
 
 // Exported so we can re-use to test webhook-audiences
 export const baseWebhookTests = (def: DestinationDefinition<any>) => {
@@ -140,13 +144,10 @@ export const baseWebhookTests = (def: DestinationDefinition<any>) => {
         expect(token).toEqual({ accessToken: mockResponse.access_token, refreshToken: mockResponse.refresh_token })
       })
 
-      it('should return access token for authCode type with custom body params', async () => {
+      it('should return access token for authCode type with custom params', async () => {
         const newSettings = JSON.parse(JSON.stringify(settings))
         newSettings.dynamicAuthSettings.oauth.customParams = {
-          refreshRequest: {
-            sendIn: 'body',
-            val: customParams
-          }
+          refreshRequest: customParams
         }
         const mockResponse = {
           access_token: 'accessToken123',
@@ -157,10 +158,14 @@ export const baseWebhookTests = (def: DestinationDefinition<any>) => {
             '',
             new URLSearchParams({
               ...expectedRequest,
-              ...customParams
+              param3: 'val3',
+              param4: 'val4'
             }).toString()
           )
           .matchHeader('Authorization', `Basic ${Buffer.from('clientID:clientSecret').toString('base64')}`)
+          .matchHeader('param1', 'val1')
+          .matchHeader('param2', 'val2')
+          .query({ param5: 'val5', param6: 'val6' })
           .reply(200, mockResponse)
 
         const token = await testDestination.refreshAccessToken(newSettings, auth)
@@ -168,20 +173,22 @@ export const baseWebhookTests = (def: DestinationDefinition<any>) => {
         expect(token).toEqual({ accessToken: mockResponse.access_token, refreshToken: mockResponse.refresh_token })
       })
 
-      it('should return access token for authCode type with custom header params', async () => {
+      it('should return access token for authCode type with only custom header', async () => {
         const newSettings = JSON.parse(JSON.stringify(settings))
         newSettings.dynamicAuthSettings.oauth.customParams = {
-          refreshRequest: {
-            sendIn: 'headers',
-            val: customParams
-          }
+          refreshRequest: [customParams[0], customParams[1]]
         }
         const mockResponse = {
           access_token: 'accessToken123',
           refresh_token: 'refreshToken123'
         }
         nock(`https://www.webhook-extensible/refresh_token`)
-          .post('', new URLSearchParams(expectedRequest).toString())
+          .post(
+            '',
+            new URLSearchParams({
+              ...expectedRequest
+            }).toString()
+          )
           .matchHeader('Authorization', `Basic ${Buffer.from('clientID:clientSecret').toString('base64')}`)
           .matchHeader('param1', 'val1')
           .matchHeader('param2', 'val2')
@@ -192,22 +199,50 @@ export const baseWebhookTests = (def: DestinationDefinition<any>) => {
         expect(token).toEqual({ accessToken: mockResponse.access_token, refreshToken: mockResponse.refresh_token })
       })
 
-      it('should return access token for authCode type with custom url params', async () => {
+      it('should return access token for authCode type with only custom body', async () => {
         const newSettings = JSON.parse(JSON.stringify(settings))
         newSettings.dynamicAuthSettings.oauth.customParams = {
-          refreshRequest: {
-            sendIn: 'url',
-            val: customParams
-          }
+          refreshRequest: [customParams[2], customParams[3]]
         }
         const mockResponse = {
           access_token: 'accessToken123',
           refresh_token: 'refreshToken123'
         }
         nock(`https://www.webhook-extensible/refresh_token`)
-          .post('', new URLSearchParams(expectedRequest).toString())
+          .post(
+            '',
+            new URLSearchParams({
+              ...expectedRequest,
+              param3: 'val3',
+              param4: 'val4'
+            }).toString()
+          )
           .matchHeader('Authorization', `Basic ${Buffer.from('clientID:clientSecret').toString('base64')}`)
-          .query({ param1: 'val1', param2: 'val2' })
+          .reply(200, mockResponse)
+
+        const token = await testDestination.refreshAccessToken(newSettings, auth)
+
+        expect(token).toEqual({ accessToken: mockResponse.access_token, refreshToken: mockResponse.refresh_token })
+      })
+
+      it('should return access token for authCode type with only custom query params', async () => {
+        const newSettings = JSON.parse(JSON.stringify(settings))
+        newSettings.dynamicAuthSettings.oauth.customParams = {
+          refreshRequest: [customParams[4], customParams[5]]
+        }
+        const mockResponse = {
+          access_token: 'accessToken123',
+          refresh_token: 'refreshToken123'
+        }
+        nock(`https://www.webhook-extensible/refresh_token`)
+          .post(
+            '',
+            new URLSearchParams({
+              ...expectedRequest
+            }).toString()
+          )
+          .matchHeader('Authorization', `Basic ${Buffer.from('clientID:clientSecret').toString('base64')}`)
+          .query({ param5: 'val5', param6: 'val6' })
           .reply(200, mockResponse)
 
         const token = await testDestination.refreshAccessToken(newSettings, auth)
@@ -238,14 +273,11 @@ export const baseWebhookTests = (def: DestinationDefinition<any>) => {
         expect(token).toEqual({ accessToken: mockResponse.access_token })
       })
 
-      it('should return access token for clientCredentials type with custom body params', async () => {
+      it('should return access token for clientCredentials type with custom params', async () => {
         const newSettings = JSON.parse(JSON.stringify(settings))
         newSettings.dynamicAuthSettings.oauth.type = 'clientCredentials'
         newSettings.dynamicAuthSettings.oauth.customParams = {
-          refreshRequest: {
-            sendIn: 'body',
-            val: customParams
-          }
+          refreshRequest: customParams
         }
         const mockResponse = {
           access_token: 'accessToken123',
@@ -257,10 +289,14 @@ export const baseWebhookTests = (def: DestinationDefinition<any>) => {
             new URLSearchParams({
               grant_type: 'client_credentials',
               scope: 'scope',
-              ...customParams
+              param3: 'val3',
+              param4: 'val4'
             }).toString()
           )
           .matchHeader('Authorization', `Basic ${Buffer.from('clientID:clientSecret').toString('base64')}`)
+          .query({ param5: 'val5', param6: 'val6' })
+          .matchHeader('param1', 'val1')
+          .matchHeader('param2', 'val2')
           .reply(200, mockResponse)
 
         const token = await testDestination.refreshAccessToken(newSettings, auth)
@@ -268,14 +304,11 @@ export const baseWebhookTests = (def: DestinationDefinition<any>) => {
         expect(token).toEqual({ accessToken: mockResponse.access_token })
       })
 
-      it('should return access token for clientCredentials type with custom header params', async () => {
+      it('should return access token for clientCredentials type with custom header', async () => {
         const newSettings = JSON.parse(JSON.stringify(settings))
         newSettings.dynamicAuthSettings.oauth.type = 'clientCredentials'
         newSettings.dynamicAuthSettings.oauth.customParams = {
-          refreshRequest: {
-            sendIn: 'headers',
-            val: customParams
-          }
+          refreshRequest: [customParams[0], customParams[1]]
         }
         const mockResponse = {
           access_token: 'accessToken123',
@@ -299,14 +332,39 @@ export const baseWebhookTests = (def: DestinationDefinition<any>) => {
         expect(token).toEqual({ accessToken: mockResponse.access_token })
       })
 
-      it('should return access token for clientCredentials type with custom url params', async () => {
+      it('should return access token for clientCredentials type with custom body', async () => {
         const newSettings = JSON.parse(JSON.stringify(settings))
         newSettings.dynamicAuthSettings.oauth.type = 'clientCredentials'
         newSettings.dynamicAuthSettings.oauth.customParams = {
-          refreshRequest: {
-            sendIn: 'url',
-            val: customParams
-          }
+          refreshRequest: [customParams[2], customParams[3]]
+        }
+        const mockResponse = {
+          access_token: 'accessToken123',
+          refresh_token: 'refreshToken123'
+        }
+        nock(`https://www.webhook-extensible/refresh_token`)
+          .post(
+            '',
+            new URLSearchParams({
+              grant_type: 'client_credentials',
+              scope: 'scope',
+              param3: 'val3',
+              param4: 'val4'
+            }).toString()
+          )
+          .matchHeader('Authorization', `Basic ${Buffer.from('clientID:clientSecret').toString('base64')}`)
+          .reply(200, mockResponse)
+
+        const token = await testDestination.refreshAccessToken(newSettings, auth)
+
+        expect(token).toEqual({ accessToken: mockResponse.access_token })
+      })
+
+      it('should return access token for clientCredentials type with custom query params', async () => {
+        const newSettings = JSON.parse(JSON.stringify(settings))
+        newSettings.dynamicAuthSettings.oauth.type = 'clientCredentials'
+        newSettings.dynamicAuthSettings.oauth.customParams = {
+          refreshRequest: [customParams[4], customParams[5]]
         }
         const mockResponse = {
           access_token: 'accessToken123',
@@ -321,7 +379,7 @@ export const baseWebhookTests = (def: DestinationDefinition<any>) => {
             }).toString()
           )
           .matchHeader('Authorization', `Basic ${Buffer.from('clientID:clientSecret').toString('base64')}`)
-          .query({ param1: 'val1', param2: 'val2' })
+          .query({ param5: 'val5', param6: 'val6' })
           .reply(200, mockResponse)
 
         const token = await testDestination.refreshAccessToken(newSettings, auth)

--- a/packages/destination-actions/src/destinations/webhook-extensible/__test__/webhook.test.ts
+++ b/packages/destination-actions/src/destinations/webhook-extensible/__test__/webhook.test.ts
@@ -102,6 +102,57 @@ export const baseWebhookTests = (def: DestinationDefinition<any>) => {
         expect(responses[0].status).toBe(200)
       })
 
+      it('send with custom params and no token prefix', async () => {
+        const url = 'https://example.build'
+        const event = createTestEvent()
+        const data = { cool: true }
+        const newSettings = JSON.parse(JSON.stringify(settings))
+        newSettings.dynamicAuthSettings.oauth.customParams = {
+          refreshRequest: customParams
+        }
+
+        nock(url).put('/', data).matchHeader('authorization', 'Bearer accessToken1').reply(200)
+
+        const responses = await testDestination.testAction('send', {
+          settings: newSettings,
+          event,
+          mapping: {
+            url,
+            method: 'PUT',
+            data
+          }
+        })
+
+        expect(responses.length).toBe(1)
+        expect(responses[0].status).toBe(200)
+      })
+
+      it('send with custom params and a token prefix', async () => {
+        const url = 'https://example.build'
+        const event = createTestEvent()
+        const data = { cool: true }
+        const newSettings = JSON.parse(JSON.stringify(settings))
+        newSettings.dynamicAuthSettings.oauth.customParams = {
+          refreshRequest: customParams,
+          tokenPrefix: 'Basic'
+        }
+
+        nock(url).put('/', data).matchHeader('authorization', 'Basic accessToken1').reply(200)
+
+        const responses = await testDestination.testAction('send', {
+          settings: newSettings,
+          event,
+          mapping: {
+            url,
+            method: 'PUT',
+            data
+          }
+        })
+
+        expect(responses.length).toBe(1)
+        expect(responses[0].status).toBe(200)
+      })
+
       it('should throw an error when header value is invalid', async () => {
         const url = 'https://example.build'
         const event = createTestEvent()

--- a/packages/destination-actions/src/destinations/webhook-extensible/auth-utils.ts
+++ b/packages/destination-actions/src/destinations/webhook-extensible/auth-utils.ts
@@ -1,0 +1,76 @@
+import { RefreshTokenResponse } from './types'
+import { RefreshAccessTokenResult } from '../../../../core/src/destination-kit'
+import { RequestClient } from '../../../../core/src/create-request-client'
+import { RequestOptions } from '../../../../core/src/request-client'
+
+export const sendRefreshTokenReq = async (
+  request: RequestClient,
+  settings: any,
+  auth: any
+): Promise<RefreshAccessTokenResult> => {
+  let res
+  const { oauth } = settings.dynamicAuthSettings
+
+  if (oauth.type === 'authCode') {
+    res = await request<RefreshTokenResponse>(getRequestUrl(oauth), getRequestOptions(oauth, auth))
+    return {
+      accessToken: res.data.access_token,
+      refreshToken: res.data.refresh_token
+    }
+  } else {
+    res = await request<RefreshTokenResponse>(getRequestUrl(oauth), getRequestOptions(oauth, auth))
+    return { accessToken: res.data.access_token }
+  }
+}
+
+const getRequestUrl = (oauth: any) => {
+  if (oauth?.customParams?.refreshRequest?.sendIn === 'url') {
+    const customParamVal = new URLSearchParams(oauth.customParams.refreshRequest.val)
+    return `${oauth.refreshTokenServerUrl}?${customParamVal ?? ''}`
+  }
+  return oauth.refreshTokenServerUrl
+}
+
+const getRequestOptions = (oauth: any, auth: any): RequestOptions => {
+  let bodyParams = {}
+  const { clientId, clientSecret } = auth
+  let headers = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+    Authorization: `Basic ${Buffer.from(clientId + ':' + clientSecret).toString('base64')}`
+  }
+
+  if (oauth.type === 'authCode') {
+    bodyParams = {
+      grant_type: 'refresh_token',
+      refresh_token: auth.refreshToken ?? oauth.access.refresh_token,
+      scope: oauth.scopes,
+      client_id: clientId,
+      client_secret: clientSecret
+    }
+  } else {
+    bodyParams = {
+      grant_type: 'client_credentials',
+      scope: oauth.scopes
+    }
+  }
+
+  if (oauth?.customParams?.refreshRequest?.sendIn === 'body') {
+    bodyParams = {
+      ...bodyParams,
+      ...oauth.customParams.refreshRequest.val
+    }
+  } else if (oauth?.customParams?.refreshRequest?.sendIn === 'headers') {
+    headers = {
+      ...headers,
+      ...oauth.customParams.refreshRequest.val
+    }
+  }
+
+  const body = new URLSearchParams(bodyParams)
+
+  return {
+    method: 'POST',
+    headers,
+    body
+  }
+}

--- a/packages/destination-actions/src/destinations/webhook-extensible/index.ts
+++ b/packages/destination-actions/src/destinations/webhook-extensible/index.ts
@@ -1,6 +1,6 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
-import { RefreshTokenResponse } from './types'
+import { sendRefreshTokenReq } from './auth-utils'
 
 import send from './send'
 
@@ -22,43 +22,8 @@ const destination: DestinationDefinition<SettingsWithDynamicAuth> = {
       }
     },
     refreshAccessToken: async (request, { settings, auth }) => {
-      let res
-      const { clientId, clientSecret } = auth
-      const { oauth } = settings.dynamicAuthSettings
-
-      if (oauth.type === 'authCode') {
-        res = await request<RefreshTokenResponse>(oauth.refreshTokenServerUrl, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            Authorization: `Basic ${Buffer.from(clientId + ':' + clientSecret).toString('base64')}`
-          },
-          body: new URLSearchParams({
-            grant_type: 'refresh_token',
-            refresh_token: auth.refreshToken ?? oauth.access.refresh_token,
-            scope: oauth.scopes,
-            client_id: clientId,
-            client_secret: clientSecret
-          })
-        })
-        return {
-          accessToken: res.data.access_token,
-          refreshToken: res.data.refresh_token
-        }
-      } else {
-        res = await request<RefreshTokenResponse>(oauth.refreshTokenServerUrl, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            Authorization: `Basic ${Buffer.from(clientId + ':' + clientSecret).toString('base64')}`
-          },
-          body: new URLSearchParams({
-            grant_type: 'client_credentials',
-            scope: oauth.scopes
-          })
-        })
-        return { accessToken: res.data.access_token }
-      }
+      const res = await sendRefreshTokenReq(request, settings, auth)
+      return res
     }
   },
   extendRequest: ({ settings, auth }) => {

--- a/packages/destination-actions/src/destinations/webhook-extensible/index.ts
+++ b/packages/destination-actions/src/destinations/webhook-extensible/index.ts
@@ -29,14 +29,16 @@ const destination: DestinationDefinition<SettingsWithDynamicAuth> = {
   extendRequest: ({ settings, auth }) => {
     const { dynamicAuthSettings } = settings
     let accessToken
+    let tokenPrefix = 'Bearer'
     if (dynamicAuthSettings?.bearer) {
       accessToken = dynamicAuthSettings?.bearer?.bearerToken
     } else {
       accessToken = auth?.accessToken ?? dynamicAuthSettings?.oauth?.access?.access_token
+      tokenPrefix = dynamicAuthSettings?.oauth?.customParams?.tokenPrefix ?? 'Bearer'
     }
     return {
       headers: {
-        authorization: `Bearer ${accessToken}`
+        authorization: `${tokenPrefix} ${accessToken}`
       }
     }
   },


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Changes have been made to make the Token prefix as dynamic

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
