### PR TITLE
[LAB-1803] Correct Presets for Linked Audience Activations

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/index.ts
@@ -157,15 +157,15 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   presets: [
     {
       name: 'Entities Audience Entered',
-      partnerAction: 'upsertProfile',
-      mapping: defaultValues(upsertProfile.fields),
+      partnerAction: 'addProfileToList',
+      mapping: defaultValues(addProfileToList.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_entered_track'
     },
     {
       name: 'Entities Audience Exited',
-      partnerAction: 'removeProfile',
-      mapping: defaultValues(removeProfile.fields),
+      partnerAction: 'removeProfileFromList',
+      mapping: defaultValues(removeProfileFromList.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_exited_track'
     }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

We picked the wrong presets, these are the right ones.

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
