### PR TITLE
Worked on handling empty array being sent to Klaviyo resulting 400 Bad request.

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/removeProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfile/__tests__/index.test.ts
@@ -235,4 +235,32 @@ describe('Remove Profile', () => {
 
     await expect(testDestination.testAction('removeProfile', { event, mapping, settings })).resolves.not.toThrowError()
   })
+
+  it('should throw payload validation error when no profile is mapped with provided identifier', async () => {
+    const phone_number = '+15005435907'
+    nock(`${API_URL}/profiles`).get(`/?filter=any(phone_number,["${phone_number}"])`).reply(200, {
+      data: []
+    })
+
+    const event = createTestEvent({
+      type: 'track',
+      userId: '123',
+      context: {
+        personas: {
+          external_audience_id: listId
+        }
+      },
+      properties: {
+        phone_number: '+15005435907'
+      }
+    })
+    const mapping = {
+      list_id: listId,
+      phone_number: '+15005435907'
+    }
+
+    await expect(testDestination.testAction('removeProfile', { event, mapping, settings })).rejects.toThrowError(
+      'No profiles found for the provided identifiers.'
+    )
+  })
 })

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfile/index.ts
@@ -64,6 +64,9 @@ const action: ActionDefinition<Settings, Payload> = {
       external_id ? [external_id] : undefined,
       phone_number ? [phone_number] : undefined
     )
+    if (!profileIds?.length) {
+      throw new PayloadValidationError('No profiles found for the provided identifiers.')
+    }
     return await removeProfileFromList(request, profileIds, list_id)
   },
   performBatch: async (request, { payload }) => {

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfileFromList/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfileFromList/__tests__/index.test.ts
@@ -190,4 +190,28 @@ describe('Remove List from Profile', () => {
       testDestination.testAction('removeProfileFromList', { event, mapping, settings })
     ).resolves.not.toThrowError()
   })
+
+  it('should throw payload validation error when no profile is mapped with provided identifier', async () => {
+    const email = 'test@example.com'
+    nock(`${API_URL}/profiles`).get(`/?filter=any(email,["${email}"])`).reply(200, {
+      data: []
+    })
+
+    const event = createTestEvent({
+      type: 'track',
+      userId: '123',
+      context: {
+        personas: {
+          external_audience_id: listId
+        },
+        traits: {
+          email: 'test@example.com'
+        }
+      }
+    })
+
+    await expect(
+      testDestination.testAction('removeProfileFromList', { event, settings, useDefaultMappings: true })
+    ).rejects.toThrowError('No profiles found for the provided identifiers.')
+  })
 })

--- a/packages/destination-actions/src/destinations/klaviyo/removeProfileFromList/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/removeProfileFromList/index.ts
@@ -30,6 +30,9 @@ const action: ActionDefinition<Settings, Payload> = {
       external_id ? [external_id] : undefined,
       phone_number ? [phone_number] : undefined
     )
+    if (!profileIds?.length) {
+      throw new PayloadValidationError('No profiles found for the provided identifiers.')
+    }
     return await removeProfileFromList(request, profileIds, list_id)
   },
   performBatch: async (request, { payload }) => {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR is to handle empty array being sent to Klaviyo resulting 400 Bad Request.

Jira Ticket :- https://segment.atlassian.net/jira/software/c/projects/STRATCONN/boards/310?assignee=63617339fc0cc7a600b03c6b&selectedIssue=STRATCONN-5759

**Problem:-** 
**When Data is sent as empty array due to no profile Id found for provided identifier.** 
<img width="1064" alt="Screenshot 2025-04-24 at 6 49 17 PM" src="https://github.com/user-attachments/assets/660ab59d-3269-4e61-9bc2-0fc100b1ac2d" />

**API threw an error.** 
<img width="998" alt="Screenshot 2025-04-24 at 6 48 54 PM" src="https://github.com/user-attachments/assets/4d4b5e7f-8d0c-41ad-9368-b53fef03b335" />

**Solution:-**
**When Data is sent as empty array due to no profile Id found for provided identifier,handled it and throws a Payload Validation Error before making an API request.** 
<img width="1094" alt="Screenshot 2025-04-24 at 6 53 46 PM" src="https://github.com/user-attachments/assets/24fc6f31-c127-4457-9f47-9f8eb140669e" />

**In case of valid Identifier , it successfully makes an API request and works as expected.**
<img width="1093" alt="Screenshot 2025-04-24 at 6 54 51 PM" src="https://github.com/user-attachments/assets/5c680ff1-f44b-4872-839e-66a6141646f4" />

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
