### PR TITLE
Update Trubrics action destination

### DIFF
--- a/packages/destination-actions/src/destinations/trubrics/identify/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/trubrics/identify/__tests__/index.test.ts
@@ -4,13 +4,17 @@ import Destination from '../../index'
 
 const testDestination = createTestIntegration(Destination)
 const settings = { apiKey: 'api-key', url: 'app.trubrics.com/api/ingestion' }
+const mapping = { user_id: 'user-id', timestamp: '2021-01-01T00:00:00.000Z', anonymous_id: 'my-id', traits: {} }
 
 describe('Trubrics.identify', () => {
   it('should work', async () => {
-    nock(settings.url).post('/identify_segment_users').matchHeader('x-api-key', settings.apiKey).reply(200, {})
+    nock(`https://${settings.url}`)
+      .post('/identify_segment_users', [mapping])
+      .matchHeader('x-api-key', settings.apiKey)
+      .reply(200, {})
 
     const responses = await testDestination.testAction('identify', {
-      mapping: { anonymousId: 'my-id', traits: {}, timestamp: '2021-01-01T00:00:00.000Z', user_id: 'user-id' },
+      mapping,
       settings
     })
 

--- a/packages/destination-actions/src/destinations/trubrics/identify/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/trubrics/identify/__tests__/index.test.ts
@@ -5,17 +5,12 @@ import Destination from '../../index'
 const testDestination = createTestIntegration(Destination)
 const settings = { apiKey: 'api-key', url: 'app.trubrics.com/api/ingestion' }
 
-describe('Trubrics.track', () => {
+describe('Trubrics.identify', () => {
   it('should work', async () => {
-    nock(settings.url).post('/publish_segment_events').matchHeader('x-api-key', settings.apiKey).reply(200, {})
+    nock(settings.url).post('/identify_segment_users').matchHeader('x-api-key', settings.apiKey).reply(200, {})
 
-    const responses = await testDestination.testAction('track', {
-      mapping: {
-        anonymous_id: 'my-id',
-        event: 'test event',
-        timestamp: '2021-01-01T00:00:00.000Z',
-        user_id: 'user-id'
-      },
+    const responses = await testDestination.testAction('identify', {
+      mapping: { anonymousId: 'my-id', traits: {}, timestamp: '2021-01-01T00:00:00.000Z', user_id: 'user-id' },
       settings
     })
 

--- a/packages/destination-actions/src/destinations/trubrics/identify/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/trubrics/identify/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'identify'
+const destinationSlug = 'Trubrics'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it.skip('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it.skip('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/trubrics/identify/generated-types.ts
+++ b/packages/destination-actions/src/destinations/trubrics/identify/generated-types.ts
@@ -1,0 +1,22 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID of the user performing the event.
+   */
+  user_id: string
+  /**
+   * An anonymous identifier
+   */
+  anonymous_id?: string
+  /**
+   * The traits of the user.
+   */
+  traits?: {
+    [k: string]: unknown
+  }
+  /**
+   * The timestamp of the event
+   */
+  timestamp?: string
+}

--- a/packages/destination-actions/src/destinations/trubrics/identify/index.ts
+++ b/packages/destination-actions/src/destinations/trubrics/identify/index.ts
@@ -1,0 +1,48 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Payload } from './generated-types'
+import type { Settings } from '../generated-types'
+import { sendRequest } from './utils'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Identify',
+  description: 'Identify a user in Trubrics and associate traits with them.',
+  fields: {
+    user_id: {
+      label: 'User ID',
+      type: 'string',
+      description: 'The ID of the user performing the event.',
+      required: true,
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    anonymous_id: {
+      type: 'string',
+      description: 'An anonymous identifier',
+      required: false,
+      label: 'Anonymous ID',
+      default: { '@path': '$.anonymousId' }
+    },
+    traits: {
+      label: 'Traits',
+      type: 'object',
+      description: 'The traits of the user.',
+      required: false,
+      default: {
+        '@path': '$.traits'
+      }
+    },
+    timestamp: {
+      type: 'string',
+      format: 'date-time',
+      required: false,
+      description: 'The timestamp of the event',
+      label: 'Timestamp',
+      default: { '@path': '$.timestamp' }
+    }
+  },
+  perform: async (request, { settings, payload }) => await sendRequest(request, settings, [payload]),
+  performBatch: async (request, { settings, payload }) => await sendRequest(request, settings, payload)
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/trubrics/identify/utils.ts
+++ b/packages/destination-actions/src/destinations/trubrics/identify/utils.ts
@@ -1,0 +1,23 @@
+import type { Payload } from './generated-types'
+import type { Settings } from '../generated-types'
+
+const prepareJSON = (payload: Payload) => {
+  return {
+    user_id: payload.user_id,
+    timestamp: payload.timestamp,
+    anonymous_id: payload.anonymous_id,
+    traits: payload.traits
+  }
+}
+
+export const sendRequest = async (request: Function, settings: Settings, payload: Payload[]) => {
+  const json = payload.map(prepareJSON)
+
+  return await request(`https://${settings.url}/identify_segment_users`, {
+    method: 'post',
+    headers: {
+      'x-api-key': settings.apiKey
+    },
+    json
+  })
+}

--- a/packages/destination-actions/src/destinations/trubrics/index.ts
+++ b/packages/destination-actions/src/destinations/trubrics/index.ts
@@ -2,6 +2,7 @@ import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
 import track from './track'
+import identify from './identify'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Trubrics',
@@ -22,12 +23,13 @@ const destination: DestinationDefinition<Settings> = {
         description: 'The Trubrics API URL. In most cases the default value should be used.',
         type: 'string',
         required: true,
-        default: 'api.trubrics.com'
+        default: 'app.trubrics.com/api/ingestion'
       }
     }
   },
   actions: {
-    track
+    track,
+    identify
   }
 }
 

--- a/packages/destination-actions/src/destinations/trubrics/track/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/trubrics/track/__tests__/index.test.ts
@@ -4,18 +4,22 @@ import Destination from '../../index'
 
 const testDestination = createTestIntegration(Destination)
 const settings = { apiKey: 'api-key', url: 'app.trubrics.com/api/ingestion' }
+const mapping = {
+  anonymous_id: 'my-id',
+  event: 'test event',
+  timestamp: '2021-01-01T00:00:00.000Z',
+  user_id: 'user-id'
+}
 
 describe('Trubrics.track', () => {
   it('should work', async () => {
-    nock(settings.url).post('/publish_segment_events').matchHeader('x-api-key', settings.apiKey).reply(200, {})
+    nock(`https://${settings.url}`)
+      .post('/publish_segment_events', [mapping])
+      .matchHeader('x-api-key', settings.apiKey)
+      .reply(200, {})
 
     const responses = await testDestination.testAction('track', {
-      mapping: {
-        anonymous_id: 'my-id',
-        event: 'test event',
-        timestamp: '2021-01-01T00:00:00.000Z',
-        user_id: 'user-id'
-      },
+      mapping,
       settings
     })
 

--- a/packages/destination-actions/src/destinations/trubrics/track/generated-types.ts
+++ b/packages/destination-actions/src/destinations/trubrics/track/generated-types.ts
@@ -6,15 +6,42 @@ export interface Payload {
    */
   event: string
   /**
+   * The timestamp of the event
+   */
+  timestamp?: string
+  /**
+   * The ID associated with the user
+   */
+  user_id?: string
+  /**
+   * The properties associated with an LLM event
+   */
+  llm_properties?: {
+    /**
+     * The LLM assistant ID (often the model name)
+     */
+    assistant_id?: string
+    /**
+     * A user prompt to an LLM
+     */
+    prompt?: string
+    /**
+     * An LLM assistant response
+     */
+    generation?: string
+    /**
+     * The thread/conversation ID of the LLM conversation.
+     */
+    thread_id?: string
+    /**
+     * The latency in seconds between the LLM prompt and generation
+     */
+    latency?: number
+  }
+  /**
    * Properties to send with the event
    */
   properties?: {
-    [k: string]: unknown
-  }
-  /**
-   * user properties to send with the event
-   */
-  traits?: {
     [k: string]: unknown
   }
   /**
@@ -23,14 +50,6 @@ export interface Payload {
   context?: {
     [k: string]: unknown
   }
-  /**
-   * The timestamp of the event
-   */
-  timestamp: string
-  /**
-   * The ID associated with the user
-   */
-  user_id?: string
   /**
    * The Anonymous ID associated with the user
    */

--- a/packages/destination-actions/src/destinations/trubrics/track/utils.ts
+++ b/packages/destination-actions/src/destinations/trubrics/track/utils.ts
@@ -1,0 +1,26 @@
+import type { Payload } from './generated-types'
+import type { Settings } from '../generated-types'
+
+const prepareJSON = (payload: Payload) => {
+  return {
+    event: payload.event,
+    timestamp: payload.timestamp,
+    user_id: payload.user_id,
+    anonymous_id: payload.anonymous_id,
+    llm_properties: payload.llm_properties,
+    context: payload.context,
+    properties: payload.properties
+  }
+}
+
+export const sendRequest = async (request: Function, settings: Settings, payload: Payload[]) => {
+  const json = payload.map(prepareJSON)
+
+  return await request(`https://${settings.url}/publish_segment_events`, {
+    method: 'post',
+    headers: {
+      'x-api-key': settings.apiKey
+    },
+    json
+  })
+}


### PR DESCRIPTION
## Changes
- Added an Identify action
- Modified the Track action to point to the new segment_track endpoint

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
