### PR TITLE
[STRATCONN-5683] Amazon AMC - Increased timeout to 15 seconds

### DIFF
--- a/packages/destination-actions/src/destinations/amazon-amc/function.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/function.ts
@@ -22,7 +22,8 @@ export async function processPayload(
     body: payloadString,
     headers: {
       'Content-Type': 'application/vnd.amcaudiences.v1+json'
-    }
+    },
+    timeout: 15000
   })
 
   const result = response.data
@@ -155,7 +156,8 @@ export async function processBatchPayload(
     throwHttpErrors: false,
     headers: {
       'Content-Type': 'application/vnd.amcaudiences.v1+json'
-    }
+    },
+    timeout: 15000
   })
   if (!response.ok && response.status == 401) {
     throw new InvalidAuthenticationError(response.statusText)

--- a/packages/destination-actions/src/destinations/amazon-amc/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/index.ts
@@ -48,7 +48,8 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json'
-          }
+          },
+          timeout: 15000
         })
       } catch (e: any) {
         const error = e as AmazonTestAuthenticationError
@@ -208,7 +209,8 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         body: payloadString,
         headers: {
           'Content-Type': 'application/vnd.amcaudiences.v1+json'
-        }
+        },
+        timeout: 15000
       })
 
       const res = await response.text()
@@ -228,7 +230,8 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         throw new IntegrationError('Missing audienceId value', 'MISSING_REQUIRED_FIELD', 400)
       }
       const response = await request(`${endpoint}/amc/audiences/metadata/${audience_id}`, {
-        method: 'GET'
+        method: 'GET',
+        timeout: 15000
       })
       const res = await response.text()
       // Regular expression to find a audienceId number and replace the audienceId with quoted string

--- a/packages/destination-actions/src/destinations/amazon-amc/utils.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/utils.ts
@@ -74,7 +74,8 @@ export const getAuthToken = async (request: RequestClient, settings: Settings, a
       headers: {
         // Amazon ads refresh token API throws error with authorization header so explicity overriding Authorization header here.
         authorization: ''
-      }
+      },
+      timeout: 15000
     })
     return data.access_token
   } catch (e: any) {


### PR DESCRIPTION
This PR increases HTTP Client's timeout to 15 seconds for Amazon AMC.

## Testing

Testing not required as this is just a timeout change in the request client.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
