### PR TITLE
Add batch bytes to Marketo

### DIFF
--- a/packages/destination-actions/src/destinations/marketo-static-lists/addToList/index.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/addToList/index.ts
@@ -1,7 +1,7 @@
 import type { IntegrationError, ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { external_id, lookup_field, data, enable_batching, batch_size, event_name } from '../properties'
+import { external_id, lookup_field, data, enable_batching, batch_size, event_name, batch_bytes } from '../properties'
 import { addToList, addToListBatch, createList, getList } from '../functions'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -14,6 +14,7 @@ const action: ActionDefinition<Settings, Payload> = {
     data: { ...data },
     enable_batching: { ...enable_batching },
     batch_size: { ...batch_size },
+    batch_bytes: { ...batch_bytes },
     event_name: { ...event_name }
   },
   hooks: {

--- a/packages/destination-actions/src/destinations/marketo-static-lists/properties.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/properties.ts
@@ -92,7 +92,7 @@ export const batch_size: InputField = {
 export const batch_bytes: InputField = {
   type: 'number',
   label: 'Batch Bytes',
-  description: 'The number of bytes to write to the Marketo in a single batch. Limit is 2MB.',
+  description: 'The number of bytes to write to the Marketo in a single batch. Limit is 10MB.',
   default: 10000000, // 10MB,
   required: false,
   unsafe_hidden: true

--- a/packages/destination-actions/src/destinations/marketo-static-lists/properties.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/properties.ts
@@ -89,6 +89,15 @@ export const batch_size: InputField = {
   required: true
 }
 
+export const batch_bytes: InputField = {
+  type: 'number',
+  label: 'Batch Bytes',
+  description: 'The number of bytes to write to the Marketo in a single batch. Limit is 2MB.',
+  default: 10000000, // 10MB,
+  required: false,
+  unsafe_hidden: true
+}
+
 export const event_name: InputField = {
   label: 'Event Name',
   description: 'The name of the current Segment event.',


### PR DESCRIPTION
Marketo enforces a 10 MB file size limit for uploads via its Bulk Import API. We are adding the new `batch_bytes` limit to ensure that customers do not exceed this limit.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
