### PR TITLE
Update subscription presets and action descriptions for audience destinations for Journeys V2

### DIFF
--- a/packages/destination-actions/src/destinations/amazon-amc/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/index.ts
@@ -253,6 +253,15 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
+    },
+    {
+      name: 'Journeys Step Entered',
+      partnerAction: 'syncAudiencesToDSP',
+      mapping: {
+        ...defaultValues(syncAudiencesToDSP.fields)
+      },
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/aws-s3/index.ts
+++ b/packages/destination-actions/src/destinations/aws-s3/index.ts
@@ -105,6 +105,13 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       mapping: defaultValues(syncAudienceToCSV.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
+    },
+    {
+      name: 'Journeys Step Entered',
+      partnerAction: 'syncAudienceToCSV',
+      mapping: defaultValues(syncAudienceToCSV.fields),
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/delivrai-activate/index.ts
+++ b/packages/destination-actions/src/destinations/delivrai-activate/index.ts
@@ -6,7 +6,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   name: 'Delivr AI Audiences',
   slug: 'actions-delivrai-audiences',
   mode: 'cloud',
-  description: 'Sync Segment Engage Audiences to Delivr AI Audience Segmentation.',
+  description: 'Sync Segment Audiences to Delivr AI Audience Segmentation.',
   authentication: {
     scheme: 'custom',
     fields: {
@@ -47,6 +47,15 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
+    },
+    {
+      name: 'Journeys Step Entered',
+      partnerAction: 'updateSegment',
+      mapping: {
+        ...defaultValues(updateSegment.fields)
+      },
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/delivrai-activate/index.ts
+++ b/packages/destination-actions/src/destinations/delivrai-activate/index.ts
@@ -6,7 +6,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   name: 'Delivr AI Audiences',
   slug: 'actions-delivrai-audiences',
   mode: 'cloud',
-  description: 'Sync Segment Audiences to Delivr AI Audience Segmentation.',
+  description: 'Sync users to Delivr AI Audience Segmentation.',
   authentication: {
     scheme: 'custom',
     fields: {

--- a/packages/destination-actions/src/destinations/display-video-360/index.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/index.ts
@@ -183,7 +183,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       eventSlug: 'warehouse_audience_exited_track'
     },
     {
-      name: 'Journeys Step Transition Track',
+      name: 'Journeys Step Entered',
       partnerAction: 'addToAudience',
       mapping: defaultValues(addToAudience.fields),
       type: 'specificEvent',

--- a/packages/destination-actions/src/destinations/display-video-360/index.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/index.ts
@@ -175,13 +175,19 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_entered_track'
     },
-
     {
       name: 'Entities Audience Exited',
       partnerAction: 'removeFromAudience',
       mapping: defaultValues(removeFromAudience.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_exited_track'
+    },
+    {
+      name: 'Journeys Step Transition Track',
+      partnerAction: 'addToAudience',
+      mapping: defaultValues(addToAudience.fields),
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/index.ts
@@ -146,6 +146,15 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
+    },
+    {
+      name: 'Journeys Step Entered',
+      partnerAction: 'syncAudience',
+      mapping: {
+        ...defaultValues(syncAudience.fields)
+      },
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
@@ -5,7 +5,7 @@ import { getUpsertURL, hashAndEncode, getDataCenter, getSectionId } from '../hel
 
 const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
   title: 'Sync Audience',
-  description: 'Sync Segment Engage Audiences to Dynamic Yield',
+  description: 'Sync Segment Audiences to Dynamic Yield',
   defaultSubscription: 'type = "identify" or type = "track"',
   fields: {
     message_id: {

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
@@ -5,7 +5,7 @@ import { getUpsertURL, hashAndEncode, getDataCenter, getSectionId } from '../hel
 
 const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
   title: 'Sync Audience',
-  description: 'Sync Segment Audiences to Dynamic Yield',
+  description: 'Sync users to Dynamic Yield',
   defaultSubscription: 'type = "identify" or type = "track"',
   fields: {
     message_id: {

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/index.ts
@@ -114,6 +114,13 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       mapping: defaultValues(sync.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
+    },
+    {
+      name: 'Journeys Step Entered',
+      partnerAction: 'sync',
+      mapping: defaultValues(sync.fields),
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/first-party-dv360/index.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/index.ts
@@ -263,7 +263,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       eventSlug: 'warehouse_audience_exited_track'
     },
     {
-      name: 'Journeys Step Transition Track',
+      name: 'Journeys Step Entered',
       partnerAction: 'addToAudContactInfo',
       mapping: defaultValues(addToAudContactInfo.fields),
       type: 'specificEvent',

--- a/packages/destination-actions/src/destinations/first-party-dv360/index.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/index.ts
@@ -255,13 +255,19 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_entered_track'
     },
-
     {
       name: 'Entities Audience Exited',
       partnerAction: 'removeFromAudContactInfo',
       mapping: defaultValues(removeFromAudContactInfo.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_exited_track'
+    },
+    {
+      name: 'Journeys Step Transition Track',
+      partnerAction: 'addToAudContactInfo',
+      mapping: defaultValues(addToAudContactInfo.fields),
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -182,6 +182,13 @@ const destination: AudienceDestinationDefinition<Settings> = {
       mapping: defaultValues(userList.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
+    },
+    {
+      name: 'Journeys Step Entered',
+      partnerAction: 'userList',
+      mapping: defaultValues(userList.fields),
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/index.ts
@@ -14,7 +14,7 @@ import { UserListResponse } from '../types'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Customer Match User List',
-  description: 'Sync a Segment Engage Audience into a Google Customer Match User List.',
+  description: 'Sync a Segment Audience into a Google Customer Match User List.',
   defaultSubscription: 'event = "Audience Entered" or event = "Audience Exited"',
   syncMode: {
     description: 'Define how the records will be synced to Google',

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/index.ts
@@ -14,7 +14,7 @@ import { UserListResponse } from '../types'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Customer Match User List',
-  description: 'Sync a Segment Audience into a Google Customer Match User List.',
+  description: 'Sync users into a Google Customer Match User List.',
   defaultSubscription: 'event = "Audience Entered" or event = "Audience Exited"',
   syncMode: {
     description: 'Define how the records will be synced to Google',

--- a/packages/destination-actions/src/destinations/iterable-lists/index.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/index.ts
@@ -8,7 +8,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   name: 'Iterable Lists',
   slug: 'actions-iterable-lists',
   mode: 'cloud',
-  description: 'Sync Segment Engage Audiences to Iterable Lists',
+  description: 'Sync Segment Audiences to Iterable Lists',
 
   authentication: {
     scheme: 'custom',
@@ -95,6 +95,13 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       mapping: defaultValues(syncAudience.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
+    },
+    {
+      name: 'Journeys Step Entered',
+      partnerAction: 'syncAudience',
+      mapping: defaultValues(syncAudience.fields),
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/iterable-lists/index.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/index.ts
@@ -8,7 +8,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   name: 'Iterable Lists',
   slug: 'actions-iterable-lists',
   mode: 'cloud',
-  description: 'Sync Segment Audiences to Iterable Lists',
+  description: 'Sync users to Iterable Lists',
 
   authentication: {
     scheme: 'custom',

--- a/packages/destination-actions/src/destinations/iterable/index.ts
+++ b/packages/destination-actions/src/destinations/iterable/index.ts
@@ -157,6 +157,18 @@ const destination: DestinationDefinition<Settings> = {
       },
       type: 'specificEvent',
       eventSlug: 'journeys_step_entered_track'
+    },
+    {
+      name: 'Journeys Step Entered',
+      partnerAction: 'updateUser',
+      mapping: {
+        ...defaultValues(updateUser.fields),
+        dataFields: {
+          '@path': '$.traits'
+        }
+      },
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/klaviyo/addProfileToList/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/addProfileToList/index.ts
@@ -20,7 +20,7 @@ import {
 } from '../properties'
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Add Profile to List (Engage)',
+  title: 'Add Profile to List',
   description: 'Add Profile To List',
   defaultSubscription: 'event = "Audience Entered"',
   fields: {

--- a/packages/destination-actions/src/destinations/klaviyo/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/index.ts
@@ -168,6 +168,13 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       mapping: defaultValues(removeProfileFromList.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_exited_track'
+    },
+    {
+      name: 'Journeys Step Transition Track',
+      partnerAction: 'addProfileToList',
+      mapping: defaultValues(addProfileToList.fields),
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/klaviyo/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/index.ts
@@ -170,7 +170,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       eventSlug: 'warehouse_audience_exited_track'
     },
     {
-      name: 'Journeys Step Transition Track',
+      name: 'Journeys Step Entered',
       partnerAction: 'addProfileToList',
       mapping: defaultValues(addProfileToList.fields),
       type: 'specificEvent',

--- a/packages/destination-actions/src/destinations/marketo-static-lists/addToList/index.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/addToList/index.ts
@@ -6,7 +6,7 @@ import { addToList, addToListBatch, createList, getList } from '../functions'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Add to List',
-  description: 'Add users from an Engage Audience to a list in Marketo.',
+  description: 'Add users to a list in Marketo.',
   defaultSubscription: 'event = "Audience Entered"',
   fields: {
     external_id: { ...external_id },

--- a/packages/destination-actions/src/destinations/marketo-static-lists/index.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/index.ts
@@ -114,7 +114,7 @@ const destination: AudienceDestinationDefinition<Settings> = {
       eventSlug: 'warehouse_audience_exited_track'
     },
     {
-      name: 'Journeys Step Transition Track',
+      name: 'Journeys Step Entered',
       partnerAction: 'addToList',
       mapping: { ...defaultValues(addToList.fields) },
       type: 'specificEvent',

--- a/packages/destination-actions/src/destinations/marketo-static-lists/index.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/index.ts
@@ -106,13 +106,19 @@ const destination: AudienceDestinationDefinition<Settings> = {
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_entered_track'
     },
-
     {
       name: 'Entities Audience Exited',
       partnerAction: 'removeFromList',
       mapping: defaultValues(removeFromList.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_exited_track'
+    },
+    {
+      name: 'Journeys Step Transition Track',
+      partnerAction: 'addToList',
+      mapping: { ...defaultValues(addToList.fields) },
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/reddit-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/reddit-audiences/index.ts
@@ -93,6 +93,13 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       mapping: defaultValues(syncAudience.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
+    },
+    {
+      name: 'Journeys Step Entered',
+      partnerAction: 'syncAudience',
+      mapping: defaultValues(syncAudience.fields),
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/reddit-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/reddit-audiences/syncAudience/index.ts
@@ -5,7 +5,7 @@ import { send } from './functions'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Sync Audience',
-  description: 'Sync a Segment Audience to Reddit',
+  description: 'Sync users to Reddit',
   defaultSubscription: 'type = "identify" or type = "track"',
   fields: {
     segment_computation_action: {

--- a/packages/destination-actions/src/destinations/reddit-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/reddit-audiences/syncAudience/index.ts
@@ -5,7 +5,7 @@ import { send } from './functions'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Sync Audience',
-  description: 'Sync a Segment Engage Audience to Reddit',
+  description: 'Sync a Segment Audience to Reddit',
   defaultSubscription: 'type = "identify" or type = "track"',
   fields: {
     segment_computation_action: {
@@ -18,7 +18,10 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.context.personas.computation_class'
       },
-      choices: [{ label: 'audience', value: 'audience' },{ label: 'journey_step', value: 'journey_step' }]
+      choices: [
+        { label: 'audience', value: 'audience' },
+        { label: 'journey_step', value: 'journey_step' }
+      ]
     },
     computation_key: {
       label: 'Audience Computation Key',

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/index.ts
@@ -8,7 +8,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   name: 'SendGrid Lists (Actions)',
   slug: 'actions-sendgrid-audiences',
   mode: 'cloud',
-  description: 'Sync Segment Engage Audiences to Sengrid Lists.',
+  description: 'Sync Segment Audiences to Sengrid Lists.',
   authentication: {
     scheme: 'custom',
     fields: {
@@ -90,6 +90,13 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       mapping: defaultValues(syncAudience.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
+    },
+    {
+      name: 'Journeys Step Entered',
+      partnerAction: 'syncAudience',
+      mapping: defaultValues(syncAudience.fields),
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/index.ts
@@ -8,7 +8,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   name: 'SendGrid Lists (Actions)',
   slug: 'actions-sendgrid-audiences',
   mode: 'cloud',
-  description: 'Sync Segment Audiences to Sengrid Lists.',
+  description: 'Sync users to Sengrid Lists.',
   authentication: {
     scheme: 'custom',
     fields: {

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/index.ts
@@ -7,7 +7,7 @@ import { dynamicCustomFields } from './dynamic-fields'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Sync Audience',
-  description: 'Sync a Segment Audience to a Sendgrid List',
+  description: 'Sync users to a Sendgrid List',
   defaultSubscription: 'type = "identify" or type = "track"',
   fields,
   dynamicFields: {

--- a/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/sendgrid-audiences/syncAudience/index.ts
@@ -7,23 +7,23 @@ import { dynamicCustomFields } from './dynamic-fields'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Sync Audience',
-  description: 'Sync a Segment Engage Audience to a Sendgrid List',
+  description: 'Sync a Segment Audience to a Sendgrid List',
   defaultSubscription: 'type = "identify" or type = "track"',
   fields,
   dynamicFields: {
     custom_text_fields: {
       __keys__: async (request, { payload }) => {
-        return await dynamicCustomFields(request, payload, "Text")
+        return await dynamicCustomFields(request, payload, 'Text')
       }
     },
     custom_number_fields: {
       __keys__: async (request, { payload }) => {
-        return await dynamicCustomFields(request, payload, "Number")
+        return await dynamicCustomFields(request, payload, 'Number')
       }
     },
     custom_date_fields: {
       __keys__: async (request, { payload }) => {
-        return await dynamicCustomFields(request, payload, "Date")
+        return await dynamicCustomFields(request, payload, 'Date')
       }
     }
   },

--- a/packages/destination-actions/src/destinations/snap-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/snap-audiences/index.ts
@@ -72,6 +72,13 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       eventSlug: 'warehouse_audience_membership_changed_identify'
     },
     {
+      name: 'Journeys Step Entered',
+      partnerAction: 'syncAudience',
+      mapping: defaultValues(syncAudience.fields),
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
+    },
+    {
       name: 'Sync Audience with Email',
       subscribe: 'type = "track" and context.traits.email exists',
       partnerAction: 'syncAudience',

--- a/packages/destination-actions/src/destinations/snap-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/snap-audiences/syncAudience/index.ts
@@ -6,7 +6,7 @@ import { validationError, sortPayload } from './utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Sync Audience',
-  description: 'Sync Segment Audiences to Snap',
+  description: 'Sync users to Snap',
   defaultSubscription: 'type = "track"',
   fields: {
     external_audience_id: {

--- a/packages/destination-actions/src/destinations/snap-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/snap-audiences/syncAudience/index.ts
@@ -6,7 +6,7 @@ import { validationError, sortPayload } from './utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Sync Audience',
-  description: 'Sync Segment Engage Audiences to Snap',
+  description: 'Sync Segment Audiences to Snap',
   defaultSubscription: 'type = "track"',
   fields: {
     external_audience_id: {

--- a/packages/destination-actions/src/destinations/taboola-actions/index.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/index.ts
@@ -152,6 +152,13 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       mapping: defaultValues(syncAudience.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
+    },
+    {
+      name: 'Journeys Step Entered',
+      partnerAction: 'syncAudience',
+      mapping: defaultValues(syncAudience.fields),
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/taboola-actions/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/syncAudience/index.ts
@@ -6,7 +6,7 @@ import { TaboolaClient } from './client'
 
 const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
   title: 'Sync Audience',
-  description: 'Sync a Segment Audience to Taboola.',
+  description: 'Sync users to Taboola.',
   defaultSubscription: 'type = "track"',
   fields: {
     external_audience_id: {

--- a/packages/destination-actions/src/destinations/taboola-actions/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/taboola-actions/syncAudience/index.ts
@@ -6,7 +6,7 @@ import { TaboolaClient } from './client'
 
 const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
   title: 'Sync Audience',
-  description: 'Sync a Segment Engage Audience to Taboola.',
+  description: 'Sync a Segment Audience to Taboola.',
   defaultSubscription: 'type = "track"',
   fields: {
     external_audience_id: {
@@ -39,7 +39,10 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
       default: {
         '@path': '$.context.personas.computation_class'
       },
-      choices: [{ label: 'audience', value: 'audience' },{ label: 'journey_step', value: 'journey_step' }]
+      choices: [
+        { label: 'audience', value: 'audience' },
+        { label: 'journey_step', value: 'journey_step' }
+      ]
     },
     user_email: {
       label: 'Email address',

--- a/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
@@ -180,6 +180,13 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       mapping: defaultValues(removeFromAudience.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_exited_track'
+    },
+    {
+      name: 'Journeys Step Transition Track',
+      partnerAction: 'addToAudience',
+      mapping: defaultValues(addToAudience.fields),
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/index.ts
@@ -182,7 +182,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       eventSlug: 'warehouse_audience_exited_track'
     },
     {
-      name: 'Journeys Step Transition Track',
+      name: 'Journeys Step Entered',
       partnerAction: 'addToAudience',
       mapping: defaultValues(addToAudience.fields),
       type: 'specificEvent',

--- a/packages/destination-actions/src/destinations/webhook-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/webhook-audiences/index.ts
@@ -167,6 +167,13 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       mapping: defaultValues(send.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
+    },
+    {
+      name: 'Journeys Step Entered',
+      partnerAction: 'send',
+      mapping: defaultValues(send.fields),
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/yahoo-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/index.ts
@@ -17,7 +17,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   name: 'Yahoo Audiences',
   slug: 'actions-yahoo-audiences',
   mode: 'cloud',
-  description: 'Sync Segment Engage Audiences to Yahoo Ads',
+  description: 'Sync Segment Audiences to Yahoo Ads',
   authentication: {
     scheme: 'oauth2',
     fields: {
@@ -176,6 +176,13 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       mapping: defaultValues(updateSegment.fields),
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_membership_changed_identify'
+    },
+    {
+      name: 'Journeys Step Entered',
+      partnerAction: 'updateSegment',
+      mapping: defaultValues(updateSegment.fields),
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ]
 }

--- a/packages/destination-actions/src/destinations/yahoo-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/index.ts
@@ -17,7 +17,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   name: 'Yahoo Audiences',
   slug: 'actions-yahoo-audiences',
   mode: 'cloud',
-  description: 'Sync Segment Audiences to Yahoo Ads',
+  description: 'Sync users to Yahoo Ads',
   authentication: {
     scheme: 'oauth2',
     fields: {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

We need to 1. add subscription presets to the actions we will support in audience destinations in Journeys V2 and 2. update destination subscriptions to be product agnostic (currently many are specific to the Audiences product).

**Description from jira ticket:**

We need to update the action-destinations repo for the action audience destinations we support (non full-sync).

All audience action audience destinations we support (all but full sync) are updated with subscription presets for JV2

Similar audience PR doing this: https://github.com/segmentio/action-destinations/pull/2714/files (we will add presets to the same destinations as this PR)

We’ll use our event emitter definition however: https://github.com/segmentio/action-emitters/blob/a434f767c6b72a6d2e4f37d451348c1c444c6846/src/index.ts#L85 

We will only support the “Add profile to list” and “Sync profiles” actions (i.e. don’t add subscription presets for create audience actions, remove profile from list actions, etc.)

Looked through the action descriptions and remove any Engage Audience specific language

E.g. for marketo, we need to update the description here from “Add users from an Engage Audience to a list in Marketo.“ to “Add users to a list in Marketo.” https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/marketo-static-lists/addToList/index.ts#L9 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
