### PR TITLE
add Segment partner ID to Reddit Pixel

### DIFF
--- a/packages/browser-destinations/destinations/reddit-pixel/src/init-pixel.ts
+++ b/packages/browser-destinations/destinations/reddit-pixel/src/init-pixel.ts
@@ -16,9 +16,9 @@ export function initializePixel(settings) {
     }
   })(window, document)
 
-  rdt.init = (pixel_id, ldu) => {
+  rdt.init = (pixel_id, options = {}) => {
     if (!rdt.init_already_called) {
-      rdt('init', pixel_id, ldu)
+      rdt('init', pixel_id, options)
     }
     rdt.init_already_called = true
   }

--- a/packages/browser-destinations/destinations/reddit-pixel/src/types.ts
+++ b/packages/browser-destinations/destinations/reddit-pixel/src/types.ts
@@ -2,7 +2,8 @@ export interface RedditPixel {
   page: () => void
   init: (
     pixelId: string,
-    ldu?: {
+    options?: {
+      partner?: string
       dpm?: string
       dpcc?: string
       dprc?: string

--- a/packages/browser-destinations/destinations/reddit-pixel/src/utils.ts
+++ b/packages/browser-destinations/destinations/reddit-pixel/src/utils.ts
@@ -5,6 +5,7 @@ import { RedditPixel, EventMetadata } from './types'
 
 export function initPixel(rdt: RedditPixel, payload: StandardEvent | CustomEvent, settings: Settings) {
   rdt.init(settings.pixel_id, {
+    partner: 'SEGMENT',
     ...(settings.ldu && {
       dpm: 'LDU', // Currently "LDU" is the only value supported if the LDU toggle is enabled.
       dpcc: payload.data_processing_options?.country,


### PR DESCRIPTION
Hi, this is to add a `partner` field to the Reddit Pixel Browser Destination (https://github.com/segmentio/action-destinations/tree/main/packages/browser-destinations/destinations/reddit-pixel). This will allow us to identify which advertisers are using the pixel integration via Segment. 

Added `partner: 'SEGMENT'` to the `init` function object in the Pixel.


## Testing
- Tested using the Actions-tester tool, and now seeing the `partner` field populate with `SEGMENT` in the pixel requests (screenshot attached).
- Tested for all events that we have pre-mapped in the integration.

<img width="1225" height="647" alt="image" src="https://github.com/user-attachments/assets/caff2ddb-3001-43dd-a75d-647e650c9d0c" />

