### PR TITLE
[Ortto] - New Cloud Mode Destination

### DIFF
--- a/packages/destination-actions/src/destinations/ortto/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/ortto/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-ortto destination: trackActivity action - all fields 1`] = `
+Array [
+  Object {
+    "anonymous_id": "]25AcEh01MO",
+    "audience_update_mode": "add",
+    "batch_size": -14362795269160.96,
+    "enable_batching": true,
+    "event": "]25AcEh01MO",
+    "ip": "107.255.187.198",
+    "location": Object {
+      "city": "]25AcEh01MO",
+      "country": "]25AcEh01MO",
+      "post_code": "]25AcEh01MO",
+      "state": "]25AcEh01MO",
+    },
+    "message_id": "]25AcEh01MO",
+    "namespace": "]25AcEh01MO",
+    "properties": Object {
+      "testType": "]25AcEh01MO",
+    },
+    "timestamp": "2125-06-22T17:21:01.417Z",
+    "traits": Object {
+      "email": "vepaj@apzujhuw.sm",
+      "first_name": "]25AcEh01MO",
+      "last_name": "]25AcEh01MO",
+      "phone": "]25AcEh01MO",
+    },
+    "user_id": "]25AcEh01MO",
+  },
+]
+`;
+
+exports[`Testing snapshot for actions-ortto destination: trackActivity action - required fields 1`] = `
+Array [
+  Object {
+    "anonymous_id": "]25AcEh01MO",
+    "event": "]25AcEh01MO",
+    "message_id": "]25AcEh01MO",
+    "user_id": "]25AcEh01MO",
+  },
+]
+`;
+
+exports[`Testing snapshot for actions-ortto destination: upsertContactProfile action - all fields 1`] = `
+Array [
+  Object {
+    "anonymous_id": "TBOtXZm4yQy]54s",
+    "audience_update_mode": "remove",
+    "batch_size": 29635016308817.92,
+    "enable_batching": false,
+    "ip": "169.155.93.138",
+    "location": Object {
+      "city": "TBOtXZm4yQy]54s",
+      "country": "TBOtXZm4yQy]54s",
+      "post_code": "TBOtXZm4yQy]54s",
+      "state": "TBOtXZm4yQy]54s",
+    },
+    "message_id": "TBOtXZm4yQy]54s",
+    "timestamp": "2086-08-12T11:15:40.692Z",
+    "traits": Object {
+      "email": "cu@wolpawwe.me",
+      "first_name": "TBOtXZm4yQy]54s",
+      "last_name": "TBOtXZm4yQy]54s",
+      "phone": "TBOtXZm4yQy]54s",
+    },
+    "user_id": "TBOtXZm4yQy]54s",
+  },
+]
+`;
+
+exports[`Testing snapshot for actions-ortto destination: upsertContactProfile action - required fields 1`] = `
+Array [
+  Object {
+    "anonymous_id": "TBOtXZm4yQy]54s",
+    "message_id": "TBOtXZm4yQy]54s",
+    "user_id": "TBOtXZm4yQy]54s",
+  },
+]
+`;

--- a/packages/destination-actions/src/destinations/ortto/__tests__/client.test.ts
+++ b/packages/destination-actions/src/destinations/ortto/__tests__/client.test.ts
@@ -1,0 +1,39 @@
+import { InvalidAuthenticationError, PayloadValidationError } from '@segment/actions-core'
+import { Errors } from '../ortto-client'
+import OrttoClient from '../ortto-client'
+import { Settings } from '../generated-types'
+import { TEST_API_KEY } from '../types'
+
+const settings: Settings = {
+  api_key: TEST_API_KEY
+}
+
+describe('Ortto.Client', () => {
+
+  it('createAudience: should validate API key', async () => {
+    const fakeRequest = jest.fn().mockResolvedValue({
+      data: {} // no errors in response
+    })
+
+    const client = new OrttoClient(fakeRequest)
+    const response = client.createAudience(
+      {
+        api_key: 'invalid api key'
+      },
+      'audience name'
+    )
+    await expect(response).rejects.toThrowError(new InvalidAuthenticationError(Errors.InvalidAPIKey))
+    expect(fakeRequest).not.toHaveBeenCalled()
+  })
+
+  it('createAudience: should validate empty audience name', async () => {
+    const fakeRequest = jest.fn().mockResolvedValue({
+      data: {} // no errors in response
+    })
+
+    const client = new OrttoClient(fakeRequest)
+    const response = client.createAudience(settings, '')
+    await expect(response).rejects.toThrowError(new PayloadValidationError(Errors.MissingAudienceName))
+    expect(fakeRequest).not.toHaveBeenCalled()
+  })
+})

--- a/packages/destination-actions/src/destinations/ortto/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/ortto/__tests__/index.test.ts
@@ -1,0 +1,42 @@
+import nock from 'nock'
+import { createTestIntegration, InvalidAuthenticationError } from '@segment/actions-core'
+import Definition from '../index'
+import { API_VERSION } from '../ortto-client'
+import { TEST_API_KEY } from '../types'
+
+const testDestination = createTestIntegration(Definition)
+describe('Ortto', () => {
+  describe('authentication', () => {
+    it('should reject empty api keys', async () => {
+      try {
+        await testDestination.testAuthentication({ api_key: '' })
+      } catch (err) {
+        expect(err instanceof InvalidAuthenticationError)
+      }
+    })
+
+    it('should reject whitespace api keys', async () => {
+      try {
+        await testDestination.testAuthentication({ api_key: '    ' })
+      } catch (err) {
+        expect(err instanceof InvalidAuthenticationError)
+      }
+    })
+
+    it('should reject invalid api keys', async () => {
+      try {
+        await testDestination.testAuthentication({ api_key: 'invalid' })
+      } catch (err) {
+        expect(err instanceof InvalidAuthenticationError)
+      }
+    })
+
+    it('should accept valid api keys', async () => {
+      nock('https://segment-action-api-au.ortto.app')
+        .get(`/${API_VERSION}/me`)
+        .matchHeader('authorization', `Bearer ${TEST_API_KEY}`)
+        .reply(200, {})
+      await expect(testDestination.testAuthentication({ api_key: TEST_API_KEY })).resolves.not.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/ortto/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/ortto/__tests__/snapshot.test.ts
@@ -1,0 +1,80 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+import { TEST_API_KEY } from '../types'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-ortto'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+      nock(/.*/).persist().delete(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: { api_key: TEST_API_KEY },
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+      nock(/.*/).persist().delete(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: { api_key: TEST_API_KEY },
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/ortto/__tests__/utils.test.ts
+++ b/packages/destination-actions/src/destinations/ortto/__tests__/utils.test.ts
@@ -1,0 +1,106 @@
+import { cleanObject } from '../utils'
+
+describe('Ortto', () => {
+  describe('utils', () => {
+    it('cleanobject must remove empty keys with value', async () => {
+      expect(cleanObject({ '': 'v', k: 'v' })).toStrictEqual({ k: 'v' })
+    })
+  })
+
+  describe('utils', () => {
+    it('cleanobject must remove empty keys with empty value', async () => {
+      expect(cleanObject({ '': '', k: 'v' })).toStrictEqual({ k: 'v' })
+    })
+  })
+
+  describe('utils', () => {
+    it('cleanobject must remove multiple empty keys', async () => {
+      expect(cleanObject({ '': '', '': 'v', k: 'v' })).toStrictEqual({ k: 'v' })
+    })
+  })
+
+  describe('utils', () => {
+    it('cleanobject should not remove empty values', async () => {
+      expect(
+        cleanObject({
+          k1: '',
+          k2: 'v2',
+          k3: 0,
+          k4: false,
+          k5: [],
+          k6: {},
+          k7: null,
+          k8: undefined
+        })
+      ).toStrictEqual({
+        k1: '',
+        k2: 'v2',
+        k3: 0,
+        k4: false,
+        k5: [],
+        k6: {},
+        k7: null,
+        k8: undefined
+      })
+    })
+  })
+
+  describe('utils', () => {
+    it('cleanobject should not process arrays', async () => {
+      expect(
+        cleanObject({
+          k1: ['', undefined, null, 'v', { x: 'y', '': '', k1: undefined, k2: null }],
+          '': '',
+          k2: {},
+          k3: ['', undefined, null, 'v', { x: 'y', '': '' }],
+          k4: {
+            '': '',
+            k: 100
+          }
+        })
+      ).toStrictEqual({
+        k1: ['', undefined, null, 'v', { x: 'y', '': '', k1: undefined, k2: null }],
+        k2: {},
+        k3: ['', undefined, null, 'v', { x: 'y', '': '' }],
+        k4: {
+          k: 100
+        }
+      })
+    })
+  })
+
+  describe('utils', () => {
+    it('cleanobject must clean nested objects', async () => {
+      expect(
+        cleanObject({
+          '': 'v',
+          k: 'v',
+          l1: {
+            '': '',
+            k2: undefined,
+            k3: null,
+            k4: 'v4',
+            l2: {
+              '': '',
+              k2: undefined,
+              k5: 'v5',
+              k3: null
+            }
+          }
+        })
+      ).toStrictEqual({
+        k: 'v',
+        l1: {
+          k2: undefined,
+          k3: null,
+          k4: 'v4',
+          l2: {
+            k2: undefined,
+            k5: 'v5',
+            k3: null
+          }
+        }
+      })
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/ortto/common-fields.ts
+++ b/packages/destination-actions/src/destinations/ortto/common-fields.ts
@@ -1,0 +1,216 @@
+import { InputField } from '@segment/actions-core'
+
+export const commonFields: Record<string, InputField> = {
+  timestamp: {
+    label: 'Timestamp',
+    description: 'Event timestamp',
+    type: 'string',
+    readOnly: true,
+    format: 'date-time',
+    default: {
+      '@path': '$.timestamp'
+    }
+  },
+  message_id: {
+    label: 'Message ID',
+    description: 'Message ID',
+    type: 'string',
+    readOnly: true,
+    default: {
+      '@path': '$.messageId'
+    }
+  },
+  enable_batching: {
+    type: 'boolean',
+    label: 'Batch data',
+    description: 'When enabled, events will be sent to Ortto in batches for improved efficiency.',
+    default: true
+  },
+  user_id: {
+    label: 'User ID',
+    description: 'The unique user identifier',
+    type: 'string',
+    required: {
+      conditions: [
+        {
+          fieldKey: 'anonymous_id',
+          operator: 'is',
+          value: undefined
+        }
+      ]
+    },
+    default: {
+      '@path': '$.userId'
+    }
+  },
+  anonymous_id: {
+    label: 'Anonymous ID',
+    description: 'Anonymous user identifier',
+    type: 'string',
+    required: {
+      conditions: [
+        {
+          fieldKey: 'user_id',
+          operator: 'is',
+          value: undefined
+        }
+      ]
+    },
+    default: {
+      '@path': '$.anonymousId'
+    }
+  },
+  ipV4: {
+    label: 'IP Address',
+    description: "The Contact's IP address",
+    placeholder: '180.1.12.125',
+    type: 'string',
+    format: 'ipv4',
+    default: { '@path': '$.context.ip' },
+    allowNull: true
+  },
+  location: {
+    label: 'Location',
+    description: "The Contact's location. Takes priority over the IP address.",
+    type: 'object',
+    defaultObjectUI: 'keyvalue:only',
+    additionalProperties: false,
+    allowNull: true,
+    properties: {
+      country: {
+        label: 'Country',
+        type: 'string',
+        allowNull: true
+      },
+      state: {
+        label: 'State',
+        type: 'string',
+        allowNull: true
+      },
+      city: {
+        label: 'City',
+        type: 'string',
+        allowNull: true
+      },
+      post_code: {
+        label: 'Postcode',
+        type: 'string',
+        allowNull: true
+      }
+    },
+    default: {
+      country: {
+        '@if': {
+          exists: { '@path': '$.traits.address.country' },
+          then: { '@path': '$.traits.address.country' },
+          else: { '@path': '$.context.traits.address.country' }
+        }
+      },
+      state: {
+        '@if': {
+          exists: { '@path': '$.traits.address.state' },
+          then: { '@path': '$.traits.address.state' },
+          else: { '@path': '$.context.traits.address.state' }
+        }
+      },
+      city: {
+        '@if': {
+          exists: { '@path': '$.traits.address.city' },
+          then: { '@path': '$.traits.address.city' },
+          else: { '@path': '$.context.traits.address.city' }
+        }
+      },
+      post_code: {
+        '@if': {
+          exists: { '@path': '$.traits.address.postal_code' },
+          then: { '@path': '$.traits.address.postal_code' },
+          else: { '@path': '$.context.traits.address.postal_code' }
+        }
+      }
+    }
+  },
+  traits: {
+    label: 'Custom Contact traits',
+    description: 'An object containing key-value pairs representing custom properties assigned to Contact profile',
+    type: 'object',
+    defaultObjectUI: 'keyvalue',
+    properties: {
+      email: {
+        label: 'Email',
+        description: "The Contact's email address",
+        placeholder: 'john.smith@example.com',
+        type: 'string',
+        format: 'email'
+      },
+      phone: {
+        label: 'Phone Number',
+        description: "The Contact's phone number (including the country code is strongly recommended)",
+        placeholder: '+15555555555',
+        type: 'string'
+      },
+      first_name: {
+        label: 'First Name',
+        description: "The Contact's first name",
+        placeholder: 'John',
+        type: 'string'
+      },
+      last_name: {
+        label: 'Last Name',
+        description: "The Contact's last name",
+        placeholder: 'Smith',
+        type: 'string'
+      }
+    },
+    default: {
+      email: {
+        '@if': {
+          exists: { '@path': '$.traits.email' },
+          then: { '@path': '$.traits.email' },
+          else: { '@path': '$.context.traits.email' }
+        }
+      },
+      phone: {
+        '@if': {
+          exists: { '@path': '$.traits.phone' },
+          then: { '@path': '$.traits.phone' },
+          else: { '@path': '$.context.traits.phone' }
+        }
+      },
+      first_name: {
+        '@if': {
+          exists: { '@path': '$.traits.first_name' },
+          then: { '@path': '$.traits.first_name' },
+          else: { '@path': '$.context.traits.first_name' }
+        }
+      },
+      last_name: {
+        '@if': {
+          exists: { '@path': '$.traits.last_name' },
+          then: { '@path': '$.traits.last_name' },
+          else: { '@path': '$.context.traits.last_name' }
+        }
+      }
+    }
+  },
+  audience_update_mode: {
+    label: 'Audience update mode',
+    description: 'Indicates whether the Contact should be added to or removed from the Audience.',
+    type: 'string',
+    required: false,
+    choices: [
+      { label: 'Add', value: 'add' },
+      { label: 'Remove', value: 'remove' }
+    ],
+    default: 'add'
+  },
+  // Hidden Fields
+  batch_size: {
+    label: 'Batch Size',
+    description: 'Maximum number of events to include in each batch.',
+    type: 'number',
+    required: false,
+    default: 500,
+    readOnly: true,
+    unsafe_hidden: true
+  }
+}

--- a/packages/destination-actions/src/destinations/ortto/generated-types.ts
+++ b/packages/destination-actions/src/destinations/ortto/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Ortto API key
+   */
+  api_key: string
+}

--- a/packages/destination-actions/src/destinations/ortto/index.ts
+++ b/packages/destination-actions/src/destinations/ortto/index.ts
@@ -1,0 +1,54 @@
+import { defaultValues, DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+import upsertContactProfile from './upsertContactProfile'
+import OrttoClient from './ortto-client'
+
+import trackActivity from './trackActivity'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Ortto (Actions)',
+  slug: 'actions-ortto',
+  mode: 'cloud',
+  description:
+    'Send customer data from Segment to Ortto in real time to power campaigns, trigger journeys, and manage audiences with greater flexibility and control.',
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      api_key: {
+        label: 'API Key',
+        description: 'Ortto API key',
+        type: 'password',
+        required: true
+      }
+    },
+    testAuthentication: async (request, { settings }) => {
+      const client: OrttoClient = new OrttoClient(request)
+      return await client.testAuth(settings)
+    }
+  },
+  extendRequest({ settings }) {
+    if (process?.env?.ORTTO_API_KEY) {
+      settings.api_key = process?.env?.ORTTO_API_KEY
+    }
+    return {
+      headers: {
+        Authorization: `Bearer ${settings.api_key}`
+      }
+    }
+  },
+  presets: [
+    {
+      name: upsertContactProfile.title,
+      subscribe: 'type = "identify"',
+      partnerAction: 'upsertContactProfile',
+      mapping: defaultValues(upsertContactProfile.fields),
+      type: 'automatic'
+    }
+  ],
+  actions: {
+    upsertContactProfile,
+    trackActivity
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/ortto/ortto-client.ts
+++ b/packages/destination-actions/src/destinations/ortto/ortto-client.ts
@@ -1,0 +1,192 @@
+import {
+  InvalidAuthenticationError,
+  PayloadValidationError,
+  RequestClient,
+  MultiStatusResponse,
+  JSONLikeObject,
+  ErrorCodes
+} from '@segment/actions-core'
+import { Settings } from './generated-types'
+import { Payload as UpsertContactPayload } from './upsertContactProfile/generated-types'
+import { Payload as EventPayload } from './trackActivity/generated-types'
+import { cleanObject } from './utils'
+import { Audience, BatchResponse } from './types'
+
+export const API_VERSION = 'v1'
+export const Success = {
+  status: 200,
+  body: 'Processed successfully'
+}
+export const Errors: Record<string, string> = {
+  InvalidAPIKey: `Invalid API key`,
+  MissingEventName: `Missing event name`,
+  MissingAudienceName: `Missing audience name`,
+  MissingAudienceId: `Missing audience Id`
+}
+export default class OrttoClient {
+  request: RequestClient
+  constructor(request: RequestClient) {
+    this.request = request
+  }
+
+  upsertContacts = async (
+    settings: Settings,
+    payloads: UpsertContactPayload[],
+    hookAudienceID: string
+  ): Promise<MultiStatusResponse> => {
+    const response = new MultiStatusResponse()
+    const cleaned: JSONLikeObject[] = []
+    for (let i = 0; i < payloads.length; i++) {
+      const event = payloads[i]
+      const clean = cleanObject(event) as JSONLikeObject
+      if (hookAudienceID && (event.audience_update_mode === 'add' || event.audience_update_mode === 'remove')) {
+        clean.audience = {
+          mode: event.audience_update_mode,
+          id: hookAudienceID
+        }
+      }
+      cleaned.push(clean)
+    }
+
+    const url = this.getEndpoint(settings.api_key).concat('/identify')
+    const { data } = await this.request<BatchResponse>(url, {
+      method: 'POST',
+      json: cleaned
+    })
+
+    cleaned.forEach((payload, idx) => {
+      response.setSuccessResponseAtIndex(idx, {
+        ...Success,
+        sent: payload
+      })
+    })
+
+    if (data.errors) {
+      data.errors.forEach((err) => {
+        const { status, message, index } = err
+        response.setErrorResponseAtIndex(index, {
+          status,
+          errormessage: message,
+          sent: cleaned[index]
+        })
+      })
+    }
+
+    return response
+  }
+
+  sendActivities = async (
+    settings: Settings,
+    payloads: EventPayload[],
+    hookAudienceID: string
+  ): Promise<MultiStatusResponse> => {
+    const filtered: JSONLikeObject[] = []
+    const indexBitmap: number[] = []
+    const response = new MultiStatusResponse()
+
+    for (let i = 0; i < payloads.length; i++) {
+      const event = payloads[i]
+      const clean = cleanObject(event) as JSONLikeObject
+      if (!event.event || event.event.trim() === '') {
+        response.setErrorResponseAtIndex(i, {
+          status: 400,
+          sent: clean,
+          errortype: ErrorCodes.PAYLOAD_VALIDATION_FAILED,
+          errormessage: Errors.MissingEventName
+        })
+        continue
+      }
+      if (event.namespace === 'ortto.com') {
+        response.setSuccessResponseAtIndex(i, {
+          status: 200,
+          sent: clean,
+          body: `${event.event} was originated from ${event.namespace} (Ignored)`
+        })
+        continue
+      }
+
+      if (hookAudienceID && (event.audience_update_mode === 'add' || event.audience_update_mode === 'remove')) {
+        clean.audience = {
+          mode: event.audience_update_mode,
+          id: hookAudienceID
+        }
+      }
+      filtered.push(clean)
+      indexBitmap.push(i)
+    }
+
+    if (filtered.length == 0) {
+      return response
+    }
+    const url = this.getEndpoint(settings.api_key).concat(`/track`)
+    const { data } = await this.request<BatchResponse>(url, {
+      method: 'POST',
+      json: filtered
+    })
+
+    filtered.forEach((payload, idx) => {
+      const originalIndex = indexBitmap[idx]
+      response.setSuccessResponseAtIndex(originalIndex, {
+        ...Success,
+        sent: payload
+      })
+    })
+
+    if (data.errors) {
+      data.errors.forEach((err) => {
+        const { status, message, index } = err
+        const originalIndex = indexBitmap[index]
+        response.setErrorResponseAtIndex(originalIndex, {
+          status: status,
+          errormessage: message,
+          sent: filtered[index]
+        })
+      })
+    }
+    return response
+  }
+
+  testAuth = async (settings: Settings) => {
+    const url = this.getEndpoint(settings.api_key).concat('/me')
+    return this.request(url, {
+      method: 'GET'
+    })
+  }
+
+  createAudience = async (settings: Settings, audienceName: string): Promise<Audience> => {
+    audienceName = audienceName?.trim()
+    if (!audienceName) {
+      throw new PayloadValidationError(Errors.MissingAudienceName)
+    }
+    const url = this.getEndpoint(settings.api_key).concat('/audiences/create')
+    const { data } = await this.request<Audience>(url, {
+      method: 'POST',
+      json: { name: audienceName }
+    })
+    return data
+  }
+
+  private getEndpoint(apiKey: string): string {
+    if (process?.env?.ORTTO_LOCAL_ENDPOINT) {
+      return `${process?.env?.ORTTO_LOCAL_ENDPOINT}/${API_VERSION}`
+    }
+    if (!apiKey) {
+      throw new InvalidAuthenticationError(Errors.InvalidAPIKey)
+    }
+    const idx = apiKey.indexOf('-')
+    if (idx != 3) {
+      throw new InvalidAuthenticationError(Errors.InvalidAPIKey)
+    }
+
+    let env = ''
+    if (apiKey.charAt(0) == 's') {
+      env = '-stg'
+    }
+    const region = apiKey.substring(1, idx).trim()
+    if (region.length != 2) {
+      throw new InvalidAuthenticationError(Errors.InvalidAPIKey)
+    }
+
+    return `https://segment-action-api-${region}.ortto${env}.app/${API_VERSION}`
+  }
+}

