### PR TITLE
[SMART-HASHING] [STRATCONN-5637] Updated smart-hashing in dynamic-yield

### DIFF
--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/helpers.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/helpers.ts
@@ -1,11 +1,12 @@
-import { createHash } from 'crypto'
+import { Features } from '@segment/actions-core'
+import { processHashing } from '../../lib/hashing-utils'
 
-export function hashAndEncode(property: string): string {
-  return createHash('sha256').update(property).digest('hex')
+export function hashAndEncode(property: string, features: Features): string {
+  return processHashing(property, 'sha256', 'hex', features, 'actions-dynamic-yield-audiences')
 }
 
-export function hashAndEncodeToInt(property: string): number {
-  const hash = createHash('sha256').update(property).digest('hex')
+export function hashAndEncodeToInt(property: string, features: Features): number {
+  const hash = processHashing(property, 'sha256', 'hex', features, 'actions-dynamic-yield-audiences')
   const bigInt = BigInt('0x' + hash)
   let integerString = bigInt.toString()
   if (integerString.length > 16) {
@@ -38,10 +39,14 @@ export function getCreateAudienceURL(dataCenter: string): string {
   return `https://cdp-extensions-api.${getDomain(dataCenter)}.dynamicyield.com/cdp/segment/audiences/subscription`
 }
 
-export function getDataCenter(sectionId: string){
-  return sectionId.toLocaleLowerCase().startsWith("9") ? "EU" : sectionId.toLocaleLowerCase().startsWith("8") ? "US" : "DEV" 
+export function getDataCenter(sectionId: string) {
+  return sectionId.toLocaleLowerCase().startsWith('9')
+    ? 'EU'
+    : sectionId.toLocaleLowerCase().startsWith('8')
+    ? 'US'
+    : 'DEV'
 }
 
-export function getSectionId(sectionId: string){
+export function getSectionId(sectionId: string) {
   return sectionId.toLocaleLowerCase().replace('dev', '')
 }

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/index.ts
@@ -90,7 +90,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         throw new IntegrationError('Missing computation parameters: Id and Key', 'MISSING_REQUIRED_FIELD', 400)
       }
 
-      const audience_id = hashAndEncodeToInt(personas.computation_id)
+      const audience_id = hashAndEncodeToInt(personas.computation_id, createAudienceInput.features || {})
 
       const json = {
         type: 'audience_subscription_request',

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
@@ -72,7 +72,10 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
       default: {
         '@path': '$.context.personas.computation_class'
       },
-      choices: [{ label: 'audience', value: 'audience' },{ label: 'journey_step', value: 'journey_step' }]
+      choices: [
+        { label: 'audience', value: 'audience' },
+        { label: 'journey_step', value: 'journey_step' }
+      ]
     },
     email: {
       label: 'Email',
@@ -107,7 +110,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     }
   },
 
-  perform: async (request, { audienceSettings, payload, settings }) => {
+  perform: async (request, { audienceSettings, payload, settings, features }) => {
     const { external_audience_id } = payload
 
     if (!audienceSettings?.audience_name) {
@@ -174,7 +177,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
             {
               type: idTypeToSend,
               encoding: idTypeToSend === 'email' ? '"sha-256"' : 'raw',
-              value: idTypeToSend === 'email' ? hashAndEncode(primaryIdentifier) : primaryIdentifier
+              value: idTypeToSend === 'email' ? hashAndEncode(primaryIdentifier, features || {}) : primaryIdentifier
             }
           ],
           audiences: [

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
@@ -81,7 +81,6 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
       label: 'Email',
       description: "User's email address",
       type: 'string',
-      format: 'email',
       required: false,
       unsafe_hidden: true,
       default: {

--- a/packages/destination-actions/src/destinations/hyperengage/__tests__/validateInput.test.ts
+++ b/packages/destination-actions/src/destinations/hyperengage/__tests__/validateInput.test.ts
@@ -81,7 +81,7 @@ describe('validateInput', () => {
       expect(payload.traits.industry).toEqual(fakeGroupData.industry)
       expect(payload.traits.website).toEqual(fakeGroupData.website)
       expect(payload.traits).toHaveProperty('required')
-      expect(payload.local_tz_offset).toEqual(60)
+      expect(payload.local_tz_offset).toEqual(120)
     })
   })
 


### PR DESCRIPTION
Updated smart hashing on Dynamic-yield destinations

JIRA TICKETS: https://segment.atlassian.net/browse/STRATCONN-5637

TESTING DOCS: https://docs.google.com/document/d/10-776AUC9pQKt3IEjsdnN-ulOQcr_ZP2ui6S6WzwUrE/edit?tab=t.eruhzqrr8l1u

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
