### PR TITLE
[warehouse-destinations] Fix getDefinitions method to require from dist folder

### DIFF
--- a/packages/warehouse-destinations/src/destinations/index.ts
+++ b/packages/warehouse-destinations/src/destinations/index.ts
@@ -10,7 +10,7 @@ import type { WarehouseDestinationDefinition } from '@segment/actions-core'
 // Gets all the destination definitions from the warehouse destinations directory
 // Used by the CLI to push the destination definitions
 export const getDefinitions = async (dirPath: string): Promise<WarehouseDestinationDefinition[]> => {
-  const destPath = path.join(dirPath, 'src/destinations/*')
+  const destPath = path.join(dirPath, 'dist/destinations/*')
   const warehouseDestDirs = await globby(destPath, {
     expandDirectories: false,
     onlyDirectories: true,


### PR DESCRIPTION
`actions-cli` was failing while loading definitions from warehouse-destination. This PR fixes the issue by loading the destination fom dist folder instead of typescript file.

Testing completed successfully in local and workbench


## Testing

N/A