### PR TITLE
[STRATCONN-5602] - Sendgrid EU endpoint

### DIFF
--- a/packages/destination-actions/src/destinations/sendgrid/generated-types.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/generated-types.ts
@@ -5,4 +5,8 @@ export interface Settings {
    * The Api key for your SendGrid account.
    */
   sendGridApiKey: string
+  /**
+   * The regional processing endpoint for your SendGrid account. [See more details](https://www.twilio.com/en-us/blog/send-emails-in-eu?_gl=1*7hyri9*_gcl_au*MTg0MTQwMjAzNi4xNzQzMDAyNzc4*_ga*MTk4OTI2MDk1LjE3NDMwMDI3Nzg.*_ga_8W5LR442LD*MTc0MzY3NTc2NC41LjAuMTc0MzY3NTc2NC4wLjAuMA..)
+   */
+  endpoint?: string
 }

--- a/packages/destination-actions/src/destinations/sendgrid/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/index.ts
@@ -1,5 +1,6 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
+import { GLOBAL_ENDPOINT, EU_ENDPOINT } from './sendgrid-properties'
 
 import updateUserProfile from './updateUserProfile'
 
@@ -19,13 +20,23 @@ const destination: DestinationDefinition<Settings> = {
         type: 'password',
         description: 'The Api key for your SendGrid account.',
         required: true
+      },
+      endpoint: {
+        label: 'Regional Processing Endpoint',
+        type: 'string',
+        description:
+          'The regional processing endpoint for your SendGrid account. [See more details](https://www.twilio.com/en-us/blog/send-emails-in-eu?_gl=1*7hyri9*_gcl_au*MTg0MTQwMjAzNi4xNzQzMDAyNzc4*_ga*MTk4OTI2MDk1LjE3NDMwMDI3Nzg.*_ga_8W5LR442LD*MTc0MzY3NTc2NC41LjAuMTc0MzY3NTc2NC4wLjAuMA..)',
+        required: false,
+        default: GLOBAL_ENDPOINT,
+        choices: [
+          { label: `Global (${GLOBAL_ENDPOINT})`, value: GLOBAL_ENDPOINT },
+          { label: `EU (${EU_ENDPOINT})`, value: EU_ENDPOINT }
+        ]
       }
     },
-    testAuthentication: (request) => {
-      // Return a request that tests/validates the user's credentials.
-      // If you do not have a way to validate the authentication fields safely,
-      // you can remove the `testAuthentication` function, though discouraged.
-      return request('https://api.sendgrid.com/v3/user/account')
+    testAuthentication: (request, { settings }) => {
+      const endpoint = settings?.endpoint || GLOBAL_ENDPOINT
+      return request(`${endpoint}/v3/user/account`)
     }
   },
 

