### PR TITLE
[STRATCONN-5489] - Add batch_keys to Klaviyo actions

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -31,6 +31,20 @@ Object {
 }
 `;
 
+exports[`Testing snapshot for actions-klaviyo destination: addProfileToList action - batch keys 1`] = `
+Object {
+  "default": Array [
+    "list_id",
+  ],
+  "description": "The keys to use for batching the events.",
+  "label": "Batch Keys",
+  "multiple": true,
+  "required": false,
+  "type": "string",
+  "unsafe_hidden": true,
+}
+`;
+
 exports[`Testing snapshot for actions-klaviyo destination: orderCompleted action - all fields 1`] = `
 Object {
   "data": Object {
@@ -68,7 +82,35 @@ Object {
 
 exports[`Testing snapshot for actions-klaviyo destination: removeProfile action - all fields 1`] = `""`;
 
+exports[`Testing snapshot for actions-klaviyo destination: removeProfile action - batch keys 1`] = `
+Object {
+  "default": Array [
+    "list_id",
+  ],
+  "description": "The keys to use for batching the events.",
+  "label": "Batch Keys",
+  "multiple": true,
+  "required": false,
+  "type": "string",
+  "unsafe_hidden": true,
+}
+`;
+
 exports[`Testing snapshot for actions-klaviyo destination: removeProfileFromList action - all fields 1`] = `""`;
+
+exports[`Testing snapshot for actions-klaviyo destination: removeProfileFromList action - batch keys 1`] = `
+Object {
+  "default": Array [
+    "list_id",
+  ],
+  "description": "The keys to use for batching the events.",
+  "label": "Batch Keys",
+  "multiple": true,
+  "required": false,
+  "type": "string",
+  "unsafe_hidden": true,
+}
+`;
 
 exports[`Testing snapshot for actions-klaviyo destination: subscribeProfile action - all fields 1`] = `
 Object {
@@ -111,6 +153,21 @@ Object {
     },
     "type": "profile-subscription-bulk-create-job",
   },
+}
+`;
+
+exports[`Testing snapshot for actions-klaviyo destination: subscribeProfile action - batch keys 1`] = `
+Object {
+  "default": Array [
+    "list_id",
+    "custom_source",
+  ],
+  "description": "The keys to use for batching the events.",
+  "label": "Batch Keys",
+  "multiple": true,
+  "required": false,
+  "type": "string",
+  "unsafe_hidden": true,
 }
 `;
 
@@ -193,6 +250,20 @@ Object {
 }
 `;
 
+exports[`Testing snapshot for actions-klaviyo destination: unsubscribeProfile action - batch keys 1`] = `
+Object {
+  "default": Array [
+    "list_id",
+  ],
+  "description": "The keys to use for batching the events.",
+  "label": "Batch Keys",
+  "multiple": true,
+  "required": false,
+  "type": "string",
+  "unsafe_hidden": true,
+}
+`;
+
 exports[`Testing snapshot for actions-klaviyo destination: upsertProfile action - all fields 1`] = `
 Object {
   "data": Object {
@@ -221,5 +292,20 @@ Object {
     },
     "type": "profile",
   },
+}
+`;
+
+exports[`Testing snapshot for actions-klaviyo destination: upsertProfile action - batch keys 1`] = `
+Object {
+  "default": Array [
+    "list_id",
+    "override_list_id",
+  ],
+  "description": "The keys to use for batching the events.",
+  "label": "Batch Keys",
+  "multiple": true,
+  "required": false,
+  "type": "string",
+  "unsafe_hidden": true,
 }
 `;

--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/snapshot.test.ts
@@ -45,5 +45,12 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
         expect(rawBody).toMatchSnapshot()
       }
     })
+
+    const action = destination.actions[actionSlug]
+    if (action.fields.batch_keys) {
+      it(`${actionSlug} action - batch keys`, async () => {
+        expect(action.fields.batch_keys).toMatchSnapshot()
+      })
+    }
   }
 })

--- a/packages/destination-actions/src/destinations/klaviyo/addProfileToList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/addProfileToList/generated-types.ts
@@ -68,4 +68,8 @@ export interface Payload {
    * Country Code in ISO 3166-1 alpha-2 format. If provided, this will be used to validate and automatically format Phone Number field in E.164 format accepted by Klaviyo.
    */
   country_code?: string
+  /**
+   * The keys to use for batching the events.
+   */
+  batch_keys?: string[]
 }

--- a/packages/destination-actions/src/destinations/klaviyo/addProfileToList/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/addProfileToList/index.ts
@@ -57,6 +57,7 @@ const action: ActionDefinition<Settings, Payload> = {
       enable_batching,
       batch_size,
       country_code,
+      batch_keys,
       ...additionalAttributes
     } = payload
     const phone_number = processPhoneNumber(initialPhoneNumber, country_code)

--- a/packages/destination-actions/src/destinations/klaviyo/addProfileToList/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/addProfileToList/index.ts
@@ -66,8 +66,8 @@ const action: ActionDefinition<Settings, Payload> = {
     const profileId = await createProfile(request, email, external_id, phone_number, additionalAttributes)
     return await addProfileToList(request, profileId, list_id)
   },
-  performBatch: async (request, { payload }) => {
-    return sendBatchedProfileImportJobRequest(request, payload)
+  performBatch: async (request, { payload, statsContext }) => {
+    return sendBatchedProfileImportJobRequest(request, payload, statsContext)
   }
 }
 

--- a/packages/destination-actions/src/destinations/klaviyo/addProfileToList/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/addProfileToList/index.ts
@@ -37,7 +37,16 @@ const action: ActionDefinition<Settings, Payload> = {
     organization: { ...organization },
     location: { ...location },
     properties: { ...properties },
-    country_code: { ...country_code }
+    country_code: { ...country_code },
+    batch_keys: {
+      label: 'Batch Keys',
+      description: 'The keys to use for batching the events.',
+      type: 'string',
+      unsafe_hidden: true,
+      required: false,
+      multiple: true,
+      default: ['list_id']
+    }
   },
   perform: async (request, { payload }) => {
     const {

--- a/packages/destination-actions/src/destinations/klaviyo/functions.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/functions.ts
@@ -544,7 +544,7 @@ export async function removeBulkProfilesFromList(
     const { tags, statsClient } = statsContext
     const set = new Set()
     filteredPayloads.forEach((x) => set.add(x.list_id))
-    statsClient.histogram('actions-klaviyo.remove_profile_from_list.unique_list_id', set.size, tags)
+    statsClient?.histogram('actions-klaviyo.remove_profile_from_list.unique_list_id', set.size, tags)
   }
 
   const listId = filteredPayloads[0]?.list_id as string
@@ -697,7 +697,7 @@ export async function sendBatchedProfileImportJobRequest(
     const { tags, statsClient } = statsContext
     const set = new Set()
     filteredPayloads.forEach((x) => set.add(x.list_id))
-    statsClient.histogram('actions-klaviyo.add_profile_to_list.unique_list_id', set.size, tags)
+    statsClient?.histogram('actions-klaviyo.add_profile_to_list.unique_list_id', set.size, tags)
   }
   const importJobPayload = constructBulkProfileImportPayload(
     filteredPayloads as unknown as KlaviyoProfile[],

--- a/packages/destination-actions/src/destinations/klaviyo/functions.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/functions.ts
@@ -142,7 +142,7 @@ export const createImportJobPayload = (profiles: Payload[], listId?: string): { 
     attributes: {
       profiles: {
         data: profiles.map(
-          ({ list_id, enable_batching, batch_size, override_list_id, country_code, ...attributes }) => ({
+          ({ list_id, enable_batching, batch_size, override_list_id, country_code, batch_keys, ...attributes }) => ({
             type: 'profile',
             attributes
           })
@@ -652,7 +652,7 @@ function validateAndConstructProfilePayload(payload: AddProfileToListPayload): {
     delete payload.country_code
   }
 
-  const { list_id, enable_batching, batch_size, country_code, ...attributes } = payload
+  const { list_id, enable_batching, batch_size, country_code, batch_keys, ...attributes } = payload
 
   response.validPayload = { type: 'profile', attributes: attributes as JSONLikeObject }
   return response

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfile/generated-types.ts
@@ -29,4 +29,8 @@ export interface Payload {
    * Country Code in ISO 3166-1 alpha-2 format. If provided, this will be used to validate and automatically format Phone Number field in E.164 format accepted by Klaviyo.
    */
   country_code?: string
+  /**
+   * The keys to use for batching the events.
+   */
+  batch_keys?: string[]
 }

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
@@ -75,8 +75,8 @@ const action: ActionDefinition<Settings, Payload> = {
     )
     return await removeProfileFromList(request, profileIds, list_id)
   },
-  performBatch: async (request, { payload }) => {
-    return await removeBulkProfilesFromList(request, payload)
+  performBatch: async (request, { payload, statsContext }) => {
+    return await removeBulkProfilesFromList(request, payload, statsContext)
   }
 }
 

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
@@ -45,6 +45,15 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     country_code: {
       ...country_code
+    },
+    batch_keys: {
+      label: 'Batch Keys',
+      description: 'The keys to use for batching the events.',
+      type: 'string',
+      unsafe_hidden: true,
+      required: false,
+      multiple: true,
+      default: ['list_id']
     }
   },
   dynamicFields: {

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfileFromList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfileFromList/generated-types.ts
@@ -29,4 +29,8 @@ export interface Payload {
    * Maximum number of events to include in each batch. Actual batch sizes may be lower.
    */
   batch_size?: number
+  /**
+   * The keys to use for batching the events.
+   */
+  batch_keys?: string[]
 }

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfileFromList/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfileFromList/index.ts
@@ -16,7 +16,16 @@ const action: ActionDefinition<Settings, Payload> = {
     phone_number: { ...phone_number },
     enable_batching: { ...enable_batching },
     country_code: { ...country_code },
-    batch_size: { ...batch_size, default: 1000 }
+    batch_size: { ...batch_size, default: 1000 },
+    batch_keys: {
+      label: 'Batch Keys',
+      description: 'The keys to use for batching the events.',
+      type: 'string',
+      unsafe_hidden: true,
+      required: false,
+      multiple: true,
+      default: ['list_id']
+    }
   },
   perform: async (request, { payload }) => {
     const { email, list_id, external_id, phone_number: initialPhoneNumber, country_code } = payload

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfileFromList/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfileFromList/index.ts
@@ -41,8 +41,8 @@ const action: ActionDefinition<Settings, Payload> = {
     )
     return await removeProfileFromList(request, profileIds, list_id)
   },
-  performBatch: async (request, { payload }) => {
-    return await removeBulkProfilesFromList(request, payload)
+  performBatch: async (request, { payload, statsContext }) => {
+    return await removeBulkProfilesFromList(request, payload, statsContext)
   }
 }
 

--- a/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/generated-types.ts
@@ -29,4 +29,8 @@ export interface Payload {
    * When enabled, the action will use the Klaviyo batch API.
    */
   enable_batching?: boolean
+  /**
+   * The keys to use for batching the events.
+   */
+  batch_keys?: string[]
 }

--- a/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/index.ts
@@ -122,7 +122,7 @@ const action: ActionDefinition<Settings, Payload> = {
       filteredPayload.forEach((profile) => {
         set.add(`${profile.list_id}-${profile.custom_source}`)
       })
-      statsClient.histogram('actions-klaviyo.subscribe_profile.unique_list_id', set.size, tags)
+      statsClient?.histogram('actions-klaviyo.subscribe_profile.unique_list_id', set.size, tags)
     }
 
     // if there are no payloads with phone or email throw error

--- a/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/index.ts
@@ -67,6 +67,15 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'boolean',
       label: 'Batch Data to Klaviyo',
       description: 'When enabled, the action will use the Klaviyo batch API.'
+    },
+    batch_keys: {
+      label: 'Batch Keys',
+      description: 'The keys to use for batching the events.',
+      type: 'string',
+      unsafe_hidden: true,
+      required: false,
+      multiple: true,
+      default: ['list_id', 'custom_source']
     }
   },
   dynamicFields: {

--- a/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/index.ts
@@ -116,6 +116,15 @@ const action: ActionDefinition<Settings, Payload> = {
       return profile.email || profile.phone_number
     })
 
+    if (statsContext) {
+      const { statsClient, tags } = statsContext
+      const set = new Set()
+      filteredPayload.forEach((profile) => {
+        set.add(`${profile.list_id}-${profile.custom_source}`)
+      })
+      statsClient.histogram('actions-klaviyo.subscribe_profile.unique_list_id', set.size, tags)
+    }
+
     // if there are no payloads with phone or email throw error
     if (filteredPayload.length === 0) {
       throw new PayloadValidationError('Phone Number or Email is required.')

--- a/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/index.ts
@@ -99,7 +99,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: subData
     })
   },
-  performBatch: async (request, { payload, statsContext, features }) => {
+  performBatch: async (request, { payload, statsContext }) => {
     // remove payloads that have niether email or phone_number
     const filteredPayload = payload.filter((profile) => {
       // Validate and convert the phone number using the provided country code
@@ -150,16 +150,6 @@ const action: ActionDefinition<Settings, Payload> = {
       throw new PayloadValidationError(
         'Exceeded maximum allowed batches due to unique list_id and custom_source pairings'
       )
-    }
-    const statsClient = statsContext?.statsClient
-    const tags = statsContext?.tags
-
-    if (features && features['klaviyo-list-id']) {
-      const set = new Set()
-      payload.forEach((profile) => {
-        set.add(profile.list_id)
-      })
-      statsClient?.histogram(`klaviyo_list_id`, set.size, tags)
     }
     const requests: Promise<ModifiedResponse<Response>>[] = []
     batches.forEach((key) => {

--- a/packages/destination-actions/src/destinations/klaviyo/unsubscribeProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/unsubscribeProfile/generated-types.ts
@@ -21,4 +21,8 @@ export interface Payload {
    * When enabled, the action will use the Klaviyo batch API.
    */
   enable_batching?: boolean
+  /**
+   * The keys to use for batching the events.
+   */
+  batch_keys?: string[]
 }

--- a/packages/destination-actions/src/destinations/klaviyo/unsubscribeProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/unsubscribeProfile/index.ts
@@ -106,7 +106,7 @@ const action: ActionDefinition<Settings, Payload> = {
       filteredPayload.forEach((profile) => {
         set.add(profile.list_id)
       })
-      statsClient.histogram('actions-klaviyo.unsubscribe_profile.unique_list_id', set.size, tags)
+      statsClient?.histogram('actions-klaviyo.unsubscribe_profile.unique_list_id', set.size, tags)
     }
 
     // if there are no payloads with phone or email throw error

--- a/packages/destination-actions/src/destinations/klaviyo/unsubscribeProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/unsubscribeProfile/index.ts
@@ -51,6 +51,15 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'boolean',
       label: 'Batch Data to Klaviyo',
       description: 'When enabled, the action will use the Klaviyo batch API.'
+    },
+    batch_keys: {
+      label: 'Batch Keys',
+      description: 'The keys to use for batching the events.',
+      type: 'string',
+      unsafe_hidden: true,
+      required: false,
+      multiple: true,
+      default: ['list_id']
     }
   },
   dynamicFields: {

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/generated-types.ts
@@ -72,6 +72,10 @@ export interface Payload {
    * Klaviyo list ID to override the default list ID when provided in an event payload. Added to support backward compatibility with klaviyo(classic) and facilitate a seamless migration.
    */
   override_list_id?: string
+  /**
+   * The keys to use for batching the events.
+   */
+  batch_keys?: string[]
 }
 // Generated file. DO NOT MODIFY IT BY HAND.
 

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
@@ -309,7 +309,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
 
-  performBatch: async (request, { payload, hookOutputs }) => {
+  performBatch: async (request, { payload, hookOutputs, statsContext }) => {
     payload = payload.filter((profile) => {
       // Validate and convert the phone number using the provided country code
       const validPhoneNumber = validateAndConvertPhoneNumber(profile.phone_number, profile.country_code)
@@ -324,6 +324,13 @@ const action: ActionDefinition<Settings, Payload> = {
       }
       return profile.email || profile.phone_number || profile.external_id
     })
+
+    if (statsContext) {
+      const { tags, statsClient } = statsContext
+      const set = new Set()
+      payload.forEach((x) => set.add(`${x.list_id}-${x.override_list_id}`))
+      statsClient.histogram('actions-klaviyo.remove_profile_from_list.unique_list_id', set.size, tags)
+    }
 
     const profilesWithList: Payload[] = []
     const profilesWithoutList: Payload[] = []

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
@@ -156,6 +156,15 @@ const action: ActionDefinition<Settings, Payload> = {
         'Klaviyo list ID to override the default list ID when provided in an event payload. Added to support backward compatibility with klaviyo(classic) and facilitate a seamless migration.',
       type: 'string',
       default: { '@path': '$.integrations.Klaviyo.listId' }
+    },
+    batch_keys: {
+      label: 'Batch Keys',
+      description: 'The keys to use for batching the events.',
+      type: 'string',
+      unsafe_hidden: true,
+      required: false,
+      multiple: true,
+      default: ['list_id']
     }
   },
   hooks: {

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
@@ -248,6 +248,7 @@ const action: ActionDefinition<Settings, Payload> = {
       list_id: otherListId,
       override_list_id,
       country_code,
+      batch_keys,
       ...otherAttributes
     } = payload
 

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
@@ -164,7 +164,7 @@ const action: ActionDefinition<Settings, Payload> = {
       unsafe_hidden: true,
       required: false,
       multiple: true,
-      default: ['list_id']
+      default: ['list_id', 'override_list_id']
     }
   },
   hooks: {

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
@@ -329,7 +329,7 @@ const action: ActionDefinition<Settings, Payload> = {
       const { tags, statsClient } = statsContext
       const set = new Set()
       payload.forEach((x) => set.add(`${x.list_id}-${x.override_list_id}`))
-      statsClient.histogram('actions-klaviyo.remove_profile_from_list.unique_list_id', set.size, tags)
+      statsClient?.histogram('actions-klaviyo.remove_profile_from_list.unique_list_id', set.size, tags)
     }
 
     const profilesWithList: Payload[] = []


### PR DESCRIPTION
This PR adds a new hidden `batch_keys` mapping to all Klaviyo actions. This mapping controls how events are batched together. 

This PR in itself won't have any effect as it depends on https://github.com/segmentio/integrations-go/pull/449. The integrations-go changes are behind a flagon and we'll be doing a controlled rollout.


Test Doc - [here](https://docs.google.com/document/d/12lgCwYzZ7Cgbv-XbcG3cViuHWJCiMxyvYr8E4S1lu90/edit?tab=t.wfswq4c8kfqn#bookmark=id.p26s2vlok2eg)

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
