### PR TITLE
[EagleEye] Implement action for EagleEye Behavioral Action triggers

### DIFF
--- a/packages/destination-actions/src/destinations/eagleeye-actions/generated-types.ts
+++ b/packages/destination-actions/src/destinations/eagleeye-actions/generated-types.ts
@@ -1,0 +1,12 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Eagle Eye URL of the Segment connector provided by your EagleEye CSM
+   */
+  connectorUrl: string
+  /**
+   * Key to authenticate with the connector provided by your EagleEye CSM
+   */
+  externalKey: string
+}

--- a/packages/destination-actions/src/destinations/eagleeye-actions/index.ts
+++ b/packages/destination-actions/src/destinations/eagleeye-actions/index.ts
@@ -1,0 +1,50 @@
+import { defaultValues, type DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import triggerBehavioralAction from './triggerBehavioralAction'
+
+const presets: DestinationDefinition['presets'] = [
+  {
+    name: 'Trigger Points Reward',
+    subscribe: 'type = "track" and event = "Loyalty Program Joined"',
+    partnerAction: 'triggerBehavioralAction',
+    mapping: {
+      ...defaultValues(triggerBehavioralAction.fields),
+    },
+    type: 'automatic'
+  },
+]
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Eagle Eye (Actions)',
+  slug: 'eagleeye-actions',
+  mode: 'cloud',
+  description: 'Trigger Behavioral Actions in Eagle Eye AIR based on Segment events to provide rewards for your customers',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      connectorUrl: {
+        label: 'Connector URL',
+        description: 'Eagle Eye URL of the Segment connector provided by your EagleEye CSM',
+        type: 'string',
+        format: 'uri',
+        required: true
+      },
+      externalKey: {
+        label: 'Connector External Key',
+        description: 'Key to authenticate with the connector provided by your EagleEye CSM',
+        type: 'password',
+        required: true
+      },
+    }
+  },
+
+  presets,
+
+  actions: {
+    triggerBehavioralAction
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/eagleeye-actions/triggerBehavioralAction/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/eagleeye-actions/triggerBehavioralAction/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for EagleeyeSegmentActions's triggerBehavioralAction destination action: all fields 1`] = `
+Object {
+  "body": Object {
+    "identityValue": "hsNw(#(*It$j9]TbPFxH",
+    "triggers": Array [
+      Object {
+        "reference": "hsNw(#(*It$j9]TbPFxH",
+      },
+    ],
+    "walletTransaction": Object {
+      "reference": "hsNw(#(*It$j9]TbPFxH",
+    },
+  },
+  "type": "services/trigger",
+}
+`;
+
+exports[`Testing snapshot for EagleeyeSegmentActions's triggerBehavioralAction destination action: required fields 1`] = `
+Object {
+  "body": Object {
+    "identityValue": "hsNw(#(*It$j9]TbPFxH",
+    "triggers": Array [
+      Object {
+        "reference": "hsNw(#(*It$j9]TbPFxH",
+      },
+    ],
+  },
+  "type": "services/trigger",
+}
+`;

--- a/packages/destination-actions/src/destinations/eagleeye-actions/triggerBehavioralAction/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/eagleeye-actions/triggerBehavioralAction/__tests__/index.test.ts
@@ -1,0 +1,54 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('EagleeyeActions.triggerBehavioralAction', () => {
+  it('makes the correct API call to trigger a Behavioral Action in EE AIR', async () => {
+    const connectorUrl = 'https://some.url/in/segment/some-connector-id'
+    nock(connectorUrl).post('').reply(200, {})
+
+    const event = createTestEvent({
+      userId: 'some-user-id',
+      properties: {}
+    })
+    const settings = {
+      connectorUrl,
+      externalKey: 'external-key'
+    }
+    const behavioralActionTriggerReferences = 'A0001,P0001'
+
+    let responses, error
+    try {
+      responses = await testDestination.testAction('triggerBehavioralAction', {
+        event,
+        settings,
+        useDefaultMappings: true,
+        mapping: {
+          behavioralActionTriggerReferences
+        }
+      })
+    } catch (err) {
+      error = err
+    }
+
+    expect(responses).toBeDefined()
+    expect(error).toBeUndefined()
+
+    expect(responses && responses[0].options.headers && responses[0].options.headers.get('x-auth-token')).toEqual(
+      settings.externalKey
+    )
+    expect(responses && responses[0].options.body).toEqual(
+      JSON.stringify({
+        type: 'services/trigger',
+        body: {
+          identityValue: event.userId,
+          triggers: behavioralActionTriggerReferences.split(',').map((reference) => ({
+            reference
+          }))
+        }
+      })
+    )
+  })
+})

--- a/packages/destination-actions/src/destinations/eagleeye-actions/triggerBehavioralAction/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/eagleeye-actions/triggerBehavioralAction/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'triggerBehavioralAction'
+const destinationSlug = 'EagleeyeSegmentActions'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/eagleeye-actions/triggerBehavioralAction/generated-types.ts
+++ b/packages/destination-actions/src/destinations/eagleeye-actions/triggerBehavioralAction/generated-types.ts
@@ -1,0 +1,16 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Customer wallet identity value in AIR for this event
+   */
+  identityValue: string
+  /**
+   * Optional wallet transaction reference from the event triggering this Behavioral Action
+   */
+  walletTransactionReference?: string
+  /**
+   * Accepts a comma delimited list of reference strings for the Behavioral Action to be executed. E.g.: A0001,P0001
+   */
+  behavioralActionTriggerReferences: string
+}

--- a/packages/destination-actions/src/destinations/eagleeye-actions/triggerBehavioralAction/index.ts
+++ b/packages/destination-actions/src/destinations/eagleeye-actions/triggerBehavioralAction/index.ts
@@ -1,0 +1,65 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { BehavioralActionPayload } from './types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Trigger Behavioral Action',
+  description: 'Trigger behavioral actions in AIR based on tracked events',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    identityValue: {
+      label: 'User identity value',
+      type: 'string',
+      description: 'Customer wallet identity value in AIR for this event',
+      default: {
+        '@path': '$.userId'
+      },
+      required: true
+    },
+    walletTransactionReference: {
+      label: 'Wallet transaction reference',
+      type: 'string',
+      description: 'Optional wallet transaction reference from the event triggering this Behavioral Action',
+      default: {
+        '@path': '$.properties.order_id'
+      }
+    },
+    behavioralActionTriggerReferences: {
+      label: 'Behavioral Action trigger reference',
+      type: 'string',
+      description:
+        'Accepts a comma delimited list of reference strings for the Behavioral Action to be executed. E.g.: A0001,P0001',
+      default: '',
+      required: true
+    }
+  },
+  perform: (request, { settings, payload }) => {
+    const triggerReferences = payload.behavioralActionTriggerReferences.replace(/\s*/g, '').split(',')
+
+    const behavioralActionPayload: BehavioralActionPayload = {
+      type: 'services/trigger',
+      body: {
+        identityValue: payload.identityValue,
+        walletTransaction: payload.walletTransactionReference
+          ? {
+              reference: payload.walletTransactionReference
+            }
+          : undefined,
+        triggers: triggerReferences.map((triggerReference) => ({
+          reference: triggerReference
+        }))
+      }
+    }
+
+    return request(settings.connectorUrl, {
+      method: 'post',
+      headers: {
+        'X-Auth-Token': settings.externalKey
+      },
+      json: behavioralActionPayload
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/eagleeye-actions/triggerBehavioralAction/types.ts
+++ b/packages/destination-actions/src/destinations/eagleeye-actions/triggerBehavioralAction/types.ts
@@ -1,0 +1,12 @@
+export interface BehavioralActionPayload {
+	type: 'services/trigger'
+	body: {
+		identityValue: string
+		walletTransaction?: {
+			reference: string
+		}
+		triggers: Array<{
+			reference: string
+		}>
+	}
+}


### PR DESCRIPTION
This PR introduces a Destination Action for Eagle Eye's AIR platform. It allows clients to trigger Behavioral Actions in AIR, which provide rewards to customers based on certain interactions, upon receiving certain events on Segment.

Processed events will go through a connector acting as middleware for the AIR platform. Both the connector and this destination action are an ongoing project between Eagle Eye and Apply Digital.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
