### PR TITLE
[required-field-check] Run yarn install after switching to main branch

### DIFF
--- a/.github/workflows/required-field-check.yml
+++ b/.github/workflows/required-field-check.yml
@@ -61,7 +61,8 @@ jobs:
           # This is important because the main branch may have different dependencies
           # than the current branch, and we want to ensure that the required fields are
           # checked against the correct version of the dependencies
-          yarn install --frozen-lockfile
+          yarn install --frozen-lockfile --silent
+          # Run the list-required-fields command on the main branch to get the required fields
           REQUIRED_FIELDS_MAIN_BRANCH=$(./bin/run list-required-fields -p ${{ steps.get_files.outputs.files }} | jq -c .)
           echo "REQUIRED_FIELDS_MAIN_BRANCH=$REQUIRED_FIELDS_MAIN_BRANCH" >> $GITHUB_ENV
 


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/required-field-check.yml` file to enhance the reliability of the required fields check process. The most important changes are:

Workflow improvements:

* Added `set -e` to ensure the script exits immediately if a command exits with a non-zero status, improving error handling.
* Added a step to run `yarn install --frozen-lockfile` on the main branch

## Testing

The new check passes on this branch

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
