### PR TITLE
Pipes through statsContext to evaluateLiquid directive function

### DIFF
--- a/packages/browser-destinations/webpack.config.js
+++ b/packages/browser-destinations/webpack.config.js
@@ -104,7 +104,6 @@ const unobfuscatedOutput = {
     mainFields: ['exports', 'module', 'browser', 'main'],
     extensions: ['.ts', '.js'],
     fallback: {
-      perf_hooks: false, // perf_hooks is not available in the browser. This fixes a build error.
       vm: require.resolve('vm-browserify'),
       crypto: false
     },

--- a/packages/browser-destinations/webpack.config.js
+++ b/packages/browser-destinations/webpack.config.js
@@ -104,6 +104,7 @@ const unobfuscatedOutput = {
     mainFields: ['exports', 'module', 'browser', 'main'],
     extensions: ['.ts', '.js'],
     fallback: {
+      perf_hooks: false, // perf_hooks is not available in the browser. This fixes a build error.
       vm: require.resolve('vm-browserify'),
       crypto: false
     },

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -318,7 +318,7 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
     const results: Result[] = []
 
     // Resolve/transform the mapping with the input data
-    let payload = transform(bundle.mapping, bundle.data) as Payload
+    let payload = transform(bundle.mapping, bundle.data, bundle.statsContext) as Payload
     results.push({ output: 'Mappings resolved' })
 
     // Remove empty values (`null`, `undefined`, `''`) when not explicitly accepted

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -387,7 +387,7 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
 
     const mapping: JSONObject = bundle.mapping
 
-    let payloads = transformBatch(mapping, bundle.data) as Payload[]
+    let payloads = transformBatch(mapping, bundle.data, bundle.statsContext) as Payload[]
     const batchPayloadLength = payloads.length
 
     const multiStatusResponse: ResultMultiStatusNode[] = []

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -726,14 +726,7 @@ export class Destination<Settings = JSONObject, AudienceSettings = JSONObject> {
     const isBatch = Array.isArray(events)
 
     if (options?.statsContext?.tags !== undefined) {
-      options.statsContext.tags = [
-        ...options.statsContext.tags,
-        `actionConfigId:${subscription.ConfigID}`,
-        `actionId:${subscription.ActionID}`,
-        `destinationConfigId:${subscription.ConfigID}`,
-        `sourceId:${subscription.ProjectID}`,
-        `partnerAction:${subscription.partnerAction}`
-      ]
+      options.statsContext.tags = [...options.statsContext.tags, `partnerAction:${subscription.partnerAction}`]
     }
 
     const subscriptionStartedAt = time()

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -725,6 +725,17 @@ export class Destination<Settings = JSONObject, AudienceSettings = JSONObject> {
   ): Promise<Result[]> {
     const isBatch = Array.isArray(events)
 
+    if (options?.statsContext?.tags !== undefined) {
+      options.statsContext.tags = [
+        ...options.statsContext.tags,
+        `actionConfigId:${subscription.ConfigID}`,
+        `actionId:${subscription.ActionID}`,
+        `destinationConfigId:${subscription.ConfigID}`,
+        `sourceId:${subscription.ProjectID}`,
+        `partnerAction:${subscription.partnerAction}`
+      ]
+    }
+
     const subscriptionStartedAt = time()
     const actionSlug = subscription.partnerAction
     const input = {

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -9,6 +9,7 @@ import { arrify } from '../arrify'
 import { flattenObject } from './flatten'
 import { evaluateLiquid } from './liquid-directive'
 import { StatsContext } from '../destination-kit'
+import { isLiquidDirective } from './value-keys'
 
 export type InputData = { [key: string]: unknown }
 export type Features = { [key: string]: boolean }
@@ -392,7 +393,12 @@ function resolve(mapping: JSONLike, payload: JSONObject, statsContext?: StatsCon
   }
 
   if (isDirective(mapping)) {
-    return runDirective(mapping, payload, statsContext)
+    if (isLiquidDirective(mapping)) {
+      // Only include stats, and therefore extra fieldKey tags, if the mapping is a liquid directive to save on costs
+      return runDirective(mapping, payload, statsContext)
+    }
+
+    return runDirective(mapping, payload)
   }
 
   if (Array.isArray(mapping)) {

--- a/packages/core/src/mapping-kit/index.ts
+++ b/packages/core/src/mapping-kit/index.ts
@@ -8,10 +8,11 @@ import validate from './validate'
 import { arrify } from '../arrify'
 import { flattenObject } from './flatten'
 import { evaluateLiquid } from './liquid-directive'
+import { StatsContext } from '../destination-kit'
 
 export type InputData = { [key: string]: unknown }
 export type Features = { [key: string]: boolean }
-type Directive = (options: JSONValue, payload: JSONObject) => JSONLike
+type Directive = (options: JSONValue, payload: JSONObject, statsContext?: StatsContext | undefined) => JSONLike
 type StringDirective = (value: string, payload: JSONObject) => JSONLike
 
 interface Directives {
@@ -42,13 +43,17 @@ function registerStringDirective(name: string, fn: StringDirective): void {
   })
 }
 
-function runDirective(obj: JSONObject, payload: JSONObject): JSONLike {
+function runDirective(obj: JSONObject, payload: JSONObject, statsContext?: StatsContext | undefined): JSONLike {
   const name = Object.keys(obj).find((key) => key.startsWith('@')) as string
   const directiveFn = directives[name]
   const value = obj[name]
 
   if (typeof directiveFn !== 'function') {
     throw new Error(`${name} is not a valid directive, got ${realTypeOf(directiveFn)}`)
+  }
+
+  if (name === '@liquid') {
+    return directiveFn(value, payload, statsContext)
   }
 
   return directiveFn(value, payload)
@@ -326,8 +331,8 @@ registerDirective('@excludeWhenNull', (value, payload) => {
   return cleanNulls(resolved)
 })
 
-registerDirective('@liquid', (opts, payload) => {
-  return evaluateLiquid(opts, payload)
+registerDirective('@liquid', (opts, payload, statsContext) => {
+  return evaluateLiquid(opts, payload, statsContext)
 })
 
 // Recursively remove all null values from an object
@@ -381,13 +386,13 @@ function getMappingToProcess(mapping: JSONLikeObject): JSONLikeObject {
  * @param payload - the input data to apply to the mapping directives
  * @todo support arrays or array directives?
  */
-function resolve(mapping: JSONLike, payload: JSONObject): JSONLike {
+function resolve(mapping: JSONLike, payload: JSONObject, statsContext?: StatsContext | undefined): JSONLike {
   if (!isObject(mapping) && !isArray(mapping)) {
     return mapping
   }
 
   if (isDirective(mapping)) {
-    return runDirective(mapping, payload)
+    return runDirective(mapping, payload, statsContext)
   }
 
   if (Array.isArray(mapping)) {
@@ -409,7 +414,11 @@ function resolve(mapping: JSONLike, payload: JSONObject): JSONLike {
  * @param mapping - the directives and raw values
  * @param data - the input data to apply to directives
  */
-function transform(mapping: JSONLikeObject, data: InputData | undefined = {}): JSONObject {
+function transform(
+  mapping: JSONLikeObject,
+  data: InputData | undefined = {},
+  statsContext?: StatsContext | undefined
+): JSONObject {
   const realType = realTypeOf(data)
   if (realType !== 'object') {
     throw new Error(`data must be an object, got ${realType}`)
@@ -420,7 +429,7 @@ function transform(mapping: JSONLikeObject, data: InputData | undefined = {}): J
   // throws if the mapping config is invalid
   validate(mappingToProcess)
 
-  const resolved = resolve(mappingToProcess, data as JSONObject)
+  const resolved = resolve(mappingToProcess, data as JSONObject, statsContext)
   const cleaned = removeUndefined(resolved)
 
   // Cast because we know there are no `undefined` values anymore

--- a/packages/core/src/mapping-kit/liquid-directive.ts
+++ b/packages/core/src/mapping-kit/liquid-directive.ts
@@ -1,6 +1,5 @@
 import { Liquid } from 'liquidjs'
 import { StatsContext } from '../destination-kit'
-import { performance } from 'perf_hooks'
 
 const liquidEngine = new Liquid({
   renderLimit: 500, // 500 ms
@@ -75,12 +74,12 @@ export function evaluateLiquid(liquidValue: any, event: any, statsContext?: Stat
   }
 
   let res
-  const start = performance.now()
+  const start = Date.now()
   let duration
   try {
     res = liquidEngine.parseAndRenderSync(liquidValue, event)
   } catch (e) {
-    duration = performance.now() - start
+    duration = Date.now() - start
 
     statsContext?.statsClient?.histogram('liquid.template.evaluation_ms', duration, [
       ...statsContext.tags,
@@ -88,7 +87,7 @@ export function evaluateLiquid(liquidValue: any, event: any, statsContext?: Stat
     ])
     throw e
   }
-  duration = performance.now() - start
+  duration = Date.now() - start
 
   statsContext?.statsClient?.histogram('liquid.template.evaluation_ms', duration, [
     ...statsContext.tags,

--- a/packages/core/src/mapping-kit/liquid-directive.ts
+++ b/packages/core/src/mapping-kit/liquid-directive.ts
@@ -1,5 +1,6 @@
 import { Liquid } from 'liquidjs'
 import { StatsContext } from '../destination-kit'
+import { performance } from 'perf_hooks'
 
 const liquidEngine = new Liquid({
   renderLimit: 500, // 500 ms

--- a/packages/core/src/mapping-kit/liquid-directive.ts
+++ b/packages/core/src/mapping-kit/liquid-directive.ts
@@ -1,4 +1,5 @@
 import { Liquid } from 'liquidjs'
+import { StatsContext } from '../destination-kit'
 
 const liquidEngine = new Liquid({
   renderLimit: 500, // 500 ms
@@ -58,7 +59,8 @@ export function getLiquidKeys(liquidValue: string): string[] {
   return liquidEngine.fullVariablesSync(liquidValue)
 }
 
-export function evaluateLiquid(liquidValue: any, event: any): string {
+export function evaluateLiquid(liquidValue: any, event: any, statsContext?: StatsContext | undefined): string {
+  const fieldId = 'TODO'
   if (typeof liquidValue !== 'string') {
     // type checking of @liquid directive is done in validate.ts as well
     throw new Error('liquid template value must be a string')
@@ -72,7 +74,21 @@ export function evaluateLiquid(liquidValue: any, event: any): string {
     throw new Error('liquid template values are limited to 1000 characters')
   }
 
-  const res = liquidEngine.parseAndRenderSync(liquidValue, event)
+  let status = 'success'
+  let res
+  const start = performance.now()
+  try {
+    res = liquidEngine.parseAndRenderSync(liquidValue, event)
+  } catch (_e) {
+    status = 'fail'
+  }
+  const duration = performance.now() - start
+
+  statsContext?.statsClient?.histogram('liquid.template.evaluation_ms', duration, [
+    ...statsContext.tags,
+    `field_id:${fieldId}`,
+    `result:${status}` // status = success/fail, not in the psudocode for simplicity
+  ])
 
   if (typeof res !== 'string') {
     return 'error'

--- a/packages/core/src/mapping-kit/liquid-directive.ts
+++ b/packages/core/src/mapping-kit/liquid-directive.ts
@@ -60,7 +60,6 @@ export function getLiquidKeys(liquidValue: string): string[] {
 }
 
 export function evaluateLiquid(liquidValue: any, event: any, statsContext?: StatsContext | undefined): string {
-  const fieldId = 'TODO'
   if (typeof liquidValue !== 'string') {
     // type checking of @liquid directive is done in validate.ts as well
     throw new Error('liquid template value must be a string')
@@ -86,7 +85,6 @@ export function evaluateLiquid(liquidValue: any, event: any, statsContext?: Stat
 
   statsContext?.statsClient?.histogram('liquid.template.evaluation_ms', duration, [
     ...statsContext.tags,
-    `field_id:${fieldId}`,
     `result:${status}` // status = success/fail, not in the psudocode for simplicity
   ])
 

--- a/packages/core/src/mapping-kit/liquid-directive.ts
+++ b/packages/core/src/mapping-kit/liquid-directive.ts
@@ -73,26 +73,22 @@ export function evaluateLiquid(liquidValue: any, event: any, statsContext?: Stat
     throw new Error('liquid template values are limited to 1000 characters')
   }
 
-  let res
+  let res: string
   const start = Date.now()
-  let duration
+  let status: 'success' | 'fail' = 'success'
+
   try {
     res = liquidEngine.parseAndRenderSync(liquidValue, event)
   } catch (e) {
-    duration = Date.now() - start
-
+    status = 'fail'
+    throw e
+  } finally {
+    const duration = Date.now() - start
     statsContext?.statsClient?.histogram('liquid.template.evaluation_ms', duration, [
       ...statsContext.tags,
-      `result:fail` // status = success/fail, not in the psudocode for simplicity
+      `result:${status}`
     ])
-    throw e
   }
-  duration = Date.now() - start
-
-  statsContext?.statsClient?.histogram('liquid.template.evaluation_ms', duration, [
-    ...statsContext.tags,
-    `result:success` // status = success/fail, not in the psudocode for simplicity
-  ])
 
   if (typeof res !== 'string') {
     return 'error'


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR supports the rollout of Liquid Templates by adding some stats tracking including tags for which field is triggering the metrics.

## Testing

Tested successfully in stage by triggering a Liquid template evaluation in the action tester. 
Metrics come through as expected

<img width="1070" height="769" alt="Screenshot 2025-08-18 at 10 01 56 AM" src="https://github.com/user-attachments/assets/45f2255b-1b1a-4f34-b0eb-773357db7cf4" />


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
