### PR TITLE
pre-hashed email bug fix

### DIFF
--- a/packages/destination-actions/src/destinations/reddit-conversions-api/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/reddit-conversions-api/__tests__/index.test.ts
@@ -60,7 +60,7 @@ describe('Reddit Conversions Api', () => {
             click_id: 'click_id_1',
             event_at: '2024-01-08T13:52:50.212Z',
             event_metadata: {
-              conversion_id: '492ebaa71872336ef94c7093b77d2232fdba7e469f716586a816d861367b183f',
+              conversion_id: 'ea3d01f99e303d2338cfb4e71f182441eb57c9a3cb129c40bcae9f5d641a7375',
               currency: 'USD',
               item_count: 10,
               products: [
@@ -227,7 +227,7 @@ describe('Reddit Conversions Api', () => {
             click_id: 'click_id_1',
             event_at: '2024-01-08T13:52:50.212Z',
             event_metadata: {
-              conversion_id: '492ebaa71872336ef94c7093b77d2232fdba7e469f716586a816d861367b183f',
+              conversion_id: 'ea3d01f99e303d2338cfb4e71f182441eb57c9a3cb129c40bcae9f5d641a7375',
               currency: 'USD',
               item_count: 10,
               products: [
@@ -307,7 +307,7 @@ describe('Reddit Conversions Api', () => {
             click_id: 'click_id_1',
             event_at: '2024-01-08T13:52:50.212Z',
             event_metadata: {
-              conversion_id: '492ebaa71872336ef94c7093b77d2232fdba7e469f716586a816d861367b183f',
+              conversion_id: 'ea3d01f99e303d2338cfb4e71f182441eb57c9a3cb129c40bcae9f5d641a7375',
               currency: 'USD',
               products: [
                 {

--- a/packages/destination-actions/src/destinations/reddit-conversions-api/utils.ts
+++ b/packages/destination-actions/src/destinations/reddit-conversions-api/utils.ts
@@ -184,5 +184,9 @@ const smartHash = (
   cleaningFunction?: (value: string) => string
 ): string | undefined => {
   if (value === undefined) return
+  const sha256Regex = /^[a-f0-9]{64}$/i
+  if (sha256Regex.test(value)) {
+    return value
+  }
   return processHashing(value, 'sha256', 'hex', features, 'actions-reddit-conversions-api', cleaningFunction)
 }


### PR DESCRIPTION
Hi, 
an advertiser reached out and said that they were running into this error when trying to test out the destination: 
**500: Cannot read properties of undefined (reading 'toLowerCase')**

We are only calling this `toLowerCase` function in this line here: https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/reddit-conversions-api/utils.ts#L178

I was able to reproduce the issue. The error gets thrown whenever someone is trying to pass an already hashed email address, such as in this example screenshot. If the email is not hashed, then it worked fine.: 
![image](https://github.com/user-attachments/assets/949c2031-e2c6-443e-a54b-35b0f89ab97b)

I found these 2 recent PRs that uses a new hashing function "smartHash" built by Segment:

https://github.com/segmentio/action-destinations/pull/2841
https://github.com/segmentio/action-destinations/pull/2802

It seems like the smartHash is supposed to detect if the value is already hashed, and to ignore it if so. But it kept going into the cleaningFunction (which in this case was the canonicalizeEmail function) even when the email was already hashed. And when it goes into that function, the "localPartAndDomain[1].toLowerCase()" part causes an error because localPartAndDomain[1] does not exist when the email is already hashed since there is no "@" character to split on. So that threw the undefined error.

I'm not sure if smartHash should have been picking up that the value is already hashed and to leave it as is, but I included an if statement to just check the regex of the value and see if it already looks hashed, and if so then to return it as is. Let me know if this is OK or if smartHash should be letting this value pass as is if it's already hashed.

I also fixed some of the tests that were added from the smartHash change, since it seemed like it was trying to expect a hashed value of an already hashed value and was failing.

## Testing

- [x ] Added unit tests for hashed email values that successfully passed
- [ x] Tested end-to-end using the [local server]: https://app.segment.com/dev-center/actions-tester
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
