### PR TITLE
[Hubspot] Add de-duplication logic in Hubspot

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/upsertObject/__tests__/validate.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertObject/__tests__/validate.test.ts
@@ -1,4 +1,4 @@
-import { validate } from '../functions/validation-functions'
+import { mergeAndDeduplicateById, validate } from '../functions/validation-functions'
 import { Payload } from '../generated-types'
 
 const payload: Payload = {
@@ -91,5 +91,113 @@ describe('Hubspot.upsertObject', () => {
   it('validate function should ensure no leading or trailing spaces in properties sent to Hubspot', async () => {
     const validatedPayload = validate([payload])
     expect(validatedPayload).toEqual(expectedValidatedPayload)
+  })
+})
+
+describe('mergeAndDeduplicateById', () => {
+  const basePayload = (overrides: Partial<Payload> = {}) => ({
+    object_details: {
+      id_field_name: 'email',
+      id_field_value: 'user@example.com',
+      object_type: 'contact',
+      ...((overrides.object_details as object) || {})
+    },
+    association_sync_mode: 'upsert',
+    enable_batching: true,
+    batch_size: 100,
+    properties: { foo: 'bar' },
+    sensitive_properties: { secret: '123' },
+    timestamp: '2024-01-01T00:00:00.000Z',
+    ...overrides
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(mergeAndDeduplicateById([])).toEqual([])
+  })
+
+  it('deduplicates payloads by id_field_value', () => {
+    const payloads: Payload[] = [
+      basePayload({ properties: { a: 1 }, timestamp: '2024-01-01T00:00:00.000Z' }),
+      basePayload({ properties: { b: 2 }, timestamp: '2024-01-02T00:00:00.000Z' })
+    ]
+    const result = mergeAndDeduplicateById(payloads)
+    expect(result).toHaveLength(1)
+    expect(result[0].properties).toEqual({ a: 1, b: 2 })
+    expect(result[0]).not.toHaveProperty('timestamp')
+  })
+
+  it('merges properties preferring latest timestamp', () => {
+    const payloads: Payload[] = [
+      basePayload({ properties: { foo: 'old', bar: 'keep' }, timestamp: '2024-01-01T00:00:00.000Z' }),
+      basePayload({ properties: { foo: 'new' }, timestamp: '2024-01-03T00:00:00.000Z' })
+    ]
+    const result = mergeAndDeduplicateById(payloads)
+    expect(result[0].properties).toEqual({ foo: 'new', bar: 'keep' })
+  })
+
+  it('merges sensitive_properties preferring latest timestamp', () => {
+    const payloads: Payload[] = [
+      basePayload({ sensitive_properties: { secret: 'old', keep: 'yes' }, timestamp: '2024-01-01T00:00:00.000Z' }),
+      basePayload({ sensitive_properties: { secret: 'new' }, timestamp: '2024-01-03T00:00:00.000Z' })
+    ]
+    const result = mergeAndDeduplicateById(payloads)
+    expect(result[0].sensitive_properties).toEqual({ secret: 'new', keep: 'yes' })
+  })
+
+  it('merges associations', () => {
+    const assoc1 = {
+      id_field_name: 'email',
+      id_field_value: 'user@example.com',
+      object_type: 'contact' as string,
+      association_label: 'primary'
+    }
+    const assoc2 = {
+      id_field_name: 'email',
+      id_field_value: 'user@example.com',
+      object_type: 'contact' as string,
+      association_label: 'secondary'
+    }
+    const payloads: Payload[] = [
+      basePayload({ associations: [assoc1], timestamp: '2024-01-01T00:00:00.000Z' }),
+      basePayload({ associations: [assoc2], timestamp: '2024-01-02T00:00:00.000Z' })
+    ]
+    const result = mergeAndDeduplicateById(payloads)
+    expect(result[0].associations).toHaveLength(2)
+    expect(result[0].associations).toEqual(expect.arrayContaining([assoc1, assoc2]))
+  })
+
+  it('handles multiple ids and returns merged payloads for each', () => {
+    const payloads: Payload[] = [
+      basePayload({
+        object_details: { id_field_name: 'email', id_field_value: 'a@example.com', object_type: 'contact' },
+        properties: { foo: 1 }
+      }),
+      basePayload({
+        object_details: { id_field_name: 'email', id_field_value: 'b@example.com', object_type: 'contact' },
+        properties: { bar: 2 }
+      })
+    ]
+    const result = mergeAndDeduplicateById(payloads)
+    expect(result).toHaveLength(2)
+    expect(result.map((r) => r.object_details.id_field_value).sort()).toEqual(['a@example.com', 'b@example.com'])
+  })
+
+  it('skips payloads without id_field_value', () => {
+    const payloads: Payload[] = [
+      basePayload({ object_details: { id_field_name: 'email', id_field_value: '', object_type: 'contact' } }),
+      basePayload({ object_details: { id_field_name: 'email', id_field_value: null as any, object_type: 'contact' } }),
+      basePayload({
+        object_details: { id_field_name: 'email', id_field_value: 'valid@example.com', object_type: 'contact' }
+      })
+    ]
+    const result = mergeAndDeduplicateById(payloads)
+    expect(result).toHaveLength(1)
+    expect(result[0].object_details.id_field_value).toBe('valid@example.com')
+  })
+
+  it('removes timestamp from final output', () => {
+    const payloads: Payload[] = [basePayload({ timestamp: '2024-01-01T00:00:00.000Z' })]
+    const result = mergeAndDeduplicateById(payloads)
+    expect(result[0]).not.toHaveProperty('timestamp')
   })
 })

--- a/packages/destination-actions/src/destinations/hubspot/upsertObject/common-fields.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertObject/common-fields.ts
@@ -137,5 +137,15 @@ export const commonFields: Record<string, InputField> = {
     required: true,
     unsafe_hidden: true,
     default: MAX_HUBSPOT_BATCH_SIZE
+  },
+  timestamp: {
+    label: 'Timestamp',
+    description:
+      'The time the event occurred. This will be used to de-duplicate the events before sending them to hubspot.',
+    type: 'string',
+    required: false,
+    default: { '@path': '$.timestamp' },
+    dynamic: true,
+    disabledInputMethods: ['literal', 'variable', 'function', 'freeform', 'enrichment']
   }
 }