--- a/packages/destination-actions/src/destinations/ortto/trackActivity/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/ortto/trackActivity/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Ortto's trackActivity destination action: all fields 1`] = `
+Array [
+  Object {
+    "anonymous_id": "9QX1u",
+    "audience_update_mode": "add",
+    "batch_size": -87829560678154.23,
+    "enable_batching": true,
+    "event": "9QX1u",
+    "ip": "4.211.147.169",
+    "location": Object {
+      "city": "9QX1u",
+      "country": "9QX1u",
+      "post_code": "9QX1u",
+      "state": "9QX1u",
+    },
+    "message_id": "9QX1u",
+    "namespace": "9QX1u",
+    "properties": Object {
+      "testType": "9QX1u",
+    },
+    "timestamp": "2108-01-18T15:43:16.331Z",
+    "traits": Object {
+      "email": "diudouro@fanpufuju.nz",
+      "first_name": "9QX1u",
+      "last_name": "9QX1u",
+      "phone": "9QX1u",
+    },
+    "user_id": "9QX1u",
+  },
+]
+`;
+
+exports[`Testing snapshot for Ortto's trackActivity destination action: required fields 1`] = `
+Array [
+  Object {
+    "anonymous_id": "9QX1u",
+    "event": "9QX1u",
+    "message_id": "9QX1u",
+    "user_id": "9QX1u",
+  },
+]
+`;

--- a/packages/destination-actions/src/destinations/ortto/trackActivity/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/ortto/trackActivity/__tests__/index.test.ts
@@ -1,0 +1,324 @@
+import nock from 'nock'
+import {
+  createTestEvent,
+  createTestIntegration,
+  SegmentEvent,
+  InvalidAuthenticationError,
+  ErrorCodes
+} from '@segment/actions-core'
+import Destination from '../../index'
+import { Errors, API_VERSION, Success } from '../../ortto-client'
+import OrttoClient from '../../ortto-client'
+import { Settings } from '../../generated-types'
+import { TEST_API_KEY } from '../../types'
+import { Payload } from '../generated-types'
+
+const testDestination = createTestIntegration(Destination)
+
+const settings: Settings = {
+  api_key: TEST_API_KEY
+}
+
+const validPayload = {
+  timestamp: '2024-01-08T13:52:50.212Z',
+  type: 'track',
+  userId: 'user_id',
+  anonymousId: 'anonymous_id',
+  event: 'event',
+  messageId: 'message_id',
+  properties: {
+    arrtibute1: 'value1',
+    arrtibute2: 'value2'
+  }
+} as Partial<SegmentEvent>
+
+describe('Ortto.trackActivity', () => {
+  it('should track event with default mappings', async () => {
+    nock('https://segment-action-api-au.ortto.app')
+      .post(`/${API_VERSION}/track`)
+      .matchHeader('authorization', `Bearer ${settings.api_key}`)
+      .reply(200, {})
+
+    const responses = await testDestination.testAction('trackActivity', {
+      settings: settings,
+      event: createTestEvent(validPayload),
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.method).toBe('POST')
+  })
+
+  it('should reject payloads with empty event name', async () => {
+    const events: Payload[] = [
+      {
+        user_id: 'user_id_1',
+        anonymous_id: 'anonymous_id_1',
+        message_id: 'message_id_1',
+        event: '  '
+      },
+      {
+        user_id: 'user_id_2',
+        anonymous_id: 'anonymous_id_2',
+        message_id: 'message_id_2',
+        event: ''
+      }
+    ]
+    const fakeRequest = jest.fn()
+    const client = new OrttoClient(fakeRequest)
+    const response = await client.sendActivities(settings, events, 'audience-id')
+
+    const all = response.getAllResponses()
+    expect(all.length).toBe(2)
+    expect(all[0].value()).toMatchObject({
+      status: 400,
+      sent: events[0],
+      errortype: ErrorCodes.PAYLOAD_VALIDATION_FAILED,
+      errormessage: Errors.MissingEventName
+    })
+    expect(all[1].value()).toMatchObject({
+      status: 400,
+      sent: events[1],
+      errortype: ErrorCodes.PAYLOAD_VALIDATION_FAILED,
+      errormessage: Errors.MissingEventName
+    })
+    expect(fakeRequest).not.toHaveBeenCalled()
+  })
+
+  it('should ignore events with namespace "ortto.com"', async () => {
+    const event: Payload = {
+      user_id: 'user_id',
+      anonymous_id: 'anonymous_id',
+      message_id: 'message_id',
+      event: 'Sample Event',
+      namespace: 'ortto.com'
+    }
+
+    const fakeRequest = jest.fn()
+    const client = new OrttoClient(fakeRequest)
+    const response = await client.sendActivities(settings, [event], 'audience-id')
+
+    const all = response.getAllResponses()
+    expect(all.length).toBe(1)
+    expect(all[0].value()).toMatchObject({
+      status: 200,
+      sent: event,
+      body: `Sample Event was originated from ortto.com (Ignored)`
+    })
+    expect(fakeRequest).not.toHaveBeenCalled()
+  })
+
+  it('should validate API key', async () => {
+    const event = createTestEvent(validPayload)
+    await expect(
+      testDestination.testAction('trackActivity', {
+        settings: {
+          api_key: 'invalid api key'
+        },
+        event: event,
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError(new InvalidAuthenticationError(Errors.InvalidAPIKey))
+  })
+
+  it('should process a single valid event successfully', async () => {
+    const event: Payload = {
+      user_id: 'user_id',
+      anonymous_id: 'anon_id',
+      message_id: 'msg_id',
+      event: 'Valid Event'
+    }
+
+    const fakeRequest = jest.fn().mockResolvedValue({
+      data: {} // no errors in response
+    })
+
+    const client = new OrttoClient(fakeRequest)
+    const response = await client.sendActivities(settings, [event], 'audience-id')
+
+    const all = response.getAllResponses()
+    expect(all.length).toBe(1)
+    expect(all[0].value()).toMatchObject({
+      ...Success,
+      sent: event
+    })
+    expect(fakeRequest).toHaveBeenCalledTimes(1)
+    expect(fakeRequest).toHaveBeenCalledWith(expect.stringContaining('/track'), {
+      method: 'POST',
+      json: expect.any(Array)
+    })
+  })
+
+  it('should process a mix of valid and invalid events', async () => {
+    const events: Payload[] = [
+      {
+        user_id: 'user_id_valid',
+        event: 'Valid Event'
+      },
+      {
+        user_id: 'user_id_invalid',
+        event: ''
+      },
+      {
+        user_id: 'user_id_ignored',
+        event: 'Ignored Event',
+        namespace: 'ortto.com'
+      }
+    ]
+
+    const fakeRequest = jest.fn().mockResolvedValue({ data: {} })
+    const client = new OrttoClient(fakeRequest)
+    const response = await client.sendActivities(settings, events, 'audience-id')
+
+    const all = response.getAllResponses()
+    expect(all.length).toBe(3)
+    expect(all[0].value()).toMatchObject({
+      ...Success,
+      sent: events[0]
+    })
+    expect(all[1].value()).toMatchObject({
+      status: 400,
+      sent: events[1],
+      errormessage: Errors.MissingEventName
+    })
+    expect(all[2].value()).toMatchObject({
+      status: 200,
+      sent: events[2],
+      body: `Ignored Event was originated from ortto.com (Ignored)`
+    })
+  })
+
+  it('should handle API-level errors properly', async () => {
+    const event: Payload = {
+      user_id: 'user_id',
+      event: 'Bad Event'
+    }
+
+    const fakeRequest = jest.fn().mockResolvedValue({
+      data: {
+        errors: [
+          {
+            index: 0,
+            status: 422,
+            message: 'Unprocessable Entity'
+          }
+        ]
+      }
+    })
+
+    const client = new OrttoClient(fakeRequest)
+    const response = await client.sendActivities(settings, [event], 'audience-id')
+
+    const all = response.getAllResponses()
+    expect(all.length).toBe(1)
+    expect(all[0].value()).toMatchObject({
+      status: 422,
+      errormessage: 'Unprocessable Entity',
+      sent: event
+    })
+  })
+
+  it('should inject audience object when audience_update_mode is set', async () => {
+    const event: Payload = {
+      user_id: 'user_id',
+      event: 'Event with audience',
+      audience_update_mode: 'add'
+    }
+
+    const fakeRequest = jest.fn().mockResolvedValue({ data: {} })
+    const client = new OrttoClient(fakeRequest)
+    await client.sendActivities(settings, [event], 'audience-123')
+
+    expect(fakeRequest).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        json: [
+          expect.objectContaining({
+            audience: {
+              mode: 'add',
+              id: 'audience-123'
+            }
+          })
+        ]
+      })
+    )
+  })
+
+  it('should process mix of successful, API error, invalid and ignored events', async () => {
+    const events: Payload[] = [
+      {
+        user_id: 'user_valid_1',
+        event: 'Valid Event 1'
+      },
+      {
+        user_id: 'user_invalid',
+        event: '' // Invalid event: missing name
+      },
+      {
+        user_id: 'user_ignored',
+        event: 'Event to Ignore',
+        namespace: 'ortto.com' // Should be ignored
+      },
+      {
+        user_id: 'user_error',
+        event: 'Event causing error'
+      },
+      {
+        user_id: 'user_valid_2',
+        event: 'Valid Event 2'
+      }
+    ]
+
+    const fakeRequest = jest.fn().mockResolvedValue({
+      data: {
+        errors: [
+          {
+            index: 1,
+            status: 422,
+            message: 'Failed to process event'
+          }
+        ]
+      }
+    })
+
+    const client = new OrttoClient(fakeRequest)
+    const response = await client.sendActivities(settings, events, 'audience-xyz')
+
+    const all = response.getAllResponses()
+    expect(all.length).toBe(5)
+
+    // Valid event should succeed
+    expect(all[0].value()).toMatchObject({
+      ...Success,
+      sent: events[0]
+    })
+
+    // Invalid event should fail
+    expect(all[1].value()).toMatchObject({
+      status: 400,
+      errormessage: Errors.MissingEventName,
+      sent: events[1]
+    })
+
+    // Ignored event due to namespace
+    expect(all[2].value()).toMatchObject({
+      status: 200,
+      body: expect.stringContaining('Ignored'),
+      sent: events[2]
+    })
+
+    // API error
+    expect(all[3].value()).toMatchObject({
+      status: 422,
+      errormessage: 'Failed to process event',
+      sent: events[3]
+    })
+
+    // Valid event should also succeed
+    expect(all[4].value()).toMatchObject({
+      ...Success,
+      sent: events[4]
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/ortto/trackActivity/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/ortto/trackActivity/__tests__/snapshot.test.ts
@@ -1,0 +1,76 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+import { TEST_API_KEY } from '../../types'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'trackActivity'
+const destinationSlug = 'Ortto'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: { api_key: TEST_API_KEY },
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: { api_key: TEST_API_KEY },
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/ortto/trackActivity/generated-types.ts
+++ b/packages/destination-actions/src/destinations/ortto/trackActivity/generated-types.ts
@@ -1,0 +1,100 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Event timestamp
+   */
+  timestamp?: string
+  /**
+   * Message ID
+   */
+  message_id?: string
+  /**
+   * The unique user identifier
+   */
+  user_id?: string
+  /**
+   * Anonymous user identifier
+   */
+  anonymous_id?: string
+  /**
+   * When enabled, events will be sent to Ortto in batches for improved efficiency.
+   */
+  enable_batching?: boolean
+  /**
+   * The IP address of the location where the activity occurred.
+   */
+  ip?: string | null
+  /**
+   * The location where the activity occurred. Takes priority over the IP address.
+   */
+  location?: {
+    country?: string | null
+    state?: string | null
+    city?: string | null
+    post_code?: string | null
+  }
+  /**
+   * key-value custom property pairs to be assigned to the Contact's profile
+   */
+  traits?: {
+    /**
+     * The Contact's email address
+     */
+    email?: string
+    /**
+     * The Contact's phone number (including the country code is strongly recommended)
+     */
+    phone?: string
+    /**
+     * The Contact's first name
+     */
+    first_name?: string
+    /**
+     * The Contact's last name
+     */
+    last_name?: string
+  }
+  /**
+   * Indicates whether the Contact should be added to or removed from the Audience.
+   */
+  audience_update_mode?: string
+  /**
+   * Maximum number of events to include in each batch.
+   */
+  batch_size?: number
+  /**
+   * Event name
+   */
+  event: string
+  /**
+   * Event namespace
+   */
+  namespace?: string
+  /**
+   * An object containing key-value pairs representing activity attributes
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface RetlOnMappingSaveInputs {
+  /**
+   * The name of the Ortto Audience to link the Contact to.
+   */
+  audience_name?: string
+}
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface RetlOnMappingSaveOutputs {
+  /**
+   * The ID of the Ortto Audience Contacts will be linked to.
+   */
+  audience_id?: string
+  /**
+   * The name of the Ortto Audience contacts will be linkted to.
+   */
+  audience_name?: string
+}

--- a/packages/destination-actions/src/destinations/ortto/trackActivity/index.ts
+++ b/packages/destination-actions/src/destinations/ortto/trackActivity/index.ts
@@ -1,0 +1,126 @@
+import type { ActionDefinition, APIError } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import OrttoClient from '../ortto-client'
+import { commonFields } from '../common-fields'
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Track Activity',
+  description: 'Track user activity',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    timestamp: commonFields.timestamp,
+    message_id: commonFields.message_id,
+    user_id: commonFields.user_id,
+    anonymous_id: commonFields.anonymous_id,
+    enable_batching: commonFields.enable_batching,
+    ip: {
+      ...commonFields.ipV4,
+      description: 'The IP address of the location where the activity occurred.'
+    },
+    location: {
+      ...commonFields.location,
+      description: 'The location where the activity occurred. Takes priority over the IP address.'
+    },
+    traits: {
+      ...commonFields.traits,
+      description:
+        "key-value custom property pairs to be assigned to the Contact's profile"
+    },
+    audience_update_mode: commonFields.audience_update_mode,
+    batch_size: commonFields.batch_size,
+    event: {
+      label: 'Event name',
+      description: 'Event name',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.event'
+      }
+    },
+    namespace: {
+      label: 'Namespace',
+      description: 'Event namespace',
+      type: 'string',
+      readOnly: true,
+      unsafe_hidden: true,
+      default: {
+        '@path': '$.context.app.namespace'
+      }
+    },
+    properties: {
+      label: 'Activity properties',
+      description: 'An object containing key-value pairs representing activity attributes',
+      type: 'object',
+      defaultObjectUI: 'keyvalue'
+    }
+  },
+  hooks: {
+    retlOnMappingSave: {
+      label: 'Associate Audience',
+      description:
+        'Link the Contact to an Audience in Ortto. If the Audience does not already exist, it will be created in Ortto.',
+      inputFields: {
+        audience_name: {
+          type: 'string',
+          label: 'Audience Name',
+          description: 'The name of the Ortto Audience to link the Contact to.'
+        }
+      },
+      outputTypes: {
+        audience_id: {
+          type: 'string',
+          label: 'ID',
+          description: 'The ID of the Ortto Audience Contacts will be linked to.',
+          required: false
+        },
+        audience_name: {
+          type: 'string',
+          label: 'Name',
+          description: 'The name of the Ortto Audience contacts will be linkted to.',
+          required: false
+        }
+      },
+      performHook: async (request, { settings, hookInputs }) => {
+        if (!hookInputs.audience_name) {
+          return {}
+        }
+        try {
+          const client: OrttoClient = new OrttoClient(request)
+          const audience = await client.createAudience(settings, hookInputs.audience_name as string)
+          return {
+            successMessage: `Connected to Audience '${audience.name}' (id: ${audience.id}) successfully.`,
+            savedData: {
+              audience_id: audience.id,
+              audience_name: audience.name
+            }
+          }
+        } catch (err) {
+          return {
+            error: {
+              message: (err as APIError).message ?? 'Unknown Error',
+              code: (err as APIError).status?.toString() ?? 'Unknown Error'
+            }
+          }
+        }
+      }
+    }
+  },
+  perform: async (request, { settings, payload, hookOutputs }) => {
+    const client: OrttoClient = new OrttoClient(request)
+    return await client.sendActivities(
+      settings,
+      [payload],
+      (hookOutputs?.retlOnMappingSave?.outputs?.audience_id as string) ?? ''
+    )
+  },
+  performBatch: async (request, { settings, payload, hookOutputs }) => {
+    const client: OrttoClient = new OrttoClient(request)
+    return await client.sendActivities(
+      settings,
+      payload,
+      (hookOutputs?.retlOnMappingSave?.outputs?.audience_id as string) ?? ''
+    )
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/ortto/types.ts
+++ b/packages/destination-actions/src/destinations/ortto/types.ts
@@ -1,0 +1,17 @@
+export const TEST_API_KEY = 'pau-key'
+export interface Audience {
+  id: string
+  name: string
+}
+export interface AudienceList {
+  audiences: Audience[]
+  next_page: string
+}
+
+export interface BatchResponse {
+  errors: {
+    status: number
+    message: string
+    index: number
+  }[]
+}

--- a/packages/destination-actions/src/destinations/ortto/upsertContactProfile/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/ortto/upsertContactProfile/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Ortto's upsertContactProfile destination action: all fields 1`] = `
+Array [
+  Object {
+    "anonymous_id": "2fUSE5G",
+    "audience_update_mode": "add",
+    "batch_size": -57176944814325.76,
+    "enable_batching": true,
+    "ip": "47.188.17.159",
+    "location": Object {
+      "city": "2fUSE5G",
+      "country": "2fUSE5G",
+      "post_code": "2fUSE5G",
+      "state": "2fUSE5G",
+    },
+    "message_id": "2fUSE5G",
+    "timestamp": "2099-03-03T14:35:24.780Z",
+    "traits": Object {
+      "email": "goc@udhuc.th",
+      "first_name": "2fUSE5G",
+      "last_name": "2fUSE5G",
+      "phone": "2fUSE5G",
+    },
+    "user_id": "2fUSE5G",
+  },
+]
+`;
+
+exports[`Testing snapshot for Ortto's upsertContactProfile destination action: required fields 1`] = `
+Array [
+  Object {
+    "anonymous_id": "2fUSE5G",
+    "message_id": "2fUSE5G",
+    "user_id": "2fUSE5G",
+  },
+]
+`;

