### PR TITLE
STRATCONN-6051 - [Clay] - New Destination

### DIFF
--- a/packages/destination-actions/src/destinations/clay/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/clay/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-clay destination: pageVisit action - all fields 1`] = `
+Object {
+  "anonymousId": "eu76@B#kao",
+  "ip": "eu76@B#kao",
+  "messageId": Any<String>,
+  "page": Object {
+    "testType": "eu76@B#kao",
+  },
+  "timestamp": Any<String>,
+  "url": "eu76@B#kao",
+  "userAgent": "eu76@B#kao",
+  "userId": "eu76@B#kao",
+}
+`;
+
+exports[`Testing snapshot for actions-clay destination: pageVisit action - required fields 1`] = `
+Object {
+  "ip": "eu76@B#kao",
+  "messageId": Any<String>,
+}
+`;

--- a/packages/destination-actions/src/destinations/clay/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/clay/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -5,11 +5,19 @@ Object {
   "anonymousId": "eu76@B#kao",
   "ip": "eu76@B#kao",
   "messageId": Any<String>,
+  "name": "eu76@B#kao",
   "page": Object {
+    "path": "eu76@B#kao",
+    "referrer": "eu76@B#kao",
+    "search": "eu76@B#kao",
+    "title": "eu76@B#kao",
+    "url": "eu76@B#kao",
+  },
+  "properties": Object {
     "testType": "eu76@B#kao",
   },
   "timestamp": Any<String>,
-  "url": "eu76@B#kao",
+  "type": "eu76@B#kao",
   "userAgent": "eu76@B#kao",
   "userId": "eu76@B#kao",
 }
@@ -19,5 +27,38 @@ exports[`Testing snapshot for actions-clay destination: pageVisit action - requi
 Object {
   "ip": "eu76@B#kao",
   "messageId": Any<String>,
+  "type": "eu76@B#kao",
+}
+`;
+
+exports[`Testing snapshot for actions-clay destination: track action - all fields 1`] = `
+Object {
+  "anonymousId": "NHQVrUx(HtHKStZdY",
+  "event": "NHQVrUx(HtHKStZdY",
+  "ip": "NHQVrUx(HtHKStZdY",
+  "messageId": Any<String>,
+  "page": Object {
+    "path": "NHQVrUx(HtHKStZdY",
+    "referrer": "NHQVrUx(HtHKStZdY",
+    "search": "NHQVrUx(HtHKStZdY",
+    "title": "NHQVrUx(HtHKStZdY",
+    "url": "NHQVrUx(HtHKStZdY",
+  },
+  "properties": Object {
+    "testType": "NHQVrUx(HtHKStZdY",
+  },
+  "timestamp": Any<String>,
+  "type": "NHQVrUx(HtHKStZdY",
+  "userAgent": "NHQVrUx(HtHKStZdY",
+  "userId": "NHQVrUx(HtHKStZdY",
+}
+`;
+
+exports[`Testing snapshot for actions-clay destination: track action - required fields 1`] = `
+Object {
+  "event": "NHQVrUx(HtHKStZdY",
+  "ip": "NHQVrUx(HtHKStZdY",
+  "messageId": Any<String>,
+  "type": "NHQVrUx(HtHKStZdY",
 }
 `;

--- a/packages/destination-actions/src/destinations/clay/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/clay/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -17,7 +17,7 @@ Object {
     "testType": "eu76@B#kao",
   },
   "timestamp": Any<String>,
-  "type": "eu76@B#kao",
+  "type": "page",
   "userAgent": "eu76@B#kao",
   "userId": "eu76@B#kao",
 }
@@ -27,7 +27,7 @@ exports[`Testing snapshot for actions-clay destination: pageVisit action - requi
 Object {
   "ip": "eu76@B#kao",
   "messageId": Any<String>,
-  "type": "eu76@B#kao",
+  "type": "page",
 }
 `;
 
@@ -48,7 +48,7 @@ Object {
     "testType": "NHQVrUx(HtHKStZdY",
   },
   "timestamp": Any<String>,
-  "type": "NHQVrUx(HtHKStZdY",
+  "type": "track",
   "userAgent": "NHQVrUx(HtHKStZdY",
   "userId": "NHQVrUx(HtHKStZdY",
 }
@@ -59,6 +59,6 @@ Object {
   "event": "NHQVrUx(HtHKStZdY",
   "ip": "NHQVrUx(HtHKStZdY",
   "messageId": Any<String>,
-  "type": "NHQVrUx(HtHKStZdY",
+  "type": "track",
 }
 `;

