### PR TITLE
fix pinterest-conversions destination item_price field type

### DIFF
--- a/packages/destination-actions/src/destinations/pinterest-conversions/pinterest-capi-custom-data.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/pinterest-capi-custom-data.ts
@@ -14,7 +14,7 @@ export const custom_data_field: InputField = {
       label: 'Value',
       description:
         'Total value of the event. E.g. if there are multiple items in a checkout event, value should be the total price of all items',
-      type: 'number'
+      type: 'string'
     },
     content_ids: {
       label: 'Content IDs',
@@ -35,7 +35,7 @@ export const custom_data_field: InputField = {
         },
         item_price: {
           label: 'Price',
-          type: 'number',
+          type: 'string',
           description: 'The price of the Item'
         },
         quantity: {


### PR DESCRIPTION
The Type of the item_price is a string according to the documentation and we get an error as the type is automatically converted to as number. The value field type is also corrected as a string.

https://developers.pinterest.com/docs/api/v5/events-create/

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