--- a/packages/destination-actions/src/destinations/hubspot/upsertObject/common-fields.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertObject/common-fields.ts
@@ -145,7 +145,6 @@ export const commonFields: Record<string, InputField> = {
     type: 'string',
     required: false,
     default: { '@path': '$.timestamp' },
-    dynamic: true,
     disabledInputMethods: ['literal', 'variable', 'function', 'freeform', 'enrichment']
   }
 }

--- a/packages/destination-actions/src/destinations/hubspot/upsertObject/constants.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertObject/constants.ts
@@ -18,3 +18,5 @@ export const SUPPORTED_HUBSPOT_OBJECT_TYPES = [
 ]
 
 export const MAX_HUBSPOT_BATCH_SIZE = 100
+
+export const HUBSPOT_DEDUPLICATION_FLAGON = 'hubspot-object-deduplication'

--- a/packages/destination-actions/src/destinations/hubspot/upsertObject/functions/validation-functions.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertObject/functions/validation-functions.ts
@@ -179,7 +179,7 @@ export function ensureValidTimestamps(payloads: Payload[], rawData?: Payload[]):
   payloads.forEach((item, index) => {
     if (!isValidTimestamp(item.timestamp)) {
       item.timestamp =
-        rawData && rawData[index] && isValidTimestamp(rawData[index]?.timestamp)
+        rawData && Array.isArray(rawData) && rawData[index] && isValidTimestamp(rawData[index]?.timestamp)
           ? item.timestamp
           : new Date().toISOString()
     }

--- a/packages/destination-actions/src/destinations/hubspot/upsertObject/functions/validation-functions.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertObject/functions/validation-functions.ts
@@ -180,7 +180,7 @@ export function ensureValidTimestamps(payloads: Payload[], rawData?: Payload[]):
     if (!isValidTimestamp(item.timestamp)) {
       item.timestamp =
         rawData && Array.isArray(rawData) && rawData[index] && isValidTimestamp(rawData[index]?.timestamp)
-          ? item.timestamp
+          ? rawData[index]?.timestamp
           : new Date().toISOString()
     }
   })

