### PR TITLE
[Liveramp] Add bucket path mapping in liveramp S3

### DIFF
--- a/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/liveramp.test.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/liveramp.test.ts
@@ -83,7 +83,8 @@ describe('Liveramp Audiences', () => {
           audience_key: 'audience_key',
           delimiter: ',',
           filename: 'filename.csv',
-          enable_batching: true
+          enable_batching: true,
+          s3_aws_bucket_path: 'folder1/folder2'
         },
         subscriptionMetadata: {
           destinationConfigId: 'destinationConfigId',
@@ -125,6 +126,39 @@ describe('Liveramp Audiences', () => {
         expect(e).toBeInstanceOf(PayloadValidationError)
         expect(e.message).toEqual(
           `received payload count below LiveRamp's ingestion limits. expected: >=${LIVERAMP_MIN_RECORD_COUNT} actual: 3`
+        )
+        expect(e.status).toEqual(400)
+      }
+    })
+
+    it(`should throw error if S3 bucket path is invalid`, async () => {
+      try {
+        await testDestination.executeBatch('audienceEnteredS3', {
+          events: mockedEvents,
+          mapping: {
+            s3_aws_access_key: 's3_aws_access_key',
+            s3_aws_secret_key: 's3_aws_secret_key',
+            s3_aws_bucket_name: 's3_aws_bucket_name',
+            s3_aws_region: 's3_aws_region',
+            audience_key: 'audience_key',
+            delimiter: ',',
+            filename: 'filename.csv',
+            enable_batching: true,
+            s3_aws_bucket_path: '/invalid[]/path/'
+          },
+          subscriptionMetadata: {
+            destinationConfigId: 'destinationConfigId',
+            actionConfigId: 'actionConfigId'
+          },
+          settings: {
+            __segment_internal_engage_force_full_sync: true,
+            __segment_internal_engage_batch_sync: true
+          }
+        })
+      } catch (e) {
+        expect(e).toBeInstanceOf(PayloadValidationError)
+        expect(e.message).toEqual(
+          `Invalid S3 bucket path. It must be a valid S3 object key, avoid leading/trailing slashes and forbidden characters (e.g., \\ { } ^ [ ] % \` " < > # | ~). Use a relative path like "folder1/folder2".`
         )
         expect(e.status).toEqual(400)
       }

--- a/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/snapshot.test.ts
@@ -81,6 +81,7 @@ describe(`Testing snapshot for ${destinationSlug}'s audienceEnteredS3 destinatio
     eventData.s3_aws_bucket_name = 'bucket'
     eventData.s3_aws_region = 'us-west'
     eventData.filename = 'myfile'
+    eventData.s3_aws_bucket_path = 'folder1/folder2'
 
     nock(/.*/).persist().get(/.*/).reply(200)
     nock(/.*/).persist().post(/.*/).reply(200)

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/generated-types.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/generated-types.ts
@@ -50,7 +50,7 @@ export interface Payload {
    */
   batch_size?: number
   /**
-   * Optional path within the S3 bucket where the files will be uploaded to. If not provided, files will be uploaded to the root of the bucket. Example: "audiences/"
+   * Optional path within the S3 bucket where the files will be uploaded to. If not provided, files will be uploaded to the root of the bucket. Example: "folder1/folder2"
    */
   s3_aws_bucket_path?: string
 }

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/generated-types.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/generated-types.ts
@@ -49,4 +49,8 @@ export interface Payload {
    * Maximum number of events to include in each batch. Actual batch sizes may be lower.
    */
   batch_size?: number
+  /**
+   * Optional path within the S3 bucket where the files will be uploaded to. If not provided, files will be uploaded to the root of the bucket. Example: "audiences/"
+   */
+  s3_aws_bucket_path?: string
 }

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
@@ -153,7 +153,7 @@ async function processData(input: ProcessDataInput<Payload>, subscriptionMetadat
     return sendEventToAWS(input.request, {
       audienceComputeId: input.rawData?.[0].context?.personas?.computation_id,
       uploadType: 's3',
-      filename: input.payloads[0].s3_aws_bucket_path ? `${input.payloads[0].s3_aws_bucket_path}/${filename}` : filename,
+      filename: filename,
       destinationInstanceID: subscriptionMetadata?.destinationConfigId,
       subscriptionId: subscriptionMetadata?.actionConfigId,
       fileContents,
@@ -161,7 +161,8 @@ async function processData(input: ProcessDataInput<Payload>, subscriptionMetadat
         s3BucketName: input.payloads[0].s3_aws_bucket_name,
         s3Region: input.payloads[0].s3_aws_region,
         s3AccessKeyId: input.payloads[0].s3_aws_access_key,
-        s3SecretAccessKey: input.payloads[0].s3_aws_secret_key
+        s3SecretAccessKey: input.payloads[0].s3_aws_secret_key,
+        s3BucketPath: input.payloads[0].s3_aws_bucket_path
       }
     })
   }

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, PayloadValidationError } from '@segment/actions-core'
-import { isValidS3Path, uploadS3 } from './s3'
+import { isValidS3Path, normalizeS3Path, uploadS3 } from './s3'
 import { generateFile } from '../operations'
 import { sendEventToAWS } from '../awsClient'
 import { LIVERAMP_MIN_RECORD_COUNT, LIVERAMP_LEGACY_FLOW_FLAG_NAME } from '../properties'
@@ -131,11 +131,11 @@ async function processData(input: ProcessDataInput<Payload>, subscriptionMetadat
     )
   }
 
-  // ? Is it ok to assume that all the payloads will have the same path?
   // validate s3 path
+  input.payloads[0].s3_aws_bucket_path = normalizeS3Path(input.payloads[0].s3_aws_bucket_path)
   if (input.payloads[0].s3_aws_bucket_path && !isValidS3Path(input.payloads[0].s3_aws_bucket_path)) {
     throw new PayloadValidationError(
-      `Invalid S3 bucket path: ${input.payloads[0].s3_aws_bucket_path}. Must be a valid S3 URI format (e.g., s3://bucket-name/path/).`
+      `Invalid S3 bucket path. It must be a valid S3 object key, avoid leading/trailing slashes and forbidden characters (e.g., \\ { } ^ [ ] % \` " < > # | ~). Use a relative path like "folder1/folder2".`
     )
   }
 

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
@@ -89,7 +89,7 @@ const action: ActionDefinition<Settings, Payload> = {
     s3_aws_bucket_path: {
       label: 'AWS Bucket Path [optional]',
       description:
-        'Optional path within the S3 bucket where the files will be uploaded to. If not provided, files will be uploaded to the root of the bucket. Example: "audiences/"',
+        'Optional path within the S3 bucket where the files will be uploaded to. If not provided, files will be uploaded to the root of the bucket. Example: "folder1/folder2"',
       required: false,
       type: 'string'
     }

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/s3.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/s3.ts
@@ -20,6 +20,15 @@ function validateS3(payload: Payload) {
   }
 }
 
+function isValidS3Path(path: string): boolean {
+  if (typeof path !== 'string') return false
+  if (path.startsWith('/')) return false
+  if (path.includes('\\')) return false
+  const byteLength = Buffer.byteLength(path, 'utf8')
+  if (byteLength > 1024) return false
+  return true
+}
+
 async function uploadS3(
   payload: Payload,
   filename: string,
@@ -47,4 +56,4 @@ async function uploadS3(
   })
 }
 
-export { validateS3, uploadS3 }
+export { validateS3, uploadS3, isValidS3Path }

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/s3.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/s3.ts
@@ -20,15 +20,6 @@ function validateS3(payload: Payload) {
   }
 }
 
-function isValidS3Path(path: string): boolean {
-  if (typeof path !== 'string') return false
-  if (path.startsWith('/')) return false
-  if (path.includes('\\')) return false
-  const byteLength = Buffer.byteLength(path, 'utf8')
-  if (byteLength > 1024) return false
-  return true
-}
-
 async function uploadS3(
   payload: Payload,
   filename: string,
@@ -56,4 +47,45 @@ async function uploadS3(
   })
 }
 
