### PR TITLE
[MAIN] [STRATCONN-5978] Added historical import parameter in klaviyo

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -117,7 +117,6 @@ Object {
   "data": Object {
     "attributes": Object {
       "custom_source": "TsKr#",
-      "historical_import": true,
       "profiles": Object {
         "data": Array [
           Object {
@@ -139,11 +138,13 @@ Object {
                 },
               },
             },
+            "historical_import": false,
             "type": "profile",
           },
         ],
       },
     },
+    "historical_import": true,
     "relationships": Object {
       "list": Object {
         "data": Object {

--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -117,6 +117,7 @@ Object {
   "data": Object {
     "attributes": Object {
       "custom_source": "TsKr#",
+      "historical_import": true,
       "profiles": Object {
         "data": Array [
           Object {
@@ -138,13 +139,11 @@ Object {
                 },
               },
             },
-            "historical_import": false,
             "type": "profile",
           },
         ],
       },
     },
-    "historical_import": true,
     "relationships": Object {
       "list": Object {
         "data": Object {

--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -117,6 +117,7 @@ Object {
   "data": Object {
     "attributes": Object {
       "custom_source": "TsKr#",
+      "historical_import": true,
       "profiles": Object {
         "data": Array [
           Object {

--- a/packages/destination-actions/src/destinations/klaviyo/functions.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/functions.ts
@@ -223,10 +223,12 @@ export async function getProfiles(
 export function formatSubscribeProfile(
   email: string | undefined,
   phone_number: string | undefined,
-  consented_at: string | number | undefined
+  consented_at: string | number | undefined,
+  historical_import: boolean | undefined = false
 ) {
   const profileToSubscribe: SubscribeProfile = {
     type: 'profile',
+    historical_import: historical_import,
     attributes: {
       subscriptions: {}
     }
@@ -262,7 +264,7 @@ export function formatSubscribeRequestBody(
   profiles: SubscribeProfile | SubscribeProfile[],
   list_id: string | undefined,
   custom_source: string | undefined,
-  historical_import: boolean | undefined = false
+  historical_import: boolean
 ) {
   if (!Array.isArray(profiles)) {
     profiles = [profiles]
@@ -273,7 +275,7 @@ export function formatSubscribeRequestBody(
     data: {
       type: 'profile-subscription-bulk-create-job',
       attributes: {
-        historical_import: historical_import ?? false,
+        historical_import: historical_import,
         profiles: {
           data: profiles
         }

--- a/packages/destination-actions/src/destinations/klaviyo/functions.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/functions.ts
@@ -261,7 +261,8 @@ export function formatSubscribeProfile(
 export function formatSubscribeRequestBody(
   profiles: SubscribeProfile | SubscribeProfile[],
   list_id: string | undefined,
-  custom_source: string | undefined
+  custom_source: string | undefined,
+  historical_import: boolean | undefined = false
 ) {
   if (!Array.isArray(profiles)) {
     profiles = [profiles]
@@ -272,6 +273,7 @@ export function formatSubscribeRequestBody(
     data: {
       type: 'profile-subscription-bulk-create-job',
       attributes: {
+        historical_import: historical_import ?? false,
         profiles: {
           data: profiles
         }

--- a/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/__tests__/index.test.ts
@@ -50,6 +50,7 @@ describe('Subscribe Profile', () => {
         type: 'profile-subscription-bulk-create-job',
         attributes: {
           custom_source: 'Marketing Event',
+          historical_import: false,
           profiles: {
             data: [
               {
@@ -121,6 +122,7 @@ describe('Subscribe Profile', () => {
         type: 'profile-subscription-bulk-create-job',
         attributes: {
           custom_source: '-59',
+          historical_import: false,
           profiles: {
             data: [
               {
@@ -194,6 +196,7 @@ describe('Subscribe Profile', () => {
       data: {
         type: 'profile-subscription-bulk-create-job',
         attributes: {
+          historical_import: false,
           custom_source: 'Marketing Event',
           profiles: {
             data: [
@@ -261,6 +264,7 @@ describe('Subscribe Profile', () => {
       data: {
         type: 'profile-subscription-bulk-create-job',
         attributes: {
+          historical_import: false,
           custom_source: '-59',
           profiles: {
             data: [
@@ -463,6 +467,7 @@ describe('Subscribe Profile', () => {
       data: {
         type: 'profile-subscription-bulk-create-job',
         attributes: {
+          historical_import: false,
           profiles: {
             data: [
               {
@@ -547,6 +552,7 @@ describe('Subscribe Profile', () => {
       data: {
         type: 'profile-subscription-bulk-create-job',
         attributes: {
+          historical_import: false,
           custom_source: '-59',
           profiles: {
             data: [
@@ -672,6 +678,7 @@ describe('Subscribe Profile', () => {
       data: {
         type: 'profile-subscription-bulk-create-job',
         attributes: {
+          historical_import: false,
           custom_source: 'Test Event',
           profiles: {
             data: [
@@ -706,6 +713,7 @@ describe('Subscribe Profile', () => {
       data: {
         type: 'profile-subscription-bulk-create-job',
         attributes: {
+          historical_import: false,
           custom_source: 'Test Event',
           profiles: {
             data: [
@@ -741,6 +749,7 @@ describe('Subscribe Profile', () => {
       data: {
         type: 'profile-subscription-bulk-create-job',
         attributes: {
+          historical_import: false,
           custom_source: 'Marketing Event',
           profiles: {
             data: [

--- a/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/subscribeProfile/generated-types.ts
@@ -22,6 +22,10 @@ export interface Payload {
    */
   custom_source?: string
   /**
+   * When set to true, the profile will be subscribed as a historical import. This is useful for importing existing profiles into Klaviyo without sending them an email or SMS.
+   */
+  historical_import?: boolean
+  /**
    * The timestamp of when the profile's consent was gathered.
    */
   consented_at?: string | number

--- a/packages/destination-actions/src/destinations/klaviyo/types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/types.ts
@@ -141,6 +141,7 @@ export interface GetProfileResponse {
 
 export interface SubscribeProfile {
   type: string
+  historical_import?: boolean
   attributes: {
     email?: string
     phone_number?: string

--- a/packages/destination-actions/src/destinations/klaviyo/types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/types.ts
@@ -165,6 +165,7 @@ export interface SubscribeEventData {
   data: {
     type: string
     attributes: {
+      historical_import: boolean
       custom_source?: string | number
       profiles: {
         data: SubscribeProfile[]

--- a/packages/destination-actions/src/destinations/ortto/trackActivity/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/ortto/trackActivity/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -20,7 +20,7 @@ Array [
     "properties": Object {
       "testType": "9QX1u",
     },
-    "timestamp": "2108-01-18T15:43:16.331Z",
+    "timestamp": "2108-01-18T10:13:16.331Z",
     "traits": Object {
       "testType": "9QX1u",
     },
@@ -35,7 +35,7 @@ Array [
     "anonymous_id": "9QX1u",
     "event": "9QX1u",
     "message_id": "9QX1u",
-    "timestamp": "2108-01-18T15:43:16.331Z",
+    "timestamp": "2108-01-18T10:13:16.331Z",
     "user_id": "9QX1u",
   },
 ]

--- a/packages/destination-actions/src/destinations/ortto/upsertContactProfile/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/ortto/upsertContactProfile/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -15,7 +15,7 @@ Array [
       "state": "2fUSE5G",
     },
     "message_id": "2fUSE5G",
-    "timestamp": "2099-03-03T14:35:24.780Z",
+    "timestamp": "2099-03-03T09:05:24.780Z",
     "traits": Object {
       "testType": "2fUSE5G",
     },
@@ -29,7 +29,7 @@ Array [
   Object {
     "anonymous_id": "2fUSE5G",
     "message_id": "2fUSE5G",
-    "timestamp": "2099-03-03T14:35:24.780Z",
+    "timestamp": "2099-03-03T09:05:24.780Z",
     "user_id": "2fUSE5G",
   },
 ]


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

In this PR, the historical_import parameter is added in Klaviyo. 

Klaviyo docs URL: https://developers.klaviyo.com/en/reference/bulk_subscribe_profiles

JIRA TICKETS: https://twilio-engineering.atlassian.net/browse/STRATCONN-5978

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [X] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [X] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
