### PR TITLE
fix: update Aampe event_name field to use correct fallback path

### DIFF
--- a/packages/destination-actions/src/destinations/aampe/fields.ts
+++ b/packages/destination-actions/src/destinations/aampe/fields.ts
@@ -22,7 +22,7 @@ export const event_name: InputField = {
     '@if': {
       exists: { '@path': '$.event' },
       then: { '@path': '$.event' },
-      else: { '@path': '$.name' }
+      else: { '@path': '$.type' }
     }
   },
   required: true


### PR DESCRIPTION
The path of the event name was wrong which led to not sending events as its a reguired field

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
