### PR TITLE
STRATCONN-5919 [Kafka] - Connections bug

### DIFF
--- a/packages/destination-actions/src/destinations/kafka/constants.ts
+++ b/packages/destination-actions/src/destinations/kafka/constants.ts
@@ -1,3 +1,5 @@
 export const PRODUCER_TTL_MS = Number(process.env.KAFKA_PRODUCER_TTL_MS) || 0.5 * 60 * 1000 // defaults to 30 seconds
 
+export const PRODUCER_REQUEST_TIMEOUT_MS = Number(process.env.KAFKA_PRODUCER_REQUEST_TIMEOUT_MS) || 10 * 1000 // defaults to 10 seconds
+
 export const FLAGON_NAME = 'actions-kafka-optimize-connection'

--- a/packages/destination-actions/src/destinations/kafka/constants.ts
+++ b/packages/destination-actions/src/destinations/kafka/constants.ts
@@ -1,3 +1,3 @@
-export const PRODUCER_TTL_MS = 0.5 * 60 * 1000 // 30 seconds
+export const PRODUCER_TTL_MS = Number(process.env.KAFKA_PRODUCER_TTL_MS) || 0.5 * 60 * 1000 // defaults to 30 seconds
 
 export const FLAGON_NAME = 'actions-kafka-optimize-connection'

--- a/packages/destination-actions/src/destinations/kafka/constants.ts
+++ b/packages/destination-actions/src/destinations/kafka/constants.ts
@@ -1,0 +1,3 @@
+export const PRODUCER_TTL_MS = 0.5 * 60 * 1000 // 30 seconds
+
+export const FLAGON_NAME = 'actions-kafka-optimize-connection'

--- a/packages/destination-actions/src/destinations/kafka/depends-on.ts
+++ b/packages/destination-actions/src/destinations/kafka/depends-on.ts
@@ -1,0 +1,40 @@
+import { DependsOnConditions } from '@segment/actions-core/destination-kittypes'
+
+export const DEPENDS_ON_PLAIN_OR_SCRAM: DependsOnConditions = {
+  match: 'any',
+  conditions: [
+    {
+      fieldKey: 'mechanism',
+      operator: 'is',
+      value: 'plain'
+    },
+    {
+      fieldKey: 'mechanism',
+      operator: 'is',
+      value: 'scram-sha-256'
+    },
+    {
+      fieldKey: 'mechanism',
+      operator: 'is',
+      value: 'scram-sha-512'
+    }
+  ]
+}
+export const DEPEONDS_ON_AWS: DependsOnConditions = {
+  conditions: [
+    {
+      fieldKey: 'mechanism',
+      operator: 'is',
+      value: 'aws'
+    }
+  ]
+}
+export const DEPENDS_ON_CLIENT_CERT: DependsOnConditions = {
+  conditions: [
+    {
+      fieldKey: 'mechanism',
+      operator: 'is',
+      value: 'client-cert-auth'
+    }
+  ]
+}