--- a/packages/destination-actions/src/destinations/clay/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/clay/__tests__/index.test.ts
@@ -1,0 +1,20 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition, { CLAY_API_BASE_URL } from '../index'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Clay', () => {
+  describe('testAuthentication', () => {
+    it('should validate authentication inputs', async () => {
+      nock(CLAY_API_BASE_URL).get('/segment/test_connection_key/auth').reply(200, {})
+
+      await expect(
+        testDestination.testAuthentication({
+          connection_key: 'test_connection_key',
+          secret_key: 'test_secret_key'
+        })
+      ).resolves.not.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/clay/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/clay/__tests__/snapshot.test.ts
@@ -1,0 +1,82 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-clay'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot({
+          messageId: expect.any(String)
+        })
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot({
+          messageId: expect.any(String),
+          timestamp: expect.any(String)
+        })
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/clay/generated-types.ts
+++ b/packages/destination-actions/src/destinations/clay/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Settings {
   /**
-   * Your Clay connection key for page visit events
+   * Your Clay connection key
    */
   connection_key: string
   /**
-   * Your Clay secret key for page visit events
+   * Your Clay secret key
    */
   secret_key: string
 }

--- a/packages/destination-actions/src/destinations/clay/generated-types.ts
+++ b/packages/destination-actions/src/destinations/clay/generated-types.ts
@@ -1,0 +1,12 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your Clay connection key for page visit events
+   */
+  connection_key: string
+  /**
+   * Your Clay secret key for page visit events
+   */
+  secret_key: string
+}

--- a/packages/destination-actions/src/destinations/clay/index.ts
+++ b/packages/destination-actions/src/destinations/clay/index.ts
@@ -2,6 +2,7 @@ import type { DestinationDefinition } from '@segment/actions-core'
 import { defaultValues } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import pageVisit from './pageVisit'
+import track from './track'
 
 export const CLAY_API_BASE_URL = 'https://segment-session.clay.com'
 
@@ -11,6 +12,13 @@ const presets: DestinationDefinition['presets'] = [
     subscribe: 'type = "page"',
     partnerAction: 'pageVisit',
     mapping: defaultValues(pageVisit.fields),
+    type: 'automatic'
+  },
+  {
+    name: 'Track Calls',
+    subscribe: 'type = "track"',
+    partnerAction: 'track',
+    mapping: defaultValues(track.fields),
     type: 'automatic'
   }
 ]
