### PR TITLE
[Smart Hashing] Remove redundant hashing descriptions

### DIFF
--- a/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/generated-types.ts
@@ -26,7 +26,7 @@ export interface Payload {
    */
   phone?: string
   /**
-   * POstal Code.
+   * Postal Code.
    */
   postal?: string
   /**

--- a/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/generated-types.ts
@@ -10,35 +10,35 @@ export interface Payload {
    */
   externalUserId: string
   /**
-   * User email address. Vaule will be hashed before sending to Amazon.
+   * User email address.
    */
   email?: string
   /**
-   * User first name. Value will be hashed before sending to Amazon.
+   * User first name.
    */
   firstName?: string
   /**
-   * User Last name. Value will be hashed before sending to Amazon.
+   * User Last name.
    */
   lastName?: string
   /**
-   * Phone Number. Value will be hashed before sending to Amazon.
+   * Phone Number.
    */
   phone?: string
   /**
-   * POstal Code. Value will be hashed before sending to Amazon.
+   * POstal Code.
    */
   postal?: string
   /**
-   * State Code. Value will be hashed before sending to Amazon.
+   * State Code.
    */
   state?: string
   /**
-   * City name. Value will be hashed before sending to Amazon.
+   * City name.
    */
   city?: string
   /**
-   * Address Code. Value will be hashed before sending to Amazon.
+   * Address Code.
    */
   address?: string
   /**

--- a/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/index.ts
@@ -26,7 +26,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     email: {
       label: 'Email',
-      description: 'User email address. Vaule will be hashed before sending to Amazon.',
+      description: 'User email address.',
       type: 'string',
       required: false,
       default: {
@@ -40,7 +40,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     firstName: {
       label: 'First name',
-      description: 'User first name. Value will be hashed before sending to Amazon.',
+      description: 'User first name.',
       type: 'string',
       required: false,
       default: { '@path': '$.properties.first_name' },
@@ -48,7 +48,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     lastName: {
       label: 'Last name',
-      description: 'User Last name. Value will be hashed before sending to Amazon.',
+      description: 'User Last name.',
       type: 'string',
       required: false,
       default: { '@path': '$.properties.last_name' },
@@ -56,7 +56,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     phone: {
       label: 'Phone',
-      description: 'Phone Number. Value will be hashed before sending to Amazon.',
+      description: 'Phone Number.',
       type: 'string',
       required: false,
       default: { '@path': '$.properties.phone' },
@@ -64,7 +64,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     postal: {
       label: 'Postal',
-      description: 'POstal Code. Value will be hashed before sending to Amazon.',
+      description: 'POstal Code.',
       type: 'string',
       required: false,
       default: { '@path': '$.properties.postal' },
@@ -72,7 +72,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     state: {
       label: 'State',
-      description: 'State Code. Value will be hashed before sending to Amazon.',
+      description: 'State Code.',
       type: 'string',
       required: false,
       default: { '@path': '$.properties.state' },
@@ -80,7 +80,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     city: {
       label: 'City',
-      description: 'City name. Value will be hashed before sending to Amazon.',
+      description: 'City name.',
       type: 'string',
       required: false,
       default: { '@path': '$.properties.city' },
@@ -88,7 +88,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     address: {
       label: 'Address',
-      description: 'Address Code. Value will be hashed before sending to Amazon.',
+      description: 'Address Code.',
       type: 'string',
       required: false,
       default: { '@path': '$.properties.address' },

--- a/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/index.ts
@@ -64,7 +64,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     postal: {
       label: 'Postal',
-      description: 'POstal Code.',
+      description: 'Postal Code.',
       type: 'string',
       required: false,
       default: { '@path': '$.properties.postal' },

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/index.ts
@@ -158,7 +158,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.properties.address.street' },
           else: { '@path': '$.traits.address.street' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     city: {
       label: 'City',

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/generated-types.ts
@@ -22,11 +22,11 @@ export interface Payload {
    */
   conversion_timestamp: string
   /**
-   * Email address of the individual who triggered the conversion event. Segment will hash this value before sending to Google.
+   * Email address of the individual who triggered the conversion event
    */
   email_address?: string
   /**
-   * Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000. Segment will hash this value before sending to Google.
+   * Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000
    */
   phone_number?: string
   /**

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -66,8 +66,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     email_address: {
       label: 'Email Address',
-      description:
-        'Email address of the individual who triggered the conversion event. Segment will hash this value before sending to Google.',
+      description: 'Email address of the individual who triggered the conversion event',
       type: 'string',
       default: {
         '@if': {
@@ -81,7 +80,7 @@ const action: ActionDefinition<Settings, Payload> = {
     phone_number: {
       label: 'Phone Number',
       description:
-        'Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000. Segment will hash this value before sending to Google.',
+        'Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000',
       type: 'string',
       default: {
         '@if': {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/generated-types.ts
@@ -22,11 +22,11 @@ export interface Payload {
    */
   conversion_timestamp: string
   /**
-   * Email address of the individual who triggered the conversion event. Segment will hash this value before sending to Google.
+   * Email address of the individual who triggered the conversion event
    */
   email_address?: string
   /**
-   * Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000. Segment will hash this value before sending to Google.
+   * Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000
    */
   phone_number?: string
   /**

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -73,8 +73,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     email_address: {
       label: 'Email Address',
-      description:
-        'Email address of the individual who triggered the conversion event. Segment will hash this value before sending to Google.',
+      description: 'Email address of the individual who triggered the conversion event',
       type: 'string',
       default: {
         '@if': {
@@ -88,7 +87,7 @@ const action: ActionDefinition<Settings, Payload> = {
     phone_number: {
       label: 'Phone Number',
       description:
-        'Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000. Segment will hash this value before sending to Google.',
+        'Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000',
       type: 'string',
       default: {
         '@if': {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/generated-types.ts
@@ -34,19 +34,19 @@ export interface Payload {
    */
   restatement_currency_code?: string
   /**
-   * Email address of the individual who triggered the conversion event. Segment will hash this value before sending to Google.
+   * Email address of the individual who triggered the conversion event.
    */
   email_address?: string
   /**
-   * Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000. Segment will hash this value before sending to Google.
+   * Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000
    */
   phone_number?: string
   /**
-   * First name of the user who performed the conversion. Segment will hash this value before sending to Google.
+   * First name of the user who performed the conversion
    */
   first_name?: string
   /**
-   * Last name of the user who performed the conversion. Segment will hash this value before sending to Google.
+   * Last name of the user who performed the conversion
    */
   last_name?: string
   /**
@@ -66,7 +66,7 @@ export interface Payload {
    */
   postal_code?: string
   /**
-   * Street address of the user who performed the conversion. Segment will hash this value before sending to Google.
+   * Street address of the user who performed the conversion
    */
   street_address?: string
   /**

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
@@ -104,8 +104,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     email_address: {
       label: 'Email Address',
-      description:
-        'Email address of the individual who triggered the conversion event. Segment will hash this value before sending to Google.',
+      description: 'Email address of the individual who triggered the conversion event.',
       type: 'string',
       default: {
         '@if': {
@@ -119,7 +118,7 @@ const action: ActionDefinition<Settings, Payload> = {
     phone_number: {
       label: 'Phone Number',
       description:
-        'Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000. Segment will hash this value before sending to Google.',
+        'Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000',
       type: 'string',
       default: {
         '@if': {
@@ -132,8 +131,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     first_name: {
       label: 'First Name',
-      description:
-        'First name of the user who performed the conversion. Segment will hash this value before sending to Google.',
+      description: 'First name of the user who performed the conversion',
       type: 'string',
       default: {
         '@if': {
@@ -145,8 +143,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     last_name: {
       label: 'Last Name',
-      description:
-        'Last name of the user who performed the conversion. Segment will hash this value before sending to Google.',
+      description: 'Last name of the user who performed the conversion',
       type: 'string',
       default: {
         '@if': {
@@ -154,7 +151,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.properties.lastName' },
           else: { '@path': '$.context.traits.lastName' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     city: {
       label: 'City',
@@ -206,8 +204,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     street_address: {
       label: 'Street Address',
-      description:
-        'Street address of the user who performed the conversion. Segment will hash this value before sending to Google.',
+      description: 'Street address of the user who performed the conversion',
       type: 'string',
       default: {
         '@if': {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment2/generated-types.ts
@@ -34,19 +34,19 @@ export interface Payload {
    */
   restatement_currency_code?: string
   /**
-   * Email address of the individual who triggered the conversion event. Segment will hash this value before sending to Google.
+   * Email address of the individual who triggered the conversion event.
    */
   email_address?: string
   /**
-   * Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000. Segment will hash this value before sending to Google.
+   * Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000.
    */
   phone_number?: string
   /**
-   * First name of the user who performed the conversion. Segment will hash this value before sending to Google.
+   * First name of the user who performed the conversion.
    */
   first_name?: string
   /**
-   * Last name of the user who performed the conversion. Segment will hash this value before sending to Google.
+   * Last name of the user who performed the conversion.
    */
   last_name?: string
   /**
@@ -66,7 +66,7 @@ export interface Payload {
    */
   postal_code?: string
   /**
-   * Street address of the user who performed the conversion. Segment will hash this value before sending to Google.
+   * Street address of the user who performed the conversion.
    */
   street_address?: string
   /**

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment2/index.ts
@@ -116,8 +116,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     email_address: {
       label: 'Email Address',
-      description:
-        'Email address of the individual who triggered the conversion event. Segment will hash this value before sending to Google.',
+      description: 'Email address of the individual who triggered the conversion event.',
       type: 'string',
       default: {
         '@if': {
@@ -131,7 +130,7 @@ const action: ActionDefinition<Settings, Payload> = {
     phone_number: {
       label: 'Phone Number',
       description:
-        'Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000. Segment will hash this value before sending to Google.',
+        'Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000.',
       type: 'string',
       default: {
         '@if': {
@@ -144,8 +143,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     first_name: {
       label: 'First Name',
-      description:
-        'First name of the user who performed the conversion. Segment will hash this value before sending to Google.',
+      description: 'First name of the user who performed the conversion.',
       type: 'string',
       default: {
         '@if': {
@@ -157,8 +155,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     last_name: {
       label: 'Last Name',
-      description:
-        'Last name of the user who performed the conversion. Segment will hash this value before sending to Google.',
+      description: 'Last name of the user who performed the conversion.',
       type: 'string',
       default: {
         '@if': {
@@ -166,7 +163,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.properties.lastName' },
           else: { '@path': '$.context.traits.lastName' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     city: {
       label: 'City',
@@ -218,8 +216,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     street_address: {
       label: 'Street Address',
-      description:
-        'Street address of the user who performed the conversion. Segment will hash this value before sending to Google.',
+      description: 'Street address of the user who performed the conversion.',
       type: 'string',
       default: {
         '@if': {
@@ -227,7 +224,8 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.properties.address.street,' },
           else: { '@path': '$.context.traits.address.street' }
         }
-      }
+      },
+      category: 'hashedPII'
     },
     user_agent: {
       label: 'User Agent',

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/generated-types.ts
@@ -2,19 +2,19 @@
 
 export interface Payload {
   /**
-   * The user's first name. If not hashed, Segment will normalize and hash this value.
+   * The user's first name.
    */
   first_name?: string
   /**
-   * The user's last name. If not hashed, Segment will normalize and hash this value.
+   * The user's last name.
    */
   last_name?: string
   /**
-   * The user's email address. If not hashed, Segment will normalize and hash this value.
+   * The user's email address.
    */
   email?: string
   /**
-   * The user's phone number. If not hashed, Segment will convert the phone number to the E.164 format and hash this value.
+   * The user's phone number.
    */
   phone?: string
   /**

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/index.ts
@@ -22,7 +22,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     first_name: {
       label: 'First Name',
-      description: "The user's first name. If not hashed, Segment will normalize and hash this value.",
+      description: "The user's first name.",
       type: 'string',
       default: {
         '@if': {
@@ -35,7 +35,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     last_name: {
       label: 'Last Name',
-      description: "The user's last name. If not hashed, Segment will normalize and hash this value.",
+      description: "The user's last name.",
       type: 'string',
       default: {
         '@if': {
@@ -48,7 +48,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     email: {
       label: 'Email',
-      description: "The user's email address. If not hashed, Segment will normalize and hash this value.",
+      description: "The user's email address.",
       type: 'string',
       default: {
         '@if': {
@@ -61,8 +61,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     phone: {
       label: 'Phone',
-      description:
-        "The user's phone number. If not hashed, Segment will convert the phone number to the E.164 format and hash this value.",
+      description: "The user's phone number. ",
       type: 'string',
       default: {
         '@if': {

--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions/common_fields.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions/common_fields.ts
@@ -27,7 +27,7 @@ export const commonFields: Record<string, InputField> = {
   phone_numbers: {
     label: 'Phone Number',
     description:
-      'A single phone number or array of phone numbers in E.164 standard format. Segment will hash this value before sending to TikTok. At least one phone number value is required if both Email and External ID fields are empty.',
+      'A single phone number or array of phone numbers in E.164 standard format. At least one phone number value is required if both Email and External ID fields are empty.',
     type: 'string',
     multiple: true,
     default: {
@@ -42,7 +42,7 @@ export const commonFields: Record<string, InputField> = {
   email_addresses: {
     label: 'Email',
     description:
-      'A single email address or an array of email addresses. Segment will hash this value before sending to TikTok. At least one email value is required if both Phone Number and External ID fields are empty.',
+      'A single email address or an array of email addresses. At least one email value is required if both Phone Number and External ID fields are empty.',
     type: 'string',
     multiple: true,
     default: {
@@ -73,7 +73,7 @@ export const commonFields: Record<string, InputField> = {
   external_ids: {
     label: 'External ID',
     description:
-      'Uniquely identifies the user who triggered the conversion event. Segment will hash this value before sending to TikTok. TikTok Offline Conversions Destination supports both string and string[] types for sending external ID(s). At least one external ID value is required if both Email and Phone Number fields are empty.',
+      'Uniquely identifies the user who triggered the conversion event. TikTok Offline Conversions Destination supports both string and string[] types for sending external ID(s). At least one external ID value is required if both Email and Phone Number fields are empty.',
     type: 'string',
     multiple: true,
     default: {

--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions/reportOfflineEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions/reportOfflineEvent/generated-types.ts
@@ -14,11 +14,11 @@ export interface Payload {
    */
   timestamp?: string
   /**
-   * A single phone number or array of phone numbers in E.164 standard format. Segment will hash this value before sending to TikTok. At least one phone number value is required if both Email and External ID fields are empty.
+   * A single phone number or array of phone numbers in E.164 standard format. At least one phone number value is required if both Email and External ID fields are empty.
    */
   phone_numbers?: string[]
   /**
-   * A single email address or an array of email addresses. Segment will hash this value before sending to TikTok. At least one email value is required if both Phone Number and External ID fields are empty.
+   * A single email address or an array of email addresses. At least one email value is required if both Phone Number and External ID fields are empty.
    */
   email_addresses?: string[]
   /**
@@ -30,7 +30,7 @@ export interface Payload {
    */
   shop_id?: string
   /**
-   * Uniquely identifies the user who triggered the conversion event. Segment will hash this value before sending to TikTok. TikTok Offline Conversions Destination supports both string and string[] types for sending external ID(s). At least one external ID value is required if both Email and Phone Number fields are empty.
+   * Uniquely identifies the user who triggered the conversion event. TikTok Offline Conversions Destination supports both string and string[] types for sending external ID(s). At least one external ID value is required if both Email and Phone Number fields are empty.
    */
   external_ids?: string[]
   /**

--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions/trackNonPaymentOfflineConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions/trackNonPaymentOfflineConversion/generated-types.ts
@@ -14,11 +14,11 @@ export interface Payload {
    */
   timestamp?: string
   /**
-   * A single phone number or array of phone numbers in E.164 standard format. Segment will hash this value before sending to TikTok. At least one phone number value is required if both Email and External ID fields are empty.
+   * A single phone number or array of phone numbers in E.164 standard format. At least one phone number value is required if both Email and External ID fields are empty.
    */
   phone_numbers?: string[]
   /**
-   * A single email address or an array of email addresses. Segment will hash this value before sending to TikTok. At least one email value is required if both Phone Number and External ID fields are empty.
+   * A single email address or an array of email addresses. At least one email value is required if both Phone Number and External ID fields are empty.
    */
   email_addresses?: string[]
   /**
@@ -30,7 +30,7 @@ export interface Payload {
    */
   shop_id?: string
   /**
-   * Uniquely identifies the user who triggered the conversion event. Segment will hash this value before sending to TikTok. TikTok Offline Conversions Destination supports both string and string[] types for sending external ID(s). At least one external ID value is required if both Email and Phone Number fields are empty.
+   * Uniquely identifies the user who triggered the conversion event. TikTok Offline Conversions Destination supports both string and string[] types for sending external ID(s). At least one external ID value is required if both Email and Phone Number fields are empty.
    */
   external_ids?: string[]
   /**

--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions/trackPaymentOfflineConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions/trackPaymentOfflineConversion/generated-types.ts
@@ -14,11 +14,11 @@ export interface Payload {
    */
   timestamp?: string
   /**
-   * A single phone number or array of phone numbers in E.164 standard format. Segment will hash this value before sending to TikTok. At least one phone number value is required if both Email and External ID fields are empty.
+   * A single phone number or array of phone numbers in E.164 standard format. At least one phone number value is required if both Email and External ID fields are empty.
    */
   phone_numbers?: string[]
   /**
-   * A single email address or an array of email addresses. Segment will hash this value before sending to TikTok. At least one email value is required if both Phone Number and External ID fields are empty.
+   * A single email address or an array of email addresses. At least one email value is required if both Phone Number and External ID fields are empty.
    */
   email_addresses?: string[]
   /**
@@ -30,7 +30,7 @@ export interface Payload {
    */
   shop_id?: string
   /**
-   * Uniquely identifies the user who triggered the conversion event. Segment will hash this value before sending to TikTok. TikTok Offline Conversions Destination supports both string and string[] types for sending external ID(s). At least one external ID value is required if both Email and Phone Number fields are empty.
+   * Uniquely identifies the user who triggered the conversion event. TikTok Offline Conversions Destination supports both string and string[] types for sending external ID(s). At least one external ID value is required if both Email and Phone Number fields are empty.
    */
   external_ids?: string[]
   /**


### PR DESCRIPTION
This PR removes redundant hashing descriptions in 

- google enhanced conversions
- tiktok offline conversions
- amazon amc

## Testing

N/A - Only description changes

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
