### PR TITLE
[Smart Hashing] Add eslint rule to limit usage of createHash from crypto module

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,7 +93,7 @@ module.exports = {
           {
             selector: "ImportDeclaration[source.value='crypto'] ImportSpecifier[imported.name='createHash']",
             message:
-              'Avoid importing the "createHash" function from "crypto". Use "destination-actions/lib/hashing-utils" instead.'
+              'The "destination-actions/lib/hashing-utils/processHashing" can autodetect  prehashed values and avoid double hashing [https://github.com/segmentio/action-destinations/blob/139f434ff2828ed37c8f364f6ff9bb63dd3725d1/README.md?plain=1#L963]. Avoid importing the "createHash" function from "crypto"'
           }
         ]
       }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,6 +84,19 @@ module.exports = {
       rules: {
         '@typescript-eslint/no-unsafe-call': 'off'
       }
+    },
+    {
+      files: ['packages/destination-actions/**/*.ts'],
+      rules: {
+        'no-restricted-syntax': [
+          'error',
+          {
+            selector: "ImportDeclaration[source.value='crypto'] ImportSpecifier[imported.name='createHash']",
+            message:
+              'Avoid importing the "createHash" function from "crypto". Use "destination-actions/lib/hashing-utils" instead.'
+          }
+        ]
+      }
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/criteo-audiences/criteo-audiences.ts
+++ b/packages/destination-actions/src/destinations/criteo-audiences/criteo-audiences.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-syntax
 import { createHash } from 'crypto'
 import { IntegrationError, RetryableError } from '@segment/actions-core'
 import type { RequestClient } from '@segment/actions-core'

--- a/packages/destination-actions/src/destinations/emarsys/emarsys-helper.ts
+++ b/packages/destination-actions/src/destinations/emarsys/emarsys-helper.ts
@@ -1,6 +1,7 @@
 import type { Settings } from './generated-types'
 import type { RequestClient } from '@segment/actions-core'
 import { DynamicFieldResponse } from '@segment/actions-core'
+// eslint-disable-next-line no-restricted-syntax
 import { randomBytes, createHash } from 'crypto'
 
 export const API_HOST = 'https://api.emarsys.net'

--- a/packages/destination-actions/src/destinations/engage-messaging-sendgrid/previewApiLookup/apiLookups.ts
+++ b/packages/destination-actions/src/destinations/engage-messaging-sendgrid/previewApiLookup/apiLookups.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-syntax
 import { createHash } from 'crypto'
 import { IntegrationError } from '@segment/actions-core'
 import { InputField } from '@segment/actions-core'

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-syntax
 import { createHash } from 'crypto'
 import {
   ConversionCustomVariable,

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/formatter.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/postConversion/formatter.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-syntax
 import { createHash } from 'crypto'
 
 /**

--- a/packages/destination-actions/src/destinations/nextdoor-capi/sendConversion/utils.ts
+++ b/packages/destination-actions/src/destinations/nextdoor-capi/sendConversion/utils.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-syntax
 import { createHash } from 'crypto'
 
 export function hashAndEncode(value: string) {

--- a/packages/destination-actions/src/destinations/reddit-audiences/syncAudience/functions.ts
+++ b/packages/destination-actions/src/destinations/reddit-audiences/syncAudience/functions.ts
@@ -2,6 +2,7 @@ import { PayloadValidationError, RequestClient } from '@segment/actions-core'
 import { Payload } from '../syncAudience/generated-types'
 import { UpdateAudienceReq, Columns } from '../types'
 import { EMAIL_SCHEMA_NAME, MAID_SCHEMA_NAME } from '../const'
+// eslint-disable-next-line no-restricted-syntax
 import { createHash } from 'crypto'
 
 export async function send(request: RequestClient, payloads: Payload[]) {

--- a/packages/destination-actions/src/destinations/singlestore/index.ts
+++ b/packages/destination-actions/src/destinations/singlestore/index.ts
@@ -3,6 +3,7 @@ import { Settings } from './generated-types'
 import { SingleStoreCreateJSON } from './types'
 import { createUrl } from './const'
 import send from './send'
+// eslint-disable-next-line no-restricted-syntax
 import { createHash } from 'crypto'
 import { encryptText, destinationId, checkChamber } from './util'
 

--- a/packages/destination-actions/src/destinations/singlestore/util.ts
+++ b/packages/destination-actions/src/destinations/singlestore/util.ts
@@ -2,6 +2,7 @@ import * as crypto from 'crypto'
 import { CLIENT_ID, STAGE_BROKERS, PROD_BROKERS } from './const'
 import { IntegrationError } from '@segment/actions-core'
 import { Settings } from './generated-types'
+// eslint-disable-next-line no-restricted-syntax
 import { createHash } from 'crypto'
 import { KafkaConfig, ProducerRecord } from 'kafkajs'
 

--- a/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/utils.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/utils.ts
@@ -1,4 +1,5 @@
 import { Features, IntegrationError } from '@segment/actions-core'
+// eslint-disable-next-line no-restricted-syntax
 import { createHash } from 'crypto'
 import { processHashing } from '../../../lib/hashing-utils'
 

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/functions.ts
@@ -1,4 +1,5 @@
 import { APIError, createRequestClient, DynamicFieldResponse } from '@segment/actions-core'
+// eslint-disable-next-line no-restricted-syntax
 import { createHash } from 'crypto'
 
 interface Advertiser {

--- a/packages/destination-actions/src/destinations/taboola-actions/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/syncAudience/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration, IntegrationError } from '@segment/actions-core'
 import Destination from '../../index'
+// eslint-disable-next-line no-restricted-syntax
 import { createHash } from 'crypto'
 
 const testDestination = createTestIntegration(Destination)

--- a/packages/destination-actions/src/destinations/taboola-actions/syncAudience/client.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/syncAudience/client.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-syntax
 import { createHash } from 'crypto'
 import type { ModifiedResponse } from '@segment/actions-core'
 import { RequestClient, IntegrationError } from '@segment/actions-core'

--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/functions.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/functions.ts
@@ -1,6 +1,7 @@
 import { RequestClient, ModifiedResponse, PayloadValidationError } from '@segment/actions-core'
 import { Settings } from './generated-types'
 import { Payload } from './syncAudience/generated-types'
+// eslint-disable-next-line no-restricted-syntax
 import { createHash } from 'crypto'
 import { IntegrationError } from '@segment/actions-core'
 

--- a/packages/destination-actions/src/destinations/tiktok-conversions-sandbox/formatter.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions-sandbox/formatter.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-syntax
 import { createHash } from 'crypto'
 
 /**

--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions-sandbox/formatter.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions-sandbox/formatter.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-syntax
 import { createHash } from 'crypto'
 
 /**


### PR DESCRIPTION
This PR adds a Es lint rule that restricts the usage of createHash from crypto module, to encourage the usage of Smart hashing module for hashing.

For other usage of Crypto module, Eslint disable is added.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
