### PR TITLE
Support min/max string length validation

### DIFF
--- a/packages/core/src/__tests__/schema-validation.test.ts
+++ b/packages/core/src/__tests__/schema-validation.test.ts
@@ -1566,6 +1566,27 @@ describe('validateSchema', () => {
     expect(validateSchema(greater_than_max_payload, min_max_schema, { throwIfInvalid: false })).toBeFalsy()
   })
 
+  it('should validate min/max for string type fields', async () => {
+    const smallString = 'a'
+    const longString = 'a'.repeat(100)
+    const stringEqualToMin = 'a'.repeat(5)
+    const stringEqualToMax = 'a'.repeat(10)
+
+    const min_max_schema = fieldsToJsonSchema({
+      limitedString: {
+        type: 'string',
+        label: 'Test Field',
+        minimum: 5,
+        maximum: 10
+      }
+    })
+
+    expect(validateSchema({ limitedString: stringEqualToMin }, min_max_schema)).toBeTruthy()
+    expect(validateSchema({ limitedString: stringEqualToMax }, min_max_schema)).toBeTruthy()
+    expect(validateSchema({ limitedString: smallString }, min_max_schema, { throwIfInvalid: false })).toBeFalsy()
+    expect(validateSchema({ limitedString: longString }, min_max_schema, { throwIfInvalid: false })).toBeFalsy()
+  })
+
   it('should allow exempted properties', () => {
     const payload = {
       a: 'a',

--- a/packages/core/src/destination-kit/fields-to-jsonschema.ts
+++ b/packages/core/src/destination-kit/fields-to-jsonschema.ts
@@ -310,6 +310,15 @@ export function fieldsToJsonSchema(
       schema.format = 'password'
     } else if (field.type === 'text') {
       schema.format = 'text'
+    } else if (field.type === 'string') {
+      const { minimum = null, maximum = null } = field as InputField
+      if (minimum) {
+        schema.minLength = (field as InputField)?.minimum
+      }
+      if (maximum) {
+        schema.maxLength = (field as InputField)?.maximum
+      }
+      console.log('minimum', minimum, 'maximum', maximum)
     } else if (field.type === 'number') {
       const { minimum = null, maximum = null } = field as InputField
       if (minimum) {

--- a/packages/core/src/destination-kit/fields-to-jsonschema.ts
+++ b/packages/core/src/destination-kit/fields-to-jsonschema.ts
@@ -318,7 +318,6 @@ export function fieldsToJsonSchema(
       if (maximum) {
         schema.maxLength = (field as InputField)?.maximum
       }
-      console.log('minimum', minimum, 'maximum', maximum)
     } else if (field.type === 'number') {
       const { minimum = null, maximum = null } = field as InputField
       if (minimum) {

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -257,9 +257,15 @@ export interface InputField extends InputFieldJSONSchema {
    */
   disabledInputMethods?: FieldInputMethods[]
 
-  /** Minimum value for a field of type 'number' */
+  /**
+   * Minimum value for a field of type 'number'
+   * When applied to a string field the minimum length of the string
+   * */
   minimum?: number
-  /** Maximum value for a field of type 'number' */
+  /**
+   * Maximum value for a field of type 'number'
+   * When applied to a string field the maximum length of the string
+   */
   maximum?: number
 }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR applies the existing `InputField.minimum/maximum` properties to the JSON schema we generate and use for validation against string fields. This functionality already existed for numeric fields. A string min/max property should be interpreted as min/max of the length of the string.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
