### PR TITLE
support for multi-status response

### DIFF
--- a/packages/destination-actions/src/destinations/amazon-eventbridge/functionsv2.ts
+++ b/packages/destination-actions/src/destinations/amazon-eventbridge/functionsv2.ts
@@ -1,0 +1,103 @@
+import { Payload } from './send/generated-types'
+import { Settings } from './generated-types'
+import { IntegrationError, MultiStatusResponse } from '@segment/actions-core'
+import {
+  EventBridgeClient,
+  PutPartnerEventsCommand,
+  CreatePartnerEventSourceCommand,
+  ListPartnerEventSourcesCommand,
+  PutPartnerEventsCommandOutput
+} from '@aws-sdk/client-eventbridge'
+
+export async function send(payloads: Payload[], settings: Settings): Promise<MultiStatusResponse> {
+  return await process_data(payloads, settings)
+}
+
+async function process_data(events: Payload[], settings: Settings): Promise<MultiStatusResponse> {
+  const client = new EventBridgeClient({ region: settings.awsRegion })
+  const awsAccountId = settings.awsAccountId
+
+  // Ensure the Partner Event Source exists before sending events
+  await ensurePartnerSourceExists(
+    client,
+    awsAccountId,
+    events[0].sourceId,
+    settings.createPartnerEventSource || false,
+    settings.partnerEventSourceName
+  )
+
+  const ebPayload = {
+    Entries: events.map((event) => ({
+      EventBusName: event.sourceId,
+      Source: `${settings.partnerEventSourceName}/${event.sourceId}`,
+      DetailType: String(event.detailType),
+      Detail: JSON.stringify(event.data),
+      Resources: event.resources ? [event.resources] : []
+    }))
+  }
+
+  const command = new PutPartnerEventsCommand(ebPayload)
+  const response: PutPartnerEventsCommandOutput = await client.send(command)
+
+  const entries = response.Entries ?? []
+  // Initialize MultiStatusResponse
+  const multiStatusResponse = new MultiStatusResponse()
+  events.forEach((event, index) => {
+    const entry = entries[index] ?? {}
+    if (entry.ErrorCode || entry.ErrorMessage) {
+      multiStatusResponse.setErrorResponseAtIndex(index, {
+        status: 400,
+        errormessage: entry.ErrorMessage ?? 'Unknown Error',
+        sent: JSON.stringify(event),
+        body: JSON.stringify(entry)
+      })
+    } else {
+      multiStatusResponse.setSuccessResponseAtIndex(index, {
+        status: 200,
+        body: 'Event sent successfully',
+        sent: JSON.stringify(event)
+      })
+    }
+  })
+  return multiStatusResponse
+}
+
+async function ensurePartnerSourceExists(
+  client: EventBridgeClient,
+  awsAccountId: string | undefined,
+  sourceId: unknown,
+  createPartnerEventSource: boolean,
+  partnerEventSourceName: string | undefined
+) {
+  const namePrefix = `${partnerEventSourceName}/${sourceId}`
+
+  const listCommand = new ListPartnerEventSourcesCommand({ NamePrefix: namePrefix })
+  const listResponse = await client.send(listCommand)
+
+  if (listResponse?.PartnerEventSources && listResponse.PartnerEventSources.length > 0) {
+    return true
+  }
+
+  if (createPartnerEventSource) {
+    await create_partner_source(client, awsAccountId, namePrefix)
+  } else {
+    throw new IntegrationError(
+      `Partner Event Source ${namePrefix} does not exist.`,
+      'PARTNER_EVENT_SOURCE_NOT_FOUND',
+      400
+    )
+  }
+}
+
+async function create_partner_source(
+  client: EventBridgeClient,
+  aws_account_id: string | undefined,
+  partnerEventSourceName: string
+) {
+  const command = new CreatePartnerEventSourceCommand({
+    Account: aws_account_id,
+    Name: partnerEventSourceName
+  })
+  const response = await client.send(command)
+  return response
+}

--- a/packages/destination-actions/src/destinations/amazon-eventbridge/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-eventbridge/index.ts
@@ -4,6 +4,8 @@ import { DEFAULT_REQUEST_TIMEOUT } from '@segment/actions-core'
 
 import send from './send'
 