-export { validateS3, uploadS3, isValidS3Path }
+/**
+ * Checks whether the provided string is a valid S3 object key path.
+ * https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-choose
+ *
+ * @param key - The S3 object key path to validate.
+ * @returns `true` if the key is valid according to the above rules, otherwise `false`.
+ */
+function isValidS3Path(key: string): boolean {
+  const encoder = new TextEncoder()
+  const byteLength = encoder.encode(key).length
+  if (byteLength > 1024 || key.trim() === '') {
+    return false
+  }
+
+  const forbiddenChars = new Set(['\\', '{', '}', '^', '[', ']', '%', '`', '"', '<', '>', '#', '|', '~'])
+
+  for (let i = 0; i < key.length; i++) {
+    const charCode = key.charCodeAt(i)
+
+    if ((charCode >= 0 && charCode <= 31) || (charCode >= 128 && charCode <= 255)) {
+      return false
+    }
+
+    if (forbiddenChars.has(key[i])) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * Normalizes an S3 path by removing any leading or trailing slashes.
+ *
+ * @param path - The S3 path to normalize. Can be undefined.
+ * @returns The normalized S3 path without leading or trailing slashes, or undefined if the input is undefined.
+ */
+function normalizeS3Path(path?: string): string | undefined {
+  return path?.replace(/^\/+|\/+$/g, '')
+}
+
+export { validateS3, uploadS3, isValidS3Path, normalizeS3Path }

--- a/packages/destination-actions/src/destinations/liveramp-audiences/awsClient.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/awsClient.ts
@@ -23,6 +23,7 @@ interface SendToAWSRequest {
     s3Region?: string
     s3AccessKeyId?: string
     s3SecretAccessKey?: string
+    s3BucketPath?: string
   }
 }
 
@@ -42,6 +43,7 @@ interface LRMetaPayload {
     s3Region: string
     s3AccessKeyId: string
     s3SecretAccessKey: string
+    s3BucketPath?: string
   }
 }
 
@@ -90,7 +92,8 @@ export const sendEventToAWS = async (request: RequestClient, input: SendToAWSReq
       s3BucketName: input.s3Info?.s3BucketName || '',
       s3Region: input.s3Info?.s3Region || '',
       s3AccessKeyId: input.s3Info?.s3AccessKeyId || '',
-      s3SecretAccessKey: input.s3Info?.s3SecretAccessKey || ''
+      s3SecretAccessKey: input.s3Info?.s3SecretAccessKey || '',
+      s3BucketPath: input.s3Info?.s3BucketPath || ''
     }
   }
 


### PR DESCRIPTION
Due to regulatory requirements, EU region customers require files to be uploaded to a designated folder within the S3 bucket.

- Add a new S3 bucket folder mapping
- sanitise and validate the S3 bucket path
- pass the path in the meta file to be read in integrations-outbound-controller.

JIRA -> https://twilio-engineering.atlassian.net/browse/STRATCONN-5844

[Related `integrations-outbound-controller` PR](https://github.com/segmentio/integrations-outbound-controller/pull/39)

## Testing

Tested completed successfully in staging via app and internal-k8s-bulkapi.

[Stage testing doc.](https://docs.google.com/document/d/19hNXe3QU5a5GCWmeRoEe4kJcZmi_ySG0XXuoCWdkv-E/edit?usp=sharing)

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
