### PR TITLE
[Smart Hashing] Rename processHashingV2 back to processHashing

### DIFF
--- a/packages/destination-actions/src/destinations/amazon-amc/function.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/function.ts
@@ -4,7 +4,7 @@ import { AudienceSettings, Settings } from './generated-types'
 import type { Payload } from './syncAudiencesToDSP/generated-types'
 import { AudienceRecord, HashedPIIObject } from './types'
 import { CONSTANTS, RecordsResponseType, REGEX_EXTERNALUSERID } from './utils'
-import { processHashingV2 } from '../../lib/hashing-utils'
+import { processHashing } from '../../lib/hashing-utils'
 
 export async function processPayload(
   request: RequestClient,
@@ -233,28 +233,28 @@ function hashedPayload(payload: Payload): HashedPIIObject {
   const hashedPII: HashedPIIObject = {}
 
   if (payload.firstName) {
-    hashedPII.firstname = processHashingV2(payload.firstName, 'sha256', 'hex', normalizeStandard)
+    hashedPII.firstname = processHashing(payload.firstName, 'sha256', 'hex', normalizeStandard)
   }
   if (payload.lastName) {
-    hashedPII.lastname = processHashingV2(payload.lastName, 'sha256', 'hex', normalizeStandard)
+    hashedPII.lastname = processHashing(payload.lastName, 'sha256', 'hex', normalizeStandard)
   }
   if (payload.address) {
-    hashedPII.address = processHashingV2(payload.address, 'sha256', 'hex', normalizeStandard)
+    hashedPII.address = processHashing(payload.address, 'sha256', 'hex', normalizeStandard)
   }
   if (payload.postal) {
-    hashedPII.postal = processHashingV2(payload.postal, 'sha256', 'hex', normalizeStandard)
+    hashedPII.postal = processHashing(payload.postal, 'sha256', 'hex', normalizeStandard)
   }
   if (payload.phone) {
-    hashedPII.phone = processHashingV2(payload.phone, 'sha256', 'hex', normalizePhone)
+    hashedPII.phone = processHashing(payload.phone, 'sha256', 'hex', normalizePhone)
   }
   if (payload.city) {
-    hashedPII.city = processHashingV2(payload.city, 'sha256', 'hex', normalizeStandard)
+    hashedPII.city = processHashing(payload.city, 'sha256', 'hex', normalizeStandard)
   }
   if (payload.state) {
-    hashedPII.state = processHashingV2(payload.state, 'sha256', 'hex', normalizeStandard)
+    hashedPII.state = processHashing(payload.state, 'sha256', 'hex', normalizeStandard)
   }
   if (payload.email) {
-    hashedPII.email = processHashingV2(payload.email, 'sha256', 'hex', normalizeEmail)
+    hashedPII.email = processHashing(payload.email, 'sha256', 'hex', normalizeEmail)
   }
 
   return hashedPII

--- a/packages/destination-actions/src/destinations/delivrai-activate/utils-rt.ts
+++ b/packages/destination-actions/src/destinations/delivrai-activate/utils-rt.ts
@@ -2,7 +2,7 @@ import { Payload } from './updateSegment/generated-types'
 import { DelivrAIPayload } from './types'
 import { RequestClient } from '@segment/actions-core'
 import { DELIVRAI_BASE_URL, DELIVRAI_GET_TOKEN } from './constants'
-import { processHashingV2 } from '../../lib/hashing-utils'
+import { processHashing } from '../../lib/hashing-utils'
 
 /**
  * Generates JWT for Realtime API authentication
@@ -64,7 +64,7 @@ export function gen_update_segment_payload(payloads: Payload[], client_identifie
   for (const event of payloads) {
     let hashed_email: string | undefined = ''
     if (event.email) {
-      hashed_email = processHashingV2(event.email.toLowerCase(), 'sha256', 'hex')
+      hashed_email = processHashing(event.email.toLowerCase(), 'sha256', 'hex')
     }
     let idfa: string | undefined = ''
     let gpsaid: string | undefined = ''

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/helpers.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/helpers.ts
@@ -1,11 +1,11 @@
-import { processHashingV2 } from '../../lib/hashing-utils'
+import { processHashing } from '../../lib/hashing-utils'
 
 export function hashAndEncode(property: string): string {
-  return processHashingV2(property, 'sha256', 'hex')
+  return processHashing(property, 'sha256', 'hex')
 }
 
 export function hashAndEncodeToInt(property: string): number {
-  const hash = processHashingV2(property, 'sha256', 'hex')
+  const hash = processHashing(property, 'sha256', 'hex')
   const bigInt = BigInt('0x' + hash)
   let integerString = bigInt.toString()
   if (integerString.length > 16) {

--- a/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-user-data.ts
+++ b/packages/destination-actions/src/destinations/facebook-conversions-api/fb-capi-user-data.ts
@@ -2,7 +2,7 @@ import { InputField } from '@segment/actions-core/destination-kit/types'
 import { US_STATE_CODES, COUNTRY_CODES } from './constants'
 import { Payload } from './addToCart/generated-types'
 import isEmpty from 'lodash/isEmpty'
-import { processHashingV2 } from '../../lib/hashing-utils'
+import { processHashing } from '../../lib/hashing-utils'
 
 // Implementation of Facebook user data object
 // https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters
@@ -196,10 +196,10 @@ const hash = (value: string | string[] | undefined): string | string[] | undefin
   if (value === undefined || !value.length) return
 
   if (typeof value == 'string') {
-    return processHashingV2(value, 'sha256', 'hex')
+    return processHashing(value, 'sha256', 'hex')
   }
 
-  return value.map((el: string) => processHashingV2(el, 'sha256', 'hex'))
+  return value.map((el: string) => processHashing(el, 'sha256', 'hex'))
 }
 
 /**

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/__tests__/fb-operations.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/__tests__/fb-operations.test.ts
@@ -6,7 +6,7 @@ import { Payload } from '../sync/generated-types'
 import { normalizationFunctions } from '../fbca-properties'
 import { Features } from '@segment/actions-core/mapping-kit'
 import { API_VERSION, BASE_URL, CANARY_API_VERSION } from '../constants'
-import { processHashingV2 } from '../../../lib/hashing-utils'
+import { processHashing } from '../../../lib/hashing-utils'
 
 const requestClient = createRequestClient()
 const settings: Settings = {
@@ -70,14 +70,14 @@ describe('Facebook Custom Audiences', () => {
       expect(generateData(payloads)).toEqual([
         [
           '5', // external_id is not hashed or normalized
-          processHashingV2(payloads[0].email || '', 'sha256', 'hex', normalizationFunctions.get('email')),
-          processHashingV2(payloads[0].phone || '', 'sha256', 'hex', normalizationFunctions.get('phone')),
+          processHashing(payloads[0].email || '', 'sha256', 'hex', normalizationFunctions.get('email')),
+          processHashing(payloads[0].phone || '', 'sha256', 'hex', normalizationFunctions.get('phone')),
           EMPTY, // gender
           EMPTY, // year
           EMPTY, // month
           EMPTY, // day
-          processHashingV2(payloads[0].name?.last || '', 'sha256', 'hex', normalizationFunctions.get('last')),
-          processHashingV2(payloads[0].name?.first || '', 'sha256', 'hex', normalizationFunctions.get('first')),
+          processHashing(payloads[0].name?.last || '', 'sha256', 'hex', normalizationFunctions.get('last')),
+          processHashing(payloads[0].name?.first || '', 'sha256', 'hex', normalizationFunctions.get('first')),
           EMPTY, // first_initial
           EMPTY, // city
           EMPTY, // state
@@ -128,14 +128,14 @@ describe('Facebook Custom Audiences', () => {
       expect(generateData(payloads)).toEqual([
         [
           '5', // external_id
-          processHashingV2(payloads[0].email || '', 'sha256', 'hex', normalizationFunctions.get('email')),
+          processHashing(payloads[0].email || '', 'sha256', 'hex', normalizationFunctions.get('email')),
           '89a0af94167fe6b92b614c681cc5599cd23ff45f7e9cc7929ed5fabe26842468',
           EMPTY, // gender
           EMPTY, // year
           EMPTY, // month
           EMPTY, // day
-          processHashingV2(payloads[0].name?.last || '', 'sha256', 'hex', normalizationFunctions.get('last')),
-          processHashingV2(payloads[0].name?.first || '', 'sha256', 'hex', normalizationFunctions.get('first')),
+          processHashing(payloads[0].name?.last || '', 'sha256', 'hex', normalizationFunctions.get('last')),
+          processHashing(payloads[0].name?.first || '', 'sha256', 'hex', normalizationFunctions.get('first')),
           EMPTY, // first_initial
           EMPTY, // city
           EMPTY, // state
@@ -145,25 +145,25 @@ describe('Facebook Custom Audiences', () => {
         ],
         [
           '6', // external_id
-          processHashingV2(payloads[1].email || '', 'sha256', 'hex', normalizationFunctions.get('email')),
+          processHashing(payloads[1].email || '', 'sha256', 'hex', normalizationFunctions.get('email')),
           EMPTY, // phone
-          processHashingV2(payloads[1].gender || '', 'sha256', 'hex', normalizationFunctions.get('gender')),
-          processHashingV2(payloads[1].birth?.year || '', 'sha256', 'hex', normalizationFunctions.get('year')),
-          processHashingV2(payloads[1].birth?.month || '', 'sha256', 'hex', normalizationFunctions.get('month')),
-          processHashingV2(payloads[1].birth?.day || '', 'sha256', 'hex', normalizationFunctions.get('day')),
-          processHashingV2(payloads[1].name?.last || '', 'sha256', 'hex', normalizationFunctions.get('last')),
-          processHashingV2(payloads[1].name?.first || '', 'sha256', 'hex', normalizationFunctions.get('first')),
-          processHashingV2(
+          processHashing(payloads[1].gender || '', 'sha256', 'hex', normalizationFunctions.get('gender')),
+          processHashing(payloads[1].birth?.year || '', 'sha256', 'hex', normalizationFunctions.get('year')),
+          processHashing(payloads[1].birth?.month || '', 'sha256', 'hex', normalizationFunctions.get('month')),
+          processHashing(payloads[1].birth?.day || '', 'sha256', 'hex', normalizationFunctions.get('day')),
+          processHashing(payloads[1].name?.last || '', 'sha256', 'hex', normalizationFunctions.get('last')),
+          processHashing(payloads[1].name?.first || '', 'sha256', 'hex', normalizationFunctions.get('first')),
+          processHashing(
             payloads[1].name?.firstInitial || '',
             'sha256',
             'hex',
             normalizationFunctions.get('firstInitial')
           ),
-          processHashingV2(payloads[1].city || '', 'sha256', 'hex', normalizationFunctions.get('city')),
-          processHashingV2(payloads[1].state || '', 'sha256', 'hex', normalizationFunctions.get('state')),
-          processHashingV2(payloads[1].zip || '', 'sha256', 'hex', normalizationFunctions.get('zip')),
+          processHashing(payloads[1].city || '', 'sha256', 'hex', normalizationFunctions.get('city')),
+          processHashing(payloads[1].state || '', 'sha256', 'hex', normalizationFunctions.get('state')),
+          processHashing(payloads[1].zip || '', 'sha256', 'hex', normalizationFunctions.get('zip')),
           EMPTY, // mobile_advertiser_id,
-          processHashingV2(payloads[1].country || '', 'sha256', 'hex', normalizationFunctions.get('country'))
+          processHashing(payloads[1].country || '', 'sha256', 'hex', normalizationFunctions.get('country'))
         ]
       ])
     })

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/fbca-operations.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/fbca-operations.ts
@@ -1,7 +1,7 @@
 import { DynamicFieldItem, DynamicFieldError, RequestClient, Features } from '@segment/actions-core'
 import { Payload } from './sync/generated-types'
 import { segmentSchemaKeyToArrayIndex, SCHEMA_PROPERTIES, normalizationFunctions } from './fbca-properties'
-import { processHashingV2 } from '../../lib/hashing-utils'
+import { processHashing } from '../../lib/hashing-utils'
 import { StatsContext } from '@segment/actions-core/destination-kit'
 import { API_VERSION, BASE_URL, CANARY_API_VERSION, FACEBOOK_CUSTOM_AUDIENCE_FLAGON } from './constants'
 
@@ -76,7 +76,7 @@ const appendToDataRow = (key: string, value: string | number, row: (string | num
     return
   }
 
-  row[index] = processHashingV2(value, 'sha256', 'hex', normalizationFunctions.get(key))
+  row[index] = processHashing(value, 'sha256', 'hex', normalizationFunctions.get(key))
 }
 
 export const getApiVersion = (features?: Features, statsContext?: StatsContext): string => {

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/index.test.ts
@@ -4,7 +4,7 @@ import nock from 'nock'
 import { SCHEMA_PROPERTIES } from '../../fbca-properties'
 import { normalizationFunctions } from '../../fbca-properties'
 import { BASE_URL, CANARY_API_VERSION, API_VERSION } from '../../constants'
-import { processHashingV2 } from '../../../../lib/hashing-utils'
+import { processHashing } from '../../../../lib/hashing-utils'
 
 const testDestination = createTestIntegration(Destination)
 const auth = {
@@ -50,12 +50,7 @@ describe('FacebookCustomAudiences.sync', () => {
               [
                 event.properties?.id, // external_id
                 '816341caf0c06dbc4c156d3465323f52b3cb62533241d5f9247c008f657e8343', // email
-                processHashingV2(
-                  event.properties?.phone as string,
-                  'sha256',
-                  'hex',
-                  normalizationFunctions.get('phone')
-                ),
+                processHashing(event.properties?.phone as string, 'sha256', 'hex', normalizationFunctions.get('phone')),
                 EMPTY, // gender
                 EMPTY, // year
                 EMPTY, // month
@@ -63,21 +58,16 @@ describe('FacebookCustomAudiences.sync', () => {
                 EMPTY, // last_name
                 EMPTY, // first_name
                 EMPTY, // first_initial
-                processHashingV2(event.properties?.city as string, 'sha256', 'hex', normalizationFunctions.get('city')),
-                processHashingV2(
-                  event.properties?.state as string,
-                  'sha256',
-                  'hex',
-                  normalizationFunctions.get('state')
-                ),
-                processHashingV2(
+                processHashing(event.properties?.city as string, 'sha256', 'hex', normalizationFunctions.get('city')),
+                processHashing(event.properties?.state as string, 'sha256', 'hex', normalizationFunctions.get('state')),
+                processHashing(
                   (event.properties?.zip_code as string) || '',
                   'sha256',
                   'hex',
                   normalizationFunctions.get('zip')
                 ),
                 '2024', // mobile_advertiser_id,
-                processHashingV2('US', 'sha256', 'hex', normalizationFunctions.get('country'))
+                processHashing('US', 'sha256', 'hex', normalizationFunctions.get('country'))
               ]
             ],
             app_ids: ['2024']
@@ -141,7 +131,7 @@ describe('FacebookCustomAudiences.sync', () => {
               [
                 event.properties?.id, // external_id
                 '816341caf0c06dbc4c156d3465323f52b3cb62533241d5f9247c008f657e8343', // email
-                processHashingV2(
+                processHashing(
                   (event.properties?.phone as string) || '',
                   'sha256',
                   'hex',
@@ -154,26 +144,26 @@ describe('FacebookCustomAudiences.sync', () => {
                 EMPTY, // last_name
                 EMPTY, // first_name
                 EMPTY, // first_initial
-                processHashingV2(
+                processHashing(
                   (event.properties?.city as string) || '',
                   'sha256',
                   'hex',
                   normalizationFunctions.get('city')
                 ),
-                processHashingV2(
+                processHashing(
                   (event.properties?.state as string) || '',
                   'sha256',
                   'hex',
                   normalizationFunctions.get('state')
                 ),
-                processHashingV2(
+                processHashing(
                   (event.properties?.zip_code as string) || '',
                   'sha256',
                   'hex',
                   normalizationFunctions.get('zip')
                 ),
                 '2024', // mobile_advertiser_id,
-                processHashingV2('US', 'sha256', 'hex', normalizationFunctions.get('country')) // country
+                processHashing('US', 'sha256', 'hex', normalizationFunctions.get('country')) // country
               ]
             ],
             app_ids: ['2024']

--- a/packages/destination-actions/src/destinations/first-party-dv360/functions.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/functions.ts
@@ -1,7 +1,7 @@
 import { IntegrationError, RequestClient, StatsContext } from '@segment/actions-core'
 import { Payload } from './addToAudContactInfo/generated-types'
 import { Payload as DeviceIdPayload } from './addToAudMobileDeviceId/generated-types'
-import { processHashingV2 } from '../../lib/hashing-utils'
+import { processHashing } from '../../lib/hashing-utils'
 
 const DV360API = `https://displayvideo.googleapis.com/v3/firstAndThirdPartyAudiences`
 const CONSENT_STATUS_GRANTED = 'CONSENT_STATUS_GRANTED' // Define consent status
@@ -179,7 +179,7 @@ function normalizeAndHash(data: string) {
   // Normalize the data
   const normalizedData = data.toLowerCase().trim() // Example: Convert to lowercase and remove leading/trailing spaces
   // Hash the normalized data using SHA-256
-  return processHashingV2(normalizedData, 'sha256', 'hex')
+  return processHashing(normalizedData, 'sha256', 'hex')
 }
 
 function processPayload(payload: Payload) {

--- a/packages/destination-actions/src/destinations/google-campaign-manager-360/utils.ts
+++ b/packages/destination-actions/src/destinations/google-campaign-manager-360/utils.ts
@@ -16,7 +16,7 @@ import {
   ConsentType,
   EncryptionInfo
 } from './types'
-import { processHashingV2 } from '../../lib/hashing-utils'
+import { processHashing } from '../../lib/hashing-utils'
 
 export async function send(
   request: RequestClient,
@@ -154,19 +154,19 @@ export function getJSON(payloads: UploadPayload[] | Adjustayload[], settings: Se
         const identifiers: UserIdentifier[] = []
         if (email) {
           identifiers.push({
-            hashedEmail: processHashingV2(email, 'sha256', 'hex')
+            hashedEmail: processHashing(email, 'sha256', 'hex')
           })
         }
         if (phone) {
           identifiers.push({
-            hashedPhoneNumber: processHashingV2(phone, 'sha256', 'hex')
+            hashedPhoneNumber: processHashing(phone, 'sha256', 'hex')
           })
         }
         if (firstName || lastName || streetAddress || city || state || postalCode || countryCode) {
           const addressInfo: AddressInfo = {
-            hashedFirstName: firstName ? processHashingV2(firstName, 'sha256', 'hex') : undefined,
-            hashedLastName: lastName ? processHashingV2(lastName, 'sha256', 'hex') : undefined,
-            hashedStreetAddress: streetAddress ? processHashingV2(streetAddress, 'sha256', 'hex') : undefined,
+            hashedFirstName: firstName ? processHashing(firstName, 'sha256', 'hex') : undefined,
+            hashedLastName: lastName ? processHashing(lastName, 'sha256', 'hex') : undefined,
+            hashedStreetAddress: streetAddress ? processHashing(streetAddress, 'sha256', 'hex') : undefined,
             city: city ?? undefined,
             state: state ?? undefined,
             postalCode: postalCode ?? undefined,
@@ -190,7 +190,7 @@ export function getJSON(payloads: UploadPayload[] | Adjustayload[], settings: Se
         encryptedUserIdCandidates
           ?.split(',')
           .map((value) => {
-            return processHashingV2(value, 'sha256', 'hex')
+            return processHashing(value, 'sha256', 'hex')
           })
           .filter((str): str is string => str !== undefined) ?? []
     } as Conversion

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -32,7 +32,7 @@ import { HTTPError } from '@segment/actions-core'
 import type { Payload as UserListPayload } from './userList/generated-types'
 import { RefreshTokenResponse } from '.'
 import { STATUS_CODE_MAPPING } from './constants'
-import { processHashingV2 } from '../../lib/hashing-utils'
+import { processHashing } from '../../lib/hashing-utils'
 export const API_VERSION = 'v17'
 export const CANARY_API_VERSION = 'v17'
 export const FLAGON_NAME = 'google-enhanced-canary-version'
@@ -463,12 +463,12 @@ const extractUserIdentifiers = (payloads: UserListPayload[], idType: string, syn
       const identifiers = []
       if (payload.email) {
         identifiers.push({
-          hashedEmail: processHashingV2(payload.email, 'sha256', 'hex', commonEmailValidation)
+          hashedEmail: processHashing(payload.email, 'sha256', 'hex', commonEmailValidation)
         })
       }
       if (payload.phone) {
         identifiers.push({
-          hashedPhoneNumber: processHashingV2(payload.phone, 'sha256', 'hex', (value) =>
+          hashedPhoneNumber: processHashing(payload.phone, 'sha256', 'hex', (value) =>
             formatPhone(value, payload.phone_country_code)
           )
         })
@@ -476,10 +476,10 @@ const extractUserIdentifiers = (payloads: UserListPayload[], idType: string, syn
       if (payload.first_name || payload.last_name || payload.country_code || payload.postal_code) {
         const addressInfo: any = {}
         if (payload.first_name) {
-          addressInfo.hashedFirstName = processHashingV2(payload.first_name, 'sha256', 'hex')
+          addressInfo.hashedFirstName = processHashing(payload.first_name, 'sha256', 'hex')
         }
         if (payload.last_name) {
-          addressInfo.hashedLastName = processHashingV2(payload.last_name, 'sha256', 'hex')
+          addressInfo.hashedLastName = processHashing(payload.last_name, 'sha256', 'hex')
         }
         addressInfo.countryCode = payload.country_code ?? ''
         addressInfo.postalCode = payload.postal_code ?? ''
@@ -796,13 +796,13 @@ export const createIdentifierExtractors = () => ({
 
     if (payload.email) {
       identifiers.push({
-        hashedEmail: processHashingV2(payload.email, 'sha256', 'hex', commonEmailValidation)
+        hashedEmail: processHashing(payload.email, 'sha256', 'hex', commonEmailValidation)
       })
     }
 
     if (payload.phone) {
       identifiers.push({
-        hashedPhoneNumber: processHashingV2(payload.phone, 'sha256', 'hex', (value) =>
+        hashedPhoneNumber: processHashing(payload.phone, 'sha256', 'hex', (value) =>
           formatPhone(value, payload.phone_country_code)
         )
       })
@@ -811,8 +811,8 @@ export const createIdentifierExtractors = () => ({
     if (payload.first_name || payload.last_name || payload.country_code || payload.postal_code) {
       identifiers.push({
         addressInfo: {
-          hashedFirstName: payload.first_name ? processHashingV2(payload.first_name, 'sha256', 'hex') : undefined,
-          hashedLastName: payload.last_name ? processHashingV2(payload.last_name, 'sha256', 'hex') : undefined,
+          hashedFirstName: payload.first_name ? processHashing(payload.first_name, 'sha256', 'hex') : undefined,
+          hashedLastName: payload.last_name ? processHashing(payload.last_name, 'sha256', 'hex') : undefined,
           countryCode: payload.country_code || '',
           postalCode: payload.postal_code || ''
         }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -25,7 +25,7 @@ import {
   formatPhone
 } from '../functions'
 import { GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE } from '../constants'
-import { processHashingV2 } from '../../../lib/hashing-utils'
+import { processHashing } from '../../../lib/hashing-utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Upload Click Conversion',
@@ -319,7 +319,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (payload.email_address) {
-      const validatedEmail: string = processHashingV2(payload.email_address, 'sha256', 'hex', commonEmailValidation)
+      const validatedEmail: string = processHashing(payload.email_address, 'sha256', 'hex', commonEmailValidation)
 
       request_object.userIdentifiers.push({
         hashedEmail: validatedEmail
@@ -328,7 +328,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
     if (payload.phone_number) {
       request_object.userIdentifiers.push({
-        hashedPhoneNumber: processHashingV2(payload.phone_number, 'sha256', 'hex', (value) =>
+        hashedPhoneNumber: processHashing(payload.phone_number, 'sha256', 'hex', (value) =>
           formatPhone(value, payload.phone_country_code)
         )
       } as UserIdentifierInterface)
@@ -426,7 +426,7 @@ const action: ActionDefinition<Settings, Payload> = {
         }
 
         if (payload.email_address) {
-          const validatedEmail: string = processHashingV2(payload.email_address, 'sha256', 'hex', commonEmailValidation)
+          const validatedEmail: string = processHashing(payload.email_address, 'sha256', 'hex', commonEmailValidation)
 
           request_object.userIdentifiers.push({
             hashedEmail: validatedEmail
@@ -435,7 +435,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
         if (payload.phone_number) {
           request_object.userIdentifiers.push({
-            hashedPhoneNumber: processHashingV2(payload.phone_number, 'sha256', 'hex', (value) =>
+            hashedPhoneNumber: processHashing(payload.phone_number, 'sha256', 'hex', (value) =>
               formatPhone(value, payload.phone_country_code)
             )
           } as UserIdentifierInterface)

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -26,7 +26,7 @@ import {
   formatPhone
 } from '../functions'
 import { GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE } from '../constants'
-import { processHashingV2 } from '../../../lib/hashing-utils'
+import { processHashing } from '../../../lib/hashing-utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Click Conversion V2',
@@ -327,7 +327,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
 
       if (payload.email_address) {
-        const validatedEmail: string = processHashingV2(payload.email_address, 'sha256', 'hex', commonEmailValidation)
+        const validatedEmail: string = processHashing(payload.email_address, 'sha256', 'hex', commonEmailValidation)
 
         request_object.userIdentifiers.push({
           hashedEmail: validatedEmail
@@ -336,7 +336,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
       if (payload.phone_number) {
         request_object.userIdentifiers.push({
-          hashedPhoneNumber: processHashingV2(payload.phone_number, 'sha256', 'hex', (value) =>
+          hashedPhoneNumber: processHashing(payload.phone_number, 'sha256', 'hex', (value) =>
             formatPhone(value, payload.phone_country_code)
           )
         } as UserIdentifierInterface)
@@ -439,7 +439,7 @@ const action: ActionDefinition<Settings, Payload> = {
         }
 
         if (payloadItem.email_address) {
-          const validatedEmail: string = processHashingV2(
+          const validatedEmail: string = processHashing(
             payloadItem.email_address,
             'sha256',
             'hex',
@@ -453,7 +453,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
         if (payloadItem.phone_number) {
           request_object.userIdentifiers.push({
-            hashedPhoneNumber: processHashingV2(payloadItem.phone_number, 'sha256', 'hex', (value) =>
+            hashedPhoneNumber: processHashing(payloadItem.phone_number, 'sha256', 'hex', (value) =>
               formatPhone(value, payloadItem.phone_country_code)
             )
           } as UserIdentifierInterface)

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment/index.ts
@@ -12,7 +12,7 @@ import type { Payload } from './generated-types'
 import { PartialErrorResponse, ConversionAdjustmentRequestObjectInterface, UserIdentifierInterface } from '../types'
 import { ModifiedResponse } from '@segment/actions-core'
 import { GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE } from '../constants'
-import { processHashingV2 } from '../../../lib/hashing-utils'
+import { processHashing } from '../../../lib/hashing-utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Upload Conversion Adjustment',
@@ -290,7 +290,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     if (payload.email_address) {
-      const validatedEmail: string = processHashingV2(payload.email_address, 'sha256', 'hex', commonEmailValidation)
+      const validatedEmail: string = processHashing(payload.email_address, 'sha256', 'hex', commonEmailValidation)
 
       request_object.userIdentifiers.push({
         hashedEmail: validatedEmail
@@ -299,7 +299,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
     if (payload.phone_number) {
       request_object.userIdentifiers.push({
-        hashedPhoneNumber: processHashingV2(payload.phone_number, 'sha256', 'hex', (value) =>
+        hashedPhoneNumber: processHashing(payload.phone_number, 'sha256', 'hex', (value) =>
           formatPhone(value, payload.phone_country_code)
         )
       } as UserIdentifierInterface)
@@ -317,13 +317,13 @@ const action: ActionDefinition<Settings, Payload> = {
     if (containsAddressInfo) {
       const addressInfo: any = {}
       if (payload.first_name) {
-        addressInfo.hashedFirstName = processHashingV2(payload.first_name, 'sha256', 'hex')
+        addressInfo.hashedFirstName = processHashing(payload.first_name, 'sha256', 'hex')
       }
       if (payload.last_name) {
-        addressInfo.hashedLastName = processHashingV2(payload.last_name, 'sha256', 'hex')
+        addressInfo.hashedLastName = processHashing(payload.last_name, 'sha256', 'hex')
       }
       if (payload.street_address) {
-        addressInfo.hashedStreetAddress = processHashingV2(payload.street_address, 'sha256', 'hex')
+        addressInfo.hashedStreetAddress = processHashing(payload.street_address, 'sha256', 'hex')
       }
       addressInfo.city = payload.city
       addressInfo.state = payload.state
@@ -389,12 +389,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
 
       if (payloadItem.email_address) {
-        const validatedEmail: string = processHashingV2(
-          payloadItem.email_address,
-          'sha256',
-          'hex',
-          commonEmailValidation
-        )
+        const validatedEmail: string = processHashing(payloadItem.email_address, 'sha256', 'hex', commonEmailValidation)
 
         request_object.userIdentifiers.push({
           hashedEmail: validatedEmail
@@ -403,7 +398,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
       if (payloadItem.phone_number) {
         request_object.userIdentifiers.push({
-          hashedPhoneNumber: processHashingV2(payloadItem.phone_number, 'sha256', 'hex', (value) =>
+          hashedPhoneNumber: processHashing(payloadItem.phone_number, 'sha256', 'hex', (value) =>
             formatPhone(value, payloadItem.phone_country_code)
           )
         } as UserIdentifierInterface)
@@ -421,13 +416,13 @@ const action: ActionDefinition<Settings, Payload> = {
       if (containsAddressInfo) {
         const addressInfo: any = {}
         if (payloadItem.first_name) {
-          addressInfo.hashedFirstName = processHashingV2(payloadItem.first_name, 'sha256', 'hex')
+          addressInfo.hashedFirstName = processHashing(payloadItem.first_name, 'sha256', 'hex')
         }
         if (payloadItem.last_name) {
-          addressInfo.hashedLastName = processHashingV2(payloadItem.last_name, 'sha256', 'hex')
+          addressInfo.hashedLastName = processHashing(payloadItem.last_name, 'sha256', 'hex')
         }
         if (payloadItem.street_address) {
-          addressInfo.hashedStreetAddress = processHashingV2(payloadItem.street_address, 'sha256', 'hex')
+          addressInfo.hashedStreetAddress = processHashing(payloadItem.street_address, 'sha256', 'hex')
         }
         addressInfo.city = payloadItem.city
         addressInfo.state = payloadItem.state

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadConversionAdjustment2/index.ts
@@ -18,7 +18,7 @@ import type { Payload } from './generated-types'
 import { PartialErrorResponse, ConversionAdjustmentRequestObjectInterface, UserIdentifierInterface } from '../types'
 import { ModifiedResponse } from '@segment/actions-core'
 import { GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE } from '../constants'
-import { processHashingV2 } from '../../../lib/hashing-utils'
+import { processHashing } from '../../../lib/hashing-utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Conversion Adjustment V2',
@@ -304,7 +304,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
 
       if (payload.email_address) {
-        const validatedEmail: string = processHashingV2(payload.email_address, 'sha256', 'hex', commonEmailValidation)
+        const validatedEmail: string = processHashing(payload.email_address, 'sha256', 'hex', commonEmailValidation)
 
         request_object.userIdentifiers.push({
           hashedEmail: validatedEmail
@@ -313,7 +313,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
       if (payload.phone_number) {
         request_object.userIdentifiers.push({
-          hashedPhoneNumber: processHashingV2(payload.phone_number, 'sha256', 'hex', (value) =>
+          hashedPhoneNumber: processHashing(payload.phone_number, 'sha256', 'hex', (value) =>
             formatPhone(value, payload.phone_country_code)
           )
         } as UserIdentifierInterface)
@@ -331,13 +331,13 @@ const action: ActionDefinition<Settings, Payload> = {
       if (containsAddressInfo) {
         const addressInfo: any = {}
         if (payload.first_name) {
-          addressInfo.hashedFirstName = processHashingV2(payload.first_name, 'sha256', 'hex')
+          addressInfo.hashedFirstName = processHashing(payload.first_name, 'sha256', 'hex')
         }
         if (payload.last_name) {
-          addressInfo.hashedLastName = processHashingV2(payload.last_name, 'sha256', 'hex')
+          addressInfo.hashedLastName = processHashing(payload.last_name, 'sha256', 'hex')
         }
         if (payload.street_address) {
-          addressInfo.hashedStreetAddress = processHashingV2(payload.street_address, 'sha256', 'hex')
+          addressInfo.hashedStreetAddress = processHashing(payload.street_address, 'sha256', 'hex')
         }
         addressInfo.city = payload.city
         addressInfo.state = payload.state
@@ -413,12 +413,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
 
       if (payloadItem.email_address) {
-        const validatedEmail: string = processHashingV2(
-          payloadItem.email_address,
-          'sha256',
-          'hex',
-          commonEmailValidation
-        )
+        const validatedEmail: string = processHashing(payloadItem.email_address, 'sha256', 'hex', commonEmailValidation)
 
         request_object.userIdentifiers.push({
           hashedEmail: validatedEmail
@@ -427,7 +422,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
       if (payloadItem.phone_number) {
         request_object.userIdentifiers.push({
-          hashedPhoneNumber: processHashingV2(payloadItem.phone_number, 'sha256', 'hex', (value) =>
+          hashedPhoneNumber: processHashing(payloadItem.phone_number, 'sha256', 'hex', (value) =>
             formatPhone(value, payloadItem.phone_country_code)
           )
         } as UserIdentifierInterface)
@@ -445,13 +440,13 @@ const action: ActionDefinition<Settings, Payload> = {
       if (containsAddressInfo) {
         const addressInfo: any = {}
         if (payloadItem.first_name) {
-          addressInfo.hashedFirstName = processHashingV2(payloadItem.first_name, 'sha256', 'hex')
+          addressInfo.hashedFirstName = processHashing(payloadItem.first_name, 'sha256', 'hex')
         }
         if (payloadItem.last_name) {
-          addressInfo.hashedLastName = processHashingV2(payloadItem.last_name, 'sha256', 'hex')
+          addressInfo.hashedLastName = processHashing(payloadItem.last_name, 'sha256', 'hex')
         }
         if (payloadItem.street_address) {
-          addressInfo.hashedStreetAddress = processHashingV2(payloadItem.street_address, 'sha256', 'hex')
+          addressInfo.hashedStreetAddress = processHashing(payloadItem.street_address, 'sha256', 'hex')
         }
         addressInfo.city = payloadItem.city
         addressInfo.state = payloadItem.state

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
@@ -4,7 +4,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { LinkedInAudiences } from '../api'
 import { LinkedInAudiencePayload } from '../types'
-import { processHashingV2 } from '../../../lib/hashing-utils'
+import { processHashing } from '../../../lib/hashing-utils'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Sync To LinkedIn DMP Segment',
@@ -293,7 +293,7 @@ function getUserIds(settings: Settings, payload: Payload): Record<string, string
   if (payload.email && settings.send_email === true) {
     userIds.push({
       idType: 'SHA256_EMAIL',
-      idValue: processHashingV2(payload.email, 'sha256', 'hex')
+      idValue: processHashing(payload.email, 'sha256', 'hex')
     })
   }
 

--- a/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/api/index.ts
@@ -19,7 +19,7 @@ import type {
   ConversionRuleUpdateResponse
 } from '../types'
 import type { Payload, OnMappingSaveInputs, OnMappingSaveOutputs } from '../streamConversion/generated-types'
-import { processHashingV2 } from '../../../lib/hashing-utils'
+import { processHashing } from '../../../lib/hashing-utils'
 
 interface ConversionRuleUpdateValues {
   name?: string
@@ -419,7 +419,7 @@ export class LinkedInConversions {
     const userIds: UserID[] = []
 
     if (payload.email) {
-      const hashedEmail = processHashingV2(payload.email, 'sha256', 'hex', this.normalizeEmail)
+      const hashedEmail = processHashing(payload.email, 'sha256', 'hex', this.normalizeEmail)
       userIds.push({
         idType: 'SHA256_EMAIL',
         idValue: hashedEmail

--- a/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/operations.test.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/operations.test.ts
@@ -1,12 +1,12 @@
 import { enquoteIdentifier, generateFile, normalize } from '../operations'
 import type { Payload } from '../audienceEnteredSftp/generated-types'
-import { processHashingV2 } from '../../../lib/hashing-utils'
+import { processHashing } from '../../../lib/hashing-utils'
 
 describe('Test operations', () => {
   describe('hash', () => {
     it('produces consistent SHA-256 hash for a given input', () => {
       const input = 'test input'
-      expect(processHashingV2(input, 'sha256', 'hex')).toBe(
+      expect(processHashing(input, 'sha256', 'hex')).toBe(
         '9dfe6f15d1ab73af898739394fd22fd72a03db01834582f24bb2e1c66c7aaeae'
       )
     })
@@ -15,14 +15,14 @@ describe('Test operations', () => {
   describe('hashPhoneNumber', () => {
     it('produces consistent SHA-1 hash for a given phone number', () => {
       const phoneNumber = '123-456-7890'
-      expect(processHashingV2(phoneNumber, 'sha1', 'hex')).toBe('d94cf047843c27e4ebf4495804dfb264a2181d45')
+      expect(processHashing(phoneNumber, 'sha1', 'hex')).toBe('d94cf047843c27e4ebf4495804dfb264a2181d45')
     })
   })
 
   describe('hashEmail', () => {
     it('produces consistent SHA-256 hash for a given email address', () => {
       const email = 'user@example.com'
-      expect(processHashingV2(email, 'sha256', 'hex')).toBe(
+      expect(processHashing(email, 'sha256', 'hex')).toBe(
         'b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514'
       )
     })
@@ -108,7 +108,7 @@ describe('Test operations', () => {
         }
       ]
       const normalizedName = normalize('name', 'John Doe')
-      const hashedName = processHashingV2(normalizedName, 'sha256', 'hex')
+      const hashedName = processHashing(normalizedName, 'sha256', 'hex')
       const result = generateFile(payloads)
       const expected = `audience_key,name,email\n${enquoteIdentifier('1002')},${enquoteIdentifier(
         hashedName
@@ -135,8 +135,8 @@ describe('Test operations', () => {
           enable_batching: true
         }
       ]
-      const hashedAlice = processHashingV2('Alice', 'sha256', 'hex', (value: string) => normalize('name', value))
-      const hashedBob = processHashingV2('Bob', 'sha256', 'hex', (value: string) => normalize('name', value))
+      const hashedAlice = processHashing('Alice', 'sha256', 'hex', (value: string) => normalize('name', value))
+      const hashedBob = processHashing('Bob', 'sha256', 'hex', (value: string) => normalize('name', value))
       const result = generateFile(payloads)
       const expected = `audience_key,name,email\n${enquoteIdentifier('1003')},${enquoteIdentifier(
         hashedAlice
@@ -157,7 +157,7 @@ describe('Test operations', () => {
           enable_batching: true
         }
       ]
-      const hashedEve = processHashingV2('Eve', 'sha256', 'hex', (value: string) => normalize('name', value))
+      const hashedEve = processHashing('Eve', 'sha256', 'hex', (value: string) => normalize('name', value))
       const result = generateFile(payloads)
       const expected = `audience_key,name\n${enquoteIdentifier('1005')},${enquoteIdentifier(hashedEve)}`
       expect(result.fileContents.toString()).toBe(expected)
@@ -174,7 +174,7 @@ describe('Test operations', () => {
           enable_batching: true
         }
       ]
-      const hashedNote = processHashingV2('Hello, "John"\nNew line', 'sha256', 'hex')
+      const hashedNote = processHashing('Hello, "John"\nNew line', 'sha256', 'hex')
       const result = generateFile(payloads)
       const expected = `audience_key,note,email\n${enquoteIdentifier('1006')},${enquoteIdentifier(
         hashedNote
@@ -414,7 +414,7 @@ describe('Test operations', () => {
         }
       ]
 
-      const hashedUnhashedEmail = processHashingV2('unhashed@example.com', 'sha256', 'hex', (value: string) =>
+      const hashedUnhashedEmail = processHashing('unhashed@example.com', 'sha256', 'hex', (value: string) =>
         normalize('email', value)
       )
 
@@ -492,7 +492,7 @@ describe('Test operations', () => {
         }
       ]
 
-      const hashedUniqueValue = processHashingV2('424242', 'sha256', 'hex', (value: string) =>
+      const hashedUniqueValue = processHashing('424242', 'sha256', 'hex', (value: string) =>
         normalize('unique_value', value)
       )
       const result = generateFile(payloads)
@@ -577,8 +577,8 @@ describe('Test operations', () => {
 
       const result = generateFile(payloads)
 
-      const hashedCountry = processHashingV2('US', 'sha256', 'hex', (value: string) => normalize('country', value))
-      const hashedUniqueValue = processHashingV2('only_in_third', 'sha256', 'hex', (value: string) =>
+      const hashedCountry = processHashing('US', 'sha256', 'hex', (value: string) => normalize('country', value))
+      const hashedUniqueValue = processHashing('only_in_third', 'sha256', 'hex', (value: string) =>
         normalize('unique_value', value)
       )
 

--- a/packages/destination-actions/src/destinations/liveramp-audiences/operations.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/operations.ts
@@ -1,7 +1,7 @@
 import { RequestClient, ExecuteInput } from '@segment/actions-core'
 import type { Payload as s3Payload } from './audienceEnteredS3/generated-types'
 import type { Payload as sftpPayload } from './audienceEnteredSftp/generated-types'
-import { processHashingV2 } from '../../lib/hashing-utils'
+import { processHashing } from '../../lib/hashing-utils'
 
 // Type definitions
 export type RawData = {
@@ -77,11 +77,11 @@ function generateFile(payloads: s3Payload[] | sftpPayload[]) {
         /*Identifiers need to be hashed according to LiveRamp spec's: https://docs.liveramp.com/connect/en/formatting-identifiers.html 
         Phone Number requires SHA1 and email uses sha256 */
         if (key === 'phone_number') {
-          row[index] = `"${processHashingV2(String(payload.unhashed_identifier_data[key]), 'sha1', 'hex', (value) =>
+          row[index] = `"${processHashing(String(payload.unhashed_identifier_data[key]), 'sha1', 'hex', (value) =>
             normalize(key, value)
           )}"`
         } else {
-          row[index] = `"${processHashingV2(String(payload.unhashed_identifier_data[key]), 'sha256', 'hex', (value) =>
+          row[index] = `"${processHashing(String(payload.unhashed_identifier_data[key]), 'sha256', 'hex', (value) =>
             normalize(key, value)
           )}"`
         }

