### PR TITLE
[STRATCONN-5608] - Make ssl_enabled and ssl_reject_unauthorized_ca settings optional

### DIFF
--- a/packages/destination-actions/src/destinations/kafka/generated-types.ts
+++ b/packages/destination-actions/src/destinations/kafka/generated-types.ts
@@ -36,7 +36,7 @@ export interface Settings {
   /**
    * Indicates if SSL should be enabled.
    */
-  ssl_enabled: boolean
+  ssl_enabled?: boolean
   /**
    * The Certificate Authority for your Kafka instance. Exclude the first and last lines from the file. i.e `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`.
    */
@@ -52,5 +52,5 @@ export interface Settings {
   /**
    * Whether to reject unauthorized CAs or not. This can be useful when testing, but is unadvised in Production.
    */
-  ssl_reject_unauthorized_ca: boolean
+  ssl_reject_unauthorized_ca?: boolean
 }

--- a/packages/destination-actions/src/destinations/kafka/index.ts
+++ b/packages/destination-actions/src/destinations/kafka/index.ts
@@ -84,7 +84,7 @@ const destination: DestinationDefinition<Settings> = {
         label: 'SSL Enabled',
         description: 'Indicates if SSL should be enabled.',
         type: 'boolean',
-        required: true,
+        required: false,
         default: true
       },
       ssl_ca: {
@@ -115,7 +115,7 @@ const destination: DestinationDefinition<Settings> = {
         description:
           'Whether to reject unauthorized CAs or not. This can be useful when testing, but is unadvised in Production.',
         type: 'boolean',
-        required: true,
+        required: false,
         default: true
       }
     },

--- a/packages/destination-actions/src/destinations/kafka/utils.ts
+++ b/packages/destination-actions/src/destinations/kafka/utils.ts
@@ -60,7 +60,7 @@ interface TopicMessages {
 
 interface SSLConfig {
   ca: string[]
-  rejectUnauthorized: boolean
+  rejectUnauthorized?: boolean
   key?: string
   cert?: string
 }


### PR DESCRIPTION
This PR resolves a bug associated with enabling actions-kafka destination. SSL enabled and ssl_reject_unauthorized_ca are boolean options. If disabled, these required fields are considered as undefined and `enable destination` button is greyed out in  destination settings page.

It doesn't make any sense to have a boolean field as required as there are only two possible states. So, this PR marks both the fields as `required:false`.

Confirmed that this has no impact on functionality as the Kafka library itself considers these two as optional.

![image-20250326-093359](https://github.com/user-attachments/assets/aba98a33-bb09-4ec3-9fe5-ecdccdaa9d3f)

![image-20250326-093245](https://github.com/user-attachments/assets/7e28f814-2328-4712-8710-74e46de3cc0b)


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
