### PR TITLE
Updated SingleStore table data types

### DIFF
--- a/packages/destination-actions/src/destinations/singlestore/index.ts
+++ b/packages/destination-actions/src/destinations/singlestore/index.ts
@@ -59,15 +59,15 @@ const destination: DestinationDefinition<Settings> = {
 
       const sql = `
         CREATE TABLE IF NOT EXISTS \`${tableName.replace(/`/g, '``')}\` (
-          messageId VARCHAR(255) NOT NULL,
-          timestamp DATETIME NOT NULL,
-          type VARCHAR(255) NOT NULL,
-          event VARCHAR(255),
-          name VARCHAR(255),
+          messageId TEXT NOT NULL,
+          timestamp DATETIME(6) NOT NULL,
+          type TEXT NOT NULL,
+          event TEXT,
+          name TEXT,
           properties JSON,
-          userId VARCHAR(255),
-          anonymousId VARCHAR(255),
-          groupId VARCHAR(255),
+          userId TEXT,
+          anonymousId TEXT,
+          groupId TEXT,
           traits JSON,
           context JSON,
           SHARD KEY ()

--- a/packages/destination-actions/src/destinations/singlestore/send/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/singlestore/send/__tests__/index.test.ts
@@ -192,15 +192,15 @@ const sendMultipleJSON = {
 const createTableJSON = {
   sql: `
         CREATE TABLE IF NOT EXISTS \`testtable\` (
-          messageId VARCHAR(255) NOT NULL,
-          timestamp DATETIME NOT NULL,
-          type VARCHAR(255) NOT NULL,
-          event VARCHAR(255),
-          name VARCHAR(255),
+          messageId TEXT NOT NULL,
+          timestamp DATETIME(6) NOT NULL,
+          type TEXT NOT NULL,
+          event TEXT,
+          name TEXT,
           properties JSON,
-          userId VARCHAR(255),
-          anonymousId VARCHAR(255),
-          groupId VARCHAR(255),
+          userId TEXT,
+          anonymousId TEXT,
+          groupId TEXT,
           traits JSON,
           context JSON,
           SHARD KEY ()


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR updates the datatypes of specific columns in the table that Segment creates for SingleStore:

* Changed VARCHAR(255) to TEXT to support storing strings longer than 255 characters. This ensures the system can handle larger payloads without errors.

* Updated DATETIME to DATETIME(6) to preserve millisecond precision, which can be important for accurate event timestamping.

These changes improve data integrity and support more flexible data ingestion.


## Testing

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