--- a/packages/destination-actions/src/destinations/pinterest-conversions/pinterset-capi-user-data.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/pinterset-capi-user-data.ts
@@ -1,7 +1,7 @@
 import { InputField } from '@segment/actions-core/destination-kit/types'
 import { Payload } from './reportConversionEvent/generated-types'
 import isEmpty from 'lodash/isEmpty'
-import { processHashingV2 } from '../../lib/hashing-utils'
+import { processHashing } from '../../lib/hashing-utils'
 
 // Implementation of Pinterest user data object
 // https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters
@@ -172,72 +172,72 @@ export const normalisedAndHashed = (payload: UserData) => {
     if (!isEmpty(payload.user_data?.email)) {
       // Regex removes all whitespace in the string.
       payload.user_data.email = payload.user_data?.email?.map((el: string) =>
-        processHashingV2(el, 'sha256', 'hex', normalize)
+        processHashing(el, 'sha256', 'hex', normalize)
       ) as string[]
     }
 
     if (!isEmpty(payload.user_data?.phone)) {
       // Regex removes all non-numeric characters from the string.
       payload.user_data.phone = payload.user_data?.phone?.map((el: string) =>
-        processHashingV2(el, 'sha256', 'hex', normalizePhone)
+        processHashing(el, 'sha256', 'hex', normalizePhone)
       ) as string[]
     }
 
     if (!isEmpty(payload.user_data?.gender)) {
       payload.user_data.gender = payload.user_data?.gender?.map((el: string) => {
-        return processHashingV2(el, 'sha256', 'hex', normalizeGender)
+        return processHashing(el, 'sha256', 'hex', normalizeGender)
       }) as string[]
     }
 
     if (!isEmpty(payload.user_data?.last_name)) {
       payload.user_data.last_name = payload.user_data?.last_name?.map((el: string) =>
-        processHashingV2(el, 'sha256', 'hex', normalize)
+        processHashing(el, 'sha256', 'hex', normalize)
       ) as string[]
     }
 
     if (!isEmpty(payload.user_data?.first_name)) {
       payload.user_data.first_name = payload.user_data?.first_name?.map((el: string) =>
-        processHashingV2(el, 'sha256', 'hex', normalize)
+        processHashing(el, 'sha256', 'hex', normalize)
       ) as string[]
     }
 
     if (!isEmpty(payload.user_data?.city)) {
       payload.user_data.city = payload.user_data?.city?.map((el: string) =>
-        processHashingV2(el, 'sha256', 'hex', normalize)
+        processHashing(el, 'sha256', 'hex', normalize)
       ) as string[]
     }
 
     if (!isEmpty(payload.user_data?.state)) {
       payload.user_data.state = payload.user_data?.state?.map((el: string) =>
-        processHashingV2(el, 'sha256', 'hex', normalize)
+        processHashing(el, 'sha256', 'hex', normalize)
       ) as string[]
     }
 
     if (!isEmpty(payload.user_data?.zip)) {
       payload.user_data.zip = payload.user_data?.zip?.map((el: string) =>
-        processHashingV2(el, 'sha256', 'hex', normalize)
+        processHashing(el, 'sha256', 'hex', normalize)
       ) as string[]
     }
 
     if (!isEmpty(payload.user_data?.country)) {
       payload.user_data.country = payload.user_data?.country?.map((el: string) =>
-        processHashingV2(el, 'sha256', 'hex', normalize)
+        processHashing(el, 'sha256', 'hex', normalize)
       ) as string[]
     }
 
     if (!isEmpty(payload.user_data?.external_id)) {
       payload.user_data.external_id = payload.user_data?.external_id?.map((el: string) =>
-        processHashingV2(el, 'sha256', 'hex', normalize)
+        processHashing(el, 'sha256', 'hex', normalize)
       ) as string[]
     }
     if (!isEmpty(payload.user_data?.hashed_maids)) {
       payload.user_data.hashed_maids = payload.user_data?.hashed_maids?.map((el: string) =>
-        processHashingV2(el, 'sha256', 'hex', normalize)
+        processHashing(el, 'sha256', 'hex', normalize)
       ) as string[]
     }
     if (!isEmpty(payload.user_data?.date_of_birth)) {
       payload.user_data.date_of_birth = payload.user_data?.date_of_birth?.map((el: string) =>
-        processHashingV2(el, 'sha256', 'hex', normalize)
+        processHashing(el, 'sha256', 'hex', normalize)
       ) as string[]
     }
   }

