### PR TITLE
[STRATCONN-5733] - Add new mapping-kit github workflow

### DIFF
--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -60,3 +60,46 @@ jobs:
               });
               await Promise.all(requests);
             }
+
+      - name: Comment for mapping-kit changes
+        uses: actions/github-script@v7
+        env:
+          labelsToAdd: '${{ steps.compute-labels.outputs.add }}'
+          labelsToRemove: '${{ steps.compute-labels.outputs.remove }}'
+        with:
+          script: |
+            const { labelsToAdd, labelsToRemove, DRY_RUN } = process.env
+            const shouldAddComment = labelsToAdd.length > 0 && labelsToAdd.split(",").some(x=>x.includes("mappingkit"))
+            const shouldRemoveComment = labelsToRemove.length > 0 && labelsToRemove.split(",").some(x=>x.includes("mappingkit"))
+            // Get the list of comments on the PR
+            const response = await github.rest.issues.listComments({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo
+            })
+            const mappingKitComment = response.data.find(comment => comment.body.includes('mapping-kit go'))
+            if(shouldAddComment){
+                if (mappingKitComment) {
+                  console.log('Already commented on this PR')
+                  return
+                }
+                // Add comment to the PR
+                await github.rest.issues.createComment({
+                    issue_number: context.issue.number,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    body: `This PR makes changes to mapping-kit. Please ensure that the changes are reflected in the [mapping-kit go](https://github.com/segmentio/mapping-kit) library as well and link the PR in description.`
+                  })
+            }
+            if(shouldRemoveComment) {
+              if (!mappingKitComment) {
+                console.log('No mapping-kit comment to remove')
+                return
+              }
+              // Remove comment from the PR
+              await github.rest.issues.deleteComment({
+                  comment_id: mappingKitComment.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo
+                })
+            }

--- a/scripts/github-action/compute-labels.js
+++ b/scripts/github-action/compute-labels.js
@@ -70,13 +70,15 @@ async function computeFileBasedLabels(github, context, core) {
   const MODE_CLOUD_LABEL = 'mode:cloud'
   const MODE_DEVICE_LABEL = 'mode:device'
   const ACTIONS_CORE_LABEL = 'actions:core'
+  const MAPPING_KIT_LABEL = 'actions:mappingkit'
 
   const allLabels = [
     DEPLOY_REGISTRATION_LABEL,
     DEPLOY_PUSH_LABEL,
     MODE_CLOUD_LABEL,
     MODE_DEVICE_LABEL,
-    ACTIONS_CORE_LABEL
+    ACTIONS_CORE_LABEL,
+    MAPPING_KIT_LABEL
   ]
 
   const newLabels = []
@@ -131,6 +133,12 @@ async function computeFileBasedLabels(github, context, core) {
   const generatedTypesRegex = /packages\/.*\/generated\-types.ts/i
   if (files.some((file) => generatedTypesRegex.test(file.filename))) {
     newLabels.push(DEPLOY_PUSH_LABEL)
+  }
+
+  // Check if PR contains changes to mapping-kit
+  const mappingKitRegex = /packages\/core\/src\/mapping\-kit\/.*/i
+  if (files.some((file) => mappingKitRegex.test(file.filename))) {
+    newLabels.push(MAPPING_KIT_LABEL)
   }
 
   // Remove the existing custom labels if they are not required anymore


### PR DESCRIPTION
This PR adds a new mapping-kit alerting workflow that reminds to update mapping-kit go when mapping-kit ts is updated.

This is a temporary setup. We'll work on simplifying the update process in the future.


## Testing

Tested via this PR

![image](https://github.com/user-attachments/assets/7dc27b0a-7546-459c-b6f7-4fc484bd25e3)


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
