### PR TITLE
[STRATCONN-5488] Introduces batch_keys field (pilot)

### DIFF
--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -108,32 +108,34 @@ export default class Validate extends Command {
     if (!field.default) {
       errors.push(new Error(`The action "${actionKey}" has a field "batch_keys" that is missing a default value.`))
     }
-    if (Array.isArray(!field.default)) {
+    if (!Array.isArray(field.default)) {
       errors.push(
         new Error(`The action "${actionKey}" has a field "batch_keys" that doesn't have array default value.`)
       )
-    }
-    const batchKeys = field.default as string[]
-    if (batchKeys.length > 3) {
-      errors.push(
-        new Error(`The action "${actionKey}" has a field "batch_keys" that has more than 3 keys. Max allowed is 3.`)
-      )
-    }
-    const unknownKeys = batchKeys.filter((key) => action.fields[key] === undefined)
-    if (unknownKeys.length > 0) {
-      errors.push(
-        new Error(
-          `The action "${actionKey}" has a field "batch_keys" that has unknown keys: ${unknownKeys.join(
-            ', '
-          )}. only allowed keys are: ${Object.keys(action.fields).join(', ')}`
+    } else {
+      const batchKeys = field.default as string[]
+      if (batchKeys.length > 3) {
+        errors.push(
+          new Error(`The action "${actionKey}" has a field "batch_keys" that has more than 3 keys. Max allowed is 3.`)
         )
-      )
+      }
+      const unknownKeys = batchKeys.filter((key) => action.fields[key] === undefined)
+      if (unknownKeys.length > 0) {
+        errors.push(
+          new Error(
+            `The action "${actionKey}" has a field "batch_keys" that has unknown keys: ${unknownKeys.join(
+              ', '
+            )}. only allowed keys are: ${Object.keys(action.fields).join(', ')}`
+          )
+        )
+      }
+      if (batchKeys.includes('batch_keys')) {
+        errors.push(
+          new Error(`The action "${actionKey}" has a field "batch_keys" that includes itself. This is not allowed.`)
+        )
+      }
     }
-    if (batchKeys.includes('batch_keys')) {
-      errors.push(
-        new Error(`The action "${actionKey}" has a field "batch_keys" that includes itself. This is not allowed.`)
-      )
-    }
+
     return errors
   }
 

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -94,14 +94,14 @@ export default class Validate extends Command {
     const batchKeys = field.default as string[]
     if (batchKeys.length > 3) {
       errors.push(
-        new Error(`The action "${actionKey}" has a field "batch_keys" that has more than 3 keys. Max allowed is 3.`)
+        new Error(`The action "${actionKey}" has a "batch_keys" field that has more than 3 keys. Max allowed is 3.`)
       )
     }
     const unknownKeys = batchKeys.filter((key) => action.fields[key] === undefined)
     if (unknownKeys.length > 0) {
       errors.push(
         new Error(
-          `The action "${actionKey}" has a field "batch_keys" that has unknown keys: ${unknownKeys.join(
+          `The action "${actionKey}" has a "batch_keys" field that has unknown keys: ${unknownKeys.join(
             ', '
           )}. only allowed keys are: ${Object.keys(action.fields).join(', ')}`
         )
@@ -109,7 +109,7 @@ export default class Validate extends Command {
     }
     if (batchKeys.includes('batch_keys')) {
       errors.push(
-        new Error(`The action "${actionKey}" has a field "batch_keys" that includes itself. This is not allowed.`)
+        new Error(`The action "${actionKey}" has a "batch_keys" field that includes itself. This is not allowed.`)
       )
     }
 

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -91,49 +91,26 @@ export default class Validate extends Command {
 
   validateBatchKeysField(field: InputField, actionKey: string, action: BaseActionDefinition): Error[] {
     const errors: Error[] = []
-    if (field.type !== 'string') {
-      errors.push(new Error(`The action "${actionKey}" has a field "batch_keys" that is not of type "string".`))
-    }
-    if (field.unsafe_hidden !== true) {
+    const batchKeys = field.default as string[]
+    if (batchKeys.length > 3) {
       errors.push(
-        new Error(`The action "${actionKey}" has a field "batch_keys" that is not marked as "unsafe_hidden".`)
+        new Error(`The action "${actionKey}" has a field "batch_keys" that has more than 3 keys. Max allowed is 3.`)
       )
     }
-    if (field.multiple !== true) {
-      errors.push(new Error(`The action "${actionKey}" has a field "batch_keys" that is not marked as "multiple".`))
-    }
-    if (field.required !== false && field.required !== undefined) {
-      errors.push(new Error(`The action "${actionKey}" has a field "batch_keys" that is marked as "required".`))
-    }
-    if (!field.default) {
-      errors.push(new Error(`The action "${actionKey}" has a field "batch_keys" that is missing a default value.`))
-    }
-    if (!Array.isArray(field.default)) {
+    const unknownKeys = batchKeys.filter((key) => action.fields[key] === undefined)
+    if (unknownKeys.length > 0) {
       errors.push(
-        new Error(`The action "${actionKey}" has a field "batch_keys" that doesn't have array default value.`)
+        new Error(
+          `The action "${actionKey}" has a field "batch_keys" that has unknown keys: ${unknownKeys.join(
+            ', '
+          )}. only allowed keys are: ${Object.keys(action.fields).join(', ')}`
+        )
       )
-    } else {
-      const batchKeys = field.default as string[]
-      if (batchKeys.length > 3) {
-        errors.push(
-          new Error(`The action "${actionKey}" has a field "batch_keys" that has more than 3 keys. Max allowed is 3.`)
-        )
-      }
-      const unknownKeys = batchKeys.filter((key) => action.fields[key] === undefined)
-      if (unknownKeys.length > 0) {
-        errors.push(
-          new Error(
-            `The action "${actionKey}" has a field "batch_keys" that has unknown keys: ${unknownKeys.join(
-              ', '
-            )}. only allowed keys are: ${Object.keys(action.fields).join(', ')}`
-          )
-        )
-      }
-      if (batchKeys.includes('batch_keys')) {
-        errors.push(
-          new Error(`The action "${actionKey}" has a field "batch_keys" that includes itself. This is not allowed.`)
-        )
-      }
+    }
+    if (batchKeys.includes('batch_keys')) {
+      errors.push(
+        new Error(`The action "${actionKey}" has a field "batch_keys" that includes itself. This is not allowed.`)
+      )
     }
 
     return errors

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -46,8 +46,8 @@ export type RequestFn<Settings, Payload, Return = any, AudienceSettings = any, A
 
 interface ReservedInputFields {
   batch_keys?: {
-    label: 'Batch Keys'
-    description: 'The mapping keys to use to batch events together. Events with the same values for these keys will be batched together.'
+    label: string
+    description: string
     type: 'string'
     unsafe_hidden?: true
     multiple?: true

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -44,6 +44,20 @@ export type RequestFn<Settings, Payload, Return = any, AudienceSettings = any, A
   data: ExecuteInput<Settings, Payload, AudienceSettings, ActionHookInputs>
 ) => MaybePromise<Return>
 
+interface ReservedInputFields {
+  batch_keys?: {
+    label: 'Batch Keys'
+    description: 'The mapping keys to use to batch events together. Events with the same values for these keys will be batched together.'
+    type: 'string'
+    unsafe_hidden?: true
+    multiple?: true
+    required?: false
+    default?: string[]
+  }
+}
+
+type ActionFields = Omit<Record<string, InputField>, keyof ReservedInputFields> & ReservedInputFields
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface BaseActionDefinition {
   /** The display title of the action */
@@ -67,7 +81,7 @@ export interface BaseActionDefinition {
   /**
    * The fields used to perform the action. These fields should match what the partner API expects.
    */
-  fields: Record<string, InputField>
+  fields: ActionFields
 }
 
 type HookValueTypes = string | boolean | number | Array<string | boolean | number>


### PR DESCRIPTION
This PR 
- updates `fields` type in ActionDefinition to specify specific shape for batch_keys
- adds some validations for batch_keys field so that we can catch configuration errors earlier.

## Testing

![image](https://github.com/user-attachments/assets/8b50a1be-c2e6-477f-9058-e5711b75df72)
![image](https://github.com/user-attachments/assets/dc3d87d8-a497-4822-b556-be800064171c)


**Scenario: 2**
![image](https://github.com/user-attachments/assets/83377c9b-e938-4b75-babe-23f2fe581edc)
![image](https://github.com/user-attachments/assets/419d54ea-3c2f-4a5a-8143-df3a0ed3b7e7)


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
