### PR TITLE
[CM-360] - fixing timestamp

### DIFF
--- a/packages/destination-actions/src/destinations/google-campaign-manager-360/conversionAdjustmentUpload/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/google-campaign-manager-360/conversionAdjustmentUpload/__tests__/index.test.ts
@@ -363,7 +363,7 @@ describe('CampaignManager360.conversionAdjustmentUpload', () => {
         })
 
         expect(responses[0].options.body).toBe(
-          `{"conversions":[{"childDirectedTreatment":true,"floodlightActivityId":"23456","floodlightConfigurationId":"34567","gclid":"54321","kind":"dfareporting#conversion","limitAdTracking":true,"nonPersonalizedAd":true,"ordinal":"1","quantity":"2","timestampMicros":"1718042884000","treatmentForUnderage":true,"userIdentifiers":[{"hashedEmail":"8e46bd4eaabb5d6324e327751b599f190dbaacd90066e66c94a046640bed60d0"}],"value":100,"customVariables":[],"encryptedUserIdCandidates":[]}],"kind":"dfareporting#conversionsBatchInsertRequest"}`
+          `{"conversions":[{"childDirectedTreatment":true,"floodlightActivityId":"23456","floodlightConfigurationId":"34567","gclid":"54321","kind":"dfareporting#conversion","limitAdTracking":true,"nonPersonalizedAd":true,"ordinal":"1","quantity":"2","timestampMicros":"1718042884000000","treatmentForUnderage":true,"userIdentifiers":[{"hashedEmail":"8e46bd4eaabb5d6324e327751b599f190dbaacd90066e66c94a046640bed60d0"}],"value":100,"customVariables":[],"encryptedUserIdCandidates":[]}],"kind":"dfareporting#conversionsBatchInsertRequest"}`
         )
         expect(responses.length).toBe(1)
         expect(responses[0].status).toBe(200)

--- a/packages/destination-actions/src/destinations/google-campaign-manager-360/conversionUpload/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/google-campaign-manager-360/conversionUpload/__tests__/index.test.ts
@@ -360,7 +360,7 @@ describe('Cm360.conversionUpload', () => {
         })
 
         expect(responses[0].options.body).toBe(
-          `{"conversions":[{"childDirectedTreatment":true,"floodlightActivityId":"23456","floodlightConfigurationId":"34567","gclid":"54321","kind":"dfareporting#conversion","limitAdTracking":true,"nonPersonalizedAd":true,"ordinal":"1","quantity":"1","timestampMicros":"1718042884000","treatmentForUnderage":true,"userIdentifiers":[{"hashedEmail":"8e46bd4eaabb5d6324e327751b599f190dbaacd90066e66c94a046640bed60d0"}],"value":123,"customVariables":[],"encryptedUserIdCandidates":[]}],"kind":"dfareporting#conversionsBatchInsertRequest"}`
+          `{"conversions":[{"childDirectedTreatment":true,"floodlightActivityId":"23456","floodlightConfigurationId":"34567","gclid":"54321","kind":"dfareporting#conversion","limitAdTracking":true,"nonPersonalizedAd":true,"ordinal":"1","quantity":"1","timestampMicros":"1718042884000000","treatmentForUnderage":true,"userIdentifiers":[{"hashedEmail":"8e46bd4eaabb5d6324e327751b599f190dbaacd90066e66c94a046640bed60d0"}],"value":123,"customVariables":[],"encryptedUserIdCandidates":[]}],"kind":"dfareporting#conversionsBatchInsertRequest"}`
         )
         expect(responses.length).toBe(1)
         expect(responses[0].status).toBe(201)

--- a/packages/destination-actions/src/destinations/google-campaign-manager-360/utils.ts
+++ b/packages/destination-actions/src/destinations/google-campaign-manager-360/utils.ts
@@ -145,7 +145,7 @@ export function getJSON(payloads: UploadPayload[] | Adjustayload[], settings: Se
       ordinal,
       quantity,
       timestampMicros: (() => {
-        return String(BigInt(new Date(timestamp).getTime()))
+        return String(BigInt(new Date(timestamp).getTime()) * 1000n)
       })(),
       treatmentForUnderage: treatmentForUnderage ?? undefined,
       userIdentifiers: (() => {


### PR DESCRIPTION
Fixing timestamp issue
Was not converting to microseconds. 

Details provided by Anirudh Paul:
- **What is the issue?** The CM360 API requires timestamps to be provided in microseconds using the timestampMicros
- **What problem did the issue cause?** Providing timestamps without microseconds leads to errors when consuming the CM360 APIs for conversions.
- **How to replicate the issue:** This issue can be observed when testing the CM360 destination locally by submitting conversion data with timestamps lacking microsecond precision.
Request Payload :
```
{
  "requiredId": {
    "matchId": "04db489e-bec4-48c8-b608-bdc9d60da597"
  },
  "floodlightConfigurationId": "4270108",
  "floodlightActivityId": "7169983",
  "userDetails": {},
  "timestamp": "2025-05-14T00:47:39.535Z",
  "value": "2",
  "quantity": "1",
  "ordinal": "123456778",
  "limitAdTracking": false,
  "childDirectedTreatment": false,
  "nonPersonalizedAd": true,
  "treatmentForUnderage": false
}
```
Destination response (tested destination locally to get the error details) where Timestamp is not in micro Sec:
```
"errors": [
            {
              "code": "INVALID_ARGUMENT",
              "message": "The timestamp is too old.; Invalid field: timestampMicros",
              "kind": "dfareporting#conversionError"
            }
          ],
          "kind": "dfareporting#conversionStatus"
        }
```

Success when Timestamp is in Microsec :
```
"hasFailures": false,
      "status": [
        {
          "conversion": {
            "floodlightConfigurationId": "4270108",
            "floodlightActivityId": "7169983",
            "timestampMicros": "1747183659535000",
            "value": 2,
            "quantity": "1",
            "ordinal": "123456778",
            "limitAdTracking": false,
            "childDirectedTreatment": false,
            "nonPersonalizedAd": true,
            "treatmentForUnderage": false,
            "matchId": "04db489e-bec4-48c8-b608-bdc9d60da597",
            "kind": "dfareporting#conversion"
          },
          "kind": "dfareporting#conversionStatus"
        }
```

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
