### PR TITLE
[Smart hashing] Return undefined from smart hash if hash field are not defined

### DIFF
--- a/packages/destination-actions/src/destinations/google-campaign-manager-360/conversionUpload/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/google-campaign-manager-360/conversionUpload/__tests__/index.test.ts
@@ -263,6 +263,108 @@ describe('Cm360.conversionUpload', () => {
         expect(responses.length).toBe(1)
         expect(responses[0].status).toBe(201)
       })
+
+      it('sends an event and handles hashing with partial data correctly', async () => {
+        const event = createTestEvent({
+          timestamp,
+          event: 'Test Event',
+          context: {
+            traits: {
+              email: 'daffy@warnerbros.com'
+            }
+          },
+          properties: {
+            ordinal: '1',
+            quantity: '1',
+            value: '123',
+            gclid: '54321',
+            limitAdTracking: true,
+            childDirectedTreatment: true,
+            nonPersonalizedAd: true,
+            treatmentForUnderage: true
+          }
+        })
+
+        nock(`https://dfareporting.googleapis.com/dfareporting/v4/userprofiles/${profileId}/conversions/batchinsert`)
+          .post('')
+          .reply(201, { results: [{}] })
+
+        const responses = await testDestination.testAction('conversionUpload', {
+          event,
+          mapping: {
+            requiredId: {
+              gclid: {
+                '@path': '$.properties.gclid'
+              }
+            },
+            timestamp: {
+              '@path': '$.timestamp'
+            },
+            value: {
+              '@path': '$.properties.value'
+            },
+            quantity: {
+              '@path': '$.properties.quantity'
+            },
+            ordinal: {
+              '@path': '$.properties.ordinal'
+            },
+            userDetails: {
+              email: {
+                '@path': '$.context.traits.email'
+              },
+              phone: {
+                '@path': '$.context.traits.phone'
+              },
+              firstName: {
+                '@path': '$.context.traits.firstName'
+              },
+              lastName: {
+                '@path': '$.context.traits.lastName'
+              },
+              streetAddress: {
+                '@path': '$.context.traits.streetAddress'
+              },
+              city: {
+                '@path': '$.context.traits.city'
+              },
+              state: {
+                '@path': '$.context.traits.state'
+              },
+              postalCode: {
+                '@path': '$.context.traits.postalCode'
+              },
+              countryCode: {
+                '@path': '$.context.traits.countryCode'
+              }
+            },
+            limitAdTracking: {
+              '@path': '$.properties.limitAdTracking'
+            },
+            childDirectedTreatment: {
+              '@path': '$.properties.childDirectedTreatment'
+            },
+            nonPersonalizedAd: {
+              '@path': '$.properties.nonPersonalizedAd'
+            },
+            treatmentForUnderage: {
+              '@path': '$.properties.treatmentForUnderage'
+            }
+          },
+          useDefaultMappings: true,
+          settings: {
+            profileId,
+            defaultFloodlightActivityId: floodlightActivityId,
+            defaultFloodlightConfigurationId: floodlightConfigurationId
+          }
+        })
+
+        expect(responses[0].options.body).toBe(
+          `{"conversions":[{"childDirectedTreatment":true,"floodlightActivityId":"23456","floodlightConfigurationId":"34567","gclid":"54321","kind":"dfareporting#conversion","limitAdTracking":true,"nonPersonalizedAd":true,"ordinal":"1","quantity":"1","timestampMicros":"1718042884000","treatmentForUnderage":true,"userIdentifiers":[{"hashedEmail":"8e46bd4eaabb5d6324e327751b599f190dbaacd90066e66c94a046640bed60d0"}],"value":123,"customVariables":[],"encryptedUserIdCandidates":[]}],"kind":"dfareporting#conversionsBatchInsertRequest"}`
+        )
+        expect(responses.length).toBe(1)
+        expect(responses[0].status).toBe(201)
+      })
     })
 
     describe('Batch', () => {

--- a/packages/destination-actions/src/destinations/google-campaign-manager-360/utils.ts
+++ b/packages/destination-actions/src/destinations/google-campaign-manager-360/utils.ts
@@ -169,27 +169,15 @@ export function getJSON(
         }
         if (firstName || lastName || streetAddress || city || state || postalCode || countryCode) {
           const addressInfo: AddressInfo = {
-            hashedFirstName: processHashing(
-              firstName ?? '',
-              'sha256',
-              'hex',
-              features,
-              'actions-google-campaign-manager-360'
-            ),
-            hashedLastName: processHashing(
-              lastName ?? '',
-              'sha256',
-              'hex',
-              features,
-              'actions-google-campaign-manager-360'
-            ),
-            hashedStreetAddress: processHashing(
-              streetAddress ?? '',
-              'sha256',
-              'hex',
-              features,
-              'actions-google-campaign-manager-360'
-            ),
+            hashedFirstName: firstName
+              ? processHashing(firstName, 'sha256', 'hex', features, 'actions-google-campaign-manager-360')
+              : undefined,
+            hashedLastName: lastName
+              ? processHashing(lastName, 'sha256', 'hex', features, 'actions-google-campaign-manager-360')
+              : undefined,
+            hashedStreetAddress: streetAddress
+              ? processHashing(streetAddress, 'sha256', 'hex', features, 'actions-google-campaign-manager-360')
+              : undefined,
             city: city ?? undefined,
             state: state ?? undefined,
             postalCode: postalCode ?? undefined,

--- a/packages/destination-actions/src/destinations/reddit-conversions-api/utils.ts
+++ b/packages/destination-actions/src/destinations/reddit-conversions-api/utils.ts
@@ -117,14 +117,7 @@ function getMetadata(
     item_count: cleanNum(metadata?.item_count),
     value_decimal: cleanNum(metadata?.value_decimal),
     products: getProducts(products),
-    conversion_id: processHashing(
-      conversion_id ?? '',
-      'sha256',
-      'hex',
-      features,
-      'actions-reddit-conversions-api',
-      (value) => value.trim()
-    )
+    conversion_id: smartHash(conversion_id, features, (value) => value.trim())
   }
 }
 
@@ -135,7 +128,7 @@ function getAdId(
 ): { [key: string]: string | undefined } | undefined {
   if (!device_type) return undefined
   if (!advertising_id) return undefined
-  const hashedAdId = processHashing(advertising_id, 'sha256', 'hex', features, 'actions-reddit-conversions-api')
+  const hashedAdId = smartHash(advertising_id, features)
   return device_type === 'ios' ? { idfa: hashedAdId } : { aaid: hashedAdId }
 }
 
@@ -168,30 +161,9 @@ function getUser(
 
   return {
     ...getAdId(user.device_type, user.advertising_id, features),
-    email: processHashing(
-      user.email ?? '',
-      'sha256',
-      'hex',
-      features,
-      'actions-reddit-conversions-api',
-      canonicalizeEmail
-    ),
-    external_id: processHashing(
-      user.external_id ?? '',
-      'sha256',
-      'hex',
-      features,
-      'actions-reddit-conversions-api',
-      (value) => value.trim()
-    ),
-    ip_address: processHashing(
-      user.ip_address ?? '',
-      'sha256',
-      'hex',
-      features,
-      'actions-reddit-conversions-api',
-      (value) => value.trim()
-    ),
+    email: smartHash(user.email, features, canonicalizeEmail),
+    external_id: smartHash(user.external_id, features, (value) => value.trim()),
+    ip_address: smartHash(user.ip_address, features, (value) => value.trim()),
     user_agent: clean(user.user_agent),
     uuid: clean(user.uuid),
     data_processing_options: getDataProcessingOptions(dataProcessingOptions),
@@ -204,4 +176,13 @@ function canonicalizeEmail(value: string): string {
   const localPartAndDomain = value.split('@')
   const localPart = localPartAndDomain[0].replace(/\./g, '').split('+')[0]
   return `${localPart.toLowerCase()}@${localPartAndDomain[1].toLowerCase()}`
+}
+
+const smartHash = (
+  value: string | undefined,
+  features?: Features,
+  cleaningFunction?: (value: string) => string
+): string | undefined => {
+  if (value === undefined) return
+  return processHashing(value, 'sha256', 'hex', features, 'actions-reddit-conversions-api', cleaningFunction)
 }


### PR DESCRIPTION
This PR enhances the implementation of smart hashing for Reddit CAPI and Google Campaign Manager 360 destinations. Previously, when a field intended for hashing was missing from the event, we inadvertently added an empty string to the final payload. This issue resulted in a SEV incident for Snap CAPI. To address this, we are now ensuring that no empty strings are added for missing fields across all destinations.

## Testing
https://docs.google.com/document/d/10-776AUC9pQKt3IEjsdnN-ulOQcr_ZP2ui6S6WzwUrE/edit?tab=t.3qmwj3cgyd1j#heading=h.5k9akbnoyo19

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
