### PR TITLE
s3_aws_region marked required

### DIFF
--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/generated-types.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/generated-types.ts
@@ -16,7 +16,7 @@ export interface Payload {
   /**
    * Region where the S3 bucket is hosted.
    */
-  s3_aws_region?: string
+  s3_aws_region: string
   /**
    * Unique ID that identifies members of an audience. A typical audience key might be client customer IDs, email addresses, or phone numbers. See more information on [LiveRamp Audience Key](https://docs.liveramp.com/connect/en/onboarding-terms-and-concepts.html#audience-key)
    */

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
@@ -32,7 +32,8 @@ const action: ActionDefinition<Settings, Payload> = {
     s3_aws_region: {
       label: 'AWS Region (S3 only)',
       description: 'Region where the S3 bucket is hosted.',
-      type: 'string'
+      type: 'string',
+      required: true
     },
     audience_key: {
       label: 'LiveRamp Audience Key',


### PR DESCRIPTION


<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This change marks the s3_aws_region field as required property
<img width="2064" height="230" alt="image (1)" src="https://github.com/user-attachments/assets/777b51e9-8f67-4f14-97a5-8d5bd055be48" />

## Testing
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
