### PR TITLE
[Smart Hashing] Add Eslint rule to restrict usage of crypto module

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,6 +84,19 @@ module.exports = {
       rules: {
         '@typescript-eslint/no-unsafe-call': 'off'
       }
+    },
+    {
+      files: ['packages/destination-actions/**/*.ts'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            name: 'crypto',
+            message:
+              'Avoid importing "crypto" module directly. Use "destination-actions/lib/hashing-utils" for hashing PII instead.'
+          }
+        ]
+      }
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/criteo-audiences/criteo-audiences.ts
+++ b/packages/destination-actions/src/destinations/criteo-audiences/criteo-audiences.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { createHash } from 'crypto'
 import { IntegrationError, RetryableError } from '@segment/actions-core'
 import type { RequestClient } from '@segment/actions-core'

--- a/packages/destination-actions/src/destinations/emarsys/emarsys-helper.ts
+++ b/packages/destination-actions/src/destinations/emarsys/emarsys-helper.ts
@@ -1,6 +1,7 @@
 import type { Settings } from './generated-types'
 import type { RequestClient } from '@segment/actions-core'
 import { DynamicFieldResponse } from '@segment/actions-core'
+// eslint-disable-next-line no-restricted-imports
 import { randomBytes, createHash } from 'crypto'
 
 export const API_HOST = 'https://api.emarsys.net'

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/previewApiLookup/apiLookups.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/previewApiLookup/apiLookups.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { createHash } from 'crypto'
 import { IntegrationError } from '@segment/actions-core'
 import { InputField } from '@segment/actions-core'

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'crypto'
 import {
   ConversionCustomVariable,
   PartialErrorResponse,
@@ -79,16 +78,6 @@ export function formatCustomVariables(
   })
 
   return variables
