### PR TITLE
Cleanup Node 18 checks from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version: [18.x, 22.x]
+        node-version: [22.x]
 
     steps:
       # See nx recipe: https://nx.dev/recipes/ci/monorepo-ci-github-actions
@@ -58,7 +58,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        node-version: [18.x, 22.x]
+        node-version: [22.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -92,7 +92,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        node-version: [18.x, 22.x]
+        node-version: [22.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -139,7 +139,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        node-version: [18.x, 22.x]
+        node-version: [22.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -177,7 +177,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 22.x]
+        node-version: [22.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -220,7 +220,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 22.x]
+        node-version: [22.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ext.yml
+++ b/.github/workflows/ext.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 22.x]
+        node-version: [22.x]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR cleans up node-18 related stages on CI.

## Testing

Testing not required as this is a CI change.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
