### PR TITLE
Add User-Agent header to Drip destination for source identification

### DIFF
--- a/packages/destination-actions/src/destinations/drip/index.ts
+++ b/packages/destination-actions/src/destinations/drip/index.ts
@@ -50,7 +50,8 @@ const destination: DestinationDefinition<Settings> = {
     return {
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Basic ${settings.apiKey}`
+        Authorization: `Basic ${settings.apiKey}`,
+        'User-Agent': 'Segment (Actions)'
       }
     }
   },


### PR DESCRIPTION
This PR adds a `'User-Agent': 'Segment (Actions)'` header to the Drip destination's `extendRequest` method to properly identify Segment as the source of API requests to Drip.

The User-Agent header approach was selected because it:
- Uses a standardized HTTP header recognized by all API providers
- Doesn't modify the request payload structure
- Follows patterns used in other Segment destinations
- Maintains simple, clear source identification

## Testing

- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination.

This approach required no test updates as the existing tests don't specifically verify header content.

- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