@@ -24,13 +32,13 @@ const destination: DestinationDefinition<Settings> = {
     fields: {
       connection_key: {
         label: 'Connection Key',
-        description: 'Your Clay connection key for page visit events',
+        description: 'Your Clay connection key',
         type: 'string',
         required: true
       },
       secret_key: {
         label: 'Secret Key',
-        description: 'Your Clay secret key for page visit events',
+        description: 'Your Clay secret key',
         type: 'string',
         required: true
       }
@@ -46,7 +54,8 @@ const destination: DestinationDefinition<Settings> = {
   },
   presets,
   actions: {
-    pageVisit
+    pageVisit,
+    track
   }
 }
 

--- a/packages/destination-actions/src/destinations/clay/index.ts
+++ b/packages/destination-actions/src/destinations/clay/index.ts
@@ -1,0 +1,53 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import { defaultValues } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+import pageVisit from './pageVisit'
+
+export const CLAY_API_BASE_URL = 'https://segment-session.clay.com'
+
+const presets: DestinationDefinition['presets'] = [
+  {
+    name: 'Page Visit',
+    subscribe: 'type = "page"',
+    partnerAction: 'pageVisit',
+    mapping: defaultValues(pageVisit.fields),
+    type: 'automatic'
+  }
+]
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Clay',
+  slug: 'actions-clay',
+  mode: 'cloud',
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      connection_key: {
+        label: 'Connection Key',
+        description: 'Your Clay connection key for page visit events',
+        type: 'string',
+        required: true
+      },
+      secret_key: {
+        label: 'Secret Key',
+        description: 'Your Clay secret key for page visit events',
+        type: 'string',
+        required: true
+      }
+    },
+    testAuthentication: (request, { settings }) => {
+      return request(`${CLAY_API_BASE_URL}/segment/${settings.connection_key}/auth`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${settings.secret_key}`
+        }
+      })
+    }
+  },
+  presets,
+  actions: {
+    pageVisit
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/clay/pageVisit/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/clay/pageVisit/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -17,7 +17,7 @@ Object {
     "testType": "zZg8#WaG5V1[W1",
   },
   "timestamp": Any<String>,
-  "type": "zZg8#WaG5V1[W1",
+  "type": "page",
   "userAgent": "zZg8#WaG5V1[W1",
   "userId": "zZg8#WaG5V1[W1",
 }
@@ -38,10 +38,9 @@ Object {
   "properties": Object {
     "ip": "zZg8#WaG5V1[W1",
     "messageId": "zZg8#WaG5V1[W1",
-    "type": "zZg8#WaG5V1[W1",
   },
   "timestamp": Any<String>,
-  "type": "zZg8#WaG5V1[W1",
+  "type": "page",
   "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
   "userId": "user1234",
 }

--- a/packages/destination-actions/src/destinations/clay/pageVisit/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/clay/pageVisit/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -5,11 +5,19 @@ Object {
   "anonymousId": "zZg8#WaG5V1[W1",
   "ip": "zZg8#WaG5V1[W1",
   "messageId": Any<String>,
+  "name": "zZg8#WaG5V1[W1",
   "page": Object {
+    "path": "zZg8#WaG5V1[W1",
+    "referrer": "zZg8#WaG5V1[W1",
+    "search": "zZg8#WaG5V1[W1",
+    "title": "zZg8#WaG5V1[W1",
+    "url": "zZg8#WaG5V1[W1",
+  },
+  "properties": Object {
     "testType": "zZg8#WaG5V1[W1",
   },
   "timestamp": Any<String>,
-  "url": "zZg8#WaG5V1[W1",
+  "type": "zZg8#WaG5V1[W1",
   "userAgent": "zZg8#WaG5V1[W1",
   "userId": "zZg8#WaG5V1[W1",
 }
@@ -27,8 +35,13 @@ Object {
     "title": "Analytics Academy",
     "url": "https://segment.com/academy/",
   },
+  "properties": Object {
+    "ip": "zZg8#WaG5V1[W1",
+    "messageId": "zZg8#WaG5V1[W1",
+    "type": "zZg8#WaG5V1[W1",
+  },
   "timestamp": Any<String>,
-  "url": "https://segment.com/academy/",
+  "type": "zZg8#WaG5V1[W1",
   "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
   "userId": "user1234",
 }

--- a/packages/destination-actions/src/destinations/clay/pageVisit/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/clay/pageVisit/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Clay's pageVisit destination action: all fields 1`] = `
+Object {
+  "anonymousId": "zZg8#WaG5V1[W1",
+  "ip": "zZg8#WaG5V1[W1",
+  "messageId": Any<String>,
+  "page": Object {
+    "testType": "zZg8#WaG5V1[W1",
+  },
+  "timestamp": Any<String>,
+  "url": "zZg8#WaG5V1[W1",
+  "userAgent": "zZg8#WaG5V1[W1",
+  "userId": "zZg8#WaG5V1[W1",
+}
+`;
+
+exports[`Testing snapshot for Clay's pageVisit destination action: required fields 1`] = `
+Object {
+  "anonymousId": "anonId1234",
+  "ip": "zZg8#WaG5V1[W1",
+  "messageId": Any<String>,
+  "page": Object {
+    "path": "/academy/",
+    "referrer": "",
+    "search": "",
+    "title": "Analytics Academy",
+    "url": "https://segment.com/academy/",
+  },
+  "timestamp": Any<String>,
+  "url": "https://segment.com/academy/",
+  "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
+  "userId": "user1234",
+}
+`;

--- a/packages/destination-actions/src/destinations/clay/pageVisit/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/clay/pageVisit/__tests__/index.test.ts
@@ -1,0 +1,79 @@
+import { createTestIntegration } from '@segment/actions-core'
+import nock from 'nock'
+import Destination, { CLAY_API_BASE_URL } from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Clay.pageVisit', () => {
+  it('sends page event to Clay with correct payload', async () => {
+    nock(CLAY_API_BASE_URL).post('/segment/test_connection_key/events').reply(200, {})
+
+    const responses = await testDestination.testAction('pageVisit', {
+      settings: {
+        connection_key: 'test_connection_key',
+        secret_key: 'test_secret_key'
+      },
+      mapping: {
+        timestamp: '2023-03-03T00:00:00.000Z',
+        url: 'https://example.com/page',
+        page: {
+          title: 'Example Page',
+          url: 'https://example.com/page',
+          path: '/page',
+          referrer: 'https://google.com'
+        },
+        ip: '192.168.0.1',
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+        anonymousId: 'anonymous_user_123',
+        userId: 'user_456',
+        messageId: 'segment_message_789'
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect((responses[0].options.headers as any)?.get?.('authorization')).toBe('Bearer test_secret_key')
+
+    const payload = JSON.parse(responses[0].options.body?.toString() ?? '')
+    expect(payload).toMatchObject({
+      timestamp: '2023-03-03T00:00:00.000Z',
+      url: 'https://example.com/page',
+      page: {
+        title: 'Example Page',
+        url: 'https://example.com/page',
+        path: '/page',
+        referrer: 'https://google.com'
+      },
+      ip: '192.168.0.1',
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+      anonymousId: 'anonymous_user_123',
+      userId: 'user_456',
+      messageId: 'segment_message_789'
+    })
+  })
+
+  it('handles minimal required fields', async () => {
+    nock(CLAY_API_BASE_URL).post('/segment/test_connection_key/events').reply(200, {})
+
+    const responses = await testDestination.testAction('pageVisit', {
+      settings: {
+        connection_key: 'test_connection_key',
+        secret_key: 'test_secret_key'
+      },
+      mapping: {
+        ip: '192.168.0.1',
+        messageId: 'segment_message_minimal'
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect((responses[0].options.headers as any)?.get?.('authorization')).toBe('Bearer test_secret_key')
+
+    const payload = JSON.parse(responses[0].options.body?.toString() ?? '')
+    expect(payload).toMatchObject({
+      ip: '192.168.0.1',
+      messageId: 'segment_message_minimal'
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/clay/pageVisit/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/clay/pageVisit/__tests__/snapshot.test.ts
@@ -1,0 +1,83 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'pageVisit'
+const destinationSlug = 'Clay'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined,
+      useDefaultMappings: true
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot({
+        timestamp: expect.any(String),
+        messageId: expect.any(String)
+      })
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined,
+      useDefaultMappings: true
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot({
+        timestamp: expect.any(String),
+        messageId: expect.any(String)
+      })
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/clay/pageVisit/generated-types.ts
+++ b/packages/destination-actions/src/destinations/clay/pageVisit/generated-types.ts
@@ -35,4 +35,10 @@ export interface Payload {
    * The Segment messageId
    */
   messageId: string
+  /**
+   * Properties to associate with the event
+   */
+  properties?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/clay/pageVisit/generated-types.ts
+++ b/packages/destination-actions/src/destinations/clay/pageVisit/generated-types.ts
@@ -1,0 +1,38 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The timestamp of the page event
+   */
+  timestamp?: string
+  /**
+   * URL of the webpage
+   */
+  url?: string
+  /**
+   * Contains context information regarding a webpage
+   */
+  page?: {
+    [k: string]: unknown
+  }
+  /**
+   * IP address of the user
+   */
+  ip: string
+  /**
+   * User-Agent of the user
+   */
+  userAgent?: string
+  /**
+   * The anonymous ID associated with the user
+   */
+  anonymousId?: string
+  /**
+   * The ID associated with the user
+   */
+  userId?: string
+  /**
+   * The Segment messageId
+   */
+  messageId: string
+}

--- a/packages/destination-actions/src/destinations/clay/pageVisit/generated-types.ts
+++ b/packages/destination-actions/src/destinations/clay/pageVisit/generated-types.ts
@@ -6,10 +6,6 @@ export interface Payload {
    */
   name?: string
   /**
-   * The type of the event. Either "page" or "track"
-   */
-  type: string
-  /**
    * The timestamp of the page event
    */
   timestamp?: string

--- a/packages/destination-actions/src/destinations/clay/pageVisit/index.ts
+++ b/packages/destination-actions/src/destinations/clay/pageVisit/index.ts
@@ -15,13 +15,6 @@ const action: ActionDefinition<Settings, Payload> = {
       required: false,
       default: { '@path': '$.name' }
     },
-    type: {
-      type: 'string',
-      description: 'The type of the event. Either "page" or "track"',
-      label: 'Type',
-      required: true,
-      default: { '@path': '$.type' }
-    },
     timestamp: {
       type: 'string',
       format: 'date-time',
@@ -123,7 +116,10 @@ const action: ActionDefinition<Settings, Payload> = {
       headers: {
         Authorization: `Bearer ${settings.secret_key}`
       },
-      json: payload
+      json: {
+        ...payload,
+        type: 'page'
+      }
     })
   }
 }

--- a/packages/destination-actions/src/destinations/clay/pageVisit/index.ts
+++ b/packages/destination-actions/src/destinations/clay/pageVisit/index.ts
@@ -70,6 +70,12 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'The Segment messageId',
       label: 'MessageId',
       default: { '@path': '$.messageId' }
+    },
+    properties: {
+      type: 'object',
+      label: 'Properties',
+      description: 'Properties to associate with the event',
+      default: { '@path': '$.properties' }
     }
   },
   perform: (request, { payload, settings }) => {

--- a/packages/destination-actions/src/destinations/clay/pageVisit/index.ts
+++ b/packages/destination-actions/src/destinations/clay/pageVisit/index.ts
@@ -1,0 +1,86 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { CLAY_API_BASE_URL } from '../index'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Page Visit',
+  description: 'Send a page event to Clay',
+  defaultSubscription: 'type = "page"',
+  fields: {
+    timestamp: {
+      type: 'string',
+      format: 'date-time',
+      required: false,
+      description: 'The timestamp of the page event',
+      label: 'Timestamp',
+      default: { '@path': '$.timestamp' }
+    },
+    url: {
+      type: 'string',
+      required: false,
+      description: 'URL of the webpage',
+      label: 'Page URL',
+      default: { '@path': '$.context.page.url' }
+    },
+    page: {
+      description: 'Contains context information regarding a webpage',
+      label: 'Page',
+      required: false,
+      type: 'object',
+      default: {
+        '@path': '$.context.page'
+      }
+    },
+    ip: {
+      description: 'IP address of the user',
+      label: 'IP Address',
+      required: true,
+      type: 'string',
+      default: {
+        '@path': '$.context.ip'
+      }
+    },
+    userAgent: {
+      description: 'User-Agent of the user',
+      label: 'User Agent',
+      required: false,
+      type: 'string',
+      default: {
+        '@path': '$.context.userAgent'
+      }
+    },
+    anonymousId: {
+      type: 'string',
+      required: false,
+      description: 'The anonymous ID associated with the user',
+      label: 'Anonymous ID',
+      default: { '@path': '$.anonymousId' }
+    },
+    userId: {
+      type: 'string',
+      required: false,
+      description: 'The ID associated with the user',
+      label: 'User ID',
+      default: { '@path': '$.userId' }
+    },
+    messageId: {
+      type: 'string',
+      required: true,
+      description: 'The Segment messageId',
+      label: 'MessageId',
+      default: { '@path': '$.messageId' }
+    }
+  },
+  perform: (request, { payload, settings }) => {
+    return request(`${CLAY_API_BASE_URL}/segment/${settings.connection_key}/events`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${settings.secret_key}`
+      },
+      json: payload
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/clay/track/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/clay/track/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -17,7 +17,7 @@ Object {
     "testType": "s#NxR#]zhFrIncI7QBq",
   },
   "timestamp": "2050-11-27T17:19:35.865Z",
-  "type": "s#NxR#]zhFrIncI7QBq",
+  "type": "track",
   "userAgent": "s#NxR#]zhFrIncI7QBq",
   "userId": "s#NxR#]zhFrIncI7QBq",
 }
@@ -28,6 +28,6 @@ Object {
   "event": "s#NxR#]zhFrIncI7QBq",
   "ip": "s#NxR#]zhFrIncI7QBq",
   "messageId": "s#NxR#]zhFrIncI7QBq",
-  "type": "s#NxR#]zhFrIncI7QBq",
+  "type": "track",
 }
 `;

--- a/packages/destination-actions/src/destinations/clay/track/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/clay/track/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Clay's track destination action: all fields 1`] = `
+Object {
+  "anonymousId": "s#NxR#]zhFrIncI7QBq",
+  "event": "s#NxR#]zhFrIncI7QBq",
+  "ip": "s#NxR#]zhFrIncI7QBq",
+  "messageId": "s#NxR#]zhFrIncI7QBq",
+  "page": Object {
+    "path": "s#NxR#]zhFrIncI7QBq",
+    "referrer": "s#NxR#]zhFrIncI7QBq",
+    "search": "s#NxR#]zhFrIncI7QBq",
+    "title": "s#NxR#]zhFrIncI7QBq",
+    "url": "s#NxR#]zhFrIncI7QBq",
+  },
+  "properties": Object {
+    "testType": "s#NxR#]zhFrIncI7QBq",
+  },
+  "timestamp": "2050-11-27T17:19:35.865Z",
+  "type": "s#NxR#]zhFrIncI7QBq",
+  "userAgent": "s#NxR#]zhFrIncI7QBq",
+  "userId": "s#NxR#]zhFrIncI7QBq",
+}
+`;
+
+exports[`Testing snapshot for Clay's track destination action: required fields 1`] = `
+Object {
+  "event": "s#NxR#]zhFrIncI7QBq",
+  "ip": "s#NxR#]zhFrIncI7QBq",
+  "messageId": "s#NxR#]zhFrIncI7QBq",
+  "type": "s#NxR#]zhFrIncI7QBq",
+}
+`;

--- a/packages/destination-actions/src/destinations/clay/track/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/clay/track/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -5,7 +5,7 @@ Object {
   "anonymousId": "s#NxR#]zhFrIncI7QBq",
   "event": "s#NxR#]zhFrIncI7QBq",
   "ip": "s#NxR#]zhFrIncI7QBq",
-  "messageId": "s#NxR#]zhFrIncI7QBq",
+  "messageId": Any<String>,
   "page": Object {
     "path": "s#NxR#]zhFrIncI7QBq",
     "referrer": "s#NxR#]zhFrIncI7QBq",
@@ -16,7 +16,7 @@ Object {
   "properties": Object {
     "testType": "s#NxR#]zhFrIncI7QBq",
   },
-  "timestamp": "2050-11-27T17:19:35.865Z",
+  "timestamp": Any<String>,
   "type": "track",
   "userAgent": "s#NxR#]zhFrIncI7QBq",
   "userId": "s#NxR#]zhFrIncI7QBq",
@@ -25,9 +25,25 @@ Object {
 
 exports[`Testing snapshot for Clay's track destination action: required fields 1`] = `
 Object {
+  "anonymousId": "anonId1234",
   "event": "s#NxR#]zhFrIncI7QBq",
   "ip": "s#NxR#]zhFrIncI7QBq",
-  "messageId": "s#NxR#]zhFrIncI7QBq",
+  "messageId": Any<String>,
+  "page": Object {
+    "path": "/academy/",
+    "referrer": "",
+    "search": "",
+    "title": "Analytics Academy",
+    "url": "https://segment.com/academy/",
+  },
+  "properties": Object {
+    "event": "s#NxR#]zhFrIncI7QBq",
+    "ip": "s#NxR#]zhFrIncI7QBq",
+    "messageId": "s#NxR#]zhFrIncI7QBq",
+  },
+  "timestamp": Any<String>,
   "type": "track",
+  "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
+  "userId": "user1234",
 }
 `;

--- a/packages/destination-actions/src/destinations/clay/track/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/clay/track/__tests__/index.test.ts
@@ -1,31 +1,32 @@
-import { createTestIntegration } from '@segment/actions-core'
 import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
 import Destination, { CLAY_API_BASE_URL } from '../../index'
 
 const testDestination = createTestIntegration(Destination)
 
-describe('Clay.pageVisit', () => {
-  it('sends page event to Clay with correct payload', async () => {
+describe('Clay.track', () => {
+  it('sends track event to Clay with correct payload', async () => {
     nock(CLAY_API_BASE_URL).post('/segment/test_connection_key/events').reply(200, {})
 
-    const responses = await testDestination.testAction('pageVisit', {
+    const responses = await testDestination.testAction('track', {
       settings: {
         connection_key: 'test_connection_key',
         secret_key: 'test_secret_key'
       },
       mapping: {
-        type: 'page',
+        type: 'track',
         timestamp: '2023-03-03T00:00:00.000Z',
-        page: {
-          title: 'Example Page',
-          url: 'https://example.com/page',
-          path: '/page',
-          referrer: 'https://google.com'
+        event: 'Purchase Completed',
+        properties: {
+          product_id: 'prod_123',
+          price: 29.99,
+          currency: 'USD',
+          category: 'Electronics'
         },
+        userId: 'user_456',
+        anonymousId: 'anonymous_user_123',
         ip: '192.168.0.1',
         userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
-        anonymousId: 'anonymous_user_123',
-        userId: 'user_456',
         messageId: 'segment_message_789'
       }
     })
@@ -36,18 +37,19 @@ describe('Clay.pageVisit', () => {
 
     const payload = JSON.parse(responses[0].options.body?.toString() ?? '')
     expect(payload).toMatchObject({
-      type: 'page',
+      type: 'track',
       timestamp: '2023-03-03T00:00:00.000Z',
-      page: {
-        title: 'Example Page',
-        url: 'https://example.com/page',
-        path: '/page',
-        referrer: 'https://google.com'
+      event: 'Purchase Completed',
+      properties: {
+        product_id: 'prod_123',
+        price: 29.99,
+        currency: 'USD',
+        category: 'Electronics'
       },
+      userId: 'user_456',
+      anonymousId: 'anonymous_user_123',
       ip: '192.168.0.1',
       userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
-      anonymousId: 'anonymous_user_123',
-      userId: 'user_456',
       messageId: 'segment_message_789'
     })
   })
@@ -55,13 +57,14 @@ describe('Clay.pageVisit', () => {
   it('handles minimal required fields', async () => {
     nock(CLAY_API_BASE_URL).post('/segment/test_connection_key/events').reply(200, {})
 
-    const responses = await testDestination.testAction('pageVisit', {
+    const responses = await testDestination.testAction('track', {
       settings: {
         connection_key: 'test_connection_key',
         secret_key: 'test_secret_key'
       },
       mapping: {
-        type: 'page',
+        type: 'track',
+        event: 'Button Click',
         ip: '192.168.0.1',
         messageId: 'segment_message_minimal'
       }
@@ -73,7 +76,8 @@ describe('Clay.pageVisit', () => {
 
     const payload = JSON.parse(responses[0].options.body?.toString() ?? '')
     expect(payload).toMatchObject({
-      type: 'page',
+      type: 'track',
+      event: 'Button Click',
       ip: '192.168.0.1',
       messageId: 'segment_message_minimal'
     })

--- a/packages/destination-actions/src/destinations/clay/track/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/clay/track/__tests__/snapshot.test.ts
@@ -25,7 +25,8 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       event: event,
       mapping: event.properties,
       settings: settingsData,
-      auth: undefined
+      auth: undefined,
+      useDefaultMappings: true
     })
 
     const request = responses[0].request
@@ -33,7 +34,10 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
 
     try {
       const json = JSON.parse(rawBody)
-      expect(json).toMatchSnapshot()
+      expect(json).toMatchSnapshot({
+        timestamp: expect.any(String),
+        messageId: expect.any(String)
+      })
       return
     } catch (err) {
       expect(rawBody).toMatchSnapshot()
@@ -58,7 +62,8 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       event: event,
       mapping: event.properties,
       settings: settingsData,
-      auth: undefined
+      auth: undefined,
+      useDefaultMappings: true
     })
 
     const request = responses[0].request
@@ -66,7 +71,10 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
 
     try {
       const json = JSON.parse(rawBody)
-      expect(json).toMatchSnapshot()
+      expect(json).toMatchSnapshot({
+        timestamp: expect.any(String),
+        messageId: expect.any(String)
+      })
       return
     } catch (err) {
       expect(rawBody).toMatchSnapshot()

--- a/packages/destination-actions/src/destinations/clay/track/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/clay/track/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'track'
+const destinationSlug = 'Clay'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/clay/track/generated-types.ts
+++ b/packages/destination-actions/src/destinations/clay/track/generated-types.ts
@@ -2,15 +2,15 @@
 
 export interface Payload {
   /**
-   * The name of the page
+   * The name of the event
    */
-  name?: string
+  event: string
   /**
    * The type of the event. Either "page" or "track"
    */
   type: string
   /**
-   * The timestamp of the page event
+   * The timestamp of the track event
    */
   timestamp?: string
   /**

--- a/packages/destination-actions/src/destinations/clay/track/generated-types.ts
+++ b/packages/destination-actions/src/destinations/clay/track/generated-types.ts
@@ -6,10 +6,6 @@ export interface Payload {
    */
   event: string
   /**
-   * The type of the event. Either "page" or "track"
-   */
-  type: string
-  /**
    * The timestamp of the track event
    */
   timestamp?: string

--- a/packages/destination-actions/src/destinations/clay/track/index.ts
+++ b/packages/destination-actions/src/destinations/clay/track/index.ts
@@ -15,13 +15,6 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Event Name',
       default: { '@path': '$.event' }
     },
-    type: {
-      type: 'string',
-      description: 'The type of the event. Either "page" or "track"',
-      label: 'Type',
-      required: true,
-      default: { '@path': '$.type' }
-    },
     timestamp: {
       type: 'string',
       format: 'date-time',
@@ -123,7 +116,10 @@ const action: ActionDefinition<Settings, Payload> = {
       headers: {
         Authorization: `Bearer ${settings.secret_key}`
       },
-      json: payload
+      json: {
+        ...payload,
+        type: 'track'
+      }
     })
   }
 }

--- a/packages/destination-actions/src/destinations/clay/track/index.ts
+++ b/packages/destination-actions/src/destinations/clay/track/index.ts
@@ -4,16 +4,16 @@ import type { Payload } from './generated-types'
 import { CLAY_API_BASE_URL } from '../index'
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Page Visit',
-  description: 'Send a page event to Clay',
-  defaultSubscription: 'type = "page"',
+  title: 'Track',
+  description: 'Send a track event to Clay',
+  defaultSubscription: 'type = "track"',
   fields: {
-    name: {
+    event: {
       type: 'string',
-      description: 'The name of the page',
+      required: true,
+      description: 'The name of the event',
       label: 'Event Name',
-      required: false,
-      default: { '@path': '$.name' }
+      default: { '@path': '$.event' }
     },
     type: {
       type: 'string',
@@ -26,7 +26,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       format: 'date-time',
       required: false,
-      description: 'The timestamp of the page event',
+      description: 'The timestamp of the track event',
       label: 'Timestamp',
       default: { '@path': '$.timestamp' }
     },


### PR DESCRIPTION
Created a new partner action for [clay](https://clay.com). This includes a page event type that sends data to Clay.

## Testing

 We've tested this locally and with unit tests.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
