### PR TITLE
STRATCONN-5564: add quotes object support

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/upsertObject/constants.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertObject/constants.ts
@@ -13,7 +13,8 @@ export const SUPPORTED_HUBSPOT_OBJECT_TYPES = [
   { label: 'Subscription', value: 'subscription' },
   { label: 'Product', value: 'product' },
   { label: 'Appointment', value: '0-421' },
-  { label: 'Order', value: 'order' }
+  { label: 'Order', value: 'order' },
+  { label: 'Quote', value: 'quote' }
 ]
 
 export const MAX_HUBSPOT_BATCH_SIZE = 100


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Support for Hubspot custom object Quotes

## Testing

Testing completed successfully in stage. Here is the [Mapping](https://app.segment.build/arjun-test/destinations/actions-hubspot-cloud/sources/test/instances/680a223f0192785e92f156b2/actions/rWaqV8V8BFRprRpdj41EcB)

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