--- a/packages/destination-actions/src/destinations/podscribe/track/index.ts
+++ b/packages/destination-actions/src/destinations/podscribe/track/index.ts
@@ -152,7 +152,7 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: (request, { settings, payload }) => {
     if (payload.email) {
-      payload.email = processHashing(payload.email, 'sha256', 'hex', undefined, 'podscribe', normalizeEmail)
+      payload.email = processHashing(payload.email, 'sha256', 'hex', normalizeEmail)
     }
 
     const params = serializeParams({

--- a/packages/destination-actions/src/destinations/reddit-conversions-api/utils.ts
+++ b/packages/destination-actions/src/destinations/reddit-conversions-api/utils.ts
@@ -10,7 +10,7 @@ import {
   EventMetadata,
   DatapProcessingOptions
 } from './types'
-import { processHashingV2 } from '../../lib/hashing-utils'
+import { processHashing } from '../../lib/hashing-utils'
 
 type EventMetadataType = StandardEvent['event_metadata'] | CustomEvent['event_metadata']
 type ProductsType = StandardEvent['products'] | CustomEvent['products']
@@ -165,5 +165,5 @@ function canonicalizeEmail(value: string): string {
 
 const smartHash = (value: string | undefined, cleaningFunction?: (value: string) => string): string | undefined => {
   if (value === undefined) return
-  return processHashingV2(value, 'sha256', 'hex', cleaningFunction)
+  return processHashing(value, 'sha256', 'hex', cleaningFunction)
 }

--- a/packages/destination-actions/src/destinations/snap-audiences/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/snap-audiences/syncAudience/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration, PayloadValidationError } from '@segment/actions-core'
 import Destination from '../../index'
-import { processHashingV2 } from '../../../../lib/hashing-utils'
+import { processHashing } from '../../../../lib/hashing-utils'
 import { normalize, normalizePhone } from '../utils'
 
 const testDestination = createTestIntegration(Destination)
@@ -133,10 +133,10 @@ describe('Snapchat Audiences syncAudience', () => {
     const email2 = 'Person@email.com'
     const email3 = 'Person@email.com '
     const hashedEmail = 'b375b7bbddb3de3298fbc7641063d9f03a38e118aa4480c8ab9f58740982e8bd'
-    const email1Res = processHashingV2(email1, 'sha256', 'hex', normalize)
-    const email2Res = processHashingV2(email2, 'sha256', 'hex', normalize)
-    const email3Res = processHashingV2(email3, 'sha256', 'hex', normalize)
-    const alreadyHashedResEmail = processHashingV2(hashedEmail, 'sha256', 'hex', normalize)
+    const email1Res = processHashing(email1, 'sha256', 'hex', normalize)
+    const email2Res = processHashing(email2, 'sha256', 'hex', normalize)
+    const email3Res = processHashing(email3, 'sha256', 'hex', normalize)
+    const alreadyHashedResEmail = processHashing(hashedEmail, 'sha256', 'hex', normalize)
     expect(email1Res).toEqual(hashedEmail)
     expect(email2Res).toEqual(hashedEmail)
     expect(email3Res).toEqual(hashedEmail)
@@ -146,10 +146,10 @@ describe('Snapchat Audiences syncAudience', () => {
     const phone2 = '001(706)-767-5127'
     const phone3 = '01(706)-767-5127'
     const hashedPhone = '2fd199db6d3fa9fe754886ff1822f2867fcb104a6639495eca25c2978efe4ed4'
-    const phone1Res = processHashingV2(phone1, 'sha256', 'hex', normalizePhone)
-    const phone2Res = processHashingV2(phone2, 'sha256', 'hex', normalizePhone)
-    const phone3Res = processHashingV2(phone3, 'sha256', 'hex', normalizePhone)
-    const alreadyHashedResPhone = processHashingV2(hashedPhone, 'sha256', 'hex', normalizePhone)
+    const phone1Res = processHashing(phone1, 'sha256', 'hex', normalizePhone)
+    const phone2Res = processHashing(phone2, 'sha256', 'hex', normalizePhone)
+    const phone3Res = processHashing(phone3, 'sha256', 'hex', normalizePhone)
+    const alreadyHashedResPhone = processHashing(hashedPhone, 'sha256', 'hex', normalizePhone)
     expect(phone1Res).toEqual(hashedPhone)
     expect(phone2Res).toEqual(hashedPhone)
     expect(phone3Res).toEqual(hashedPhone)
@@ -158,9 +158,9 @@ describe('Snapchat Audiences syncAudience', () => {
     const mobileAdId1 = 'f81d4fae-7dec-11d0-a765-00a0c91e6bf6'
     const mobileAdId2 = 'F81D4FAE-7DEC-11D0-A765-00A0C91E6BF6'
     const hashedMobileAdId = '30a5154b77ab8b2ddbe19f5e7af72f33cc2a4a41f22940d965102650a1c72863'
-    const mobileAdId1Res = processHashingV2(mobileAdId1, 'sha256', 'hex', normalize)
-    const mobileAdId2Res = processHashingV2(mobileAdId2, 'sha256', 'hex', normalize)
-    const alreadyHashedResMobileAdId = processHashingV2(hashedMobileAdId, 'sha256', 'hex', normalize)
+    const mobileAdId1Res = processHashing(mobileAdId1, 'sha256', 'hex', normalize)
+    const mobileAdId2Res = processHashing(mobileAdId2, 'sha256', 'hex', normalize)
+    const alreadyHashedResMobileAdId = processHashing(hashedMobileAdId, 'sha256', 'hex', normalize)
     expect(mobileAdId1Res).toEqual(hashedMobileAdId)
     expect(mobileAdId2Res).toEqual(hashedMobileAdId)
     expect(alreadyHashedResMobileAdId).toEqual(hashedMobileAdId)

--- a/packages/destination-actions/src/destinations/snap-audiences/syncAudience/utils.ts
+++ b/packages/destination-actions/src/destinations/snap-audiences/syncAudience/utils.ts
@@ -1,5 +1,5 @@
 import type { Payload } from './generated-types'
-import { processHashingV2 } from '../../../lib/hashing-utils'
+import { processHashing } from '../../../lib/hashing-utils'
 
 // Filters out events with missing identifiers and sorts based on audience entered/exited
 export const sortPayload = (payload: Payload[]) => {
@@ -50,13 +50,13 @@ const validateAndExtractIdentifier = (
   mobileAdId: string | undefined
 ): string | null => {
   if (schemaType === 'EMAIL_SHA256' && email) {
-    return processHashingV2(email, 'sha256', 'hex', normalize)
+    return processHashing(email, 'sha256', 'hex', normalize)
   }
   if (schemaType === 'MOBILE_AD_ID_SHA256' && mobileAdId) {
-    return processHashingV2(mobileAdId, 'sha256', 'hex', normalize)
+    return processHashing(mobileAdId, 'sha256', 'hex', normalize)
   }
   if (schemaType === 'PHONE_SHA256' && phone) {
-    return processHashingV2(phone, 'sha256', 'hex', normalizePhone)
+    return processHashing(phone, 'sha256', 'hex', normalizePhone)
   }
 
   return null

--- a/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-v3.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-v3.ts
@@ -13,7 +13,7 @@ import {
   parseDateSafe,
   smartHash
 } from './utils'
-import { processHashingV2 } from '../../../lib/hashing-utils'
+import { processHashing } from '../../../lib/hashing-utils'
 
 const CURRENCY_ISO_4217_CODES = new Set([
   'USD',
@@ -470,7 +470,7 @@ const buildUserData = (payload: Payload) => {
   const hashedCountry = smartHash(user_data?.country, normalizedCountry)
 
   const external_id = user_data?.externalId?.map((id) => {
-    return processHashingV2(id, 'sha256', 'hex', normalizedValue)
+    return processHashing(id, 'sha256', 'hex', normalizedValue)
   })
 
   const db = smartHash(user_data?.dateOfBirth)

--- a/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/utils.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/utils.ts
@@ -1,5 +1,5 @@
 import { IntegrationError } from '@segment/actions-core'
-import { processHashingV2 } from '../../../lib/hashing-utils'
+import { processHashing } from '../../../lib/hashing-utils'
 
 export const isNullOrUndefined = <T>(v: T | null | undefined): v is null | undefined => v == null
 
@@ -76,5 +76,5 @@ export const smartHash = (
 ): string | undefined => {
   if (value === undefined) return
 
-  return processHashingV2(value, 'sha256', 'hex', cleaningFunction)
+  return processHashing(value, 'sha256', 'hex', cleaningFunction)
 }

--- a/packages/destination-actions/src/destinations/tiktok-audiences/functions.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/functions.ts
@@ -7,7 +7,7 @@ import { Payload as CreateAudiencePayload } from './createAudience/generated-typ
 import { Settings } from './generated-types'
 import { CreateAudienceAPIResponse } from './types'
 import { AudienceSettings } from './generated-types'
-import { processHashingV2 } from '../../lib/hashing-utils'
+import { processHashing } from '../../lib/hashing-utils'
 
 type LegacyPayload = AddUserPayload | RemoveUserPayload
 type GenericPayload = LegacyPayload | AddToAudiencePayload
@@ -102,7 +102,7 @@ export function getIDSchema(payload: GenericPayload): string[] {
 const isHashedInformation = (information: string): boolean => new RegExp(/[0-9abcdef]{64}/gi).test(information)
 
 const hash = (value: string): string => {
-  return processHashingV2(value, 'sha256', 'hex')
+  return processHashing(value, 'sha256', 'hex')
 }
 
 export function extractUsers(payloads: GenericPayload[]): {}[][] {

--- a/packages/destination-actions/src/destinations/tiktok-conversions/formatter.ts
+++ b/packages/destination-actions/src/destinations/tiktok-conversions/formatter.ts
@@ -1,4 +1,4 @@
-import { processHashingV2 } from '../../lib/hashing-utils'
+import { processHashing } from '../../lib/hashing-utils'
 /**
  * Convert emails to lower case, and hash in SHA256.
  */
@@ -64,5 +64,5 @@ export function formatAddress(address: string | undefined | null): string | unde
 }
 
 function hashAndEncode(property: string, cleaningFunction?: (value: string) => string): string {
-  return processHashingV2(property, 'sha256', 'hex', cleaningFunction)
+  return processHashing(property, 'sha256', 'hex', cleaningFunction)
 }

--- a/packages/destination-actions/src/destinations/tiktok-offline-conversions/formatter.ts
+++ b/packages/destination-actions/src/destinations/tiktok-offline-conversions/formatter.ts
@@ -1,4 +1,4 @@
-import { processHashingV2 } from '../../lib/hashing-utils'
+import { processHashing } from '../../lib/hashing-utils'
 /**
  * Convert emails to lower case, and hash in SHA256.
  */
@@ -54,5 +54,5 @@ export function formatUserIds(userIds: string[] | undefined): string[] {
 }
 
 function hashAndEncode(property: string, cleaningFunction?: (value: string) => string): string {
-  return processHashingV2(property, 'sha256', 'hex', cleaningFunction)
+  return processHashing(property, 'sha256', 'hex', cleaningFunction)
 }

--- a/packages/destination-actions/src/destinations/yahoo-audiences/utils-rt.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/utils-rt.ts
@@ -2,7 +2,7 @@ import { createHmac } from 'crypto'
 import { Payload } from './updateSegment/generated-types'
 import { YahooPayload } from './types'
 import { gen_random_id } from './utils-tax'
-import { processHashingV2 } from '../../lib/hashing-utils'
+import { processHashing } from '../../lib/hashing-utils'
 
 /**
  * Creates a SHA256 hash from the input
@@ -11,7 +11,7 @@ import { processHashingV2 } from '../../lib/hashing-utils'
  */
 export function create_hash(input: string | undefined): string | undefined {
   if (input === undefined) return
-  return processHashingV2(input, 'sha256', 'hex', (value: string) => value.toLowerCase())
+  return processHashing(input, 'sha256', 'hex', (value: string) => value.toLowerCase())
 }
 
 /**

--- a/packages/destination-actions/src/lib/hashing-utils.ts
+++ b/packages/destination-actions/src/lib/hashing-utils.ts
@@ -3,7 +3,6 @@
  * It includes functionality to check if a value is already hashed and to process hashing with optional cleaning.
  */
 import * as crypto from 'crypto'
-import { Features } from '@segment/actions-core'
 
 export const EncryptionMethods = ['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512'] as const
 export type EncryptionMethod = typeof EncryptionMethods[number]
@@ -23,20 +22,6 @@ export const hashConfigs: {
   sha384: { lengthHex: 96, lengthBase64: 64 },
   sha512: { lengthHex: 128, lengthBase64: 88 }
 }
-
-const slugsToBypassFeatureFlag = [
-  'actions-facebook-custom-audiences',
-  'actions-linkedin-audiences',
-  'actions-snap-audiences',
-  'actions-snap-conversions',
-  'actions-tiktok-offline-conversions',
-  'tiktok-conversions',
-  'actions-google-enhanced-conversions',
-  'actions-google-campaign-manager-360',
-  'actions-facebook-conversions-api',
-  'actions-tiktok-audiences'
-]
-
 class SmartHashing {
   private preHashed: boolean
 
@@ -89,60 +74,11 @@ class SmartHashing {
  * @param value - The string value to be hashed.
  * @param encryptionMethod - The method of encryption to be used.
  * @param digest - The type of digest to be used.
- * @param features - An object containing feature flags.
- * @param destinationSlugForBypass - A slug that, if present in the bypassFlagSlugs array, will bypass the flag check.
  * @param cleaningFunction - An optional function to clean the value before hashing.
  * @returns The hashed value or the original value if it is already hashed.
  */
+
 export function processHashing(
-  value: string,
-  encryptionMethod: EncryptionMethod,
-  digest: DigestType,
-  features: Features | undefined,
-  destinationSlugForBypass: string,
-  cleaningFunction?: CleaningFunction
-): string {
-  if (value.trim() === '') {
-    return ''
-  }
-
-  const smartHashing = new SmartHashing(encryptionMethod, digest)
-  /**
-   * Determines whether the flag should be bypasssed or not.
-   * If the slug is present in the bypassFlagSlugs array, the flag check will be bypassed.
-   */
-  const bypassFlag = destinationSlugForBypass && slugsToBypassFeatureFlag.includes(destinationSlugForBypass)
-
-  // If smart-hashing feature flag is not enabled, clean and hash the value directly
-  if (!bypassFlag && !(features && features['smart-hashing'])) {
-    if (cleaningFunction) {
-      value = cleaningFunction(value)
-    }
-    return smartHashing.hash(value)
-  }
-
-  if (smartHashing.isAlreadyHashed(value)) {
-    return value
-  }
-
-  if (cleaningFunction) {
-    value = cleaningFunction(value)
-  }
-
-  return smartHashing.hash(value)
-}
-
-/**
- * Processes the hashing of a given value based on the provided encryption method, digest type, features, and optional cleaning function.
- *
- * @param value - The string value to be hashed.
- * @param encryptionMethod - The method of encryption to be used.
- * @param digest - The type of digest to be used.
- * @param cleaningFunction - An optional function to clean the value before hashing.
- * @returns The hashed value or the original value if it is already hashed.
- */
-
-export function processHashingV2(
   value: string,
   encryptionMethod: EncryptionMethod,
   digest: DigestType,


### PR DESCRIPTION
This PR renames the processHashingV2 function used for cleanup back to processHashing.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
