### PR TITLE
Stratconn 6002 braze canvas trigger

### DIFF
--- a/packages/destination-actions/src/destinations/braze/index.ts
+++ b/packages/destination-actions/src/destinations/braze/index.ts
@@ -12,6 +12,7 @@ import trackEvent2 from './trackEvent2'
 import trackPurchase2 from './trackPurchase2'
 import updateUserProfile2 from './updateUserProfile2'
 import triggerCampaign from './triggerCampaign'
+import triggerCanvas from './triggerCanvas'
 
 import upsertCatalogItem from './upsertCatalogItem'
 
@@ -89,7 +90,8 @@ const destination: DestinationDefinition<Settings> = {
     updateUserProfile2,
     createAlias2,
     upsertCatalogItem,
-    triggerCampaign
+    triggerCampaign,
+    triggerCanvas
   },
   presets: [
     {
@@ -136,6 +138,13 @@ const destination: DestinationDefinition<Settings> = {
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_entity_removed_track'
+    },
+    {
+      name: 'Trigger Canvas',
+      subscribe: 'type = "track" and event = "Trigger Canvas"',
+      partnerAction: 'triggerCanvas',
+      mapping: defaultValues(triggerCanvas.fields),
+      type: 'automatic'
     },
     {
       name: 'Entities Audience Entered',

--- a/packages/destination-actions/src/destinations/braze/triggerCanvas/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/braze/triggerCanvas/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,253 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Braze's triggerCanvas destination action: all fields 1`] = `
+Object {
+  "canvas_entry_properties": Object {
+    "testType": "jjoQf0&!",
+  },
+  "canvas_id": "jjoQf0&!",
+  "recipients": Array [
+    Object {
+      "attributes": Object {
+        "testType": "jjoQf0&!",
+      },
+      "canvas_entry_properties": Object {
+        "testType": "jjoQf0&!",
+      },
+      "email": "uwe@tizo.bd",
+      "external_user_id": "jjoQf0&!",
+      "prioritization": Array [
+        "identified",
+        "identified",
+      ],
+      "send_to_existing_only": true,
+      "user_alias": Object {
+        "alias_label": "test-alias-label",
+        "alias_name": "test-alias",
+      },
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for Braze's triggerCanvas destination action: all fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer jjoQf0&!",
+    ],
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Testing snapshot for Braze's triggerCanvas destination action: required fields 1`] = `
+Object {
+  "canvas_id": "jjoQf0&!",
+  "recipients": Array [
+    Object {
+      "external_user_id": "test-user-123",
+      "send_to_existing_only": true,
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for Braze's triggerCanvas destination action: required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer jjoQf0&!",
+    ],
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Testing snapshot for Braze's triggerCanvas destination action: with audience object 1`] = `
+Object {
+  "audience": Object {
+    "AND": Array [
+      Object {
+        "custom_attribute": Object {
+          "attribute_name": "eye_color",
+          "comparison": "equals",
+          "value": "blue",
+        },
+      },
+      Object {
+        "custom_attribute": Object {
+          "attribute_name": "age",
+          "comparison": "greater_than",
+          "value": 30,
+        },
+      },
+    ],
+  },
+  "broadcast": true,
+  "canvas_entry_properties": Object {
+    "testType": "jjoQf0&!",
+  },
+  "canvas_id": "jjoQf0&!",
+  "prioritization": Object {
+    "first_priority": "identified",
+    "second_priority": "identified",
+  },
+}
+`;
+
+exports[`Testing snapshot for Braze's triggerCanvas destination action: with audience object 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer jjoQf0&!",
+    ],
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Testing snapshot for Braze's triggerCanvas destination action: with canvas entry properties 1`] = `
+Object {
+  "canvas_entry_properties": Object {
+    "discount_amount": 25,
+    "product_name": "Test Product",
+    "user_tier": "premium",
+  },
+  "canvas_id": "jjoQf0&!",
+  "recipients": Array [
+    Object {
+      "attributes": Object {
+        "testType": "jjoQf0&!",
+      },
+      "canvas_entry_properties": Object {
+        "testType": "jjoQf0&!",
+      },
+      "email": "uwe@tizo.bd",
+      "external_user_id": "jjoQf0&!",
+      "prioritization": Array [
+        "identified",
+        "identified",
+      ],
+      "send_to_existing_only": true,
+      "user_alias": Object {},
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for Braze's triggerCanvas destination action: with canvas entry properties 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer jjoQf0&!",
+    ],
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Testing snapshot for Braze's triggerCanvas destination action: with prioritization 1`] = `
+Object {
+  "canvas_entry_properties": Object {
+    "testType": "jjoQf0&!",
+  },
+  "canvas_id": "jjoQf0&!",
+  "recipients": Array [
+    Object {
+      "email": "test@example.com",
+      "external_user_id": "user-123",
+      "prioritization": Array [
+        "identified",
+        "most_recently_updated",
+      ],
+      "send_to_existing_only": true,
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for Braze's triggerCanvas destination action: with prioritization 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer jjoQf0&!",
+    ],
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Testing snapshot for Braze's triggerCanvas destination action: with recipients array 1`] = `
+Object {
+  "canvas_entry_properties": Object {
+    "testType": "jjoQf0&!",
+  },
+  "canvas_id": "jjoQf0&!",
+  "recipients": Array [
+    Object {
+      "canvas_entry_properties": Object {
+        "customData": "test",
+        "name": "John Doe",
+      },
+      "email": "test@example.com",
+      "external_user_id": "user-123",
+      "prioritization": Array [
+        "identified",
+        "identified",
+      ],
+      "send_to_existing_only": true,
+    },
+    Object {
+      "email": "another@example.com",
+      "external_user_id": "user-456",
+      "prioritization": Array [
+        "identified",
+        "identified",
+      ],
+      "send_to_existing_only": true,
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for Braze's triggerCanvas destination action: with recipients array 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer jjoQf0&!",
+    ],
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;

--- a/packages/destination-actions/src/destinations/braze/triggerCanvas/__tests__/dynamic-field-functions.test.ts
+++ b/packages/destination-actions/src/destinations/braze/triggerCanvas/__tests__/dynamic-field-functions.test.ts
@@ -1,0 +1,162 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import destination from '../../index'
+
+const testDestination = createTestIntegration(destination)
+
+describe('Braze triggerCanvas dynamic field functions', () => {
+  const settings = {
+    app_id: 'test-app-id',
+    api_key: 'test-api-key',
+    endpoint: 'https://rest.iad-01.braze.com'
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    nock.cleanAll()
+  })
+
+  describe('canvas_id', () => {
+    it('should return canvases as choices', async () => {
+      const mockCanvases = [
+        { id: 'canvas-1', name: 'Test Canvas 1' },
+        { id: 'canvas-2', name: 'Test Canvas 2' }
+      ]
+
+      // Mock the first page of canvases
+      nock('https://rest.iad-01.braze.com')
+        .get('/canvas/list')
+        .query({ page: '0' })
+        .reply(200, { canvases: mockCanvases })
+
+      // Mock the second page (empty) to end pagination
+      nock('https://rest.iad-01.braze.com').get('/canvas/list').query({ page: '1' }).reply(200, { canvases: [] })
+
+      const result = await testDestination.testDynamicField('triggerCanvas', 'canvas_id', { settings, payload: {} })
+
+      expect(result).toEqual({
+        choices: [
+          { label: 'Test Canvas 1', value: 'canvas-1' },
+          { label: 'Test Canvas 2', value: 'canvas-2' }
+        ]
+      })
+    })
+
+    it('should handle empty canvases list', async () => {
+      // Mock empty canvases response
+      nock('https://rest.iad-01.braze.com').get('/canvas/list').query({ page: '0' }).reply(200, { canvases: [] })
+
+      const result = await testDestination.testDynamicField('triggerCanvas', 'canvas_id', { settings, payload: {} })
+
+      expect(result).toEqual({
+        choices: []
+      })
+    })
+
+    it('should handle API error with error message', async () => {
+      // Mock API error
+      nock('https://rest.iad-01.braze.com')
+        .get('/canvas/list')
+        .query({ page: '0' })
+        .reply(500, { message: 'Internal Server Error' })
+
+      await expect(
+        testDestination.testDynamicField('triggerCanvas', 'canvas_id', { settings, payload: {} })
+      ).rejects.toThrow('Failed to fetch canvas list: Internal Server Error')
+    })
+
+    it('should handle multiple pages of canvases', async () => {
+      const mockCanvasesPage1 = [
+        { id: 'canvas-1', name: 'Test Canvas 1' },
+        { id: 'canvas-2', name: 'Test Canvas 2' }
+      ]
+
+      const mockCanvasesPage2 = [
+        { id: 'canvas-3', name: 'Test Canvas 3' },
+        { id: 'canvas-4', name: 'Test Canvas 4' }
+      ]
+
+      // Mock the first page of canvases
+      nock('https://rest.iad-01.braze.com')
+        .get('/canvas/list')
+        .query({ page: '0' })
+        .reply(200, { canvases: mockCanvasesPage1 })
+
+      // Mock the second page
+      nock('https://rest.iad-01.braze.com')
+        .get('/canvas/list')
+        .query({ page: '1' })
+        .reply(200, { canvases: mockCanvasesPage2 })
+
+      // Mock the third page (empty) to end pagination
+      nock('https://rest.iad-01.braze.com').get('/canvas/list').query({ page: '2' }).reply(200, { canvases: [] })
+
+      const result = await testDestination.testDynamicField('triggerCanvas', 'canvas_id', { settings, payload: {} })
+
+      expect(result).toEqual({
+        choices: [
+          { label: 'Test Canvas 1', value: 'canvas-1' },
+          { label: 'Test Canvas 2', value: 'canvas-2' },
+          { label: 'Test Canvas 3', value: 'canvas-3' },
+          { label: 'Test Canvas 4', value: 'canvas-4' }
+        ]
+      })
+    })
+
+    it('should handle malformed response', async () => {
+      // Mock malformed response without canvases array
+      nock('https://rest.iad-01.braze.com')
+        .get('/canvas/list')
+        .query({ page: '0' })
+        .reply(200, { message: 'Success but no canvases field' })
+
+      const result = await testDestination.testDynamicField('triggerCanvas', 'canvas_id', { settings, payload: {} })
+
+      expect(result).toEqual({
+        choices: []
+      })
+    })
+
+    it('should sort canvases by name', async () => {
+      const mockCanvases = [
+        { id: 'canvas-z', name: 'Z Canvas' },
+        { id: 'canvas-a', name: 'A Canvas' },
+        { id: 'canvas-m', name: 'M Canvas' }
+      ]
+
+      // Mock the first page of canvases
+      nock('https://rest.iad-01.braze.com')
+        .get('/canvas/list')
+        .query({ page: '0' })
+        .reply(200, { canvases: mockCanvases })
+
+      // Mock the second page (empty) to end pagination
+      nock('https://rest.iad-01.braze.com').get('/canvas/list').query({ page: '1' }).reply(200, { canvases: [] })
+
+      const result = await testDestination.testDynamicField('triggerCanvas', 'canvas_id', { settings, payload: {} })
+
+      expect(result).toEqual({
+        choices: [
+          { label: 'A Canvas', value: 'canvas-a' },
+          { label: 'M Canvas', value: 'canvas-m' },
+          { label: 'Z Canvas', value: 'canvas-z' }
+        ]
+      })
+    })
+
+    it('should handle missing endpoint setting', async () => {
+      const settingsWithoutEndpoint = {
+        app_id: 'test-app-id',
+        api_key: 'test-api-key',
+        endpoint: undefined as any
+      }
+
+      await expect(
+        testDestination.testDynamicField('triggerCanvas', 'canvas_id', {
+          settings: settingsWithoutEndpoint,
+          payload: {}
+        })
+      ).rejects.toThrow('Braze REST API endpoint is required.')
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/braze/triggerCanvas/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/braze/triggerCanvas/__tests__/index.test.ts
@@ -398,7 +398,7 @@ describe(`Unit tests for ${destinationSlug}'s ${actionSlug} destination action:`
             alias_name: 'test-alias',
             alias_label: 'test-alias-label'
           },
-          send_to_existing_only: false,
+          send_to_existing_only: true,
           attributes: {
             email: 'test@example.com'
           }

--- a/packages/destination-actions/src/destinations/braze/triggerCanvas/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/braze/triggerCanvas/__tests__/index.test.ts
@@ -1,0 +1,477 @@
+import { createTestEvent, createTestIntegration, PayloadValidationError, APIError } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'triggerCanvas'
+const destinationSlug = 'Braze'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Unit tests for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  // Test error case when neither broadcast nor recipients is provided
+  it('throws PayloadValidationError when neither broadcast nor recipients is provided', async () => {
+    const action = destination.actions[actionSlug]
+    const [_, settingsData] = generateTestData(seedName, destination, action, false)
+
+    // Create invalid test data with no targeting params
+    const invalidEventData = {
+      canvas_id: 'canvas-123',
+      // Remove all targeting parameters
+      broadcast: false,
+      recipients: [],
+      audience: null
+    }
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: invalidEventData
+    })
+
+    await expect(
+      testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: invalidEventData,
+        settings: settingsData,
+        auth: undefined
+      })
+    ).rejects.toThrow(PayloadValidationError)
+  })
+
+  // Test error case when canvas_id is missing
+  it('throws error when canvas_id is not provided', async () => {
+    const action = destination.actions[actionSlug]
+    const [_, settingsData] = generateTestData(seedName, destination, action, false)
+
+    // Create invalid test data with no canvas_id
+    const invalidEventData = {
+      // Missing canvas_id
+      broadcast: true,
+      audience: null
+    }
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: invalidEventData
+    })
+
+    await expect(
+      testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: invalidEventData,
+        settings: settingsData,
+        auth: undefined
+      })
+    ).rejects.toThrowError("The root value is missing the required field 'canvas_id'.")
+  })
+
+  // Test error case: broadcast is true and recipients are provided
+  it('throws PayloadValidationError when broadcast is true and recipients are provided', async () => {
+    const action = destination.actions[actionSlug]
+    const [_, settingsData] = generateTestData(seedName, destination, action, false)
+
+    // Create test data with both broadcast and recipients
+    const invalidEventData = {
+      canvas_id: 'canvas-123',
+      broadcast: true,
+      recipients: [{ external_user_id: 'user-123', send_to_existing_only: true }],
+      audience: null
+    }
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: invalidEventData
+    })
+
+    await expect(
+      testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: invalidEventData,
+        settings: settingsData,
+        auth: undefined
+      })
+    ).rejects.toThrow(PayloadValidationError)
+  })
+
+  // Test success case: broadcast with optional audience
+  it('allows broadcast with optional audience', async () => {
+    const action = destination.actions[actionSlug]
+    const [_, settingsData] = generateTestData(seedName, destination, action, false)
+
+    // Create valid test data with broadcast and audience
+    const validEventData = {
+      canvas_id: 'canvas-123',
+      broadcast: true,
+      audience: {
+        AND: [
+          {
+            custom_attribute: {
+              custom_attribute_name: 'test_attribute',
+              comparison: 'equals',
+              value: 'test_value'
+            }
+          }
+        ]
+      }
+    }
+
+    // Mock the API request
+    const mockRequest = nock('https://rest.iad-01.braze.com')
+      .post('/canvas/trigger/send', (body) => {
+        expect(body.canvas_id).toBe('canvas-123')
+        expect(body.broadcast).toBe(true)
+        expect(body.audience).toBeDefined()
+        expect(body.recipients).toBeUndefined()
+        return true
+      })
+      .reply(200, { success: true })
+
+    const event = createTestEvent({
+      properties: validEventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: validEventData,
+      settings: { ...settingsData, endpoint: 'https://rest.iad-01.braze.com' },
+      auth: undefined
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(mockRequest.isDone()).toBe(true)
+  })
+
+  // Test success case: broadcast without audience
+  it('allows broadcast without audience', async () => {
+    const action = destination.actions[actionSlug]
+    const [_, settingsData] = generateTestData(seedName, destination, action, false)
+
+    // Create valid test data with just broadcast
+    const validEventData = {
+      canvas_id: 'canvas-123',
+      broadcast: true
+    }
+
+    // Mock the API request
+    const mockRequest = nock('https://rest.iad-01.braze.com')
+      .post('/canvas/trigger/send', (body) => {
+        expect(body.canvas_id).toBe('canvas-123')
+        expect(body.broadcast).toBe(true)
+        expect(body.recipients).toBeUndefined()
+        return true
+      })
+      .reply(200, { success: true })
+
+    const event = createTestEvent({
+      properties: validEventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: validEventData,
+      settings: { ...settingsData, endpoint: 'https://rest.iad-01.braze.com' },
+      auth: undefined
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(mockRequest.isDone()).toBe(true)
+  })
+
+  // Test success case: recipients with canvas entry properties
+  it('allows recipients with canvas entry properties', async () => {
+    const action = destination.actions[actionSlug]
+    const [_, settingsData] = generateTestData(seedName, destination, action, false)
+
+    // Create test data with recipients and canvas entry properties
+    const validEventData = {
+      canvas_id: 'canvas-123',
+      recipients: [
+        {
+          external_user_id: 'user-123',
+          canvas_entry_properties: {
+            custom_property: 'custom_value'
+          },
+          send_to_existing_only: true
+        }
+      ]
+    }
+
+    // Mock the API request
+    const mockRequest = nock('https://rest.iad-01.braze.com')
+      .post('/canvas/trigger/send', (body) => {
+        expect(body.canvas_id).toBe('canvas-123')
+        expect(body.recipients.length).toBe(1)
+        expect(body.recipients[0].external_user_id).toBe('user-123')
+        expect(body.recipients[0].canvas_entry_properties).toEqual({
+          custom_property: 'custom_value'
+        })
+        return true
+      })
+      .reply(200, { success: true })
+
+    const event = createTestEvent({
+      properties: validEventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: validEventData,
+      settings: { ...settingsData, endpoint: 'https://rest.iad-01.braze.com' },
+      auth: undefined
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(mockRequest.isDone()).toBe(true)
+  })
+
+  // Test success case: recipients with email and attributes
+  it('allows recipients with email and attributes', async () => {
+    const action = destination.actions[actionSlug]
+    const [_, settingsData] = generateTestData(seedName, destination, action, false)
+
+    // Create test data with recipients and email/attributes
+    const validEventData = {
+      canvas_id: 'canvas-123',
+      recipients: [
+        {
+          external_user_id: 'user-456',
+          email: 'test@example.com',
+          send_to_existing_only: false,
+          attributes: {
+            first_name: 'John',
+            last_name: 'Doe'
+          }
+        }
+      ]
+    }
+
+    // Mock the API request
+    const mockRequest = nock('https://rest.iad-01.braze.com')
+      .post('/canvas/trigger/send', (body) => {
+        expect(body.canvas_id).toBe('canvas-123')
+        expect(body.recipients.length).toBe(1)
+        expect(body.recipients[0].external_user_id).toBe('user-456')
+        expect(body.recipients[0].email).toBe('test@example.com')
+        expect(body.recipients[0].attributes).toEqual({
+          first_name: 'John',
+          last_name: 'Doe'
+        })
+        return true
+      })
+      .reply(200, { success: true })
+
+    const event = createTestEvent({
+      properties: validEventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: validEventData,
+      settings: { ...settingsData, endpoint: 'https://rest.iad-01.braze.com' },
+      auth: undefined
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(mockRequest.isDone()).toBe(true)
+  })
+
+  // Test with prioritization settings
+  it('transforms prioritization object into array and applies to recipients', async () => {
+    const action = destination.actions[actionSlug]
+    const [_, settingsData] = generateTestData(seedName, destination, action, false)
+
+    // Create test data with recipients and prioritization
+    const validEventData = {
+      canvas_id: 'canvas-123',
+      recipients: [
+        {
+          external_user_id: 'user-123',
+          email: 'test@example.com',
+          send_to_existing_only: true
+        },
+        {
+          external_user_id: 'user-456',
+          email: 'test2@example.com',
+          send_to_existing_only: true
+        }
+      ],
+      prioritization: {
+        first_priority: 'identified',
+        second_priority: 'most_recently_updated'
+      }
+    }
+
+    // Mock the API request
+    const mockRequest = nock('https://rest.iad-01.braze.com')
+      .post('/canvas/trigger/send', (body) => {
+        expect(body.canvas_id).toBe('canvas-123')
+        // Check that the top-level prioritization is removed
+        expect(body.prioritization).toBeUndefined()
+
+        // Check that the prioritization array is applied to each recipient
+        expect(body.recipients.length).toBe(2)
+        expect(body.recipients[0].prioritization).toEqual(['identified', 'most_recently_updated'])
+        expect(body.recipients[1].prioritization).toEqual(['identified', 'most_recently_updated'])
+        return true
+      })
+      .reply(200, { success: true })
+
+    const event = createTestEvent({
+      properties: validEventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: validEventData,
+      settings: { ...settingsData, endpoint: 'https://rest.iad-01.braze.com' },
+      auth: undefined
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(mockRequest.isDone()).toBe(true)
+  })
+
+  // Test to verify prioritization with only first_priority
+  it('creates prioritization array with just first_priority', async () => {
+    const action = destination.actions[actionSlug]
+    const [_, settingsData] = generateTestData(seedName, destination, action, false)
+
+    // Create test data with recipients and only first_priority
+    const validEventData = {
+      canvas_id: 'canvas-123',
+      recipients: [{ external_user_id: 'user-123', send_to_existing_only: true }],
+      prioritization: {
+        first_priority: 'unidentified'
+      }
+    }
+
+    // Mock the API request
+    const mockRequest = nock('https://rest.iad-01.braze.com')
+      .post('/canvas/trigger/send', (body) => {
+        // Check that the prioritization array contains only the first priority
+        expect(body.recipients[0].prioritization).toEqual(['unidentified'])
+        return true
+      })
+      .reply(200, { success: true })
+
+    const event = createTestEvent({
+      properties: validEventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: validEventData,
+      settings: { ...settingsData, endpoint: 'https://rest.iad-01.braze.com' },
+      auth: undefined
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(mockRequest.isDone()).toBe(true)
+  })
+
+  // Test with user alias
+  it('allows recipients with user alias', async () => {
+    const action = destination.actions[actionSlug]
+    const [_, settingsData] = generateTestData(seedName, destination, action, false)
+
+    // Create test data with user alias
+    const validEventData = {
+      canvas_id: 'canvas-123',
+      recipients: [
+        {
+          user_alias: {
+            alias_name: 'test-alias',
+            alias_label: 'test-alias-label'
+          },
+          send_to_existing_only: false,
+          attributes: {
+            email: 'test@example.com'
+          }
+        }
+      ]
+    }
+
+    // Mock the API request
+    const mockRequest = nock('https://rest.iad-01.braze.com')
+      .post('/canvas/trigger/send', (body) => {
+        expect(body.canvas_id).toBe('canvas-123')
+        expect(body.recipients[0].user_alias).toEqual({
+          alias_name: 'test-alias',
+          alias_label: 'test-alias-label'
+        })
+        expect(body.recipients[0].attributes).toEqual({
+          email: 'test@example.com'
+        })
+        return true
+      })
+      .reply(200, { success: true })
+
+    const event = createTestEvent({
+      properties: validEventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: validEventData,
+      settings: { ...settingsData, endpoint: 'https://rest.iad-01.braze.com' },
+      auth: undefined
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(mockRequest.isDone()).toBe(true)
+  })
+
+  // Test error handling for Braze API errors
+  it('handles Braze API errors and surfaces error message as APIError', async () => {
+    const action = destination.actions[actionSlug]
+    const [_, settingsData] = generateTestData(seedName, destination, action, false)
+
+    // Create valid test data that will trigger an API error
+    const eventData = {
+      canvas_id: 'invalid-canvas-123',
+      broadcast: true
+    }
+
+    // Mock the API request to return an error with a message
+    const mockRequest = nock('https://rest.iad-01.braze.com')
+      .post('/canvas/trigger/send')
+      .reply(400, { message: 'Canvas with id invalid-canvas-123 not found' })
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    // Check that the error is thrown
+    try {
+      await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: eventData,
+        settings: { ...settingsData, endpoint: 'https://rest.iad-01.braze.com' },
+        auth: undefined
+      })
+    } catch (error) {
+      // The error should be an APIError with the correct message and status
+      expect(error).toBeInstanceOf(APIError)
+      expect(error.message).toBe('Canvas with id invalid-canvas-123 not found')
+      expect(error.status).toBe(400)
+    }
+
+    expect(mockRequest.isDone()).toBe(true)
+  })
+})

--- a/packages/destination-actions/src/destinations/braze/triggerCanvas/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/braze/triggerCanvas/__tests__/snapshot.test.ts
@@ -1,0 +1,280 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'triggerCanvas'
+const destinationSlug = 'Braze'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+    // Add the required targeting parameter (recipients array with minimal required field)
+    delete eventData.audience // Ensure only one targeting parameters are used
+    const modifiedEventData = {
+      ...eventData,
+      recipients: [
+        {
+          external_user_id: 'test-user-123',
+          send_to_existing_only: true
+        }
+      ]
+    }
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: modifiedEventData
+    })
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: modifiedEventData,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+    delete eventData.audience // Ensure only one targeting parameters are used
+    delete eventData.broadcast // Remove broadcast to avoid conflict with recipients
+    eventData.recipients[0].user_alias = {
+      alias_name: 'test-alias',
+      alias_label: 'test-alias-label'
+    }
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  // Test with recipients array
+  it('with recipients array', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+    delete eventData.audience // Ensure only one targeting parameters are used
+    delete eventData.broadcast // Remove broadcast to avoid conflict with recipients
+    // Ensure we have recipients data
+    const customEventData = {
+      ...eventData,
+      recipients: [
+        {
+          external_user_id: 'user-123',
+          email: 'test@example.com',
+          send_to_existing_only: true,
+          canvas_entry_properties: {
+            name: 'John Doe',
+            customData: 'test'
+          }
+        },
+        {
+          external_user_id: 'user-456',
+          email: 'another@example.com',
+          send_to_existing_only: true
+        }
+      ]
+    }
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: customEventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: customEventData,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  // Test with audience object
+  it('with audience object', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    // Create a test with audience data and broadcast true
+    const customEventData = {
+      ...eventData,
+      broadcast: true, // Required when using audience without recipients
+      audience: {
+        AND: [
+          { custom_attribute: { attribute_name: 'eye_color', comparison: 'equals', value: 'blue' } },
+          { custom_attribute: { attribute_name: 'age', comparison: 'greater_than', value: 30 } }
+        ]
+      }
+      // recipients not included when broadcast is true
+    }
+    // Remove recipients since we're using broadcast
+    delete customEventData.recipients
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: customEventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: customEventData,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  // Test with canvas entry properties
+  it('with canvas entry properties', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+    delete eventData.audience // Ensure only one targeting parameters are used
+    delete eventData.broadcast // Remove broadcast to avoid conflict with recipients
+    // Create a test with canvas entry properties
+    const customEventData = {
+      ...eventData,
+      canvas_entry_properties: {
+        product_name: 'Test Product',
+        discount_amount: 25,
+        user_tier: 'premium'
+      }
+    }
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: customEventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: customEventData,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  // Test with prioritization
+  it('with prioritization', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+    delete eventData.audience // Ensure only one targeting parameters are used
+    delete eventData.broadcast // Remove broadcast to avoid conflict with recipients
+    // Create a test with prioritization
+    const customEventData = {
+      ...eventData,
+      recipients: [
+        {
+          external_user_id: 'user-123',
+          email: 'test@example.com',
+          send_to_existing_only: true
+        }
+      ],
+      prioritization: {
+        first_priority: 'identified',
+        second_priority: 'most_recently_updated'
+      }
+    }
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: customEventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: customEventData,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+    expect(request.headers).toMatchSnapshot()
+  })
+})

--- a/packages/destination-actions/src/destinations/braze/triggerCanvas/functions/dynamic-field-functions.ts
+++ b/packages/destination-actions/src/destinations/braze/triggerCanvas/functions/dynamic-field-functions.ts
@@ -41,7 +41,6 @@ export const dynamicFields = {
 
         const canvases = response?.data?.canvases || []
 
-        // If we got less canvases than expected or none, we've reached the end
         if (canvases.length === 0) {
           hasMore = false
         } else {

--- a/packages/destination-actions/src/destinations/braze/triggerCanvas/functions/dynamic-field-functions.ts
+++ b/packages/destination-actions/src/destinations/braze/triggerCanvas/functions/dynamic-field-functions.ts
@@ -1,0 +1,71 @@
+import type { DynamicFieldResponse, ModifiedResponse, RequestClient } from '@segment/actions-core'
+import type { Settings } from '../../generated-types'
+import { APIError } from '@segment/actions-core'
+
+interface Canvas {
+  id: string
+  name: string
+}
+
+interface ListItemResponse {
+  label: string
+  value: string
+}
+
+interface BrazeCanvasResponse {
+  canvases: Canvas[]
+  message: string
+}
+
+export const dynamicFields = {
+  canvas_id: async (request: RequestClient, { settings }: { settings: Settings }): Promise<DynamicFieldResponse> => {
+    const canvasListItems: ListItemResponse[] = []
+
+    if (!settings.endpoint) {
+      throw new APIError('Braze REST API endpoint is required.', 400)
+    }
+
+    try {
+      // Initialize variables for pagination
+      let page = 0
+      let hasMore = true
+
+      // Fetch all canvases with pagination
+      while (hasMore) {
+        const response: ModifiedResponse<BrazeCanvasResponse> = await request(`${settings.endpoint}/canvas/list`, {
+          method: 'GET',
+          searchParams: {
+            page: page
+          }
+        })
+
+        const canvases = response?.data?.canvases || []
+
+        // If we got less canvases than expected or none, we've reached the end
+        if (canvases.length === 0) {
+          hasMore = false
+        } else {
+          // Process this page of canvases
+          canvases.forEach((canvas: Canvas) => {
+            canvasListItems.push({
+              label: `${canvas.name}`,
+              value: canvas.id
+            })
+          })
+
+          // Move to next page
+          page++
+        }
+      }
+
+      // Sort by name for readability after all pages are fetched
+      canvasListItems.sort((a: ListItemResponse, b: ListItemResponse) => a.label.localeCompare(b.label))
+    } catch (error) {
+      throw new APIError(`Failed to fetch canvas list: ${error instanceof Error ? error.message : String(error)}`, 400)
+    }
+
+    return {
+      choices: canvasListItems
+    }
+  }
+}

--- a/packages/destination-actions/src/destinations/braze/triggerCanvas/functions/dynamic-field-functions.ts
+++ b/packages/destination-actions/src/destinations/braze/triggerCanvas/functions/dynamic-field-functions.ts
@@ -29,6 +29,7 @@ export const dynamicFields = {
       // Initialize variables for pagination
       let page = 0
       let hasMore = true
+      const MAX_PAGES = 100 // Limit to prevent infinite loops in case of API issues
 
       // Fetch all canvases with pagination
       while (hasMore) {
@@ -41,7 +42,7 @@ export const dynamicFields = {
 
         const canvases = response?.data?.canvases || []
 
-        if (canvases.length === 0) {
+        if (canvases.length === 0 || page >= MAX_PAGES) {
           hasMore = false
         } else {
           // Process this page of canvases

--- a/packages/destination-actions/src/destinations/braze/triggerCanvas/generated-types.ts
+++ b/packages/destination-actions/src/destinations/braze/triggerCanvas/generated-types.ts
@@ -1,0 +1,79 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID of the canvas to trigger. The canvas must be API-triggered and the status must be "Draft" or "Active".
+   */
+  canvas_id: string
+  /**
+   * Optional data that will be used to personalize the canvas message. Personalization key-value pairs that will apply to all users in this request.
+   */
+  canvas_entry_properties?: {
+    [k: string]: unknown
+  }
+  /**
+   * If set to true, the canvas will be sent to all the users in the segment targeted by the canvas. It cannot be used with "recipients".
+   */
+  broadcast?: boolean
+  /**
+   * An array of user identifiers to send the canvas to. It cannot be used with "broadcast".
+   */
+  recipients?: {
+    /**
+     * External identifier of user to receive message.
+     */
+    external_user_id?: string
+    /**
+     * User alias object to identify the user.
+     */
+    user_alias?: {
+      /**
+       * The name of the alias
+       */
+      alias_name?: string
+      /**
+       * The label of the alias
+       */
+      alias_label?: string
+    }
+    /**
+     * Email address of user to receive message.
+     */
+    email?: string
+    /**
+     * Properties that will override the default canvas_entry_properties for a specific user.
+     */
+    canvas_entry_properties?: {
+      [k: string]: unknown
+    }
+    /**
+     * Defaults to true, cannot be used with user aliases; if set to false, an attributes object must also be included.
+     */
+    send_to_existing_only?: boolean
+    /**
+     * Fields in the attributes object will create or update an attribute of that name with the given value on the specified user profile before the message is sent and existing values will be overwritten.
+     */
+    attributes?: {
+      [k: string]: unknown
+    }
+  }[]
+  /**
+   * Prioritization settings; required when using email in recipients. This prioritization will be applied to all recipients.
+   */
+  prioritization?: {
+    /**
+     * First priority in the prioritization sequence
+     */
+    first_priority?: string
+    /**
+     * Second priority in the prioritization sequence
+     */
+    second_priority?: string
+  }
+  /**
+   * A standard audience object to specify the users to send the canvas to. Including "audience" will only send to users in the audience
+   */
+  audience?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/braze/triggerCanvas/generated-types.ts
+++ b/packages/destination-actions/src/destinations/braze/triggerCanvas/generated-types.ts
@@ -24,7 +24,7 @@ export interface Payload {
      */
     external_user_id?: string
     /**
-     * User alias object to identify the user.
+     * User alias object of the user.
      */
     user_alias?: {
       /**

--- a/packages/destination-actions/src/destinations/braze/triggerCanvas/index.ts
+++ b/packages/destination-actions/src/destinations/braze/triggerCanvas/index.ts
@@ -202,14 +202,7 @@ const action: ActionDefinition<Settings, Payload> = {
     try {
       return await request(`${settings.endpoint}/canvas/trigger/send`, {
         method: 'POST',
-        json: {
-          canvas_id: payload.canvas_id,
-          canvas_entry_properties: payload.canvas_entry_properties,
-          broadcast: payload.broadcast,
-          recipients: payload.recipients,
-          prioritization: payload.prioritization,
-          audience: payload.audience
-        }
+        json: payload
       })
     } catch (error) {
       // Handle error response format specific to trigger/send endpoint

--- a/packages/destination-actions/src/destinations/braze/triggerCanvas/index.ts
+++ b/packages/destination-actions/src/destinations/braze/triggerCanvas/index.ts
@@ -1,0 +1,151 @@
+import { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { dynamicFields } from './functions/dynamic-field-functions'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Trigger Canvas',
+  description: 'Trigger a Braze Canvas to deliver a cross-channel message to the specified user.',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    canvas_id: {
+      label: 'Canvas ID',
+      description:
+        'The ID of the canvas to trigger. The canvas must be API-triggered and the status must be "Draft" or "Active".',
+      type: 'string',
+      required: true,
+      dynamic: true,
+      default: {
+        '@path': '$.properties.canvas_id'
+      }
+    },
+
+    canvas_entry_properties: {
+      label: 'Canvas Entry Properties',
+      description:
+        'Optional data that will be used to personalize the canvas message. Personalization key-value pairs that will apply to all users in this request.',
+      type: 'object',
+      defaultObjectUI: 'keyvalue',
+      default: {
+        '@path': '$.properties'
+      }
+    },
+    broadcast: {
+      label: 'Broadcast',
+      description:
+        'If set to true, the canvas will be sent to all the users in the segment targeted by the canvas. It cannot be used with "recipients".',
+      type: 'boolean',
+      default: {
+        '@path': '$.properties.broadcast'
+      }
+    },
+    recipients: {
+      label: 'Recipients',
+      description: 'An array of user identifiers to send the canvas to. It cannot be used with "broadcast".',
+      type: 'object',
+      multiple: true,
+      properties: {
+        external_user_id: {
+          label: 'External User ID',
+          description: 'External identifier of user to receive message.',
+          type: 'string',
+          default: {
+            '@path': '$.userId'
+          }
+        },
+        user_alias: {
+          label: 'User Alias',
+          description: 'User alias object to identify the user.',
+          type: 'object',
+          properties: {
+            alias_name: {
+              label: 'Alias Name',
+              type: 'string',
+              description: 'The name of the alias',
+              default: {
+                '@path': '$.traits.braze_alias'
+              }
+            },
+            alias_label: {
+              label: 'Alias Label',
+              type: 'string',
+              description: 'The label of the alias',
+              default: {
+                '@path': '$.traits.braze_alias_label'
+              }
+            }
+          }
+        },
+
+        email: {
+          label: 'Email',
+          description: 'Email address of user to receive message.',
+          type: 'string',
+          default: {
+            '@path': '$.traits.email'
+          }
+        },
+        canvas_entry_properties: {
+          label: 'Canvas Entry Properties',
+          description: 'Properties that will override the default canvas_entry_properties for a specific user.',
+          type: 'object',
+          defaultObjectUI: 'keyvalue'
+        },
+        send_to_existing_only: {
+          label: 'Send to Existing Only',
+          description:
+            'Defaults to true, cannot be used with user aliases; if set to false, an attributes object must also be included.',
+          type: 'boolean'
+        },
+        attributes: {
+          label: 'Attributes',
+          description:
+            'Fields in the attributes object will create or update an attribute of that name with the given value on the specified user profile before the message is sent and existing values will be overwritten.',
+          type: 'object',
+          defaultObjectUI: 'keyvalue'
+        }
+      }
+    },
+    prioritization: {
+      label: 'Prioritization',
+      description:
+        'Prioritization settings; required when using email in recipients. This prioritization will be applied to all recipients.',
+      type: 'object',
+      properties: {
+        first_priority: {
+          label: 'First Priority',
+          description: 'First priority in the prioritization sequence',
+          type: 'string'
+        },
+        second_priority: {
+          label: 'Second Priority',
+          description: 'Second priority in the prioritization sequence',
+          type: 'string'
+        }
+      }
+    },
+    audience: {
+      label: 'Audience',
+      description:
+        'A standard audience object to specify the users to send the canvas to. Including "audience" will only send to users in the audience',
+      type: 'object',
+      defaultObjectUI: 'keyvalue'
+    }
+  },
+  dynamicFields,
+  perform: async (request, { payload, settings }) => {
+    return request(`${settings.endpoint}/canvas/trigger/send`, {
+      method: 'POST',
+      json: {
+        canvas_id: payload.canvas_id,
+        canvas_entry_properties: payload.canvas_entry_properties,
+        broadcast: payload.broadcast,
+        recipients: payload.recipients,
+        prioritization: payload.prioritization,
+        audience: payload.audience
+      }
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/braze/triggerCanvas/index.ts
+++ b/packages/destination-actions/src/destinations/braze/triggerCanvas/index.ts
@@ -56,7 +56,7 @@ const action: ActionDefinition<Settings, Payload> = {
         },
         user_alias: {
           label: 'User Alias',
-          description: 'User alias object to identify the user.',
+          description: 'User alias object of the user.',
           type: 'object',
           properties: {
             alias_name: {
@@ -77,7 +77,6 @@ const action: ActionDefinition<Settings, Payload> = {
             }
           }
         },
-
         email: {
           label: 'Email',
           description: 'Email address of user to receive message.',

--- a/packages/destination-actions/src/destinations/braze/triggerCanvas/index.ts
+++ b/packages/destination-actions/src/destinations/braze/triggerCanvas/index.ts
@@ -153,17 +153,7 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'A standard audience object to specify the users to send the canvas to. Including "audience" will only send to users in the audience',
       type: 'object',
-      defaultObjectUI: 'keyvalue',
-      depends_on: {
-        match: 'all',
-        conditions: [
-          {
-            fieldKey: 'broadcast',
-            operator: 'is',
-            value: true
-          }
-        ]
-      }
+      defaultObjectUI: 'keyvalue'
     }
   },
   dynamicFields,

--- a/packages/destination-actions/src/destinations/braze/triggerCanvas/index.ts
+++ b/packages/destination-actions/src/destinations/braze/triggerCanvas/index.ts
@@ -14,10 +14,7 @@ const action: ActionDefinition<Settings, Payload> = {
         'The ID of the canvas to trigger. The canvas must be API-triggered and the status must be "Draft" or "Active".',
       type: 'string',
       required: true,
-      dynamic: true,
-      default: {
-        '@path': '$.properties.canvas_id'
-      }
+      dynamic: true
     },
 
     canvas_entry_properties: {
@@ -104,6 +101,16 @@ const action: ActionDefinition<Settings, Payload> = {
           type: 'object',
           defaultObjectUI: 'keyvalue'
         }
+      },
+      depends_on: {
+        match: 'all',
+        conditions: [
+          {
+            fieldKey: 'broadcast',
+            operator: 'is_not',
+            value: true
+          }
+        ]
       }
     },
     prioritization: {
@@ -122,6 +129,16 @@ const action: ActionDefinition<Settings, Payload> = {
           description: 'Second priority in the prioritization sequence',
           type: 'string'
         }
+      },
+      depends_on: {
+        match: 'all',
+        conditions: [
+          {
+            fieldKey: 'broadcast',
+            operator: 'is_not',
+            value: true
+          }
+        ]
       }
     },
     audience: {
@@ -129,7 +146,17 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'A standard audience object to specify the users to send the canvas to. Including "audience" will only send to users in the audience',
       type: 'object',
-      defaultObjectUI: 'keyvalue'
+      defaultObjectUI: 'keyvalue',
+      depends_on: {
+        match: 'all',
+        conditions: [
+          {
+            fieldKey: 'broadcast',
+            operator: 'is',
+            value: true
+          }
+        ]
+      }
     }
   },
   dynamicFields,

--- a/packages/destination-actions/src/destinations/braze/triggerCanvas/index.ts
+++ b/packages/destination-actions/src/destinations/braze/triggerCanvas/index.ts
@@ -31,10 +31,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Broadcast',
       description:
         'If set to true, the canvas will be sent to all the users in the segment targeted by the canvas. It cannot be used with "recipients".',
-      type: 'boolean',
-      default: {
-        '@path': '$.properties.broadcast'
-      }
+      type: 'boolean'
     },
     recipients: {
       label: 'Recipients',

--- a/packages/destination-actions/src/destinations/braze/triggerCanvas/index.ts
+++ b/packages/destination-actions/src/destinations/braze/triggerCanvas/index.ts
@@ -1,8 +1,7 @@
-import { ActionDefinition, APIError, ModifiedResponse, PayloadValidationError } from '@segment/actions-core'
+import { ActionDefinition, APIError, ModifiedResponse, PayloadValidationError, HTTPError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { dynamicFields } from './functions/dynamic-field-functions'
-import { HTTPError } from '@segment/actions-core/*'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Trigger Canvas',

--- a/packages/destination-actions/src/destinations/braze/triggerCanvas/index.ts
+++ b/packages/destination-actions/src/destinations/braze/triggerCanvas/index.ts
@@ -112,6 +112,16 @@ const action: ActionDefinition<Settings, Payload> = {
             value: true
           }
         ]
+      },
+      required: {
+        match: 'all',
+        conditions: [
+          {
+            fieldKey: 'broadcast',
+            operator: 'is_not',
+            value: true
+          }
+        ]
       }
     },
     prioritization: {


### PR DESCRIPTION
This pull request implements a new action `Trigger Canvas` under braze destination.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 

[Staging Tests
](https://docs.google.com/document/d/15JS9dL4F2jn_qIHMAXO0uIUMYSFFBHgiUDszS9RUE60/edit?usp=sharing)