-}
-
-export const hash = (value: string | undefined): string | undefined => {
-  if (value === undefined) {
-    return
-  }
-
-  const hash = createHash('sha256')
-  hash.update(value)
-  return hash.digest('hex')
 }
 
 export async function getCustomVariables(

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/formatter.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/formatter.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { createHash } from 'crypto'
 
 /**

--- a/packages/destination-actions/src/destinations/nextdoor-capi/sendConversion/utils.ts
+++ b/packages/destination-actions/src/destinations/nextdoor-capi/sendConversion/utils.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { createHash } from 'crypto'
 
 export function hashAndEncode(value: string) {

--- a/packages/destination-actions/src/destinations/recombee/addBookmark/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/addBookmark/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 import { Settings } from '../../generated-types'
+// eslint-disable-next-line no-restricted-imports
 import { randomUUID } from 'crypto'
 
 const testDestination = createTestIntegration(Destination)

--- a/packages/destination-actions/src/destinations/recombee/addCartAddition/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/addCartAddition/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 import { Settings } from '../../generated-types'
+// eslint-disable-next-line no-restricted-imports
 import { randomUUID } from 'crypto'
 
 const testDestination = createTestIntegration(Destination)

--- a/packages/destination-actions/src/destinations/recombee/addDetailView/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/addDetailView/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 import { Settings } from '../../generated-types'
+// eslint-disable-next-line no-restricted-imports
 import { randomUUID } from 'crypto'
 
 const testDestination = createTestIntegration(Destination)

--- a/packages/destination-actions/src/destinations/recombee/addPurchase/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/addPurchase/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 import { Settings } from '../../generated-types'
+// eslint-disable-next-line no-restricted-imports
 import { randomUUID } from 'crypto'
 
 const testDestination = createTestIntegration(Destination)

--- a/packages/destination-actions/src/destinations/recombee/addRating/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/addRating/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 import { Settings } from '../../generated-types'
+// eslint-disable-next-line no-restricted-imports
 import { randomUUID } from 'crypto'
 
 const testDestination = createTestIntegration(Destination)

--- a/packages/destination-actions/src/destinations/recombee/recombeeApiClient.ts
+++ b/packages/destination-actions/src/destinations/recombee/recombeeApiClient.ts
@@ -1,5 +1,6 @@
 import { InvalidAuthenticationError, RequestClient } from '@segment/actions-core'
 import { Settings } from './generated-types'
+// eslint-disable-next-line no-restricted-imports
 import { createHmac } from 'crypto'
 
 enum DatabaseRegion {

--- a/packages/destination-actions/src/destinations/recombee/setViewPortion/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/setViewPortion/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 import { Settings } from '../../generated-types'
+// eslint-disable-next-line no-restricted-imports
 import { randomUUID } from 'crypto'
 
 const testDestination = createTestIntegration(Destination)

--- a/packages/destination-actions/src/destinations/recombee/setViewPortionFromWatchTime/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/recombee/setViewPortionFromWatchTime/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 import { Settings } from '../../generated-types'
+// eslint-disable-next-line no-restricted-imports
 import { randomUUID } from 'crypto'
 
 const testDestination = createTestIntegration(Destination)

--- a/packages/destination-actions/src/destinations/reddit-audiences/syncAudience/functions.ts
+++ b/packages/destination-actions/src/destinations/reddit-audiences/syncAudience/functions.ts
@@ -2,6 +2,7 @@ import { PayloadValidationError, RequestClient } from '@segment/actions-core'
 import { Payload } from '../syncAudience/generated-types'
 import { UpdateAudienceReq, Columns } from '../types'
 import { EMAIL_SCHEMA_NAME, MAID_SCHEMA_NAME } from '../const'
+// eslint-disable-next-line no-restricted-imports
 import { createHash } from 'crypto'
 
 export async function send(request: RequestClient, payloads: Payload[]) {

--- a/packages/destination-actions/src/destinations/singlestore/index.ts
+++ b/packages/destination-actions/src/destinations/singlestore/index.ts
@@ -3,6 +3,7 @@ import { Settings } from './generated-types'
 import { SingleStoreCreateJSON } from './types'
 import { createUrl } from './const'
 import send from './send'
+// eslint-disable-next-line no-restricted-imports
 import { createHash } from 'crypto'
 import { encryptText, destinationId, checkChamber } from './util'
 

--- a/packages/destination-actions/src/destinations/singlestore/util.ts
+++ b/packages/destination-actions/src/destinations/singlestore/util.ts
@@ -1,7 +1,9 @@
+// eslint-disable-next-line no-restricted-imports
 import * as crypto from 'crypto'
 import { CLIENT_ID, STAGE_BROKERS, PROD_BROKERS } from './const'
 import { IntegrationError } from '@segment/actions-core'
 import { Settings } from './generated-types'
+// eslint-disable-next-line no-restricted-imports
 import { createHash } from 'crypto'
 import { KafkaConfig, ProducerRecord } from 'kafkajs'
 

--- a/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/utils.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/utils.ts
@@ -1,4 +1,5 @@
 import { Features, IntegrationError } from '@segment/actions-core'
+// eslint-disable-next-line no-restricted-imports
 import { createHash } from 'crypto'
 import { processHashing } from '../../../lib/hashing-utils'
 

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/functions.ts
@@ -1,4 +1,5 @@
 import { APIError, createRequestClient, DynamicFieldResponse } from '@segment/actions-core'
+// eslint-disable-next-line no-restricted-imports
 import { createHash } from 'crypto'
 
 interface Advertiser {

--- a/packages/destination-actions/src/destinations/taboola-actions/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/syncAudience/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration, IntegrationError } from '@segment/actions-core'
 import Destination from '../../index'
+// eslint-disable-next-line no-restricted-imports
 import { createHash } from 'crypto'
 
 const testDestination = createTestIntegration(Destination)

--- a/packages/destination-actions/src/destinations/taboola-actions/syncAudience/client.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/syncAudience/client.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { createHash } from 'crypto'
 import type { ModifiedResponse } from '@segment/actions-core'
 import { RequestClient, IntegrationError } from '@segment/actions-core'

--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/functions.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/functions.ts
@@ -1,6 +1,7 @@
 import { RequestClient, ModifiedResponse, PayloadValidationError } from '@segment/actions-core'
 import { Settings } from './generated-types'
 import { Payload } from './syncAudience/generated-types'
+// eslint-disable-next-line no-restricted-imports
 import { createHash } from 'crypto'
 import { IntegrationError } from '@segment/actions-core'
 

--- a/packages/destination-actions/src/destinations/tiktok-conversions-sandbox/formatter.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions-sandbox/formatter.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { createHash } from 'crypto'
 
 /**

--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions-sandbox/formatter.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions-sandbox/formatter.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { createHash } from 'crypto'
 
 /**

--- a/packages/destination-actions/src/destinations/vwo/utility.ts
+++ b/packages/destination-actions/src/destinations/vwo/utility.ts
@@ -1,4 +1,5 @@
 import type { commonPayload, vwoPayload } from './types'
+// eslint-disable-next-line no-restricted-imports
 import * as crypto from 'crypto'
 
 const VWO_NAMESPACE = '11e13cd7-6c48-53ec-8679-7e9c752273c5'

--- a/packages/destination-actions/src/destinations/webhook-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/webhook-audiences/index.ts
@@ -3,6 +3,7 @@ import type { Settings, AudienceSettings } from './generated-types'
 
 import send from '../webhook/send'
 import { defaultValues, IntegrationError } from '@segment/actions-core'
+// eslint-disable-next-line no-restricted-imports
 import { createHmac } from 'crypto'
 import { Payload } from './send.types'
 const externalIdKey = 'externalId'

--- a/packages/destination-actions/src/destinations/webhook/__test__/webhook.test.ts
+++ b/packages/destination-actions/src/destinations/webhook/__test__/webhook.test.ts
@@ -6,6 +6,7 @@ import {
   DestinationDefinition
 } from '@segment/actions-core'
 import Webhook from '../index'
+// eslint-disable-next-line no-restricted-imports
 import { createHmac, timingSafeEqual } from 'crypto'
 import { SegmentEvent } from '@segment/actions-core'
 

--- a/packages/destination-actions/src/destinations/webhook/index.ts
+++ b/packages/destination-actions/src/destinations/webhook/index.ts
@@ -1,5 +1,6 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
+// eslint-disable-next-line no-restricted-imports
 import { createHmac } from 'crypto'
 
 import send from './send'

--- a/packages/destination-actions/src/destinations/yahoo-audiences/utils-rt.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/utils-rt.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { createHmac } from 'crypto'
 import { Payload } from './updateSegment/generated-types'
 import { YahooPayload } from './types'

--- a/packages/destination-actions/src/destinations/yahoo-audiences/utils-tax.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/utils-tax.ts
@@ -1,4 +1,5 @@
 import type { Settings } from './generated-types'
+// eslint-disable-next-line no-restricted-imports
 import { createHmac } from 'crypto'
 import { CredsObj, YahooSubTaxonomy } from './types'
 import { RequestClient, IntegrationError } from '@segment/actions-core'

--- a/packages/destination-actions/src/lib/hashing-utils.ts
+++ b/packages/destination-actions/src/lib/hashing-utils.ts
@@ -2,6 +2,7 @@
  * Utility module for hashing values using various encryption methods and digest types.
  * It includes functionality to check if a value is already hashed and to process hashing with optional cleaning.
  */
+// eslint-disable-next-line no-restricted-imports
 import * as crypto from 'crypto'
 import { Features } from '@segment/actions-core'
 


### PR DESCRIPTION
This PR adds a Es lint rule that restricts the usage of `crypto` module, to encourage the usage of Smart hashing moduel for hashing.

For other usage of Crypto module, Eslint disable is added. 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
