### PR TITLE
[Salesforce] Advanced stats for CSV generation

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce/__tests__/sf-utils.test.ts
@@ -2,7 +2,6 @@ import { GenericPayload } from '../sf-types'
 import { buildCSVData } from '../sf-utils'
 import Salesforce from '../sf-operations'
 import createRequestClient from '../../../../../core/src/create-request-client'
-import { StatsContext } from '@segment/actions-core/*'
 
 const requestClient = createRequestClient()
 
@@ -318,23 +317,9 @@ describe('Salesforce Utils', () => {
         }
       ]
 
-      const logging = {
-        shouldLog: true,
-        stats: {
-          statsClient: {
-            incr: jest.fn(),
-            observe: jest.fn(),
-            _name: jest.fn(),
-            _tags: jest.fn(),
-            set: jest.fn(),
-            histogram: jest.fn()
-          },
-          tags: []
-        } as StatsContext,
-        jobId: '1234'
-      }
+      const csvStats = { shouldLog: true, numberOfColumns: 0, numberOfValuesInCSV: 0, numberOfNullsInCSV: 0 }
 
-      const csv = buildCSVData(createPayloads, '', 'insert', logging)
+      const csv = buildCSVData(createPayloads, '', 'insert', csvStats)
       const expected = `Name,Phone,Description\n"SpongeBob Squarepants","1234567890","Krusty Krab"\n"Squidward Tentacles","1234567891","Krusty Krab"\n`
 
       expect(csv).toEqual(expected)
@@ -358,42 +343,17 @@ describe('Salesforce Utils', () => {
         }
       ]
 
-      const logging = {
-        shouldLog: true,
-        stats: {
-          statsClient: {
-            incr: jest.fn(),
-            observe: jest.fn(),
-            _name: jest.fn(),
-            _tags: jest.fn(),
-            set: jest.fn(),
-            histogram: jest.fn()
-          },
-          tags: []
-        } as StatsContext,
-        jobId: '1234'
-      }
+      const csvStats = { shouldLog: true, numberOfColumns: 0, numberOfValuesInCSV: 0, numberOfNullsInCSV: 0 }
 
-      const csv = buildCSVData(incompleteUpdatePayloads, 'Id', 'Update', logging)
+      const csv = buildCSVData(incompleteUpdatePayloads, 'Id', 'Update', csvStats)
       const expected = `Name,Description,Phone,Id\n"SpongeBob Squarepants",#N/A,"1234567890","00"\n"Squidward Tentacles","Krusty Krab",#N/A,"01"\n`
 
       expect(csv).toEqual(expected)
 
-      expect(logging.stats.statsClient.incr).toHaveBeenNthCalledWith(1, 'bulkCSV.payloadSize', 2, expect.any(Array))
-      expect(logging.stats.statsClient.incr).toHaveBeenNthCalledWith(2, 'bulkCSV.numberOfColumns', 4, expect.any(Array))
+      expect(csvStats.numberOfColumns).toEqual(4)
 
-      expect(logging.stats.statsClient.incr).toHaveBeenNthCalledWith(
-        3,
-        'bulkCSV.numberOfValuesInCSV',
-        4,
-        expect.any(Array)
-      )
-      expect(logging.stats.statsClient.incr).toHaveBeenNthCalledWith(
-        4,
-        'bulkCSV.numberOfNullsInCSV',
-        2,
-        expect.any(Array)
-      )
+      expect(csvStats.numberOfValuesInCSV).toEqual(4)
+      expect(csvStats.numberOfNullsInCSV).toEqual(2)
     })
   })
 

--- a/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
@@ -371,7 +371,7 @@ export default class Salesforce {
     logging?: { shouldLog: boolean; logger?: Logger; stats?: StatsContext }
   ): Promise<ModifiedResponse<unknown>> {
     // construct the CSV data to catch errors before creating a bulk job
-    const csv = buildCSVData(payloads, idField, operation)
+    const csv = buildCSVData(payloads, idField, operation, logging)
     const jobId = await this.createBulkJob(sobject, idField, operation, logging)
     try {
       await this.uploadBulkCSV(jobId, csv, logging)
@@ -390,7 +390,7 @@ export default class Salesforce {
         const tags = logging?.stats?.tags
         tags?.push('jobId:' + jobId)
         statsClient?.incr('bulkJobError.caughUploadError', 1, tags)
-        logging?.logger?.crit(`Failed to close bulk job: ${jobId}. Message: ${message}. Code: ${code}`)
+        logging?.logger?.error(`Failed to close bulk job: ${jobId}. Message: ${message}. Code: ${code}`)
       })
       throw err
     }
