### PR TITLE
Eventbridge cosmetic changes

### DIFF
--- a/packages/destination-actions/src/destinations/amazon-eventbridge/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amazon-eventbridge/generated-types.ts
@@ -15,11 +15,9 @@ export interface Settings {
    */
   partnerEventSourceName: string
   /**
-   * USE WITH CAUTION: This will create the partner event source if it does not already exist.
-   *                       Use this option if you want to create the partner event source.
-   *                       projectId or context.protocols.sourceId will be used as the sourceId to
-   *                       create the partner event source.
-   *                       Use with caution.
+   * If enabled, Segment will check whether Partner Source identified by Segment source ID
+   *                       exists in EventBridge.
+   *                       If Partner Source does not exist, Segment will create a new Partner Source.
    */
   createPartnerEventSource?: boolean
 }

--- a/packages/destination-actions/src/destinations/amazon-eventbridge/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-eventbridge/index.ts
@@ -49,6 +49,7 @@ const destination: DestinationDefinition<Settings> = {
         label: 'Partner Event Source Name',
         description: 'The name of the partner event source to use for the event bus.',
         required: true,
+        unsafe_hidden: true,
         default: 'segment.com',
         choices: [
           { label: 'segment.com', value: 'aws.partner/segment.com' },
@@ -58,11 +59,9 @@ const destination: DestinationDefinition<Settings> = {
       createPartnerEventSource: {
         type: 'boolean',
         label: 'Create Partner Event Source',
-        description: `USE WITH CAUTION: This will create the partner event source if it does not already exist.
-                      Use this option if you want to create the partner event source.
-                      projectId or context.protocols.sourceId will be used as the sourceId to 
-                      create the partner event source.
-                      Use with caution.`,
+        description: `If enabled, Segment will check whether Partner Source identified by Segment source ID 
+                      exists in EventBridge. 
+                      If Partner Source does not exist, Segment will create a new Partner Source.`,
         default: false
       }
     },

--- a/packages/destination-actions/src/destinations/amazon-eventbridge/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-eventbridge/index.ts
@@ -49,7 +49,6 @@ const destination: DestinationDefinition<Settings> = {
         label: 'Partner Event Source Name',
         description: 'The name of the partner event source to use for the event bus.',
         required: true,
-        unsafe_hidden: true,
         default: 'segment.com',
         choices: [
           { label: 'segment.com', value: 'aws.partner/segment.com' },

--- a/packages/destination-actions/src/destinations/amazon-eventbridge/send/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amazon-eventbridge/send/generated-types.ts
@@ -8,7 +8,8 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * The detail type for the event.
+   * Detail Type of the event. Used to determine what fields to expect in the event Detail.
+   *                     Values longer than 128 characters are trimmed
    */
   detailType: string
   /**

--- a/packages/destination-actions/src/destinations/amazon-eventbridge/send/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-eventbridge/send/index.ts
@@ -16,7 +16,8 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     detailType: {
       label: 'Detail Type',
-      description: 'The detail type for the event.',
+      description: `Detail Type of the event. Used to determine what fields to expect in the event Detail. 
+                    Values longer than 128 characters are trimmed`,
       type: 'string',
       default: { '@path': '$.type' },
       required: true


### PR DESCRIPTION
Changed descriptions of fields
Update the hint for ‘Detail Type’:
Before: ‘Detail Type for the event’
After: ‘Detail Type of the event. Used to determine what fields to expect in the event Detail. Values longer than 128 characters are trimmed’
Update Create Partner Event Source global setting description:
Before: “USE WITH CAUTION: This will create the partner event source if it does not already exist. Use this option if you want to create the partner event source. projectId or context.protocols.sourceId will be used as the sourceId to create the partner event source. Use with caution.”
After: “If enabled, Segment will check whether Partner Source identified by Segment source ID exists in EventBridge. If Partner Source does not exist, Segment will create a new Partner Source.”

## Testing

No testing needed. Only changed description of 2 fields

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
