### PR TITLE
[Google Ads] Fixes Journeys use cases with the userList action

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/generated-types.ts
@@ -76,7 +76,7 @@ export interface RetlOnMappingSaveInputs {
   /**
    * Customer match upload key types.
    */
-  external_id_type: string
+  external_id_type?: string
   /**
    * A string that uniquely identifies a mobile application from which the data was collected. Required if external ID type is mobile advertising ID
    */

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/index.ts
@@ -174,7 +174,6 @@ const action: ActionDefinition<Settings, Payload> = {
           label: 'Existing List ID',
           description:
             'The ID of an existing Google list that you would like to sync users to. If you provide this, we will not create a new list.',
-          required: false,
           dynamic: async (request, { settings, auth, features, statsContext }) => {
             return await getListIds(request, settings, auth, features, statsContext)
           }
@@ -182,14 +181,12 @@ const action: ActionDefinition<Settings, Payload> = {
         list_name: {
           type: 'string',
           label: 'List Name',
-          description: 'The name of the Google list that you would like to create.',
-          required: false
+          description: 'The name of the Google list that you would like to create.'
         },
         external_id_type: {
           type: 'string',
           label: 'External ID Type',
           description: 'Customer match upload key types.',
-          required: true,
           default: 'CONTACT_INFO',
           choices: [
             { label: 'CONTACT INFO', value: 'CONTACT_INFO' },
@@ -253,7 +250,7 @@ const action: ActionDefinition<Settings, Payload> = {
               savedData: {
                 id: hookInputs.list_id,
                 name: response.results[0].userList.name,
-                external_id_type: hookInputs.external_id_type
+                external_id_type: hookInputs.external_id_type ?? 'CONTACT_INFO'
               }
             }
           } catch (e) {
@@ -273,7 +270,7 @@ const action: ActionDefinition<Settings, Payload> = {
             audienceName: hookInputs.list_name,
             settings: settings,
             audienceSettings: {
-              external_id_type: hookInputs.external_id_type,
+              external_id_type: hookInputs.external_id_type ?? 'CONTACT_INFO',
               app_id: hookInputs.app_id
             }
           }
@@ -290,7 +287,7 @@ const action: ActionDefinition<Settings, Payload> = {
             savedData: {
               id: listId,
               name: hookInputs.list_name,
-              external_id_type: hookInputs.external_id_type
+              external_id_type: hookInputs.external_id_type ?? 'CONTACT_INFO'
             }
           }
         } catch (e) {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR updates the userList 'external_id_type' hook input field to no longer be required. Since that field already has a default this is an acceptable remediation for an issue this destination was having when connected to Journeys. Previously when connected to Journeys the RETL Mapping Save hook defined for this action would not be shown to users (as intended) but the required 'external_id_type' field would still be enforced, making it impossible to publish a Journey with this action. 
Now that field is not required, but we will still default to 'CONTACT_INFO' if a user doesn't fill it out. 

## Testing
Tested successfully in stage by connecting a Journey to Google Ads UserList action
![Screenshot 2025-06-13 at 16 09 06](https://github.com/user-attachments/assets/2fd0a3a9-b597-4f48-b207-cdc77ba2bbb7)
![Screenshot 2025-06-13 at 16 34 59 (1)](https://github.com/user-attachments/assets/51b121e8-2f78-4f9d-977c-9babee89075c)


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