--- a/packages/destination-actions/src/destinations/ortto/upsertContactProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/ortto/upsertContactProfile/__tests__/index.test.ts
@@ -1,0 +1,190 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration, SegmentEvent, InvalidAuthenticationError } from '@segment/actions-core'
+import Destination from '../../index'
+import { Errors, API_VERSION, Success } from '../../ortto-client'
+import OrttoClient from '../../ortto-client'
+import { Settings } from '../../generated-types'
+import { TEST_API_KEY } from '../../types'
+import { Payload } from '../generated-types'
+
+const testDestination = createTestIntegration(Destination)
+
+const settings: Settings = {
+  api_key: TEST_API_KEY
+}
+
+const validPayload = {
+  timestamp: '2024-01-08T13:52:50.212Z',
+  type: 'identify',
+  userId: 'user_id',
+  anonymousId: 'anonymous_id',
+  messageId: 'message_id',
+  traits: {
+    first_name: 'John',
+    last_name: 'Smith'
+  }
+} as Partial<SegmentEvent>
+
+describe('Ortto.upsertContactProfile', () => {
+  it('should upsert profile with default mappings', async () => {
+    nock('https://segment-action-api-au.ortto.app')
+      .post(`/${API_VERSION}/identify`)
+      .matchHeader('authorization', `Bearer ${settings.api_key}`)
+      .reply(200, {})
+
+    const responses = await testDestination.testAction('upsertContactProfile', {
+      settings: settings,
+      event: createTestEvent(validPayload),
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.method).toBe('POST')
+  })
+
+  it('should inject audience object when audience_update_mode is set', async () => {
+    const event: Payload = {
+      user_id: 'user_id',
+      audience_update_mode: 'add'
+    }
+
+    const fakeRequest = jest.fn().mockResolvedValue({ data: {} })
+    const client = new OrttoClient(fakeRequest)
+    await client.upsertContacts(settings, [event], 'audience-123')
+
+    expect(fakeRequest).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        json: [
+          expect.objectContaining({
+            audience: {
+              mode: 'add',
+              id: 'audience-123'
+            }
+          })
+        ]
+      })
+    )
+  })
+
+  it('should process a single valid event successfully', async () => {
+    const event: Payload = {
+      user_id: 'user_id',
+      anonymous_id: 'anon_id',
+      message_id: 'msg_id'
+    }
+
+    const fakeRequest = jest.fn().mockResolvedValue({
+      data: {} // no errors in response
+    })
+
+    const client = new OrttoClient(fakeRequest)
+    const response = await client.upsertContacts(settings, [event], 'audience-id')
+
+    const all = response.getAllResponses()
+    expect(all.length).toBe(1)
+    expect(all[0].value()).toMatchObject({
+      ...Success,
+      sent: event
+    })
+    expect(fakeRequest).toHaveBeenCalledTimes(1)
+    expect(fakeRequest).toHaveBeenCalledWith(expect.stringContaining('/identify'), {
+      method: 'POST',
+      json: expect.any(Array)
+    })
+  })
+
+  it('should process mix of successful, API error, invalid and ignored events', async () => {
+    const events: Payload[] = [
+      {
+        user_id: 'user_valid_1'
+      },
+      {
+        user_id: 'user_error_1'
+      },
+      {
+        user_id: 'user_valid_2'
+      },
+      {
+        user_id: 'user_error_3'
+      },
+      {
+        user_id: 'user_error_4'
+      },
+      {
+        user_id: 'user_valid_2'
+      }
+    ]
+
+    const fakeRequest = jest.fn().mockResolvedValue({
+      data: {
+        errors: [
+          {
+            index: 1,
+            status: 422,
+            message: 'Failed to process event#1'
+          },
+          {
+            index: 3,
+            status: 423,
+            message: 'Failed to process event#3'
+          },
+          {
+            index: 4,
+            status: 424,
+            message: 'Failed to process event#4'
+          }
+        ]
+      }
+    })
+
+    const client = new OrttoClient(fakeRequest)
+    const response = await client.upsertContacts(settings, events, 'audience-xyz')
+
+    const all = response.getAllResponses()
+
+    expect(all.length).toBe(6)
+
+    expect(all[0].value()).toMatchObject({
+      ...Success,
+      sent: events[0]
+    })
+    expect(all[1].value()).toMatchObject({
+      status: 422,
+      errormessage: 'Failed to process event#1',
+      sent: events[1]
+    })
+    expect(all[2].value()).toMatchObject({
+      ...Success,
+      sent: events[2]
+    })
+    expect(all[3].value()).toMatchObject({
+      status: 423,
+      errormessage: 'Failed to process event#3',
+      sent: events[3]
+    })
+    expect(all[4].value()).toMatchObject({
+      status: 424,
+      errormessage: 'Failed to process event#4',
+      sent: events[4]
+    })
+    expect(all[5].value()).toMatchObject({
+      ...Success,
+      sent: events[5]
+    })
+  })
+
+  it('should validate API key', async () => {
+    const event = createTestEvent(validPayload)
+    await expect(
+      testDestination.testAction('upsertContactProfile', {
+        settings: {
+          api_key: 'invalid api key'
+        },
+        event: event,
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError(new InvalidAuthenticationError(Errors.InvalidAPIKey))
+  })
+})

--- a/packages/destination-actions/src/destinations/ortto/upsertContactProfile/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/ortto/upsertContactProfile/__tests__/snapshot.test.ts
@@ -1,0 +1,76 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+import { TEST_API_KEY } from '../../types'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'upsertContactProfile'
+const destinationSlug = 'Ortto'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: { api_key: TEST_API_KEY },
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: { api_key: TEST_API_KEY },
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/ortto/upsertContactProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/ortto/upsertContactProfile/generated-types.ts
@@ -1,0 +1,86 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Event timestamp
+   */
+  timestamp?: string
+  /**
+   * Message ID
+   */
+  message_id?: string
+  /**
+   * The unique user identifier
+   */
+  user_id?: string
+  /**
+   * Anonymous user identifier
+   */
+  anonymous_id?: string
+  /**
+   * When enabled, events will be sent to Ortto in batches for improved efficiency.
+   */
+  enable_batching?: boolean
+  /**
+   * The Contact's IP address
+   */
+  ip?: string | null
+  /**
+   * The Contact's location. Takes priority over the IP address.
+   */
+  location?: {
+    country?: string | null
+    state?: string | null
+    city?: string | null
+    post_code?: string | null
+  }
+  /**
+   * An object containing key-value pairs representing custom properties assigned to Contact profile
+   */
+  traits?: {
+    /**
+     * The Contact's email address
+     */
+    email?: string
+    /**
+     * The Contact's phone number (including the country code is strongly recommended)
+     */
+    phone?: string
+    /**
+     * The Contact's first name
+     */
+    first_name?: string
+    /**
+     * The Contact's last name
+     */
+    last_name?: string
+  }
+  /**
+   * Indicates whether the Contact should be added to or removed from the Audience.
+   */
+  audience_update_mode?: string
+  /**
+   * Maximum number of events to include in each batch.
+   */
+  batch_size?: number
+}
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface RetlOnMappingSaveInputs {
+  /**
+   * The name of the Ortto Audience to link the Contact to.
+   */
+  audience_name?: string
+}
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface RetlOnMappingSaveOutputs {
+  /**
+   * The ID of the Ortto Audience Contacts will be linked to.
+   */
+  audience_id?: string
+  /**
+   * The name of the Ortto Audience contacts will be linkted to.
+   */
+  audience_name?: string
+}

