### PR TITLE
[Amazon CAPI] - Changing how custom attribute field works

### DIFF
--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/__tests__/fields.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/__tests__/fields.test.ts
@@ -43,7 +43,6 @@ describe('trackConversion fields', () => {
         expect(fields.dataProcessingOptions?.multiple).toBe(true)
         expect(fields.consent?.type).toBe('object')
         expect(fields.customAttributes?.type).toBe('object')
-        expect(fields.customAttributes?.multiple).toBe(true)
         expect(fields.enable_batching.type).toBe('boolean')
         expect(fields.batch_size?.type).toBe('number')
     })
@@ -109,15 +108,5 @@ describe('trackConversion fields', () => {
         expect(fields.consent?.properties?.amznUserData).toBeDefined()
         expect(fields.consent?.properties?.tcf).toBeDefined()
         expect(fields.consent?.properties?.gpp).toBeDefined()
-    })
-
-    it('should define customAttributes with proper nested structure', () => {
-        expect(fields.customAttributes?.properties).toBeDefined()
-        expect(fields.customAttributes?.properties?.name).toBeDefined()
-        expect(fields.customAttributes?.properties?.name.required).toBe(true)
-        expect(fields.customAttributes?.properties?.dataType).toBeDefined()
-        expect(fields.customAttributes?.properties?.dataType?.choices).toContainEqual({ label: 'String', value: 'STRING' })
-        expect(fields.customAttributes?.properties?.value).toBeDefined()
-        expect(fields.customAttributes?.properties?.value.required).toBe(true)
     })
 })

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/__tests__/utils.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/__tests__/utils.test.ts
@@ -590,14 +590,71 @@ describe('trackConversion utils', () => {
           amznAdStorage: 'GRANTED',
           amznUserData: 'GRANTED'
         },
-        customAttributes: [
-          { name: 'color', dataType: 'STRING', value: 'blue' },
-          { name: 'size', dataType: 'STRING', value: 'medium' }
-        ],
+        customAttributes: {
+          color: 'blue',
+          size: 'medium',
+          age: 30,
+          stringNum: "9099", // should stay as string
+          stringBool: 'true', // should stay as string
+          stringNegBool: 'false', // should stay as string
+          isMember: true,
+          preferences: { newsletter: true, notifications: false }, // should stringify object
+          tags: ['premium', 'loyalty', 9099], // should stringify array
+          iAmNull: null, // should be ignored
+          iAmUndefined: undefined // should be ignored
+        },
         enable_batching: true
       }
 
       const result = prepareEventData(payload, settings)
+
+      const customAttributes = [
+        {
+          dataType: "STRING",
+          name: "color",
+          value: "blue"
+        },
+        {
+          dataType: "STRING",
+          name: "size",
+          value: "medium"
+        },
+        {
+          dataType: "NUMBER",
+          name: "age",
+          value: "30"
+        },
+        {
+          dataType: "STRING",
+          name: "stringNum",
+          value: "9099"
+        },
+        {
+          dataType: "STRING",
+          name: "stringBool",
+          value: "true"
+        },
+        {
+          dataType: "STRING",
+          name: "stringNegBool",
+          value: "false"
+        },
+        {
+          dataType: "BOOLEAN",
+          name: "isMember",
+          value: "true"
+        },
+        {
+          dataType: "STRING",
+          name: "preferences",
+          value: "{\"newsletter\":true,\"notifications\":false}"
+        },
+        {
+          dataType: "STRING",
+          name: "tags",
+          value: "[\"premium\",\"loyalty\",9099]"
+        }
+      ]
 
       // Check all optional fields are included
       expect(result.value).toBe(99.99)
@@ -606,7 +663,7 @@ describe('trackConversion utils', () => {
       expect(result.clientDedupeId).toBe('dedup-123')
       expect(result.dataProcessingOptions).toEqual(['LIMITED_DATA_USE'])
       expect(result.consent).toBeDefined()
-      expect(result.customAttributes).toEqual(payload.customAttributes)
+      expect(result.customAttributes).toEqual(customAttributes)
     })
   })
 })

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/fields.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/fields.ts
@@ -369,35 +369,9 @@ export const fields: Record<string, InputField> = {
     label: 'Custom Attributes',
     description: 'Custom attributes associated with the event to provide additional context.',
     type: 'object',
-    multiple: true,
     required: false,
-    defaultObjectUI: 'arrayeditor',
-    additionalProperties: false,
-    properties: {
-      name: {
-        label: 'Name',
-        description: 'Name of the custom attribute. Only letters, numbers and the underscore character are allowed.',
-        type: 'string',
-        required: true
-      },
-      dataType: {
-        label: 'Data Type',
-        description: 'Data type of the custom attribute.',
-        type: 'string',
-        required: false,
-        choices: [
-          { label: 'String', value: 'STRING' },
-          { label: 'Number', value: 'NUMBER' },
-          { label: 'Boolean', value: 'BOOLEAN' }
-        ]
-      },
-      value: {
-        label: 'Value',
-        description: 'Value of the custom attribute. Max length 256 characters.',
-        type: 'string',
-        required: true
-      }
-    }
+    additionalProperties: true,
+    defaultObjectUI: 'keyvalue'
   },
   amazonImpressionId: {
     label: 'Amazon impression ID',

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/generated-types.ts
@@ -119,19 +119,8 @@ export interface Payload {
    * Custom attributes associated with the event to provide additional context.
    */
   customAttributes?: {
-    /**
-     * Name of the custom attribute. Only letters, numbers and the underscore character are allowed.
-     */
-    name: string
-    /**
-     * Data type of the custom attribute.
-     */
-    dataType?: string
-    /**
-     * Value of the custom attribute. Max length 256 characters.
-     */
-    value: string
-  }[]
+    [k in string]: unknown
+  }
   /**
    * The Amazon impression ID associated with the event.
    */


### PR DESCRIPTION
This is a breaking change for customers who have the Amazon CAPI Destination installed ( for private beta testing )

Custom Attributes field is being converted into a regular object field, defaulting to key:value UI display. 

Types for each attribute will now be inferred by Segment before being sent to Amazon. 
null and undefined - these will be dropped
number, boolean, object - these will be stringified and sent
string - these will be sent

Customers already using the Integration will need to reconfigure the Custom Attributes field.  

## Testing

Tested locally