### PR TITLE
Better error handling for Google Enhanced Conversions Create Audience

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -1,4 +1,4 @@
-import { AudienceDestinationDefinition, defaultValues } from '@segment/actions-core'
+import { AudienceDestinationDefinition, defaultValues, IntegrationError } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import postConversion from './postConversion'
 import uploadCallConversion from './uploadCallConversion'
@@ -129,13 +129,25 @@ const destination: AudienceDestinationDefinition<Settings> = {
 
       createAudienceInput.settings.customerId = verifyCustomerId(createAudienceInput.settings.customerId)
       const auth = createAudienceInput.settings.oauth
-      const userListId = await createGoogleAudience(
-        request,
-        createAudienceInput,
-        auth,
-        createAudienceInput.features,
-        createAudienceInput.statsContext
-      )
+
+      let userListId
+      try {
+        userListId = await createGoogleAudience(
+          request,
+          createAudienceInput,
+          auth,
+          createAudienceInput.features,
+          createAudienceInput.statsContext
+        )
+      } catch (err) {
+        let status = err.status || err.code
+        if (!status && err.response && err.response.status) {
+          status = Number(err.response.status)
+        }
+        const message = err.response?.content || err.message
+
+        throw new IntegrationError(message, 'CREATE_AUDIENCE_FAILED', status || 400)
+      }
 
       return {
         externalId: userListId

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -144,6 +144,11 @@ const destination: AudienceDestinationDefinition<Settings> = {
         if (!status && err.response && err.response.status) {
           status = Number(err.response.status)
         }
+        // NOTE:
+        // We are embedding the entire error message here.
+        // This is not ideal as we should properly parse it and assemble the respective error message.
+        // For now, this and its counterpart in EAMS will parse the error and show it to the user but
+        // ultimately destinations should own this.
         const message = err.response?.content || err.message
 
         throw new IntegrationError(message, 'CREATE_AUDIENCE_FAILED', status || 400)


### PR DESCRIPTION
Errors that are not wrapped around `IntegrationError` are deemed `Internal Errors` which in turn return a 500. This also has another downside, services that call these methods will lose the actual error message and thus upstream has little to no information about what went wrong downstream. 

This PR adds a try/catch block to the createExternalAudience call within Google Enhanced Conversions so EAMS can report properly on it.

## Testing

Testing completed successfully locally

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
