### PR TITLE
[STRATCONN-5918] Support contact details on Mantle Identify

### DIFF
--- a/packages/destination-actions/src/destinations/mantle/identify/generated-types.ts
+++ b/packages/destination-actions/src/destinations/mantle/identify/generated-types.ts
@@ -27,4 +27,20 @@ export interface Payload {
   customFields?: {
     [k: string]: unknown
   }
+  /**
+   * The name of the contact / user
+   */
+  contactName?: string
+  /**
+   * The email of the contact / user
+   */
+  contactEmail?: string
+  /**
+   * The phone number of the contact / user
+   */
+  contactPhone?: string
+  /**
+   * The role of the contact / user. For example primary, secondary, user, etc
+   */
+  contactRole?: string
 }

--- a/packages/destination-actions/src/destinations/mantle/identify/index.ts
+++ b/packages/destination-actions/src/destinations/mantle/identify/index.ts
@@ -54,6 +54,34 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.traits.custom_fields'
       }
+    },
+    contactName: {
+      label: 'Contact Name',
+      description: 'The name of the contact / user',
+      type: 'string',
+      required: false,
+      default: { '@path': '$.traits.contact_name' }
+    },
+    contactEmail: {
+      label: 'Contact Email',
+      description: 'The email of the contact / user',
+      type: 'string',
+      required: false,
+      default: { '@path': '$.traits.contact_email' }
+    },
+    contactPhone: {
+      label: 'Contact Phone',
+      description: 'The phone number of the contact / user',
+      type: 'string',
+      required: false,
+      default: { '@path': '$.traits.contact_phone' }
+    },
+    contactRole: {
+      label: 'Contact Role',
+      description: 'The role of the contact / user. For example primary, secondary, user, etc',
+      type: 'string',
+      required: false,
+      default: { '@path': '$.traits.contact_role' }
     }
   },
   perform: (request, data) => {
@@ -66,7 +94,19 @@ const action: ActionDefinition<Settings, Payload> = {
         name: data.payload.name,
         email: data.payload.email,
         ...(data.payload.platformPlanName ? { platformPlanName: data.payload.platformPlanName } : {}),
-        ...(data.payload.customFields ? { customFields: data.payload.customFields } : {})
+        ...(data.payload.customFields ? { customFields: data.payload.customFields } : {}),
+        ...(data.payload.contactEmail && data.payload.contactRole
+          ? {
+              contacts: [
+                {
+                  email: data.payload.contactEmail,
+                  label: data.payload.contactRole,
+                  ...(data.payload.contactPhone ? { phone: data.payload.contactPhone } : {}),
+                  ...(data.payload.contactName ? { name: data.payload.contactName } : {})
+                }
+              ]
+            }
+          : {})
       }
     })
   }


### PR DESCRIPTION
Update the Mantle Identify action to support contact name/email/role inputs, which will create the contact in Mantle.

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