--- a/packages/destination-actions/src/destinations/sendgrid/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/index.ts
@@ -27,6 +27,7 @@ const destination: DestinationDefinition<Settings> = {
         description:
           'The regional processing endpoint for your SendGrid account. [See more details](https://www.twilio.com/en-us/blog/send-emails-in-eu?_gl=1*7hyri9*_gcl_au*MTg0MTQwMjAzNi4xNzQzMDAyNzc4*_ga*MTk4OTI2MDk1LjE3NDMwMDI3Nzg.*_ga_8W5LR442LD*MTc0MzY3NTc2NC41LjAuMTc0MzY3NTc2NC4wLjAuMA..)',
         required: false,
+        format: 'uri',
         default: GLOBAL_ENDPOINT,
         choices: [
           { label: `Global (${GLOBAL_ENDPOINT})`, value: GLOBAL_ENDPOINT },

--- a/packages/destination-actions/src/destinations/sendgrid/sendEmail/__tests__/dynamic-fields.test.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/sendEmail/__tests__/dynamic-fields.test.ts
@@ -6,25 +6,26 @@ import Definition from '../../index'
 
 const testDestination = createTestIntegration(Definition)
 
+const settings = { sendGridApiKey: 'test-api-key' }
+const payload = {
+  template_id: 'd-test-template-id',
+  dynamic_template_data: { existingKey: 'value' },
+  from: {
+    name: 'John Doe',
+    email: 'john@doe.com'
+  },
+  to: {
+    name: 'John Doe',
+    email: 'john@doe.com'
+  }
+}
+
 describe('dynamicTemplateData', () => {
   function getMockURL(settings: { sendGridApiKey: string; endpoint?: string }) {
     const templateId = 'd-test-template-id'
     const templateContentUrl = getTemplateContentURL(settings, templateId)
     const { origin, pathname } = URL.parse(templateContentUrl) as URL
     return { origin, pathname }
-  }
-  const settings = { sendGridApiKey: 'test-api-key' }
-  const payload = {
-    template_id: 'd-test-template-id',
-    dynamic_template_data: { existingKey: 'value' },
-    from: {
-      name: 'John Doe',
-      email: 'john@doe.com'
-    },
-    to: {
-      name: 'John Doe',
-      email: 'john@doe.com'
-    }
   }
 
   afterEach(() => {
@@ -214,5 +215,615 @@ describe('dynamicTemplateData', () => {
       payload
     })) as DynamicFieldResponse
     expect(response.choices).toEqual([{ label: 'user', value: 'user' }])
+  })
+})
+describe('dynamicGroupId', () => {
+  const settings = { sendGridApiKey: 'test-api-key' }
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('should return group ids from the API', async () => {
+    nock('https://api.sendgrid.com')
+      .get('/v3/asm/groups')
+      .reply(200, [
+        {
+          id: '123',
+          name: 'Newsletter',
+          description: 'Monthly newsletter subscribers'
+        },
+        {
+          id: '456',
+          name: 'Marketing',
+          description: 'Marketing emails'
+        }
+      ])
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'group_id', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response.choices).toEqual([
+      { label: 'Newsletter [123]', value: 'Newsletter [123]' },
+      { label: 'Marketing [456]', value: 'Marketing [456]' }
+    ])
+  })
+
+  it('should return an empty list if no groups exist', async () => {
+    nock('https://api.sendgrid.com').get('/v3/asm/groups').reply(200, [])
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'group_id', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response.choices).toEqual([])
+  })
+
+  it('should handle HTTP errors gracefully', async () => {
+    nock('https://api.sendgrid.com')
+      .get('/v3/asm/groups')
+      .reply(500, {
+        errors: [{ message: 'Internal Server Error' }]
+      })
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'group_id', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response).toEqual({
+      choices: [],
+      error: {
+        message: 'Internal Server Error',
+        code: '500'
+      }
+    })
+  })
+
+  it('should handle authentication errors', async () => {
+    nock('https://api.sendgrid.com')
+      .get('/v3/asm/groups')
+      .reply(401, {
+        errors: [{ message: 'Invalid API key' }]
+      })
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'group_id', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response).toEqual({
+      choices: [],
+      error: {
+        message: 'Invalid API key',
+        code: '401'
+      }
+    })
+  })
+
+  it('should succeed with EU endpoint', async () => {
+    const settingsEU = { ...settings, endpoint: 'https://api.eu.sendgrid.com' }
+
+    nock('https://api.eu.sendgrid.com')
+      .get('/v3/asm/groups')
+      .reply(200, [
+        {
+          id: '123',
+          name: 'Newsletter',
+          description: 'Monthly newsletter subscribers'
+        }
+      ])
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'group_id', {
+      settings: settingsEU,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response.choices).toEqual([{ label: 'Newsletter [123]', value: 'Newsletter [123]' }])
+  })
+})
+
+describe('dynamicDomain', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('should return valid domains from the API', async () => {
+    nock('https://api.sendgrid.com')
+      .get('/v3/whitelabel/domains?limit=200')
+      .reply(200, [
+        {
+          id: '123',
+          domain: 'example.com',
+          subdomain: 'mail',
+          username: 'john',
+          valid: true
+        },
+        {
+          id: '456',
+          domain: 'mydomain.com',
+          subdomain: 'email',
+          username: 'jane',
+          valid: true
+        },
+        {
+          id: '789',
+          domain: 'invalid.com',
+          subdomain: 'mail',
+          username: 'admin',
+          valid: false
+        }
+      ])
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'domain', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response.choices).toEqual([
+      { label: 'example.com', value: 'example.com' },
+      { label: 'mydomain.com', value: 'mydomain.com' }
+    ])
+  })
+
+  it('should filter out invalid domains', async () => {
+    nock('https://api.sendgrid.com')
+      .get('/v3/whitelabel/domains?limit=200')
+      .reply(200, [
+        {
+          id: '123',
+          domain: 'valid.com',
+          username: 'john',
+          valid: true
+        },
+        {
+          id: '456',
+          domain: 'invalid.com',
+          username: 'jane',
+          valid: false
+        }
+      ])
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'domain', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response.choices).toEqual([{ label: 'valid.com', value: 'valid.com' }])
+  })
+
+  it('should return an empty list if no domains exist', async () => {
+    nock('https://api.sendgrid.com').get('/v3/whitelabel/domains?limit=200').reply(200, [])
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'domain', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response.choices).toEqual([])
+  })
+
+  it('should handle HTTP errors gracefully', async () => {
+    nock('https://api.sendgrid.com')
+      .get('/v3/whitelabel/domains')
+      .reply(500, {
+        errors: [{ message: 'Internal Server Error' }]
+      })
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'domain', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response).toEqual({
+      choices: [],
+      error: {
+        message: 'Unknown error: dynamicDomain',
+        code: '500'
+      }
+    })
+  })
+
+  it('should handle authentication errors', async () => {
+    nock('https://api.sendgrid.com')
+      .get('/v3/whitelabel/domains?limit=200')
+      .reply(401, {
+        errors: [{ message: 'Invalid API key' }]
+      })
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'domain', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response).toEqual({
+      choices: [],
+      error: {
+        message: 'Invalid API key',
+        code: '401'
+      }
+    })
+  })
+
+  it('should succeed with EU endpoint', async () => {
+    const settingsEU = { ...settings, endpoint: 'https://api.eu.sendgrid.com' }
+
+    nock('https://api.eu.sendgrid.com')
+      .get('/v3/whitelabel/domains?limit=200')
+      .reply(200, [
+        {
+          id: '123',
+          domain: 'eu-domain.com',
+          subdomain: 'mail',
+          username: 'john',
+          valid: true
+        }
+      ])
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'domain', {
+      settings: settingsEU,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response.choices).toEqual([{ label: 'eu-domain.com', value: 'eu-domain.com' }])
+  })
+})
+describe('dynamicTemplateId', () => {
+  const settings = { sendGridApiKey: 'test-api-key' }
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('should return template ids from the API', async () => {
+    nock('https://api.sendgrid.com')
+      .get('/v3/templates?generations=dynamic&page_size=200')
+      .reply(200, {
+        result: [
+          {
+            id: '123',
+            name: 'Welcome Email',
+            generation: 'dynamic',
+            versions: [
+              {
+                id: 'v1',
+                template_id: 'd-abc123',
+                active: 1,
+                name: 'Default Version',
+                subject: 'Welcome to our service'
+              }
+            ]
+          },
+          {
+            id: '456',
+            name: 'Monthly Newsletter',
+            generation: 'dynamic',
+            versions: [
+              {
+                id: 'v2',
+                template_id: 'd-def456',
+                active: 1,
+                name: 'April Edition',
+                subject: 'April Newsletter'
+              },
+              {
+                id: 'v3',
+                template_id: 'd-ghi789',
+                active: 0, // not active
+                name: 'May Edition',
+                subject: 'May Newsletter'
+              }
+            ]
+          }
+        ]
+      })
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'template_id', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response.choices).toEqual([
+      { label: 'Welcome Email - Default Version [d-abc123]', value: 'Welcome Email - Default Version [d-abc123]' },
+      { label: 'Monthly Newsletter - April Edition [d-def456]', value: 'Monthly Newsletter - April Edition [d-def456]' }
+    ])
+  })
+
+  it('should truncate long template and version names', async () => {
+    nock('https://api.sendgrid.com')
+      .get('/v3/templates?generations=dynamic&page_size=200')
+      .reply(200, {
+        result: [
+          {
+            id: '123',
+            name: 'This is a very long template name that should be truncated in the results',
+            generation: 'dynamic',
+            versions: [
+              {
+                id: 'v1',
+                template_id: 'd-abc123',
+                active: 1,
+                name: 'This is a very long version name that should also be truncated in the results',
+                subject: 'Welcome to our service'
+              }
+            ]
+          }
+        ]
+      })
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'template_id', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response.choices[0].label).toContain('...')
+    expect(response.choices[0].value).toContain('...')
+    expect(response.choices[0].label.length).toBeLessThan(
+      'This is a very long template name that should be truncated in the results'.length +
+        'This is a very long version name that should also be truncated in the results'.length
+    )
+  })
+
+  it('should filter out non-active versions', async () => {
+    nock('https://api.sendgrid.com')
+      .get('/v3/templates?generations=dynamic&page_size=200')
+      .reply(200, {
+        result: [
+          {
+            id: '123',
+            name: 'Welcome Email',
+            generation: 'dynamic',
+            versions: [
+              {
+                id: 'v1',
+                template_id: 'd-abc123',
+                active: 0, // not active
+                name: 'Default Version',
+                subject: 'Welcome to our service'
+              }
+            ]
+          }
+        ]
+      })
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'template_id', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response.choices).toEqual([])
+  })
+
+  it('should filter out non-dynamic templates', async () => {
+    nock('https://api.sendgrid.com')
+      .get('/v3/templates?generations=dynamic&page_size=200')
+      .reply(200, {
+        result: [
+          {
+            id: '123',
+            name: 'Legacy Template',
+            generation: 'legacy',
+            versions: [
+              {
+                id: 'v1',
+                template_id: 'd-abc123',
+                active: 1,
+                name: 'Default Version',
+                subject: 'Welcome to our service'
+              }
+            ]
+          }
+        ]
+      })
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'template_id', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response.choices).toEqual([])
+  })
+
+  it('should return an empty list if no templates exist', async () => {
+    nock('https://api.sendgrid.com').get('/v3/templates?generations=dynamic&page_size=200').reply(200, {
+      result: []
+    })
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'template_id', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response.choices).toEqual([])
+  })
+
+  it('should handle HTTP errors gracefully', async () => {
+    nock('https://api.sendgrid.com')
+      .get('/v3/templates?generations=dynamic&page_size=200')
+      .reply(500, {
+        errors: [{ message: 'Internal Server Error' }]
+      })
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'template_id', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response).toEqual({
+      choices: [],
+      error: {
+        message: 'Internal Server Error',
+        code: '500'
+      }
+    })
+  })
+
+  it('should handle authentication errors', async () => {
+    nock('https://api.sendgrid.com')
+      .get('/v3/templates?generations=dynamic&page_size=200')
+      .reply(401, {
+        errors: [{ message: 'Invalid API key' }]
+      })
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'template_id', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response).toEqual({
+      choices: [],
+      error: {
+        message: 'Invalid API key',
+        code: '401'
+      }
+    })
+  })
+
+  it('should succeed with EU endpoint', async () => {
+    const settingsEU = { ...settings, endpoint: 'https://api.eu.sendgrid.com' }
+
+    nock('https://api.eu.sendgrid.com')
+      .get('/v3/templates?generations=dynamic&page_size=200')
+      .reply(200, {
+        result: [
+          {
+            id: '123',
+            name: 'EU Template',
+            generation: 'dynamic',
+            versions: [
+              {
+                id: 'v1',
+                template_id: 'd-abc123',
+                active: 1,
+                name: 'EU Version',
+                subject: 'Welcome to our EU service'
+              }
+            ]
+          }
+        ]
+      })
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'template_id', {
+      settings: settingsEU,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response.choices).toEqual([
+      { label: 'EU Template - EU Version [d-abc123]', value: 'EU Template - EU Version [d-abc123]' }
+    ])
+  })
+})
+
+describe('dynamicIpPoolNames', () => {
+  const settings = { sendGridApiKey: 'test-api-key' }
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('should return IP pool names from the API', async () => {
+    nock('https://api.sendgrid.com')
+      .get('/v3/ips/pools')
+      .reply(200, [
+        {
+          name: 'Transactional',
+          id: 'trans123'
+        },
+        {
+          name: 'Marketing',
+          id: 'mark456'
+        },
+        {
+          name: 'Notifications',
+          id: 'notif789'
+        }
+      ])
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'ip_pool_name', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response.choices).toEqual([
+      { label: 'Transactional', value: 'Transactional' },
+      { label: 'Marketing', value: 'Marketing' },
+      { label: 'Notifications', value: 'Notifications' }
+    ])
+  })
+
+  it('should return an empty list if no IP pools exist', async () => {
+    nock('https://api.sendgrid.com').get('/v3/ips/pools').reply(200, [])
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'ip_pool_name', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response.choices).toEqual([])
+  })
+
+  it('should handle HTTP errors gracefully', async () => {
+    nock('https://api.sendgrid.com')
+      .get('/v3/ips/pools')
+      .reply(500, {
+        errors: [{ message: 'Internal Server Error' }]
+      })
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'ip_pool_name', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response).toEqual({
+      choices: [],
+      error: {
+        message: 'Internal Server Error',
+        code: '500'
+      }
+    })
+  })
+
+  it('should handle authentication errors', async () => {
+    nock('https://api.sendgrid.com')
+      .get('/v3/ips/pools')
+      .reply(401, {
+        errors: [{ message: 'Invalid API key' }]
+      })
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'ip_pool_name', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response).toEqual({
+      choices: [],
+      error: {
+        message: 'Invalid API key',
+        code: '401'
+      }
+    })
+  })
+
+  it('should succeed with EU endpoint', async () => {
+    const settingsEU = { ...settings, endpoint: 'https://api.eu.sendgrid.com' }
+
+    nock('https://api.eu.sendgrid.com')
+      .get('/v3/ips/pools')
+      .reply(200, [
+        {
+          name: 'EU Pool',
+          id: 'eu123'
+        }
+      ])
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'ip_pool_name', {
+      settings: settingsEU,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response.choices).toEqual([{ label: 'EU Pool', value: 'EU Pool' }])
   })
 })

