### PR TITLE
[STRATCONN-5882] - Enable gating based on patch code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,7 +15,9 @@ coverage:
   status:
     project:
       default:
+        target: 70%
         informational: false
     patch:
       default:
+        target: 80%
         informational: false


### PR DESCRIPTION
Set project target level to 70% and patch target level to 80%

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
