### PR TITLE
Add initial status to drip destination

### DIFF
--- a/packages/destination-actions/src/destinations/drip/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/drip/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -8,6 +8,7 @@ Object {
         "testType": "XoS!vJs",
       },
       "email": "mivsaj@pu.co.uk",
+      "initial_status": "XoS!vJs",
       "ip_address": "33.172.51.152",
       "phone": "XoS!vJs",
       "status": "XoS!vJs",

--- a/packages/destination-actions/src/destinations/drip/identify/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/drip/identify/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -8,6 +8,7 @@ Object {
         "testType": "DVw6A7$UK[I",
       },
       "email": "okavno@kulusof.bg",
+      "initial_status": "DVw6A7$UK[I",
       "ip_address": "100.102.165.77",
       "phone": "DVw6A7$UK[I",
       "status": "DVw6A7$UK[I",

--- a/packages/destination-actions/src/destinations/drip/identify/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/drip/identify/__tests__/index.test.ts
@@ -22,6 +22,7 @@ describe('Drip.identify', () => {
       traits: {
         email: 'test@example.com',
         phone: '1234567890',
+        initial_status: 'active',
         status: 'unsubscribed',
         status_updated_at: '2021-01-01T00:00:00Z',
         custom_fields: {
@@ -57,6 +58,7 @@ describe('Drip.identify', () => {
           email: 'test@example.com',
           ip_address: '127.0.0.1',
           phone: '1234567890',
+          initial_status: 'active',
           status: 'unsubscribed',
           status_updated_at: '2021-01-01T00:00:00Z',
           tags: ['tag1', 'tag2'],
@@ -90,7 +92,7 @@ describe('Drip.identify', () => {
         {
           email: 'foo@bar.com',
           ip_address: '8.8.8.8', // This could be wrong. Is this the IP address of the client, or segment?
-          status: 'unsubscribed',
+          initial_status: 'unsubscribed',
           time_zone: 'Europe/Amsterdam'
         }
       ]
@@ -112,6 +114,7 @@ describe('Drip.identify', () => {
       traits: {
         properties: {
           email: 'test@example.com',
+          initial_status: 'awaiting_confirmation',
           status: 'active',
           status_updated_at: '2023-01-01T00:00:00Z',
           custom_fields: {
@@ -129,6 +132,9 @@ describe('Drip.identify', () => {
       mapping: {
         email: {
           '@path': '$.traits.properties.email'
+        },
+        initial_status: {
+          '@path': '$.traits.properties.initial_status'
         },
         status: {
           '@path': '$.traits.properties.status'
@@ -160,6 +166,7 @@ describe('Drip.identify', () => {
           },
           email: 'test@example.com',
           ip_address: '127.0.0.1',
+          initial_status: 'awaiting_confirmation',
           status: 'active',
           status_updated_at: '2023-01-01T00:00:00Z',
           tags: ['vip', 'premium'],

--- a/packages/destination-actions/src/destinations/drip/identify/generated-types.ts
+++ b/packages/destination-actions/src/destinations/drip/identify/generated-types.ts
@@ -20,7 +20,11 @@ export interface Payload {
    */
   phone?: string
   /**
-   * The person's subscription status.
+   * The person's subscription status if newly identified.
+   */
+  initial_status?: string
+  /**
+   * The person's subscription status. Overrides initial_status.
    */
   status?: string
   /**

--- a/packages/destination-actions/src/destinations/drip/identify/index.ts
+++ b/packages/destination-actions/src/destinations/drip/identify/index.ts
@@ -15,6 +15,7 @@ const person = (payload: Payload) => {
     email: payload.email,
     ip_address: payload.ip,
     phone: payload.phone,
+    initial_status: payload.initial_status,
     status: payload.status,
     status_updated_at: payload.status_updated_at,
     tags: payload.tags?.split(',').map((tag) => tag.trim()),
@@ -57,18 +58,25 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       default: { '@path': '$.traits.phone' }
     },
-    status: {
-      description: "The person's subscription status.",
-      label: 'Status',
+    initial_status: {
+      description: "The person's subscription status if newly identified.",
+      label: 'Initial Status',
       required: false,
       type: 'string',
       default: {
         '@if': {
-          exists: { '@path': '$.traits.status' },
-          then: { '@path': '$.traits.status' },
+          exists: { '@path': '$.traits.initial_status' },
+          then: { '@path': '$.traits.initial_status' },
           else: 'unsubscribed'
         }
       }
+    },
+    status: {
+      description: "The person's subscription status. Overrides initial_status.",
+      label: 'Status',
+      required: false,
+      type: 'string',
+      default: { '@path': '$.traits.status' }
     },
     status_updated_at: {
       description: "The timestamp associated with the update to a person's status.",


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

The default behavior for `status` is a footgun for users. Prefer the more forgiving `initial_status` instead. When combined with `status_updated_at` this will updated a person's status as if the change happened at that timestamp. When `status_updated_at` is missing, any existing status will take priority.

Previously, we assumed that the user would always want to update the status when identifying a person. We defaulted to unsubscribing, and at the current timestamp. This has proven to be a poor assumption in practice. With this new behavior, if the `status_updated_at` was intended to be passed but missing, we won't modify the person's status in drip.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
