### PR TITLE
[STRATCONN-5657] - Add batch keys to webhook action destination

### DIFF
--- a/packages/destination-actions/src/destinations/webhook-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/webhook-audiences/index.ts
@@ -148,7 +148,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
           for (const p of payload) {
             set.add(`${p.url} ${p.method} ${JSON.stringify(p.headers)}`)
           }
-          statsClient?.incr('webhook.configurable_batch_keys.unique_keys', set.size, tags)
+          statsClient?.histogram('webhook.configurable_batch_keys.unique_keys', set.size, tags)
         }
 
         // Call the same performBatch function from the regular webhook destination

--- a/packages/destination-actions/src/destinations/webhook-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/webhook-audiences/index.ts
@@ -139,8 +139,17 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
           settings
         })
       },
-      performBatch: (request, { payload, settings, audienceSettings }) => {
+      performBatch: (request, { payload, settings, audienceSettings, statsContext }) => {
         const extras = parseExtraSettingsJson(audienceSettings?.extras)
+
+        if (statsContext) {
+          const { statsClient, tags } = statsContext
+          const set = new Set()
+          for (const p of payload) {
+            set.add(`${p.url} ${p.method} ${JSON.stringify(p.headers)}`)
+          }
+          statsClient?.incr('webhook.configurable_batch_keys.unique_keys', set.size, tags)
+        }
 
         // Call the same performBatch function from the regular webhook destination
         // and add in our extraSettings

--- a/packages/destination-actions/src/destinations/webhook-audiences/send.types.ts
+++ b/packages/destination-actions/src/destinations/webhook-audiences/send.types.ts
@@ -25,4 +25,8 @@ export interface Payload {
   data?: {
     [k: string]: unknown
   }
+  /**
+   * The mapping keys to batch events together by.
+   */
+  batch_keys?: string[]
 }

--- a/packages/destination-actions/src/destinations/webhook/__test__/webhook.test.ts
+++ b/packages/destination-actions/src/destinations/webhook/__test__/webhook.test.ts
@@ -177,6 +177,70 @@ export const baseWebhookTests = (def: DestinationDefinition<any>) => {
           })
         ).rejects.toThrow(PayloadValidationError)
       })
+
+      it('should incr stats by unique url, headers and method count', async () => {
+        const testEvent1 = {
+          properties: {
+            url: 'https://example.build',
+            method: 'POST',
+            headers: {
+              'sample-header': 'value1'
+            }
+          }
+        }
+        const testEvent2 = {
+          properties: {
+            url: 'https://example.build',
+            method: 'PUT',
+            headers: {
+              'sample-header': 'value1'
+            }
+          }
+        }
+        const events = [createTestEvent(testEvent1), createTestEvent(testEvent2)]
+
+        nock(testEvent1.properties.url).post('/').reply(200, { success: true })
+
+        const statsClient = {
+          incr: jest.fn(),
+          observe: jest.fn(),
+          _name: jest.fn(),
+          _tags: jest.fn(),
+          set: jest.fn,
+          histogram: jest.fn()
+        }
+        const statsContext = {
+          statsClient,
+          tags: ['test:tag']
+        }
+
+        const responses = await testDestination.testBatchAction('send', {
+          events,
+          mapping: {
+            url: {
+              '@path': '$.properties.url'
+            },
+            method: {
+              '@path': '$.properties.method'
+            },
+            headers: {
+              'sample-header': {
+                '@path': '$.properties.sample-header'
+              }
+            }
+          },
+          useDefaultMappings: true,
+          statsContext
+        })
+
+        expect(responses.length).toBe(1)
+        expect(responses[0].status).toBe(200)
+        expect(statsClient.incr).toHaveBeenCalledWith(
+          'webhook.configurable_batch_keys.unique_keys',
+          2,
+          statsContext.tags
+        )
+      })
     })
   })
 }

--- a/packages/destination-actions/src/destinations/webhook/__test__/webhook.test.ts
+++ b/packages/destination-actions/src/destinations/webhook/__test__/webhook.test.ts
@@ -235,7 +235,7 @@ export const baseWebhookTests = (def: DestinationDefinition<any>) => {
 
         expect(responses.length).toBe(1)
         expect(responses[0].status).toBe(200)
-        expect(statsClient.incr).toHaveBeenCalledWith(
+        expect(statsClient.histogram).toHaveBeenCalledWith(
           'webhook.configurable_batch_keys.unique_keys',
           2,
           statsContext.tags

--- a/packages/destination-actions/src/destinations/webhook/__test__/webhook.test.ts
+++ b/packages/destination-actions/src/destinations/webhook/__test__/webhook.test.ts
@@ -242,6 +242,13 @@ export const baseWebhookTests = (def: DestinationDefinition<any>) => {
         )
       })
     })
+
+    it('should have batch keys default to url, method, headers', () => {
+      const action = testDestination.definition.actions.send
+      expect(action.fields.batch_keys).toBeDefined()
+      expect(action.fields.batch_keys?.default).toBeDefined()
+      expect(action.fields.batch_keys?.default).toEqual(['url', 'method', 'headers'])
+    })
   })
 }
 

--- a/packages/destination-actions/src/destinations/webhook/send/generated-types.ts
+++ b/packages/destination-actions/src/destinations/webhook/send/generated-types.ts
@@ -25,4 +25,8 @@ export interface Payload {
   data?: {
     [k: string]: unknown
   }
+  /**
+   * The mapping keys to batch events together by.
+   */
+  batch_keys?: string[]
 }

--- a/packages/destination-actions/src/destinations/webhook/send/index.ts
+++ b/packages/destination-actions/src/destinations/webhook/send/index.ts
@@ -78,7 +78,7 @@ const action: ActionDefinition<Settings, Payload> = {
       for (const p of payload) {
         set.add(`${p.url} ${p.method} ${JSON.stringify(p.headers)}`)
       }
-      statsClient?.incr('webhook.configurable_batch_keys.unique_keys', set.size, tags)
+      statsClient?.histogram('webhook.configurable_batch_keys.unique_keys', set.size, tags)
     }
 
     try {

--- a/packages/destination-actions/src/destinations/webhook/send/index.ts
+++ b/packages/destination-actions/src/destinations/webhook/send/index.ts
@@ -45,6 +45,15 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'Payload to deliver to webhook URL (JSON-encoded).',
       type: 'object',
       default: { '@path': '$.' }
+    },
+    batch_keys: {
+      label: 'Batch Keys',
+      description: 'The mapping keys to batch events together by.',
+      type: 'string',
+      multiple: true,
+      required: false,
+      unsafe_hidden: true,
+      default: ['url', 'method']
     }
   },
   perform: (request, { payload }) => {


### PR DESCRIPTION
This PR adds a new hidden `batch_keys` mapping. This mapping controls how events are batched together. This PR in itself won't have any effect as it depends on https://github.com/segmentio/integrations-go/pull/449. The integrations-go changes are behind a flagon and we'll be doing a controlled rollout.

Testing doc - [[ref](https://docs.google.com/document/d/12lgCwYzZ7Cgbv-XbcG3cViuHWJCiMxyvYr8E4S1lu90/edit?tab=t.wfswq4c8kfqn#bookmark=id.3me5wyq5rm3y)]

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
