### PR TITLE
[Amazon Conversion API] Refining descriptions for few fields and fixing bug for potential double counting of events

### DIFF
--- a/packages/destination-actions/src/destinations/amazon-conversions-api/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/index.ts
@@ -63,17 +63,6 @@ const destination: DestinationDefinition<Settings> = {
   },
   presets: [
     {
-      name: 'Other',
-      subscribe:
-        'type = "track" AND event != "Product Added" and event != "Application Submitted" and event != "Checkout Started" and event != "Callback Started" and event != "Lead Generated" and event != "Order Completed" and event != "Application Opened" and event != "Products Searched" and event != "Signed Up" and event != "Subscription Created"',
-      partnerAction: 'trackConversion',
-      mapping: {
-        ...defaultValues(trackConversion.fields),
-        eventType: 'OTHER'
-      },
-      type: 'automatic'
-    },
-    {
       name: 'Add to Shopping Cart',
       subscribe: 'type = "track" AND event = "Product Added"',
       partnerAction: 'trackConversion',
@@ -182,7 +171,17 @@ const destination: DestinationDefinition<Settings> = {
         eventType: 'SUBSCRIBE'
       },
       type: 'automatic'
-    }
+    },
+    {
+      name: 'Other',
+      subscribe: 'type = "track" AND event = "Other"',
+      partnerAction: 'trackConversion',
+      mapping: {
+        ...defaultValues(trackConversion.fields),
+        eventType: 'OTHER'
+      },
+      type: 'automatic'
+    },
   ],
   actions: {
     trackConversion

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/fields.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/fields.ts
@@ -135,7 +135,7 @@ export const fields: Record<string, InputField> = {
   },
   clientDedupeId: {
     label: 'Client Dedupe ID',
-    description: 'The client specified id for the event. For events with the same clientDedupeId only the latest event will be kept.',
+    description: 'Amazon Conversions API uses the `clientDedupeId` field to prevent duplicate events. By default, Segment maps the messageId to this field. For events with the same clientDedupeId, only the latest event will be processed. Please be advised that deduplication occurs across all event types, rather than being limited to individual event types.',
     type: 'string',
     required: false,
     default: {
@@ -218,7 +218,7 @@ export const fields: Record<string, InputField> = {
       },
       matchId: {
         label: 'Match ID',
-        description: 'Match ID for the customer.',
+        description: 'Match ID serves as an anonymous, opaque unique identifier that corresponds to individual users within an advertiser system, such as loyalty membership identifications and order references. This functionality enables advertisers to precisely monitor campaign effectiveness while maintaining customer data privacy, eliminating the need to share sensitive information like hashed email addresses or phone numbers with Amazon, particularly when analyzing complex customer journeys across multiple channels and devices. The advertisers who implement the Amazon Advertising Tag (AAT) on their websites can transmit match_id as a parameter in conjunction with online event tracking. The Amazon system subsequently correlates these identifiers with users through cookies or hashed Personally Identifiable Information (PII). In instances where users complete offline conversions, advertisers can report these activities through the Conversions API (CAPI) utilizing the corresponding match_id, ensuring seamless cross-channel attribution.',
         type: 'string',
         required: false
       }

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/generated-types.ts
@@ -34,7 +34,7 @@ export interface Payload {
    */
   unitsSold?: number
   /**
-   * The client specified id for the event. For events with the same clientDedupeId only the latest event will be kept.
+   * Amazon Conversions API uses the `clientDedupeId` field to prevent duplicate events. By default, Segment maps the messageId to this field. For events with the same clientDedupeId, only the latest event will be processed. Please be advised that deduplication occurs across all event types, rather than being limited to individual event types.
    */
   clientDedupeId?: string
   /**
@@ -82,7 +82,7 @@ export interface Payload {
      */
     rampId?: string
     /**
-     * Match ID for the customer.
+     * Match ID serves as an anonymous, opaque unique identifier that corresponds to individual users within an advertiser system, such as loyalty membership identifications and order references. This functionality enables advertisers to precisely monitor campaign effectiveness while maintaining customer data privacy, eliminating the need to share sensitive information like hashed email addresses or phone numbers with Amazon, particularly when analyzing complex customer journeys across multiple channels and devices. The advertisers who implement the Amazon Advertising Tag (AAT) on their websites can transmit match_id as a parameter in conjunction with online event tracking. The Amazon system subsequently correlates these identifiers with users through cookies or hashed Personally Identifiable Information (PII). In instances where users complete offline conversions, advertisers can report these activities through the Conversions API (CAPI) utilizing the corresponding match_id, ensuring seamless cross-channel attribution.
      */
     matchId?: string
   }


### PR DESCRIPTION
[Amazon Conversion API] Refining descriptions for few fields and fixing bug for potential double counting of events

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
