### PR TITLE
[Google Enhanced Conversions]- adding additional validation for gclid wbraid and gbraid

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
@@ -697,9 +697,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
-      )
+      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -760,9 +758,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
-      )
+      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -823,9 +819,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
-      )
+      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -1017,9 +1011,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
-      )
+      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -1081,9 +1073,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
-      )
+      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -1203,9 +1193,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
-      )
+      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -1269,9 +1257,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"64eab4e4d9e8e4f801e34d4f9043494ac3ccf778fb428dcbb555e632bb29d84b\\"}],\\"consent\\":{\\"adPersonalization\\":\\"GRANTED\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"1dba01a96da19f6df771cff07e0a8d822126709b82ae7adc6a3839b3aaa68a16\\"}],\\"consent\\":{\\"adPersonalization\\":\\"GRANTED\\"}}],\\"partialFailure\\":true}"`
-      )
+      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -1394,9 +1380,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"}],\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"}],\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}}],\\"partialFailure\\":true}"`
-      )
+      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
     })

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
@@ -35,7 +35,7 @@ describe('GoogleEnhancedConversions', () => {
 
       const responses = await testDestination.testAction('uploadClickConversion', {
         event,
-        mapping: { conversion_action: '12345' },
+        mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
         useDefaultMappings: true,
         settings: {
           customerId
@@ -43,7 +43,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)
@@ -77,7 +77,7 @@ describe('GoogleEnhancedConversions', () => {
 
       const responses = await testDestination.testAction('uploadClickConversion', {
         event,
-        mapping: { conversion_action: '12345' },
+        mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
         useDefaultMappings: true,
         settings: {
           customerId
@@ -85,7 +85,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)
@@ -119,7 +119,7 @@ describe('GoogleEnhancedConversions', () => {
 
       const responses = await testDestination.testAction('uploadClickConversion', {
         event,
-        mapping: { conversion_action: '12345' },
+        mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
         useDefaultMappings: true,
         settings: {
           customerId
@@ -127,7 +127,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)
@@ -175,7 +175,11 @@ describe('GoogleEnhancedConversions', () => {
 
       const responses = await testDestination.testAction('uploadClickConversion', {
         event,
-        mapping: { conversion_action: '12345', custom_variables: { username: 'spongebob' } },
+        mapping: {
+          conversion_action: '12345',
+          custom_variables: { username: 'spongebob' },
+          gclid: { '@path': '$.properties.gclid' }
+        },
         useDefaultMappings: true,
         settings: {
           customerId
@@ -183,7 +187,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[1].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[],\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[],\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(2)
@@ -217,7 +221,7 @@ describe('GoogleEnhancedConversions', () => {
       try {
         await testDestination.testAction('uploadClickConversion', {
           event,
-          mapping: { conversion_action: '12345' },
+          mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
           useDefaultMappings: true,
           settings: {}
         })
@@ -254,7 +258,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testAction('uploadClickConversion', {
         event,
         features: { 'google-enhanced-v12': true },
-        mapping: { conversion_action: '12345' },
+        mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
         useDefaultMappings: true,
         settings: {
           customerId
@@ -262,7 +266,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)
@@ -297,7 +301,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testAction('uploadClickConversion', {
         event,
         features: { 'google-enhanced-v12': true },
-        mapping: { conversion_action: '12345' },
+        mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
         useDefaultMappings: true,
         settings: {
           customerId
@@ -305,7 +309,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)
@@ -340,7 +344,7 @@ describe('GoogleEnhancedConversions', () => {
         await testDestination.testAction('uploadClickConversion', {
           event,
           features: { 'google-enhanced-v12': true },
-          mapping: { conversion_action: '12345' },
+          mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
           useDefaultMappings: true,
           settings: {}
         })
@@ -376,7 +380,7 @@ describe('GoogleEnhancedConversions', () => {
 
       const responses = await testDestination.testAction('uploadClickConversion', {
         event,
-        mapping: { conversion_action: '12345' },
+        mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
         useDefaultMappings: true,
         settings: {
           customerId
@@ -387,7 +391,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)
@@ -423,7 +427,8 @@ describe('GoogleEnhancedConversions', () => {
         event,
         mapping: {
           conversion_action: '12345',
-          ad_personalization_consent_state: 'GRANTED'
+          ad_personalization_consent_state: 'GRANTED',
+          gclid: { '@path': '$.properties.gclid' }
         },
         useDefaultMappings: true,
         settings: {
@@ -432,7 +437,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"1dba01a96da19f6df771cff07e0a8d822126709b82ae7adc6a3839b3aaa68a16\\"}],\\"consent\\":{\\"adPersonalization\\":\\"GRANTED\\"}}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"1dba01a96da19f6df771cff07e0a8d822126709b82ae7adc6a3839b3aaa68a16\\"}],\\"consent\\":{\\"adPersonalization\\":\\"GRANTED\\"}}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)
@@ -467,7 +472,7 @@ describe('GoogleEnhancedConversions', () => {
         await testDestination.testAction('uploadClickConversion', {
           event,
           features: { 'google-enhanced-v12': true },
-          mapping: { conversion_action: '12345' },
+          mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
           useDefaultMappings: true,
           settings: {
             customerId
@@ -508,7 +513,8 @@ describe('GoogleEnhancedConversions', () => {
         mapping: {
           conversion_action: '12345',
           ad_user_data_consent_state: 'DENIED',
-          ad_personalization_consent_state: 'DENIED'
+          ad_personalization_consent_state: 'DENIED',
+          gclid: { '@path': '$.properties.gclid' }
         },
         useDefaultMappings: true,
         settings: {
@@ -517,7 +523,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}],\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}],\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}}],\\"partialFailure\\":true}"`
       )
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -549,7 +555,7 @@ describe('GoogleEnhancedConversions', () => {
 
       const responses = await testDestination.testAction('uploadClickConversion', {
         event,
-        mapping: { conversion_action: '12345' },
+        mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
         useDefaultMappings: true,
         settings: {
           customerId
@@ -588,7 +594,7 @@ describe('GoogleEnhancedConversions', () => {
 
       const responses = await testDestination.testAction('uploadClickConversion', {
         event,
-        mapping: { conversion_action: '12345' },
+        mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
         useDefaultMappings: true,
         settings: {
           customerId
@@ -627,7 +633,7 @@ describe('GoogleEnhancedConversions', () => {
 
       const responses = await testDestination.testAction('uploadClickConversion', {
         event,
-        mapping: { conversion_action: '12345' },
+        mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
         useDefaultMappings: true,
         settings: {
           customerId
@@ -690,14 +696,16 @@ describe('GoogleEnhancedConversions', () => {
 
       const responses = await testDestination.testBatchAction('uploadClickConversion', {
         events,
-        mapping: { conversion_action: '12345' },
+        mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
         useDefaultMappings: true,
         settings: {
           customerId
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
+      )
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -751,14 +759,16 @@ describe('GoogleEnhancedConversions', () => {
 
       const responses = await testDestination.testBatchAction('uploadClickConversion', {
         events,
-        mapping: { conversion_action: '12345' },
+        mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
         useDefaultMappings: true,
         settings: {
           customerId
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
+      )
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -812,14 +822,16 @@ describe('GoogleEnhancedConversions', () => {
 
       const responses = await testDestination.testBatchAction('uploadClickConversion', {
         events,
-        mapping: { conversion_action: '12345' },
+        mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
         useDefaultMappings: true,
         settings: {
           customerId
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
+      )
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -885,7 +897,11 @@ describe('GoogleEnhancedConversions', () => {
 
       const responses = await testDestination.testBatchAction('uploadClickConversion', {
         events,
-        mapping: { conversion_action: '12345', custom_variables: { username: 'spongebob' } },
+        mapping: {
+          conversion_action: '12345',
+          custom_variables: { username: 'spongebob' },
+          gclid: { '@path': '$.properties.gclid' }
+        },
         useDefaultMappings: true,
         settings: {
           customerId
@@ -893,7 +909,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[1].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[],\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[],\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[],\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[],\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(2)
@@ -947,7 +963,7 @@ describe('GoogleEnhancedConversions', () => {
       try {
         await testDestination.testBatchAction('uploadClickConversion', {
           events,
-          mapping: { conversion_action: '12345' },
+          mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
           useDefaultMappings: true,
           settings: {}
         })
@@ -1004,14 +1020,16 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testBatchAction('uploadClickConversion', {
         events,
         features: { 'google-enhanced-v12': true },
-        mapping: { conversion_action: '12345' },
+        mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
         useDefaultMappings: true,
         settings: {
           customerId
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
+      )
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -1066,14 +1084,16 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testBatchAction('uploadClickConversion', {
         events,
         features: { 'google-enhanced-v12': true },
-        mapping: { conversion_action: '12345' },
+        mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
         useDefaultMappings: true,
         settings: {
           customerId
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
+      )
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -1127,7 +1147,7 @@ describe('GoogleEnhancedConversions', () => {
         await testDestination.testBatchAction('uploadClickConversion', {
           events,
           features: { 'google-enhanced-v12': true },
-          mapping: { conversion_action: '12345' },
+          mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
           useDefaultMappings: true,
           settings: {}
         })
@@ -1183,7 +1203,7 @@ describe('GoogleEnhancedConversions', () => {
 
       const responses = await testDestination.testBatchAction('uploadClickConversion', {
         events,
-        mapping: { conversion_action: '12345' },
+        mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
         useDefaultMappings: true,
         settings: {
           customerId
@@ -1193,7 +1213,9 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
+      )
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -1249,7 +1271,8 @@ describe('GoogleEnhancedConversions', () => {
         events,
         mapping: {
           conversion_action: '12345',
-          ad_personalization_consent_state: 'GRANTED'
+          ad_personalization_consent_state: 'GRANTED',
+          gclid: { '@path': '$.properties.gclid' }
         },
         useDefaultMappings: true,
         settings: {
@@ -1257,7 +1280,9 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"64eab4e4d9e8e4f801e34d4f9043494ac3ccf778fb428dcbb555e632bb29d84b\\"}],\\"consent\\":{\\"adPersonalization\\":\\"GRANTED\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"1dba01a96da19f6df771cff07e0a8d822126709b82ae7adc6a3839b3aaa68a16\\"}],\\"consent\\":{\\"adPersonalization\\":\\"GRANTED\\"}}],\\"partialFailure\\":true}"`
+      )
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -1311,7 +1336,7 @@ describe('GoogleEnhancedConversions', () => {
         await testDestination.testBatchAction('uploadClickConversion', {
           events,
           features: { 'google-enhanced-v12': true },
-          mapping: { conversion_action: '12345' },
+          mapping: { conversion_action: '12345', gclid: { '@path': '$.properties.gclid' } },
           useDefaultMappings: true,
           settings: {
             customerId
@@ -1372,7 +1397,8 @@ describe('GoogleEnhancedConversions', () => {
         mapping: {
           conversion_action: '12345',
           ad_user_data_consent_state: 'DENIED',
-          ad_personalization_consent_state: 'DENIED'
+          ad_personalization_consent_state: 'DENIED',
+          gclid: { '@path': '$.properties.gclid' }
         },
         useDefaultMappings: true,
         settings: {
@@ -1380,7 +1406,9 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"}],\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"}],\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}}],\\"partialFailure\\":true}"`
+      )
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
     })

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
@@ -647,6 +647,94 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
     })
+
+    it('fails if more than one of gclid, wbraid and gbraid is provided', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        properties: {
+          gclid: '54321',
+          wbraid: '12345',
+          gbraid: '67890',
+          email: 'test@test.com',
+          orderId: '1234',
+          total: '200',
+          currency: 'USD',
+          products: [
+            {
+              product_id: '1234',
+              quantity: 3,
+              price: 10.99
+            }
+          ]
+        }
+      })
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, {})
+
+      try {
+        await testDestination.testAction('uploadClickConversion', {
+          event,
+          features: { 'google-enhanced-v12': true },
+          mapping: {
+            conversion_action: '12345',
+            gclid: { '@path': '$.properties.gclid' },
+            wbraid: { '@path': '$.properties.wbraid' },
+            gbraid: { '@path': '$.properties.gbraid' }
+          },
+          useDefaultMappings: true,
+          settings: {
+            customerId
+          }
+        })
+        fail('the test should have thrown an error')
+      } catch (e: any) {
+        expect(e.message).toBe('Exactly one of GCLID, GBRAID or WBRAID should be provided.')
+      }
+    })
+
+    it('fails if none of gclid, wbraid and gbraid is provided', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        properties: {
+          email: 'test@test.com',
+          orderId: '1234',
+          total: '200',
+          currency: 'USD',
+          products: [
+            {
+              product_id: '1234',
+              quantity: 3,
+              price: 10.99
+            }
+          ]
+        }
+      })
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, {})
+
+      try {
+        await testDestination.testAction('uploadClickConversion', {
+          event,
+          features: { 'google-enhanced-v12': true },
+          mapping: {
+            conversion_action: '12345'
+          },
+          useDefaultMappings: true,
+          settings: {
+            customerId
+          }
+        })
+        fail('the test should have thrown an error')
+      } catch (e: any) {
+        expect(e.message).toBe('Exactly one of GCLID, GBRAID or WBRAID should be provided.')
+      }
+    })
   })
 
   describe('uploadClickConversion Batch Event', () => {
@@ -1409,6 +1497,144 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[0].options.body).toMatchInlineSnapshot(
         `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"}],\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"}],\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}}],\\"partialFailure\\":true}"`
       )
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('strips out wbraid and gbraid if gclid is already provided', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            gclid: '54321',
+            wbraid: 'wbraid123',
+            gbraid: 'gbraid123',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            gclid: '54321',
+            wbraid: 'wbraid123',
+            gbraid: 'gbraid123',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          gclid: { '@path': '$.properties.gclid' },
+          wbraid: { '@path': '$.properties.wbraid' },
+          gbraid: { '@path': '$.properties.gbraid' }
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('strips out wbraid if wbraid and gbraid provided and gclid not provided', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            wbraid: 'wbraid123',
+            gbraid: 'gbraid123',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            wbraid: 'wbraid123',
+            gbraid: 'gbraid123',
+            email: 'test@gmail.com',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          gclid: { '@path': '$.properties.gclid' },
+          wbraid: { '@path': '$.properties.wbraid' },
+          gbraid: { '@path': '$.properties.gbraid' }
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gbraid\\":\\"gbraid123\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gbraid\\":\\"gbraid123\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
+      )
+
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
     })

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
@@ -194,6 +194,50 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[1].status).toBe(201)
     })
 
+    it('excludes custom variables if gbraid or wbraid are set', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        properties: {
+          wbraid: '54321',
+          orderId: '1234',
+          total: '200',
+          currency: 'USD',
+          products: [
+            {
+              product_id: '1234',
+              quantity: 3,
+              price: 10.99
+            }
+          ]
+        }
+      })
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testAction('uploadClickConversion', {
+        event,
+        mapping: {
+          conversion_action: '12345',
+          custom_variables: { username: 'spongebob' },
+          wbraid: { '@path': '$.properties.wbraid' }
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"wbraid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[]}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
     it('fails if customerId not set - basic', async () => {
       const event = createTestEvent({
         timestamp,
@@ -1002,6 +1046,69 @@ describe('GoogleEnhancedConversions', () => {
 
       expect(responses.length).toBe(2)
       expect(responses[1].status).toBe(201)
+    })
+
+    it('excludes custom variables if gbraid or wbraid set', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: {
+            wbraid: '54321',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: {
+            wbraid: '54321',
+            orderId: '1234',
+            total: '200',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '1234',
+                quantity: 3,
+                price: 10.99
+              }
+            ]
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          custom_variables: { username: 'spongebob' },
+          wbraid: { '@path': '$.properties.wbraid' }
+        },
+        useDefaultMappings: true,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"wbraid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"wbraid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[]}],\\"partialFailure\\":true}"`
+      )
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
     })
 
     it('fails if customerId not set - basic', async () => {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
@@ -38,6 +38,7 @@ describe('GoogleEnhancedConversions', () => {
         event,
         mapping: {
           conversion_action: '12345',
+          gclid: '54321',
           __segment_internal_sync_mode: 'add'
         },
         useDefaultMappings: true,
@@ -47,7 +48,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)
@@ -82,6 +83,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testAction('uploadClickConversion2', {
         event,
         mapping: {
+          gclid: '54321',
           conversion_action: '12345',
           __segment_internal_sync_mode: 'add'
         },
@@ -92,7 +94,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)
@@ -127,6 +129,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testAction('uploadClickConversion2', {
         event,
         mapping: {
+          gclid: '54321',
           conversion_action: '12345',
           __segment_internal_sync_mode: 'add'
         },
@@ -137,7 +140,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)
@@ -186,6 +189,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testAction('uploadClickConversion2', {
         event,
         mapping: {
+          gclid: '54321',
           conversion_action: '12345',
           custom_variables: { username: 'spongebob' },
           __segment_internal_sync_mode: 'add'
@@ -197,7 +201,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[1].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[],\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[],\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(2)
@@ -232,6 +236,7 @@ describe('GoogleEnhancedConversions', () => {
         await testDestination.testAction('uploadClickConversion2', {
           event,
           mapping: {
+            gclid: '54321',
             conversion_action: '12345',
             __segment_internal_sync_mode: 'add'
           },
@@ -272,6 +277,7 @@ describe('GoogleEnhancedConversions', () => {
         event,
         features: { 'google-enhanced-v12': true },
         mapping: {
+          gclid: '54321',
           conversion_action: '12345',
           __segment_internal_sync_mode: 'add'
         },
@@ -282,7 +288,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)
@@ -318,6 +324,7 @@ describe('GoogleEnhancedConversions', () => {
         event,
         features: { 'google-enhanced-v12': true },
         mapping: {
+          gclid: '54321',
           conversion_action: '12345',
           __segment_internal_sync_mode: 'add'
         },
@@ -328,7 +335,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)
@@ -364,6 +371,7 @@ describe('GoogleEnhancedConversions', () => {
           event,
           features: { 'google-enhanced-v12': true },
           mapping: {
+            gclid: '54321',
             conversion_action: '12345',
             __segment_internal_sync_mode: 'add'
           },
@@ -403,6 +411,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testAction('uploadClickConversion2', {
         event,
         mapping: {
+          gclid: '54321',
           conversion_action: '12345',
           __segment_internal_sync_mode: 'add'
         },
@@ -416,7 +425,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)
@@ -451,6 +460,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testAction('uploadClickConversion2', {
         event,
         mapping: {
+          gclid: '54321',
           conversion_action: '12345',
           ad_personalization_consent_state: 'GRANTED',
           __segment_internal_sync_mode: 'add'
@@ -462,7 +472,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"1dba01a96da19f6df771cff07e0a8d822126709b82ae7adc6a3839b3aaa68a16\\"}],\\"consent\\":{\\"adPersonalization\\":\\"GRANTED\\"}}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"1dba01a96da19f6df771cff07e0a8d822126709b82ae7adc6a3839b3aaa68a16\\"}],\\"consent\\":{\\"adPersonalization\\":\\"GRANTED\\"}}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)
@@ -498,6 +508,7 @@ describe('GoogleEnhancedConversions', () => {
           event,
           features: { 'google-enhanced-v12': true },
           mapping: {
+            gclid: '54321',
             conversion_action: '12345',
             __segment_internal_sync_mode: 'add'
           },
@@ -539,6 +550,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testAction('uploadClickConversion2', {
         event,
         mapping: {
+          gclid: '54321',
           conversion_action: '12345',
           ad_user_data_consent_state: 'DENIED',
           ad_personalization_consent_state: 'DENIED',
@@ -551,7 +563,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}],\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}],\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}}],\\"partialFailure\\":true}"`
       )
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -585,6 +597,7 @@ describe('GoogleEnhancedConversions', () => {
         await testDestination.testAction('uploadClickConversion2', {
           event,
           mapping: {
+            gclid: '54321',
             conversion_action: '12345',
             __segment_internal_sync_mode: 'upsert'
           },
@@ -646,6 +659,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testBatchAction('uploadClickConversion2', {
         events,
         mapping: {
+          gclid: '54321',
           conversion_action: '12345',
           __segment_internal_sync_mode: 'add'
         },
@@ -656,7 +670,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)
@@ -712,6 +726,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testBatchAction('uploadClickConversion2', {
         events,
         mapping: {
+          gclid: '54321',
           conversion_action: '12345',
           __segment_internal_sync_mode: 'add'
         },
@@ -722,7 +737,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)
@@ -779,6 +794,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testBatchAction('uploadClickConversion2', {
         events,
         mapping: {
+          gclid: '54321',
           conversion_action: '12345',
           __segment_internal_sync_mode: 'add'
         },
@@ -789,7 +805,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"22563905dd330440cb95d11761541dd3bd7f9b704b132392c717a3633582884c\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"22563905dd330440cb95d11761541dd3bd7f9b704b132392c717a3633582884c\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(1)
@@ -857,6 +873,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testBatchAction('uploadClickConversion2', {
         events,
         mapping: {
+          gclid: '54321',
           conversion_action: '12345',
           custom_variables: { username: 'spongebob' },
           __segment_internal_sync_mode: 'add'
@@ -868,7 +885,7 @@ describe('GoogleEnhancedConversions', () => {
       })
 
       expect(responses[1].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[],\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[],\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]}],\\"partialFailure\\":true}"`
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[],\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"gclid\\":\\"54321\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[],\\"customVariables\\":[{\\"conversionCustomVariable\\":\\"customers/1234/conversionCustomVariables/123445\\",\\"value\\":\\"spongebob\\"}]}],\\"partialFailure\\":true}"`
       )
 
       expect(responses.length).toBe(2)
@@ -983,6 +1000,7 @@ describe('GoogleEnhancedConversions', () => {
         events,
         features: { 'google-enhanced-v12': true },
         mapping: {
+          gclid: '54321',
           conversion_action: '12345',
           __segment_internal_sync_mode: 'add'
         },
@@ -992,9 +1010,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"}]}],\\"partialFailure\\":true}"`
-      )
+      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -1050,6 +1066,7 @@ describe('GoogleEnhancedConversions', () => {
         events,
         features: { 'google-enhanced-v12': true },
         mapping: {
+          gclid: '54321',
           conversion_action: '12345',
           __segment_internal_sync_mode: 'add'
         },
@@ -1059,9 +1076,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"22563905dd330440cb95d11761541dd3bd7f9b704b132392c717a3633582884c\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
-      )
+      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -1116,6 +1131,7 @@ describe('GoogleEnhancedConversions', () => {
           events,
           features: { 'google-enhanced-v12': true },
           mapping: {
+            gclid: '54321',
             conversion_action: '12345',
             __segment_internal_sync_mode: 'add'
           },
@@ -1175,6 +1191,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testBatchAction('uploadClickConversion2', {
         events,
         mapping: {
+          gclid: '54321',
           conversion_action: '12345',
           __segment_internal_sync_mode: 'add'
         },
@@ -1187,9 +1204,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}]}],\\"partialFailure\\":true}"`
-      )
+      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -1244,6 +1259,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testBatchAction('uploadClickConversion2', {
         events,
         mapping: {
+          gclid: '54321',
           conversion_action: '12345',
           ad_personalization_consent_state: 'GRANTED',
           __segment_internal_sync_mode: 'add'
@@ -1254,9 +1270,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9\\"},{\\"hashedPhoneNumber\\":\\"64eab4e4d9e8e4f801e34d4f9043494ac3ccf778fb428dcbb555e632bb29d84b\\"}],\\"consent\\":{\\"adPersonalization\\":\\"GRANTED\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47\\"},{\\"hashedPhoneNumber\\":\\"1dba01a96da19f6df771cff07e0a8d822126709b82ae7adc6a3839b3aaa68a16\\"}],\\"consent\\":{\\"adPersonalization\\":\\"GRANTED\\"}}],\\"partialFailure\\":true}"`
-      )
+      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -1311,6 +1325,7 @@ describe('GoogleEnhancedConversions', () => {
           events,
           features: { 'google-enhanced-v12': true },
           mapping: {
+            gclid: '54321',
             conversion_action: '12345',
             __segment_internal_sync_mode: 'add'
           },
@@ -1372,6 +1387,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testBatchAction('uploadClickConversion2', {
         events,
         mapping: {
+          gclid: '54321',
           conversion_action: '12345',
           ad_user_data_consent_state: 'DENIED',
           ad_personalization_consent_state: 'DENIED',
@@ -1383,9 +1399,7 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}],\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}},{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"}],\\"consent\\":{\\"adUserData\\":\\"DENIED\\",\\"adPersonalization\\":\\"DENIED\\"}}],\\"partialFailure\\":true}"`
-      )
+      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
     })
@@ -1438,6 +1452,7 @@ describe('GoogleEnhancedConversions', () => {
         await testDestination.testBatchAction('uploadClickConversion2', {
           events,
           mapping: {
+            gclid: '54321',
             conversion_action: '12345',
             __segment_internal_sync_mode: 'upsert'
           },

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
@@ -38,7 +38,7 @@ describe('GoogleEnhancedConversions', () => {
         event,
         mapping: {
           conversion_action: '12345',
-          gclid: '54321',
+          gclid: { '@path': '$.properties.gclid' },
           __segment_internal_sync_mode: 'add'
         },
         useDefaultMappings: true,
@@ -83,7 +83,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testAction('uploadClickConversion2', {
         event,
         mapping: {
-          gclid: '54321',
+          gclid: { '@path': '$.properties.gclid' },
           conversion_action: '12345',
           __segment_internal_sync_mode: 'add'
         },
@@ -129,7 +129,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testAction('uploadClickConversion2', {
         event,
         mapping: {
-          gclid: '54321',
+          gclid: { '@path': '$.properties.gclid' },
           conversion_action: '12345',
           __segment_internal_sync_mode: 'add'
         },
@@ -236,7 +236,7 @@ describe('GoogleEnhancedConversions', () => {
         await testDestination.testAction('uploadClickConversion2', {
           event,
           mapping: {
-            gclid: '54321',
+            gclid: { '@path': '$.properties.gclid' },
             conversion_action: '12345',
             __segment_internal_sync_mode: 'add'
           },
@@ -277,7 +277,7 @@ describe('GoogleEnhancedConversions', () => {
         event,
         features: { 'google-enhanced-v12': true },
         mapping: {
-          gclid: '54321',
+          gclid: { '@path': '$.properties.gclid' },
           conversion_action: '12345',
           __segment_internal_sync_mode: 'add'
         },
@@ -324,7 +324,7 @@ describe('GoogleEnhancedConversions', () => {
         event,
         features: { 'google-enhanced-v12': true },
         mapping: {
-          gclid: '54321',
+          gclid: { '@path': '$.properties.gclid' },
           conversion_action: '12345',
           __segment_internal_sync_mode: 'add'
         },
@@ -371,7 +371,7 @@ describe('GoogleEnhancedConversions', () => {
           event,
           features: { 'google-enhanced-v12': true },
           mapping: {
-            gclid: '54321',
+            gclid: { '@path': '$.properties.gclid' },
             conversion_action: '12345',
             __segment_internal_sync_mode: 'add'
           },
@@ -508,7 +508,7 @@ describe('GoogleEnhancedConversions', () => {
           event,
           features: { 'google-enhanced-v12': true },
           mapping: {
-            gclid: '54321',
+            gclid: { '@path': '$.properties.gclid' },
             conversion_action: '12345',
             __segment_internal_sync_mode: 'add'
           },
@@ -550,7 +550,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testAction('uploadClickConversion2', {
         event,
         mapping: {
-          gclid: '54321',
+          gclid: { '@path': '$.properties.gclid' },
           conversion_action: '12345',
           ad_user_data_consent_state: 'DENIED',
           ad_personalization_consent_state: 'DENIED',
@@ -597,7 +597,7 @@ describe('GoogleEnhancedConversions', () => {
         await testDestination.testAction('uploadClickConversion2', {
           event,
           mapping: {
-            gclid: '54321',
+            gclid: { '@path': '$.properties.gclid' },
             conversion_action: '12345',
             __segment_internal_sync_mode: 'upsert'
           },
@@ -659,7 +659,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testBatchAction('uploadClickConversion2', {
         events,
         mapping: {
-          gclid: '54321',
+          gclid: { '@path': '$.properties.gclid' },
           conversion_action: '12345',
           __segment_internal_sync_mode: 'add'
         },
@@ -726,7 +726,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testBatchAction('uploadClickConversion2', {
         events,
         mapping: {
-          gclid: '54321',
+          gclid: { '@path': '$.properties.gclid' },
           conversion_action: '12345',
           __segment_internal_sync_mode: 'add'
         },
@@ -794,7 +794,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testBatchAction('uploadClickConversion2', {
         events,
         mapping: {
-          gclid: '54321',
+          gclid: { '@path': '$.properties.gclid' },
           conversion_action: '12345',
           __segment_internal_sync_mode: 'add'
         },
@@ -873,7 +873,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testBatchAction('uploadClickConversion2', {
         events,
         mapping: {
-          gclid: '54321',
+          gclid: { '@path': '$.properties.gclid' },
           conversion_action: '12345',
           custom_variables: { username: 'spongebob' },
           __segment_internal_sync_mode: 'add'
@@ -941,6 +941,7 @@ describe('GoogleEnhancedConversions', () => {
           events,
           mapping: {
             conversion_action: '12345',
+            gclid: { '@path': '$.properties.gclid' },
             __segment_internal_sync_mode: 'add'
           },
           useDefaultMappings: true,
@@ -1000,7 +1001,7 @@ describe('GoogleEnhancedConversions', () => {
         events,
         features: { 'google-enhanced-v12': true },
         mapping: {
-          gclid: '54321',
+          gclid: { '@path': '$.properties.gclid' },
           conversion_action: '12345',
           __segment_internal_sync_mode: 'add'
         },
@@ -1403,7 +1404,7 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
     })
-
+ 
     it('fails if sync mode is not supported', async () => {
       const events: SegmentEvent[] = [
         createTestEvent({

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
@@ -953,264 +953,6 @@ describe('GoogleEnhancedConversions', () => {
       }
     })
 
-    it('sends an event with default mappings - with enhanced v12 flag', async () => {
-      const events: SegmentEvent[] = [
-        createTestEvent({
-          timestamp,
-          event: 'Test Event 1',
-          properties: {
-            gclid: '54321',
-            email: 'test1@gmail.com',
-            orderId: '1234',
-            total: '200',
-            currency: 'USD',
-            products: [
-              {
-                product_id: '1234',
-                quantity: 3,
-                price: 10.99
-              }
-            ]
-          }
-        }),
-        createTestEvent({
-          timestamp,
-          event: 'Test Event 2',
-          properties: {
-            gclid: '54321',
-            email: 'test2@gmail.com',
-            orderId: '1234',
-            total: '200',
-            currency: 'USD',
-            products: [
-              {
-                product_id: '1234',
-                quantity: 3,
-                price: 10.99
-              }
-            ]
-          }
-        })
-      ]
-
-      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
-        .post('')
-        .reply(201, { results: [{}] })
-
-      const responses = await testDestination.testBatchAction('uploadClickConversion2', {
-        events,
-        features: { 'google-enhanced-v12': true },
-        mapping: {
-          gclid: { '@path': '$.properties.gclid' },
-          conversion_action: '12345',
-          __segment_internal_sync_mode: 'add'
-        },
-        useDefaultMappings: true,
-        settings: {
-          customerId
-        }
-      })
-
-      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
-
-      expect(responses.length).toBe(1)
-      expect(responses[0].status).toBe(201)
-    })
-
-    it('sends email and phone user_identifiers - with enhanced v12 flag', async () => {
-      const events: SegmentEvent[] = [
-        createTestEvent({
-          timestamp,
-          event: 'Test Event 1',
-          properties: {
-            gclid: '54321',
-            email: 'test1@gmail.com',
-            phone: '6161729101',
-            orderId: '1234',
-            total: '200',
-            currency: 'USD',
-            products: [
-              {
-                product_id: '1234',
-                quantity: 3,
-                price: 10.99
-              }
-            ]
-          }
-        }),
-        createTestEvent({
-          timestamp,
-          event: 'Test Event 2',
-          properties: {
-            gclid: '54321',
-            email: 'test2@gmail.com',
-            phone: '6161729102',
-            orderId: '1234',
-            total: '200',
-            currency: 'USD',
-            products: [
-              {
-                product_id: '1234',
-                quantity: 3,
-                price: 10.99
-              }
-            ]
-          }
-        })
-      ]
-
-      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
-        .post('')
-        .reply(201, { results: [{}] })
-
-      const responses = await testDestination.testBatchAction('uploadClickConversion2', {
-        events,
-        features: { 'google-enhanced-v12': true },
-        mapping: {
-          gclid: '54321',
-          conversion_action: '12345',
-          __segment_internal_sync_mode: 'add'
-        },
-        useDefaultMappings: true,
-        settings: {
-          customerId
-        }
-      })
-
-      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
-
-      expect(responses.length).toBe(1)
-      expect(responses[0].status).toBe(201)
-    })
-
-    it('fails if customerId not set - with enhanced v12 flag', async () => {
-      const events: SegmentEvent[] = [
-        createTestEvent({
-          timestamp,
-          event: 'Test Event 1',
-          properties: {
-            gclid: '54321',
-            email: 'test@gmail.com',
-            orderId: '1234',
-            total: '200',
-            currency: 'USD',
-            products: [
-              {
-                product_id: '1234',
-                quantity: 3,
-                price: 10.99
-              }
-            ]
-          }
-        }),
-        createTestEvent({
-          timestamp,
-          event: 'Test Event 2',
-          properties: {
-            gclid: '54321',
-            email: 'test@gmail.com',
-            orderId: '1234',
-            total: '200',
-            currency: 'USD',
-            products: [
-              {
-                product_id: '1234',
-                quantity: 3,
-                price: 10.99
-              }
-            ]
-          }
-        })
-      ]
-
-      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
-        .post('')
-        .reply(201, {})
-
-      try {
-        await testDestination.testBatchAction('uploadClickConversion2', {
-          events,
-          features: { 'google-enhanced-v12': true },
-          mapping: {
-            gclid: '54321',
-            conversion_action: '12345',
-            __segment_internal_sync_mode: 'add'
-          },
-          useDefaultMappings: true,
-          settings: {}
-        })
-        fail('the test should have thrown an error')
-      } catch (e: any) {
-        expect(e.message).toBe('Customer ID is required for this action. Please set it in destination settings.')
-      }
-    })
-
-    it('uses canary API version if flagon gate is set', async () => {
-      const events: SegmentEvent[] = [
-        createTestEvent({
-          timestamp,
-          event: 'Test Event 1',
-          properties: {
-            gclid: '54321',
-            email: 'test@gmail.com',
-            orderId: '1234',
-            total: '200',
-            currency: 'USD',
-            products: [
-              {
-                product_id: '1234',
-                quantity: 3,
-                price: 10.99
-              }
-            ]
-          }
-        }),
-        createTestEvent({
-          timestamp,
-          event: 'Test Event 2',
-          properties: {
-            gclid: '54321',
-            email: 'test@gmail.com',
-            orderId: '1234',
-            total: '200',
-            currency: 'USD',
-            products: [
-              {
-                product_id: '1234',
-                quantity: 3,
-                price: 10.99
-              }
-            ]
-          }
-        })
-      ]
-
-      nock(`https://googleads.googleapis.com/${CANARY_API_VERSION}/customers/${customerId}:uploadClickConversions`)
-        .post('')
-        .reply(201, { results: [{}] })
-
-      const responses = await testDestination.testBatchAction('uploadClickConversion2', {
-        events,
-        mapping: {
-          gclid: '54321',
-          conversion_action: '12345',
-          __segment_internal_sync_mode: 'add'
-        },
-        useDefaultMappings: true,
-        settings: {
-          customerId
-        },
-        features: {
-          [FLAGON_NAME]: true
-        }
-      })
-
-      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
-
-      expect(responses.length).toBe(1)
-      expect(responses[0].status).toBe(201)
-    })
-
     it('hashed email and phone', async () => {
       const events: SegmentEvent[] = [
         createTestEvent({
@@ -1260,7 +1002,7 @@ describe('GoogleEnhancedConversions', () => {
       const responses = await testDestination.testBatchAction('uploadClickConversion2', {
         events,
         mapping: {
-          gclid: '54321',
+          gclid: { '@path': '$.properties.gclid' },
           conversion_action: '12345',
           ad_personalization_consent_state: 'GRANTED',
           __segment_internal_sync_mode: 'add'
@@ -1271,7 +1013,51 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
+      expect(JSON.parse(responses[0].options.body as string)).toStrictEqual({
+        conversions: [
+          {
+            conversionAction: 'customers/1234/conversionActions/12345',
+            conversionDateTime: '2021-06-10 18:08:04+00:00',
+            gclid: '54321',
+            orderId: '1234',
+            conversionValue: 200,
+            currencyCode: 'USD',
+            cartData: {
+              items: [{ productId: '1234', quantity: 3, unitPrice: 10.99 }]
+            },
+            userIdentifiers: [
+              {
+                hashedEmail: 'a295fa4e457ca8c72751ffb6196f34b2349dcd91443b8c70ad76082d30dbdcd9'
+              },
+              {
+                hashedPhoneNumber: '64eab4e4d9e8e4f801e34d4f9043494ac3ccf778fb428dcbb555e632bb29d84b'
+              }
+            ],
+            consent: { adPersonalization: 'GRANTED' }
+          },
+          {
+            conversionAction: 'customers/1234/conversionActions/12345',
+            conversionDateTime: '2021-06-10 18:08:04+00:00',
+            gclid: '54321',
+            orderId: '1234',
+            conversionValue: 200,
+            currencyCode: 'USD',
+            cartData: {
+              items: [{ productId: '1234', quantity: 3, unitPrice: 10.99 }]
+            },
+            userIdentifiers: [
+              {
+                hashedEmail: 'cc2e166955ec49675e749f9dce21db0cbd2979d4aac4a845bdde35ccb642bc47'
+              },
+              {
+                hashedPhoneNumber: '1dba01a96da19f6df771cff07e0a8d822126709b82ae7adc6a3839b3aaa68a16'
+              }
+            ],
+            consent: { adPersonalization: 'GRANTED' }
+          }
+        ],
+        partialFailure: true
+      })
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
@@ -1400,11 +1186,68 @@ describe('GoogleEnhancedConversions', () => {
         }
       })
 
-      expect(responses[0].options.body).toMatchInlineSnapshot(`"{\\"conversions\\":[],\\"partialFailure\\":true}"`)
+      expect(JSON.parse(responses[0].options.body as string)).toStrictEqual({
+        conversions: [
+          {
+            conversionAction: 'customers/1234/conversionActions/12345',
+            conversionDateTime: '2021-06-10 18:08:04+00:00',
+            gclid: '54321',
+            orderId: '1234',
+            conversionValue: 200,
+            currencyCode: 'USD',
+            cartData: {
+              items: [
+                {
+                  productId: '1234',
+                  quantity: 3,
+                  unitPrice: 10.99
+                }
+              ]
+            },
+            userIdentifiers: [
+              {
+                hashedEmail: '87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674'
+              }
+            ],
+            consent: {
+              adUserData: 'DENIED',
+              adPersonalization: 'DENIED'
+            }
+          },
+          {
+            conversionAction: 'customers/1234/conversionActions/12345',
+            conversionDateTime: '2021-06-10 18:08:04+00:00',
+            gclid: '54321',
+            orderId: '1234',
+            conversionValue: 200,
+            currencyCode: 'USD',
+            cartData: {
+              items: [
+                {
+                  productId: '1234',
+                  quantity: 3,
+                  unitPrice: 10.99
+                }
+              ]
+            },
+            userIdentifiers: [
+              {
+                hashedEmail: '87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674'
+              }
+            ],
+            consent: {
+              adUserData: 'DENIED',
+              adPersonalization: 'DENIED'
+            }
+          }
+        ],
+        partialFailure: true
+      })
+
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(201)
     })
- 
+
     it('fails if sync mode is not supported', async () => {
       const events: SegmentEvent[] = [
         createTestEvent({

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -222,9 +222,6 @@ export function getApiVersion(features?: Features, statsContext?: StatsContext):
   const version = features && features[FLAGON_NAME] ? CANARY_API_VERSION : API_VERSION
   tags?.push(`version:${version}`)
   statsClient?.incr(`google_api_version`, 1, tags)
-
-  console.log(`XXXXXXXXXXXXXXXXXXXXXXXXXXX: ${version}`)
-
   return version
 }
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -222,6 +222,9 @@ export function getApiVersion(features?: Features, statsContext?: StatsContext):
   const version = features && features[FLAGON_NAME] ? CANARY_API_VERSION : API_VERSION
   tags?.push(`version:${version}`)
   statsClient?.incr(`google_api_version`, 1, tags)
+
+  console.log(`XXXXXXXXXXXXXXXXXXXXXXXXXXX: ${version}`)
+
   return version
 }
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/generated-types.ts
@@ -6,15 +6,15 @@ export interface Payload {
    */
   conversion_action: number
   /**
-   * The Google click ID (gclid) associated with this conversion.
+   * The Google click ID (gclid) associated with this conversion. if not provided, GBRAID or WBRAID is required.
    */
   gclid?: string
   /**
-   * The click identifier for clicks associated with app conversions and originating from iOS devices starting with iOS14.
+   * The click identifier for clicks associated with app conversions and originating from iOS devices starting with iOS14. if not provided, GCLID or WBRAID is required.
    */
   gbraid?: string
   /**
-   * The click identifier for clicks associated with web conversions and originating from iOS devices starting with iOS14.
+   * The click identifier for clicks associated with web conversions and originating from iOS devices starting with iOS14. if not provided, GCLID or GBRAID is required.
    */
   wbraid?: string
   /**
@@ -83,7 +83,7 @@ export interface Payload {
     price?: number
   }[]
   /**
-   * The custom variables associated with this conversion. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value See [Google’s documentation on how to create custom conversion variables.](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables)
+   * The custom variables associated with this conversion. Will not be sent if GBRAID or WBRAID fields populated. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value See [Google’s documentation on how to create custom conversion variables.](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables)
    */
   custom_variables?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/generated-types.ts
@@ -6,15 +6,15 @@ export interface Payload {
    */
   conversion_action: number
   /**
-   * The Google click ID (gclid) associated with this conversion. if not provided, GBRAID or WBRAID is required.
+   * The Google click ID (gclid) associated with this conversion. One of GCLID, GBRAID or WBRAID must be provided.
    */
   gclid?: string
   /**
-   * The click identifier for clicks associated with app conversions and originating from iOS devices starting with iOS14. if not provided, GCLID or WBRAID is required.
+   * The click identifier for clicks associated with app conversions and originating from iOS devices starting with iOS14. One of GCLID, GBRAID or WBRAID must be provided.
    */
   gbraid?: string
   /**
-   * The click identifier for clicks associated with web conversions and originating from iOS devices starting with iOS14. if not provided, GCLID or GBRAID is required.
+   * The click identifier for clicks associated with web conversions and originating from iOS devices starting with iOS14. One of GCLID, GBRAID or WBRAID must be provided.
    */
   wbraid?: string
   /**
@@ -83,7 +83,7 @@ export interface Payload {
     price?: number
   }[]
   /**
-   * The custom variables associated with this conversion. Will not be sent if GBRAID or WBRAID fields populated. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value See [Google’s documentation on how to create custom conversion variables.](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables)
+   * The custom variables associated with this conversion. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value Will not be sent if GBRAID or WBRAID fields populated. See [Google’s documentation on how to create custom conversion variables.](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables)
    */
   custom_variables?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/generated-types.ts
@@ -83,7 +83,7 @@ export interface Payload {
     price?: number
   }[]
   /**
-   * The custom variables associated with this conversion. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value Will not be sent if GBRAID or WBRAID fields populated. See [Google’s documentation on how to create custom conversion variables.](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables)
+   * The custom variables associated with this conversion. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value. Will not be sent if GBRAID or WBRAID fields populated. See [Google’s documentation on how to create custom conversion variables.](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables)
    */
   custom_variables?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -41,40 +41,19 @@ const action: ActionDefinition<Settings, Payload> = {
     gclid: {
       label: 'GCLID',
       description: 'The Google click ID (gclid) associated with this conversion. if not provided, GBRAID or WBRAID is required.',
-      type: 'string',
-      required: {
-        match: 'all',
-        conditions: [
-          { fieldKey: 'gbraid', operator: 'is_not', value: [undefined, null, ''] },
-          { fieldKey: 'wbraid', operator: 'is_not', value: [undefined, null, ''] }
-        ]
-      }
+      type: 'string'
     },
     gbraid: {
       label: 'GBRAID',
       description:
         'The click identifier for clicks associated with app conversions and originating from iOS devices starting with iOS14. if not provided, GCLID or WBRAID is required.',
-      type: 'string',
-      required: {
-        match: 'all',
-        conditions: [
-          { fieldKey: 'gclid', operator: 'is_not', value: [undefined, null, ''] },
-          { fieldKey: 'wbraid', operator: 'is_not', value: [undefined, null, ''] }
-        ]
-      }
+      type: 'string'
     },
     wbraid: {
       label: 'WBRAID',
       description:
         'The click identifier for clicks associated with web conversions and originating from iOS devices starting with iOS14. if not provided, GCLID or GBRAID is required.',
-      type: 'string',
-      required: {
-        match: 'all',
-        conditions: [
-          { fieldKey: 'gclid', operator: 'is_not', value: [undefined, null, ''] },
-          { fieldKey: 'gbraid', operator: 'is_not', value: [undefined, null, ''] }
-        ]
-      }
+      type: 'string'
     },
     conversion_timestamp: {
       label: 'Conversion Timestamp',
@@ -281,6 +260,11 @@ const action: ActionDefinition<Settings, Payload> = {
         'Customer ID is required for this action. Please set it in destination settings.'
       )
     }
+
+    if ([payload.gclid, payload.gbraid, payload.wbraid].filter(Boolean).length !== 1) {
+      throw new PayloadValidationError('Only one of GCLID, GBRAID or WBRAID should be provided.')
+    }
+
     settings.customerId = settings.customerId.replace(/-/g, '')
 
     let cartItems: CartItemInterface[] = []
@@ -389,6 +373,21 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const request_objects: ClickConversionRequestObjectInterface[] = await Promise.all(
       payload.map(async (payload) => {
+
+        if ([payload.gclid, payload.gbraid, payload.wbraid].filter(Boolean).length !== 1) {
+          // ensure only one of GCLID, GBRAID or WBRAID is provided. We don't have the luxury of throwing an error in batch mode
+          if (payload.gclid) {
+            delete payload.gbraid
+            delete payload.wbraid
+          } else if (payload.gbraid) {
+            delete payload.gclid
+            delete payload.wbraid
+          } else if (payload.wbraid) {
+            delete payload.gclid
+            delete payload.gbraid
+          }
+        }
+
         let cartItems: CartItemInterface[] = []
         if (payload.items) {
           cartItems = payload.items.map((product) => {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -40,20 +40,41 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     gclid: {
       label: 'GCLID',
-      description: 'The Google click ID (gclid) associated with this conversion.',
-      type: 'string'
+      description: 'The Google click ID (gclid) associated with this conversion. if not provided, GBRAID or WBRAID is required.',
+      type: 'string',
+      required: {
+        match: 'all',
+        conditions: [
+          { fieldKey: 'gbraid', operator: 'is_not', value: [undefined, null, ''] },
+          { fieldKey: 'wbraid', operator: 'is_not', value: [undefined, null, ''] }
+        ]
+      }
     },
     gbraid: {
       label: 'GBRAID',
       description:
-        'The click identifier for clicks associated with app conversions and originating from iOS devices starting with iOS14.',
-      type: 'string'
+        'The click identifier for clicks associated with app conversions and originating from iOS devices starting with iOS14. if not provided, GCLID or WBRAID is required.',
+      type: 'string',
+      required: {
+        match: 'all',
+        conditions: [
+          { fieldKey: 'gclid', operator: 'is_not', value: [undefined, null, ''] },
+          { fieldKey: 'wbraid', operator: 'is_not', value: [undefined, null, ''] }
+        ]
+      }
     },
     wbraid: {
       label: 'WBRAID',
       description:
-        'The click identifier for clicks associated with web conversions and originating from iOS devices starting with iOS14.',
-      type: 'string'
+        'The click identifier for clicks associated with web conversions and originating from iOS devices starting with iOS14. if not provided, GCLID or GBRAID is required.',
+      type: 'string',
+      required: {
+        match: 'all',
+        conditions: [
+          { fieldKey: 'gclid', operator: 'is_not', value: [undefined, null, ''] },
+          { fieldKey: 'gbraid', operator: 'is_not', value: [undefined, null, ''] }
+        ]
+      }
     },
     conversion_timestamp: {
       label: 'Conversion Timestamp',
@@ -200,7 +221,7 @@ const action: ActionDefinition<Settings, Payload> = {
     custom_variables: {
       label: 'Custom Variables',
       description:
-        'The custom variables associated with this conversion. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value See [Google’s documentation on how to create custom conversion variables.](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables) ',
+        'The custom variables associated with this conversion. Will not be sent if GBRAID or WBRAID fields populated. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value See [Google’s documentation on how to create custom conversion variables.](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables) ',
       type: 'object',
       additionalProperties: true,
       defaultObjectUI: 'keyvalue:only'
@@ -308,7 +329,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
 
     // Retrieves all of the custom variables that the customer has created in their Google Ads account
-    if (payload.custom_variables) {
+    if (payload.custom_variables && !payload.gbraid && !payload.wbraid) {
       const customVariableIds = await getCustomVariables(settings.customerId, auth, request, features, statsContext)
       if (customVariableIds?.data?.length) {
         request_object.customVariables = formatCustomVariables(

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -200,7 +200,7 @@ const action: ActionDefinition<Settings, Payload> = {
     custom_variables: {
       label: 'Custom Variables',
       description:
-        'The custom variables associated with this conversion. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value Will not be sent if GBRAID or WBRAID fields populated. See [Google’s documentation on how to create custom conversion variables.](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables) ',
+        'The custom variables associated with this conversion. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value. Will not be sent if GBRAID or WBRAID fields populated. See [Google’s documentation on how to create custom conversion variables.](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables) ',
       type: 'object',
       additionalProperties: true,
       defaultObjectUI: 'keyvalue:only'

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -40,7 +40,8 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     gclid: {
       label: 'GCLID',
-      description: 'The Google click ID (gclid) associated with this conversion. One of GCLID, GBRAID or WBRAID must be provided.',
+      description:
+        'The Google click ID (gclid) associated with this conversion. One of GCLID, GBRAID or WBRAID must be provided.',
       type: 'string'
     },
     gbraid: {
@@ -263,9 +264,9 @@ const action: ActionDefinition<Settings, Payload> = {
     settings.customerId = settings.customerId.replace(/-/g, '')
 
     if ([payload.gclid, payload.gbraid, payload.wbraid].filter(Boolean).length !== 1) {
-      throw new PayloadValidationError('Only one of GCLID, GBRAID or WBRAID should be provided.')
+      throw new PayloadValidationError('Exactly one of GCLID, GBRAID or WBRAID should be provided.')
     }
-    
+
     let cartItems: CartItemInterface[] = []
     if (payload.items) {
       cartItems = payload.items.map((product) => {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -1,35 +1,22 @@
-import {
-  ActionDefinition,
-  PayloadValidationError,
-  ModifiedResponse,
-  RequestClient,
-  DynamicFieldResponse
-} from '@segment/actions-core'
+import { ActionDefinition, DynamicFieldResponse, PayloadValidationError, RequestClient } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import {
-  CartItemInterface,
-  PartialErrorResponse,
-  ClickConversionRequestObjectInterface,
-  UserIdentifierInterface
-} from '../types'
-import {
+  convertTimestamp,
   formatCustomVariables,
   getCustomVariables,
   memoizedGetCustomVariables,
-  handleGoogleErrors,
-  convertTimestamp,
   getApiVersion,
-  commonEmailValidation,
-  getConversionActionDynamicData,
-  formatPhone
+  handleGoogleErrors,
+  getConversionActionDynamicData
 } from '../functions'
+import { CallConversionRequestObjectInterface, PartialErrorResponse } from '../types'
+import { ModifiedResponse } from '@segment/actions-core'
 import { GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE } from '../constants'
-import { processHashing } from '../../../lib/hashing-utils'
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Upload Click Conversion',
-  description: 'Upload an offline click conversion to the Google Ads API.',
+  title: 'Upload Call Conversion',
+  description: 'Upload an offline call conversion to the Google Ads API.',
   fields: {
     conversion_action: {
       label: 'Conversion Action ID',
@@ -38,22 +25,19 @@ const action: ActionDefinition<Settings, Payload> = {
       required: true,
       dynamic: true
     },
-    gclid: {
-      label: 'GCLID',
-      description: 'The Google click ID (gclid) associated with this conversion. if not provided, GBRAID or WBRAID is required.',
-      type: 'string'
-    },
-    gbraid: {
-      label: 'GBRAID',
+    caller_id: {
+      label: 'Caller ID',
       description:
-        'The click identifier for clicks associated with app conversions and originating from iOS devices starting with iOS14. if not provided, GCLID or WBRAID is required.',
-      type: 'string'
+        'The caller ID from which this call was placed. Caller ID is expected to be in E.164 format with preceding + sign, e.g. "+16502531234".',
+      type: 'string',
+      required: true
     },
-    wbraid: {
-      label: 'WBRAID',
+    call_timestamp: {
+      label: 'Call Timestamp',
       description:
-        'The click identifier for clicks associated with web conversions and originating from iOS devices starting with iOS14. if not provided, GCLID or GBRAID is required.',
-      type: 'string'
+        'The date time at which the call occurred. The timezone must be specified. The format is "yyyy-mm-dd hh:mm:ss+|-hh:mm", e.g. "2019-01-01 12:32:45-08:00".',
+      type: 'string',
+      required: true
     },
     conversion_timestamp: {
       label: 'Conversion Timestamp',
@@ -63,51 +47,6 @@ const action: ActionDefinition<Settings, Payload> = {
       required: true,
       default: {
         '@path': '$.timestamp'
-      }
-    },
-    email_address: {
-      label: 'Email Address',
-      description: 'Email address of the individual who triggered the conversion event',
-      type: 'string',
-      default: {
-        '@if': {
-          exists: { '@path': '$.properties.email' },
-          then: { '@path': '$.properties.email' },
-          else: { '@path': '$.context.traits.email' }
-        }
-      },
-      category: 'hashedPII'
-    },
-    phone_country_code: {
-      label: 'Phone Number Country Code',
-      description: `The numeric country code to associate with the phone number. If not provided Segment will default to '+1'. If the country code does not start with '+' Segment will add it.`,
-      type: 'string'
-    },
-    phone_number: {
-      label: 'Phone Number',
-      description:
-        'Phone number of the individual who triggered the conversion event, in E.164 standard format, e.g. +14150000000',
-      type: 'string',
-      default: {
-        '@if': {
-          exists: { '@path': '$.properties.phone' },
-          then: { '@path': '$.properties.phone' },
-          else: { '@path': '$.context.traits.phone' }
-        }
-      },
-      category: 'hashedPII'
-    },
-    order_id: {
-      label: 'Order ID',
-      description:
-        'The order ID associated with the conversion. An order ID can only be used for one conversion per conversion action.',
-      type: 'string',
-      default: {
-        '@if': {
-          exists: { '@path': '$.properties.orderId' },
-          then: { '@path': '$.properties.orderId' },
-          else: { '@path': '$.properties.order_id' }
-        }
       }
     },
     value: {
@@ -126,81 +65,10 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.properties.currency'
       }
     },
-    conversion_environment: {
-      label: 'Conversion Environment',
-      description:
-        'The environment this conversion was recorded on, e.g. APP or WEB. Sending the environment field requires an allowlist in your Google Ads account. Leave this field blank if your account has not been allowlisted.',
-      type: 'string',
-      choices: [
-        { label: 'APP', value: 'APP' },
-        { label: 'WEB', value: 'WEB' },
-        { label: 'UNSPECIFIED', value: 'UNSPECIFIED' }
-      ]
-    },
-    merchant_id: {
-      label: 'Merchant Center ID',
-      description: 'The ID of the Merchant Center account where the items are uploaded.',
-      type: 'string'
-    },
-    merchant_country_code: {
-      label: 'Merchant Center Feed Country Code',
-      description: 'The ISO 3166 two-character region code of the Merchant Center feed where the items are uploaded.',
-      type: 'string'
-    },
-    merchant_language_code: {
-      label: 'Merchant Center Feed Language Code',
-      description: 'The ISO 639-1 language code of the Merchant Center feed where the items are uploaded.',
-      type: 'string'
-    },
-    local_cost: {
-      label: 'Local Transaction Cost',
-      description:
-        'Sum of all transaction-level discounts, such as free shipping and coupon discounts for the whole cart.',
-      type: 'number'
-    },
-    items: {
-      label: 'Items',
-      description: 'Data of the items purchased.',
-      type: 'object',
-      multiple: true,
-      properties: {
-        product_id: {
-          label: 'Product ID',
-          type: 'string',
-          description: 'The ID of the item sold.'
-        },
-        quantity: {
-          label: 'Quantity',
-          type: 'number',
-          description: 'Number of items sold.'
-        },
-        price: {
-          label: 'Price',
-          type: 'number',
-          description: 'Unit price excluding tax, shipping, and any transaction level discounts.'
-        }
-      },
-      default: {
-        '@arrayPath': [
-          '$.properties.products',
-          {
-            product_id: {
-              '@path': '$.product_id'
-            },
-            quantity: {
-              '@path': '$.quantity'
-            },
-            price: {
-              '@path': '$.price'
-            }
-          }
-        ]
-      }
-    },
     custom_variables: {
       label: 'Custom Variables',
       description:
-        'The custom variables associated with this conversion. Will not be sent if GBRAID or WBRAID fields populated. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value See [Google’s documentation on how to create custom conversion variables.](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables) ',
+        'The custom variables associated with this conversion. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value See [Google’s documentation on how to create custom conversion variables](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables).',
       type: 'object',
       additionalProperties: true,
       defaultObjectUI: 'keyvalue:only'
@@ -208,7 +76,7 @@ const action: ActionDefinition<Settings, Payload> = {
     ad_user_data_consent_state: {
       label: 'Ad User Data Consent State',
       description:
-        'This represents consent for ad user data.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v19/Consent).',
+        'This represents consent for ad user data. For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v19/Consent).',
       type: 'string',
       choices: [
         { label: 'GRANTED', value: 'GRANTED' },
@@ -261,42 +129,17 @@ const action: ActionDefinition<Settings, Payload> = {
       )
     }
 
-    if ([payload.gclid, payload.gbraid, payload.wbraid].filter(Boolean).length !== 1) {
-      throw new PayloadValidationError('Only one of GCLID, GBRAID or WBRAID should be provided.')
-    }
-
     settings.customerId = settings.customerId.replace(/-/g, '')
 
-    let cartItems: CartItemInterface[] = []
-    if (payload.items) {
-      cartItems = payload.items.map((product) => {
-        return {
-          productId: product.product_id,
-          quantity: product.quantity,
-          unitPrice: product.price
-        } as CartItemInterface
-      })
+    const request_object: CallConversionRequestObjectInterface = {
+      conversionAction: `customers/${settings.customerId}/conversionActions/${payload.conversion_action}`,
+      callerId: payload.caller_id,
+      callStartDateTime: convertTimestamp(payload.call_timestamp),
+      conversionDateTime: convertTimestamp(payload.conversion_timestamp),
+      conversionValue: payload.value,
+      currencyCode: payload.currency
     }
 
-    const request_object: ClickConversionRequestObjectInterface = {
-      conversionAction: `customers/${settings.customerId}/conversionActions/${payload.conversion_action}`,
-      conversionDateTime: convertTimestamp(payload.conversion_timestamp),
-      gclid: payload.gclid,
-      gbraid: payload.gbraid,
-      wbraid: payload.wbraid,
-      orderId: payload.order_id,
-      conversionValue: payload.value,
-      currencyCode: payload.currency,
-      conversionEnvironment: payload.conversion_environment,
-      cartData: {
-        merchantId: payload.merchant_id,
-        feedCountryCode: payload.merchant_country_code,
-        feedLanguageCode: payload.merchant_language_code,
-        localTransactionCost: payload.local_cost,
-        items: cartItems
-      },
-      userIdentifiers: []
-    }
     // Add Consent Signals 'adUserData' if it is defined
     if (payload.ad_user_data_consent_state) {
       request_object['consent'] = {
@@ -311,38 +154,18 @@ const action: ActionDefinition<Settings, Payload> = {
         adPersonalization: payload.ad_personalization_consent_state
       }
     }
-
     // Retrieves all of the custom variables that the customer has created in their Google Ads account
-    if (payload.custom_variables && !payload.gbraid && !payload.wbraid) {
+    if (payload.custom_variables) {
       const customVariableIds = await getCustomVariables(settings.customerId, auth, request, features, statsContext)
-      if (customVariableIds?.data?.length) {
-        request_object.customVariables = formatCustomVariables(
-          payload.custom_variables,
-          customVariableIds.data[0].results
-        )
-      }
+      request_object.customVariables = formatCustomVariables(
+        payload.custom_variables,
+        customVariableIds.data[0].results
+      )
     }
-
-    if (payload.email_address) {
-      const validatedEmail: string = processHashing(payload.email_address, 'sha256', 'hex', commonEmailValidation)
-
-      request_object.userIdentifiers.push({
-        hashedEmail: validatedEmail
-      } as UserIdentifierInterface)
-    }
-
-    if (payload.phone_number) {
-      request_object.userIdentifiers.push({
-        hashedPhoneNumber: processHashing(payload.phone_number, 'sha256', 'hex', (value) =>
-          formatPhone(value, payload.phone_country_code)
-        )
-      } as UserIdentifierInterface)
-    }
-
     const response: ModifiedResponse<PartialErrorResponse> = await request(
       `https://googleads.googleapis.com/${getApiVersion(features, statsContext)}/customers/${
         settings.customerId
-      }:uploadClickConversions`,
+      }:uploadCallConversions`,
       {
         method: 'post',
         headers: {
@@ -360,111 +183,52 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   performBatch: async (request, { auth, settings, payload, features, statsContext }) => {
     /* Enforcing this here since Customer ID is required for the Google Ads API
-    but not for the Enhanced Conversions API. */
+  but not for the Enhanced Conversions API. */
     if (!settings.customerId) {
       throw new PayloadValidationError(
         'Customer ID is required for this action. Please set it in destination settings.'
       )
     }
 
-    const validatedPayloads: Payload[] = payload.reduce<Payload[]>((acc, p) => {
-      if ([p.gclid, p.gbraid, p.wbraid].filter(Boolean).length !== 1) {
-        if (p.gclid) {
-          delete p.gbraid
-          delete p.wbraid
-        } else if (p.gbraid) {
-          delete p.gclid
-          delete p.wbraid
-        } else if (p.wbraid) {
-          delete p.gclid
-          delete p.gbraid
-        } else {
-          return acc // skip this item
-        }
-      }
-      acc.push(p)
-      return acc
-    }, [])
-
     const customerId = settings.customerId.replace(/-/g, '')
 
+    // Retrieves all of the custom variables that the customer has created in their Google Ads account
     const getCustomVariables = memoizedGetCustomVariables()
 
-
-
-    const request_objects: ClickConversionRequestObjectInterface[] = await Promise.all(
-      validatedPayloads.map(async (payload) => {
-        let cartItems: CartItemInterface[] = []
-        if (payload.items) {
-          cartItems = payload.items.map((product) => {
-            return {
-              productId: product.product_id,
-              quantity: product.quantity,
-              unitPrice: product.price
-            } as CartItemInterface
-          })
-        }
-
-        const request_object: ClickConversionRequestObjectInterface = {
-          conversionAction: `customers/${customerId}/conversionActions/${payload.conversion_action}`,
-          conversionDateTime: convertTimestamp(payload.conversion_timestamp),
-          gclid: payload.gclid,
-          gbraid: payload.gbraid,
-          wbraid: payload.wbraid,
-          orderId: payload.order_id,
-          conversionValue: payload.value,
-          currencyCode: payload.currency,
-          conversionEnvironment: payload.conversion_environment,
-          cartData: {
-            merchantId: payload.merchant_id,
-            feedCountryCode: payload.merchant_country_code,
-            feedLanguageCode: payload.merchant_language_code,
-            localTransactionCost: payload.local_cost,
-            items: cartItems
-          },
-          userIdentifiers: []
+    const request_objects: CallConversionRequestObjectInterface[] = await Promise.all(
+      payload.map(async (payloadItem) => {
+        const request_object: CallConversionRequestObjectInterface = {
+          conversionAction: `customers/${customerId}/conversionActions/${payloadItem.conversion_action}`,
+          callerId: payloadItem.caller_id,
+          callStartDateTime: convertTimestamp(payloadItem.call_timestamp),
+          conversionDateTime: convertTimestamp(payloadItem.conversion_timestamp),
+          conversionValue: payloadItem.value,
+          currencyCode: payloadItem.currency
         }
 
         // Add Consent Signals 'adUserData' if it is defined
-        if (payload.ad_user_data_consent_state) {
+        if (payloadItem.ad_user_data_consent_state) {
           request_object['consent'] = {
-            adUserData: payload.ad_user_data_consent_state
+            adUserData: payloadItem.ad_user_data_consent_state
           }
         }
 
         // Add Consent Signals 'adPersonalization' if it is defined
-        if (payload.ad_personalization_consent_state) {
+        if (payloadItem.ad_personalization_consent_state) {
           request_object['consent'] = {
             ...request_object['consent'],
-            adPersonalization: payload.ad_personalization_consent_state
+            adPersonalization: payloadItem.ad_personalization_consent_state
           }
         }
 
-        // Retrieves all of the custom variables that the customer has created in their Google Ads account
-        if (payload.custom_variables && !payload.gbraid && !payload.wbraid) {
+        if (payloadItem.custom_variables) {
           const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
           if (customVariableIds?.data?.length) {
             request_object.customVariables = formatCustomVariables(
-              payload.custom_variables,
+              payloadItem.custom_variables,
               customVariableIds.data[0].results
             )
           }
-        }
-
-        if (payload.email_address) {
-          const validatedEmail: string = processHashing(payload.email_address, 'sha256', 'hex', commonEmailValidation)
-
-          request_object.userIdentifiers.push({
-            hashedEmail: validatedEmail
-          } as UserIdentifierInterface)
-        }
-
-        if (payload.phone_number) {
-          request_object.userIdentifiers.push({
-            hashedPhoneNumber: processHashing(payload.phone_number, 'sha256', 'hex', (value) =>
-              formatPhone(value, payload.phone_country_code)
-            )
-          } as UserIdentifierInterface)
         }
 
         return request_object
@@ -472,10 +236,9 @@ const action: ActionDefinition<Settings, Payload> = {
     )
 
     const response: ModifiedResponse<PartialErrorResponse> = await request(
-      `https://googleads.googleapis.com/${getApiVersion(
-        features,
-        statsContext
-      )}/customers/${customerId}:uploadClickConversions`,
+      `https://googleads.googleapis.com/${getApiVersion(features, statsContext)}/customers/${
+        settings.customerId
+      }:uploadCallConversions`,
       {
         method: 'post',
         headers: {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/generated-types.ts
@@ -6,15 +6,15 @@ export interface Payload {
    */
   conversion_action: number
   /**
-   * The Google click ID (gclid) associated with this conversion.
+   * The Google click ID (gclid) associated with this conversion. if not provided, GBRAID or WBRAID is required.
    */
   gclid?: string
   /**
-   * The click identifier for clicks associated with app conversions and originating from iOS devices starting with iOS14.
+   * The click identifier for clicks associated with app conversions and originating from iOS devices starting with iOS14. if not provided, GCLID or WBRAID is required.
    */
   gbraid?: string
   /**
-   * The click identifier for clicks associated with web conversions and originating from iOS devices starting with iOS14.
+   * The click identifier for clicks associated with web conversions and originating from iOS devices starting with iOS14. if not provided, GCLID or GBRAID is required.
    */
   wbraid?: string
   /**
@@ -83,7 +83,7 @@ export interface Payload {
     price?: number
   }[]
   /**
-   * The custom variables associated with this conversion. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value See [Google’s documentation on how to create custom conversion variables.](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables)
+   * The custom variables associated with this conversion. Will not be sent if GBRAID or WBRAID fields populated. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value See [Google’s documentation on how to create custom conversion variables.](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables)
    */
   custom_variables?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/generated-types.ts
@@ -6,15 +6,15 @@ export interface Payload {
    */
   conversion_action: number
   /**
-   * The Google click ID (gclid) associated with this conversion. if not provided, GBRAID or WBRAID is required.
+   * The Google click ID (gclid) associated with this conversion. One of GCLID, GBRAID or WBRAID must be provided.
    */
   gclid?: string
   /**
-   * The click identifier for clicks associated with app conversions and originating from iOS devices starting with iOS14. if not provided, GCLID or WBRAID is required.
+   * The click identifier for clicks associated with app conversions and originating from iOS devices starting with iOS14. One of GCLID, GBRAID or WBRAID must be provided.
    */
   gbraid?: string
   /**
-   * The click identifier for clicks associated with web conversions and originating from iOS devices starting with iOS14. if not provided, GCLID or GBRAID is required.
+   * The click identifier for clicks associated with web conversions and originating from iOS devices starting with iOS14. One of GCLID, GBRAID or WBRAID must be provided.
    */
   wbraid?: string
   /**
@@ -83,7 +83,7 @@ export interface Payload {
     price?: number
   }[]
   /**
-   * The custom variables associated with this conversion. Will not be sent if GBRAID or WBRAID fields populated. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value See [Google’s documentation on how to create custom conversion variables.](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables)
+   * The custom variables associated with this conversion. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value. Will not be sent if GBRAID or WBRAID fields populated. See [Google’s documentation on how to create custom conversion variables.](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables)
    */
   custom_variables?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -47,20 +47,41 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     gclid: {
       label: 'GCLID',
-      description: 'The Google click ID (gclid) associated with this conversion.',
-      type: 'string'
+      description: 'The Google click ID (gclid) associated with this conversion. if not provided, GBRAID or WBRAID is required.',
+      type: 'string',
+      required: {
+        match: 'all',
+        conditions: [
+          { fieldKey: 'gbraid', operator: 'is_not', value: [undefined, null, ''] },
+          { fieldKey: 'wbraid', operator: 'is_not', value: [undefined, null, ''] }
+        ]
+      }
     },
     gbraid: {
       label: 'GBRAID',
       description:
-        'The click identifier for clicks associated with app conversions and originating from iOS devices starting with iOS14.',
-      type: 'string'
+        'The click identifier for clicks associated with app conversions and originating from iOS devices starting with iOS14. if not provided, GCLID or WBRAID is required.',
+      type: 'string',
+      required: {
+        match: 'all',
+        conditions: [
+          { fieldKey: 'gclid', operator: 'is_not', value: [undefined, null, ''] },
+          { fieldKey: 'wbraid', operator: 'is_not', value: [undefined, null, ''] }
+        ]
+      }
     },
     wbraid: {
       label: 'WBRAID',
       description:
-        'The click identifier for clicks associated with web conversions and originating from iOS devices starting with iOS14.',
-      type: 'string'
+        'The click identifier for clicks associated with web conversions and originating from iOS devices starting with iOS14. if not provided, GCLID or GBRAID is required.',
+      type: 'string',
+      required: {
+        match: 'all',
+        conditions: [
+          { fieldKey: 'gclid', operator: 'is_not', value: [undefined, null, ''] },
+          { fieldKey: 'gbraid', operator: 'is_not', value: [undefined, null, ''] }
+        ]
+      }
     },
     conversion_timestamp: {
       label: 'Conversion Timestamp',
@@ -207,7 +228,7 @@ const action: ActionDefinition<Settings, Payload> = {
     custom_variables: {
       label: 'Custom Variables',
       description:
-        'The custom variables associated with this conversion. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value See [Google’s documentation on how to create custom conversion variables.](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables) ',
+        'The custom variables associated with this conversion. Will not be sent if GBRAID or WBRAID fields populated. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value See [Google’s documentation on how to create custom conversion variables.](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables) ',
       type: 'object',
       additionalProperties: true,
       defaultObjectUI: 'keyvalue:only'
@@ -316,7 +337,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
 
       // Retrieves all of the custom variables that the customer has created in their Google Ads account
-      if (payload.custom_variables) {
+      if (payload.custom_variables && !payload.gbraid && !payload.wbraid) {
         const customVariableIds = await getCustomVariables(settings.customerId, auth, request, features, statsContext)
         if (customVariableIds?.data?.length) {
           request_object.customVariables = formatCustomVariables(

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -47,7 +47,8 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     gclid: {
       label: 'GCLID',
-      description: 'The Google click ID (gclid) associated with this conversion. One of GCLID, GBRAID or WBRAID must be provided.',
+      description:
+        'The Google click ID (gclid) associated with this conversion. One of GCLID, GBRAID or WBRAID must be provided.',
       type: 'string'
     },
     gbraid: {
@@ -268,9 +269,9 @@ const action: ActionDefinition<Settings, Payload> = {
           'Customer ID is required for this action. Please set it in destination settings.'
         )
       }
-      
+
       if ([payload.gclid, payload.gbraid, payload.wbraid].filter(Boolean).length !== 1) {
-        throw new PayloadValidationError('Only one of GCLID, GBRAID or WBRAID should be provided.')
+        throw new PayloadValidationError('Exactly one of GCLID, GBRAID or WBRAID should be provided.')
       }
 
       settings.customerId = settings.customerId.replace(/-/g, '')

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -47,19 +47,19 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     gclid: {
       label: 'GCLID',
-      description: 'The Google click ID (gclid) associated with this conversion. if not provided, GBRAID or WBRAID is required.',
+      description: 'The Google click ID (gclid) associated with this conversion. One of GCLID, GBRAID or WBRAID must be provided.',
       type: 'string'
     },
     gbraid: {
       label: 'GBRAID',
       description:
-        'The click identifier for clicks associated with app conversions and originating from iOS devices starting with iOS14. if not provided, GCLID or WBRAID is required.',
+        'The click identifier for clicks associated with app conversions and originating from iOS devices starting with iOS14. One of GCLID, GBRAID or WBRAID must be provided.',
       type: 'string'
     },
     wbraid: {
       label: 'WBRAID',
       description:
-        'The click identifier for clicks associated with web conversions and originating from iOS devices starting with iOS14. if not provided, GCLID or GBRAID is required.',
+        'The click identifier for clicks associated with web conversions and originating from iOS devices starting with iOS14. One of GCLID, GBRAID or WBRAID must be provided.',
       type: 'string'
     },
     conversion_timestamp: {
@@ -207,7 +207,7 @@ const action: ActionDefinition<Settings, Payload> = {
     custom_variables: {
       label: 'Custom Variables',
       description:
-        'The custom variables associated with this conversion. Will not be sent if GBRAID or WBRAID fields populated. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value See [Google’s documentation on how to create custom conversion variables.](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables) ',
+        'The custom variables associated with this conversion. On the left-hand side, input the name of the custom variable as it appears in your Google Ads account. On the right-hand side, map the Segment field that contains the corresponding value. Will not be sent if GBRAID or WBRAID fields populated. See [Google’s documentation on how to create custom conversion variables.](https://developers.google.com/google-ads/api/docs/conversions/conversion-custom-variables) ',
       type: 'object',
       additionalProperties: true,
       defaultObjectUI: 'keyvalue:only'
@@ -381,17 +381,18 @@ const action: ActionDefinition<Settings, Payload> = {
       )
     }
 
+    // It would be preferable to validate using required: field conditions, but they don't work for this use case.
     const validatedPayloads: Payload[] = payload.reduce<Payload[]>((acc, p) => {
       if ([p.gclid, p.gbraid, p.wbraid].filter(Boolean).length !== 1) {
         if (p.gclid) {
-          delete p.gbraid
-          delete p.wbraid
+          p.gbraid = undefined
+          p.wbraid = undefined
         } else if (p.gbraid) {
-          delete p.gclid
-          delete p.wbraid
+          p.gclid = undefined
+          p.wbraid = undefined
         } else if (p.wbraid) {
-          delete p.gclid
-          delete p.gbraid
+          p.gclid = undefined
+          p.gbraid = undefined
         } else {
           return acc // skip this item
         }


### PR DESCRIPTION
Rewrite of this [PR](https://github.com/segmentio/action-destinations/pull/2365) but with a different approach which should work for performBatch as well as individual events. 

Change in functionality as follows: 

- These 2 Actions are changed: `uploadClickConversion, uploadClickConversion2`
- Changes for both are the same. 
- Change 1: only one of `gclid, wbraid or gbraid` fields should be accepted. For perform() we throw an error if this condition not met. For performBatch() we remove additional fields in order of priority but we don't throw an error. 
- Change 2: `customVariables` object should not be included in payload if either `gbraid` or `wbraid` present. 

For Change 1, it would have been preferable to use field conditions to validate, however the field condition capability isn't flexible enough to do this, and are not compatible with unit tests. I've messaged Nick AG about this. If the field conditions capability is improved then this PR should be revisited. 

## Testing

Multiple unit tests updated and new tests added. 