### PR TITLE
Update required-field-check to pin node-version

### DIFF
--- a/.github/workflows/required-field-check.yml
+++ b/.github/workflows/required-field-check.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-22.04
 
     timeout-minutes: 5
-
+    strategy:
+      matrix:
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Required field check has been failing because node verison has been missing.

## Testing

Testing completed successfully via this pr. All checks before this was failing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