@@ -406,7 +406,7 @@ export default class Salesforce {
 
       tags?.push('jobId:' + jobId)
       statsClient?.incr('bulkJobError', 1, tags)
-      logging?.logger?.crit(`Failed to close bulk job: ${jobId}. Message: ${message}. Code: ${code}`)
+      logging?.logger?.error(`Failed to close bulk job: ${jobId}. Message: ${message}. Code: ${code}`)
 
       throw err
     }
@@ -441,7 +441,7 @@ export default class Salesforce {
     }
 
     if (logging?.shouldLog) {
-      logging.logger?.crit(`Created bulk job: ${res.data.id} with data: ${JSON.stringify(jsonData)}`)
+      logging.logger?.error(`Created bulk job: ${res.data.id} with data: ${JSON.stringify(jsonData)}`)
 
       const statsClient = logging.stats?.statsClient
       const tags = logging.stats?.tags
@@ -459,7 +459,7 @@ export default class Salesforce {
     logging?: { shouldLog: boolean; logger?: Logger; stats?: StatsContext }
   ) => {
     if (logging?.shouldLog) {
-      logging.logger?.crit(`Uploading CSV to job: ${jobId}\nCSV: ${csv}`)
+      logging.logger?.error(`Uploading CSV to job: ${jobId}\nCSV: ${csv}`)
 
       const statsClient = logging.stats?.statsClient
       const tags = logging.stats?.tags
@@ -482,7 +482,7 @@ export default class Salesforce {
     logging?: { shouldLog: boolean; logger?: Logger; stats?: StatsContext }
   ) => {
     if (logging?.shouldLog) {
-      logging.logger?.crit(`Closing job: ${jobId}`)
+      logging.logger?.error(`Closing job: ${jobId}`)
 
       const statsClient = logging.stats?.statsClient
       const tags = logging.stats?.tags

--- a/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-operations.ts
@@ -371,7 +371,7 @@ export default class Salesforce {
     logging?: { shouldLog: boolean; logger?: Logger; stats?: StatsContext }
   ): Promise<ModifiedResponse<unknown>> {
     // construct the CSV data to catch errors before creating a bulk job
-    const csv = buildCSVData(payloads, idField, operation, logging)
+    const csv = buildCSVData(payloads, idField, operation, { shouldLog: logging?.shouldLog, stats: logging?.stats })
     const jobId = await this.createBulkJob(sobject, idField, operation, logging)
     try {
       await this.uploadBulkCSV(jobId, csv, logging)

--- a/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
+++ b/packages/destination-actions/src/destinations/salesforce/sf-utils.ts
@@ -1,6 +1,7 @@
-import { IntegrationError } from '@segment/actions-core'
+import { IntegrationError, StatsContext } from '@segment/actions-core'
 import { GenericPayload } from './sf-types'
 import camelCase from 'lodash/camelCase'
+import { Logger } from '@segment/actions-core/destination-kit'
 
 type CSVData = string | number | boolean
 
@@ -177,7 +178,8 @@ const getUniqueIdValue = (payload: GenericPayload, operation: string | undefined
 export const buildCSVData = (
   payloads: GenericPayload[],
   uniqueIdName: string,
-  operation: string | undefined
+  operation: string | undefined,
+  logging?: { shouldLog: boolean; logger?: Logger; stats?: StatsContext }
 ): string => {
   const headerMap = buildHeaderMap(payloads)
   let csv = buildHeaders(headerMap)


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR implements some more advanced stats tracking around our CSV generation logic. It counts the following values:
* How many rows per CSV
* How many columns per CSV
* How many real values in the CSV
* How many null values in the CSV

This will enable improved debugging for certain customers.

## Testing

Tested successfully in stage.
The stats are correctly picked up in DataDog:

<img width="935" alt="Screenshot 2025-03-24 at 10 28 10 AM" src="https://github.com/user-attachments/assets/7aff68bd-4117-4973-b587-885c30e01ee8" />

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