+import sendV2 from './sendV2'
+
 const destination: DestinationDefinition<Settings> = {
   name: 'Amazon Eventbridge',
   slug: 'actions-amazon-eventbridge',
@@ -76,7 +78,8 @@ const destination: DestinationDefinition<Settings> = {
     }
   },
   actions: {
-    send
+    send,
+    sendV2
   }
 }
 

--- a/packages/destination-actions/src/destinations/amazon-eventbridge/send/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-eventbridge/send/__tests__/index.test.ts
@@ -1,4 +1,5 @@
 import { send } from '../../functions' // Adjust path as needed
+
 import {
   PutPartnerEventsCommand,
   ListPartnerEventSourcesCommand,

--- a/packages/destination-actions/src/destinations/amazon-eventbridge/send/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-eventbridge/send/index.ts
@@ -2,6 +2,7 @@ import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { send } from '../functions'
+import { send as sendV2 } from '../functionsv2'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send',
@@ -84,7 +85,10 @@ const action: ActionDefinition<Settings, Payload> = {
     return send([payload], settings)
   },
   performBatch: (_, data) => {
-    const { payload, settings } = data
+    const { payload, settings, features } = data
+    if (features?.['amazon-eventbridge-v2']) {
+      return sendV2(payload, settings)
+    }
     return send(payload, settings)
   }
 }

