### PR TITLE
[STRATCONN-5488] - Adds batch config field to action definition

### DIFF
--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -1,5 +1,5 @@
 import { Command, flags } from '@oclif/command'
-import type { BaseActionDefinition } from '@segment/actions-core'
+import type { ActionDefinition, BaseActionDefinition } from '@segment/actions-core'
 import { ErrorCondition, parseFql } from '@segment/destination-subscriptions'
 import ora from 'ora'
 import { getManifest, DestinationDefinition } from '../lib/destinations'
@@ -81,6 +81,19 @@ export default class Validate extends Command {
           errors.push(new Error(`The action "${actionKey}" is missing a description for the field "${fieldKey}".`))
         }
       }
+
+      const actionDef = action as ActionDefinition<unknown, unknown, unknown, unknown>
+      if (actionDef.advancedBatchSettings) {
+        const batchSettings = actionDef.advancedBatchSettings
+        // Limit the number of batch keys to 3 or fewer
+        if (batchSettings.batchKeys && batchSettings.batchKeys.length > 3) {
+          errors.push(
+            new Error(
+              `The action "${actionKey}" has more than 3 batch keys. Please limit the number of batch keys to 3 or fewer.`
+            )
+          )
+        }
+      }
     }
 
     return errors
@@ -140,7 +153,7 @@ export default class Validate extends Command {
         // this.isInvalid = true
         const typ = fieldValues?.type
 
-        if ((typ === 'boolean' || typ === 'number') && typeof fieldValues?.default != "undefined") {
+        if ((typ === 'boolean' || typ === 'number') && typeof fieldValues?.default != 'undefined') {
           if (typeof fieldValues?.default !== typ) {
             errors.push(
               new Error(

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -103,6 +103,15 @@ export default class Validate extends Command {
       return []
     }
 
+    // Ensure that no fields are named "batch_keys"
+    if (action.fields['batch_keys']) {
+      errors.push(
+        new Error(
+          `The action "${actionKey}" has a field named "batch_keys". This field is reserved for use in batch settings. Please rename the field to something else.`
+        )
+      )
+    }
+
     // Limit the number of batch keys to 3 or fewer
     if (batchSettings.batchKeys && batchSettings.batchKeys.length > 3) {
       errors.push(
@@ -116,7 +125,7 @@ export default class Validate extends Command {
     if (batchSettings.batchSize && action.fields['batch_size']) {
       errors.push(
         new Error(
-          `The action "${actionKey}" has both a batch size key and also batch_size defined in batch settings. Please use only one of these options.`
+          `The action "${actionKey}" has both a batch_size key and also batch_size defined in batch settings. Please use only one of these options.`
         )
       )
     }
@@ -125,7 +134,7 @@ export default class Validate extends Command {
     if (batchSettings.batchBytes && action.fields['batch_bytes']) {
       errors.push(
         new Error(
-          `The action "${actionKey}" has both a batch size and batch settings. Please use only one of these options.`
+          `The action "${actionKey}" has both a batch_bytes field and also batch bytes defined in batch settings. Please use only one of these options.`
         )
       )
     }
@@ -138,6 +147,19 @@ export default class Validate extends Command {
         )
       )
     }
+
+    const validateType = (key: string, type: string) => {
+      if (action.fields[key]?.type !== type) {
+        errors.push(new Error(`The action "${actionKey}" has a field named "${key}" that is not of type "${type}".`))
+      }
+    }
+
+    // Validates the types of reserved batch settings fields
+    validateType('batch_size', 'number')
+    validateType('batch_bytes', 'number')
+    validateType('enable_batching', 'boolean')
+    validateType('batch_keys', 'string')
+
     return errors
   }
 

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -13,8 +13,7 @@ export const RESERVED_FIELD_NAMES = [
   'password',
   'secretkey',
   'secret',
-  'securitytoken',
-  'batch_keys'
+  'securitytoken'
 ]
 
 export const OAUTH_SCHEME = 'oauth2'

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -13,7 +13,8 @@ export const RESERVED_FIELD_NAMES = [
   'password',
   'secretkey',
   'secret',
-  'securitytoken'
+  'securitytoken',
+  'batch_keys'
 ]
 
 export const OAUTH_SCHEME = 'oauth2'

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -143,7 +143,10 @@ export interface ActionDefinition<
   /** The sync mode setting definition. This enables subscription sync mode selection when subscribing to this action. */
   syncMode?: SyncModeDefinition
 
-  /** The configuration for batching events. These configurations are only applicable when performBatch is implemented. */
+  /** The configuration for batching events. These configurations are only applicable when performBatch is implemented.
+   * Note: if fields with same keys are present in fields and batchConfig, the values from fields will be used.
+   * Example: If fields has a key named 'enable_batching' and batchConfig has a key named 'enable_batching', the value from fields will take precendence.
+   */
   batchConfig?: BatchConfiguration<Payload>
 }
 
@@ -238,7 +241,11 @@ const isSyncMode = (value: unknown): value is SyncMode => {
   return syncModeTypes.find((validValue) => value === validValue) !== undefined
 }
 
-const INTERNAL_HIDDEN_FIELDS = ['__segment_internal_sync_mode', '__segment_internal_matching_key']
+const INTERNAL_HIDDEN_FIELDS = [
+  '__segment_internal_sync_mode',
+  '__segment_internal_matching_key',
+  '__segment_internal_batch_keys'
+]
 const removeInternalHiddenFields = (mapping: JSONObject): JSONObject => {
   return Object.keys(mapping).reduce((acc, key) => {
     return INTERNAL_HIDDEN_FIELDS.includes(key) ? acc : { ...acc, [key]: mapping[key] }

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -17,7 +17,7 @@ import type {
   ActionDestinationSuccessResponseType,
   ActionDestinationErrorResponseType,
   ResultMultiStatusNode,
-  BatchConfiguration
+  BatchSettings
 } from './types'
 import { syncModeTypes } from './types'
 import { HTTPError, NormalizedOptions } from '../request-client'
@@ -143,11 +143,10 @@ export interface ActionDefinition<
   /** The sync mode setting definition. This enables subscription sync mode selection when subscribing to this action. */
   syncMode?: SyncModeDefinition
 
-  /** The configuration for batching events. These configurations are only applicable when performBatch is implemented.
-   * Note: if fields with same keys are present in fields and batchConfig, the values from fields will be used.
-   * Example: If fields has a key named 'enable_batching' and batchConfig has a key named 'enable_batching', the value from fields will take precendence.
+  /** Advanced configuration for batching events. These configurations are only applicable when performBatch is implemented
+   * and these settings should not be exposed via the UI to the user.
    */
-  batchConfig?: BatchConfiguration<Payload>
+  advancedBatchSettings?: BatchSettings<Payload>
 }
 
 export const hookTypeStrings = ['onMappingSave', 'retlOnMappingSave'] as const

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -16,7 +16,8 @@ import type {
   DynamicFieldContext,
   ActionDestinationSuccessResponseType,
   ActionDestinationErrorResponseType,
-  ResultMultiStatusNode
+  ResultMultiStatusNode,
+  BatchConfiguration
 } from './types'
 import { syncModeTypes } from './types'
 import { HTTPError, NormalizedOptions } from '../request-client'
@@ -141,6 +142,9 @@ export interface ActionDefinition<
 
   /** The sync mode setting definition. This enables subscription sync mode selection when subscribing to this action. */
   syncMode?: SyncModeDefinition
+
+  /** The configuration for batching events. These configurations are only applicable when performBatch is implemented. */
+  batchConfig?: BatchConfiguration<Payload>
 }
 
 export const hookTypeStrings = ['onMappingSave', 'retlOnMappingSave'] as const

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -143,10 +143,8 @@ export interface ActionDefinition<
   /** The sync mode setting definition. This enables subscription sync mode selection when subscribing to this action. */
   syncMode?: SyncModeDefinition
 
-  /** Advanced configuration for batching events. These configurations are only applicable when performBatch is implemented
-   * and these settings should not be exposed via the UI to the user.
-   */
-  advancedBatchSettings?: BatchSettings<Payload>
+  /** Batch settings for the action. All these settings will be hidden from the user. */
+  batchSettings?: BatchSettings<Payload>
 }
 
 export const hookTypeStrings = ['onMappingSave', 'retlOnMappingSave'] as const
@@ -240,11 +238,7 @@ const isSyncMode = (value: unknown): value is SyncMode => {
   return syncModeTypes.find((validValue) => value === validValue) !== undefined
 }
 
-const INTERNAL_HIDDEN_FIELDS = [
-  '__segment_internal_sync_mode',
-  '__segment_internal_matching_key',
-  '__segment_internal_batch_keys'
-]
+const INTERNAL_HIDDEN_FIELDS = ['__segment_internal_sync_mode', '__segment_internal_matching_key']
 const removeInternalHiddenFields = (mapping: JSONObject): JSONObject => {
   return Object.keys(mapping).reduce((acc, key) => {
     return INTERNAL_HIDDEN_FIELDS.includes(key) ? acc : { ...acc, [key]: mapping[key] }

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -401,11 +401,15 @@ export type BatchConfiguration<Payload> = {
   /** The maximum number of events to include in each batch. Actual batch sizes may be lower.
    *  By default, the batch size is 1000, the field is hidden by default.
    */
-  batch_size?: number
+  batch_size?: Partial<InputField> | number
   /** The maximum number of bytes to include in each batch. Actual batch sizes may be lower.
    *  By default, max batch size is 4MB, the field is hidden by default.
    */
-  batch_bytes?: number
+  batch_bytes?: Partial<InputField> | number
+  /**
+   * Should enable batching for the destination by default.
+   */
+  enable_batching?: Partial<InputField> | boolean
   /** The keys to batch events by. Maximum number of keys is allowed is 3.
    *  Ensure keys are of fields with low cardinality values to avoid poor batch performance.
    *  This field is always hidden.

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -407,4 +407,16 @@ export type BatchSettings<Payload> = {
    *  This field is always hidden.
    */
   batchKeys?: Array<keyof Payload>
+
+  /** The maximum number of events to include in each batch. Actual batch sizes may be lower. This will be hidden by default.
+   * If you wish to expose this to the customer, consider defining this as a field and customize it.
+   */
+  batchSize?: number
+
+  /**
+   * Whether or not to enable batching for this action by default.
+   * This will hide the enable_batching field in the UI and set default state to true.
+   * If you wish to expose this to the customer, consider defining this as a field and customize it.
+   */
+  hideEnableBatching?: boolean
 }

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -402,7 +402,7 @@ export type BatchSettings<Payload> = {
    *  By default, max batch size is 4MB and this field is always hidden.
    */
   batchBytes?: number
-  /** The keys to batch events by. Maximum number of keys is allowed is 3.
+  /** The keys to batch events by. A maximum of 3 keys can be defined for batching events.
    *  Ensure keys are of fields with low cardinality values to avoid poor batch performance.
    *  This field is always hidden.
    */

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -401,15 +401,16 @@ export type BatchConfiguration<Payload> = {
   /** The maximum number of events to include in each batch. Actual batch sizes may be lower.
    *  By default, the batch size is 1000, the field is hidden by default.
    */
-  batch_size?: Partial<InputField> | number
+  batch_size?: number
   /** The maximum number of bytes to include in each batch. Actual batch sizes may be lower.
    *  By default, max batch size is 4MB, the field is hidden by default.
    */
-  batch_bytes?: Partial<InputField> | number
+  batch_bytes?: number
   /**
-   * Should enable batching for the destination by default.
+   * Whether batching should be enabled by default for this action.
+   * By defaut, batching is false and the field is displayed by default.
    */
-  enable_batching?: Partial<InputField> | boolean
+  enable_batching?: boolean
   /** The keys to batch events by. Maximum number of keys is allowed is 3.
    *  Ensure keys are of fields with low cardinality values to avoid poor batch performance.
    *  This field is always hidden.

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -397,23 +397,14 @@ export type ResultMultiStatusNode =
       errorreporter: MultiStatusErrorReporter
     })
 
-export type BatchConfiguration<Payload> = {
-  /** The maximum number of events to include in each batch. Actual batch sizes may be lower.
-   *  By default, the batch size is 1000, the field is hidden by default.
-   */
-  batch_size?: number
+export type BatchSettings<Payload> = {
   /** The maximum number of bytes to include in each batch. Actual batch sizes may be lower.
-   *  By default, max batch size is 4MB, the field is hidden by default.
+   *  By default, max batch size is 4MB and this field is always hidden.
    */
-  batch_bytes?: number
-  /**
-   * Whether batching should be enabled by default for this action.
-   * By defaut, batching is false and the field is displayed by default.
-   */
-  enable_batching?: boolean
+  batchBytes?: number
   /** The keys to batch events by. Maximum number of keys is allowed is 3.
    *  Ensure keys are of fields with low cardinality values to avoid poor batch performance.
    *  This field is always hidden.
    */
-  batch_keys?: Array<keyof Payload>
+  batchKeys?: Array<keyof Payload>
 }

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -396,3 +396,19 @@ export type ResultMultiStatusNode =
   | (ActionDestinationErrorResponseType & {
       errorreporter: MultiStatusErrorReporter
     })
+
+export type BatchConfiguration<Payload> = {
+  /** The maximum number of events to include in each batch. Actual batch sizes may be lower.
+   *  By default, the batch size is 1000, the field is hidden by default.
+   */
+  batch_size?: number
+  /** The maximum number of bytes to include in each batch. Actual batch sizes may be lower.
+   *  By default, max batch size is 4MB, the field is hidden by default.
+   */
+  batch_bytes?: number
+  /** The keys to batch events by. Maximum number of keys is allowed is 3.
+   *  Ensure keys are of fields with low cardinality values to avoid poor batch performance.
+   *  This field is always hidden.
+   */
+  batch_keys?: Array<keyof Payload>
+}


### PR DESCRIPTION
This PR adds new batch config field to action definition. This will allow devs to consicely define batch options. Most of the destinations define these batch options as hidden fields. So, this new definition makes them hidden by default. To override, builders simply have to define a field with appropriate keys and then customize the option further.

- batch bytes - max number of bytes allowed in batch
- batch keys - the keys based on which batching has to be done.
- batch size - max number of events to include in a batch
- hideEnableBatching - hides the default generated enable_batching option and sets default value to true.


**Does it impact to existing configurations?**

No impact to existing batch configurations. This PR adds a new convenient way to configure batch related configurations and batch keys moving forward.

If these configurations are defined in both batch settings and as fields, yarn validate run from CI would through an error. This is to ensure we don't end up defining values in two places.

This PR  is no-op without action-cli PR - https://github.com/segmentio/action-cli/pull/211

Documentation will be updated after we launch batch_keys feature.

## Testing

Tested changes validate.ts 

<img width="570" alt="image" src="https://github.com/user-attachments/assets/d84860d1-6acd-4c5f-a5df-f319123e9981" />

<img width="1037" alt="image" src="https://github.com/user-attachments/assets/c46c5107-2c5f-45c9-a01b-09b09653accb" />

<img width="1249" alt="image" src="https://github.com/user-attachments/assets/5dfdcf6c-0c65-4185-b981-070b7c040cf8" />


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