--- a/packages/destination-actions/src/destinations/kafka/index.ts
+++ b/packages/destination-actions/src/destinations/kafka/index.ts
@@ -1,6 +1,7 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
-import { validate, getTopics, DEPENDS_ON_CLIENT_CERT, DEPEONDS_ON_AWS, DEPENDS_ON_PLAIN_OR_SCRAM } from './utils'
+import { validate, getTopics } from './utils'
+import { DEPENDS_ON_CLIENT_CERT, DEPEONDS_ON_AWS, DEPENDS_ON_PLAIN_OR_SCRAM } from './depends-on'
 import send from './send'
 
 const destination: DestinationDefinition<Settings> = {

--- a/packages/destination-actions/src/destinations/kafka/send/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/kafka/send/__tests__/index.test.ts
@@ -68,6 +68,7 @@ describe('Kafka.send', () => {
      {
         clientId: 'yourClientId',
         brokers: ['yourBroker'],
+        requestTimeout: 10000,
         ssl: true,
         sasl: {
           mechanism: 'plain',
@@ -93,6 +94,7 @@ describe('Kafka.send', () => {
      {
         clientId: 'yourClientId',
         brokers: ['yourBroker'],
+        requestTimeout: 10000,
         ssl: true,
         sasl: {
           mechanism: 'scram-sha-256',
@@ -118,6 +120,7 @@ describe('Kafka.send', () => {
      {
         clientId: 'yourClientId',
         brokers: ['yourBroker'],
+        requestTimeout: 10000,
         ssl: true,
         sasl: {
           mechanism: 'scram-sha-512',
@@ -146,6 +149,7 @@ describe('Kafka.send', () => {
      {
         clientId: 'yourClientId',
         brokers: ['yourBroker'],
+        requestTimeout: 10000,
         ssl: true,
         sasl: {
           mechanism: 'aws',
@@ -173,6 +177,7 @@ describe('Kafka.send', () => {
      {
         clientId: 'yourClientId',
         brokers: ['yourBroker'],
+        requestTimeout: 10000,
         ssl: {
           ca: ['-----BEGIN CERTIFICATE-----\nyourCACert\n-----END CERTIFICATE-----'],
           rejectUnauthorized: true
@@ -208,6 +213,7 @@ describe('Kafka.send', () => {
      {
         clientId: 'yourClientId',
         brokers: ['yourBroker'],
+        requestTimeout: 10000,
         ssl: {
           ca: ['-----BEGIN CERTIFICATE-----\nyourCACert\n-----END CERTIFICATE-----'],
           rejectUnauthorized: true,

--- a/packages/destination-actions/src/destinations/kafka/send/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/kafka/send/__tests__/index.test.ts
@@ -1,6 +1,9 @@
 import { createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 import { Kafka, KafkaConfig, Partitioners } from 'kafkajs'
+import { producersByConfig, serializeKafkaConfig, getOrCreateProducer } from '../../utils'
+import { Settings } from '../../generated-types'
+import { Producer } from 'kafkajs'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -239,5 +242,136 @@ describe('Kafka.send', () => {
         }
       ]
     })
+  })
+
+  it('serializeKafkaConfig() generates the correct producer connection cache key', async () => {
+    const settings: Settings = {
+      clientId: 'testClientId',
+      brokers: 'https://broker1:9092,https://broker2:9092',
+      mechanism: 'plain',
+      username: 'testUsername',
+      password: 'testPassword',
+      accessKeyId: 'testAccessKeyId',
+      secretAccessKey: 'testSecretAccessKey',
+      authorizationIdentity: 'testAuthorizationIdentity',
+      ssl_ca: 'testCACert',
+      ssl_cert: 'testCert',
+      ssl_key: 'testKey',
+      ssl_reject_unauthorized_ca: true,
+      ssl_enabled: true
+    }
+
+    const key = serializeKafkaConfig(settings)
+    expect(typeof key).toBe('string')
+    expect(key).toBe('{"clientId":"testClientId","brokers":["https://broker1:9092","https://broker2:9092"],"mechanism":"plain","username":"testUsername","password":"testPassword","accessKeyId":"testAccessKeyId","secretAccessKey":"testSecretAccessKey","authorizationIdentity":"testAuthorizationIdentity","ssl_ca":"testCACert","ssl_cert":"testCert","ssl_key":"testKey","ssl_reject_unauthorized_ca":true,"ssl_enabled":true}')
+  })
+
+  it('serializeKafkaConfig generates the correct producer connection cache key', async () => {
+    const settings: Settings = {
+      clientId: 'testClientId',
+      brokers: 'https://broker1:9092,https://broker2:9092',
+      mechanism: 'plain',
+      username: 'testUsername',
+      password: 'testPassword',
+      accessKeyId: 'testAccessKeyId',
+      secretAccessKey: 'testSecretAccessKey',
+      authorizationIdentity: 'testAuthorizationIdentity',
+      ssl_ca: 'testCACert',
+      ssl_cert: 'testCert',
+      ssl_key: 'testKey',
+      ssl_reject_unauthorized_ca: true,
+      ssl_enabled: true
+    }
+
+    const key = serializeKafkaConfig(settings)
+    expect(typeof key).toBe('string')
+    expect(key).toBe('{"clientId":"testClientId","brokers":["https://broker1:9092","https://broker2:9092"],"mechanism":"plain","username":"testUsername","password":"testPassword","accessKeyId":"testAccessKeyId","secretAccessKey":"testSecretAccessKey","authorizationIdentity":"testAuthorizationIdentity","ssl_ca":"testCACert","ssl_cert":"testCert","ssl_key":"testKey","ssl_reject_unauthorized_ca":true,"ssl_enabled":true}')
+  })
+})
+
+describe('getOrCreateProducer', () => {
+  const settings = {
+    clientId: 'testClientId',
+    brokers: 'https://broker1:9092,https://broker2:9092',
+    mechanism: 'plain',
+    username: 'testUsername',
+    password: 'testPassword',
+    accessKeyId: 'testAccessKeyId',
+    secretAccessKey: 'testSecretAccessKey',
+    authorizationIdentity: 'testAuthorizationIdentity',
+    ssl_ca: 'testCACert',
+    ssl_cert: 'testCert',
+    ssl_key: 'testKey',
+    ssl_reject_unauthorized_ca: true,
+    ssl_enabled: true
+  }
+
+  afterEach(() => {
+    for (const key in producersByConfig) {
+      delete producersByConfig[key]
+    }
+    jest.restoreAllMocks()
+  })
+
+  it('getOrCreateProducer ensures existing connections are reused', async () => {
+    const now = Date.now()
+    const key = serializeKafkaConfig(settings)
+
+    const fakeProducer = {
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+      send: jest.fn(),
+      sendBatch: jest.fn(),
+      transaction: jest.fn()
+    } as unknown as Producer
+
+    // Insert into producer cache as active and recent
+    producersByConfig[key] = {
+      producer: fakeProducer,
+      isConnected: true,
+      lastUsed: now
+    }
+
+    jest.spyOn(Date, 'now').mockReturnValue(now)
+
+    const result = await getOrCreateProducer(settings, undefined)
+
+    expect(result).toBe(fakeProducer)
+    expect(fakeProducer.connect).not.toHaveBeenCalled()
+  })
+
+  it('getOrCreateProducer replaces expired connections and creates a new connection', async () => {
+    const now = Date.now()
+    const expiredTime = now - (31 * 60 * 1000) // 31 minutes ago
+    const key = serializeKafkaConfig(settings)
+
+    const oldProducer = {
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+      send: jest.fn(),
+      sendBatch: jest.fn(),
+      transaction: jest.fn()
+    } as unknown as Producer
+
+    // Put expired producer in cache
+    producersByConfig[key] = {
+      producer: oldProducer,
+      isConnected: true,
+      lastUsed: expiredTime
+    }
+
+    jest.spyOn(Date, 'now').mockReturnValue(now)
+
+    const result = await getOrCreateProducer(settings, undefined)
+
+    // Expect the old producer to be cleaned up
+    expect(oldProducer.disconnect).toHaveBeenCalled()
+
+    // Expect a new producer to have connected
+    expect(result.connect).toHaveBeenCalled()
+
+    // Cache should now hold a new producer
+    expect(producersByConfig[key].producer).toBe(result)
+    expect(result).not.toBe(oldProducer)
   })
 })

--- a/packages/destination-actions/src/destinations/kafka/send/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/kafka/send/__tests__/index.test.ts
@@ -337,7 +337,7 @@ describe('getOrCreateProducer', () => {
     const result = await getOrCreateProducer(settings, undefined)
 
     expect(result).toBe(fakeProducer)
-    expect(fakeProducer.connect).not.toHaveBeenCalled()
+    expect(fakeProducer.connect).toHaveBeenCalled() // this is a no-op since it's already connected, but is done to ensure the producer is ready anyway. It's an  idempotent operation.
   })
 
   it('getOrCreateProducer replaces expired connections and creates a new connection', async () => {

--- a/packages/destination-actions/src/destinations/kafka/send/index.ts
+++ b/packages/destination-actions/src/destinations/kafka/send/index.ts
@@ -49,11 +49,11 @@ const action: ActionDefinition<Settings, Payload> = {
       return getTopics(settings)
     }
   },
-  perform: async (_request, { settings, payload }) => {
-    await sendData(settings, [payload])
+  perform: async (_request, { settings, payload, features }) => {
+    await sendData(settings, [payload], features)
   },
-  performBatch: async (_request, { settings, payload }) => {
-    await sendData(settings, payload)
+  performBatch: async (_request, { settings, payload, features }) => {
+    await sendData(settings, payload, features)
   }
 }
 

--- a/packages/destination-actions/src/destinations/kafka/send/index.ts
+++ b/packages/destination-actions/src/destinations/kafka/send/index.ts
@@ -49,11 +49,11 @@ const action: ActionDefinition<Settings, Payload> = {
       return getTopics(settings)
     }
   },
-  perform: async (_request, { settings, payload, features }) => {
-    await sendData(settings, [payload], features)
+  perform: async (_request, { settings, payload, features, statsContext }) => {
+    await sendData(settings, [payload], features, statsContext)
   },
-  performBatch: async (_request, { settings, payload, features }) => {
-    await sendData(settings, payload, features)
+  performBatch: async (_request, { settings, payload, features, statsContext }) => {
+    await sendData(settings, payload, features, statsContext)
   }
 }
 

--- a/packages/destination-actions/src/destinations/kafka/types.ts
+++ b/packages/destination-actions/src/destinations/kafka/types.ts
@@ -1,0 +1,28 @@
+export const DEFAULT_PARTITIONER = 'DefaultPartitioner'
+import { Producer } from 'kafkajs'
+
+export interface Message {
+  value: string
+  key?: string
+  headers?: { [key: string]: string }
+  partition?: number
+  partitionerType?: typeof DEFAULT_PARTITIONER
+}
+
+export interface TopicMessages {
+  topic: string
+  messages: Message[]
+}
+
+export interface SSLConfig {
+  ca: string[]
+  rejectUnauthorized?: boolean
+  key?: string
+  cert?: string
+}
+
+export interface CachedProducer {
+  producer: Producer
+  isConnected: boolean
+  lastUsed: number
+}

--- a/packages/destination-actions/src/destinations/kafka/utils.ts
+++ b/packages/destination-actions/src/destinations/kafka/utils.ts
@@ -6,9 +6,9 @@ import { DEFAULT_PARTITIONER, Message, TopicMessages, SSLConfig, CachedProducer 
 import { PRODUCER_TTL_MS, FLAGON_NAME } from './constants'
 import { StatsContext } from '@segment/actions-core/destination-kit'
 
-const producersByConfig: Record<string, CachedProducer> = {}
+export const producersByConfig: Record<string, CachedProducer> = {}
 
-const serializeKafkaConfig = (settings: Settings): string => {
+export const serializeKafkaConfig = (settings: Settings): string => {
   const config = {
     clientId: settings.clientId,
     brokers: settings.brokers

--- a/packages/destination-actions/src/destinations/kafka/utils.ts
+++ b/packages/destination-actions/src/destinations/kafka/utils.ts
@@ -147,9 +147,9 @@ export const getOrCreateProducer = async (settings: Settings, statsContext: Stat
     if (!isExpired) {
       cached.lastUsed = now
       statsContext?.statsClient?.incr('kafka_connection_reused', 1, statsContext?.tags)
+      await cached.producer.connect() // this is idempotent, so is safe
       return cached.producer
     }
-
     if (cached.isConnected) {
       try {
         statsContext?.statsClient?.incr('kafka_connection_closed', 1, statsContext?.tags)
@@ -158,7 +158,6 @@ export const getOrCreateProducer = async (settings: Settings, statsContext: Stat
         statsContext?.statsClient?.incr('kafka_disconnect_error', 1, statsContext?.tags)
       }
     }
-
     delete producersByConfig[key]
   }
 
@@ -171,7 +170,6 @@ export const getOrCreateProducer = async (settings: Settings, statsContext: Stat
     isConnected: true,
     lastUsed: now
   }
-
   return producer
 }
 

--- a/packages/destination-actions/src/destinations/kafka/utils.ts
+++ b/packages/destination-actions/src/destinations/kafka/utils.ts
@@ -1,68 +1,34 @@
-import { Kafka, ProducerRecord, Partitioners, SASLOptions, KafkaConfig, KafkaJSError } from 'kafkajs'
-import { DynamicFieldResponse, IntegrationError } from '@segment/actions-core'
+import { Kafka, ProducerRecord, Partitioners, SASLOptions, KafkaConfig, KafkaJSError, Producer } from 'kafkajs'
+import { DynamicFieldResponse, IntegrationError, Features } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import type { Payload } from './send/generated-types'
-import { DependsOnConditions } from '@segment/actions-core/destination-kittypes'
+import { DEFAULT_PARTITIONER, Message, TopicMessages, SSLConfig, CachedProducer } from './types'
+import { PRODUCER_TTL_MS, FLAGON_NAME } from './constants'
 
-export const DEFAULT_PARTITIONER = 'DefaultPartitioner'
+const producersByConfig: Record<string, CachedProducer> = {}
 
-export const DEPENDS_ON_PLAIN_OR_SCRAM: DependsOnConditions = {
-  match: 'any',
-  conditions: [
-    {
-      fieldKey: 'mechanism',
-      operator: 'is',
-      value: 'plain'
-    },
-    {
-      fieldKey: 'mechanism',
-      operator: 'is',
-      value: 'scram-sha-256'
-    },
-    {
-      fieldKey: 'mechanism',
-      operator: 'is',
-      value: 'scram-sha-512'
-    }
-  ]
-}
-export const DEPEONDS_ON_AWS: DependsOnConditions = {
-  conditions: [
-    {
-      fieldKey: 'mechanism',
-      operator: 'is',
-      value: 'aws'
-    }
-  ]
-}
-export const DEPENDS_ON_CLIENT_CERT: DependsOnConditions = {
-  conditions: [
-    {
-      fieldKey: 'mechanism',
-      operator: 'is',
-      value: 'client-cert-auth'
-    }
-  ]
-}
+const serializeKafkaConfig = (settings: Settings): string => {
+  const config = {
+    clientId: settings.clientId,
+    brokers: settings.brokers
+      .trim()
+      .split(',')
+      .map((b) => b.trim())
+      .sort(),
+    mechanism: settings.mechanism,
+    username: settings.username,
+    password: settings.password,
+    accessKeyId: settings.accessKeyId,
+    secretAccessKey: settings.secretAccessKey,
+    authorizationIdentity: settings.authorizationIdentity,
+    ssl_ca: settings.ssl_ca,
+    ssl_cert: settings.ssl_cert,
+    ssl_key: settings.ssl_key,
+    ssl_reject_unauthorized_ca: settings.ssl_reject_unauthorized_ca,
+    ssl_enabled: settings.ssl_enabled
+  }
 
-interface Message {
-  value: string
-  key?: string
-  headers?: { [key: string]: string }
-  partition?: number
-  partitionerType?: typeof DEFAULT_PARTITIONER
-}
-
-interface TopicMessages {
-  topic: string
-  messages: Message[]
-}
-
-interface SSLConfig {
-  ca: string[]
-  rejectUnauthorized?: boolean
-  key?: string
-  cert?: string
+  return JSON.stringify(config)
 }
 
 export const getTopics = async (settings: Settings): Promise<DynamicFieldResponse> => {
@@ -169,7 +135,44 @@ const getProducer = (settings: Settings) => {
   })
 }
 
-export const sendData = async (settings: Settings, payload: Payload[]) => {
+export const getOrCreateProducer = async (settings: Settings): Promise<Producer> => {
+  const key = serializeKafkaConfig(settings)
+  const now = Date.now()
+
+  const cached = producersByConfig[key]
+
+  if (cached) {
+    const isExpired = now - cached.lastUsed > PRODUCER_TTL_MS
+    if (!isExpired) {
+      cached.lastUsed = now
+      return cached.producer
+    }
+
+    if (cached.isConnected) {
+      try {
+        await cached.producer.disconnect()
+      } catch {
+        // Intentionally ignoring disconnect errors
+      }
+    }
+
+    delete producersByConfig[key]
+  }
+
+  const kafka = getKafka(settings)
+  const producer = kafka.producer({ createPartitioner: Partitioners.DefaultPartitioner })
+  await producer.connect()
+
+  producersByConfig[key] = {
+    producer,
+    isConnected: true,
+    lastUsed: now
+  }
+
+  return producer
+}
+
+export const sendData = async (settings: Settings, payload: Payload[], features: Features | undefined) => {
   validate(settings)
 
   const groupedPayloads: { [topic: string]: Payload[] } = {}
@@ -196,9 +199,13 @@ export const sendData = async (settings: Settings, payload: Payload[]) => {
     )
   }))
 
-  const producer = getProducer(settings)
-
-  await producer.connect()
+  let producer: Producer
+  if (features && features[FLAGON_NAME]) {
+    producer = await getOrCreateProducer(settings)
+  } else {
+    producer = getProducer(settings)
+    await producer.connect()
+  }
 
   for (const data of topicMessages) {
     try {
@@ -212,5 +219,12 @@ export const sendData = async (settings: Settings, payload: Payload[]) => {
     }
   }
 
-  await producer.disconnect()
+  if (features && features[FLAGON_NAME]) {
+    const key = serializeKafkaConfig(settings)
+    if (producersByConfig[key]) {
+      producersByConfig[key].lastUsed = Date.now()
+    }
+  } else {
+    await producer.disconnect()
+  }
 }

--- a/packages/destination-actions/src/destinations/kafka/utils.ts
+++ b/packages/destination-actions/src/destinations/kafka/utils.ts
@@ -3,7 +3,7 @@ import { DynamicFieldResponse, IntegrationError, Features } from '@segment/actio
 import type { Settings } from './generated-types'
 import type { Payload } from './send/generated-types'
 import { DEFAULT_PARTITIONER, Message, TopicMessages, SSLConfig, CachedProducer } from './types'
-import { PRODUCER_TTL_MS, FLAGON_NAME } from './constants'
+import { PRODUCER_REQUEST_TIMEOUT_MS, PRODUCER_TTL_MS, FLAGON_NAME } from './constants'
 import { StatsContext } from '@segment/actions-core/destination-kit'
 
 export const producersByConfig: Record<string, CachedProducer> = {}
@@ -48,6 +48,7 @@ const getKafka = (settings: Settings) => {
       .trim()
       .split(',')
       .map((broker) => broker.trim()),
+    requestTimeout: PRODUCER_REQUEST_TIMEOUT_MS,
     sasl: ((): SASLOptions | undefined => {
       switch (settings.mechanism) {
         case 'plain':


### PR DESCRIPTION
Add Kafka producer connection caching to avoid creating too many connections downstream.  

This uses a static Map of serialized Producer configurations. 

When perform() is called, the key is generated from the settings and the Map is checked to see if the Connection already exists. It also includes a last time used. 

The timeout is set to 30 seconds but can be extended. 

## Testing

Load testing done in Stage. See [JIRA ticket](https://twilio-engineering.atlassian.net/browse/STRATCONN-5919) for details. 
Unit tests added. 
This change will be behind a feature flag named 'actions-kafka-optimize-connection'
