### PR TITLE
Allow only dropdown value in objectType and toObjectType in UpsertCustomObjectRecord.

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
@@ -65,7 +65,9 @@ const action: ActionDefinition<Settings, Payload> = {
         'The CRM object schema to use for creating a record. This can be a standard object (i.e. tickets, deals) or ***fullyQualifiedName*** of a custom object. Schema for the Custom Objects must be predefined in HubSpot. More information on Custom Objects and *fullyQualifiedName* in [HubSpot documentation](https://developers.hubspot.com/docs/api/crm/crm-custom-objects#retrieve-existing-custom-objects).',
       type: 'string',
       required: true,
-      dynamic: true
+      dynamic: true,
+      allowNull: false,
+      disabledInputMethods: ['enrichment', 'freeform', 'literal', 'function']
     },
     properties: {
       label: 'Properties',
@@ -88,7 +90,8 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'The CRM object schema to use for associating a record. This can be a standard object (i.e. tickets, deals, contacts, companies) or ***fullyQualifiedName*** of a custom object. Schema for the Custom Objects must be predefined in HubSpot. More information on Custom Objects and *fullyQualifiedName* in [HubSpot documentation](https://developers.hubspot.com/docs/api/crm/crm-custom-objects#retrieve-existing-custom-objects).',
       type: 'string',
-      dynamic: true
+      dynamic: true,
+      disabledInputMethods: ['literal', 'variable', 'function', 'freeform', 'enrichment']
     },
     associationLabel: {
       label: 'Association Label',

--- a/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertCustomObjectRecord/index.ts
@@ -67,7 +67,7 @@ const action: ActionDefinition<Settings, Payload> = {
       required: true,
       dynamic: true,
       allowNull: false,
-      disabledInputMethods: ['enrichment', 'freeform', 'literal', 'function']
+      disabledInputMethods: ['literal', 'variable', 'function', 'freeform', 'enrichment']
     },
     properties: {
       label: 'Properties',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This Pull Request is to allow only dropdown value in objectType and toObjectType in UpserCustomObjectRecord.
Jira Ticket:- https://segment.atlassian.net/jira/software/c/projects/STRATCONN/boards/310?assignee=63617339fc0cc7a600b03c6b&selectedIssue=STRATCONN-5744
## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
