### PR TITLE
[Salesforce Marketing Cloud] V2 Data Extension mapping save hook

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtensionV2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtensionV2/generated-types.ts
@@ -1,0 +1,3 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {}

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtensionV2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtensionV2/generated-types.ts
@@ -1,3 +1,192 @@
 // Generated file. DO NOT MODIFY IT BY HAND.
 
-export interface Payload {}
+export interface Payload {
+  /**
+   * The primary key(s) that uniquely identify a row in the data extension. On the left-hand side, input the SFMC key name. On the right-hand side, map the Segment field that contains the corresponding value. When multiple primary keys are provided, SFMC will update an existing row if all primary keys match, otherwise a new row will be created
+   */
+  keys: {
+    /**
+     * The unique identifier that you assign to a contact. Contact Key must be a Primary Key in the data extension that contains contact information.
+     */
+    contactKey: string
+    [k: string]: unknown
+  }
+  /**
+   * The fields in the data extension that contain data about a contact, such as Email, Last Name, etc. Fields must be created in the data extension before sending data for it. On the left-hand side, input the SFMC field name exactly how it appears in the data extension. On the right-hand side, map the Segment field that contains the corresponding value.
+   */
+  values: {
+    [k: string]: unknown
+  }
+  /**
+   * If true, data is batched before sending to the SFMC Data Extension.
+   */
+  enable_batching?: boolean
+  /**
+   * Maximum number of events to include in each batch. Actual batch sizes may be lower.
+   */
+  batch_size?: number
+}
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface RetlOnMappingSaveInputs {
+  /**
+   * Whether to create a new data extension or select an existing one for data delivery.
+   */
+  operation: string
+  /**
+   * The identifier for the data extension.
+   */
+  dataExtensionId?: string
+  /**
+   * The identifier for the folder that contains the data extension.
+   */
+  categoryId?: string
+  /**
+   * The name of the data extension.
+   */
+  name?: string
+  /**
+   * The description of the data extension.
+   */
+  description?: string
+  /**
+   * Indicates whether the custom object can be used to send messages. If the value of this property is true, then the custom object is sendable
+   */
+  isSendable?: boolean
+  /**
+   * The field on this data extension which is sendable. This must be a field that is present on this data extension.
+   */
+  sendableCustomObjectField?: string
+  /**
+   * The relationship with "Subscribers" for the Sendable Custom Object Field.
+   */
+  sendableSubscriberField?: string
+  /**
+   * A list of fields to create in the data extension.
+   */
+  columns?: {
+    /**
+     * The name of the field.
+     */
+    name: string
+    /**
+     * The data type of the field.
+     */
+    type: string
+    /**
+     * Whether the field can be null.
+     */
+    isNullable: boolean
+    /**
+     * Whether the field is a primary key.
+     */
+    isPrimaryKey: boolean
+    /**
+     * The length of the field. Required for non-boolean fields
+     */
+    length?: number
+    /**
+     * The scale of the field. Required for Decimal fields
+     */
+    scale?: number
+    /**
+     * The description of the field.
+     */
+    description?: string
+    [k: string]: unknown
+  }[]
+}
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface RetlOnMappingSaveOutputs {
+  /**
+   * The identifier for the data extension.
+   */
+  id: string
+  /**
+   * The name of the data extension.
+   */
+  name: string
+}
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface OnMappingSaveInputs {
+  /**
+   * Whether to create a new data extension or select an existing one for data delivery.
+   */
+  operation: string
+  /**
+   * The identifier for the data extension.
+   */
+  dataExtensionId?: string
+  /**
+   * The identifier for the folder that contains the data extension.
+   */
+  categoryId?: string
+  /**
+   * The name of the data extension.
+   */
+  name?: string
+  /**
+   * The description of the data extension.
+   */
+  description?: string
+  /**
+   * Indicates whether the custom object can be used to send messages. If the value of this property is true, then the custom object is sendable
+   */
+  isSendable?: boolean
+  /**
+   * The field on this data extension which is sendable. This must be a field that is present on this data extension.
+   */
+  sendableCustomObjectField?: string
+  /**
+   * The relationship with "Subscribers" for the Sendable Custom Object Field.
+   */
+  sendableSubscriberField?: string
+  /**
+   * A list of fields to create in the data extension.
+   */
+  columns?: {
+    /**
+     * The name of the field.
+     */
+    name: string
+    /**
+     * The data type of the field.
+     */
+    type: string
+    /**
+     * Whether the field can be null.
+     */
+    isNullable: boolean
+    /**
+     * Whether the field is a primary key.
+     */
+    isPrimaryKey: boolean
+    /**
+     * The length of the field. Required for non-boolean fields
+     */
+    length?: number
+    /**
+     * The scale of the field. Required for Decimal fields
+     */
+    scale?: number
+    /**
+     * The description of the field.
+     */
+    description?: string
+    [k: string]: unknown
+  }[]
+}
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface OnMappingSaveOutputs {
+  /**
+   * The identifier for the data extension.
+   */
+  id: string
+  /**
+   * The name of the data extension.
+   */
+  name: string
+}

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtensionV2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtensionV2/index.ts
@@ -1,17 +1,76 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+import { keys, enable_batching, batch_size, values_contactFields, dataExtensionHook } from '../sfmc-properties'
+import { executeUpsertWithMultiStatus, upsertRows, getDataExtensionFields } from '../sfmc-operations'
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Contact Data Extension V2',
-  description: '',
-  fields: {},
-  perform: (request, data) => {
-    // Make your partner api request here!
-    // return request('https://example.com', {
-    //   method: 'post',
-    //   json: data.payload
-    // })
+  title: 'Send Contact to Data Extension',
+  defaultSubscription: 'type = "identify"',
+  description: 'Upsert contact data as rows into an existing data extension in Salesforce Marketing Cloud.',
+  fields: {
+    keys: {
+      ...keys,
+      properties: {
+        contactKey: {
+          label: 'Contact Key',
+          description:
+            'The unique identifier that you assign to a contact. Contact Key must be a Primary Key in the data extension that contains contact information.',
+          type: 'string',
+          required: true
+        }
+      },
+      default: {
+        contactKey: { '@path': '$.userId' }
+      }
+    },
+    values: values_contactFields,
+    enable_batching: enable_batching,
+    batch_size: batch_size
+  },
+  dynamicFields: {
+    keys: {
+      __keys__: async (request, { settings, payload }) => {
+        const dataExtensionId =
+          (payload as any).onMappingSave?.outputs.id || (payload as any).retlOnMappingSave?.outputs?.id || ''
+        return await getDataExtensionFields(request, settings.subdomain, settings, dataExtensionId, true)
+      }
+    },
+    values: {
+      __keys__: async (request, { settings, payload }) => {
+        const dataExtensionId =
+          (payload as any).onMappingSave?.outputs?.id || (payload as any).retlOnMappingSave?.outputs?.id || ''
+        return await getDataExtensionFields(request, settings.subdomain, settings, dataExtensionId, false)
+      }
+    }
+  },
+  hooks: {
+    retlOnMappingSave: {
+      ...dataExtensionHook
+    },
+    onMappingSave: {
+      ...dataExtensionHook
+    }
+  },
+  perform: async (request, { settings, payload, hookOutputs }) => {
+    const dataExtensionId =
+      hookOutputs?.onMappingSave?.outputs?.id || hookOutputs?.retlOnMappingSave?.outputs?.id || payload.id
+    const deprecated_dataExtensionKey = payload.key
+
+    return upsertRows(request, settings.subdomain, [payload], dataExtensionId, deprecated_dataExtensionKey)
+  },
+  performBatch: async (request, { settings, payload, hookOutputs }) => {
+    const dataExtensionId =
+      hookOutputs?.onMappingSave?.outputs?.id || hookOutputs?.retlOnMappingSave?.outputs?.id || payload[0].id
+    const deprecated_dataExtensionKey = payload[0].key
+
+    return executeUpsertWithMultiStatus(
+      request,
+      settings.subdomain,
+      payload,
+      dataExtensionId,
+      deprecated_dataExtensionKey
+    )
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtensionV2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtensionV2/index.ts
@@ -1,0 +1,18 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Contact Data Extension V2',
+  description: '',
+  fields: {},
+  perform: (request, data) => {
+    // Make your partner api request here!
+    // return request('https://example.com', {
+    //   method: 'post',
+    //   json: data.payload
+    // })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtensionV2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtensionV2/index.ts
@@ -11,6 +11,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     keys: {
       ...keys,
+      dynamic: true,
       properties: {
         contactKey: {
           label: 'Contact Key',
@@ -24,7 +25,7 @@ const action: ActionDefinition<Settings, Payload> = {
         contactKey: { '@path': '$.userId' }
       }
     },
-    values: values_contactFields,
+    values: { ...values_contactFields, dynamic: true },
     enable_batching: enable_batching,
     batch_size: batch_size
   },

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtensionV2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtensionV2/index.ts
@@ -1,4 +1,4 @@
-import type { ActionDefinition } from '@segment/actions-core'
+import { IntegrationError, ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { keys, enable_batching, batch_size, values_contactFields, dataExtensionHook } from '../sfmc-properties'
@@ -54,12 +54,22 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, { settings, payload, hookOutputs }) => {
-    const dataExtensionId = hookOutputs?.onMappingSave?.outputs?.id || hookOutputs?.retlOnMappingSave?.outputs?.id
+    const dataExtensionId: string =
+      hookOutputs?.onMappingSave?.outputs?.id || hookOutputs?.retlOnMappingSave?.outputs?.id
+
+    if (!dataExtensionId) {
+      throw new IntegrationError('No Data Extension Connected', 'INVALID_CONFIGURATION', 400)
+    }
 
     return upsertRowsV2(request, settings.subdomain, [payload], dataExtensionId)
   },
   performBatch: async (request, { settings, payload, hookOutputs }) => {
-    const dataExtensionId = hookOutputs?.onMappingSave?.outputs?.id || hookOutputs?.retlOnMappingSave?.outputs?.id
+    const dataExtensionId: string =
+      hookOutputs?.onMappingSave?.outputs?.id || hookOutputs?.retlOnMappingSave?.outputs?.id
+
+    if (!dataExtensionId) {
+      throw new IntegrationError('No Data Extension Connected', 'INVALID_CONFIGURATION', 400)
+    }
 
     return executeUpsertWithMultiStatus(request, settings.subdomain, payload, dataExtensionId)
   }

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtensionV2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtensionV2/index.ts
@@ -5,7 +5,7 @@ import { keys, enable_batching, batch_size, values_contactFields, dataExtensionH
 import { executeUpsertWithMultiStatus, getDataExtensionFields, upsertRowsV2 } from '../sfmc-operations'
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Send Contact to Data Extension',
+  title: 'Send Contact to Data Extension (V2)',
   defaultSubscription: 'type = "identify"',
   description: 'Upsert contact data as rows into an existing data extension in Salesforce Marketing Cloud.',
   fields: {

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtensionV2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/contactDataExtensionV2/index.ts
@@ -2,7 +2,7 @@ import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { keys, enable_batching, batch_size, values_contactFields, dataExtensionHook } from '../sfmc-properties'
-import { executeUpsertWithMultiStatus, upsertRows, getDataExtensionFields } from '../sfmc-operations'
+import { executeUpsertWithMultiStatus, getDataExtensionFields, upsertRowsV2 } from '../sfmc-operations'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Contact to Data Extension',
@@ -53,24 +53,14 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, { settings, payload, hookOutputs }) => {
-    const dataExtensionId =
-      hookOutputs?.onMappingSave?.outputs?.id || hookOutputs?.retlOnMappingSave?.outputs?.id || payload.id
-    const deprecated_dataExtensionKey = payload.key
+    const dataExtensionId = hookOutputs?.onMappingSave?.outputs?.id || hookOutputs?.retlOnMappingSave?.outputs?.id
 
-    return upsertRows(request, settings.subdomain, [payload], dataExtensionId, deprecated_dataExtensionKey)
+    return upsertRowsV2(request, settings.subdomain, [payload], dataExtensionId)
   },
   performBatch: async (request, { settings, payload, hookOutputs }) => {
-    const dataExtensionId =
-      hookOutputs?.onMappingSave?.outputs?.id || hookOutputs?.retlOnMappingSave?.outputs?.id || payload[0].id
-    const deprecated_dataExtensionKey = payload[0].key
+    const dataExtensionId = hookOutputs?.onMappingSave?.outputs?.id || hookOutputs?.retlOnMappingSave?.outputs?.id
 
-    return executeUpsertWithMultiStatus(
-      request,
-      settings.subdomain,
-      payload,
-      dataExtensionId,
-      deprecated_dataExtensionKey
-    )
+    return executeUpsertWithMultiStatus(request, settings.subdomain, payload, dataExtensionId)
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtensionV2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtensionV2/generated-types.ts
@@ -1,0 +1,3 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {}

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtensionV2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtensionV2/generated-types.ts
@@ -1,3 +1,188 @@
 // Generated file. DO NOT MODIFY IT BY HAND.
 
-export interface Payload {}
+export interface Payload {
+  /**
+   * The primary key(s) that uniquely identify a row in the data extension. On the left-hand side, input the SFMC key name. On the right-hand side, map the Segment field that contains the corresponding value. When multiple primary keys are provided, SFMC will update an existing row if all primary keys match, otherwise a new row will be created
+   */
+  keys: {
+    [k: string]: unknown
+  }
+  /**
+   * The fields in the data extension that contain data about an event, such as Product Name, Revenue, Event Time, etc. Fields must be created in the data extension before sending data for it. On the left-hand side, input the SFMC field name exactly how it appears in the data extension. On the right-hand side, map the Segment field that contains the corresponding value.
+   */
+  values: {
+    [k: string]: unknown
+  }
+  /**
+   * If true, data is batched before sending to the SFMC Data Extension.
+   */
+  enable_batching?: boolean
+  /**
+   * Maximum number of events to include in each batch. Actual batch sizes may be lower.
+   */
+  batch_size?: number
+}
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface RetlOnMappingSaveInputs {
+  /**
+   * Whether to create a new data extension or select an existing one for data delivery.
+   */
+  operation: string
+  /**
+   * The identifier for the data extension.
+   */
+  dataExtensionId?: string
+  /**
+   * The identifier for the folder that contains the data extension.
+   */
+  categoryId?: string
+  /**
+   * The name of the data extension.
+   */
+  name?: string
+  /**
+   * The description of the data extension.
+   */
+  description?: string
+  /**
+   * Indicates whether the custom object can be used to send messages. If the value of this property is true, then the custom object is sendable
+   */
+  isSendable?: boolean
+  /**
+   * The field on this data extension which is sendable. This must be a field that is present on this data extension.
+   */
+  sendableCustomObjectField?: string
+  /**
+   * The relationship with "Subscribers" for the Sendable Custom Object Field.
+   */
+  sendableSubscriberField?: string
+  /**
+   * A list of fields to create in the data extension.
+   */
+  columns?: {
+    /**
+     * The name of the field.
+     */
+    name: string
+    /**
+     * The data type of the field.
+     */
+    type: string
+    /**
+     * Whether the field can be null.
+     */
+    isNullable: boolean
+    /**
+     * Whether the field is a primary key.
+     */
+    isPrimaryKey: boolean
+    /**
+     * The length of the field. Required for non-boolean fields
+     */
+    length?: number
+    /**
+     * The scale of the field. Required for Decimal fields
+     */
+    scale?: number
+    /**
+     * The description of the field.
+     */
+    description?: string
+    [k: string]: unknown
+  }[]
+}
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface RetlOnMappingSaveOutputs {
+  /**
+   * The identifier for the data extension.
+   */
+  id: string
+  /**
+   * The name of the data extension.
+   */
+  name: string
+}
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface OnMappingSaveInputs {
+  /**
+   * Whether to create a new data extension or select an existing one for data delivery.
+   */
+  operation: string
+  /**
+   * The identifier for the data extension.
+   */
+  dataExtensionId?: string
+  /**
+   * The identifier for the folder that contains the data extension.
+   */
+  categoryId?: string
+  /**
+   * The name of the data extension.
+   */
+  name?: string
+  /**
+   * The description of the data extension.
+   */
+  description?: string
+  /**
+   * Indicates whether the custom object can be used to send messages. If the value of this property is true, then the custom object is sendable
+   */
+  isSendable?: boolean
+  /**
+   * The field on this data extension which is sendable. This must be a field that is present on this data extension.
+   */
+  sendableCustomObjectField?: string
+  /**
+   * The relationship with "Subscribers" for the Sendable Custom Object Field.
+   */
+  sendableSubscriberField?: string
+  /**
+   * A list of fields to create in the data extension.
+   */
+  columns?: {
+    /**
+     * The name of the field.
+     */
+    name: string
+    /**
+     * The data type of the field.
+     */
+    type: string
+    /**
+     * Whether the field can be null.
+     */
+    isNullable: boolean
+    /**
+     * Whether the field is a primary key.
+     */
+    isPrimaryKey: boolean
+    /**
+     * The length of the field. Required for non-boolean fields
+     */
+    length?: number
+    /**
+     * The scale of the field. Required for Decimal fields
+     */
+    scale?: number
+    /**
+     * The description of the field.
+     */
+    description?: string
+    [k: string]: unknown
+  }[]
+}
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface OnMappingSaveOutputs {
+  /**
+   * The identifier for the data extension.
+   */
+  id: string
+  /**
+   * The name of the data extension.
+   */
+  name: string
+}

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtensionV2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtensionV2/index.ts
@@ -1,14 +1,8 @@
 import { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import {
-  keys,
-  enable_batching,
-  batch_size,
-  values_dataExtensionFields,
-  dataExtensionHook
-} from '../sfmc-properties'
-import { executeUpsertWithMultiStatus, upsertRows, getDataExtensionFields } from '../sfmc-operations'
+import { keys, enable_batching, batch_size, values_dataExtensionFields, dataExtensionHook } from '../sfmc-properties'
+import { executeUpsertWithMultiStatus, getDataExtensionFields, upsertRowsV2 } from '../sfmc-operations'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Event to Data Extension',
@@ -44,24 +38,14 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, { settings, payload, hookOutputs }) => {
-    const dataExtensionId =
-      hookOutputs?.onMappingSave?.outputs?.id || hookOutputs?.retlOnMappingSave?.outputs?.id || payload.id
-    const deprecated_dataExtensionKey = payload.key
+    const dataExtensionId = hookOutputs?.onMappingSave?.outputs?.id || hookOutputs?.retlOnMappingSave?.outputs?.id
 
-    return upsertRows(request, settings.subdomain, [payload], dataExtensionId, deprecated_dataExtensionKey)
+    return upsertRowsV2(request, settings.subdomain, [payload], dataExtensionId)
   },
   performBatch: async (request, { settings, payload, hookOutputs }) => {
-    const dataExtensionId =
-      hookOutputs?.onMappingSave?.outputs?.id || hookOutputs?.retlOnMappingSave?.outputs?.id || payload[0].id
-    const deprecated_dataExtensionKey = payload[0].key
+    const dataExtensionId = hookOutputs?.onMappingSave?.outputs?.id || hookOutputs?.retlOnMappingSave?.outputs?.id
 
-    return executeUpsertWithMultiStatus(
-      request,
-      settings.subdomain,
-      payload,
-      dataExtensionId,
-      deprecated_dataExtensionKey
-    )
+    return executeUpsertWithMultiStatus(request, settings.subdomain, payload, dataExtensionId)
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtensionV2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtensionV2/index.ts
@@ -1,17 +1,67 @@
-import type { ActionDefinition } from '@segment/actions-core'
+import { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
+import {
+  keys,
+  enable_batching,
+  batch_size,
+  values_dataExtensionFields,
+  dataExtensionHook
+} from '../sfmc-properties'
+import { executeUpsertWithMultiStatus, upsertRows, getDataExtensionFields } from '../sfmc-operations'
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Data Extension V2',
-  description: '',
-  fields: {},
-  perform: (request, data) => {
-    // Make your partner api request here!
-    // return request('https://example.com', {
-    //   method: 'post',
-    //   json: data.payload
-    // })
+  title: 'Send Event to Data Extension',
+  description: 'Upsert events as rows into an existing data extension in Salesforce Marketing Cloud.',
+  fields: {
+    keys: { ...keys, required: true },
+    values: values_dataExtensionFields,
+    enable_batching: enable_batching,
+    batch_size: batch_size
+  },
+  dynamicFields: {
+    keys: {
+      __keys__: async (request, { settings, payload }) => {
+        const dataExtensionId =
+          (payload as any).onMappingSave?.outputs?.id || (payload as any).retlOnMappingSave?.outputs?.id || ''
+        return await getDataExtensionFields(request, settings.subdomain, settings, dataExtensionId, true)
+      }
+    },
+    values: {
+      __keys__: async (request, { settings, payload }) => {
+        const dataExtensionId =
+          (payload as any).onMappingSave?.outputs?.id || (payload as any).retlOnMappingSave?.outputs?.id || ''
+        return await getDataExtensionFields(request, settings.subdomain, settings, dataExtensionId, false)
+      }
+    }
+  },
+  hooks: {
+    retlOnMappingSave: {
+      ...dataExtensionHook
+    },
+    onMappingSave: {
+      ...dataExtensionHook
+    }
+  },
+  perform: async (request, { settings, payload, hookOutputs }) => {
+    const dataExtensionId =
+      hookOutputs?.onMappingSave?.outputs?.id || hookOutputs?.retlOnMappingSave?.outputs?.id || payload.id
+    const deprecated_dataExtensionKey = payload.key
+
+    return upsertRows(request, settings.subdomain, [payload], dataExtensionId, deprecated_dataExtensionKey)
+  },
+  performBatch: async (request, { settings, payload, hookOutputs }) => {
+    const dataExtensionId =
+      hookOutputs?.onMappingSave?.outputs?.id || hookOutputs?.retlOnMappingSave?.outputs?.id || payload[0].id
+    const deprecated_dataExtensionKey = payload[0].key
+
+    return executeUpsertWithMultiStatus(
+      request,
+      settings.subdomain,
+      payload,
+      dataExtensionId,
+      deprecated_dataExtensionKey
+    )
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtensionV2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtensionV2/index.ts
@@ -8,8 +8,8 @@ const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Event to Data Extension',
   description: 'Upsert events as rows into an existing data extension in Salesforce Marketing Cloud.',
   fields: {
-    keys: { ...keys, required: true },
-    values: values_dataExtensionFields,
+    keys: { ...keys, required: true, dynamic: true },
+    values: { ...values_dataExtensionFields, dynamic: true },
     enable_batching: enable_batching,
     batch_size: batch_size
   },

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtensionV2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtensionV2/index.ts
@@ -1,0 +1,18 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Data Extension V2',
+  description: '',
+  fields: {},
+  perform: (request, data) => {
+    // Make your partner api request here!
+    // return request('https://example.com', {
+    //   method: 'post',
+    //   json: data.payload
+    // })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtensionV2/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtensionV2/index.ts
@@ -5,7 +5,7 @@ import { keys, enable_batching, batch_size, values_dataExtensionFields, dataExte
 import { executeUpsertWithMultiStatus, getDataExtensionFields, upsertRowsV2 } from '../sfmc-operations'
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Send Event to Data Extension',
+  title: 'Send Event to Data Extension (V2)',
   description: 'Upsert events as rows into an existing data extension in Salesforce Marketing Cloud.',
   fields: {
     keys: { ...keys, required: true, dynamic: true },

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/index.ts
@@ -5,6 +5,11 @@ import dataExtension from './dataExtension'
 import contactDataExtension from './contactDataExtension'
 import apiEvent from './apiEvent'
 
+// These actions include an actions hook which handles configuring the connected
+// data extension. They are independent from the original actions to support a slow rollout.
+import dataExtensionV2 from './dataExtensionV2'
+import contactDataExtensionV2 from './contactDataExtensionV2'
+
 interface RefreshTokenResponse {
   access_token: string
 }
@@ -71,7 +76,9 @@ const destination: DestinationDefinition<Settings> = {
     contact,
     dataExtension,
     contactDataExtension,
-    apiEvent
+    apiEvent,
+    dataExtensionV2,
+    contactDataExtensionV2
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
@@ -3,11 +3,18 @@ import {
   MultiStatusResponse,
   JSONLikeObject,
   ModifiedResponse,
-  IntegrationError
+  IntegrationError,
+  ActionHookResponse,
+  DynamicFieldResponse,
+  DynamicFieldError,
+  DynamicFieldItem
 } from '@segment/actions-core'
 import { Payload as payload_dataExtension } from './dataExtension/generated-types'
 import { Payload as payload_contactDataExtension } from './contactDataExtension/generated-types'
 import { ErrorResponse } from './types'
+import { OnMappingSaveInputs } from './dataExtension/generated-types'
+import { Settings } from './generated-types'
+import { xml2js } from 'xml-js'
 
 function generateRows(payloads: payload_dataExtension[] | payload_contactDataExtension[]): Record<string, any>[] {
   const rows: Record<string, any>[] = []
@@ -23,10 +30,11 @@ function generateRows(payloads: payload_dataExtension[] | payload_contactDataExt
 export function upsertRows(
   request: RequestClient,
   subdomain: String,
-  payloads: payload_dataExtension[] | payload_contactDataExtension[]
+  payloads: payload_dataExtension[] | payload_contactDataExtension[],
+  dataExtensionId?: string,
+  dataExtensionKey?: string
 ) {
-  const { key, id } = payloads[0]
-  if (!key && !id) {
+  if (!dataExtensionKey && !dataExtensionId) {
     throw new IntegrationError(
       `In order to send an event to a data extension either Data Extension ID or Data Extension Key must be defined.`,
       'Misconfigured required field',
@@ -34,13 +42,16 @@ export function upsertRows(
     )
   }
   const rows = generateRows(payloads)
-  if (key) {
-    return request(`https://${subdomain}.rest.marketingcloudapis.com/hub/v1/dataevents/key:${key}/rowset`, {
-      method: 'POST',
-      json: rows
-    })
+  if (dataExtensionKey) {
+    return request(
+      `https://${subdomain}.rest.marketingcloudapis.com/hub/v1/dataevents/key:${dataExtensionKey}/rowset`,
+      {
+        method: 'POST',
+        json: rows
+      }
+    )
   } else {
-    return request(`https://${subdomain}.rest.marketingcloudapis.com/hub/v1/dataevents/${id}/rowset`, {
+    return request(`https://${subdomain}.rest.marketingcloudapis.com/hub/v1/dataevents/${dataExtensionId}/rowset`, {
       method: 'POST',
       json: rows
     })
@@ -50,13 +61,15 @@ export function upsertRows(
 export async function executeUpsertWithMultiStatus(
   request: RequestClient,
   subdomain: String,
-  payloads: payload_dataExtension[] | payload_contactDataExtension[]
+  payloads: payload_dataExtension[] | payload_contactDataExtension[],
+  dataExtensionId?: string,
+  dataExtensionKey?: string
 ): Promise<MultiStatusResponse> {
   const multiStatusResponse = new MultiStatusResponse()
   let response: ModifiedResponse | undefined
   const rows = generateRows(payloads)
   try {
-    response = await upsertRows(request, subdomain, payloads)
+    response = await upsertRows(request, subdomain, payloads, dataExtensionId, dataExtensionKey)
     if (response) {
       const responseData = response.data as JSONLikeObject[]
       payloads.forEach((_, index) => {
@@ -113,4 +126,472 @@ export async function executeUpsertWithMultiStatus(
     })
   }
   return multiStatusResponse
+}
+
+interface DataExtensionCreationResponse {
+  data: {
+    id?: string
+    name?: string
+    key?: string
+    message?: string
+    errorcode?: number
+  }
+}
+
+interface DataExtensionSelectionResponse {
+  data: {
+    id?: string
+    name?: string
+    key?: string
+  }
+}
+
+interface DataExtensionSearchResponse {
+  count: number
+  items: {
+    id: string
+    name: string
+    key: string
+  }[]
+}
+
+interface DataExtensionFieldsResponse {
+  id: string
+  fields: {
+    name: string
+    type: string
+    isPrimaryKey: boolean
+  }[]
+}
+
+interface RefreshTokenResponse {
+  access_token: string
+  soap_instance_url: string
+}
+
+interface SoapResponseResult {
+  ID: {
+    _text: string
+  }
+  Name: {
+    _text: string
+  }
+  ContentType: {
+    _text: string
+  }
+}
+
+const getAccessToken = async (
+  request: RequestClient,
+  settings: Settings
+): Promise<{ accessToken: string; soapInstanceUrl: string }> => {
+  const baseUrl = `https://${settings.subdomain}.auth.marketingcloudapis.com/v2/token`
+  const res = await request<RefreshTokenResponse>(`${baseUrl}`, {
+    method: 'POST',
+    body: new URLSearchParams({
+      account_id: settings.account_id,
+      client_id: settings.client_id,
+      client_secret: settings.client_secret,
+      grant_type: 'client_credentials'
+    })
+  })
+
+  return { accessToken: res.data.access_token, soapInstanceUrl: res.data.soap_instance_url }
+}
+
+const dataExtensionRequest = async (
+  request: RequestClient,
+  hookInputs: OnMappingSaveInputs,
+  auth: { subdomain: string; accessToken: string }
+): Promise<{ id?: string; key?: string; error?: string }> => {
+  if (!hookInputs) {
+    return { id: '', key: '', error: 'No inputs provided' }
+  }
+
+  if (!hookInputs.columns) {
+    return { id: '', key: '', error: 'No columns provided' }
+  }
+
+  const fields = hookInputs.columns.map((column, i) => {
+    return {
+      name: column.name,
+      type: column.type,
+      isNullable: column.isNullable,
+      isPrimaryKey: column.isPrimaryKey,
+      length: column.length,
+      scale: column.scale,
+      description: column.description || '',
+      // these are required but we don't give the user an option
+      ordinal: i,
+      isTemplateField: false,
+      isHidden: false,
+      isReadOnly: false,
+      isInheritable: false,
+      isOverridable: false,
+      mustOverride: false
+    }
+  })
+
+  try {
+    const response = await request<DataExtensionCreationResponse>(
+      `https://${auth.subdomain}.rest.marketingcloudapis.com/data/v1/customobjects`,
+      {
+        method: 'POST',
+        json: {
+          name: hookInputs.name,
+          description: hookInputs.description,
+          categoryId: hookInputs.categoryId,
+          isSendable: hookInputs.isSendable,
+          sendableCustomObjectField: hookInputs.sendableCustomObjectField,
+          sendableSubscriberField: hookInputs.sendableSubscriberField,
+          fields
+        },
+        headers: {
+          authorization: `Bearer ${auth.accessToken}`
+        }
+      }
+    )
+
+    if (response.status !== 201) {
+      return { id: '', key: '', error: `Failed to create Data Extension` }
+    }
+
+    return {
+      id: (response as DataExtensionCreationResponse).data.id,
+      key: (response as DataExtensionCreationResponse).data.key
+    }
+  } catch (error) {
+    return { id: '', key: '', error: error.response.data.message }
+  }
+}
+
+async function createDataExtension(
+  request: RequestClient,
+  subdomain: string,
+  hookInputs: OnMappingSaveInputs,
+  settings: Settings
+): Promise<ActionHookResponse<{ id: string; name: string }>> {
+  if (!hookInputs) {
+    return {
+      error: { message: 'No inputs provided', code: 'ERROR' }
+    }
+  }
+
+  const { accessToken } = await getAccessToken(request, settings)
+
+  const { id, key, error } = await dataExtensionRequest(request, hookInputs, { subdomain, accessToken })
+
+  if (error || !id || !key) {
+    return {
+      error: { message: error || 'Unknown Error', code: 'ERROR' }
+    }
+  }
+
+  return {
+    successMessage: `Data Extension ${hookInputs.name} created successfully with External Key ${key}`,
+    savedData: {
+      id,
+      name: hookInputs.name!
+    }
+  }
+}
+
+const selectDataExtensionRequest = async (
+  request: RequestClient,
+  hookInputs: OnMappingSaveInputs,
+  auth: { subdomain: string; accessToken: string }
+): Promise<{ id?: string; name?: string; error?: string }> => {
+  if (!hookInputs) {
+    return { id: '', name: '', error: 'No inputs provided' }
+  }
+
+  if (!hookInputs.dataExtensionId) {
+    return { id: '', name: '', error: 'No Data Extension Id provided' }
+  }
+
+  try {
+    const response = await request<DataExtensionSelectionResponse>(
+      `https://${auth.subdomain}.rest.marketingcloudapis.com/data/v1/customobjects/${hookInputs.dataExtensionId}`,
+      {
+        method: 'GET',
+        headers: {
+          authorization: `Bearer ${auth.accessToken}`
+        }
+      }
+    )
+
+    if (response.status !== 200) {
+      return { id: '', name: '', error: `Failed to select Data Extension` }
+    }
+
+    return {
+      id: (response as DataExtensionSelectionResponse).data.id,
+      name: (response as DataExtensionSelectionResponse).data.name
+    }
+  } catch (err) {
+    return { id: '', name: '', error: err.response.data.message }
+  }
+}
+
+async function selectDataExtension(
+  request: RequestClient,
+  subdomain: string,
+  hookInputs: OnMappingSaveInputs,
+  settings: Settings
+): Promise<ActionHookResponse<{ id: string; name: string }>> {
+  if (!hookInputs) {
+    return {
+      error: { message: 'No inputs provided', code: 'ERROR' }
+    }
+  }
+
+  const { accessToken } = await getAccessToken(request, settings)
+
+  const { id, name, error } = await selectDataExtensionRequest(request, hookInputs, { subdomain, accessToken })
+
+  if (error || !id) {
+    return {
+      error: { message: error || 'Unknown Error', code: 'ERROR' }
+    }
+  }
+
+  return {
+    successMessage: `Data Extension ${name} selected successfully with External ID ${id}`,
+    savedData: {
+      id,
+      name: name!
+    }
+  }
+}
+
+export const selectOrCreateDataExtension = async (
+  request: RequestClient,
+  subdomain: string,
+  hookInputs: OnMappingSaveInputs,
+  settings: Settings
+): Promise<ActionHookResponse<{ id: string; name: string }>> => {
+  if (hookInputs.operation === 'create') {
+    return await createDataExtension(request, subdomain, hookInputs, settings)
+  } else if (hookInputs.operation === 'select') {
+    return await selectDataExtension(request, subdomain, hookInputs, settings)
+  }
+
+  return {
+    error: { message: 'Invalid operation', code: 'ERROR' }
+  }
+}
+
+const getDataExtensionsRequest = async (
+  request: RequestClient,
+  searchQuery: string,
+  auth: { subdomain: string; accessToken: string }
+): Promise<{ results?: DynamicFieldItem[]; error?: DynamicFieldError }> => {
+  try {
+    const response = await request<DataExtensionSearchResponse>(
+      `https://${auth.subdomain}.rest.marketingcloudapis.com/data/v1/customobjects`,
+      {
+        method: 'get',
+        searchParams: {
+          $search: searchQuery
+        },
+        headers: {
+          authorization: `Bearer ${auth.accessToken}`
+        }
+      }
+    )
+
+    if (response.status !== 200) {
+      return { error: { message: 'Failed to fetch Data Extensions', code: 'BAD_REQUEST' } }
+    }
+
+    const choices = response.data.items
+
+    return {
+      results: choices.map((choice) => {
+        return {
+          value: choice.id,
+          label: choice.name
+        }
+      })
+    }
+  } catch (err) {
+    return { error: { message: err.response.data.message, code: 'BAD_REQUEST' } }
+  }
+}
+
+export const getDataExtensions = async (
+  request: RequestClient,
+  subdomain: string,
+  settings: Settings,
+  query?: string
+): Promise<DynamicFieldResponse> => {
+  let searchQuery = '_'
+  if (query && query !== '') {
+    searchQuery = query
+  }
+
+  const { accessToken } = await getAccessToken(request, settings)
+
+  const { results, error } = await getDataExtensionsRequest(request, searchQuery, { subdomain, accessToken })
+
+  if (error) {
+    return {
+      choices: [],
+      error: error
+    }
+  }
+
+  if (!results || (Array.isArray(results) && results.length === 0)) {
+    return {
+      choices: [],
+      error: { message: 'No Data Extensions found', code: 'NOT_FOUND' }
+    }
+  }
+
+  return {
+    choices: results
+  }
+}
+
+const getDataExtensionFieldsRequest = async (
+  request: RequestClient,
+  dataExtensionId: string,
+  auth: { subdomain: string; accessToken: string },
+  primaryKey: boolean
+): Promise<{ results?: DynamicFieldItem[]; error?: DynamicFieldError }> => {
+  try {
+    const response = await request<DataExtensionFieldsResponse>(
+      `https://${auth.subdomain}.rest.marketingcloudapis.com/data/v1/customobjects/${dataExtensionId}/fields`,
+      {
+        method: 'GET',
+        headers: {
+          authorization: `Bearer ${auth.accessToken}`
+        }
+      }
+    )
+
+    if (response.status !== 200) {
+      return { error: { message: 'Failed to fetch Data Extension fields', code: 'BAD_REQUEST' } }
+    }
+
+    const filteredItems = response.data.fields.filter((field) => field.isPrimaryKey === primaryKey)
+
+    const choices = filteredItems.map((field) => {
+      return { value: field.name, label: field.name }
+    })
+
+    return { results: choices }
+  } catch (err) {
+    return { error: { message: err.response.data.message, code: 'BAD_REQUEST' } }
+  }
+}
+
+export const getDataExtensionFields = async (
+  request: RequestClient,
+  subdomain: string,
+  settings: Settings,
+  dataExtensionID: string,
+  primaryKey: boolean
+): Promise<DynamicFieldResponse> => {
+  if (!dataExtensionID) {
+    return { choices: [], error: { message: 'No Data Extension ID provided', code: 'BAD_REQUEST' } }
+  }
+  const { accessToken } = await getAccessToken(request, settings)
+
+  const { results, error } = await getDataExtensionFieldsRequest(
+    request,
+    dataExtensionID,
+    { subdomain, accessToken },
+    primaryKey
+  )
+
+  if (error) {
+    return {
+      choices: [],
+      error: error
+    }
+  }
+
+  if (!results || (Array.isArray(results) && results.length === 0)) {
+    return {
+      choices: [],
+      error: { message: 'No Data Extension fields found', code: 'NOT_FOUND' }
+    }
+  }
+
+  return {
+    choices: results
+  }
+}
+
+const getCategoriesRequest = async (
+  request: RequestClient,
+  auth: { soapInstanceUrl: string; accessToken: string }
+): Promise<{ results?: DynamicFieldItem[]; error?: DynamicFieldError }> => {
+  try {
+    const response = await request(`${auth.soapInstanceUrl}/Service.asmx`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/xml',
+        SOAPAction: 'Retrieve'
+      },
+      body: `<?xml version="1.0" encoding="UTF-8"?>
+        <SOAP-ENV:Envelope
+          xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+          xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <SOAP-ENV:Header>
+            <fueloauth xmlns="http://exacttarget.com">${auth.accessToken}</fueloauth>
+          </SOAP-ENV:Header>
+          <SOAP-ENV:Body>
+            <RetrieveRequestMsg
+              xmlns="http://exacttarget.com/wsdl/partnerAPI">
+                <RetrieveRequest>
+                  <ObjectType>DataFolder</ObjectType>
+                  <Properties>ID</Properties>
+                  <Properties>Name</Properties>
+                  <Properties>ContentType</Properties>
+                </RetrieveRequest>
+            </RetrieveRequestMsg>
+          </SOAP-ENV:Body>
+        </SOAP-ENV:Envelope>
+        `
+    })
+
+    const convert: any = xml2js(response.content, { compact: true })
+    const items = (convert['soap:Envelope']['soap:Body']['RetrieveResponseMsg']['Results'] as SoapResponseResult[]).map(
+      (item) => {
+        const type = item.ContentType._text
+
+        return {
+          label: item.Name._text,
+          value: item.ID._text,
+          description: `ContentType: ${type}`
+        }
+      }
+    )
+
+    return {
+      results: items
+    }
+  } catch (err) {
+    return { error: { message: err.response.data.message, code: 'BAD_REQUEST' } }
+  }
+}
+
+export const getCategories = async (request: RequestClient, settings: Settings): Promise<DynamicFieldResponse> => {
+  const { accessToken, soapInstanceUrl } = await getAccessToken(request, settings)
+
+  const { results, error } = await getCategoriesRequest(request, { soapInstanceUrl, accessToken })
+
+  if (error) {
+    return {
+      choices: [],
+      error: error
+    }
+  }
+
+  return {
+    choices: results || []
+  }
 }

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
@@ -436,7 +436,22 @@ const getDataExtensionsRequest = async (
       })
     }
   } catch (err) {
-    return { error: { message: err.response.data.message, code: 'BAD_REQUEST' } }
+    const errorCode: string =
+      typeof err.response.data.errorcode === 'number'
+        ? err.response.data.errorcode.toString()
+        : err.response.data.errorcode
+    const errorMessage = err.response.data.message
+
+    if (errorCode === '20002') {
+      return {
+        error: {
+          message: `${errorMessage}. Please input a data extension ID manually to configure your mapping. To resolve this authentication issue refer to the required permissions under 'Getting Started' in the documentation at https://segment.com/docs/connections/destinations/catalog/actions-salesforce-marketing-cloud/`,
+          code: errorCode
+        }
+      }
+    }
+
+    return { error: { message: err.response.data.message, code: errorCode || 'BAD_REQUEST' } }
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
@@ -12,7 +12,7 @@ import {
 import { Payload as payload_dataExtension } from './dataExtension/generated-types'
 import { Payload as payload_contactDataExtension } from './contactDataExtension/generated-types'
 import { ErrorResponse } from './types'
-import { OnMappingSaveInputs } from './dataExtension/generated-types'
+import { OnMappingSaveInputs } from './dataExtensionV2/generated-types'
 import { Settings } from './generated-types'
 import { xml2js } from 'xml-js'
 
@@ -30,11 +30,10 @@ function generateRows(payloads: payload_dataExtension[] | payload_contactDataExt
 export function upsertRows(
   request: RequestClient,
   subdomain: String,
-  payloads: payload_dataExtension[] | payload_contactDataExtension[],
-  dataExtensionId?: string,
-  dataExtensionKey?: string
+  payloads: payload_dataExtension[] | payload_contactDataExtension[]
 ) {
-  if (!dataExtensionKey && !dataExtensionId) {
+  const { key, id } = payloads[0]
+  if (!key && !id) {
     throw new IntegrationError(
       `In order to send an event to a data extension either Data Extension ID or Data Extension Key must be defined.`,
       'Misconfigured required field',
@@ -42,34 +41,56 @@ export function upsertRows(
     )
   }
   const rows = generateRows(payloads)
-  if (dataExtensionKey) {
-    return request(
-      `https://${subdomain}.rest.marketingcloudapis.com/hub/v1/dataevents/key:${dataExtensionKey}/rowset`,
-      {
-        method: 'POST',
-        json: rows
-      }
-    )
+  if (key) {
+    return request(`https://${subdomain}.rest.marketingcloudapis.com/hub/v1/dataevents/key:${key}/rowset`, {
+      method: 'POST',
+      json: rows
+    })
   } else {
-    return request(`https://${subdomain}.rest.marketingcloudapis.com/hub/v1/dataevents/${dataExtensionId}/rowset`, {
+    return request(`https://${subdomain}.rest.marketingcloudapis.com/hub/v1/dataevents/${id}/rowset`, {
       method: 'POST',
       json: rows
     })
   }
 }
 
+export function upsertRowsV2(
+  request: RequestClient,
+  subdomain: String,
+  payloads: payload_dataExtension[] | payload_contactDataExtension[],
+  dataExtensionId: string
+) {
+  if (!dataExtensionId) {
+    throw new IntegrationError(
+      `In order to send an event to a data extension Data Extension ID must be defined.`,
+      'Misconfigured required field',
+      400
+    )
+  }
+
+  const rows = generateRows(payloads)
+  return request(`https://${subdomain}.rest.marketingcloudapis.com/hub/v1/dataevents/${dataExtensionId}/rowset`, {
+    method: 'POST',
+    json: rows
+  })
+}
+
 export async function executeUpsertWithMultiStatus(
   request: RequestClient,
   subdomain: String,
   payloads: payload_dataExtension[] | payload_contactDataExtension[],
-  dataExtensionId?: string,
-  dataExtensionKey?: string
+  dataExtensionId?: string
 ): Promise<MultiStatusResponse> {
   const multiStatusResponse = new MultiStatusResponse()
   let response: ModifiedResponse | undefined
   const rows = generateRows(payloads)
   try {
-    response = await upsertRows(request, subdomain, payloads, dataExtensionId, dataExtensionKey)
+    if (dataExtensionId) {
+      response = await upsertRowsV2(request, subdomain, payloads, dataExtensionId)
+    } else {
+      response = await upsertRows(request, subdomain, payloads)
+    }
+
     if (response) {
       const responseData = response.data as JSONLikeObject[]
       payloads.forEach((_, index) => {

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-properties.ts
@@ -1,4 +1,6 @@
-import { InputField } from '@segment/actions-core/destination-kit/types'
+import { ActionHookDefinition } from '@segment/actions-core/destination-kit'
+import { InputField, FieldTypeName, DependsOnConditions } from '@segment/actions-core/destination-kit/types'
+import { getCategories, getDataExtensions, selectOrCreateDataExtension } from './sfmc-operations'
 
 export const contactKey: InputField = {
   label: 'Contact Key',
@@ -17,17 +19,19 @@ export const contactKeyAPIEvent: InputField = {
 }
 
 export const key: InputField = {
-  label: 'Data Extension Key',
+  label: 'DEPRECATED: Data Extension Key',
   description:
-    'The external key of the data extension that you want to store information in. The data extension must be predefined in SFMC. The external key is required if a Data Extension ID is not provided.',
-  type: 'string'
+    'Note: This field should be considered deprecated in favor of the hook input field "Data Extension ID". For backwards compatibility the field will not be deleted, and is instead hidden. The external key of the data extension that you want to store information in. The data extension must be predefined in SFMC. The external key is required if a Data Extension ID is not provided.',
+  type: 'string',
+  unsafe_hidden: true
 }
 
 export const id: InputField = {
-  label: 'Data Extension ID',
+  label: 'DEPRECATED: Data Extension ID',
   description:
-    'The ID of the data extension that you want to store information in. The data extension must be predefined in SFMC. The ID is required if a Data Extension Key is not provided.',
-  type: 'string'
+    'Note: This field should be considered deprecated in favor of the hook input field "Data Extension ID". For backwards compatibility the field will not be deleted, and is instead hidden. The ID of the data extension that you want to store information in. The data extension must be predefined in SFMC. The ID is required if a Data Extension Key is not provided.',
+  type: 'string',
+  unsafe_hidden: true
 }
 
 export const keys: InputField = {
@@ -37,7 +41,8 @@ export const keys: InputField = {
   type: 'object',
   required: true,
   defaultObjectUI: 'keyvalue:only',
-  additionalProperties: true
+  additionalProperties: true,
+  dynamic: true
 }
 
 export const values_contactFields: InputField = {
@@ -46,7 +51,8 @@ export const values_contactFields: InputField = {
     'The fields in the data extension that contain data about a contact, such as Email, Last Name, etc. Fields must be created in the data extension before sending data for it. On the left-hand side, input the SFMC field name exactly how it appears in the data extension. On the right-hand side, map the Segment field that contains the corresponding value.',
   type: 'object',
   defaultObjectUI: 'keyvalue:only',
-  required: true
+  required: true,
+  dynamic: true
 }
 
 export const values_dataExtensionFields: InputField = {
@@ -55,7 +61,8 @@ export const values_dataExtensionFields: InputField = {
     'The fields in the data extension that contain data about an event, such as Product Name, Revenue, Event Time, etc. Fields must be created in the data extension before sending data for it. On the left-hand side, input the SFMC field name exactly how it appears in the data extension. On the right-hand side, map the Segment field that contains the corresponding value.',
   type: 'object',
   defaultObjectUI: 'keyvalue:only',
-  required: true
+  required: true,
+  dynamic: true
 }
 
 export const eventDefinitionKey: InputField = {
@@ -93,4 +100,165 @@ export const batch_size: InputField = {
    * And: inc-sev3-6609-sfmc-timeouts-in-bulk-batching-2023-10-23
    *  */
   default: 10
+}
+
+// Scripting for the create/select existing data extension flow
+const CREATE_OPERATION: DependsOnConditions = {
+  match: 'all',
+  conditions: [{ fieldKey: 'operation', operator: 'is', value: 'create' }]
+}
+
+const SELECT_OPERATION: DependsOnConditions = {
+  match: 'all',
+  conditions: [{ fieldKey: 'operation', operator: 'is', value: 'select' }]
+}
+
+const IS_SENDABLE: DependsOnConditions = {
+  match: 'all',
+  conditions: [{ fieldKey: 'isSendable', operator: 'is', value: true }]
+}
+
+export const dataExtensionHook: ActionHookDefinition<any, any, any, any, any> = {
+  label: 'Create or Select Data Extension',
+  description: 'Connect to an existing data extension or create a new one in Salesforce Marketing Cloud.',
+  inputFields: {
+    operation: {
+      label: 'Operation',
+      description: 'Whether to create a new data extension or select an existing one for data delivery.',
+      type: 'string',
+      choices: [
+        { label: 'Create a new Data Extension', value: 'create' },
+        { label: 'Select an existing Data Extension', value: 'select' }
+      ],
+      required: true
+    },
+    dataExtensionId: {
+      label: 'Data Extension ID',
+      description: 'The identifier for the data extension.',
+      type: 'string',
+      depends_on: SELECT_OPERATION,
+      dynamic: async (request, { dynamicFieldContext, settings }) => {
+        const query = dynamicFieldContext?.query
+        return await getDataExtensions(request, settings.subdomain, settings, query)
+      }
+    },
+    categoryId: {
+      label: 'Category ID (Folder ID)',
+      description: 'The identifier for the folder that contains the data extension.',
+      type: 'string',
+      required: CREATE_OPERATION,
+      depends_on: CREATE_OPERATION,
+      dynamic: async (request, { settings }) => {
+        return await getCategories(request, settings)
+      }
+    },
+    name: {
+      label: 'Data Extension Name',
+      description: 'The name of the data extension.',
+      type: 'string',
+      required: CREATE_OPERATION,
+      depends_on: CREATE_OPERATION
+    },
+    description: {
+      label: 'Data Extension Description',
+      description: 'The description of the data extension.',
+      type: 'string',
+      depends_on: CREATE_OPERATION
+    },
+    isSendable: {
+      label: 'Is Sendable',
+      type: 'boolean',
+      depends_on: CREATE_OPERATION,
+      description:
+        'Indicates whether the custom object can be used to send messages. If the value of this property is true, then the custom object is sendable'
+    },
+    sendableCustomObjectField: {
+      label: 'Sendable Custom Object Field',
+      description:
+        'The field on this data extension which is sendable. This must be a field that is present on this data extension.',
+      type: 'string',
+      depends_on: IS_SENDABLE,
+      required: IS_SENDABLE
+    },
+    sendableSubscriberField: {
+      label: 'Sendable Subscriber Field',
+      description: 'The relationship with "Subscribers" for the Sendable Custom Object Field.',
+      type: 'string',
+      depends_on: IS_SENDABLE,
+      required: IS_SENDABLE,
+      choices: [
+        { label: 'Subscriber Key', value: '_SubscriberKey' },
+        { label: 'Subscriber ID', value: '_SubscriberID' }
+      ]
+    },
+    columns: {
+      label: 'Data Extension Fields',
+      description: 'A list of fields to create in the data extension.',
+      type: 'object' as FieldTypeName,
+      multiple: true,
+      defaultObjectUI: 'arrayeditor',
+      additionalProperties: true,
+      required: CREATE_OPERATION,
+      depends_on: CREATE_OPERATION,
+      properties: {
+        name: {
+          label: 'Field Name',
+          description: 'The name of the field.',
+          type: 'string',
+          required: true
+        },
+        type: {
+          label: 'Field Type',
+          description: 'The data type of the field.',
+          type: 'string',
+          required: true,
+          choices: ['Text', 'Number', 'Date', 'Boolean', 'EmailAddress', 'Phone', 'Decimal', 'Locale']
+        },
+        isNullable: {
+          label: 'Is Nullable',
+          description: 'Whether the field can be null.',
+          type: 'boolean',
+          required: true
+        },
+        isPrimaryKey: {
+          label: 'Is Primary Key',
+          description: 'Whether the field is a primary key.',
+          type: 'boolean',
+          required: true
+        },
+        length: {
+          label: 'Field Length',
+          description: 'The length of the field. Required for non-boolean fields',
+          type: 'integer'
+        },
+        scale: {
+          label: 'Decimal Scale',
+          description: 'The scale of the field. Required for Decimal fields',
+          type: 'integer'
+        },
+        description: {
+          label: 'Field Description',
+          description: 'The description of the field.',
+          type: 'string'
+        }
+      }
+    }
+  },
+  performHook: async (request, { settings, hookInputs }) => {
+    return await selectOrCreateDataExtension(request, settings.subdomain, hookInputs, settings)
+  },
+  outputTypes: {
+    id: {
+      label: 'Data Extension ID',
+      description: 'The identifier for the data extension.',
+      type: 'string',
+      required: true
+    },
+    name: {
+      label: 'Data Extension Name',
+      description: 'The name of the data extension.',
+      type: 'string',
+      required: true
+    }
+  }
 }

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-properties.ts
@@ -19,19 +19,17 @@ export const contactKeyAPIEvent: InputField = {
 }
 
 export const key: InputField = {
-  label: 'DEPRECATED: Data Extension Key',
+  label: 'Data Extension Key',
   description:
-    'Note: This field should be considered deprecated in favor of the hook input field "Data Extension ID". For backwards compatibility the field will not be deleted, and is instead hidden. The external key of the data extension that you want to store information in. The data extension must be predefined in SFMC. The external key is required if a Data Extension ID is not provided.',
-  type: 'string',
-  unsafe_hidden: true
+    'The external key of the data extension that you want to store information in. The data extension must be predefined in SFMC. The external key is required if a Data Extension ID is not provided.',
+  type: 'string'
 }
 
 export const id: InputField = {
-  label: 'DEPRECATED: Data Extension ID',
+  label: 'Data Extension ID',
   description:
-    'Note: This field should be considered deprecated in favor of the hook input field "Data Extension ID". For backwards compatibility the field will not be deleted, and is instead hidden. The ID of the data extension that you want to store information in. The data extension must be predefined in SFMC. The ID is required if a Data Extension Key is not provided.',
-  type: 'string',
-  unsafe_hidden: true
+    'The ID of the data extension that you want to store information in. The data extension must be predefined in SFMC. The ID is required if a Data Extension Key is not provided.',
+  type: 'string'
 }
 
 export const keys: InputField = {

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-properties.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-properties.ts
@@ -39,8 +39,7 @@ export const keys: InputField = {
   type: 'object',
   required: true,
   defaultObjectUI: 'keyvalue:only',
-  additionalProperties: true,
-  dynamic: true
+  additionalProperties: true
 }
 
 export const values_contactFields: InputField = {
@@ -49,8 +48,7 @@ export const values_contactFields: InputField = {
     'The fields in the data extension that contain data about a contact, such as Email, Last Name, etc. Fields must be created in the data extension before sending data for it. On the left-hand side, input the SFMC field name exactly how it appears in the data extension. On the right-hand side, map the Segment field that contains the corresponding value.',
   type: 'object',
   defaultObjectUI: 'keyvalue:only',
-  required: true,
-  dynamic: true
+  required: true
 }
 
 export const values_dataExtensionFields: InputField = {
@@ -59,8 +57,7 @@ export const values_dataExtensionFields: InputField = {
     'The fields in the data extension that contain data about an event, such as Product Name, Revenue, Event Time, etc. Fields must be created in the data extension before sending data for it. On the left-hand side, input the SFMC field name exactly how it appears in the data extension. On the right-hand side, map the Segment field that contains the corresponding value.',
   type: 'object',
   defaultObjectUI: 'keyvalue:only',
-  required: true,
-  dynamic: true
+  required: true
 }
 
 export const eventDefinitionKey: InputField = {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR is an update of the work started here: https://github.com/segmentio/action-destinations/pull/2711
That original PR was reverted in favor of implementing the data extension creation hook in V2 actions, which will guarantee that any existing mappings are unchanged.

These new V2 actions will be rolled out in tiers. The slow rollout will be managed by the flagon gate introduced here: https://github.com/segmentio/app/pull/23209



## Testing

Tested successfully in stage.
**🫱 ❗ [Testing Doc ](https://docs.google.com/document/d/1Lj6t-LCU_lO4uwDnrXU9PxZ_31CsrW8o0Vhi7rOudNc/edit?usp=sharing)❗ 🫲** 

✅ The V2 actions are only shown based on the flagon gate rollout:


https://github.com/user-attachments/assets/419e30e5-9fac-4868-b38d-428b9c81b9e1



- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
