### PR TITLE
[STRATCONN-5603] - Format timestamp fields without miliiseconds

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/functions.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/functions.test.ts
@@ -1,7 +1,7 @@
 import { createTestIntegration, DynamicFieldResponse } from '@segment/actions-core'
 import { Features } from '@segment/actions-core/mapping-kit'
 import nock from 'nock'
-import { CANARY_API_VERSION, formatToE164, commonEmailValidation } from '../functions'
+import { CANARY_API_VERSION, formatToE164, commonEmailValidation, convertTimestamp } from '../functions'
 import destination from '../index'
 
 const testDestination = createTestIntegration(destination)
@@ -176,5 +176,19 @@ describe('phone number formatting', () => {
     expect(formatToE164('49301234567', '+49')).toEqual('+49301234567')
     expect(formatToE164('+49 30 1234567', '49')).toEqual('+49301234567')
     expect(formatToE164('+49 30 1234567', '49')).toEqual('+49301234567')
+  })
+})
+
+describe('convertTimestamp', () => {
+  it('should convert timestamp with milliseconds', () => {
+    const timestamp = '2025-03-11T19:03:56.616960388Z'
+    const result = convertTimestamp(timestamp)
+    expect(result).toEqual('2025-03-11 19:03:56+00:00')
+  })
+
+  it('should convert timestamp without milliseconds', () => {
+    const timestamp = '2025-03-11T17:57:29Z'
+    const result = convertTimestamp(timestamp)
+    expect(result).toEqual('2025-03-11 17:57:29+00:00')
   })
 })

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -482,26 +482,28 @@ const extractUserIdentifiers = (
         })
       }
       if (payload.first_name || payload.last_name || payload.country_code || payload.postal_code) {
-        identifiers.push({
-          addressInfo: {
-            hashedFirstName: processHashing(
-              payload.first_name ?? '',
-              'sha256',
-              'hex',
-              features ?? {},
-              'actions-google-enhanced-conversions'
-            ),
-            hashedLastName: processHashing(
-              payload.last_name ?? '',
-              'sha256',
-              'hex',
-              features ?? {},
-              'actions-google-enhanced-conversions'
-            ),
-            countryCode: payload.country_code ?? '',
-            postalCode: payload.postal_code ?? ''
-          }
-        })
+        const addressInfo: any = {}
+        if (payload.first_name) {
+          addressInfo.hashedFirstName = processHashing(
+            payload.first_name,
+            'sha256',
+            'hex',
+            features ?? {},
+            'actions-google-enhanced-conversions'
+          )
+        }
+        if (payload.last_name) {
+          addressInfo.hashedLastName = processHashing(
+            payload.last_name,
+            'sha256',
+            'hex',
+            features ?? {},
+            'actions-google-enhanced-conversions'
+          )
+        }
+        addressInfo.countryCode = payload.country_code ?? ''
+        addressInfo.postalCode = payload.postal_code ?? ''
+        identifiers.push({ addressInfo })
       }
       return identifiers
     }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -568,14 +568,14 @@ const createOfflineUserJob = async (
     return (response.data as any).resourceName
   } catch (error) {
     statsContext?.statsClient?.incr('error.createJob', 1, statsContext?.tags)
-    handleGoogleAdsError(error as GoogleAdsError)
+    handleGoogleAdsError(error)
   }
 }
 
