### PR TITLE
[Smart Hashing] [Pinterest Conversions] Implement Smart Hashing Util for Pinterest Conversions

### DIFF
--- a/packages/destination-actions/src/destinations/pinterest-conversions/pinterset-capi-user-data.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/pinterset-capi-user-data.ts
@@ -1,7 +1,8 @@
 import { InputField } from '@segment/actions-core/destination-kit/types'
-import { createHash } from 'crypto'
 import { Payload } from './reportConversionEvent/generated-types'
 import isEmpty from 'lodash/isEmpty'
+import { Features } from '@segment/actions-core'
+import { processHashing } from '../../lib/hashing-utils'
 
 // Implementation of Pinterest user data object
 // https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters
@@ -128,107 +129,111 @@ export const user_data_field: InputField = {
 
 type UserData = Pick<Payload, 'user_data'>
 
-const hash = (value: string | undefined): string | undefined => {
-  if (value === undefined) return
-
-  const hash = createHash('sha256')
-  hash.update(value)
-  return hash.digest('hex')
-}
-
 // Normalization of user data properties according to Pinterest conversion event
 // https://developers.pinterest.com/docs/conversions/conversion-management/#Authenticating%20for%20the%20Conversion%20Tracking%20endpoint%23Authenticating%20for%20the%20send%20conversion%20events%20endpoint#The%20%2Cuser_data%2C%20and%20%2Ccustom_data%2C%20objects
 
-export const normalisedAndHashed = (payload: UserData) => {
+const normalize = (value: string): string => {
+  return value.replace(/\s/g, '').toLowerCase()
+}
+
+const normalizePhone = (value: string): string => {
+  return value.replace(/\D/g, '').toLowerCase()
+}
+
+const normalizeGender = (value: string): string => {
+  value = value.replace(/\s/g, '').toLowerCase()
+  switch (value) {
+    case 'male':
+      value = 'm'
+      break
+    case 'female':
+      value = 'f'
+      break
+    case 'non-binary':
+      value = 'n'
+      break
+  }
+  return value
+}
+
+export const normalisedAndHashed = (payload: UserData, features?: Features) => {
   if (payload.user_data) {
     if (!isEmpty(payload.user_data?.email)) {
       // Regex removes all whitespace in the string.
       payload.user_data.email = payload.user_data?.email?.map((el: string) =>
-        hash(el.replace(/\s/g, '').toLowerCase())
+        processHashing(el, 'sha256', 'hex', features ?? {}, 'actions-pinterest-conversions-api', normalize)
       ) as string[]
     }
 
     if (!isEmpty(payload.user_data?.phone)) {
       // Regex removes all non-numeric characters from the string.
       payload.user_data.phone = payload.user_data?.phone?.map((el: string) =>
-        hash(el.replace(/\D/g, '').toLowerCase())
+        processHashing(el, 'sha256', 'hex', features ?? {}, 'actions-pinterest-conversions-api', normalizePhone)
       ) as string[]
     }
 
     if (!isEmpty(payload.user_data?.gender)) {
       payload.user_data.gender = payload.user_data?.gender?.map((el: string) => {
-        el = el.replace(/\s/g, '').toLowerCase()
-        switch (el) {
-          case 'male':
-            el = 'm'
-            break
-          case 'female':
-            el = 'f'
-            break
-          case 'non-binary':
-            el = 'n'
-            break
-        }
-        return hash(el)
+        return processHashing(el, 'sha256', 'hex', features ?? {}, 'actions-pinterest-conversions-api', normalizeGender)
       }) as string[]
     }
 
     if (!isEmpty(payload.user_data?.last_name)) {
       payload.user_data.last_name = payload.user_data?.last_name?.map((el: string) =>
-        hash(el.replace(/\s/g, '').toLowerCase())
+        processHashing(el, 'sha256', 'hex', features ?? {}, 'actions-pinterest-conversions-api', normalize)
       ) as string[]
     }
 
     if (!isEmpty(payload.user_data?.first_name)) {
       payload.user_data.first_name = payload.user_data?.first_name?.map((el: string) =>
-        hash(el.replace(/\s/g, '').toLowerCase())
+        processHashing(el, 'sha256', 'hex', features ?? {}, 'actions-pinterest-conversions-api', normalize)
       ) as string[]
     }
 
     if (!isEmpty(payload.user_data?.city)) {
       payload.user_data.city = payload.user_data?.city?.map((el: string) =>
-        hash(el.replace(/\s/g, '').toLowerCase())
+        processHashing(el, 'sha256', 'hex', features ?? {}, 'actions-pinterest-conversions-api', normalize)
       ) as string[]
     }
 
     if (!isEmpty(payload.user_data?.state)) {
       payload.user_data.state = payload.user_data?.state?.map((el: string) =>
-        hash(el.replace(/\s/g, '').toLowerCase())
+        processHashing(el, 'sha256', 'hex', features ?? {}, 'actions-pinterest-conversions-api', normalize)
       ) as string[]
     }
 
     if (!isEmpty(payload.user_data?.zip)) {
       payload.user_data.zip = payload.user_data?.zip?.map((el: string) =>
-        hash(el.replace(/\s/g, '').toLowerCase())
+        processHashing(el, 'sha256', 'hex', features ?? {}, 'actions-pinterest-conversions-api', normalize)
       ) as string[]
     }
 
     if (!isEmpty(payload.user_data?.country)) {
       payload.user_data.country = payload.user_data?.country?.map((el: string) =>
-        hash(el.replace(/\s/g, '').toLowerCase())
+        processHashing(el, 'sha256', 'hex', features ?? {}, 'actions-pinterest-conversions-api', normalize)
       ) as string[]
     }
 
     if (!isEmpty(payload.user_data?.external_id)) {
       payload.user_data.external_id = payload.user_data?.external_id?.map((el: string) =>
-        hash(el.replace(/\s/g, '').toLowerCase())
+        processHashing(el, 'sha256', 'hex', features ?? {}, 'actions-pinterest-conversions-api', normalize)
       ) as string[]
     }
     if (!isEmpty(payload.user_data?.hashed_maids)) {
       payload.user_data.hashed_maids = payload.user_data?.hashed_maids?.map((el: string) =>
-        hash(el.replace(/\s/g, '').toLowerCase())
+        processHashing(el, 'sha256', 'hex', features ?? {}, 'actions-pinterest-conversions-api', normalize)
       ) as string[]
     }
     if (!isEmpty(payload.user_data?.date_of_birth)) {
       payload.user_data.date_of_birth = payload.user_data?.date_of_birth?.map((el: string) =>
-        hash(el.replace(/\s/g, '').toLowerCase())
+        processHashing(el, 'sha256', 'hex', features ?? {}, 'actions-pinterest-conversions-api', normalize)
       ) as string[]
     }
   }
 }
 
-export const hash_user_data = (payload: UserData): Object => {
-  normalisedAndHashed(payload)
+export const hash_user_data = (payload: UserData, features?: Features): Object => {
+  normalisedAndHashed(payload, features)
   return {
     em: payload.user_data?.email,
     ph: payload.user_data?.phone,

--- a/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/__tests__/index.test.ts
@@ -178,5 +178,52 @@ describe('PinterestConversionApi', () => {
       expect(JSON.parse(responses[0]?.options?.body as string)?.data?.length).toBe(1)
       expect(responses[0].options.json).toMatchSnapshot()
     })
+
+    it('should be able to detect hashed data when flag is set', async () => {
+      nock(`https://api.pinterest.com`)
+        .post(`/${API_VERSION}/ad_accounts/${authData.ad_account_id}/events`)
+        .reply(200, {})
+
+      const responses = await testDestination.testAction('reportConversionEvent', {
+        event,
+        settings: authData,
+        useDefaultMappings: true,
+        mapping: {
+          event_name: 'checkout',
+          user_data: {
+            first_name: ['44104fcaef8476724152090d6d7bd9afa8ca5b385f6a99d3c6cf36b943b9872d'],
+            last_name: ['test'],
+            external_id: ['test_external_id'],
+            phone: ['63af7d494c194a90e1cf1db5371c13f97db650161aa803e67182c0dbaf668c7b'],
+            gender: ['male'],
+            city: ['92db9c574d420b2437b29d898d55604f61df6c17f5163e53337f2169dd70d38d'],
+            state: ['92db9c574d420b2437b29d898d55604f61df6c17f5163e53337f2169dd70d38d'],
+            zip: ['92db9c574d420b2437b29d898d55604f61df6c17f5163e53337f2169dd70d38d'],
+            country: ['92db9c574d420b2437b29d898d55604f61df6c17f5163e53337f2169dd70d38d'],
+            hashed_maids: ['test123123'],
+            date_of_birth: ['1996-02-01'],
+            email: ['c551027f06bd3f307ccd6abb61edc500def2680944c010e932ab5b27a3a8f151'],
+            client_user_agent: '5.5.5.5',
+            click_id: 'click-id1',
+            partner_id: 'partner-id1',
+            client_ip_address:
+              'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
+          },
+          custom_data: {
+            num_items: '2',
+            value: 2000
+          }
+        },
+        features: {
+          'smart-hashing': true
+        }
+      })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(JSON.parse(responses[0]?.options?.body as string)?.data?.length).toBe(1)
+      expect(responses[0].options.body).toBe(
+        '{"data":[{"event_name":"checkout","action_source":"web","event_time":1678694183,"event_id":"test-message-rocnz07d5e8","event_source_url":"https://segment.com/academy/","partner_name":"ss-segment","opt_out":true,"user_data":{"em":["c551027f06bd3f307ccd6abb61edc500def2680944c010e932ab5b27a3a8f151"],"ph":["63af7d494c194a90e1cf1db5371c13f97db650161aa803e67182c0dbaf668c7b"],"ge":["62c66a7a5dd70c3146618063c344e531e6d4b59e379808443ce962b3abd63c5a"],"db":["9e4b15bbd40f2429491316d291927f5153b4f8c28738e6ee6284009ce29d13d6"],"ln":["9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"],"fn":["44104fcaef8476724152090d6d7bd9afa8ca5b385f6a99d3c6cf36b943b9872d"],"ct":["92db9c574d420b2437b29d898d55604f61df6c17f5163e53337f2169dd70d38d"],"st":["92db9c574d420b2437b29d898d55604f61df6c17f5163e53337f2169dd70d38d"],"zp":["92db9c574d420b2437b29d898d55604f61df6c17f5163e53337f2169dd70d38d"],"country":["92db9c574d420b2437b29d898d55604f61df6c17f5163e53337f2169dd70d38d"],"external_id":["74a6a35e39c525dcf6fd98ba90e79eb3c4358df1ae204e9489d51e6946485b2b"],"client_ip_address":"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1","client_user_agent":"5.5.5.5","hashed_maids":["f4c2178860817a2c25d2cb3185aa25779b0ecaf17c30845926218e17a18a9f89"],"click_id":"click-id1","partner_id":"partner-id1"},"custom_data":{"value":"2000","num_items":2},"app_name":"InitechGlobal","app_version":"545","device_model":"iPhone7,2","device_type":"ios","os_version":"8.1.3"}]}'
+      )
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/index.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/index.ts
@@ -1,4 +1,4 @@
-import type { ActionDefinition, RequestClient } from '@segment/actions-core'
+import type { ActionDefinition, Features, RequestClient } from '@segment/actions-core'
 import { IntegrationError } from '@segment/actions-core'
 import { API_VERSION, PARTNER_NAME } from '../constants'
 import type { Settings } from '../generated-types'
@@ -161,11 +161,11 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string'
     }
   },
-  perform: async (request, { settings, payload }) => {
-    return processPayload(request, settings, payload)
+  perform: async (request, { settings, payload, features }) => {
+    return processPayload(request, settings, payload, features)
   }
 }
-async function processPayload(request: RequestClient, settings: Settings, payload: Payload) {
+async function processPayload(request: RequestClient, settings: Settings, payload: Payload, features?: Features) {
   if (
     isEmpty(payload.user_data?.email) &&
     isEmpty(payload.user_data?.hashed_maids) &&
@@ -178,7 +178,7 @@ async function processPayload(request: RequestClient, settings: Settings, payloa
     )
   }
 
-  const data = createPinterestPayload(payload)
+  const data = createPinterestPayload(payload, features)
   return request(`https://api.pinterest.com/${API_VERSION}/ad_accounts/${settings.ad_account_id}/events`, {
     method: 'POST',
     json: {
@@ -187,7 +187,7 @@ async function processPayload(request: RequestClient, settings: Settings, payloa
   })
 }
 
-function createPinterestPayload(payload: Payload) {
+function createPinterestPayload(payload: Payload, features?: Features) {
   return [
     {
       event_name: payload.event_name,
@@ -197,7 +197,7 @@ function createPinterestPayload(payload: Payload) {
       event_source_url: payload.event_source_url,
       partner_name: PARTNER_NAME,
       opt_out: payload.opt_out,
-      user_data: hash_user_data({ user_data: payload.user_data }),
+      user_data: hash_user_data({ user_data: payload.user_data }, features),
       custom_data: {
         currency: payload?.custom_data?.currency,
         value: String(payload?.custom_data?.value),


### PR DESCRIPTION
This PR implements the [smart hashing utility](https://github.com/segmentio/action-destinations/pull/2756) for Pinterest Conversions. 
The new implementation maintains the functionality of pre existing smart hashing in Pinterest Conversions.

## Testing
[Testing Document](https://docs.google.com/document/d/10-776AUC9pQKt3IEjsdnN-ulOQcr_ZP2ui6S6WzwUrE/edit?tab=t.v9s8es7yu2sl)

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
