### PR TITLE
[Pendo Web] - new page Action

### DIFF
--- a/packages/browser-destinations/destinations/pendo-web-actions/src/group/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/group/__tests__/index.test.ts
@@ -49,6 +49,7 @@ describe('Pendo.group', () => {
         initialize: jest.fn(),
         isReady: jest.fn(),
         track: jest.fn(),
+        pageLoad: jest.fn(),
         identify: jest.fn(),
         flushNow: jest.fn()
       }

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/index.ts
@@ -10,6 +10,8 @@ import identify from './identify'
 import track from './track'
 import group from './group'
 
+import page from './page'
+
 declare global {
   interface Window {
     pendo: PendoSDK
@@ -114,7 +116,8 @@ export const destination: BrowserDestinationDefinition<Settings, PendoSDK> = {
   actions: {
     track,
     identify,
-    group
+    group,
+    page
   },
   presets: [
     {

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/page/generated-types.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/page/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The URL of the page being viewed. If not provided, the current URL will be used.
+   */
+  url?: string
+}

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/page/index.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/page/index.ts
@@ -1,0 +1,26 @@
+import type { BrowserActionDefinition } from '@segment/browser-destination-runtime/types'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import type { PendoSDK } from '../types'
+
+const action: BrowserActionDefinition<Settings, PendoSDK, Payload> = {
+  title: 'Send Page Load Event',
+  description: 'Send Segment page() events to Pendo',
+  platform: 'web',
+  fields: {
+    url: {
+      label: 'Page URL',
+      description: 'The URL of the page being viewed. If not provided, the current URL will be used.',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.context.page.url'
+      }
+    }
+  },
+  perform: (pendo, { payload }) => {
+    pendo.pageLoad(payload.url ?? undefined)
+  }
+}
+
+export default action

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/track/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/track/__tests__/index.test.ts
@@ -43,6 +43,7 @@ describe('Pendo.track', () => {
         initialize: jest.fn(),
         isReady: jest.fn(),
         track: jest.fn(),
+        pageLoad: jest.fn(),
         identify: jest.fn(),
         flushNow: jest.fn()
       }

--- a/packages/browser-destinations/destinations/pendo-web-actions/src/types.ts
+++ b/packages/browser-destinations/destinations/pendo-web-actions/src/types.ts
@@ -19,6 +19,7 @@ export type PendoOptions = {
 export type PendoSDK = {
   initialize: ({ visitor, account }: PendoOptions) => void
   track: (eventName: string, metadata?: { [key: string]: unknown }) => void
+  pageLoad: (url?: string) => void
   identify: (data: PendoOptions) => void
   flushNow: (force: boolean) => void
   isReady: () => boolean


### PR DESCRIPTION
Adding support for calling the `pendo.pageLoad()` function for the Pendo Web Destination. 

## Testing

Unit test added. 
Needs to be reviewed by Pendo Developers. 