--- a/packages/destination-actions/src/destinations/amazon-eventbridge/sendV2/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-eventbridge/sendV2/__tests__/index.test.ts
@@ -1,0 +1,328 @@
+import { send } from '../../functionsv2' // Adjust path as needed
+import {
+  PutPartnerEventsCommand,
+  ListPartnerEventSourcesCommand,
+  CreatePartnerEventSourceCommand
+} from '@aws-sdk/client-eventbridge'
+import { Payload } from '../../send/generated-types'
+import { Settings } from '../../generated-types'
+
+// Mock AWS SDK
+jest.mock('@aws-sdk/client-eventbridge', () => {
+  const mockSend = jest.fn()
+  return {
+    EventBridgeClient: jest.fn(() => ({
+      send: mockSend
+    })),
+    PutPartnerEventsCommand: jest.fn(),
+    ListPartnerEventSourcesCommand: jest.fn(),
+    CreatePartnerEventSourceCommand: jest.fn(),
+    mockSend
+  }
+})
+
+const { mockSend } = jest.requireMock('@aws-sdk/client-eventbridge')
+
+describe('AWS EventBridge Integration', () => {
+  const settings: Settings = {
+    awsRegion: 'us-west-2',
+    awsAccountId: '123456789012',
+    createPartnerEventSource: true,
+    partnerEventSourceName: 'your-partner-event-source-name'
+  }
+
+  afterEach(() => {
+    jest.clearAllMocks()
+    jest.restoreAllMocks()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('send should call process_data with correct parameters', async () => {
+    const payloads: Payload[] = [
+      {
+        sourceId: 'test-source',
+        detailType: 'UserSignup',
+        data: { user: '123', event: 'signed_up' },
+        resources: 'test-resource',
+        enable_batching: true
+      }
+    ]
+
+    // Mocking the listPartnerEventSources response to simulate source existence check
+    mockSend.mockResolvedValueOnce({
+      PartnerEventSources: [{ Name: `${settings.partnerEventSourceName}/test-source` }]
+    })
+
+    // Mocking a successful PutPartnerEventsCommand response
+    mockSend.mockResolvedValueOnce({
+      FailedEntryCount: 0,
+      Entries: [{ EventId: '12345' }]
+    })
+
+    await send(payloads, settings)
+
+    expect(mockSend).toHaveBeenCalledWith(expect.any(ListPartnerEventSourcesCommand))
+    expect(mockSend).toHaveBeenCalledWith(expect.any(PutPartnerEventsCommand))
+    expect(mockSend).toHaveBeenCalledTimes(2)
+  })
+
+  test('send should throw an error if FailedEntryCount > 0', async () => {
+    const payloads: Payload[] = [
+      {
+        sourceId: 'test-source',
+        detailType: 'UserSignup',
+        data: { user: '123', event: 'signed_up' },
+        resources: 'test-resource',
+        enable_batching: true
+      }
+    ]
+
+    mockSend.mockResolvedValueOnce({
+      PartnerEventSources: [{ Name: `${settings.partnerEventSourceName}/test-source` }]
+    })
+
+    mockSend.mockResolvedValueOnce({
+      FailedEntryCount: 1,
+      Entries: [{ ErrorCode: 'EventBridgeError', ErrorMessage: 'Invalid event' }]
+    })
+
+    const result = await send(payloads, settings)
+    const responses = result.getAllResponses()
+    // Check if the first response has an error
+    if ('data' in responses[0]) {
+      expect(responses[0].data.status).toBe(400)
+    }
+  })
+
+  test('ensurePartnerSourceExists should create source if it does not exist', async () => {
+    const payloads: Payload[] = [
+      {
+        sourceId: 'test-source',
+        detailType: 'UserSignup',
+        data: { user: '123', event: 'signed_up' },
+        resources: 'test-resource',
+        enable_batching: true
+      }
+    ]
+
+    const updatedSettings: Settings = {
+      ...settings,
+      partnerEventSourceName: 'aws.partner/segment.com.test',
+      createPartnerEventSource: true
+    }
+
+    // Simulate "List" finding no source and success on creation
+    mockSend
+      .mockResolvedValueOnce({ PartnerEventSources: [] }) // No source exists
+      .mockResolvedValueOnce({}) // CreatePartnerEventSourceCommand success
+      .mockResolvedValueOnce({ FailedEntryCount: 0 }) // Event sent successfully
+
+    await send(payloads, updatedSettings)
+
+    // Ensure the List command was called
+    expect(mockSend).toHaveBeenCalledWith(expect.any(ListPartnerEventSourcesCommand))
+
+    // Ensure the Create command was called
+    expect(mockSend).toHaveBeenCalledWith(expect.any(CreatePartnerEventSourceCommand))
+
+    // Ensure the event is sent
+    expect(mockSend).toHaveBeenCalledWith(expect.any(PutPartnerEventsCommand))
+
+    // Ensure all three commands are called
+    expect(mockSend).toHaveBeenCalledTimes(3)
+  })
+
+  test('ensurePartnerSourceExists should not create source if it already exists', async () => {
+    // Mock ListPartnerEventSourcesCommand to simulate existing source
+    mockSend
+      .mockResolvedValueOnce({
+        PartnerEventSources: [{ Name: 'aws.partner/segment.com.test/test-source' }]
+      }) // ListPartnerEventSourcesCommand
+      .mockResolvedValueOnce({
+        FailedEntryCount: 0, // Mock success for PutPartnerEventsCommand
+        Entries: [{ EventId: '12345' }]
+      })
+
+    const payloads: Payload[] = [
+      {
+        sourceId: 'test-source',
+        detailType: 'UserSignup',
+        data: { user: '123', event: 'signed_up' },
+        resources: 'test-resource',
+        enable_batching: true
+      }
+    ]
+
+    const updatedSettings: Settings = {
+      ...settings,
+      partnerEventSourceName: 'your-partner-event-source-name',
+      createPartnerEventSource: false
+    }
+
+    await send(payloads, updatedSettings)
+
+    // Ensure it only calls ListPartnerEventSources and PutPartnerEventsCommand
+    expect(mockSend).toHaveBeenCalledTimes(2)
+
+    // Ensure it does NOT call CreatePartnerEventSourceCommand
+    expect(mockSend).not.toHaveBeenCalledWith(
+      expect.objectContaining({ input: expect.objectContaining({ Account: '123456789012' }) })
+    )
+  })
+
+  test('ensurePartnerSourceExists should create source if missing', async () => {
+    // Simulate "ListPartnerEventSources" - No source found
+    mockSend.mockResolvedValueOnce({ PartnerEventSources: [] })
+
+    // Simulate "CreatePartnerEventSource" - Source created
+    mockSend.mockResolvedValueOnce({})
+
+    // Simulate "PutEventsCommand" - Event sent successfully
+    mockSend.mockResolvedValueOnce({
+      FailedEntryCount: 0,
+      Entries: [{ EventId: '12345' }]
+    })
+
+    const payloads: Payload[] = [
+      {
+        sourceId: 'test-source',
+        detailType: 'UserSignup',
+        data: { user: '123', event: 'signed_up' },
+        resources: 'test-resource',
+        enable_batching: true
+      }
+    ]
+
+    await send(payloads, settings)
+
+    // Ensure all three calls are made: List, Create, and Put
+    expect(mockSend).toHaveBeenCalledTimes(3)
+
+    // Check if CreatePartnerEventSourceCommand is called
+    expect(mockSend).toHaveBeenCalledWith(expect.any(CreatePartnerEventSourceCommand))
+  })
+
+  test('should throw error if partner source is missing and createPartnerEventSource is false', async () => {
+    mockSend.mockResolvedValueOnce({ PartnerEventSources: [] })
+
+    const payloads: Payload[] = [
+      {
+        sourceId: 'test-source',
+        detailType: 'UserSignup',
+        data: { user: '123', event: 'signed_up' },
+        resources: 'test-resource',
+        enable_batching: true // Add the enable_batching property
+      }
+    ]
+
+    await expect(
+      send(payloads, {
+        ...settings,
+        createPartnerEventSource: false,
+        partnerEventSourceName: 'aws.partner/segment.com.test'
+      })
+    ).rejects.toThrow('Partner Event Source aws.partner/segment.com.test/test-source does not exist.')
+  })
+
+  test('create_partner_source should send correct request', async () => {
+    const payloads: Payload[] = [
+      {
+        sourceId: 'test-source',
+        detailType: 'UserSignup',
+        data: { user: '123', event: 'signed_up' },
+        resources: 'test-resource',
+        enable_batching: true
+      }
+    ]
+
+    // Ensure correct mock responses for all EventBridge calls
+    mockSend
+      .mockResolvedValueOnce({ PartnerEventSources: [] }) // ListPartnerEventSourcesCommand
+      .mockResolvedValueOnce({}) // CreatePartnerEventSourceCommand
+      .mockResolvedValueOnce({ FailedEntryCount: 0, Entries: [{ EventId: '12345' }] }) // PutEventsCommand
+
+    await send(payloads, settings)
+
+    expect(mockSend).toHaveBeenCalledTimes(3)
+
+    // Ensure CreatePartnerEventSourceCommand is called
+    expect(mockSend).toHaveBeenCalledWith(expect.any(CreatePartnerEventSourceCommand))
+
+    // Ensure PutEventsCommand is called with expected arguments
+    expect(mockSend).toHaveBeenCalledWith(expect.any(PutPartnerEventsCommand))
+  })
+
+  test('process_data should throw error if event send fails', async () => {
+    const payloads: Payload[] = [
+      {
+        sourceId: 'test-source',
+        detailType: 'UserSignup',
+        data: { user: '123', event: 'signed_up' },
+        resources: 'test-resource',
+        enable_batching: true
+      }
+    ]
+
+    const settings = {
+      awsRegion: 'us-west-2',
+      awsAccountId: '123456789012',
+      partnerEventSourceName: 'test-source'
+      // Other settings here
+    }
+
+    // Mock a failed response
+    mockSend
+      .mockResolvedValueOnce({
+        PartnerEventSources: [{ Name: 'aws.partner/segment.com.test/test-source' }]
+      }) // ListPartnerEventSourcesCommand
+      .mockResolvedValueOnce({
+        FailedEntryCount: 1,
+        Entries: [{ ErrorCode: 'Error', ErrorMessage: 'Failed' }]
+      })
+
+    // Call the function and assert that it throws an error
+    // await expect(send(payloads, settings)).rejects.toThrow(
+    //   'EventBridge failed with 1 errors: Error: Error, Message: Failed'
+    // )
+    const result = await send(payloads, settings)
+
+    const response = result.getAllResponses()[0].data
+
+    expect(response.status).toBe(400)
+    expect(response.errormessage).toMatch(/Failed/)
+  })
+
+  test('process_data should send event to EventBridge', async () => {
+    const payloads: Payload[] = [
+      {
+        sourceId: 'test-source',
+        detailType: 'UserSignup',
+        data: { user: '123', event: 'signed_up' },
+        resources: 'test-resource',
+        enable_batching: true
+      }
+    ]
+
+    const settings = {
+      awsRegion: 'us-west-2',
+      awsAccountId: '123456789012',
+      partnerEventSourceName: 'test-source',
+      createPartnerEventSource: true
+      // Other settings here
+    }
+
+    mockSend
+      .mockResolvedValueOnce({ PartnerEventSources: [{ Name: 'aws.partner/segment.com.test/test-source' }] }) // ListPartnerEventSourcesCommand
+      .mockResolvedValueOnce({
+        FailedEntryCount: 0,
+        Entries: [{}]
+      })
+
+    const result = await send(payloads, settings)
+    const response = result.getAllResponses()[0].data
+    expect(response.status).toBe(200)
+  })
+})

--- a/packages/destination-actions/src/destinations/amazon-eventbridge/sendV2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amazon-eventbridge/sendV2/generated-types.ts
@@ -1,0 +1,38 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The event data to send to Amazon EventBridge.
+   */
+  data: {
+    [k: string]: unknown
+  }
+  /**
+   * Detail Type of the event. Used to determine what fields to expect in the event Detail.
+   *                     Value cannot be longer than 128 characters.
+   */
+  detailType: string
+  /**
+   * The source ID for the event. HIDDEN FIELD
+   */
+  sourceId: string
+  /**
+   * AWS resources, identified by Amazon Resource Name (ARN),
+   *                     which the event primarily concerns. Any number,
+   *                     including zero, may be present.
+   */
+  resources?: string
+  /**
+   * The timestamp the event occurred.
+   */
+  time?: string
+  /**
+   * Enable Batching
+   */
+  enable_batching: boolean
+  /**
+   * Maximum number of events to include in each batch.
+   *                     Actual batch sizes may be lower.
+   */
+  batch_size?: number
+}

--- a/packages/destination-actions/src/destinations/amazon-eventbridge/sendV2/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-eventbridge/sendV2/index.ts
@@ -1,0 +1,92 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { send } from '../functionsv2'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Send',
+  description: 'Send an event to Amazon EventBridge.',
+  fields: {
+    data: {
+      label: 'Detail',
+      description: 'The event data to send to Amazon EventBridge.',
+      type: 'object',
+      default: { '@path': '$.' },
+      required: true
+    },
+    detailType: {
+      label: 'Detail Type',
+      description: `Detail Type of the event. Used to determine what fields to expect in the event Detail. 
+                    Value cannot be longer than 128 characters.`,
+      type: 'string',
+      maximum: 128,
+      default: { '@path': '$.type' },
+      required: true
+    },
+    sourceId: {
+      label: 'Source ID',
+      description: 'The source ID for the event. HIDDEN FIELD',
+      type: 'string',
+      unsafe_hidden: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.context.protocols.sourceId' },
+          then: { '@path': '$.context.protocols.sourceId' },
+          else: { '@path': '$.projectId' }
+        }
+      },
+      required: true
+    },
+    resources: {
+      label: 'Resources',
+      description: `AWS resources, identified by Amazon Resource Name (ARN), 
+                    which the event primarily concerns. Any number, 
+                    including zero, may be present.`,
+      type: 'string',
+      default: {
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      },
+      required: false
+    },
+    time: {
+      label: 'Time',
+      description: 'The timestamp the event occurred.',
+      type: 'string',
+      default: { '@path': '$.timestamp' },
+      required: false
+    },
+    enable_batching: {
+      type: 'boolean',
+      label: 'Enable Batching',
+      description: 'Enable Batching',
+      unsafe_hidden: false,
+      required: true,
+      default: true
+    },
+    batch_size: {
+      label: 'Batch Size',
+      description: `Maximum number of events to include in each batch. 
+                    Actual batch sizes may be lower.`,
+      type: 'number',
+      unsafe_hidden: true,
+      required: false,
+      default: 20,
+      minimum: 1,
+      maximum: 20
+    }
+  },
+  perform: (_, data) => {
+    const { payload, settings } = data
+    return send([payload], settings)
+  },
+  performBatch: (_, data) => {
+    const { payload, settings } = data
+    return send(payload, settings)
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/amazon-eventbridge/sendV2/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-eventbridge/sendV2/index.ts
@@ -4,7 +4,7 @@ import type { Payload } from './generated-types'
 import { send } from '../functionsv2'
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Send',
+  title: 'SendV2',
   description: 'Send an event to Amazon EventBridge.',
   fields: {
     data: {


### PR DESCRIPTION

Summary of Changes:
- Created additional action sendV2 that works similar to action send but supports multi-status responses in batch
- Batch can have multiple success/error messages that need to be surfaced correctly in DO/Event Delivery UI
## Testing
- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality

- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
