### PR TITLE
Add batch_size to identify fields in Drip (Actions)

### DIFF
--- a/packages/destination-actions/src/destinations/drip/identify/generated-types.ts
+++ b/packages/destination-actions/src/destinations/drip/identify/generated-types.ts
@@ -39,4 +39,8 @@ export interface Payload {
    * The person's timezone.
    */
   timezone?: string
+  /**
+   * Maximum number of events to include in each batch. Actual batch sizes may be lower.
+   */
+  batch_size?: number
 }

--- a/packages/destination-actions/src/destinations/drip/identify/index.ts
+++ b/packages/destination-actions/src/destinations/drip/identify/index.ts
@@ -118,7 +118,7 @@ const action: ActionDefinition<Settings, Payload> = {
       json: { subscribers: [person(payload)] }
     })
   },
-  performBatch: async (request, { settings, payload }) => {
+  performBatch: (request, { settings, payload }) => {
     const subscribers = payload.map(person)
 
     return request(`https://api.getdrip.com/v2/${settings.accountId}/subscribers/batches`, {

--- a/packages/destination-actions/src/destinations/drip/identify/index.ts
+++ b/packages/destination-actions/src/destinations/drip/identify/index.ts
@@ -107,7 +107,13 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'integer',
       required: false,
       unsafe_hidden: true,
-      default: 1000,
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.batch_size' },
+          then: { '@path': '$.traits.batch_size' },
+          else: 1000
+        }
+      },
       minimum: 1,
       maximum: 1000
     }

--- a/packages/destination-actions/src/destinations/drip/identify/index.ts
+++ b/packages/destination-actions/src/destinations/drip/identify/index.ts
@@ -98,6 +98,16 @@ const action: ActionDefinition<Settings, Payload> = {
       required: false,
       type: 'string',
       default: { '@path': '$.context.timezone' }
+    },
+    batch_size: {
+      label: 'Batch Size',
+      description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
+      type: 'integer',
+      required: false,
+      unsafe_hidden: true,
+      default: 100,
+      minimum: 1,
+      maximum: 1000
     }
   },
   perform: (request, { settings, payload }) => {

--- a/packages/destination-actions/src/destinations/drip/identify/index.ts
+++ b/packages/destination-actions/src/destinations/drip/identify/index.ts
@@ -1,8 +1,6 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { MultiStatusResponse } from '@segment/actions-core'
-import type { JSONLikeObject } from '@segment/actions-core'
 
 const person = (payload: Payload) => {
   return {
@@ -121,24 +119,12 @@ const action: ActionDefinition<Settings, Payload> = {
     })
   },
   performBatch: async (request, { settings, payload }) => {
-    const batchSize = payload[0]?.batch_size ?? 1000
-    const multiStatusResponse = new MultiStatusResponse()
-    for (let i = 0; i < payload.length; i += batchSize) {
-      const chunk = payload.slice(i, i + batchSize)
-      const subs = chunk.map(person)
-      const response = await request(`https://api.getdrip.com/v2/${settings.accountId}/subscribers/batches`, {
-        method: 'POST',
-        json: { batches: [{ subscribers: subs }] }
-      })
-      chunk.forEach((_, index) => {
-        multiStatusResponse.pushSuccessResponse({
-          status: response.status,
-          sent: subs[index],
-          body: response.data as JSONLikeObject
-        })
-      })
-    }
-    return multiStatusResponse
+    const subscribers = payload.map(person)
+
+    return request(`https://api.getdrip.com/v2/${settings.accountId}/subscribers/batches`, {
+      method: 'POST',
+      json: { batches: [{ subscribers }] }
+    })
   }
 }
 

--- a/packages/destination-actions/src/destinations/drip/identify/index.ts
+++ b/packages/destination-actions/src/destinations/drip/identify/index.ts
@@ -103,17 +103,13 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     batch_size: {
       label: 'Batch Size',
-      description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
+      disabledInputMethods: ['variable', 'function', 'enrichment'],
+      description:
+        'Maximum number of events to include in each batch. Actual batch sizes may be lower. Max size must be between 1 and 1000 inclusive.',
       type: 'integer',
       required: false,
       unsafe_hidden: true,
-      default: {
-        '@if': {
-          exists: { '@path': '$.traits.batch_size' },
-          then: { '@path': '$.traits.batch_size' },
-          else: 1000
-        }
-      },
+      default: 1000,
       minimum: 1,
       maximum: 1000
     }


### PR DESCRIPTION
Adding `batch_size` to the `identify` fields

## Testing

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
