### PR TITLE
STRATCONN-5928: Enable editing batch_size for Amazon AMC

### DIFF
--- a/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/generated-types.ts
@@ -50,7 +50,7 @@ export interface Payload {
    */
   enable_batching: boolean
   /**
-   * Maximum number of events to include in each batch. Actual batch sizes may be lower.
+   * Maximum number of events to include in each batch. Actual batch sizes may be lower. Minimum value is 1500 and maximum is 10000.
    */
   batch_size?: number
 }

--- a/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/index.ts
@@ -116,7 +116,6 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Batch Size',
       description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
       type: 'number',
-      unsafe_hidden: true,
       required: false,
       default: 10000
     }

--- a/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/index.ts
@@ -114,7 +114,8 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     batch_size: {
       label: 'Batch Size',
-      description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
+      description:
+        'Maximum number of events to include in each batch. Actual batch sizes may be lower. Minimum value is 1500 and maximum is 10000.',
       type: 'number',
       required: false,
       default: 10000,

--- a/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/index.ts
@@ -117,7 +117,9 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
       type: 'number',
       required: false,
-      default: 10000
+      default: 10000,
+      maximum: 10000,
+      minimum: 1500
     }
   },
   perform: (request, { settings, payload, audienceSettings }) => {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Enable editing batch_size for Amazon AMC as a customer encountered `payload too large` errors more [here](https://twilio-engineering.atlassian.net/browse/STRATCONN-5928) 

## Testing

<img width="1159" height="670" alt="image" src="https://github.com/user-attachments/assets/24beee2c-71e2-4eef-8607-781948593a27" />


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