--- a/packages/destination-actions/src/destinations/sendgrid/sendEmail/__tests__/dynamic-fields.test.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/sendEmail/__tests__/dynamic-fields.test.ts
@@ -1,0 +1,218 @@
+import nock from 'nock'
+import { getTemplateContentURL } from '../constants'
+import { URL } from 'node:url'
+import { createTestIntegration, DynamicFieldResponse } from '@segment/actions-core'
+import Definition from '../../index'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('dynamicTemplateData', () => {
+  function getMockURL(settings: { sendGridApiKey: string; endpoint?: string }) {
+    const templateId = 'd-test-template-id'
+    const templateContentUrl = getTemplateContentURL(settings, templateId)
+    const { origin, pathname } = URL.parse(templateContentUrl) as URL
+    return { origin, pathname }
+  }
+  const settings = { sendGridApiKey: 'test-api-key' }
+  const payload = {
+    template_id: 'd-test-template-id',
+    dynamic_template_data: { existingKey: 'value' },
+    from: {
+      name: 'John Doe',
+      email: 'john@doe.com'
+    },
+    to: {
+      name: 'John Doe',
+      email: 'john@doe.com'
+    }
+  }
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('should return dynamic fields from the template', async () => {
+    const templateId = 'd-test-template-id'
+    const templateContentUrl = getTemplateContentURL(settings, templateId)
+    const contentUrl = URL.parse(templateContentUrl) as URL
+    nock(contentUrl.origin)
+      .get(contentUrl.pathname)
+      .reply(200, {
+        generation: 'dynamic',
+        versions: [
+          {
+            active: 1,
+            html_content: '{{user.name}} {{user.email}}',
+            plain_content: '{{user.phone}}',
+            subject: '{{user.subject}}',
+            thumbnail_url: '{{user.thumbnail}}'
+          }
+        ]
+      })
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'dynamic_template_data.__keys__', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response.choices).toEqual([{ label: 'user', value: 'user' }])
+  })
+
+  it('should filter out already selected tokens', async () => {
+    const templateId = 'd-test-template-id'
+    const templateContentUrl = getTemplateContentURL(settings, templateId)
+    const { origin, pathname } = URL.parse(templateContentUrl) as URL
+
+    nock(origin)
+      .get(pathname)
+      .reply(200, {
+        generation: 'dynamic',
+        versions: [
+          {
+            active: 1,
+            html_content: '{{user}} {{user}}',
+            plain_content: '{{anotherUser}}'
+          }
+        ]
+      })
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'dynamic_template_data.__keys__', {
+      settings,
+      payload: {
+        ...payload,
+        dynamic_template_data: {
+          user: {
+            name: 'John Doe'
+          }
+        }
+      }
+    })) as DynamicFieldResponse
+
+    expect(response.choices).toEqual([{ label: 'anotherUser', value: 'anotherUser' }])
+  })
+
+  it('should return an error if template_id is missing', async () => {
+    const response = (await testDestination.testDynamicField('sendEmail', 'dynamic_template_data.__keys__', {
+      settings,
+      payload: {
+        ...payload,
+        template_id: ''
+      }
+    })) as DynamicFieldResponse
+
+    expect(response).toEqual({
+      choices: [],
+      error: {
+        message: 'Template ID Field required before Dynamic Template Data fields can be configured',
+        code: '404'
+      }
+    })
+  })
+
+  it('should return an error if template is not dynamic', async () => {
+    const templateId = 'd-test-template-id'
+    const templateContentUrl = getTemplateContentURL(settings, templateId)
+    const { origin, pathname } = URL.parse(templateContentUrl) as URL
+    nock(origin).get(pathname).reply(200, {
+      generation: 'legacy',
+      versions: []
+    })
+
+    const response = await testDestination.testDynamicField('sendEmail', 'dynamic_template_data.__keys__', {
+      settings,
+      payload
+    })
+
+    expect(response).toEqual({
+      choices: [],
+      error: { message: 'Template ID provided is not a dynamic template', code: '404' }
+    })
+  })
+
+  it('should return an error if no active version is found', async () => {
+    const { origin, pathname } = getMockURL(settings)
+
+    nock(origin).get(pathname).reply(200, {
+      generation: 'dynamic',
+      versions: []
+    })
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'dynamic_template_data.__keys__', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response).toEqual({
+      choices: [],
+      error: { message: 'No active version found for the provided template', code: '404' }
+    })
+  })
+
+  it('should return an error if template content is empty', async () => {
+    const { origin, pathname } = getMockURL(settings)
+    nock(origin)
+      .get(pathname)
+      .reply(200, {
+        generation: 'dynamic',
+        versions: [
+          {
+            active: 1,
+            html_content: '',
+            plain_content: '',
+            subject: '',
+            thumbnail_url: ''
+          }
+        ]
+      })
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'dynamic_template_data.__keys__', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response).toEqual({
+      choices: [],
+      error: { message: 'Returned template has no content', code: '404' }
+    })
+  })
+
+  it('should handle HTTP errors gracefully', async () => {
+    const { origin, pathname } = getMockURL(settings)
+
+    nock(origin).get(pathname).reply(500, { error: 'Internal Server Error' })
+
+    const response = (await testDestination.testDynamicField('sendEmail', 'dynamic_template_data.__keys__', {
+      settings,
+      payload
+    })) as DynamicFieldResponse
+
+    expect(response).toEqual({
+      choices: [],
+      error: { message: 'Unknown error: dynamicTemplateData', code: '404' }
+    })
+  })
+
+  it('should succeed with EU endpoint', async () => {
+    const settingsEU = { ...settings, endpoint: 'https://api.eu.sendgrid.com' }
+    const { origin, pathname } = getMockURL(settingsEU)
+    nock(origin)
+      .get(pathname)
+      .reply(200, {
+        generation: 'dynamic',
+        versions: [
+          {
+            active: 1,
+            html_content: '{{user.name}} {{user.email}}',
+            plain_content: '{{user.phone}}',
+            subject: '{{user.subject}}',
+            thumbnail_url: '{{user.thumbnail}}'
+          }
+        ]
+      })
+    const response = (await testDestination.testDynamicField('sendEmail', 'dynamic_template_data.__keys__', {
+      settings: { ...settings, endpoint: 'https://api.eu.sendgrid.com' },
+      payload
+    })) as DynamicFieldResponse
+    expect(response.choices).toEqual([{ label: 'user', value: 'user' }])
+  })
+})

