### PR TITLE
test string length before trying to convert it to a date

### DIFF
--- a/packages/destination-actions/src/destinations/airship/utilities.ts
+++ b/packages/destination-actions/src/destinations/airship/utilities.ts
@@ -378,6 +378,10 @@ function _parse_date(attribute_value: any): Date | null {
   /*
   This function is for converting dates or returning null if they're not valid.
   */
+  if (attribute_value.length < 8) {
+    return null // Reduce false positive dates
+  }
+
   // Attempt to parse the attribute_value as a Date
   const date = new Date(attribute_value)
 


### PR DESCRIPTION
A very simple update to make the code less opportunistic in converting strings to dates. Caught a false positive date conversion that was meant to be a string that met the ISO-8601 standard but was clearly not intended as a date.

This simply tests the length of the string to be sure that it's longer than 7 (for example '20250611' as  opposed to '30122') before trying to cast it as a date.

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
