### PR TITLE
[Google Ads] Update membership lifespan to the new max value

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -321,7 +321,7 @@ export async function createGoogleAudience(
             uploadKeyType: input.audienceSettings.external_id_type,
             appId: input.audienceSettings.app_id
           },
-          membershipLifeSpan: '10000', // In days. 10000 is interpreted as 'unlimited'.
+          membershipLifeSpan: '540',
           name: `${input.audienceName}`
         }
       }


### PR DESCRIPTION
Google made an [update](https://ads-developers.googleblog.com/2025/02/update-to-customer-match-membership.html) to implement a new maximum membership duration of 540 days. Updating Customer Match User List as Google DV360 already uses 540 as the default.

Slack thread -> https://twilio.slack.com/archives/CC97A542H/p1744140153226239?thread_ts=1743094608.206129&cid=CC97A542H
## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
