### PR TITLE
[Singlestore] - add batch size limits

### DIFF
--- a/packages/destination-actions/src/destinations/singlestore/send/index.ts
+++ b/packages/destination-actions/src/destinations/singlestore/send/index.ts
@@ -120,7 +120,9 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'The maximum number of rows to include in a batch.',
       type: 'number',
       required: true,
-      default: 100
+      default: 100,
+      minimum: 1,
+      maximum: 1000
     },
     enable_batching: {
       type: 'boolean',


### PR DESCRIPTION
Configuring min and max batch sizes for Single Store Destination. 

## Testing

Not required. Not yet in use by customers. 