--- a/packages/destination-actions/src/destinations/sendgrid/sendEmail/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/sendEmail/__tests__/index.test.ts
@@ -4,6 +4,7 @@ import Definition from '../../index'
 import { Settings } from '../../generated-types'
 import { RESERVED_HEADERS } from '../constants'
 import { parseTemplateId, parseIntFromString, toUnixTS } from '../utils'
+import { EU_ENDPOINT } from '../../sendgrid-properties'
 
 let testDestination = createTestIntegration(Definition)
 
@@ -172,6 +173,24 @@ describe('Sendgrid.sendEmail', () => {
     expect(responses[0].status).toBe(200)
   })
 
+  it('should send an email using EU endpoint', async () => {
+    const event = createTestEvent(validPayload)
+    const settings = {
+      sendGridApiKey: 'test-api-key',
+      endpoint: EU_ENDPOINT
+    }
+    // send email via Sendgrid
+    nock(EU_ENDPOINT).post('/v3/mail/send', expectedSendgridPayload).reply(200, {})
+    const responses = await testDestination.testAction('sendEmail', {
+      event,
+      settings,
+      useDefaultMappings: true,
+      mapping
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+  })
+
   it('parse template ID correctly', async () => {
     expect(parseTemplateId('DynamicTemplate1 - Version 2 [d-b8d15722e5144a809c5b0e]')).toBe('d-b8d15722e5144a809c5b0e')
     expect(parseTemplateId('d-b8d15722e5144a809c5b0e Some Other Text')).toBe('d-b8d15722e5144a809c5b0e')
@@ -183,7 +202,6 @@ describe('Sendgrid.sendEmail', () => {
     expect(parseIntFromString('123456787654')).toBe(123456787654)
     expect(parseIntFromString('')).toBe(undefined)
   })
-
 
   it('send_at date should be 10 char epoch', async () => {
     const date = '2024-01-08T13:52:50.212Z'

--- a/packages/destination-actions/src/destinations/sendgrid/sendEmail/constants.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/sendEmail/constants.ts
@@ -50,5 +50,5 @@ export const getGroupIDsURL = (settings: Settings) => {
 }
 export const getTemplateContentURL = (settings: Settings, templateId: string) => {
   const regionalEndpoint = getRegionalEndpoint(settings)
-  return `${regionalEndpoint}/v3/templates/${templateId}/versions`
+  return `${regionalEndpoint}/v3/templates/${templateId}`
 }

--- a/packages/destination-actions/src/destinations/sendgrid/sendEmail/constants.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/sendEmail/constants.ts
@@ -1,3 +1,6 @@
+import { Settings } from '../generated-types'
+import { getRegionalEndpoint } from '../sendgrid-properties'
+
 export const RESERVED_HEADERS = [
   'x-sg-id',
   'x-sg-eid',
@@ -19,16 +22,33 @@ export const MIN_IP_POOL_NAME_LENGTH = 2
 
 export const MAX_IP_POOL_NAME_LENGTH = 64
 
-export const SEND_EMAIL_URL = 'https://api.sendgrid.com/v3/mail/send'
+export const sendEmailURL = (settings: Settings) => {
+  const regionalEndpoint = getRegionalEndpoint(settings)
+  return `${regionalEndpoint}/v3/mail/send`
+}
 
-export const GET_TEMPLATES_URL = 'https://api.sendgrid.com/v3/templates?generations=dynamic&page_size=200'
+export const getTemplatesURL = (settings: Settings) => {
+  const regionalEndpoint = getRegionalEndpoint(settings)
+  return `${regionalEndpoint}/v3/templates?generations=dynamic&page_size=200`
+}
 
 export const TRUNCATE_CHAR_LENGTH = 25
 
-export const GET_IP_POOLS_URL = 'https://api.sendgrid.com/v3/ips/pools'
+export const getIPPoolsURL = (settings: Settings) => {
+  const regionalEndpoint = getRegionalEndpoint(settings)
+  return `${regionalEndpoint}/v3/ips/pools`
+}
 
-export const GET_VALID_DOMAINS_URL = 'https://api.sendgrid.com/v3/whitelabel/domains?limit=200'
+export const getValidDomainsURL = (settings: Settings) => {
+  const regionalEndpoint = getRegionalEndpoint(settings)
+  return `${regionalEndpoint}/v3/whitelabel/domains?limit=200`
+}
 
-export const GET_GROUP_IDS_URL = 'https://api.sendgrid.com/v3/asm/groups'
-
-export const GET_TEMPLATE_CONTENT_URL = 'https://api.sendgrid.com/v3/templates/'
+export const getGroupIDsURL = (settings: Settings) => {
+  const regionalEndpoint = getRegionalEndpoint(settings)
+  return `${regionalEndpoint}/v3/asm/groups`
+}
+export const getTemplateContentURL = (settings: Settings, templateId: string) => {
+  const regionalEndpoint = getRegionalEndpoint(settings)
+  return `${regionalEndpoint}/v3/templates/${templateId}/versions`
+}

--- a/packages/destination-actions/src/destinations/sendgrid/sendEmail/dynamic-fields.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/sendEmail/dynamic-fields.ts
@@ -159,7 +159,7 @@ export async function dynamicTemplateData(
     }
   } catch (err) {
     const error = err as ResultError
-    return createErrorResponse(error.data.error ?? 'Unknown error: dynamicTemplateData')
+    return createErrorResponse(error?.data?.error ?? 'Unknown error: dynamicTemplateData')
   }
 }
 

--- a/packages/destination-actions/src/destinations/sendgrid/sendEmail/dynamic-fields.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/sendEmail/dynamic-fields.ts
@@ -2,14 +2,15 @@ import { RequestClient } from '@segment/actions-core'
 import { DynamicFieldResponse } from '@segment/actions-core'
 import { Payload } from './generated-types'
 import {
-  GET_TEMPLATES_URL,
+  getTemplatesURL,
   TRUNCATE_CHAR_LENGTH,
-  GET_IP_POOLS_URL,
-  GET_VALID_DOMAINS_URL,
-  GET_GROUP_IDS_URL,
-  GET_TEMPLATE_CONTENT_URL
+  getIPPoolsURL,
+  getValidDomainsURL,
+  getGroupIDsURL,
+  getTemplateContentURL
 } from './constants'
 import { parseTemplateId } from './utils'
+import type { Settings } from '../generated-types'
 
 interface ResultError {
   response: {
@@ -45,20 +46,15 @@ export function extractVariables(content: string | undefined): string[] {
   const removeIfStartsWith = ['if', 'unless', 'and', 'or', 'equals', 'notEquals', 'lessThan', 'greaterThan', 'each']
   const removeIfMatch = ['else', 'if', 'this', 'insert', 'default', 'length', 'formatDate']
 
-  const regex1 = /{{(.*?)}}/g   // matches handlebar expressions. e.g. {{root.user.username | default: "Unknown"}}
+  const regex1 = /{{(.*?)}}/g // matches handlebar expressions. e.g. {{root.user.username | default: "Unknown"}}
   const regex2 = /(["']).*?\1/g // removes anything between quotes. e.g. {{root.user.username | default: }}
   const regex3 = /[#/]?[\w.]+/g // matches words only. e.g. root.user.username , default
 
-  const words = [
-    ...new Set(
-      [...content.matchAll(regex1)].map(match => match[1])
-    )
-  ]
-  .map(word => 
-    word.replace(regex2, '').trim()
-  )
-  .join(' ')
-  .match(regex3) ?? []
+  const words =
+    [...new Set([...content.matchAll(regex1)].map((match) => match[1]))]
+      .map((word) => word.replace(regex2, '').trim())
+      .join(' ')
+      .match(regex3) ?? []
 
   const variables = [
     ...new Set(
@@ -75,7 +71,11 @@ export function extractVariables(content: string | undefined): string[] {
   return variables
 }
 
-export async function dynamicTemplateData(request: RequestClient, payload: Payload): Promise<DynamicFieldResponse> {
+export async function dynamicTemplateData(
+  request: RequestClient,
+  payload: Payload,
+  settings: Settings
+): Promise<DynamicFieldResponse> {
   interface ResultItem {
     id: string
     template_id: string
@@ -112,7 +112,7 @@ export async function dynamicTemplateData(request: RequestClient, payload: Paylo
   }
 
   try {
-    const response: ResponseType = await request(`${GET_TEMPLATE_CONTENT_URL}${templateId}`, {
+    const response: ResponseType = await request(getTemplateContentURL(settings, templateId), {
       method: 'GET',
       skipResponseCloning: true
     })
@@ -163,7 +163,7 @@ export async function dynamicTemplateData(request: RequestClient, payload: Paylo
   }
 }
 
-export async function dynamicGroupId(request: RequestClient): Promise<DynamicFieldResponse> {
+export async function dynamicGroupId(request: RequestClient, settings: Settings): Promise<DynamicFieldResponse> {
   interface ResultItem {
     id: string
     name: string
@@ -175,7 +175,7 @@ export async function dynamicGroupId(request: RequestClient): Promise<DynamicFie
   }
 
   try {
-    const response: ResponseType = await request(GET_GROUP_IDS_URL, {
+    const response: ResponseType = await request(getGroupIDsURL(settings), {
       method: 'GET',
       skipResponseCloning: true
     })
@@ -198,7 +198,7 @@ export async function dynamicGroupId(request: RequestClient): Promise<DynamicFie
   }
 }
 
-export async function dynamicDomain(request: RequestClient): Promise<DynamicFieldResponse> {
+export async function dynamicDomain(request: RequestClient, settings: Settings): Promise<DynamicFieldResponse> {
   interface ResultItem {
     id: string
     subdomain?: string
@@ -212,7 +212,7 @@ export async function dynamicDomain(request: RequestClient): Promise<DynamicFiel
   }
 
   try {
-    const response: ResponseType = await request(GET_VALID_DOMAINS_URL, {
+    const response: ResponseType = await request(getValidDomainsURL(settings), {
       method: 'GET',
       skipResponseCloning: true
     })
@@ -237,7 +237,7 @@ export async function dynamicDomain(request: RequestClient): Promise<DynamicFiel
   }
 }
 
-export async function dynamicTemplateId(request: RequestClient): Promise<DynamicFieldResponse> {
+export async function dynamicTemplateId(request: RequestClient, settings: Settings): Promise<DynamicFieldResponse> {
   interface ResultItem {
     id: string
     name: string
@@ -260,7 +260,7 @@ export async function dynamicTemplateId(request: RequestClient): Promise<Dynamic
   }
 
   try {
-    const response: ResponseType = await request(GET_TEMPLATES_URL, {
+    const response: ResponseType = await request(getTemplatesURL(settings), {
       method: 'GET',
       skipResponseCloning: true
     })
@@ -299,7 +299,7 @@ export async function dynamicTemplateId(request: RequestClient): Promise<Dynamic
   }
 }
 
-export async function dynamicIpPoolNames(request: RequestClient): Promise<DynamicFieldResponse> {
+export async function dynamicIpPoolNames(request: RequestClient, settings: Settings): Promise<DynamicFieldResponse> {
   interface ResponseType {
     data: ResultItem[]
   }
@@ -309,7 +309,7 @@ export async function dynamicIpPoolNames(request: RequestClient): Promise<Dynami
   }
 
   try {
-    const response: ResponseType = await request(GET_IP_POOLS_URL, {
+    const response: ResponseType = await request(getIPPoolsURL(settings), {
       method: 'GET',
       skipResponseCloning: true
     })

--- a/packages/destination-actions/src/destinations/sendgrid/sendEmail/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/sendEmail/index.ts
@@ -16,26 +16,26 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Send email to recipient(s) using a Dynamic Template in Sendgrid',
   fields,
   dynamicFields: {
-    template_id: async (request) => {
-      return await dynamicTemplateId(request)
+    template_id: async (request, { settings }) => {
+      return await dynamicTemplateId(request, settings)
     },
-    ip_pool_name: async (request) => {
-      return await dynamicIpPoolNames(request)
+    ip_pool_name: async (request, { settings }) => {
+      return await dynamicIpPoolNames(request, settings)
     },
     dynamic_template_data: {
-      __keys__: async (request, { payload }) => {
-        return await dynamicTemplateData(request, payload)
+      __keys__: async (request, { payload, settings }) => {
+        return await dynamicTemplateData(request, payload, settings)
       }
     },
-    domain: async (request) => {
-      return await dynamicDomain(request)
+    domain: async (request, { settings }) => {
+      return await dynamicDomain(request, settings)
     },
-    group_id: async (request) => {
-      return await dynamicGroupId(request)
+    group_id: async (request, { settings }) => {
+      return await dynamicGroupId(request, settings)
     }
   },
-  perform: async (request, { payload }) => {
-    return await send(request, payload)
+  perform: async (request, { payload, settings }) => {
+    return await send(request, payload, settings)
   }
 }
 

--- a/packages/destination-actions/src/destinations/sendgrid/sendgrid-properties.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/sendgrid-properties.ts
@@ -1,5 +1,6 @@
 import { InputField, RequestClient, IntegrationError } from '@segment/actions-core'
 import { Payload } from './updateUserProfile/generated-types'
+import { Settings } from './generated-types'
 
 export const customFields: InputField = {
   label: 'Other Fields',
@@ -25,10 +26,18 @@ interface APIData {
   custom_fields?: CustomField[]
 }
 
+export const GLOBAL_ENDPOINT = 'https://api.sendgrid.com'
+export const EU_ENDPOINT = 'https://api.eu.sendgrid.com'
+
+export function getRegionalEndpoint(settings: Settings) {
+  return settings?.endpoint || GLOBAL_ENDPOINT
+}
+
 // Fetch all custom field definitions for the account using the Sendgrid API
 // https://docs.sendgrid.com/api-reference/custom-fields/get-all-field-definitions
-export const fetchAccountCustomFields = async (request: RequestClient): Promise<CustomField[]> => {
-  const response = await request('https://api.sendgrid.com/v3/marketing/field_definitions')
+export const fetchAccountCustomFields = async (request: RequestClient, settings: Settings): Promise<CustomField[]> => {
+  const regionalEndpoint = getRegionalEndpoint(settings)
+  const response = await request(`${regionalEndpoint}/v3/marketing/field_definitions`)
   const data: APIData = response.data as APIData
   const customFields: CustomField[] = data.custom_fields as CustomField[]
 

--- a/packages/destination-actions/src/destinations/sendgrid/sendgrid-properties.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/sendgrid-properties.ts
@@ -30,7 +30,7 @@ export const GLOBAL_ENDPOINT = 'https://api.sendgrid.com'
 export const EU_ENDPOINT = 'https://api.eu.sendgrid.com'
 
 export function getRegionalEndpoint(settings: Settings) {
-  return settings?.endpoint || GLOBAL_ENDPOINT
+  return settings?.endpoint ?? GLOBAL_ENDPOINT
 }
 
 // Fetch all custom field definitions for the account using the Sendgrid API

--- a/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid/updateUserProfile/index.ts
@@ -1,7 +1,13 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { customFields, convertPayload, fetchAccountCustomFields, CustomField } from '../sendgrid-properties'
+import {
+  customFields,
+  convertPayload,
+  fetchAccountCustomFields,
+  CustomField,
+  getRegionalEndpoint
+} from '../sendgrid-properties'
 import { IntegrationError } from '@segment/actions-core'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -238,14 +244,15 @@ const action: ActionDefinition<Settings, Payload> = {
   },
 
   perform: async (request, data) => {
-    const accountCustomFields: CustomField[] = await fetchAccountCustomFields(request)
+    const accountCustomFields: CustomField[] = await fetchAccountCustomFields(request, data.settings)
 
     // Convert input payload into SendGrid Marketing Campaigns compatible request payload
     const formattedData = { contacts: [convertPayload(data.payload, accountCustomFields)] }
 
+    const regionalEndpoint = getRegionalEndpoint(data.settings)
     // Making contacts upsert call here
     // Reference: https://docs.sendgrid.com/api-reference/contacts/add-or-update-a-contact
-    return request('https://api.sendgrid.com/v3/marketing/contacts', {
+    return request(`${regionalEndpoint}/v3/marketing/contacts`, {
       method: 'put',
       json: formattedData
     })
@@ -257,10 +264,12 @@ const action: ActionDefinition<Settings, Payload> = {
       throw new IntegrationError('No record to send', 'No data', 400)
     }
 
-    const accountCustomFields: CustomField[] = await fetchAccountCustomFields(request)
+    const accountCustomFields: CustomField[] = await fetchAccountCustomFields(request, data.settings)
 
     const formattedData = { contacts: data.payload.map((p) => convertPayload(p, accountCustomFields)) }
-    return request('https://api.sendgrid.com/v3/marketing/contacts', {
+    const regionalEndpoint = getRegionalEndpoint(data.settings)
+
+    return request(`${regionalEndpoint}/v3/marketing/contacts`, {
       method: 'put',
       json: formattedData
     })


### PR DESCRIPTION
This PR adds support for Sendgrid EU endpoint

## Testing

[Test Doc ](https://docs.google.com/document/d/1HPqydJMvnTBSyodddfCelg8910VWqWcV0BlTstWlq4E/edit?usp=sharing)

Tested all endpoints that I was able to setup and validate

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
