### PR TITLE
Explicitely handle CreateAudienceErrors for Facebook Custom Audiences

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/index.ts
@@ -81,6 +81,11 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
           try {
             const parsed = JSON.parse(message)
 
+            // NOTE
+            // Since we know the structure of the facebook error response,
+            // we can parse the fields we need to form a user-friendly error message.
+            // EAMS will receive this error message and display it to the user.
+
             if (parsed?.error) {
               userTitle = parsed.error.error_user_title
               userMsg = parsed.error.error_user_msg || parsed.error.error_user_message


### PR DESCRIPTION
In the logs we are seeing `500 - Internal Server Errors` coming from the CreateExternalAudience method of this destination. Upon further analysis, we found that the V3 handler in the Integrations Service wraps the error when it comes without an explicitly set status code:

```
 try {
      const intResponse = await invokeIntegration(instance, method, payload)
      result.success = {
        status: intResponse.status,
        body: intResponse.body
      }
    } catch (e) {
      result.err = e

      // Absence of a status or http response code means this error was internal
      const isInternal = !e.status && !e.code

      if (isInternal) {
        // Log unexpected errors from the integration in sentry
        const summary = summarize(this.integrationSlug, result.err, result.requests)
        summary.version = VERSION_SHA
        sentry.captureIntegrationException(
          result.err,
          integrationCreationName,
          result.body,
          result.context.projectId,
          summary
        )
        result.err.code = 'INTERNAL'
        result.err.status = 500
      } else if (!result.err.status) {
        // If no status is provided, go ahead and give a default status
        result.err.status = 400
      }
```

We want to keep the original status code and not label these errors as `INTERNAL` so EAMS can handle them appropriately. And thus, wrapping the `request` call in a try/catch block will guarantee that we can handle the error accordingly. Moreso, if the error looks like this:

```
 {"error":{"message":"Permissions error","type":"OAuthException","code":200,"error_subcode":1870050,"is_transient":false,"error_user_title":"Business Account Needed to Create\/Edit This Audience","error_user_msg":"To create or edit a Custom Audience made from a customer list, your admin needs to add this ad account to a business.","fbtrace_id":"x"}}
```

EAMS will react to it and render a user friendly error message.


## Testing

Tested completed successfully via EAMS/MONOSERVICE/ACTIONS combo. I ran  EAMS to form the request that centrifuge creates, then monoservice to recieve it and subsequently edited the actions package in the monoservice with this code to test it.

<img width="1765" alt="Screenshot 2025-05-07 at 4 42 57 PM" src="https://github.com/user-attachments/assets/3399f234-0518-4910-8307-96b4cb8a311b" />