--- a/packages/destination-actions/src/destinations/hubspot/upsertObject/generated-types.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertObject/generated-types.ts
@@ -67,4 +67,8 @@ export interface Payload {
    * Maximum number of events to include in each batch.
    */
   batch_size: number
+  /**
+   * The time the event occurred. This will be used to de-duplicate the events before sending them to hubspot.
+   */
+  timestamp?: string
 }

--- a/packages/destination-actions/src/destinations/hubspot/upsertObject/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertObject/index.ts
@@ -41,7 +41,6 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   performBatch: async (request, { payload, syncMode, subscriptionMetadata, statsContext }) => {
     statsContext?.tags?.push('action:custom_object_batch')
-    syncMode = 'upsert'
     return await send(request, payload, syncMode as SyncMode, subscriptionMetadata, statsContext)
   }
 }

--- a/packages/destination-actions/src/destinations/hubspot/upsertObject/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertObject/index.ts
@@ -44,7 +44,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const requestData = data as RequestData<Settings, Payload[]>
     const { payload, syncMode, subscriptionMetadata, statsContext, features, rawData } = requestData
     statsContext?.tags?.push('action:custom_object_batch')
-    return await send(request, payload, syncMode, subscriptionMetadata, statsContext, features, rawData?.timestamp)
+    return await send(request, payload, syncMode, subscriptionMetadata, statsContext, features, rawData)
   }
 }
 
@@ -55,11 +55,11 @@ const send = async (
   subscriptionMetadata?: SubscriptionMetadata,
   statsContext?: StatsContext,
   features?: Features,
-  fallbackTimestamp?: string
+  rawData?: Payload[]
 ) => {
   if (features && features[HUBSPOT_DEDUPLICATION_FLAGON] && (syncMode === 'upsert' || syncMode === 'update')) {
-    payloads = ensureValidTimestamps(payloads, fallbackTimestamp)
-    payloads = mergeAndDeduplicateById(payloads)
+    payloads = ensureValidTimestamps(payloads, rawData)
+    payloads = mergeAndDeduplicateById(payloads, statsContext)
   }
 
   const {

--- a/packages/destination-actions/src/destinations/hubspot/upsertObject/types.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertObject/types.ts
@@ -1,4 +1,6 @@
+import { Features, StatsContext } from '@segment/actions-core/*'
 import { Payload } from './generated-types'
+import { SubscriptionMetadata } from '@segment/actions-core/destination-kit'
 
 export const SyncMode = {
   Upsert: 'upsert',
@@ -207,4 +209,24 @@ export interface CreatePropsReqItem {
   dataSensitivity: 'sensitive' | undefined
   fieldType: string
   options?: Array<{ label: string; value: string; hidden: boolean; description: string; displayOrder: number }>
+}
+
+export interface RequestData<Settings, Payload> {
+  rawData: {
+    timestamp: string
+  }
+  payload: Payload
+  syncMode: SyncMode
+  subscriptionMetadata: SubscriptionMetadata
+  statsContext?: StatsContext
+  features?: Features
+  settings: Settings
+}
+
+export interface Association {
+  object_type?: string
+  association_label?: string
+  id_field_name?: string
+  id_field_value?: string
+  from_record_id?: string
 }

--- a/packages/destination-actions/src/destinations/hubspot/upsertObject/types.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertObject/types.ts
@@ -212,9 +212,7 @@ export interface CreatePropsReqItem {
 }
 
 export interface RequestData<Settings, Payload> {
-  rawData: {
-    timestamp: string
-  }
+  rawData: Payload
   payload: Payload
   syncMode: SyncMode
   subscriptionMetadata: SubscriptionMetadata


### PR DESCRIPTION
This PR adds a function to de-duplicate properties in hubspot's custom object v2 action.
Hubspot does not allow properties with same ID.

JIRA -> https://twilio-engineering.atlassian.net/browse/STRATCONN-5746?atlOrigin=eyJpIjoiMzU3ZWIxYzkzODU2NDIyMjg0MWFkYzM4OTc2MjEwZjkiLCJwIjoiaiJ9

## Testing
https://docs.google.com/document/d/17cett1m8KfzEvLxxBfzbhiFBgeRwDhzMZYnTzuRZG30/edit?tab=t.mb5dleeya8xs

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
