### PR TITLE
add phone number support to reddit-conversions-api

### DIFF
--- a/packages/destination-actions/src/destinations/reddit-conversions-api/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/reddit-conversions-api/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -35,6 +35,7 @@ Object {
         "email": "8614950525b98787b31febe07634987a801175f098b60c83bd3903bff1ec3eed",
         "external_id": "4fbe858b31ee34144cc3d009fd4636ef20fb342e095570d49a9898bb8d77598e",
         "ip_address": "4fbe858b31ee34144cc3d009fd4636ef20fb342e095570d49a9898bb8d77598e",
+        "phone_number": "+5365418331",
         "screen_dimensions": Object {
           "height": -2840640572358656,
           "width": -2840640572358656,
@@ -103,6 +104,7 @@ Object {
         "email": "6ad9c50c3cf54b266add9d94147959c9b024ebf821a18f6e860a01ad33a7b5cf",
         "external_id": "f136d03523cc17ecdfe2a4df68a819e5e98f6981316b7e50e1a8b34b018c70ae",
         "ip_address": "f136d03523cc17ecdfe2a4df68a819e5e98f6981316b7e50e1a8b34b018c70ae",
+        "phone_number": "+5112818613",
         "screen_dimensions": Object {
           "height": 2091000289820672,
           "width": 2091000289820672,

--- a/packages/destination-actions/src/destinations/reddit-conversions-api/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/reddit-conversions-api/__tests__/index.test.ts
@@ -31,7 +31,8 @@ describe('Reddit Conversions Api', () => {
             { product_id: 'product_id_1', category: 'category_1', name: 'name_1' },
             { product_id: 'product_id_2', category: 'category_2', name: 'name_2' }
           ],
-          email: 'test@test.com'
+          email: 'test@test.com',
+          phone: '1-650-555   - 1212 x450'
         },
         context: {
           userAgent: 'test-user-agent',
@@ -86,7 +87,8 @@ describe('Reddit Conversions Api', () => {
               external_id: '3482ae91c8ec52c06e19d618d400b3985814bf705e00947a302ec849a6575c4c',
               ip_address: '5feaf188de296cd3b17f7c66fd3a2aec9b694815f2b1180631f7b52f57029777',
               user_agent: 'test-user-agent',
-              uuid: 'uuid_1'
+              uuid: 'uuid_1',
+              phone_number: '1-650-555   - 1212 x450'
             }
           }
         ],
@@ -113,7 +115,8 @@ describe('Reddit Conversions Api', () => {
             { product_id: 'product_id_1', category: 'category_1', name: 'name_1' },
             { product_id: 'product_id_2', category: 'category_2', name: 'name_2' }
           ],
-          email: '388c735eec8225c4ad7a507944dd0a975296baea383198aa87177f29af2c6f69'
+          email: '388c735eec8225c4ad7a507944dd0a975296baea383198aa87177f29af2c6f69',
+          phone: 'e323ec626319ca94ee8bff2e4c87cf613be6ea19919ed1364124e16807ab3176'
         },
         context: {
           userAgent: 'test-user-agent',
@@ -169,7 +172,8 @@ describe('Reddit Conversions Api', () => {
               external_id: '3482ae91c8ec52c06e19d618d400b3985814bf705e00947a302ec849a6575c4c',
               ip_address: '5feaf188de296cd3b17f7c66fd3a2aec9b694815f2b1180631f7b52f57029777',
               user_agent: 'test-user-agent',
-              uuid: 'uuid_1'
+              uuid: 'uuid_1',
+              phone_number: 'e323ec626319ca94ee8bff2e4c87cf613be6ea19919ed1364124e16807ab3176'
             }
           }
         ],
@@ -198,7 +202,8 @@ describe('Reddit Conversions Api', () => {
             { product_id: 'product_id_1', category: 'category_1', name: 'name_1' },
             { product_id: 'product_id_2', category: 'category_2', name: 'name_2' }
           ],
-          email: 'test@test.com'
+          email: 'test@test.com',
+          phone: '1-650-555   - 1212 x450'
         },
         context: {
           userAgent: 'test-user-agent',
@@ -252,7 +257,8 @@ describe('Reddit Conversions Api', () => {
               external_id: '3482ae91c8ec52c06e19d618d400b3985814bf705e00947a302ec849a6575c4c',
               ip_address: '5feaf188de296cd3b17f7c66fd3a2aec9b694815f2b1180631f7b52f57029777',
               user_agent: 'test-user-agent',
-              uuid: 'uuid_1'
+              uuid: 'uuid_1',
+              phone_number: '1-650-555   - 1212 x450'
             }
           }
         ],
@@ -285,6 +291,9 @@ describe('Reddit Conversions Api', () => {
           ip: '111.111.111.111',
           device: {
             advertisingId: 'advertising_id_1'
+          },
+          traits: {
+            phone: '+1 (650)555-1212'
           }
         }
       })
@@ -331,7 +340,8 @@ describe('Reddit Conversions Api', () => {
               external_id: '3482ae91c8ec52c06e19d618d400b3985814bf705e00947a302ec849a6575c4c',
               ip_address: '5feaf188de296cd3b17f7c66fd3a2aec9b694815f2b1180631f7b52f57029777',
               user_agent: 'test-user-agent',
-              uuid: 'uuid_1'
+              uuid: 'uuid_1',
+              phone_number: '+1 (650)555-1212'
             }
           }
         ],

--- a/packages/destination-actions/src/destinations/reddit-conversions-api/customEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/reddit-conversions-api/customEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -35,6 +35,7 @@ Object {
         "email": "4a032ff520e2ddbb4f3467c73e41b1f94bda5faf9c9080ac7f0d0e83156d9c99",
         "external_id": "7b1d43d3d43059efd3e755045cf79aa9a554bc456f4c10d1915ccb5d79345b4a",
         "ip_address": "7b1d43d3d43059efd3e755045cf79aa9a554bc456f4c10d1915ccb5d79345b4a",
+        "phone_number": "+9658205035",
         "screen_dimensions": Object {
           "height": 8361377294974976,
           "width": 8361377294974976,

--- a/packages/destination-actions/src/destinations/reddit-conversions-api/customEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/reddit-conversions-api/customEvent/generated-types.ts
@@ -62,6 +62,10 @@ export interface Payload {
      * The value from the first-party Pixel '_rdt_uuid' cookie on your domain. Note that it is in the '{timestamp}.{uuid}' format. You may use the full value or just the UUID portion.
      */
     uuid?: string
+    /**
+     * The phone number of the user in E.164 standard format.
+     */
+    phone_number?: string
   }
   /**
    * A structure of data processing options to specify the processing type for the event.

--- a/packages/destination-actions/src/destinations/reddit-conversions-api/fields.ts
+++ b/packages/destination-actions/src/destinations/reddit-conversions-api/fields.ts
@@ -182,6 +182,11 @@ export const user: InputField = {
       description:
         "The value from the first-party Pixel '_rdt_uuid' cookie on your domain. Note that it is in the '{timestamp}.{uuid}' format. You may use the full value or just the UUID portion.",
       type: 'string'
+    },
+    phone_number: {
+      label: 'Phone Number',
+      description: 'The phone number of the user in E.164 standard format.',
+      type: 'string'
     }
   },
   default: {
@@ -208,6 +213,13 @@ export const user: InputField = {
         exists: { '@path': '$.integrations.Reddit Conversions Api.uuid' },
         then: { '@path': '$.integrations.Reddit Conversions Api.uuid' },
         else: { '@path': '$.properties.uuid' }
+      }
+    },
+    phone_number: {
+      '@if': {
+        exists: { '@path': '$.properties.phone' },
+        then: { '@path': '$.properties.phone' },
+        else: { '@path': '$.context.traits.phone' }
       }
     }
   }

--- a/packages/destination-actions/src/destinations/reddit-conversions-api/standardEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/reddit-conversions-api/standardEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -34,6 +34,7 @@ Object {
         "email": "b6887231da112cb08515e502cb0eb06a342f2efb3372c2841368397664844f4e",
         "external_id": "7da4d4522d67f6ca1c1b0654c2d91c916a22667a5d34fa75c7cdcbe0c1b452ce",
         "ip_address": "7da4d4522d67f6ca1c1b0654c2d91c916a22667a5d34fa75c7cdcbe0c1b452ce",
+        "phone_number": "+6504479800",
         "screen_dimensions": Object {
           "height": 8501184792887296,
           "width": 8501184792887296,

--- a/packages/destination-actions/src/destinations/reddit-conversions-api/standardEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/reddit-conversions-api/standardEvent/generated-types.ts
@@ -62,6 +62,10 @@ export interface Payload {
      * The value from the first-party Pixel '_rdt_uuid' cookie on your domain. Note that it is in the '{timestamp}.{uuid}' format. You may use the full value or just the UUID portion.
      */
     uuid?: string
+    /**
+     * The phone number of the user in E.164 standard format.
+     */
+    phone_number?: string
   }
   /**
    * A structure of data processing options to specify the processing type for the event.

--- a/packages/destination-actions/src/destinations/reddit-conversions-api/types.ts
+++ b/packages/destination-actions/src/destinations/reddit-conversions-api/types.ts
@@ -42,6 +42,7 @@ export interface User {
     height?: number
     width?: number
   }
+  phone_number?: string
 }
 
 export interface StandardEventPayloadItem {

--- a/packages/destination-actions/src/destinations/reddit-conversions-api/utils.ts
+++ b/packages/destination-actions/src/destinations/reddit-conversions-api/utils.ts
@@ -195,7 +195,8 @@ function getUser(
     user_agent: clean(user.user_agent),
     uuid: clean(user.uuid),
     data_processing_options: getDataProcessingOptions(dataProcessingOptions),
-    screen_dimensions: getScreen(screenDimensions?.height, screenDimensions?.width)
+    screen_dimensions: getScreen(screenDimensions?.height, screenDimensions?.width),
+    phone_number: user.phone_number
   }
 }
 


### PR DESCRIPTION
_A summary of your pull request, including the what change you're making and why._

Adding the support of passing phone numbers into the Reddit Conversions API destination (destinations/actions-reddit-conversions-api).

We have configured it to the following default mapping, please let us know if this is not the correct default value from Segment that we should use:

    default: {
      '@if': {
        exists: { '@path': '$.properties.phone' },
        then: { '@path': '$.properties.phone' },
        else: { '@path': '$.context.traits.phone' }
      }
    }


## Testing


- [ X] Added unit tests and they have passed
- [X ] Tested end-to-end using the local server / Actions Tester and checked the final payload in the request that was being sent
- [ X] [If destination is already live] Tested for backward compatibility of destination: didn't notice any issues in the unit tests or end to end test using actions tester
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
