### PR TITLE
Add batch keys for braze cohorts

### DIFF
--- a/packages/destination-actions/src/destinations/braze-cohorts/syncAudiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/braze-cohorts/syncAudiences/generated-types.ts
@@ -42,4 +42,8 @@ export interface Payload {
    * When the event occurred.
    */
   time: string
+  /**
+   * The keys to use for batching the events.
+   */
+  batch_keys?: string[]
 }

--- a/packages/destination-actions/src/destinations/braze-cohorts/syncAudiences/index.ts
+++ b/packages/destination-actions/src/destinations/braze-cohorts/syncAudiences/index.ts
@@ -101,6 +101,15 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.timestamp'
       }
+    },
+    batch_keys: {
+      label: 'Batch Keys',
+      description: 'The keys to use for batching the events.',
+      type: 'string',
+      unsafe_hidden: true,
+      default: ['cohort_name'], // This ensures all payloads from same audience are batched together.
+      multiple: true,
+      required: false
     }
   },
   perform: async (request, { settings, payload, stateContext }) => {


### PR DESCRIPTION
This PR adds batch keys for braze cohorts. Cohorts doesnot implement an audience destination defintion but it requires events to be batched together by computation_key.


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
