### PR TITLE
Handles non-http error in SFMC multistatus handler

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/_tests_/multistatus.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/_tests_/multistatus.test.ts
@@ -579,7 +579,18 @@ describe('Multistatus', () => {
     const response = await testDestination.executeBatch('contactDataExtension', {
       events,
       settings,
-      mapping
+      mapping,
+      statsContext: {
+        statsClient: {
+          incr: jest.fn(),
+          histogram: jest.fn(),
+          set: jest.fn(),
+          _tags: jest.fn(),
+          observe: jest.fn(),
+          _name: jest.fn()
+        },
+        tags: []
+      }
     })
 
     expect(response[0]).toMatchObject({

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/_tests_/multistatus.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/_tests_/multistatus.test.ts
@@ -576,7 +576,7 @@ describe('Multistatus', () => {
       })
     ]
 
-    const response = await testDestination.executeBatch('contactDataExtension', {
+    const response = await testDestination.executeBatch('dataExtension', {
       events,
       settings,
       mapping,

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtension/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/dataExtension/index.ts
@@ -18,8 +18,8 @@ const action: ActionDefinition<Settings, Payload> = {
   perform: async (request, { settings, payload }) => {
     return upsertRows(request, settings.subdomain, [payload])
   },
-  performBatch: async (request, { settings, payload }) => {
-    return executeUpsertWithMultiStatus(request, settings.subdomain, payload)
+  performBatch: async (request, { settings, payload, statsContext }) => {
+    return executeUpsertWithMultiStatus(request, settings.subdomain, payload, undefined, statsContext)
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
@@ -143,7 +143,7 @@ export async function executeUpsertWithMultiStatus(
 
     payloads.forEach((_, index) => {
       multiStatusResponse.setErrorResponseAtIndex(index, {
-        status: err?.response?.status || 400,
+        status: err?.response?.status || 500,
         errormessage: additionalError ? additionalError[0].message : errData?.message || '',
         sent: rows[index] as Object as JSONLikeObject,
         /*

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
@@ -7,7 +7,8 @@ import {
   ActionHookResponse,
   DynamicFieldResponse,
   DynamicFieldError,
-  DynamicFieldItem
+  DynamicFieldItem,
+  StatsContext
 } from '@segment/actions-core'
 import { Payload as payload_dataExtension } from './dataExtension/generated-types'
 import { Payload as payload_contactDataExtension } from './contactDataExtension/generated-types'
@@ -79,7 +80,8 @@ export async function executeUpsertWithMultiStatus(
   request: RequestClient,
   subdomain: String,
   payloads: payload_dataExtension[] | payload_contactDataExtension[],
-  dataExtensionId?: string
+  dataExtensionId?: string,
+  statsContext?: StatsContext
 ): Promise<MultiStatusResponse> {
   const multiStatusResponse = new MultiStatusResponse()
   let response: ModifiedResponse | undefined
@@ -112,6 +114,22 @@ export async function executeUpsertWithMultiStatus(
       })
       return multiStatusResponse
     }
+
+    // If the errors is not a http resposne error, we treat it as a generic error
+    if (!(error as ErrorResponse).response?.data) {
+      if (statsContext) {
+        const { tags, statsClient } = statsContext
+        statsClient?.incr('sfmc_upsert_rows_error', 1, [...tags])
+      }
+      payloads.forEach((_, index) => {
+        multiStatusResponse.setErrorResponseAtIndex(index, {
+          status: 500,
+          errormessage: error.message
+        })
+      })
+      return multiStatusResponse
+    }
+
     const err = error as ErrorResponse
     if (err?.response?.status === 401) {
       throw error


### PR DESCRIPTION
This PR handles non-http error in SFMC multistatus handler.

More context on why this fix is required - [here](https://twilio.slack.com/archives/CPZ7X5NDB/p1743459886291389)

It is difficult to reproduce this issue and hence stage testing is difficult to do for this specific scenario.

Tested for other scenarios in staging.


[Test doc
](https://docs.google.com/document/d/1KfpmCSyjsDIN67boxKO0J5ULJQM5ILOOYCPuPCxm4Q8/edit?tab=t.0)

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
