### PR TITLE
[STRATCONN-5616] | Made Event Properties hidden in Braze Cohorts.

### DIFF
--- a/packages/destination-actions/src/destinations/braze-cohorts/syncAudiences/index.ts
+++ b/packages/destination-actions/src/destinations/braze-cohorts/syncAudiences/index.ts
@@ -83,6 +83,7 @@ const action: ActionDefinition<Settings, Payload> = {
         'Displays properties of the event to add/remove users to a cohort and the traits of the specific user',
       type: 'object',
       required: true,
+      unsafe_hidden: true,
       default: {
         '@if': {
           exists: { '@path': '$.properties' },


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pull request is to hide the event properties in SyncAudience Mapping of Braze Cohorts.
Jira ticket :- https://segment.atlassian.net/jira/software/c/projects/STRATCONN/boards/310?assignee=63617339fc0cc7a600b03c6b&selectedIssue=STRATCONN-5616
Testing completed successfully in staging.
<img width="1465" alt="Screenshot 2025-03-19 at 6 05 17 PM" src="https://github.com/user-attachments/assets/03d3c34a-3156-425b-8303-dfa64280a019" />
<img width="995" alt="Screenshot 2025-03-19 at 6 03 44 PM" src="https://github.com/user-attachments/assets/9561b28c-8649-4982-9ad4-c2aa71055c2b" />
<img width="1312" alt="Screenshot 2025-03-19 at 6 26 25 PM" src="https://github.com/user-attachments/assets/25032be6-95ad-4f37-9ac4-a1aa20a48a28" />
<img width="1316" alt="Screenshot 2025-03-19 at 6 26 49 PM" src="https://github.com/user-attachments/assets/2b44ab4d-84be-4c7c-9c3e-d476c714c55f" />



## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
