### PR TITLE
[Smart Hashing] Add hashedPII category to all fields that are hashed using process hashing

### DIFF
--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -132,7 +132,7 @@ export interface GlobalSetting
 export type FieldTypeName = 'string' | 'text' | 'number' | 'integer' | 'datetime' | 'boolean' | 'password' | 'object'
 
 /** The supported field categories */
-type FieldCategory = 'identifier' | 'data' | 'internal' | 'config' | 'sync'
+type FieldCategory = 'identifier' | 'data' | 'internal' | 'config' | 'sync' | 'hashedPII'
 
 /** supported input methods when picking values */
 type FieldInputMethods = 'literal' | 'variable' | 'function' | 'enrichment' | 'freeform'

--- a/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/index.ts
@@ -35,56 +35,64 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.context.traits.email' },
           else: { '@path': '$.properties.email' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     firstName: {
       label: 'First name',
       description: 'User first name. Value will be hashed before sending to Amazon.',
       type: 'string',
       required: false,
-      default: { '@path': '$.properties.first_name' }
+      default: { '@path': '$.properties.first_name' },
+      category: 'hashedPII'
     },
     lastName: {
       label: 'Last name',
       description: 'User Last name. Value will be hashed before sending to Amazon.',
       type: 'string',
       required: false,
-      default: { '@path': '$.properties.last_name' }
+      default: { '@path': '$.properties.last_name' },
+      category: 'hashedPII'
     },
     phone: {
       label: 'Phone',
       description: 'Phone Number. Value will be hashed before sending to Amazon.',
       type: 'string',
       required: false,
-      default: { '@path': '$.properties.phone' }
+      default: { '@path': '$.properties.phone' },
+      category: 'hashedPII'
     },
     postal: {
       label: 'Postal',
       description: 'POstal Code. Value will be hashed before sending to Amazon.',
       type: 'string',
       required: false,
-      default: { '@path': '$.properties.postal' }
+      default: { '@path': '$.properties.postal' },
+      category: 'hashedPII'
     },
     state: {
       label: 'State',
       description: 'State Code. Value will be hashed before sending to Amazon.',
       type: 'string',
       required: false,
-      default: { '@path': '$.properties.state' }
+      default: { '@path': '$.properties.state' },
+      category: 'hashedPII'
     },
     city: {
       label: 'City',
       description: 'City name. Value will be hashed before sending to Amazon.',
       type: 'string',
       required: false,
-      default: { '@path': '$.properties.city' }
+      default: { '@path': '$.properties.city' },
+      category: 'hashedPII'
     },
     address: {
       label: 'Address',
       description: 'Address Code. Value will be hashed before sending to Amazon.',
       type: 'string',
       required: false,
-      default: { '@path': '$.properties.address' }
+      default: { '@path': '$.properties.address' },
+      category: 'hashedPII'
     },
     audienceId: {
       label: 'Audience ID',

--- a/packages/destination-actions/src/destinations/delivrai-activate/updateSegment/index.ts
+++ b/packages/destination-actions/src/destinations/delivrai-activate/updateSegment/index.ts
@@ -32,7 +32,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.traits.email' },
           else: { '@path': '$.context.traits.email' } // Phone is sent as identify's trait or track's context.trait
         }
-      }
+      },
+      category: 'hashedPII'
     },
     phone: {
       label: 'User Phone',
@@ -46,7 +47,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.traits.phone' }, // Phone is sent as identify's trait or track's property
           else: { '@path': '$.properties.phone' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     device_type: {
       label: 'User Mobile Device Type', // This field is required to determine the type of the advertising Id: IDFA or GAID

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
@@ -72,7 +72,10 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
       default: {
         '@path': '$.context.personas.computation_class'
       },
-      choices: [{ label: 'audience', value: 'audience' },{ label: 'journey_step', value: 'journey_step' }]
+      choices: [
+        { label: 'audience', value: 'audience' },
+        { label: 'journey_step', value: 'journey_step' }
+      ]
     },
     email: {
       label: 'Email',
@@ -87,7 +90,8 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
           then: { '@path': '$.traits.email' },
           else: { '@path': '$.context.traits.email' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     anonymousId: {
       label: 'Segment Anonymous Id',

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-user-data.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-user-data.ts
@@ -19,58 +19,69 @@ export const user_data_field: InputField = {
       description:
         'Any unique ID from the advertiser, such as loyalty membership IDs, user IDs, and external cookie IDs. You can send one or more external IDs for a given event.',
       type: 'string',
-      multiple: true // changed the type from string to array of strings.
+      multiple: true, // changed the type from string to array of strings.
+      category: 'hashedPII'
     },
     email: {
       label: 'Email',
       description: 'An email address in lowercase.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     phone: {
       label: 'Phone',
       description:
         'A phone number. Include only digits with country code, area code, and number. Remove symbols, letters, and any leading zeros. In addition, always include the country code, even if all of the data is from the same country, as the country code is used for matching.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     gender: {
       label: 'Gender',
       description: 'Gender in lowercase. Either f or m.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     dateOfBirth: {
       label: 'Date of Birth',
       description: 'A date of birth given as year, month, and day. Example: 19971226 for December 26, 1997.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     lastName: {
       label: 'Last Name',
       description: 'A last name in lowercase.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     firstName: {
       label: 'First Name',
       description: 'A first name in lowercase.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     city: {
       label: 'City',
       description: 'A city in lowercase without spaces or punctuation. Example: menlopark.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     state: {
       label: 'State',
       description: 'A two-letter state code in lowercase. Example: ca.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     zip: {
       label: 'Zip Code',
       description: 'A five-digit zip code for United States. For other locations, follow each country`s standards.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     country: {
       label: 'Country',
       description: 'A two-letter country code in lowercase.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     client_ip_address: {
       label: 'Client IP Address',

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/index.ts
@@ -157,24 +157,28 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: true,
       label: 'External ID',
+      category: 'hashedPII',
       description:
         'Your company’s custom identifier for this user. This can be any unique ID, such as loyalty membership IDs, user IDs, and external cookie IDs.'
     },
     email: {
       type: 'string',
       label: 'Email',
-      description: 'User’s email (ex: foo@bar.com)'
+      description: 'User’s email (ex: foo@bar.com)',
+      category: 'hashedPII'
     },
     phone: {
       type: 'string',
       label: 'Phone',
       description:
-        'User’s phone number, including country code. Punctuation and spaces are ok (ex: 1-234-567-8910 or +44 844 412 4653)'
+        'User’s phone number, including country code. Punctuation and spaces are ok (ex: 1-234-567-8910 or +44 844 412 4653)',
+      category: 'hashedPII'
     },
     country: {
       type: 'string',
       label: 'Country',
-      description: 'User’s country. Use 2-letter country codes in ISO 3166-1 alpha-2 format.'
+      description: 'User’s country. Use 2-letter country codes in ISO 3166-1 alpha-2 format.',
+      category: 'hashedPII'
     },
     birth: {
       type: 'object',
@@ -194,21 +198,25 @@ const action: ActionDefinition<Settings, Payload> = {
           type: 'string',
           label: 'Day'
         }
-      }
+      },
+      category: 'hashedPII'
     },
     name: {
       type: 'object',
       label: 'Name',
       description:
         'User’s name. Include as many fields as possible for better match rates. Use a-z only. No punctuation. Special characters in UTF-8 format',
+      category: 'hashedPII',
       properties: {
         first: {
           type: 'string',
-          label: 'First Name'
+          label: 'First Name',
+          category: 'hashedPII'
         },
         last: {
           type: 'string',
-          label: 'Last Name'
+          label: 'Last Name',
+          category: 'hashedPII'
         },
         firstInitial: {
           type: 'string',
@@ -219,40 +227,47 @@ const action: ActionDefinition<Settings, Payload> = {
     city: {
       type: 'string',
       label: 'City',
-      description: 'User’s city. Use a-z only. No punctuation. No special characters.'
+      description: 'User’s city. Use a-z only. No punctuation. No special characters.',
+      category: 'hashedPII'
     },
     state: {
       type: 'string',
       label: 'State',
       description:
-        'User’s state. Use the 2-character ANSI abbreviation code, Normalize states outside the US with no punctuation and no special characters.'
+        'User’s state. Use the 2-character ANSI abbreviation code, Normalize states outside the US with no punctuation and no special characters.',
+      category: 'hashedPII'
     },
     zip: {
       type: 'string',
       label: 'Postal Code',
       description:
-        'User’s postal code. For the US, use only the first 5 digits. For the UK, use the Area/District/Sector format.'
+        'User’s postal code. For the US, use only the first 5 digits. For the UK, use the Area/District/Sector format.',
+      category: 'hashedPII'
     },
     gender: {
       type: 'string',
       label: 'Gender',
-      description: 'User’s gender (m for male, f for female)'
+      description: 'User’s gender (m for male, f for female)',
+      category: 'hashedPII'
     },
     mobileAdId: {
       type: 'string',
       label: 'Mobile Advertising ID',
       description:
-        'User’s Apple IDFA, Android Ad ID, or Facebook app scoped ID. Keep hyphens (ex: AB1234CD-E123-12FG-J123)'
+        'User’s Apple IDFA, Android Ad ID, or Facebook app scoped ID. Keep hyphens (ex: AB1234CD-E123-12FG-J123)',
+      category: 'hashedPII'
     },
     appId: {
       type: 'string',
       label: 'App ID',
-      description: 'The app ID of the user.'
+      description: 'The app ID of the user.',
+      category: 'hashedPII'
     },
     pageId: {
       type: 'string',
       label: 'Page ID',
-      description: 'The page ID of the user.'
+      description: 'The page ID of the user.',
+      category: 'hashedPII'
     },
     enable_batching,
     batch_size

--- a/packages/destination-actions/src/destinations/first-party-dv360/properties.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/properties.ts
@@ -26,7 +26,8 @@ export const emails: InputField = {
   type: 'string',
   default: {
     '@path': '$.context.traits.emails'
-  }
+  },
+  category: 'hashedPII'
 }
 
 export const phoneNumbers: InputField = {
@@ -35,7 +36,8 @@ export const phoneNumbers: InputField = {
   type: 'string',
   default: {
     '@path': '$.context.traits.phoneNumbers'
-  }
+  },
+  category: 'hashedPII'
 }
 
 export const zipCodes: InputField = {
@@ -53,7 +55,8 @@ export const firstName: InputField = {
   type: 'string',
   default: {
     '@path': '$.context.traits.firstName'
-  }
+  },
+  category: 'hashedPII'
 }
 
 export const lastName: InputField = {
@@ -62,7 +65,8 @@ export const lastName: InputField = {
   type: 'string',
   default: {
     '@path': '$.context.traits.lastName'
-  }
+  },
+  category: 'hashedPII'
 }
 
 export const countryCode: InputField = {

--- a/packages/destination-actions/src/destinations/google-campaign-manager-360/common-fields.ts
+++ b/packages/destination-actions/src/destinations/google-campaign-manager-360/common-fields.ts
@@ -60,32 +60,37 @@ export const commonFields: ActionDefinition<Settings>['fields'] = {
         label: 'Email',
         description: "The user's email address. If unhashed, Segment will hash before sending to Campaign Manager 360.",
         type: 'string',
-        required: false
+        required: false,
+        category: 'hashedPII'
       },
       phone: {
         label: 'Phone',
         description: "The user's phone number. If unhashed, Segment will hash before sending to Campaign Manager 360.",
         type: 'string',
-        required: false
+        required: false,
+        category: 'hashedPII'
       },
       firstName: {
         label: 'First Name',
         description: 'First name of the user. If unhashed, Segment will hash before sending to Campaign Manager 360.',
         type: 'string',
-        required: false
+        required: false,
+        category: 'hashedPII'
       },
       lastName: {
         label: 'Last Name',
         description: 'Last name of the user. If unhashed, Segment will hash before sending to Campaign Manager 360.',
         type: 'string',
-        required: false
+        required: false,
+        category: 'hashedPII'
       },
       streetAddress: {
         label: 'Street Address',
         description:
           'The street address of the user. If unhashed, Segment will hash before sending to Campaign Manager 360.',
         type: 'string',
-        required: false
+        required: false,
+        category: 'hashedPII'
       },
       city: {
         label: 'City',

--- a/packages/destination-actions/src/destinations/google-campaign-manager-360/conversionUpload/index.ts
+++ b/packages/destination-actions/src/destinations/google-campaign-manager-360/conversionUpload/index.ts
@@ -99,7 +99,8 @@ const action: ActionDefinition<Settings, Payload> = {
           description:
             'A comma separated list of the alphanumeric encrypted user IDs. Any user ID with exposure prior to the conversion timestamp will be used in the inserted conversion. If no such user ID is found then the conversion will be rejected with INVALID_ARGUMENT error. When set, `encryptionInfo` should also be specified.',
           type: 'string',
-          required: false
+          required: false,
+          category: 'hashedPII'
         }
       },
       default: {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -75,7 +75,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.properties.email' },
           else: { '@path': '$.context.traits.email' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     phone_number: {
       label: 'Phone Number',
@@ -88,7 +89,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.properties.phone' },
           else: { '@path': '$.context.traits.phone' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     order_id: {
       label: 'Order ID',

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -82,7 +82,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.properties.email' },
           else: { '@path': '$.context.traits.email' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     phone_number: {
       label: 'Phone Number',
@@ -95,7 +96,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.properties.phone' },
           else: { '@path': '$.context.traits.phone' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     order_id: {
       label: 'Order ID',

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
@@ -113,7 +113,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.properties.email' },
           else: { '@path': '$.context.traits.email' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     phone_number: {
       label: 'Phone Number',
@@ -126,7 +127,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.properties.phone' },
           else: { '@path': '$.context.traits.phone' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     first_name: {
       label: 'First Name',

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment2/index.ts
@@ -125,7 +125,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.properties.email' },
           else: { '@path': '$.context.traits.email' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     phone_number: {
       label: 'Phone Number',
@@ -138,7 +139,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.properties.phone' },
           else: { '@path': '$.context.traits.phone' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     first_name: {
       label: 'First Name',

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/index.ts
@@ -30,7 +30,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.context.traits.firstName' },
           else: { '@path': '$.properties.firstName' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     last_name: {
       label: 'Last Name',
@@ -42,7 +43,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.context.traits.lastName' },
           else: { '@path': '$.properties.lastName' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     email: {
       label: 'Email',
@@ -54,7 +56,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.context.traits.email' },
           else: { '@path': '$.properties.email' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     phone: {
       label: 'Phone',
@@ -67,7 +70,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.context.traits.phone' },
           else: { '@path': '$.properties.phone' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     phone_country_code: {
       label: 'Phone Number Country Code',

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
@@ -36,7 +36,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.context.traits.email' },
           else: { '@path': '$.traits.email' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     first_name: {
       label: 'User First Name',

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -223,7 +223,8 @@ const action: ActionDefinition<Settings, Payload, undefined, OnMappingSaveInputs
         'Email address of the contact associated with the conversion event. Segment will hash this value before sending it to LinkedIn. One of email or LinkedIn UUID or Axciom ID or Oracle ID is required.',
       type: 'string',
       required: false,
-      default: { '@path': '$.traits.email' }
+      default: { '@path': '$.traits.email' },
+      category: 'hashedPII'
     },
     linkedInUUID: {
       label: 'LinkedIn First Party Ads Tracking UUID',

--- a/packages/destination-actions/src/destinations/pinterest-conversions/pinterset-capi-user-data.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/pinterset-capi-user-data.ts
@@ -17,13 +17,15 @@ export const user_data_field: InputField = {
       label: 'Email',
       description: 'An email address in lowercase.',
       type: 'string',
-      multiple: true
+      multiple: true,
+      category: 'hashedPII'
     },
     hashed_maids: {
       label: 'Mobile Ad Identifier',
       description: 'User’s Google advertising ID (GAIDs) or Apple’s identifier for advertisers (IDFAs).',
       type: 'string',
-      multiple: true
+      multiple: true,
+      category: 'hashedPII'
     },
     client_ip_address: {
       label: 'Client IP Address',
@@ -40,62 +42,72 @@ export const user_data_field: InputField = {
       description:
         'A phone number. Include only digits with country code, area code, and number. Remove symbols, letters, and any leading zeros. In addition, always include the country code, even if all of the data is from the same country, as the country code is used for matching.',
       type: 'string',
-      multiple: true
+      multiple: true,
+      category: 'hashedPII'
     },
     first_name: {
       label: 'First Name',
       description: 'A first name in lowercase.',
       type: 'string',
-      multiple: true
+      multiple: true,
+      category: 'hashedPII'
     },
     last_name: {
       label: 'Last Name',
       description: 'A last name in lowercase.',
       type: 'string',
-      multiple: true
+      multiple: true,
+      category: 'hashedPII'
     },
     external_id: {
       label: 'External ID',
       description:
         'Any unique ID from the advertiser, such as loyalty membership IDs, user IDs, and external cookie IDs. You can send one or more external IDs for a given event.',
       type: 'string',
-      multiple: true
+      multiple: true,
+      category: 'hashedPII'
     },
     gender: {
       label: 'Gender',
       description: 'Gender in lowercase. Either f or m.',
       type: 'string',
-      multiple: true
+      multiple: true,
+      category: 'hashedPII'
     },
     date_of_birth: {
       label: 'Date of Birth',
       description: 'A date of birth given as year, month, and day. Example: 19971226 for December 26, 1997.',
       type: 'string',
-      multiple: true
+      multiple: true,
+      category: 'hashedPII'
     },
     city: {
       label: 'City',
       description: 'A city in lowercase without spaces or punctuation. Example: menlopark.',
       type: 'string',
-      multiple: true
+      multiple: true,
+      category: 'hashedPII'
     },
     state: {
       label: 'State',
       description: 'A two-letter state code in lowercase. Example: ca.',
       type: 'string',
-      multiple: true
+      multiple: true,
+      category: 'hashedPII'
     },
     zip: {
       label: 'Zip Code',
       description: 'A five-digit zip code for United States. For other locations, follow each country`s standards.',
       type: 'string',
-      multiple: true
+      multiple: true,
+      category: 'hashedPII'
     },
     country: {
       label: 'Country',
       description: 'A two-letter country code in lowercase.',
       type: 'string',
-      multiple: true
+      multiple: true,
+      category: 'hashedPII'
     },
     click_id: {
       label: 'Click ID',

--- a/packages/destination-actions/src/destinations/reddit-conversions-api/fields.ts
+++ b/packages/destination-actions/src/destinations/reddit-conversions-api/fields.ts
@@ -55,7 +55,8 @@ export const conversion_id: InputField = {
   description: 'The unique conversion ID that corresponds to a distinct conversion event.',
   type: 'string',
   required: false,
-  default: { '@path': '$.properties.conversion_id' }
+  default: { '@path': '$.properties.conversion_id' },
+  category: 'hashedPII'
 }
 
 export const event_metadata: InputField = {
@@ -150,7 +151,8 @@ export const user: InputField = {
     advertising_id: {
       label: 'Advertising ID', // NEEDS TO BE HASHED (SHA-256)
       description: 'The mobile advertising ID for the user. This can be the iOS IDFA, Android AAID.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     device_type: {
       label: 'Device Type',
@@ -160,17 +162,20 @@ export const user: InputField = {
     email: {
       label: 'Email', // NEEDS TO BE HASHED (SHA-256)
       description: 'The email address of the user.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     external_id: {
       label: 'External ID', // NEEDS TO BE HASHED (SHA-256)
       description: 'An advertiser-assigned persistent identifier for the user.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     ip_address: {
       label: 'IP Address', // NEEDS TO BE HASHED (SHA-256)
       description: 'The IP address of the user.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     user_agent: {
       label: 'User Agent',

--- a/packages/destination-actions/src/destinations/snap-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/snap-audiences/syncAudience/index.ts
@@ -66,7 +66,8 @@ const action: ActionDefinition<Settings, Payload> = {
             value: 'PHONE_SHA256'
           }
         ]
-      }
+      },
+      category: 'hashedPII'
     },
     email: {
       label: 'Email',
@@ -84,7 +85,8 @@ const action: ActionDefinition<Settings, Payload> = {
             value: 'EMAIL_SHA256'
           }
         ]
-      }
+      },
+      category: 'hashedPII'
     },
     advertising_id: {
       label: 'Mobile Advertising ID',
@@ -104,7 +106,8 @@ const action: ActionDefinition<Settings, Payload> = {
             value: 'MOBILE_AD_ID_SHA256'
           }
         ]
-      }
+      },
+      category: 'hashedPII'
     },
     enable_batching: {
       label: 'Enable Batching',

--- a/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-input-fields-deprecated.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-input-fields-deprecated.ts
@@ -40,7 +40,8 @@ const device_model: InputField = {
 const email: InputField = {
   label: '[Deprecated] Email',
   description: 'Deprecated. Use User Data email field.',
-  type: 'string'
+  type: 'string',
+  category: 'hashedPII'
 }
 
 const event_conversion_type: InputField = {
@@ -123,7 +124,8 @@ const page_url: InputField = {
 const phone_number: InputField = {
   label: '[Deprecated] Phone Number',
   description: 'Deprecated. Use User Data phone field.',
-  type: 'string'
+  type: 'string',
+  category: 'hashedPII'
 }
 
 const price: InputField = {

--- a/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-input-fields-v3.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-input-fields-v3.ts
@@ -344,58 +344,69 @@ const user_data: InputField = {
       description:
         'Any unique ID from the advertiser, such as loyalty membership IDs, user IDs, and external cookie IDs. You can send one or more external IDs for a given event.',
       type: 'string',
-      multiple: true // changed the type from string to array of strings.
+      multiple: true, // changed the type from string to array of strings.
+      category: 'hashedPII'
     },
     email: {
       label: 'Email',
       description: 'An email address in lowercase.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     phone: {
       label: 'Phone',
       description:
         'A phone number. Include only digits with country code, area code, and number. Remove symbols, letters, and any leading zeros. In addition, always include the country code, even if all of the data is from the same country, as the country code is used for matching.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     gender: {
       label: 'Gender',
       description: 'Gender in lowercase. Either f or m.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     dateOfBirth: {
       label: 'Date of Birth',
       description: 'A date of birth given as year, month, and day. Example: 19971226 for December 26, 1997.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     lastName: {
       label: 'Last Name',
       description: 'A last name in lowercase.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     firstName: {
       label: 'First Name',
       description: 'A first name in lowercase.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     city: {
       label: 'City',
       description: 'A city in lowercase without spaces or punctuation. Example: menlopark.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     state: {
       label: 'State',
       description: 'A two-letter state code in lowercase. Example: ca.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     zip: {
       label: 'Zip Code',
       description: 'A five-digit zip code for United States. For other locations, follow each country`s standards.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     country: {
       label: 'Country',
       description: 'A two-letter country code in lowercase.',
-      type: 'string'
+      type: 'string',
+      category: 'hashedPII'
     },
     client_ip_address: {
       label: 'Client IP Address',

--- a/packages/destination-actions/src/destinations/tiktok-audiences/properties.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/properties.ts
@@ -35,7 +35,8 @@ export const email: InputField = {
       then: { '@path': '$.context.traits.email' },
       else: { '@path': '$.properties.email' }
     }
-  }
+  },
+  category: 'hashedPII'
 }
 
 export const send_email: InputField = {
@@ -55,7 +56,8 @@ export const phone: InputField = {
       then: { '@path': '$.context.traits.phone' },
       else: { '@path': '$.properties.phone' }
     }
-  }
+  },
+  category: 'hashedPII'
 }
 
 export const send_phone: InputField = {
@@ -71,7 +73,8 @@ export const advertising_id: InputField = {
   type: 'string',
   default: {
     '@path': '$.context.device.advertisingId'
-  }
+  },
+  category: 'hashedPII'
 }
 
 export const send_advertising_id: InputField = {

--- a/packages/destination-actions/src/destinations/tiktok-conversions/common_fields.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/common_fields.ts
@@ -36,7 +36,8 @@ export const commonFields: Record<string, InputField> = {
         then: { '@path': '$.properties.phone' },
         else: { '@path': '$.context.traits.phone' }
       }
-    }
+    },
+    category: 'hashedPII'
   },
   email: {
     label: 'Email',
@@ -50,7 +51,8 @@ export const commonFields: Record<string, InputField> = {
         then: { '@path': '$.properties.email' },
         else: { '@path': '$.context.traits.email' }
       }
-    }
+    },
+    category: 'hashedPII'
   },
   first_name: {
     label: 'First Name',
@@ -63,7 +65,8 @@ export const commonFields: Record<string, InputField> = {
         then: { '@path': '$.properties.first_name' },
         else: { '@path': '$.context.traits.first_name' }
       }
-    }
+    },
+    category: 'hashedPII'
   },
   last_name: {
     label: 'Last Name',
@@ -76,7 +79,8 @@ export const commonFields: Record<string, InputField> = {
         then: { '@path': '$.properties.last_name' },
         else: { '@path': '$.context.traits.last_name' }
       }
-    }
+    },
+    category: 'hashedPII'
   },
   address: {
     label: 'Address',
@@ -97,7 +101,8 @@ export const commonFields: Record<string, InputField> = {
       zip_code: {
         label: 'Zip Code',
         type: 'string',
-        description: "The customer's Zip Code."
+        description: "The customer's Zip Code.",
+        category: 'hashedPII'
       },
       state: {
         label: 'State',
@@ -164,7 +169,8 @@ export const commonFields: Record<string, InputField> = {
         then: { '@path': '$.userId' },
         else: { '@path': '$.anonymousId' }
       }
-    }
+    },
+    category: 'hashedPII'
   },
   ttclid: {
     label: 'TikTok Click ID',

--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions/common_fields.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions/common_fields.ts
@@ -36,7 +36,8 @@ export const commonFields: Record<string, InputField> = {
         then: { '@path': '$.properties.phone' },
         else: { '@path': '$.context.traits.phone' }
       }
-    }
+    },
+    category: 'hashedPII'
   },
   email_addresses: {
     label: 'Email',
@@ -50,7 +51,8 @@ export const commonFields: Record<string, InputField> = {
         then: { '@path': '$.properties.email' },
         else: { '@path': '$.context.traits.email' }
       }
-    }
+    },
+    category: 'hashedPII'
   },
   order_id: {
     label: 'Order ID',
@@ -80,7 +82,8 @@ export const commonFields: Record<string, InputField> = {
         then: { '@path': '$.userId' },
         else: { '@path': '$.anonymousId' }
       }
-    }
+    },
+    category: 'hashedPII'
   },
   ttclid: {
     label: 'TikTok Click ID',
@@ -200,7 +203,10 @@ export const commonFields: Record<string, InputField> = {
     description:
       'Type of the product item. When the `content_id` in the `Contents` field is specified as a `sku_id`, set this field to `product`. When the `content_id` in the `Contents` field is specified as an `item_group_id`, set this field to `product_group`.',
     type: 'string',
-    choices: [ { label: 'product', value: 'product' }, { label: 'product_group', value: 'product_group' }],
+    choices: [
+      { label: 'product', value: 'product' },
+      { label: 'product_group', value: 'product_group' }
+    ],
     default: 'product'
   },
   currency: {

--- a/packages/destination-actions/src/destinations/yahoo-audiences/updateSegment/index.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/updateSegment/index.ts
@@ -71,7 +71,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.traits.phone' }, // Phone is sent as identify's trait or track's property
           else: { '@path': '$.properties.phone' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     email: {
       label: 'User Email',
@@ -85,7 +86,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.traits.email' },
           else: { '@path': '$.context.traits.email' } // Phone is sent as identify's trait or track's context.trait
         }
-      }
+      },
+      category: 'hashedPII'
     },
     advertising_id: {
       label: 'User Mobile Advertising ID',


### PR DESCRIPTION
This PR adds 'hashedPII' category to all the fields that are using smart hashing.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
