### PR TITLE
Fix MultiStatus Readme

### DIFF
--- a/docs/multistatus.md
+++ b/docs/multistatus.md
@@ -355,6 +355,7 @@ const filteredPayloads: JSONLikeObject[] = []
 // A bitmap data structure that stores arr[new_index] = original_batch_payload_index
 const validPayloadIndicesBitmap: number[] = []
 
+// Iterate over the payloads and validate them
 payloads.forEach((payload, originalBatchIndex) => {
   const { email, phone } = payload
 
@@ -393,20 +394,20 @@ Assuming the API returns an HTTP 207 `MultiStatus` response as follows:
 
 ```json
 {
-  itemsProcessed: 5
-  success: 3
-  error: 2
-  errorResponses: [
+  "itemsProcessed": 5,
+  "success": 3,
+  "error": 2,
+  "errorResponses": [
     {
-      status: 400,
-      message: "Invalid zip code",
-      index: 0,
+      "status": 400,
+      "message": "Invalid zip code",
+      "index": 0
     },
     {
-      status: 400,
-      message: "Invalid zip code",
-      index: 1,
-    },
+      "status": 400,
+      "message": "Invalid zip code",
+      "index": 1
+    }
   ]
 }
 ```


### PR DESCRIPTION
This PR fixes the MultiStatus readme.

## Testing

Testing not required as this is a README update.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