--- a/packages/destination-actions/src/destinations/ortto/upsertContactProfile/index.ts
+++ b/packages/destination-actions/src/destinations/ortto/upsertContactProfile/index.ts
@@ -1,0 +1,92 @@
+import type { ActionDefinition, APIError } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import OrttoClient from '../ortto-client'
+import { commonFields } from '../common-fields'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Upsert Contact',
+  description: 'Create or update a Contact in Ortto',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    timestamp: commonFields.timestamp,
+    message_id: commonFields.message_id,
+    user_id: commonFields.user_id,
+    anonymous_id: commonFields.anonymous_id,
+    enable_batching: commonFields.enable_batching,
+    ip: commonFields.ipV4,
+    location: commonFields.location,
+    traits: commonFields.traits,
+    audience_update_mode: commonFields.audience_update_mode,
+    batch_size: commonFields.batch_size
+  },
+  hooks: {
+    retlOnMappingSave: {
+      label: 'Associate Audience',
+      description:
+        'Link the Contact to an Audience in Ortto. If the Audience does not already exist, it will be created in Ortto.',
+      inputFields: {
+        audience_name: {
+          type: 'string',
+          label: 'Audience Name',
+          description: 'The name of the Ortto Audience to link the Contact to.'
+        }
+      },
+      outputTypes: {
+        audience_id: {
+          type: 'string',
+          label: 'ID',
+          description: 'The ID of the Ortto Audience Contacts will be linked to.',
+          required: false
+        },
+        audience_name: {
+          type: 'string',
+          label: 'Name',
+          description: 'The name of the Ortto Audience contacts will be linkted to.',
+          required: false
+        }
+      },
+      performHook: async (request, { settings, hookInputs }) => {
+        if (!hookInputs.audience_name) {
+          return {}
+        }
+        try {
+          const client: OrttoClient = new OrttoClient(request)
+          const audience = await client.createAudience(settings, hookInputs.audience_name as string)
+          return {
+            successMessage: `Connected to Audience '${audience.name}' (id: ${audience.id}) successfully.`,
+            savedData: {
+              audience_id: audience.id,
+              audience_name: audience.name
+            }
+          }
+        } catch (err) {
+          return {
+            error: {
+              message: (err as APIError).message ?? 'Unknown Error',
+              code: (err as APIError).status?.toString() ?? 'Unknown Error'
+            }
+          }
+        }
+      }
+    }
+  },
+  perform: async (request, { settings, payload, hookOutputs }) => {
+    const client: OrttoClient = new OrttoClient(request)
+    return await client.upsertContacts(
+      settings,
+      [payload],
+      (hookOutputs?.retlOnMappingSave?.outputs?.audience_id as string) ?? ''
+    )
+  },
+  performBatch: async (request, { settings, payload, hookOutputs }) => {
+    const client: OrttoClient = new OrttoClient(request)
+    return await client.upsertContacts(
+      settings,
+      payload,
+      (hookOutputs?.retlOnMappingSave?.outputs?.audience_id as string) ?? ''
+    )
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/ortto/utils.ts
+++ b/packages/destination-actions/src/destinations/ortto/utils.ts
@@ -1,0 +1,7 @@
+export function cleanObject<T extends {}>(obj: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj)
+      .filter(([key, _]) => key !== '')
+      .map(([key, value]) => [key, value instanceof Object && !(value instanceof Array) ? cleanObject(value) : value])
+  ) as Partial<T>
+}


### PR DESCRIPTION
New Cloud Mode Destination Ortto

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
