### PR TITLE
STRATCONN-5564 - add sales objects

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/upsertObject/constants.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertObject/constants.ts
@@ -9,9 +9,7 @@ export const SUPPORTED_HUBSPOT_OBJECT_TYPES = [
   { label: 'Company', value: 'company' },
   { label: 'Deal', value: 'deal' },
   { label: 'Ticket', value: 'ticket' },
-  { label: 'Lead', value: 'lead' },
   { label: 'Line Item', value: 'line_item' },
-  { label: 'Quote', value: 'quote' },
   { label: 'Subscription', value: 'subscription' },
   { label: 'Product', value: 'product' }
 ]

--- a/packages/destination-actions/src/destinations/hubspot/upsertObject/constants.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertObject/constants.ts
@@ -12,7 +12,8 @@ export const SUPPORTED_HUBSPOT_OBJECT_TYPES = [
   { label: 'Lead', value: 'lead' },
   { label: 'Line Item', value: 'line_item' },
   { label: 'Quote', value: 'quote' },
-  { label: 'Subscription', value: 'subscription' }
+  { label: 'Subscription', value: 'subscription' },
+  { label: 'Product', value: 'product' }
 ]
 
 export const MAX_HUBSPOT_BATCH_SIZE = 100

--- a/packages/destination-actions/src/destinations/hubspot/upsertObject/constants.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertObject/constants.ts
@@ -8,7 +8,11 @@ export const SUPPORTED_HUBSPOT_OBJECT_TYPES = [
   { label: 'Contact', value: 'contact' },
   { label: 'Company', value: 'company' },
   { label: 'Deal', value: 'deal' },
-  { label: 'Ticket', value: 'ticket' }
+  { label: 'Ticket', value: 'ticket' },
+  { label: 'Lead', value: 'lead' },
+  { label: 'Line Item', value: 'line_item' },
+  { label: 'Quote', value: 'quote' },
+  { label: 'Subscription', value: 'subscription' }
 ]
 
 export const MAX_HUBSPOT_BATCH_SIZE = 100


### PR DESCRIPTION
Added custom objects v2 support for line_items, products and subscription.

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