-const handleGoogleAdsError = (error: GoogleAdsError) => {
+const handleGoogleAdsError = (error: any) => {
   // Google throws 400 error for CONCURRENT_MODIFICATION error which is a retryable error
   // We rewrite this error to a 500 so that Centrifuge can retry the request
-  const errors = error.response?.data?.error?.details ?? []
+  const errors = (error as GoogleAdsError).response?.data?.error?.details ?? []
   for (const errorDetails of errors) {
     for (const errorItem of errorDetails.errors) {
       // https://developers.google.com/google-ads/api/reference/rpc/v17/DatabaseErrorEnum.DatabaseError
@@ -618,7 +618,7 @@ const addOperations = async (
     return response.data
   } catch (error) {
     statsContext?.statsClient?.incr('error.addOperations', 1, statsContext?.tags)
-    handleGoogleAdsError(error as GoogleAdsError)
+    handleGoogleAdsError(error)
   }
 }
 
@@ -641,7 +641,7 @@ const runOfflineUserJob = async (
     return response.data
   } catch (error) {
     statsContext?.statsClient?.incr('error.runJob', 1, statsContext?.tags)
-    handleGoogleAdsError(error as GoogleAdsError)
+    handleGoogleAdsError(error)
   }
 }
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -9,8 +9,7 @@ import {
   CreateAudienceInput,
   CreateGoogleAudienceResponse,
   UserListResponse,
-  UserList,
-  Auth
+  UserList
 } from './types'
 import {
   ModifiedResponse,
@@ -94,7 +93,7 @@ export const hash = (value: string | undefined): string | undefined => {
 
 export async function getCustomVariables(
   customerId: string,
-  auth: Auth,
+  auth: any,
   request: RequestClient,
   features: Features | undefined,
   statsContext: StatsContext | undefined
@@ -122,7 +121,7 @@ export function memoizedGetCustomVariables() {
 
   return async (
     customerId: string,
-    auth: Auth,
+    auth: any,
     request: RequestClient,
     features: Features | undefined,
     statsContext: StatsContext | undefined
@@ -139,7 +138,7 @@ export function memoizedGetCustomVariables() {
 
 export async function getConversionActionId(
   customerId: string | undefined,
-  auth: Auth,
+  auth: any,
   request: RequestClient,
   features: Features | undefined,
   statsContext: StatsContext | undefined
@@ -164,8 +163,8 @@ export async function getConversionActionId(
 
 export async function getConversionActionDynamicData(
   request: RequestClient,
-  settings: { customerId: string },
-  auth: Auth,
+  settings: any,
+  auth: any,
   features: Features | undefined,
   statsContext: StatsContext | undefined
 ): Promise<DynamicFieldResponse> {
@@ -187,7 +186,7 @@ export async function getConversionActionDynamicData(
       nextPage: '',
       error: {
         message: (err as GoogleAdsError).response?.statusText ?? 'Unknown error',
-        code: (err as GoogleAdsError).response?.status?.toString() ?? '500'
+        code: (err as GoogleAdsError).response?.status + '' ?? '500'
       }
     }
   }
@@ -240,7 +239,7 @@ export const commonEmailValidation = (email: string): string => {
 export async function getListIds(
   request: RequestClient,
   settings: CreateAudienceInput['settings'],
-  auth?: Auth,
+  auth?: any,
   features?: Features | undefined,
   statsContext?: StatsContext
 ) {
@@ -284,7 +283,7 @@ export async function getListIds(
 export async function createGoogleAudience(
   request: RequestClient,
   input: CreateAudienceInput,
-  auth: Auth,
+  auth: CreateAudienceInput['settings']['oauth'],
   features?: Features | undefined,
   statsContext?: StatsContext
 ) {
@@ -359,7 +358,7 @@ export async function getGoogleAudience(
   request: RequestClient,
   settings: CreateAudienceInput['settings'],
   externalId: string,
-  auth: Auth,
+  auth: CreateAudienceInput['settings']['oauth'],
   features?: Features | undefined,
   statsContext?: StatsContext
 ) {
@@ -402,7 +401,7 @@ export async function getGoogleAudience(
     }
   )
 
-  const id = (response.data as UserListResponse).results[0].userList.id
+  const id = (response.data as any).results[0].userList.id
 
   if (!id) {
     statsClient?.incr('getAudience.error', 1, statsTags)
@@ -595,7 +594,7 @@ const handleGoogleAdsError = (error: GoogleAdsError) => {
 
 const addOperations = async (
   request: RequestClient,
-  userIdentifiers: UserIdentifier[],
+  userIdentifiers: any,
   resourceName: string,
   features?: Features | undefined,
   statsContext?: StatsContext | undefined

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -205,7 +205,7 @@ export function convertTimestamp(timestamp: string | undefined): string | undefi
   if (!timestamp) {
     return undefined
   }
-  return timestamp.replace(/T/, ' ').replace(/Z$/, '+00:00').replace(/\..+/, '+00:00')
+  return timestamp.replace(/T/, ' ').replace(/(\.\d+)?Z/, '+00:00')
 }
 
 export function getApiVersion(features?: Features, statsContext?: StatsContext): string {
@@ -482,28 +482,26 @@ const extractUserIdentifiers = (
         })
       }
       if (payload.first_name || payload.last_name || payload.country_code || payload.postal_code) {
-        const addressInfo: any = {}
-        if (payload.first_name) {
-          addressInfo.hashedFirstName = processHashing(
-            payload.first_name,
-            'sha256',
-            'hex',
-            features ?? {},
-            'actions-google-enhanced-conversions'
-          )
-        }
-        if (payload.last_name) {
-          addressInfo.hashedLastName = processHashing(
-            payload.last_name,
-            'sha256',
-            'hex',
-            features ?? {},
-            'actions-google-enhanced-conversions'
-          )
-        }
-        addressInfo.countryCode = payload.country_code ?? ''
-        addressInfo.postalCode = payload.postal_code ?? ''
-        identifiers.push({ addressInfo })
+        identifiers.push({
+          addressInfo: {
+            hashedFirstName: processHashing(
+              payload.first_name ?? '',
+              'sha256',
+              'hex',
+              features ?? {},
+              'actions-google-enhanced-conversions'
+            ),
+            hashedLastName: processHashing(
+              payload.last_name ?? '',
+              'sha256',
+              'hex',
+              features ?? {},
+              'actions-google-enhanced-conversions'
+            ),
+            countryCode: payload.country_code ?? '',
+            postalCode: payload.postal_code ?? ''
+          }
+        })
       }
       return identifiers
     }


### PR DESCRIPTION
This pull request updates timestamp conversion function to handle timestamps without milliseconds part.

Previously timestamp like `2025-03-11T17:57:29Z` was passed as is to google ads API. Google ads API expects timezone specified. Since a timestamp with `Z` indicates UTC, as part of this change, we simply replace Z with +00.

Adding unit test cases for timestamp formats with and without milliseconds

[JIRA](https://segment.atlassian.net/browse/STRATCONN-5603) 

## Testing

Without milliseconds
![image](https://github.com/user-attachments/assets/2fedce02-7e30-4cdb-8d0b-748283e71cfa)

With milliseconds

![image](https://github.com/user-attachments/assets/581f5762-4fca-4a0b-833a-24eea02b4f0e)


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
