### PR TITLE
[TikTok] Add error when no audience found

### DIFF
--- a/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
@@ -139,7 +139,11 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         throw new IntegrationError('Invalid response from get audience request', 'INVALID_RESPONSE', 400)
       }
 
-      const externalId = r.data['list'][0]['audience_details']['audience_id']
+      const externalId = r.data?.list?.[0]?.audience_details?.audience_id
+      if (!externalId) {
+        statsClient?.incr('getAudience.error', 1, statsTags)
+        throw new IntegrationError('Audience ID not found.', 'INVALID_REQUEST_DATA', 400)
+      }
 
       if (externalId !== getAudienceInput.externalId) {
         throw new IntegrationError(


### PR DESCRIPTION
Jira - https://segment.atlassian.net/browse/STRATCONN-5682

When an audience is not found it causes the error `Cannot read properties of undefined (reading 'audience_details'` making it hard to debug. This PR adds a more clear error message.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
