### PR TITLE
[Amazon CAPI] Removing dataType from custom attributes and removing amazonClickId and ImpressionId fields

### DIFF
--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/__tests__/fields.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/__tests__/fields.test.ts
@@ -115,8 +115,6 @@ describe('trackConversion fields', () => {
         expect(fields.customAttributes?.properties).toBeDefined()
         expect(fields.customAttributes?.properties?.name).toBeDefined()
         expect(fields.customAttributes?.properties?.name.required).toBe(true)
-        expect(fields.customAttributes?.properties?.dataType).toBeDefined()
-        expect(fields.customAttributes?.properties?.dataType?.choices).toContainEqual({ label: 'String', value: 'STRING' })
         expect(fields.customAttributes?.properties?.value).toBeDefined()
         expect(fields.customAttributes?.properties?.value.required).toBe(true)
     })

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/fields.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/fields.ts
@@ -367,7 +367,7 @@ export const fields: Record<string, InputField> = {
   },
   customAttributes: {
     label: 'Custom Attributes',
-    description: 'Custom attributes associated with the event to provide additional context.',
+    description: 'Custom attributes associated with the event to provide additional context. Only brand, category, productId and attr1 - attr10 custom attributes are used for reporting.',
     type: 'object',
     multiple: true,
     required: false,
@@ -379,17 +379,6 @@ export const fields: Record<string, InputField> = {
         description: 'Name of the custom attribute. Only letters, numbers and the underscore character are allowed.',
         type: 'string',
         required: true
-      },
-      dataType: {
-        label: 'Data Type',
-        description: 'Data type of the custom attribute.',
-        type: 'string',
-        required: false,
-        choices: [
-          { label: 'String', value: 'STRING' },
-          { label: 'Number', value: 'NUMBER' },
-          { label: 'Boolean', value: 'BOOLEAN' }
-        ]
       },
       value: {
         label: 'Value',

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/fields.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/fields.ts
@@ -388,24 +388,6 @@ export const fields: Record<string, InputField> = {
       }
     }
   },
-  amazonImpressionId: {
-    label: 'Amazon impression ID',
-    description: 'The Amazon impression ID associated with the event.',
-    type: 'string',
-    required: false,
-    default: {
-      '@path': '$.properties.amazonImpressionId'
-    }
-  },
-  amazonClickId: {
-    label: 'Amazon click ID',
-    description: 'The Amazon click ID associated with the event.',
-    type: 'string',
-    required: false,
-    default: {
-      '@path': '$.properties.amazonClickId'
-    }
-  },
   enable_batching: {
     label: 'Enable Batching',
     description: 'When enabled, Segment will send data in batching.',

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/generated-types.ts
@@ -116,17 +116,13 @@ export interface Payload {
     gpp?: string
   }
   /**
-   * Custom attributes associated with the event to provide additional context.
+   * Custom attributes associated with the event to provide additional context. Only brand, category, productId and attr1 - attr10 custom attributes are used for reporting.
    */
   customAttributes?: {
     /**
      * Name of the custom attribute. Only letters, numbers and the underscore character are allowed.
      */
     name: string
-    /**
-     * Data type of the custom attribute.
-     */
-    dataType?: string
     /**
      * Value of the custom attribute. Max length 256 characters.
      */

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/generated-types.ts
@@ -129,14 +129,6 @@ export interface Payload {
     value: string
   }[]
   /**
-   * The Amazon impression ID associated with the event.
-   */
-  amazonImpressionId?: string
-  /**
-   * The Amazon click ID associated with the event.
-   */
-  amazonClickId?: string
-  /**
    * When enabled, Segment will send data in batching.
    */
   enable_batching: boolean

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/utils.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/utils.ts
@@ -47,11 +47,11 @@ export function validateConsent(consent: Payload['consent'], region: RegionValue
     ...(hasStringValue(ipAddress) && { geo: { ipAddress } }),
     ...(hasStringValue(amznAdStorage) &&
       hasStringValue(amznUserData) && {
-        amazonConsent: {
-          amznAdStorage,
-          amznUserData
-        } as AmazonConsentFormat
-      }),
+      amazonConsent: {
+        amznAdStorage,
+        amznUserData
+      } as AmazonConsentFormat
+    }),
     ...(hasStringValue(tcf) && { tcf }),
     ...(hasStringValue(gpp) && { gpp })
   }
@@ -385,9 +385,7 @@ export function prepareEventData(payload: Payload, settings: Settings): EventDat
     ...(payload.clientDedupeId && { clientDedupeId: payload.clientDedupeId }),
     ...(payload.dataProcessingOptions && { dataProcessingOptions: payload.dataProcessingOptions }),
     ...(consent && { consent }),
-    ...(payload.customAttributes && { customAttributes: payload.customAttributes as CustomAttributeV1[] }),
-    ...(payload.amazonImpressionId && { amazonImpressionId: payload.amazonImpressionId }),
-    ...(payload.amazonClickId && { amazonClickId: payload.amazonClickId })
+    ...(payload.customAttributes && { customAttributes: payload.customAttributes as CustomAttributeV1[] })
   })
 
   return eventData

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/types.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/types.ts
@@ -26,7 +26,6 @@ export interface ConsentData {
 
 export interface CustomAttributeV1 {
     name: string
-    dataType?: 'STRING' | 'NUMBER' | 'BOOLEAN'
     value: string
 }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

1. Checked the Amazon CAPI code and discussed about custom attributes usage with our product manager. We don't use datatype from custom attributes. We only ingest name and value attributes so it's safe to remove datatype. Also, only brand, category, productId and attr1 - attr10 custom attributes are used for reporting, so added this in description.
2. Also removing amazonClickId and ImpressionId fields which are not needed for now.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
