### PR TITLE
small updates to the default mappings in the Reddit CAPI integration

### DIFF
--- a/packages/destination-actions/src/destinations/reddit-conversions-api/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/reddit-conversions-api/__tests__/index.test.ts
@@ -22,10 +22,9 @@ describe('Reddit Conversions Api', () => {
         userId: 'user_id_1',
         properties: {
           click_id: 'click_id_1',
-          conversion_id: 'ea3d01f99e303d2338cfb4e71f182441eb57c9a3cb129c40bcae9f5d641a7375',
           currency: 'USD',
           quantity: 10,
-          total: 100,
+          revenue: 100,
           uuid: 'uuid_1',
           products: [
             { product_id: 'product_id_1', category: 'category_1', name: 'name_1' },
@@ -60,7 +59,7 @@ describe('Reddit Conversions Api', () => {
             click_id: 'click_id_1',
             event_at: '2024-01-08T13:52:50.212Z',
             event_metadata: {
-              conversion_id: '492ebaa71872336ef94c7093b77d2232fdba7e469f716586a816d861367b183f',
+              conversion_id: '5184171f53a0fd17f59ea50fac8e11d9eb589ed0692920ee4f52a357112e6802',
               currency: 'USD',
               item_count: 10,
               products: [
@@ -99,12 +98,11 @@ describe('Reddit Conversions Api', () => {
       const event = createTestEvent({
         timestamp: timestamp,
         event: 'Some Custom Event Name',
-        messageId: 'test-message-id-contact',
+        messageId: '492ebaa71872336ef94c7093b77d2232fdba7e469f716586a816d861367b183f',
         type: 'track',
         userId: 'user_id_1',
         properties: {
           click_id: 'click_id_1',
-          conversion_id: '492ebaa71872336ef94c7093b77d2232fdba7e469f716586a816d861367b183f',
           currency: 'USD',
           quantity: 10,
           total: 100,
@@ -189,10 +187,10 @@ describe('Reddit Conversions Api', () => {
         userId: 'user_id_1',
         properties: {
           click_id: 'click_id_1',
-          conversion_id: 'ea3d01f99e303d2338cfb4e71f182441eb57c9a3cb129c40bcae9f5d641a7375',
           currency: 'USD',
           quantity: 10,
-          total: 100,
+          revenue: 100,
+          total: 30,
           uuid: 'uuid_1',
           products: [
             { product_id: 'product_id_1', category: 'category_1', name: 'name_1' },
@@ -227,7 +225,7 @@ describe('Reddit Conversions Api', () => {
             click_id: 'click_id_1',
             event_at: '2024-01-08T13:52:50.212Z',
             event_metadata: {
-              conversion_id: '492ebaa71872336ef94c7093b77d2232fdba7e469f716586a816d861367b183f',
+              conversion_id: '5184171f53a0fd17f59ea50fac8e11d9eb589ed0692920ee4f52a357112e6802',
               currency: 'USD',
               item_count: 10,
               products: [
@@ -270,9 +268,8 @@ describe('Reddit Conversions Api', () => {
         userId: 'user_id_1',
         properties: {
           click_id: 'click_id_1',
-          conversion_id: 'ea3d01f99e303d2338cfb4e71f182441eb57c9a3cb129c40bcae9f5d641a7375',
           currency: 'USD',
-          total: 100,
+          revenue: 100,
           uuid: 'uuid_1',
           products: [
             { product_id: 'product_id_1', category: 'category_1', name: 'name_1' },
@@ -307,7 +304,7 @@ describe('Reddit Conversions Api', () => {
             click_id: 'click_id_1',
             event_at: '2024-01-08T13:52:50.212Z',
             event_metadata: {
-              conversion_id: '492ebaa71872336ef94c7093b77d2232fdba7e469f716586a816d861367b183f',
+              conversion_id: '5184171f53a0fd17f59ea50fac8e11d9eb589ed0692920ee4f52a357112e6802',
               currency: 'USD',
               products: [
                 {
@@ -344,12 +341,11 @@ describe('Reddit Conversions Api', () => {
       const event = createTestEvent({
         timestamp: timestamp,
         event: 'Lead Generated',
-        messageId: 'test-message-id-contact',
+        messageId: 'ea3d01f99e303d2338cfb4e71f182441eb57c9a3cb129c40bcae9f5d641a7375',
         type: 'track',
         userId: 'user_id_1',
         properties: {
           click_id: 'click_id_1',
-          conversion_id: 'ea3d01f99e303d2338cfb4e71f182441eb57c9a3cb129c40bcae9f5d641a7375',
           currency: 'USD',
           total: 100,
           uuid: 'uuid_1',
@@ -466,6 +462,7 @@ describe('Reddit Conversions Api', () => {
             event_at: '2024-01-08T13:52:50.212Z',
             event_metadata: {
               currency: 'USD',
+              conversion_id: '5184171f53a0fd17f59ea50fac8e11d9eb589ed0692920ee4f52a357112e6802',
               products: [
                 {
                   category: 'category_1',

--- a/packages/destination-actions/src/destinations/reddit-conversions-api/customEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/reddit-conversions-api/customEvent/generated-types.ts
@@ -111,7 +111,7 @@ export interface Payload {
     value_decimal?: number
   }
   /**
-   * The unique conversion ID that corresponds to a distinct conversion event.
+   * The unique conversion ID that corresponds to a distinct conversion event. Use this for event deduplication.
    */
   conversion_id?: string
 }

--- a/packages/destination-actions/src/destinations/reddit-conversions-api/fields.ts
+++ b/packages/destination-actions/src/destinations/reddit-conversions-api/fields.ts
@@ -52,10 +52,11 @@ export const click_id: InputField = {
 
 export const conversion_id: InputField = {
   label: 'Conversion ID',
-  description: 'The unique conversion ID that corresponds to a distinct conversion event.',
+  description:
+    'The unique conversion ID that corresponds to a distinct conversion event. Use this for event deduplication.',
   type: 'string',
   required: false,
-  default: { '@path': '$.properties.conversion_id' },
+  default: { '@path': '$.messageId' },
   category: 'hashedPII'
 }
 
@@ -99,7 +100,11 @@ export const event_metadata: InputField = {
       '@path': '$.properties.quantity'
     },
     value_decimal: {
-      '@path': '$.properties.total'
+      '@if': {
+        exists: { '@path': '$.properties.revenue' },
+        then: { '@path': '$.properties.revenue' },
+        else: { '@path': '$.properties.total' }
+      }
     }
   }
 }

--- a/packages/destination-actions/src/destinations/reddit-conversions-api/index.ts
+++ b/packages/destination-actions/src/destinations/reddit-conversions-api/index.ts
@@ -129,7 +129,12 @@ const destination: DestinationDefinition<Settings> = {
       partnerAction: 'standardEvent',
       mapping: {
         ...defaultValues(standardEvent.fields),
-        tracking_type: 'AddToCart'
+        tracking_type: 'AddToCart',
+        event_metadata: {
+          currency: { '@path': '$.properties.currency' },
+          itemCount: { '@path': '$.properties.quantity' },
+          value: { '@path': '$.properties.price' }
+        }
       },
       type: 'automatic'
     },
@@ -139,7 +144,12 @@ const destination: DestinationDefinition<Settings> = {
       partnerAction: 'standardEvent',
       mapping: {
         ...defaultValues(standardEvent.fields),
-        tracking_type: 'AddToWishlist'
+        tracking_type: 'AddToWishlist',
+        event_metadata: {
+          currency: { '@path': '$.properties.currency' },
+          itemCount: { '@path': '$.properties.quantity' },
+          value: { '@path': '$.properties.price' }
+        }
       },
       type: 'automatic'
     },

--- a/packages/destination-actions/src/destinations/reddit-conversions-api/standardEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/reddit-conversions-api/standardEvent/generated-types.ts
@@ -111,7 +111,7 @@ export interface Payload {
     value_decimal?: number
   }
   /**
-   * The unique conversion ID that corresponds to a distinct conversion event.
+   * The unique conversion ID that corresponds to a distinct conversion event. Use this for event deduplication.
    */
   conversion_id?: string
 }


### PR DESCRIPTION
Hi, this is updating some of the default mappings for the Reddit Conversions API destination.

- Updated the "conversion_id" to be mapped to the Segment "messageID". This Conversion ID is used for deduplication so that if we receive the same ID in both the Browser Destination as well as this destination, then our system will dedupe those events.
- Minor updates to the transaction value mappings. Updated the default to be "revenue" and fall back to "total". Also updated it to be "price" for the Segment event "Product Added" and "Product Added to Wishlist" which does not have "revenue" or "total" available as a default.

## Testing

- [ X ] Updated the unit tests to account for hashing of the messageID for the conversion_id field. Also added that it will default to revenue first if revenue and total are both present. The test was failing when I tried to use "price" in the test unit for the "Lead" event for example, but the request looks OK in the testing environment itself. The Unit Testing seems to be only looking at the default mappings.
- [ X ] Tested end-to-end using the [local server] and the request and JSON response looks correct.
- [ X ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
