### PR TITLE
[Facebook Custom Audiences] - fixing fb breaking test

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/index.test.ts
@@ -259,7 +259,7 @@ describe('FacebookCustomAudiences.sync', () => {
               [
                 event.properties?.id, // external_id
                 '816341caf0c06dbc4c156d3465323f52b3cb62533241d5f9247c008f657e8343', // email
-                processHashingV2(
+                processHashing(
                   (event.properties?.phone as string) || '',
                   'sha256',
                   'hex',
@@ -272,26 +272,26 @@ describe('FacebookCustomAudiences.sync', () => {
                 EMPTY, // last_name
                 EMPTY, // first_name
                 EMPTY, // first_initial
-                processHashingV2(
+                processHashing(
                   (event.properties?.city as string) || '',
                   'sha256',
                   'hex',
                   normalizationFunctions.get('city')
                 ),
-                processHashingV2(
+                processHashing(
                   (event.properties?.state as string) || '',
                   'sha256',
                   'hex',
                   normalizationFunctions.get('state')
                 ),
-                processHashingV2(
+                processHashing(
                   (event.properties?.zip_code as string) || '',
                   'sha256',
                   'hex',
                   normalizationFunctions.get('zip')
                 ),
                 '2024', // mobile_advertiser_id,
-                processHashingV2('US', 'sha256', 'hex', normalizationFunctions.get('country')) // country
+                processHashing('US', 'sha256', 'hex', normalizationFunctions.get('country')) // country
               ]
             ],
             app_ids: ['2024']


### PR DESCRIPTION
Fixing test which is breaking build

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
