### PR TITLE
[Recombee] Add internalAdditionalData field to actions

### DIFF
--- a/packages/destination-actions/src/destinations/recombee/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/recombee/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -15,6 +15,7 @@ Object {
 
 exports[`Testing snapshot for actions-recombee destination: addBookmark action - required fields 1`] = `
 Object {
+  "additionalData": Object {},
   "cascadeCreate": true,
   "itemId": "7(iq3vwM",
   "userId": "7(iq3vwM",
@@ -38,6 +39,7 @@ Object {
 
 exports[`Testing snapshot for actions-recombee destination: addCartAddition action - required fields 1`] = `
 Object {
+  "additionalData": Object {},
   "cascadeCreate": true,
   "itemId": "fSK%!$(3gz2peZ!&@L@D",
   "userId": "fSK%!$(3gz2peZ!&@L@D",
@@ -60,6 +62,7 @@ Object {
 
 exports[`Testing snapshot for actions-recombee destination: addDetailView action - required fields 1`] = `
 Object {
+  "additionalData": Object {},
   "cascadeCreate": true,
   "itemId": "VhiOfa#s6#B[CQDV",
   "userId": "VhiOfa#s6#B[CQDV",
@@ -96,6 +99,7 @@ Object {
     Object {
       "method": "POST",
       "params": Object {
+        "additionalData": Object {},
         "cascadeCreate": true,
         "itemId": "!D2A1H%v%jv&r",
         "userId": "!D2A1H%v%jv&r",
@@ -122,6 +126,7 @@ Object {
 
 exports[`Testing snapshot for actions-recombee destination: addRating action - required fields 1`] = `
 Object {
+  "additionalData": Object {},
   "cascadeCreate": true,
   "itemId": "X9m9Urlsqof(&*PN!s",
   "rating": 63040185947914.24,
@@ -180,6 +185,7 @@ Object {
 
 exports[`Testing snapshot for actions-recombee destination: setViewPortion action - required fields 1`] = `
 Object {
+  "additionalData": Object {},
   "cascadeCreate": true,
   "itemId": "D9^z[P*Zv",
   "portion": -42971588743659.52,
@@ -204,6 +210,7 @@ Object {
 
 exports[`Testing snapshot for actions-recombee destination: setViewPortionFromWatchTime action - required fields 1`] = `
 Object {
+  "additionalData": Object {},
   "cascadeCreate": true,
   "itemId": "gpLV6!FLD#$6^LR77nTN",
   "portion": 1,

--- a/packages/destination-actions/src/destinations/recombee/addBookmark/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/recombee/addBookmark/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -15,6 +15,7 @@ Object {
 
 exports[`Testing snapshot for Recombee's addBookmark destination action: required fields 1`] = `
 Object {
+  "additionalData": Object {},
   "cascadeCreate": true,
   "itemId": "GxFzk&V2a4R8iF62G9]q",
   "userId": "GxFzk&V2a4R8iF62G9]q",

--- a/packages/destination-actions/src/destinations/recombee/addBookmark/generated-types.ts
+++ b/packages/destination-actions/src/destinations/recombee/addBookmark/generated-types.ts
@@ -18,6 +18,12 @@ export interface Payload {
    */
   recommId?: string
   /**
+   * Internal additional data to be stored with the bookmark.
+   */
+  internalAdditionalData?: {
+    [k: string]: unknown
+  }
+  /**
    * Additional data to be stored with the bookmark. *Keep this field empty unless instructed by the Recombee Support team.*
    */
   additionalData?: {

--- a/packages/destination-actions/src/destinations/recombee/addBookmark/index.ts
+++ b/packages/destination-actions/src/destinations/recombee/addBookmark/index.ts
@@ -46,12 +46,25 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: async (request, data) => {
     const client = new RecombeeApiClient(data.settings, request)
-    await client.send(new AddBookmark(data.payload))
+    await client.send(payloadToBookmark(data.payload))
   },
   performBatch: async (request, data) => {
     const client = new RecombeeApiClient(data.settings, request)
-    await client.send(new Batch(data.payload.map((payload) => new AddBookmark(payload))))
+    await client.send(new Batch(data.payload.map((payload) => payloadToBookmark(payload))))
   }
+}
+
+function payloadToBookmark(payload: Payload): AddBookmark {
+  return new AddBookmark({
+    userId: payload.userId,
+    itemId: payload.itemId,
+    timestamp: payload.timestamp,
+    recommId: payload.recommId,
+    additionalData: {
+      ...(payload.internalAdditionalData ?? {}),
+      ...(payload.additionalData ?? {})
+    }
+  })
 }
 
 export default action

--- a/packages/destination-actions/src/destinations/recombee/addCartAddition/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/recombee/addCartAddition/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -17,6 +17,7 @@ Object {
 
 exports[`Testing snapshot for Recombee's addCartAddition destination action: required fields 1`] = `
 Object {
+  "additionalData": Object {},
   "cascadeCreate": true,
   "itemId": "E$o]!yX^hLQ^46#)",
   "userId": "E$o]!yX^hLQ^46#)",

--- a/packages/destination-actions/src/destinations/recombee/addCartAddition/generated-types.ts
+++ b/packages/destination-actions/src/destinations/recombee/addCartAddition/generated-types.ts
@@ -31,6 +31,12 @@ export interface Payload {
    */
   recommId?: string
   /**
+   * Internal additional data to be stored with the cart addition.
+   */
+  internalAdditionalData?: {
+    [k: string]: unknown
+  }
+  /**
    * Additional data to be stored with the cart addition. *Keep this field empty unless instructed by the Recombee Support team.*
    */
   additionalData?: {

--- a/packages/destination-actions/src/destinations/recombee/addCartAddition/index.ts
+++ b/packages/destination-actions/src/destinations/recombee/addCartAddition/index.ts
@@ -72,21 +72,24 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: async (request, data) => {
     const client = new RecombeeApiClient(data.settings, request)
-    await client.send(payloadToInteraction(data.payload))
+    await client.send(payloadToCartAddition(data.payload))
   },
   performBatch: async (request, data) => {
     const client = new RecombeeApiClient(data.settings, request)
-    await client.send(new Batch(data.payload.map(payloadToInteraction)))
+    await client.send(new Batch(data.payload.map(payloadToCartAddition)))
   }
 }
 
-function payloadToInteraction(payload: Payload): AddCartAddition {
+function payloadToCartAddition(payload: Payload): AddCartAddition {
   return new AddCartAddition({
     userId: payload.userId,
     ...payload.item,
     timestamp: payload.timestamp,
     recommId: payload.recommId,
-    additionalData: payload.additionalData
+    additionalData: {
+      ...(payload.internalAdditionalData ?? {}),
+      ...(payload.additionalData ?? {})
+    }
   })
 }
 

--- a/packages/destination-actions/src/destinations/recombee/addDetailView/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/recombee/addDetailView/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -16,6 +16,7 @@ Object {
 
 exports[`Testing snapshot for Recombee's addDetailView destination action: required fields 1`] = `
 Object {
+  "additionalData": Object {},
   "cascadeCreate": true,
   "itemId": "nW8&[lpB",
   "userId": "nW8&[lpB",

--- a/packages/destination-actions/src/destinations/recombee/addDetailView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/recombee/addDetailView/generated-types.ts
@@ -22,6 +22,12 @@ export interface Payload {
    */
   recommId?: string
   /**
+   * Internal additional data to be stored with the view.
+   */
+  internalAdditionalData?: {
+    [k: string]: unknown
+  }
+  /**
    * Additional data to be stored with the view. *Keep this field empty unless instructed by the Recombee Support team.*
    */
   additionalData?: {

--- a/packages/destination-actions/src/destinations/recombee/addDetailView/index.ts
+++ b/packages/destination-actions/src/destinations/recombee/addDetailView/index.ts
@@ -51,12 +51,26 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: async (request, data) => {
     const client = new RecombeeApiClient(data.settings, request)
-    await client.send(new AddDetailView(data.payload))
+    await client.send(payloadToDetailView(data.payload))
   },
   performBatch: async (request, data) => {
     const client = new RecombeeApiClient(data.settings, request)
-    await client.send(new Batch(data.payload.map((payload) => new AddDetailView(payload))))
+    await client.send(new Batch(data.payload.map((payload) => payloadToDetailView(payload))))
   }
+}
+
+function payloadToDetailView(payload: Payload): AddDetailView {
+  return new AddDetailView({
+    userId: payload.userId,
+    itemId: payload.itemId,
+    timestamp: payload.timestamp,
+    duration: payload.duration,
+    recommId: payload.recommId,
+    additionalData: {
+      ...(payload.internalAdditionalData ?? {}),
+      ...(payload.additionalData ?? {})
+    }
+  })
 }
 
 export default action

--- a/packages/destination-actions/src/destinations/recombee/addPurchase/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/recombee/addPurchase/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -30,6 +30,7 @@ Object {
     Object {
       "method": "POST",
       "params": Object {
+        "additionalData": Object {},
         "cascadeCreate": true,
         "itemId": "o@fME^0ckHa[VN6e&Zv*",
         "userId": "o@fME^0ckHa[VN6e&Zv*",

--- a/packages/destination-actions/src/destinations/recombee/addPurchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/recombee/addPurchase/generated-types.ts
@@ -35,6 +35,12 @@ export interface Payload {
    */
   recommId?: string
   /**
+   * Internal additional data to be stored with the purchase.
+   */
+  internalAdditionalData?: {
+    [k: string]: unknown
+  }
+  /**
    * Additional data to be stored with the purchase. *Keep this field empty unless instructed by the Recombee Support team.*
    */
   additionalData?: {

--- a/packages/destination-actions/src/destinations/recombee/addPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/recombee/addPurchase/index.ts
@@ -92,15 +92,15 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: async (request, data) => {
     const client = new RecombeeApiClient(data.settings, request)
-    await client.send(new Batch(payloadToInteractions(data.payload)))
+    await client.send(new Batch(payloadToPurchases(data.payload)))
   },
   performBatch: async (request, data) => {
     const client = new RecombeeApiClient(data.settings, request)
-    await client.send(new Batch(data.payload.flatMap(payloadToInteractions)))
+    await client.send(new Batch(data.payload.flatMap(payloadToPurchases)))
   }
 }
 
-function payloadToInteractions(payload: Payload): AddPurchase[] {
+function payloadToPurchases(payload: Payload): AddPurchase[] {
   return payload.items.map(
     (item) =>
       new AddPurchase({
@@ -108,7 +108,10 @@ function payloadToInteractions(payload: Payload): AddPurchase[] {
         ...item,
         timestamp: payload.timestamp,
         recommId: payload.recommId,
-        additionalData: payload.additionalData
+        additionalData: {
+          ...(payload.internalAdditionalData ?? {}),
+          ...(payload.additionalData ?? {})
+        }
       })
   )
 }

--- a/packages/destination-actions/src/destinations/recombee/addRating/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/recombee/addRating/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -16,6 +16,7 @@ Object {
 
 exports[`Testing snapshot for Recombee's addRating destination action: required fields 1`] = `
 Object {
+  "additionalData": Object {},
   "cascadeCreate": true,
   "itemId": "ANsNPl1sV!#5(%#",
   "rating": 29019912231976.96,

--- a/packages/destination-actions/src/destinations/recombee/addRating/generated-types.ts
+++ b/packages/destination-actions/src/destinations/recombee/addRating/generated-types.ts
@@ -22,6 +22,12 @@ export interface Payload {
    */
   recommId?: string
   /**
+   * Internal additional data to be stored with the rating.
+   */
+  internalAdditionalData?: {
+    [k: string]: unknown
+  }
+  /**
    * Additional data to be stored with the rating. *Keep this field empty unless instructed by the Recombee Support team.*
    */
   additionalData?: {

--- a/packages/destination-actions/src/destinations/recombee/addRating/index.ts
+++ b/packages/destination-actions/src/destinations/recombee/addRating/index.ts
@@ -53,12 +53,26 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: async (request, data) => {
     const client = new RecombeeApiClient(data.settings, request)
-    await client.send(new AddRating(data.payload))
+    await client.send(payloadToRating(data.payload))
   },
   performBatch: async (request, data) => {
     const client = new RecombeeApiClient(data.settings, request)
-    await client.send(new Batch(data.payload.map((payload) => new AddRating(payload))))
+    await client.send(new Batch(data.payload.map((payload) => payloadToRating(payload))))
   }
+}
+
+function payloadToRating(payload: Payload): AddRating {
+  return new AddRating({
+    userId: payload.userId,
+    itemId: payload.itemId,
+    rating: payload.rating,
+    timestamp: payload.timestamp,
+    recommId: payload.recommId,
+    additionalData: {
+      ...(payload.internalAdditionalData ?? {}),
+      ...(payload.additionalData ?? {})
+    }
+  })
 }
 
 export default action

--- a/packages/destination-actions/src/destinations/recombee/commonFields.ts
+++ b/packages/destination-actions/src/destinations/recombee/commonFields.ts
@@ -11,12 +11,32 @@ export function interactionFields(interactionName: string): Record<string, Input
         '@path': '$.properties.recomm_id'
       }
     },
+    internalAdditionalData: {
+      label: 'Internal Additional Data',
+      description: `Internal additional data to be stored with the ${interactionName}.`,
+      type: 'object',
+      defaultObjectUI: 'keyvalue:only',
+      unsafe_hidden: true,
+      default: {
+        segmentEventType: {
+          '@path': '$.type'
+        },
+        segmentEventName: {
+          '@if': {
+            exists: { '@path': '$.event' },
+            then: { '@path': '$.event' },
+            else: { '@path': '$.name' }
+          }
+        }
+      }
+    },
     additionalData: {
       label: 'Additional Data',
       description: `Additional data to be stored with the ${interactionName}. *Keep this field empty unless instructed by the Recombee Support team.*`,
       type: 'object',
       required: false,
-      displayMode: 'collapsed'
+      displayMode: 'collapsed',
+      defaultObjectUI: 'keyvalue:only'
     }
   }
 }

--- a/packages/destination-actions/src/destinations/recombee/setViewPortion/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/recombee/setViewPortion/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -17,6 +17,7 @@ Object {
 
 exports[`Testing snapshot for Recombee's setViewPortion destination action: required fields 1`] = `
 Object {
+  "additionalData": Object {},
   "cascadeCreate": true,
   "itemId": "Np8pbQ",
   "portion": -70298178955509.76,

--- a/packages/destination-actions/src/destinations/recombee/setViewPortion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/recombee/setViewPortion/generated-types.ts
@@ -26,6 +26,12 @@ export interface Payload {
    */
   recommId?: string
   /**
+   * Internal additional data to be stored with the view portion.
+   */
+  internalAdditionalData?: {
+    [k: string]: unknown
+  }
+  /**
    * Additional data to be stored with the view portion. *Keep this field empty unless instructed by the Recombee Support team.*
    */
   additionalData?: {

--- a/packages/destination-actions/src/destinations/recombee/setViewPortion/index.ts
+++ b/packages/destination-actions/src/destinations/recombee/setViewPortion/index.ts
@@ -61,12 +61,27 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: async (request, data) => {
     const client = new RecombeeApiClient(data.settings, request)
-    await client.send(new SetViewPortion(data.payload))
+    await client.send(payloadToViewPortion(data.payload))
   },
   performBatch: async (request, data) => {
     const client = new RecombeeApiClient(data.settings, request)
-    await client.send(new Batch(data.payload.map((event) => new SetViewPortion(event))))
+    await client.send(new Batch(data.payload.map((event) => payloadToViewPortion(event))))
   }
+}
+
+function payloadToViewPortion(payload: Payload): SetViewPortion {
+  return new SetViewPortion({
+    userId: payload.userId,
+    itemId: payload.itemId,
+    portion: payload.portion,
+    sessionId: payload.sessionId,
+    timestamp: payload.timestamp,
+    recommId: payload.recommId,
+    additionalData: {
+      ...(payload.internalAdditionalData ?? {}),
+      ...(payload.additionalData ?? {})
+    }
+  })
 }
 
 export default action

--- a/packages/destination-actions/src/destinations/recombee/setViewPortionFromWatchTime/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/recombee/setViewPortionFromWatchTime/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -17,6 +17,7 @@ Object {
 
 exports[`Testing snapshot for Recombee's setViewPortionFromWatchTime destination action: required fields 1`] = `
 Object {
+  "additionalData": Object {},
   "cascadeCreate": true,
   "itemId": "FcP0tLN]UE",
   "portion": 1,

--- a/packages/destination-actions/src/destinations/recombee/setViewPortionFromWatchTime/generated-types.ts
+++ b/packages/destination-actions/src/destinations/recombee/setViewPortionFromWatchTime/generated-types.ts
@@ -35,6 +35,12 @@ export interface Payload {
    */
   recommId?: string
   /**
+   * Internal additional data to be stored with the view portion.
+   */
+  internalAdditionalData?: {
+    [k: string]: unknown
+  }
+  /**
    * Additional data to be stored with the view portion. *Keep this field empty unless instructed by the Recombee Support team.*
    */
   additionalData?: {

--- a/packages/destination-actions/src/destinations/recombee/setViewPortionFromWatchTime/index.ts
+++ b/packages/destination-actions/src/destinations/recombee/setViewPortionFromWatchTime/index.ts
@@ -95,7 +95,10 @@ function payloadToViewPortion(payload: Payload): SetViewPortion {
     timestamp: payload.timestamp,
     portion: payload.portion.watchTime / payload.portion.totalLength,
     sessionId: payload.sessionId,
-    additionalData: payload.additionalData,
+    additionalData: {
+      ...(payload.internalAdditionalData ?? {}),
+      ...(payload.additionalData ?? {})
+    },
     recommId: payload.recommId
   })
 }


### PR DESCRIPTION
This PR adds a new field, `internalAdditionalData`, to all applicable actions within the Recombee destination.

The goal is for us to be able to track the types of events that are sent using our destination, and being able to use this data in our analytics, as well as assist our customers with any issues they may be having.

We set this new field up with `unsafe_hidden` set to `true`, as end users should never be able to modify the values within this field. If this parameter doesn't prevent the user from changing the values within this object, or if there's a better way to obtain `$.type` and `$.event` within actions, please let us know.

Additionally, the original `additionalData` field (that should be present to all users) has had its `defaultObjectUI` set to `keyvalue:only`, as we want to discourage users from setting the value of this field to be an entire object.

## Testing

These changes were tested end-to-end to ensure the event data is sent in all applicable actions, and unit test snapshots were modified to account for the above-mentioned changes.

The new field is not required, meaning this is not a breaking change.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
