### PR TITLE
[MAIN][STRATCONN] Added prefix [Segment] in event_type of amplitude

### DIFF
--- a/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude/__tests__/amplitude.test.ts
@@ -21,7 +21,7 @@ describe('Amplitude', () => {
         api_key: undefined,
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Test Event',
+            event_type: '[Segment] Test Event',
             city: 'San Francisco',
             country: 'United States'
           })
@@ -148,7 +148,7 @@ describe('Amplitude', () => {
         api_key: undefined,
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Null User',
+            event_type: '[Segment] Null User',
             user_id: null
           })
         ])
@@ -180,13 +180,13 @@ describe('Amplitude', () => {
         api_key: undefined,
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Order Completed',
+            event_type: '[Segment] Order Completed',
             revenue: 1_999,
             event_properties: event.properties,
             library: 'segment'
           }),
           expect.objectContaining({
-            event_type: 'Product Purchased',
+            event_type: '[Segment] Product Purchased',
             // @ts-ignore i know what i'm doing
             event_properties: event.properties.products[0],
             library: 'segment'
@@ -221,7 +221,7 @@ describe('Amplitude', () => {
         api_key: undefined,
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Order Completed',
+            event_type: '[Segment] Order Completed',
             event_properties: event.properties,
             revenue: 9_999
           })
@@ -258,11 +258,11 @@ describe('Amplitude', () => {
         api_key: undefined,
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Order Completed',
+            event_type: '[Segment] Order Completed',
             event_properties: event.properties
           }),
           expect.objectContaining({
-            event_type: 'Product Purchased',
+            event_type: '[Segment] Product Purchased',
             revenue: 500,
             // @ts-ignore i know what i'm doing
             event_properties: event.properties.products[0]
@@ -291,7 +291,7 @@ describe('Amplitude', () => {
       expect(responses[0].options.json).toMatchObject({
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Test Event',
+            event_type: '[Segment] Test Event',
             event_properties: {},
             user_properties: {
               'some-trait-key': 'some-trait-value'
@@ -331,7 +331,7 @@ describe('Amplitude', () => {
         api_key: undefined,
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Test Event',
+            event_type: '[Segment] Test Event',
             user_properties: expect.objectContaining({
               'some-trait-key': 'some-trait-value',
               $set: {
@@ -384,7 +384,7 @@ describe('Amplitude', () => {
               "device_model": "Mac OS",
               "device_type": undefined,
               "event_properties": Object {},
-              "event_type": "Test Event",
+              "event_type": "[Segment] Test Event",
               "library": "segment",
               "os_name": "Mac OS",
               "os_version": "53",
@@ -432,7 +432,7 @@ describe('Amplitude', () => {
               "device_model": "iPhone",
               "device_type": "mobile",
               "event_properties": Object {},
-              "event_type": "Test Event",
+              "event_type": "[Segment] Test Event",
               "ip": "8.8.8.8",
               "language": "en-US",
               "library": "segment",
@@ -486,7 +486,7 @@ describe('Amplitude', () => {
               "device_model": "iPhone",
               "device_type": "mobile",
               "event_properties": Object {},
-              "event_type": "Test Event",
+              "event_type": "[Segment] Test Event",
               "ip": "8.8.8.8",
               "language": "en-US",
               "library": "segment",
@@ -527,7 +527,7 @@ describe('Amplitude', () => {
         api_key: '',
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Test Event',
+            event_type: '[Segment] Test Event',
             city: 'San Francisco',
             country: 'United States'
           })
@@ -561,7 +561,7 @@ describe('Amplitude', () => {
         api_key: '',
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Test Event',
+            event_type: '[Segment] Test Event',
             city: 'San Francisco',
             country: 'United States'
           })
@@ -601,7 +601,7 @@ describe('Amplitude', () => {
               "device_model": "Mac OS",
               "device_type": undefined,
               "event_properties": Object {},
-              "event_type": "Test Event",
+              "event_type": "[Segment] Test Event",
               "library": "segment",
               "os_name": "iPhone OS",
               "os_version": "8.1.3",
@@ -645,12 +645,12 @@ describe('Amplitude', () => {
         api_key: undefined,
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Order Completed',
+            event_type: '[Segment] Order Completed',
             event_properties: event.properties,
             library: 'segment'
           }),
           expect.objectContaining({
-            event_type: 'Product Purchased',
+            event_type: '[Segment] Product Purchased',
             revenue: 3_998,
             price: 1_999,
             quantity: 2,
@@ -702,12 +702,12 @@ describe('Amplitude', () => {
         api_key: undefined,
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Order Completed',
+            event_type: '[Segment] Order Completed',
             event_properties: event.properties,
             library: 'segment'
           }),
           expect.objectContaining({
-            event_type: 'Product Purchased',
+            event_type: '[Segment] Product Purchased',
             revenue: 3_998,
             price: 1_999,
             quantity: 2,
@@ -716,7 +716,7 @@ describe('Amplitude', () => {
             library: 'segment'
           }),
           expect.objectContaining({
-            event_type: 'Product Purchased',
+            event_type: '[Segment] Product Purchased',
             revenue: 1_999,
             // @ts-ignore i know what i'm doing
             event_properties: event.properties.products[1],
@@ -756,12 +756,12 @@ describe('Amplitude', () => {
         api_key: undefined,
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Order Completed',
+            event_type: '[Segment] Order Completed',
             event_properties: event.properties,
             library: 'segment'
           }),
           expect.objectContaining({
-            event_type: 'Product Purchased',
+            event_type: '[Segment] Product Purchased',
             revenue: 3_998,
             price: 1_999,
             quantity: 2,
@@ -834,7 +834,7 @@ describe('Amplitude', () => {
         api_key: undefined,
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Test Event',
+            event_type: '[Segment] Test Event',
             city: 'San Francisco',
             country: 'United States'
           })
@@ -905,7 +905,7 @@ describe('Amplitude', () => {
         api_key: undefined,
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Null User',
+            event_type: '[Segment] Null User',
             user_id: null
           })
         ])
@@ -937,7 +937,7 @@ describe('Amplitude', () => {
         api_key: undefined,
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Order Completed',
+            event_type: '[Segment] Order Completed',
             event_properties: event.properties,
             library: 'segment'
           })
@@ -971,7 +971,7 @@ describe('Amplitude', () => {
         api_key: undefined,
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Order Completed',
+            event_type: '[Segment] Order Completed',
             event_properties: event.properties
           })
         ])
@@ -998,7 +998,7 @@ describe('Amplitude', () => {
       expect(responses[0].options.json).toMatchObject({
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Test Event',
+            event_type: '[Segment] Test Event',
             event_properties: {},
             user_properties: {
               'some-trait-key': 'some-trait-value'
@@ -1038,7 +1038,7 @@ describe('Amplitude', () => {
         api_key: undefined,
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Test Event',
+            event_type: '[Segment] Test Event',
             user_properties: expect.objectContaining({
               'some-trait-key': 'some-trait-value',
               $set: {
@@ -1091,7 +1091,7 @@ describe('Amplitude', () => {
               "device_model": "Mac OS",
               "device_type": undefined,
               "event_properties": Object {},
-              "event_type": "Test Event",
+              "event_type": "[Segment] Test Event",
               "library": "segment",
               "os_name": "Mac OS",
               "os_version": "53",
@@ -1139,7 +1139,7 @@ describe('Amplitude', () => {
               "device_model": "iPhone",
               "device_type": "mobile",
               "event_properties": Object {},
-              "event_type": "Test Event",
+              "event_type": "[Segment] Test Event",
               "ip": "8.8.8.8",
               "language": "en-US",
               "library": "segment",
@@ -1193,7 +1193,7 @@ describe('Amplitude', () => {
               "device_model": "iPhone",
               "device_type": "mobile",
               "event_properties": Object {},
-              "event_type": "Test Event",
+              "event_type": "[Segment] Test Event",
               "ip": "8.8.8.8",
               "language": "en-US",
               "library": "segment",
@@ -1234,7 +1234,7 @@ describe('Amplitude', () => {
         api_key: '',
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Test Event',
+            event_type: '[Segment] Test Event',
             city: 'San Francisco',
             country: 'United States'
           })
@@ -1268,7 +1268,7 @@ describe('Amplitude', () => {
         api_key: '',
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Test Event',
+            event_type: '[Segment] Test Event',
             city: 'San Francisco',
             country: 'United States'
           })
@@ -1308,7 +1308,7 @@ describe('Amplitude', () => {
               "device_model": "Mac OS",
               "device_type": undefined,
               "event_properties": Object {},
-              "event_type": "Test Event",
+              "event_type": "[Segment] Test Event",
               "library": "segment",
               "os_name": "iPhone OS",
               "os_version": "8.1.3",
@@ -1338,7 +1338,7 @@ describe('Amplitude', () => {
         api_key: undefined,
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Test Event',
+            event_type: '[Segment] Test Event',
             city: 'San Francisco',
             country: 'United States'
           })
@@ -1409,7 +1409,7 @@ describe('Amplitude', () => {
         api_key: undefined,
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Null User',
+            event_type: '[Segment] Null User',
             user_id: null
           })
         ])
@@ -1441,7 +1441,7 @@ describe('Amplitude', () => {
         api_key: undefined,
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Order Completed',
+            event_type: '[Segment] Order Completed',
             event_properties: event.properties,
             library: 'segment'
           })
@@ -1475,7 +1475,7 @@ describe('Amplitude', () => {
         api_key: undefined,
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Order Completed',
+            event_type: '[Segment] Order Completed',
             event_properties: event.properties
           })
         ])
@@ -1502,7 +1502,7 @@ describe('Amplitude', () => {
       expect(responses[0].options.json).toMatchObject({
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Test Event',
+            event_type: '[Segment] Test Event',
             event_properties: {},
             user_properties: {
               'some-trait-key': 'some-trait-value'
@@ -1542,7 +1542,7 @@ describe('Amplitude', () => {
         api_key: undefined,
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Test Event',
+            event_type: '[Segment] Test Event',
             user_properties: expect.objectContaining({
               'some-trait-key': 'some-trait-value',
               $set: {
@@ -1595,7 +1595,7 @@ describe('Amplitude', () => {
               "device_model": "Mac OS",
               "device_type": undefined,
               "event_properties": Object {},
-              "event_type": "Test Event",
+              "event_type": "[Segment] Test Event",
               "library": "segment",
               "os_name": "Mac OS",
               "os_version": "53",
@@ -1643,7 +1643,7 @@ describe('Amplitude', () => {
               "device_model": "iPhone",
               "device_type": "mobile",
               "event_properties": Object {},
-              "event_type": "Test Event",
+              "event_type": "[Segment] Test Event",
               "ip": "8.8.8.8",
               "language": "en-US",
               "library": "segment",
@@ -1697,7 +1697,7 @@ describe('Amplitude', () => {
               "device_model": "iPhone",
               "device_type": "mobile",
               "event_properties": Object {},
-              "event_type": "Test Event",
+              "event_type": "[Segment] Test Event",
               "ip": "8.8.8.8",
               "language": "en-US",
               "library": "segment",
@@ -1738,7 +1738,7 @@ describe('Amplitude', () => {
         api_key: '',
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Test Event',
+            event_type: '[Segment] Test Event',
             city: 'San Francisco',
             country: 'United States'
           })
@@ -1772,7 +1772,7 @@ describe('Amplitude', () => {
         api_key: '',
         events: expect.arrayContaining([
           expect.objectContaining({
-            event_type: 'Test Event',
+            event_type: '[Segment] Test Event',
             city: 'San Francisco',
             country: 'United States'
           })
@@ -1909,7 +1909,7 @@ describe('Amplitude', () => {
               "device_model": "Mac OS",
               "device_type": undefined,
               "event_properties": Object {},
-              "event_type": "Test Event",
+              "event_type": "[Segment] Test Event",
               "library": "segment",
               "os_name": "iPhone OS",
               "os_version": "8.1.3",
@@ -1946,24 +1946,24 @@ describe('Amplitude', () => {
     expect(responses[0].status).toBe(200)
     expect(responses[0].data).toMatchObject({})
     expect(responses[0].options.json).toMatchInlineSnapshot(`
-        Object {
-          "api_key": undefined,
-          "events": Array [
-            Object {
-              "device_id": "foo",
-              "event_properties": Object {},
-              "event_type": "Test Event",
-              "idfv": "foo",
-              "library": "segment",
-              "time": 1618245157710,
-              "use_batch_endpoint": false,
-              "user_id": "user1234",
-              "user_properties": Object {},
-            },
-          ],
-          "options": undefined,
-        }
-      `)
+      Object {
+        "api_key": undefined,
+        "events": Array [
+          Object {
+            "device_id": "foo",
+            "event_properties": Object {},
+            "event_type": "[Segment] Test Event",
+            "idfv": "foo",
+            "library": "segment",
+            "time": 1618245157710,
+            "use_batch_endpoint": false,
+            "user_id": "user1234",
+            "user_properties": Object {},
+          },
+        ],
+        "options": undefined,
+      }
+    `)
   })
 
   describe('identifyUser', () => {

--- a/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEvent/index.ts
@@ -203,6 +203,10 @@ const action: ActionDefinition<Settings, Payload> = {
       properties.session_id = formatSessionId(session_id)
     }
 
+    if (properties.event_type) {
+      properties.event_type = '[Segment] ' + properties.event_type
+    }
+
     if (Object.keys(payload.utm_properties ?? {}).length || payload.referrer) {
       properties.user_properties = mergeUserProperties(
         convertUTMProperties({ utm_properties }),

--- a/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logEventV2/index.ts
@@ -251,6 +251,10 @@ const action: ActionDefinition<Settings, Payload> = {
       options = { min_id_length }
     }
 
+    if (properties.event_type) {
+      properties.event_type = '[Segment] ' + properties.event_type
+    }
+
     const setUserProperties = (
       name: '$setOnce' | '$set' | '$add',
       obj: Payload['setOnce'] | Payload['setAlways'] | Payload['add']

--- a/packages/destination-actions/src/destinations/amplitude/logPurchase/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/logPurchase/index.ts
@@ -255,6 +255,10 @@ const action: ActionDefinition<Settings, Payload> = {
       properties.session_id = formatSessionId(session_id)
     }
 
+    if (properties.event_type) {
+      properties.event_type = '[Segment] ' + properties.event_type
+    }
+
     if (Object.keys(payload.utm_properties ?? {}).length || payload.referrer) {
       properties.user_properties = mergeUserProperties(
         convertUTMProperties({ utm_properties }),
@@ -286,7 +290,7 @@ const action: ActionDefinition<Settings, Payload> = {
         // Or track revenue per product
         ...(trackRevenuePerProduct ? getRevenueProperties(product as EventRevenue) : {}),
         event_properties: product,
-        event_type: 'Product Purchased',
+        event_type: '[Segment] Product Purchased',
         insert_id: properties.insert_id ? `${properties.insert_id}-${events.length + 1}` : undefined,
         library: 'segment'
       })


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

In this PR, added prefix [Segment] in event_type of Amplitude. 
Jira Tickets: https://twilio-engineering.atlassian.net/browse/STRATCONN-5812


Testing. 

<img width="1437" alt="Screenshot 2025-05-23 at 2 52 37 PM" src="https://github.com/user-attachments/assets/9f5fd514-2649-46b2-b924-2df1dc82b31e" />



## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
