### PR TITLE
Show the batch size field

### DIFF
--- a/packages/destination-actions/src/destinations/drip/identify/index.ts
+++ b/packages/destination-actions/src/destinations/drip/identify/index.ts
@@ -106,7 +106,7 @@ const action: ActionDefinition<Settings, Payload> = {
         'Maximum number of events to include in each batch. Actual batch sizes may be lower. Max size must be between 1 and 1000 inclusive.',
       type: 'integer',
       required: false,
-      unsafe_hidden: true,
+      unsafe_hidden: false,
       default: 1000,
       minimum: 1,
       maximum: 1000


### PR DESCRIPTION
Show the batch size field in the UI for the Drip (Actions) Identify action.

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
