### PR TITLE
added context.personas.computation_key for update audience

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
@@ -96,7 +96,11 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       unsafe_hidden: true, // This field is hidden from customers because the desired value always appears at '$.properties.audience_key' in Personas events.
       default: {
-        '@path': '$.properties.audience_key'
+        '@if': {
+          exists: { '@path': '$.properties.audience_key' },
+          then: { '@path': '$.properties.audience_key' },
+          else: { '@path': '$.context.personas.computation_key' }
+        }
       }
     },
     personas_audience_key: {

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
@@ -98,7 +98,7 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         "A Segment-specific key associated with the LinkedIn DMP Segment. This is the lookup key Segment uses to fetch the DMP Segment from LinkedIn's API.",
       type: 'string',
-      unsafe_hidden: true, // This field is hidden from customers because the desired value always appears at '$.properties.audience_key' in Personas events.
+      unsafe_hidden: true, // This field is hidden from customers because the desired value always appears at '$.properties.audience_key' in Personas events and at '$.context.personas.computation_key' for events coming from Journeys v2.
       default: {
         '@if': {
           exists: { '@path': '$.properties.audience_key' },

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/index.ts
@@ -17,7 +17,11 @@ const action: ActionDefinition<Settings, Payload> = {
         'The display name of the LinkedIn DMP Segment. This field is set only when Segment creates a new audience. Updating this field after Segment has created an audience will not update the audience name in LinkedIn.',
       type: 'string',
       default: {
-        '@path': '$.properties.audience_key'
+        '@if': {
+          exists: { '@path': '$.properties.audience_key' },
+          then: { '@path': '$.properties.audience_key' },
+          else: { '@path': '$.context.personas.computation_key' }
+        }
       }
     },
     enable_batching: {


### PR DESCRIPTION
This PR includes changes required to accept context.personas.computation_key from Journeys V2 as valid segment source id for linkedin audiences destination.

https://twilio.slack.com/archives/CC97A542H/p1751466229882599

[Testing Doc](https://docs.google.com/document/d/1N66lp-ef7YDf2PKJ0OQhTvFyE2_7N3ziOKNVHTk-66g/edit?usp=sharing)

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
